### PR TITLE
chore: v1.1 polish — skills, panel fixes, README SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,39 @@
 # PawWork
 
-AI workstation that works out of the box. Download, open, get to work.
+**Process documents, analyze data, draft content. No API key, no command line, no setup.**
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![macOS](https://img.shields.io/badge/macOS-Apple_Silicon-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
 
 [中文说明](README_CN.md)
 
 ---
 
-PawWork is a desktop AI workstation for non-technical knowledge workers. No API key, no command line, no configuration needed.
+PawWork is a desktop app for knowledge workers who want AI to handle real tasks, not just chat. Download the app, open it, and start working with your files.
 
-- **Works out of the box** — built-in tools, no brew/pip/npm required
-- **Free model included** — ships with a free AI model, zero setup
-- **Desktop app** — macOS / Windows, native experience
+<!-- TODO: add screenshot here -->
+
+## What You Can Do
+
+- **Office documents** — create and edit Word (.docx), Excel (.xlsx), PowerPoint (.pptx) without installing Office
+- **Data analysis** — drop a spreadsheet or CSV, get summaries, charts, and reports
+- **Writing help** — draft emails, reports, plans, and announcements from rough notes
+- **PDF processing** — merge, split, extract, and convert PDF files
+
+All tools are built in. Nothing to install, no terminal, no package managers.
 
 ## Download
 
-macOS (Apple Silicon): [pawwork-mac-arm64.dmg](https://github.com/Astro-Han/pawwork/releases/latest)
+macOS (Apple Silicon): **[Download .dmg](https://github.com/Astro-Han/pawwork/releases/latest)**
 
 ### macOS first launch
 
-PawWork is not yet code-signed with Apple Developer ID. On first launch:
-Right-click the app → Open → confirm "Open" in the dialog.
+PawWork is not yet signed with Apple Developer ID. On first launch:
+Right-click the app > Open > confirm "Open" in the dialog.
 
-## Built-in Tools
+## Who This Is For
 
-- **Office documents** — create and edit .docx / .xlsx / .pptx (via officecli)
-- More tools coming soon
+PawWork is built for people who work with documents, spreadsheets, and writing every day but don't want to learn programming or manage API keys. If you've tried ChatGPT or Claude but wished it could just work with your files directly on your computer, this is for you.
 
 ## Build from Source
 
@@ -39,8 +48,8 @@ cd packages/desktop-electron && bun run dev
 
 ## Credits
 
-PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode) (MIT license).
+PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode).
 
 ## License
 
-MIT
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cd packages/desktop-electron && bun run dev
 
 ## Credits
 
-PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode).
+PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode), with modifications.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,30 +1,39 @@
 # 爪印 PawWork
 
-开箱即用的 AI 工作站。下载，打开，开始干活。
+**处理文档、分析数据、起草内容。不需要 API Key，不需要命令行，不需要任何配置。**
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![macOS](https://img.shields.io/badge/macOS-Apple_Silicon-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
 
 [English](README.md)
 
 ---
 
-PawWork 是一个桌面 AI 工作站，专为非技术知识工作者设计。不需要 API Key，不需要命令行，不需要任何配置。
+PawWork 是一个桌面应用，让知识工作者用 AI 直接处理手头的工作，而不只是聊天。下载，打开，开始干活。
 
-- **下载即用** — 内置工具链，不需要 brew/pip/npm
-- **免费模型** — 自带免费 AI 模型，零配置开聊
-- **桌面应用** — macOS / Windows，原生体验
+<!-- TODO: 添加截图 -->
+
+## 能做什么
+
+- **Office 文档** — 创建和编辑 Word (.docx)、Excel (.xlsx)、PowerPoint (.pptx)，不需要安装 Office
+- **数据分析** — 拖入表格或 CSV，获得汇总、图表和报告
+- **写作辅助** — 从零散笔记起草邮件、周报、方案、通知
+- **PDF 处理** — 合并、拆分、提取、转换 PDF 文件
+
+所有工具都内置在应用里。不需要安装任何东西，不需要终端，不需要包管理器。
 
 ## 下载
 
-macOS (Apple Silicon): [pawwork-mac-arm64.dmg](https://github.com/Astro-Han/pawwork/releases/latest)
+macOS (Apple Silicon): **[下载 .dmg](https://github.com/Astro-Han/pawwork/releases/latest)**
 
 ### macOS 首次打开
 
 PawWork 暂未完成 Apple 签名。首次打开时：
-右键点击应用 → 打开 → 在弹窗中确认「打开」。
+右键点击应用 > 打开 > 在弹窗中确认「打开」。
 
-## 内置工具
+## 适合谁用
 
-- **Office 文档** — 创建和编辑 .docx / .xlsx / .pptx（via officecli）
-- 更多工具持续添加中
+PawWork 是为每天跟文档、表格、写作打交道，但不想学编程或管理 API Key 的人设计的。如果你用过 ChatGPT 或 Claude，但希望 AI 能直接在你电脑上处理文件，PawWork 就是为你做的。
 
 ## 从源码构建
 
@@ -39,8 +48,8 @@ cd packages/desktop-electron && bun run dev
 
 ## 致谢
 
-PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)（MIT license）。
+PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)。
 
 ## License
 
-MIT
+[Apache License 2.0](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,7 +48,7 @@ cd packages/desktop-electron && bun run dev
 
 ## 致谢
 
-PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)。
+PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)，有修改。
 
 ## License
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -444,16 +444,16 @@ export function SessionHeader() {
                       class="titlebar-icon w-8 h-6 p-0 box-border"
                       onClick={() => view().sidePanel.toggleTab("files")}
                       aria-label={language.t("command.fileTree.toggle")}
-                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "files"}
+                      aria-expanded={view().sidePanel.opened()}
                       aria-controls="review-panel"
                     >
                       <div class="relative flex items-center justify-center size-4">
                         <Icon
                           size="small"
-                          name={view().sidePanel.opened() && view().sidePanel.tab() === "files" ? "file-tree-active" : "file-tree"}
+                          name={view().sidePanel.opened() ? "file-tree-active" : "file-tree"}
                           classList={{
-                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "files",
-                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "files"),
+                            "text-icon-strong": view().sidePanel.opened(),
+                            "text-icon-weak": !view().sidePanel.opened(),
                           }}
                         />
                       </div>

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -444,16 +444,16 @@ export function SessionHeader() {
                       class="titlebar-icon w-8 h-6 p-0 box-border"
                       onClick={() => view().sidePanel.toggleTab("files")}
                       aria-label={language.t("command.fileTree.toggle")}
-                      aria-expanded={view().sidePanel.opened()}
+                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "files"}
                       aria-controls="review-panel"
                     >
                       <div class="relative flex items-center justify-center size-4">
                         <Icon
                           size="small"
-                          name={view().sidePanel.opened() ? "file-tree-active" : "file-tree"}
+                          name={view().sidePanel.opened() && view().sidePanel.tab() === "files" ? "file-tree-active" : "file-tree"}
                           classList={{
-                            "text-icon-strong": view().sidePanel.opened(),
-                            "text-icon-weak": !view().sidePanel.opened(),
+                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "files",
+                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "files"),
                           }}
                         />
                       </div>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1093,12 +1093,15 @@ export default function Page() {
   createEffect(() => {
     if (!params.id) return
 
+    // Use Snapshot diffs (SSE-pushed, authoritative) with turnDiffs as fallback
+    // for reopened sessions where session_diff hasn't been fetched yet.
+    const source = diffs().length > 0 ? diffs() : turnDiffs()
     const next = nextFilesPanelAutoOpen(
       {
         seenAdded: view().sidePanel.filesAutoOpenSeen(),
         dismissed: view().sidePanel.filesAutoOpenDismissed(),
       },
-      diffs(),
+      source,
     )
 
     if (next.open) {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1098,7 +1098,7 @@ export default function Page() {
         seenAdded: view().sidePanel.filesAutoOpenSeen(),
         dismissed: view().sidePanel.filesAutoOpenDismissed(),
       },
-      turnDiffs(),
+      diffs(),
     )
 
     if (next.open) {

--- a/skills/data-analysis/SKILL.md
+++ b/skills/data-analysis/SKILL.md
@@ -1,51 +1,41 @@
 ---
 name: data-analysis
-description: Analyze spreadsheets and CSVs, create charts, and produce structured reports.
+description: Use when user wants analysis, charts, summaries, or reports from spreadsheets, CSVs, or tabular data
 ---
 
 # Data Analysis
 
-Use this skill when the user wants analysis, summaries, charts, comparisons, or report-ready tables from local files.
+Analyze local data files: xlsx, csv, tsv. Produce summaries, charts, or reports. If user mainly needs prose, do analysis here first, hand off tone to `writing-assistant`.
 
-## Scene Detection
+## Clarify Before Acting
 
-- Use for spreadsheets, csv, tsv, charting, KPI summaries, comparisons, and report outputs.
-- If the user mainly needs copywriting or a memo, do the analysis here first and hand off final prose tone to `writing-assistant` only if needed.
+Use `question` if the business question is vague. Skip when the request is already specific.
 
-## question Flow
+- Which file(s) contain the data
+- What question should the analysis answer
+- Desired output: report, chart image, updated spreadsheet, or all three
+- Key dimensions, metrics, or date ranges
 
-Use question to confirm:
+## Tool Selection
 
-1. Which file or files contain the data?
-2. What question should the analysis answer?
-3. Do they want a report, a chart image, an updated spreadsheet, or all three?
-4. Are there date ranges, dimensions, or metrics that matter most?
+| Task | Tool |
+|------|------|
+| xlsx with formulas/structure | `officecli` |
+| csv/tsv parsing, reshaping | Node.js |
+| Chart/image output | `sharp` |
 
-If the business question is vague, force clarity before running analysis.
+Stay within local files and bundled tools.
 
 ## Workflow
 
-1. Inspect the schema and identify the relevant tables, sheets, and columns.
-2. Validate obvious data-quality issues, missing values, malformed dates, duplicate rows, or mixed units.
-3. Run the requested aggregation or comparison.
-4. Produce the requested outputs, spreadsheet, chart image, report, or a combination.
-5. State the main finding first, then supporting detail.
+1. Inspect schema: tables, sheets, columns
+2. Flag data-quality issues (missing values, duplicates, mixed units)
+3. Run aggregation or comparison
+4. Produce requested outputs
+5. State the main finding first, then supporting detail
 
-## Tool Rules
+## Guardrails
 
-- Prefer `officecli` for xlsx reading and writing when formulas or workbook structure matter.
-- Use Node.js parsing for csv and tsv plus lightweight table reshaping.
-- Use `sharp` only for chart or image output generation.
-- Do not require `opencli`. Stay within local files and bundled tools.
-
-## Error Handling and Degradation
-
-- If the data is incomplete, contradictory, or suspicious, call it out explicitly instead of smoothing it over.
-- If a chart cannot be produced cleanly, return the analysis table and explain what blocked the chart.
-- If the workbook is too complex for safe rewriting, write a separate output file instead of corrupting the original.
-
-## Output Requirements
-
-- State the main finding first.
-- Include the exact file path for any generated spreadsheet, image, or report.
-- If data quality looks suspicious, call it out explicitly instead of smoothing it over.
+- Data incomplete or suspicious → call it out explicitly, don't smooth over
+- Chart can't render cleanly → return analysis table, explain what blocked it
+- Workbook too complex for safe rewriting → write a separate output file

--- a/skills/document-processing/SKILL.md
+++ b/skills/document-processing/SKILL.md
@@ -1,53 +1,39 @@
 ---
 name: document-processing
-description: Handle Word, Excel, PowerPoint, PDF, and mixed office-file requests.
+description: Use when user wants to create, edit, convert, or extract from Word, Excel, PowerPoint, or PDF files
 ---
 
 # Document Processing
 
-Use this skill when the user wants to create, edit, convert, clean up, or extract information from office documents.
+Process office documents: docx, xlsx, pptx, pdf, csv. Pure writing requests without source files → `writing-assistant`.
 
-## Scene Detection
+## Clarify Before Acting
 
-- Use for docx, xlsx, pptx, pdf, or mixed office-file workflows.
-- Do not use for pure writing requests without source files. Route those to `writing-assistant`.
-- Do not guess the target format from the input extension alone. Follow the requested output.
+Use `question` if ambiguous. Skip when the request is already specific.
 
-## question Flow
+- Source file(s) and target format
+- New file, edit, or conversion
+- What must stay unchanged (layout, formulas, branding)
 
-Use question to collect the missing execution constraints before touching files. Ask for:
+## Tool Selection
 
-1. Which file or files are the source material?
-2. What output format do they want, docx, xlsx, pptx, pdf, or plain text?
-3. Is this a new file, an edit to an existing file, or a conversion?
-4. What must stay unchanged, layout, formulas, page order, wording, or branding?
-
-If any of those are missing and the wrong choice would change the output, stop and ask before proceeding.
+| Format | Tool |
+|--------|------|
+| docx, xlsx, pptx | `officecli` |
+| PDF merge/split/fill/extract | `pdf-lib` |
+| Mixed formats | Decide final output format first |
 
 ## Workflow
 
-1. Inspect the source files and confirm the requested output.
-2. Choose the least-destructive toolchain for that file type.
-3. Make the edit or conversion.
-4. Verify the output exists and still matches the non-negotiable constraints.
-5. Report exactly what changed and where the file was written.
+1. Inspect source files, confirm requested output
+2. Choose least-destructive toolchain for the file type
+3. Make the edit or conversion
+4. Verify output matches constraints
+5. Report what changed and where the file was saved
 
-## Tool Rules
+## Guardrails
 
-- Prefer `officecli` for docx, xlsx, and pptx read or write tasks.
-- Use `pdf-lib` only for PDF-specific work, merge, split, reorder, fill, stamp, or extract.
-- If the request mixes office files and PDF, decide the final output format before editing.
-- If the input is ambiguous, ask before editing the wrong file.
-- When creating output, save it inside the current PawWork workspace unless the user gives a different path.
-
-## Error Handling and Degradation
-
-- If formatting fidelity is uncertain, warn before you finalize.
-- If a requested conversion would destroy formulas, layout, comments, or pagination, explain the tradeoff and offer a safer alternative.
-- If a file cannot be parsed by the preferred tool, say which file failed and switch to the closest safe fallback instead of silently skipping it.
-
-## Output Requirements
-
-- Say which file you created or changed.
-- If formatting fidelity is uncertain, warn the user before finishing.
-- If a requested conversion cannot preserve structure, offer the closest safe alternative.
+- Conversion would destroy formulas/layout/comments → explain tradeoff, offer alternative
+- Formatting fidelity uncertain → warn before finalizing
+- File can't be parsed → name the file, switch to closest safe fallback
+- Save output in current workspace unless user specifies a path

--- a/skills/writing-assistant/SKILL.md
+++ b/skills/writing-assistant/SKILL.md
@@ -1,50 +1,40 @@
 ---
 name: writing-assistant
-description: Draft and revise work writing such as emails, reports, plans, and copy.
+description: Use when user wants to draft or revise work writing like emails, reports, plans, announcements, or copy
 ---
 
 # Writing Assistant
 
-Use this skill when the user wants help writing or rewriting business content.
+Draft and revise business content. If the request is mostly file transformation or analysis, finish that first, use this skill only for the writing pass.
 
-## Scene Detection
+## Clarify Before Acting
 
-- Use for emails, reports, plans, announcements, summaries, and work copy.
-- If the request is mostly file transformation or analysis, finish that work first and only use this skill for the writing pass.
+Use `question` if ambiguous. Skip when the request is already specific.
 
-## question Flow
+- Content type (email, report, announcement, plan, copy)
+- Audience
+- Tone (concise, warm, formal, direct, persuasive)
+- Length or structure constraints
 
-Use question to collect:
-
-1. What are they writing, email, weekly update, announcement, report, or copy?
-2. Who is the audience?
-3. What tone should it have, concise, warm, formal, direct, or persuasive?
-4. What length or structure do they want?
-
-If the user gives weak or fragmented source notes, ask for the missing facts before drafting as if you know them.
+If source notes are thin, ask for missing facts before drafting.
 
 ## Workflow
 
-1. Identify the content type and audience.
-2. Pull facts, constraints, deadlines, and asks from the user's notes.
-3. If the input is thin, propose a brief structure before writing long-form output.
-4. Draft the response in the requested tone.
-5. Tighten for clarity, remove filler, and check that every claim is sourced from the provided material.
+1. Identify content type and audience
+2. Extract facts, constraints, deadlines from user's notes
+3. If input is thin, propose structure before writing long-form
+4. Draft in requested tone
+5. Tighten: remove filler, verify every claim is from provided material
 
 ## Working Rules
 
-- Default to clear, concrete wording and short paragraphs.
-- If the user provides source notes, preserve facts and tighten wording.
-- If they provide no material, propose a sensible structure before drafting long content.
-- Do not invent facts, names, numbers, or commitments.
+- Default: clear wording, short paragraphs
+- Preserve facts from source notes, tighten wording
+- Never invent facts, names, numbers, or commitments
+- Return polished copy, not brainstorming fragments (unless user asks for outline)
 
-## Error Handling and Degradation
+## Guardrails
 
-- If required facts are missing, ask instead of hallucinating.
-- If two plausible tones fit, provide the stronger default first and note the alternative briefly.
-- If the request mixes drafting and strategy, separate the final copy from the advice so the user can use the output immediately.
-
-## Output Requirements
-
-- Return polished copy, not brainstorming fragments, unless the user explicitly asks for an outline.
-- If there are two plausible tones, give the stronger default first and mention the alternative briefly.
+- Missing facts → ask, don't hallucinate
+- Two plausible tones → give stronger default first, mention alternative
+- Mixed drafting + strategy → separate final copy from advice so output is immediately usable


### PR DESCRIPTION
## Summary

- **Rewrite 3 built-in skills** with CSO-optimized structure (description uses "Use when..." triggers, unified sections, ~30% fewer words)
- **Fix right panel auto-open** — switch data source from message summary (turnDiffs) to Snapshot (sync.data.session_diff), the authoritative source
- **Fix file-tree button highlight** — button now stays active when side panel is open on any tab (not just Files), since the standalone diff icon was removed earlier
- **Rewrite dual-language READMEs** — concrete use cases, badges, "Who This Is For" section, fix license label from MIT to Apache-2.0

## Test plan

- [ ] Open a session, trigger file changes — right panel should auto-expand
- [ ] With panel open on Changes tab, verify file-tree button in header is highlighted
- [ ] Click file-tree button to toggle panel open/closed on both tabs
- [ ] Verify skill cards still work (document-processing, data-analysis, writing-assistant)
- [ ] Check README renders correctly on GitHub