### PR TITLE
feat: split desktop panel and thread locale into skills

### DIFF
--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -7,27 +7,42 @@ const expanded = async (el: { getAttribute: (name: string) => Promise<string | n
   return value === "true"
 }
 
-test("review panel can be toggled via keybind", async ({ page, gotoSession }) => {
+test("desktop side-panel buttons switch between review and files without an in-panel tab strip", async ({
+  page,
+  gotoSession,
+}) => {
   await gotoSession()
 
   const reviewPanel = page.locator("#review-panel")
-
-  const treeToggle = page.getByRole("button", { name: "Toggle file tree" }).first()
-  await expect(treeToggle).toBeVisible()
-  if (await expanded(treeToggle)) await treeToggle.click()
-  await expect(treeToggle).toHaveAttribute("aria-expanded", "false")
-
   const reviewToggle = page.getByRole("button", { name: "Toggle review" }).first()
+  const fileToggle = page.getByRole("button", { name: "Toggle file tree" }).first()
+
   await expect(reviewToggle).toBeVisible()
+  await expect(fileToggle).toBeVisible()
+
   if (await expanded(reviewToggle)) await reviewToggle.click()
+  if (await expanded(fileToggle)) await fileToggle.click()
+
+  await expect(reviewPanel.getByRole("tab", { name: "Files" })).toHaveCount(0)
+  await expect(reviewPanel.getByRole("tab", { name: "Changes" })).toHaveCount(0)
+
+  await reviewToggle.click()
+  await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
+  await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+
+  await fileToggle.click()
+  await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
+  await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
+  await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+
+  await fileToggle.click()
+  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
   await expect(reviewPanel).toHaveAttribute("aria-hidden", "true")
 
   await page.keyboard.press(`${modKey}+Shift+R`)
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
   await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
-
-  await page.keyboard.press(`${modKey}+Shift+R`)
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(reviewPanel).toHaveAttribute("aria-hidden", "true")
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 import type { Prompt } from "@/context/prompt"
 
 let createPromptSubmit: typeof import("./submit").createPromptSubmit
+let sendFollowupDraft: typeof import("./submit").sendFollowupDraft
 
 const createdClients: string[] = []
 const createdSessions: string[] = []
@@ -20,12 +21,24 @@ const storedSessions: Record<string, Array<{ id: string; title?: string }>> = {}
 const promoted: Array<{ directory: string; sessionID: string }> = []
 const sentShell: string[] = []
 const syncedDirectories: string[] = []
+const promptAsyncCalls: Array<Record<string, unknown>> = []
+const commandCalls: Array<Record<string, unknown>> = []
+const commandDefinitions: Array<{ name: string }> = []
 
 let params: { id?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
 
-const promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
+let currentIntl = "zh-Hans"
+let promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
+
+const waitForCall = async (check: () => boolean) => {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (check()) return
+    await Promise.resolve()
+  }
+  throw new Error("timed out waiting for async request")
+}
 
 const clientFor = (directory: string) => {
   createdClients.push(directory)
@@ -45,8 +58,14 @@ const clientFor = (directory: string) => {
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
-      promptAsync: async () => ({ data: undefined }),
-      command: async () => ({ data: undefined }),
+      promptAsync: async (input: Record<string, unknown>) => {
+        promptAsyncCalls.push(input)
+        return { data: undefined }
+      },
+      command: async (input: Record<string, unknown>) => {
+        commandCalls.push(input)
+        return { data: undefined }
+      },
       abort: async () => ({ data: undefined }),
     },
     worktree: {
@@ -140,7 +159,7 @@ beforeAll(async () => {
 
   mock.module("@/context/sync", () => ({
     useSync: () => ({
-      data: { command: [] },
+      data: { command: commandDefinitions },
       session: {
         optimistic: {
           add: (value: {
@@ -194,11 +213,13 @@ beforeAll(async () => {
   mock.module("@/context/language", () => ({
     useLanguage: () => ({
       t: (key: string) => key,
+      intl: () => currentIntl,
     }),
   }))
 
   const mod = await import("./submit")
   createPromptSubmit = mod.createPromptSubmit
+  sendFollowupDraft = mod.sendFollowupDraft
 })
 
 beforeEach(() => {
@@ -208,11 +229,16 @@ beforeEach(() => {
   optimistic.length = 0
   optimisticSeeded.length = 0
   promoted.length = 0
+  promptAsyncCalls.length = 0
+  commandCalls.length = 0
+  commandDefinitions.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
+  currentIntl = "zh-Hans"
+  promptValue = [{ type: "text", content: "ls", start: 0, end: 2 }]
   for (const key of Object.keys(storedSessions)) delete storedSessions[key]
 })
 
@@ -341,5 +367,117 @@ describe("prompt submit worktree selection", () => {
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("sends locale with promptAsync requests", async () => {
+    params = { id: "session-existing" }
+    currentIntl = "pt-BR"
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    expect(promptAsyncCalls.at(-1)?.locale).toBe("pt-BR")
+  })
+
+  test("queues locale on followup drafts", async () => {
+    params = { id: "session-existing" }
+    const queued: Array<Record<string, unknown>> = []
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      shouldQueue: () => true,
+      onQueue: (draft) => queued.push(draft as unknown as Record<string, unknown>),
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(queued.at(-1)?.locale).toBe("zh-Hans")
+  })
+
+  test("sends locale with direct slash-command submits", async () => {
+    params = { id: "session-existing" }
+    currentIntl = "nb-NO"
+    commandDefinitions.push({ name: "summarize" })
+    promptValue = [{ type: "text", content: "/summarize this", start: 0, end: 15 }]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => commandCalls.length > 0)
+
+    expect(commandCalls.at(-1)?.locale).toBe("nb-NO")
+  })
+
+  test("sends locale with slash-command followups", async () => {
+    await sendFollowupDraft({
+      client: clientFor("/repo/main") as any,
+      globalSync: {
+        child: () => [{}, () => undefined],
+      } as any,
+      sync: {
+        data: { command: [{ name: "summarize" }] },
+        session: {
+          optimistic: {
+            add: () => undefined,
+            remove: () => undefined,
+          },
+        },
+      } as any,
+      draft: {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        prompt: [{ type: "text", content: "/summarize this", start: 0, end: 15 }],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+        locale: "zh-Hans",
+      },
+    })
+
+    expect(commandCalls.at(-1)?.locale).toBe("zh-Hans")
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -34,6 +34,7 @@ export type FollowupDraft = {
   context: (ContextItem & { key: string })[]
   agent: string
   model: { providerID: string; modelID: string }
+  locale?: string
   variant?: string
 }
 
@@ -88,6 +89,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
         arguments: tail.join(" "),
         agent: input.draft.agent,
         model: `${input.draft.model.providerID}/${input.draft.model.modelID}`,
+        locale: input.draft.locale,
         variant: input.draft.variant,
         parts: images.map((attachment) => ({
           id: Identifier.ascending("part"),
@@ -153,6 +155,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
       sessionID: input.draft.sessionID,
       agent: input.draft.agent,
       model: input.draft.model,
+      locale: input.draft.locale,
       messageID,
       parts: requestParts,
       variant: input.draft.variant,
@@ -389,6 +392,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       modelID: currentModel.id,
       providerID: currentModel.provider.id,
     }
+    const locale = language.intl()
     const agent = currentAgent.name
     const context = prompt.context.items().slice()
     const draft: FollowupDraft = {
@@ -398,6 +402,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       context,
       agent,
       model,
+      locale,
       variant,
     }
 
@@ -462,6 +467,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             arguments: args.join(" "),
             agent,
             model: `${model.providerID}/${model.modelID}`,
+            locale,
             variant,
             parts: images.map((attachment) => ({
               id: Identifier.ascending("part"),

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -436,6 +436,31 @@ export function SessionHeader() {
 
                 <div class="hidden md:flex items-center gap-1 shrink-0">
                   <TooltipKeybind
+                    title={language.t("command.review.toggle")}
+                    keybind={command.keybind("review.toggle")}
+                  >
+                    <Button
+                      variant="ghost"
+                      class="titlebar-icon w-8 h-6 p-0 box-border"
+                      onClick={() => view().sidePanel.toggleTab("changes")}
+                      aria-label={language.t("command.review.toggle")}
+                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "changes"}
+                      aria-controls="review-panel"
+                    >
+                      <div class="relative flex items-center justify-center size-4">
+                        <Icon
+                          size="small"
+                          name={view().sidePanel.opened() && view().sidePanel.tab() === "changes" ? "review-active" : "review"}
+                          classList={{
+                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "changes",
+                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "changes"),
+                          }}
+                        />
+                      </div>
+                    </Button>
+                  </TooltipKeybind>
+
+                  <TooltipKeybind
                     title={language.t("command.fileTree.toggle")}
                     keybind={command.keybind("fileTree.toggle")}
                   >

--- a/packages/app/src/components/session/session-new-view-command.ts
+++ b/packages/app/src/components/session/session-new-view-command.ts
@@ -1,0 +1,21 @@
+import type { PawworkSkillName } from "./pawwork-skill-meta"
+
+export function buildSkillSessionCommandInput(input: {
+  sessionID: string
+  command: PawworkSkillName
+  agent: string
+  model: string
+  variant?: string
+  locale?: string
+}) {
+  return {
+    sessionID: input.sessionID,
+    command: input.command,
+    arguments: "",
+    agent: input.agent,
+    model: input.model,
+    variant: input.variant,
+    locale: input.locale,
+    parts: [],
+  }
+}

--- a/packages/app/src/components/session/session-new-view.test.ts
+++ b/packages/app/src/components/session/session-new-view.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { buildSkillSessionCommandInput } from "./session-new-view-command"
+
+describe("new session skill cards", () => {
+  test("passes locale through the built-in skill launch command", () => {
+    expect(
+      buildSkillSessionCommandInput({
+        sessionID: "session-1",
+        command: "document-processing",
+        agent: "build",
+        model: "openai/gpt-5",
+        variant: "fast",
+        locale: "pt-BR",
+      }),
+    ).toEqual({
+      sessionID: "session-1",
+      command: "document-processing",
+      arguments: "",
+      agent: "build",
+      model: "openai/gpt-5",
+      variant: "fast",
+      locale: "pt-BR",
+      parts: [],
+    })
+  })
+})

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -7,6 +7,7 @@ import { base64Encode } from "@opencode-ai/util/encode"
 import { showToast } from "@opencode-ai/ui/toast"
 import { Mark } from "@opencode-ai/ui/logo"
 import { pawworkSkillCards, type PawworkSkillName } from "./pawwork-skill-meta"
+import { buildSkillSessionCommandInput } from "./session-new-view-command"
 
 export function NewSessionView() {
   const sdk = useSDK()
@@ -39,15 +40,16 @@ export function NewSessionView() {
       local.session.promote(sdk.directory, created.id)
       navigate(`/${base64Encode(sdk.directory)}/session/${created.id}`)
 
-      await sdk.client.session.command({
-        sessionID: created.id,
-        command: name,
-        arguments: "",
-        agent: agent.name,
-        model: `${model.provider.id}/${model.id}`,
-        variant: local.model.variant.current() ?? undefined,
-        parts: [],
-      })
+      await sdk.client.session.command(
+        buildSkillSessionCommandInput({
+          sessionID: created.id,
+          command: name,
+          agent: agent.name,
+          model: `${model.provider.id}/${model.id}`,
+          variant: local.model.variant.current() ?? undefined,
+          locale: language.intl(),
+        }),
+      )
     } catch (error) {
       if (created?.id) {
         await sdk.client.session.delete({ sessionID: created.id }).catch(() => undefined)

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout"
+import { createSessionKeyReader, defaultSidePanelTab, ensureSessionKey, pruneSessionKeys } from "./layout"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -65,5 +65,13 @@ describe("pruneSessionKeys", () => {
     })
 
     expect(drop).toEqual([])
+  })
+})
+
+describe("defaultSidePanelTab", () => {
+  test("defaults the desktop side panel to files", () => {
+    expect(defaultSidePanelTab(undefined)).toBe("files")
+    expect(defaultSidePanelTab("files")).toBe("files")
+    expect(defaultSidePanelTab("changes")).toBe("changes")
   })
 })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -73,6 +73,10 @@ export function createSessionKeyReader(sessionKey: string | Accessor<string>, en
   }
 }
 
+export function defaultSidePanelTab(tab?: "files" | "changes") {
+  return tab ?? "files"
+}
+
 export function pruneSessionKeys(input: {
   keep?: string
   max: number
@@ -828,7 +832,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
               }
               this.open()
             },
-            tab: createMemo(() => s().sidePanelTab ?? "changes"),
+            tab: createMemo(() => defaultSidePanelTab(s().sidePanelTab)),
             setTab(tab: "files" | "changes") {
               const session = key()
               if (!store.sessionView[session]) {
@@ -838,7 +842,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
               setStore("sessionView", session, "sidePanelTab", tab)
             },
             toggleTab(tab: "files" | "changes") {
-              if (reviewPanelOpened() && (s().sidePanelTab ?? "changes") === tab) {
+              if (reviewPanelOpened() && defaultSidePanelTab(s().sidePanelTab) === tab) {
                 this.close()
                 return
               }

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -203,30 +203,15 @@ export function SessionSidePanel(props: {
         }}
         style={{ width: panelWidth() }}
       >
-        <Tabs
-          value={sidePanelTab()}
-          onChange={(value) => {
-            if (value !== "files" && value !== "changes") return
-            view().sidePanel.setTab(value)
-          }}
-          class="size-full border-l border-border-weaker-base"
-        >
-          <div class="sticky top-0 z-10 shrink-0 bg-background-base px-3 pt-3">
-            <Tabs.List>
-              <Tabs.Trigger value="files" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("session.panel.files")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="changes" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("session.panel.changes")}
-              </Tabs.Trigger>
-            </Tabs.List>
-          </div>
-
-          <Tabs.Content value="files" class="h-full min-h-0 overflow-hidden">
+        <div class="size-full border-l border-border-weaker-base">
+          <Show when={sidePanelTab() === "files"}>
+            <div class="h-full min-h-0 overflow-hidden">
             <FilesTab files={props.files()} />
-          </Tabs.Content>
+            </div>
+          </Show>
 
-          <Tabs.Content value="changes" class="h-full min-h-0 overflow-hidden">
+          <Show when={sidePanelTab() === "changes"}>
+            <div class="h-full min-h-0 overflow-hidden">
             <div class="size-full flex">
               <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-background-base">
                 <div class="size-full min-w-0 h-full bg-background-base">
@@ -440,8 +425,9 @@ export function SessionSidePanel(props: {
                 </div>
               </div>
             </div>
-          </Tabs.Content>
-        </Tabs>
+            </div>
+          </Show>
+        </div>
       </aside>
     </Show>
   )

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -43,7 +43,7 @@ import { Npm } from "@/npm"
 import { InstanceRef } from "@/effect/instance-ref"
 
 export namespace Config {
-  const ModelId = z.string().meta({ $ref: "https://models.dev/model-schema.json#/$defs/Model" })
+  const ModelId = z.string()
   const PluginOptions = z.record(z.string(), z.unknown())
   export const PluginSpec = z.union([z.string(), z.tuple([z.string(), PluginOptions])])
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -376,6 +376,7 @@ export namespace MessageV2 {
       modelID: ModelID.zod,
       variant: z.string().optional(),
     }),
+    locale: z.string().optional(),
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
   }).meta({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -943,6 +943,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             modelID: model.modelID,
             variant,
           },
+          locale: input.locale,
           system: input.system,
           format: input.format,
         }
@@ -1468,7 +1469,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
               const [skills, env, instructions, modelMsgs] = yield* Effect.all([
                 sys.skills(agent),
-                Effect.sync(() => sys.environment(model)),
+                Effect.sync(() => sys.environment(model, lastUser.locale)),
                 instruction.system().pipe(Effect.orDie),
                 MessageV2.toModelMessagesEffect(msgs, model),
               ])
@@ -1645,6 +1646,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           model: userModel,
           agent: userAgent,
           parts,
+          locale: input.locale,
           variant: input.variant,
         })
         yield* bus.publish(Command.Event.Executed, {
@@ -1715,6 +1717,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       .optional(),
     agent: z.string().optional(),
+    locale: z.string().optional(),
     noReply: z.boolean().optional(),
     tools: z
       .record(z.string(), z.boolean())
@@ -1815,6 +1818,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     sessionID: SessionID.zod,
     agent: z.string().optional(),
     model: z.string().optional(),
+    locale: z.string().optional(),
     arguments: z.string(),
     command: z.string(),
     variant: z.string().optional(),

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -34,7 +34,7 @@ export namespace SystemPrompt {
   }
 
   export interface Interface {
-    readonly environment: (model: Provider.Model) => string[]
+    readonly environment: (model: Provider.Model, locale?: string) => string[]
     readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
   }
 
@@ -46,20 +46,24 @@ export namespace SystemPrompt {
       const skill = yield* Skill.Service
 
       return Service.of({
-        environment(model) {
+        environment(model, locale) {
           const project = Instance.project
+          const env = [
+            `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
+            `Here is some useful information about the environment you are running in:`,
+            `<env>`,
+            `  Working directory: ${Instance.directory}`,
+            `  Workspace root folder: ${Instance.worktree}`,
+            `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
+            `  Platform: ${process.platform}`,
+            `  Today's date: ${new Date().toDateString()}`,
+          ]
+
+          if (locale) env.push(`  User locale: ${locale}`)
+
+          env.push(`</env>`)
           return [
-            [
-              `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
-              `Here is some useful information about the environment you are running in:`,
-              `<env>`,
-              `  Working directory: ${Instance.directory}`,
-              `  Workspace root folder: ${Instance.worktree}`,
-              `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
-              `  Platform: ${process.platform}`,
-              `  Today's date: ${new Date().toDateString()}`,
-              `</env>`,
-            ].join("\n"),
+            env.join("\n"),
           ]
         },
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -519,4 +519,103 @@ describe("session.agent-resolution", () => {
       },
     })
   }, 30000)
+
+  test("threads locale into system prompts for prompt, resumed loop, and command requests", async () => {
+    const systems: string[] = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) {
+          return new Response("not found", { status: 404 })
+        }
+
+        const body = (await req.json()) as {
+          messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>
+        }
+
+        const text = body.messages
+          .filter((message) => message.role === "system")
+          .map((message) =>
+            typeof message.content === "string"
+              ? message.content
+              : message.content
+                  .map((part) => ("text" in part && typeof part.text === "string" ? part.text : ""))
+                  .join("\n"),
+          )
+          .join("\n")
+
+        systems.push(text)
+        return new Response(chat("ok"), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+              command: {
+                summarize: {
+                  template: "Summarize the latest user request.",
+                  agent: "build",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+
+          await SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            parts: [{ type: "text", text: "hello" }],
+            locale: "zh-Hans",
+            noReply: true,
+          })
+
+          await SessionPrompt.loop({
+            sessionID: session.id,
+          })
+
+          await SessionPrompt.command({
+            sessionID: session.id,
+            command: "summarize",
+            arguments: "",
+            locale: "pt-BR",
+          })
+
+          expect(systems.some((text) => text.includes("User locale: zh-Hans"))).toBe(true)
+          expect(systems.some((text) => text.includes("User locale: pt-BR"))).toBe(true)
+        },
+      })
+    } finally {
+      await server.stop(true)
+    }
+  }, 30000)
 })

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -7,6 +7,33 @@ import { SystemPrompt } from "../../src/session/system"
 import { tmpdir } from "../fixture/fixture"
 
 describe("session.system", () => {
+  test("environment includes user locale only when provided", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = {
+          providerID: "openai",
+          api: { id: "gpt-5.2" },
+        } as any
+
+        const envWithLocale = await Effect.gen(function* () {
+          const svc = yield* SystemPrompt.Service
+          return svc.environment(model, "zh-Hans").join("\n")
+        }).pipe(Effect.provide(SystemPrompt.defaultLayer), Effect.runPromise)
+
+        const envWithoutLocale = await Effect.gen(function* () {
+          const svc = yield* SystemPrompt.Service
+          return svc.environment(model).join("\n")
+        }).pipe(Effect.provide(SystemPrompt.defaultLayer), Effect.runPromise)
+
+        expect(envWithLocale).toContain("User locale: zh-Hans")
+        expect(envWithoutLocale).not.toContain("User locale:")
+      },
+    })
+  })
+
   test("skills output is sorted by name and stable across calls", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -474,3 +474,79 @@ test("returns bundled skill roots for source and dist layouts", () => {
   const distRoots = Skill.builtinRoots("/repo/packages/opencode/dist/node/skill")
   expect(distRoots).toContain("/repo/skills")
 })
+
+test("bundled productivity skills enforce question-first workflow and locale guidance", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  const original = processWithResourcesPath.resourcesPath
+  Object.defineProperty(process, "resourcesPath", { value: undefined, configurable: true })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const skills = await Skill.all()
+        const getContent = (name: string) => skills.find((item) => item.name === name)?.content ?? ""
+
+        const assertSharedStructure = (content: string) => {
+          expect(content).toContain("<GATE>")
+          expect(content).toContain("ALWAYS use the `question` tool to clarify before acting.")
+          expect(content).toContain("Do NOT proceed with assumptions. Do NOT skip this step.")
+          expect(content).toContain("## Workflow")
+          expect(content).toContain("1. **Clarify**")
+          expect(content).toContain("2. **Execute**")
+          expect(content).toContain("3. **Verify**")
+          expect(content).toContain("## Step 1: Clarify")
+          expect(content).toContain("## Step 2: Execute")
+          expect(content).toContain("## Step 3: Verify")
+          expect(content).toContain("## Language")
+          expect(content).toContain('Reply in the user\'s locale (shown in system environment as "User locale").')
+          expect(content).toContain("```json")
+          expect(content).toContain('"questions"')
+        }
+
+        const documentProcessing = getContent("document-processing")
+        assertSharedStructure(documentProcessing)
+        expect(documentProcessing).toContain('"header": "Task type"')
+        expect(documentProcessing).toContain('"label": "Create new"')
+        expect(documentProcessing).toContain('"label": "Edit existing"')
+        expect(documentProcessing).toContain('"label": "Convert format"')
+        expect(documentProcessing).toContain('"label": "Extract content"')
+        expect(documentProcessing).toContain('"header": "Source"')
+        expect(documentProcessing).toContain('"label": "I\'ll upload/specify files"')
+        expect(documentProcessing).toContain('"label": "Use files from a previous step"')
+
+        const dataAnalysis = getContent("data-analysis")
+        assertSharedStructure(dataAnalysis)
+        expect(dataAnalysis).toContain('"header": "Data source"')
+        expect(dataAnalysis).toContain('"label": "Spreadsheet (xlsx/csv)"')
+        expect(dataAnalysis).toContain('"label": "Database export"')
+        expect(dataAnalysis).toContain('"label": "I\'ll describe the data"')
+        expect(dataAnalysis).toContain('"header": "Output"')
+        expect(dataAnalysis).toContain('"label": "Summary report"')
+        expect(dataAnalysis).toContain('"label": "Chart/visualization"')
+        expect(dataAnalysis).toContain('"label": "Updated spreadsheet"')
+        expect(dataAnalysis).toContain('"multiple": true')
+
+        const writingAssistant = getContent("writing-assistant")
+        assertSharedStructure(writingAssistant)
+        expect(writingAssistant).toContain('"header": "Content type"')
+        expect(writingAssistant).toContain('"label": "Email"')
+        expect(writingAssistant).toContain('"label": "Report/memo"')
+        expect(writingAssistant).toContain('"label": "Announcement"')
+        expect(writingAssistant).toContain('"label": "Plan/proposal"')
+        expect(writingAssistant).toContain('"header": "Tone"')
+        expect(writingAssistant).toContain('"label": "Formal"')
+        expect(writingAssistant).toContain('"label": "Conversational"')
+        expect(writingAssistant).toContain('"label": "Concise/direct"')
+        expect(writingAssistant).toContain('"label": "Persuasive"')
+        expect(writingAssistant).toContain('"header": "Key points"')
+        expect(writingAssistant).toContain('"label": "I\'ll provide details now"')
+        expect(writingAssistant).toContain('"label": "Draft from what I\'ve said"')
+        expect(writingAssistant).toContain('"label": "Ask me more first"')
+      },
+    })
+  } finally {
+    Object.defineProperty(process, "resourcesPath", { value: original, configurable: true })
+  }
+})

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -475,7 +475,7 @@ test("returns bundled skill roots for source and dist layouts", () => {
   expect(distRoots).toContain("/repo/skills")
 })
 
-test("bundled productivity skills enforce question-first workflow and locale guidance", async () => {
+test("bundled productivity skills enforce clarify-first workflow and locale guidance", async () => {
   await using tmp = await tmpdir({ git: true })
 
   const original = processWithResourcesPath.resourcesPath
@@ -490,8 +490,6 @@ test("bundled productivity skills enforce question-first workflow and locale gui
 
         const assertSharedStructure = (content: string) => {
           expect(content).toContain("<GATE>")
-          expect(content).toContain("ALWAYS use the `question` tool to clarify before acting.")
-          expect(content).toContain("Do NOT proceed with assumptions. Do NOT skip this step.")
           expect(content).toContain("## Workflow")
           expect(content).toContain("1. **Clarify**")
           expect(content).toContain("2. **Execute**")
@@ -501,49 +499,30 @@ test("bundled productivity skills enforce question-first workflow and locale gui
           expect(content).toContain("## Step 3: Verify")
           expect(content).toContain("## Language")
           expect(content).toContain('Reply in the user\'s locale (shown in system environment as "User locale").')
-          expect(content).toContain("```json")
-          expect(content).toContain('"questions"')
+          // Skills must NOT hardcode tool names or JSON schemas — models pick the
+          // right tool from the tool list at runtime
+          expect(content).not.toContain("```json")
+          expect(content).not.toContain("`question` tool")
         }
 
         const documentProcessing = getContent("document-processing")
         assertSharedStructure(documentProcessing)
-        expect(documentProcessing).toContain('"header": "Task type"')
-        expect(documentProcessing).toContain('"label": "Create new"')
-        expect(documentProcessing).toContain('"label": "Edit existing"')
-        expect(documentProcessing).toContain('"label": "Convert format"')
-        expect(documentProcessing).toContain('"label": "Extract content"')
-        expect(documentProcessing).toContain('"header": "Source"')
-        expect(documentProcessing).toContain('"label": "I\'ll upload/specify files"')
-        expect(documentProcessing).toContain('"label": "Use files from a previous step"')
+        expect(documentProcessing).toContain("**Task type**")
+        expect(documentProcessing).toContain("**Source**")
+        expect(documentProcessing).toContain("**Constraints**")
 
         const dataAnalysis = getContent("data-analysis")
         assertSharedStructure(dataAnalysis)
-        expect(dataAnalysis).toContain('"header": "Data source"')
-        expect(dataAnalysis).toContain('"label": "Spreadsheet (xlsx/csv)"')
-        expect(dataAnalysis).toContain('"label": "Database export"')
-        expect(dataAnalysis).toContain('"label": "I\'ll describe the data"')
-        expect(dataAnalysis).toContain('"header": "Output"')
-        expect(dataAnalysis).toContain('"label": "Summary report"')
-        expect(dataAnalysis).toContain('"label": "Chart/visualization"')
-        expect(dataAnalysis).toContain('"label": "Updated spreadsheet"')
-        expect(dataAnalysis).toContain('"multiple": true')
+        expect(dataAnalysis).toContain("**Data source**")
+        expect(dataAnalysis).toContain("**Output**")
+        expect(dataAnalysis).toContain("**Business question**")
 
         const writingAssistant = getContent("writing-assistant")
         assertSharedStructure(writingAssistant)
-        expect(writingAssistant).toContain('"header": "Content type"')
-        expect(writingAssistant).toContain('"label": "Email"')
-        expect(writingAssistant).toContain('"label": "Report/memo"')
-        expect(writingAssistant).toContain('"label": "Announcement"')
-        expect(writingAssistant).toContain('"label": "Plan/proposal"')
-        expect(writingAssistant).toContain('"header": "Tone"')
-        expect(writingAssistant).toContain('"label": "Formal"')
-        expect(writingAssistant).toContain('"label": "Conversational"')
-        expect(writingAssistant).toContain('"label": "Concise/direct"')
-        expect(writingAssistant).toContain('"label": "Persuasive"')
-        expect(writingAssistant).toContain('"header": "Key points"')
-        expect(writingAssistant).toContain('"label": "I\'ll provide details now"')
-        expect(writingAssistant).toContain('"label": "Draft from what I\'ve said"')
-        expect(writingAssistant).toContain('"label": "Ask me more first"')
+        expect(writingAssistant).toContain("**Content type**")
+        expect(writingAssistant).toContain("**Tone**")
+        expect(writingAssistant).toContain("**Key points**")
+        expect(writingAssistant).toContain("wait for their next message")
       },
     })
   } finally {

--- a/packages/sdk/js/src/v2/config-types.test-d.ts
+++ b/packages/sdk/js/src/v2/config-types.test-d.ts
@@ -1,0 +1,11 @@
+import type { AgentConfig, Config } from "./gen/types.gen.js"
+
+type Assert<T extends true> = T
+type AcceptsString<T> = Exclude<T, undefined> extends string ? true : false
+
+type CommandModel = NonNullable<Config["command"]>[string]["model"]
+
+type _AgentModelAcceptsString = Assert<AcceptsString<AgentConfig["model"]>>
+type _CommandModelAcceptsString = Assert<AcceptsString<CommandModel>>
+type _ConfigModelAcceptsString = Assert<AcceptsString<Config["model"]>>
+type _ConfigSmallModelAcceptsString = Assert<AcceptsString<Config["small_model"]>>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2165,6 +2165,7 @@ export class Session2 extends HeyApiClient {
         modelID: string
       }
       agent?: string
+      locale?: string
       noReply?: boolean
       tools?: {
         [key: string]: boolean
@@ -2187,6 +2188,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
+            { in: "body", key: "locale" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
@@ -2297,6 +2299,7 @@ export class Session2 extends HeyApiClient {
         modelID: string
       }
       agent?: string
+      locale?: string
       noReply?: boolean
       tools?: {
         [key: string]: boolean
@@ -2319,6 +2322,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
+            { in: "body", key: "locale" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
@@ -2354,6 +2358,7 @@ export class Session2 extends HeyApiClient {
       messageID?: string
       agent?: string
       model?: string
+      locale?: string
       arguments?: string
       command?: string
       variant?: string
@@ -2379,6 +2384,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
+            { in: "body", key: "locale" },
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1192,7 +1192,7 @@ export type PermissionConfig =
   | PermissionActionConfig
 
 export type AgentConfig = {
-  model?: Model
+  model?: string
   /**
    * Default model variant for this agent (applies only when using the agent's configured model).
    */
@@ -1234,7 +1234,6 @@ export type AgentConfig = {
   permission?: PermissionConfig
   [key: string]:
     | unknown
-    | Model
     | string
     | number
     | {
@@ -1446,7 +1445,7 @@ export type Config = {
       template: string
       description?: string
       agent?: string
-      model?: Model
+      model?: string
       subtask?: boolean
     }
   }
@@ -1499,8 +1498,14 @@ export type Config = {
    * When set, ONLY these providers will be enabled. All other providers will be ignored
    */
   enabled_providers?: Array<string>
-  model?: Model
-  small_model?: Model
+  /**
+   * Model to use in the format of provider/model, eg anthropic/claude-2
+   */
+  model?: string
+  /**
+   * Small model to use for tasks like title generation in the format of provider/model
+   */
+  small_model?: string
   /**
    * Default agent to use when none is specified. Must be a primary agent. Falls back to 'build' if not set or if the specified agent is invalid.
    */

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -558,6 +558,7 @@ export type UserMessage = {
     modelID: string
     variant?: string
   }
+  locale?: string
   system?: string
   tools?: {
     [key: string]: boolean
@@ -1191,7 +1192,7 @@ export type PermissionConfig =
   | PermissionActionConfig
 
 export type AgentConfig = {
-  model?: string
+  model?: Model
   /**
    * Default model variant for this agent (applies only when using the agent's configured model).
    */
@@ -1233,6 +1234,7 @@ export type AgentConfig = {
   permission?: PermissionConfig
   [key: string]:
     | unknown
+    | Model
     | string
     | number
     | {
@@ -1444,7 +1446,7 @@ export type Config = {
       template: string
       description?: string
       agent?: string
-      model?: string
+      model?: Model
       subtask?: boolean
     }
   }
@@ -1497,14 +1499,8 @@ export type Config = {
    * When set, ONLY these providers will be enabled. All other providers will be ignored
    */
   enabled_providers?: Array<string>
-  /**
-   * Model to use in the format of provider/model, eg anthropic/claude-2
-   */
-  model?: string
-  /**
-   * Small model to use for tasks like title generation in the format of provider/model
-   */
-  small_model?: string
+  model?: Model
+  small_model?: Model
   /**
    * Default agent to use when none is specified. Must be a primary agent. Falls back to 'build' if not set or if the specified agent is invalid.
    */
@@ -3674,6 +3670,7 @@ export type SessionPromptData = {
       modelID: string
     }
     agent?: string
+    locale?: string
     noReply?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
@@ -3874,6 +3871,7 @@ export type SessionPromptAsyncData = {
       modelID: string
     }
     agent?: string
+    locale?: string
     noReply?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
@@ -3923,6 +3921,7 @@ export type SessionCommandData = {
     messageID?: string
     agent?: string
     model?: string
+    locale?: string
     arguments: string
     command: string
     variant?: string

--- a/skills/data-analysis/SKILL.md
+++ b/skills/data-analysis/SKILL.md
@@ -5,37 +5,74 @@ description: Use when user wants analysis, charts, summaries, or reports from sp
 
 # Data Analysis
 
-Analyze local data files: xlsx, csv, tsv. Produce summaries, charts, or reports. If user mainly needs prose, do analysis here first, hand off tone to `writing-assistant`.
+Analyze structured local data and return conclusions, charts, or updated files.
 
-## Clarify Before Acting
-
-Use `question` if the business question is vague. Skip when the request is already specific.
-
-- Which file(s) contain the data
-- What question should the analysis answer
-- Desired output: report, chart image, updated spreadsheet, or all three
-- Key dimensions, metrics, or date ranges
-
-## Tool Selection
-
-| Task | Tool |
-|------|------|
-| xlsx with formulas/structure | `officecli` |
-| csv/tsv parsing, reshaping | Node.js |
-| Chart/image output | `sharp` |
-
-Stay within local files and bundled tools.
+<GATE>
+ALWAYS use the `question` tool to clarify before acting.
+Do NOT proceed with assumptions. Do NOT skip this step.
+</GATE>
 
 ## Workflow
 
-1. Inspect schema: tables, sheets, columns
-2. Flag data-quality issues (missing values, duplicates, mixed units)
-3. Run aggregation or comparison
-4. Produce requested outputs
-5. State the main finding first, then supporting detail
+1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+2. **Execute** - Inspect the data, run the analysis, and produce the requested outputs.
+3. **Verify** - Check that the findings and deliverables match the user's request.
 
-## Guardrails
+## Step 1: Clarify
 
-- Data incomplete or suspicious → call it out explicitly, don't smooth over
-- Chart can't render cleanly → return analysis table, explain what blocked it
-- Workbook too complex for safe rewriting → write a separate output file
+Always ask these questions before acting:
+
+```json
+{
+  "questions": [
+    {
+      "question": "What kind of data source are you working with?",
+      "header": "Data source",
+      "options": [
+        { "label": "Spreadsheet (xlsx/csv)", "description": "The data is in a spreadsheet or flat file" },
+        { "label": "Database export", "description": "The data came from a database export or report dump" },
+        { "label": "I'll describe the data", "description": "I will explain the schema or sample rows in chat" }
+      ]
+    },
+    {
+      "question": "What outputs do you want me to produce?",
+      "header": "Output",
+      "multiple": true,
+      "options": [
+        { "label": "Summary report", "description": "Write up the main findings and supporting metrics" },
+        { "label": "Chart/visualization", "description": "Create a chart or visual output" },
+        { "label": "Updated spreadsheet", "description": "Return a modified workbook or data file" }
+      ]
+    }
+  ]
+}
+```
+
+Also confirm the business question, key metrics, dimensions, and date range when they matter to the analysis.
+
+## Step 2: Execute
+
+| Task | Tool |
+| --- | --- |
+| xlsx with formulas or workbook structure | `officecli` |
+| csv or tsv parsing, reshaping, aggregation | Node.js |
+| Chart or image output | `sharp` |
+
+Execution rules:
+- Inspect sheets, tables, columns, and units before calculating anything.
+- Flag data-quality problems, such as missing values, duplicates, mixed units, or suspicious totals.
+- Keep analysis steps traceable so the result can be checked.
+- If workbook rewriting is risky, write a separate output file instead of overwriting the source.
+
+## Step 3: Verify
+
+Before reporting back:
+- Recheck the main finding against the underlying data.
+- Confirm each requested output was produced.
+- Call out any data-quality issue that changes confidence in the answer.
+- State the main finding first, then supporting detail.
+
+## Language
+
+Reply in the user's locale (shown in system environment as "User locale").
+If no locale is shown, match the language used in the user's request.

--- a/skills/data-analysis/SKILL.md
+++ b/skills/data-analysis/SKILL.md
@@ -8,47 +8,22 @@ description: Use when user wants analysis, charts, summaries, or reports from sp
 Analyze structured local data and return conclusions, charts, or updated files.
 
 <GATE>
-ALWAYS use the `question` tool to clarify before acting.
-Do NOT proceed with assumptions. Do NOT skip this step.
+Do NOT start analyzing until you understand the data and the question. Ask clarifying questions first, then act.
 </GATE>
 
 ## Workflow
 
-1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+1. **Clarify** - Ask the user what they need before touching any data.
 2. **Execute** - Inspect the data, run the analysis, and produce the requested outputs.
 3. **Verify** - Check that the findings and deliverables match the user's request.
 
 ## Step 1: Clarify
 
-Always ask these questions before acting:
+Ask the user the following before acting:
 
-```json
-{
-  "questions": [
-    {
-      "question": "What kind of data source are you working with?",
-      "header": "Data source",
-      "options": [
-        { "label": "Spreadsheet (xlsx/csv)", "description": "The data is in a spreadsheet or flat file" },
-        { "label": "Database export", "description": "The data came from a database export or report dump" },
-        { "label": "I'll describe the data", "description": "I will explain the schema or sample rows in chat" }
-      ]
-    },
-    {
-      "question": "What outputs do you want me to produce?",
-      "header": "Output",
-      "multiple": true,
-      "options": [
-        { "label": "Summary report", "description": "Write up the main findings and supporting metrics" },
-        { "label": "Chart/visualization", "description": "Create a chart or visual output" },
-        { "label": "Updated spreadsheet", "description": "Return a modified workbook or data file" }
-      ]
-    }
-  ]
-}
-```
-
-Also confirm the business question, key metrics, dimensions, and date range when they matter to the analysis.
+- **Data source** — Is it a spreadsheet (xlsx/csv), a database export, or will they describe the data in chat?
+- **Output** — Do they want a summary report, a chart or visualization, an updated spreadsheet, or some combination?
+- **Business question** — What question should the analysis answer? Confirm key metrics, dimensions, and date ranges when they matter.
 
 ## Step 2: Execute
 

--- a/skills/document-processing/SKILL.md
+++ b/skills/document-processing/SKILL.md
@@ -5,35 +5,73 @@ description: Use when user wants to create, edit, convert, or extract from Word,
 
 # Document Processing
 
-Process office documents: docx, xlsx, pptx, pdf, csv. Pure writing requests without source files → `writing-assistant`.
+Handle document creation, editing, conversion, and extraction for local office files.
 
-## Clarify Before Acting
-
-Use `question` if ambiguous. Skip when the request is already specific.
-
-- Source file(s) and target format
-- New file, edit, or conversion
-- What must stay unchanged (layout, formulas, branding)
-
-## Tool Selection
-
-| Format | Tool |
-|--------|------|
-| docx, xlsx, pptx | `officecli` |
-| PDF merge/split/fill/extract | `pdf-lib` |
-| Mixed formats | Decide final output format first |
+<GATE>
+ALWAYS use the `question` tool to clarify before acting.
+Do NOT proceed with assumptions. Do NOT skip this step.
+</GATE>
 
 ## Workflow
 
-1. Inspect source files, confirm requested output
-2. Choose least-destructive toolchain for the file type
-3. Make the edit or conversion
-4. Verify output matches constraints
-5. Report what changed and where the file was saved
+1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+2. **Execute** - Choose the least-destructive toolchain, then perform the task.
+3. **Verify** - Check the output against the user's constraints and report the result.
 
-## Guardrails
+## Step 1: Clarify
 
-- Conversion would destroy formulas/layout/comments → explain tradeoff, offer alternative
-- Formatting fidelity uncertain → warn before finalizing
-- File can't be parsed → name the file, switch to closest safe fallback
-- Save output in current workspace unless user specifies a path
+Always ask these questions before acting:
+
+```json
+{
+  "questions": [
+    {
+      "question": "What type of document task do you need?",
+      "header": "Task type",
+      "options": [
+        { "label": "Create new", "description": "Create a new document from scratch" },
+        { "label": "Edit existing", "description": "Modify an existing file" },
+        { "label": "Convert format", "description": "Convert a file into another format" },
+        { "label": "Extract content", "description": "Pull text, tables, slides, or other content from a file" }
+      ]
+    },
+    {
+      "question": "Where should I get the source material?",
+      "header": "Source",
+      "options": [
+        { "label": "I'll upload/specify files", "description": "I will name or upload the source files for this task" },
+        { "label": "Use files from a previous step", "description": "Reuse files already created or referenced earlier in this session" }
+      ]
+    }
+  ]
+}
+```
+
+Also confirm any output constraints that must stay unchanged, such as layout, formulas, comments, branding, or slide order.
+
+## Step 2: Execute
+
+| Format or task | Tool |
+| --- | --- |
+| docx, xlsx, pptx | `officecli` |
+| PDF merge, split, fill, extract | `pdf-lib` |
+| Mixed formats | Decide the final output format first, then use the safest path |
+
+Execution rules:
+- Inspect the source files before editing or converting them.
+- Prefer edits that preserve the original structure over destructive conversions.
+- If a conversion risks losing formulas, layout, comments, or branding, explain the tradeoff before finalizing.
+- Save the output in the current workspace unless the user gave a different path.
+
+## Step 3: Verify
+
+Before reporting back:
+- Confirm the output file exists and is in the expected format.
+- Check the requested constraints, such as layout, formulas, branding, or extracted sections.
+- If fidelity is uncertain, say exactly what could not be verified.
+- Report what changed and where the output was saved.
+
+## Language
+
+Reply in the user's locale (shown in system environment as "User locale").
+If no locale is shown, match the language used in the user's request.

--- a/skills/document-processing/SKILL.md
+++ b/skills/document-processing/SKILL.md
@@ -8,46 +8,22 @@ description: Use when user wants to create, edit, convert, or extract from Word,
 Handle document creation, editing, conversion, and extraction for local office files.
 
 <GATE>
-ALWAYS use the `question` tool to clarify before acting.
-Do NOT proceed with assumptions. Do NOT skip this step.
+Do NOT start working on files until you understand what the user needs. Ask clarifying questions first, then act.
 </GATE>
 
 ## Workflow
 
-1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+1. **Clarify** - Ask the user what they need before touching any files.
 2. **Execute** - Choose the least-destructive toolchain, then perform the task.
 3. **Verify** - Check the output against the user's constraints and report the result.
 
 ## Step 1: Clarify
 
-Always ask these questions before acting:
+Ask the user the following before acting:
 
-```json
-{
-  "questions": [
-    {
-      "question": "What type of document task do you need?",
-      "header": "Task type",
-      "options": [
-        { "label": "Create new", "description": "Create a new document from scratch" },
-        { "label": "Edit existing", "description": "Modify an existing file" },
-        { "label": "Convert format", "description": "Convert a file into another format" },
-        { "label": "Extract content", "description": "Pull text, tables, slides, or other content from a file" }
-      ]
-    },
-    {
-      "question": "Where should I get the source material?",
-      "header": "Source",
-      "options": [
-        { "label": "I'll upload/specify files", "description": "I will name or upload the source files for this task" },
-        { "label": "Use files from a previous step", "description": "Reuse files already created or referenced earlier in this session" }
-      ]
-    }
-  ]
-}
-```
-
-Also confirm any output constraints that must stay unchanged, such as layout, formulas, comments, branding, or slide order.
+- **Task type** — Are they creating a new document, editing an existing one, converting between formats, or extracting content?
+- **Source** — Will they upload or specify files, or should you reuse files from a previous step?
+- **Constraints** — Anything that must stay unchanged: layout, formulas, comments, branding, slide order.
 
 ## Step 2: Execute
 

--- a/skills/writing-assistant/SKILL.md
+++ b/skills/writing-assistant/SKILL.md
@@ -8,57 +8,25 @@ description: Use when user wants to draft or revise work writing like emails, re
 Draft or revise business writing without inventing facts, commitments, or details.
 
 <GATE>
-ALWAYS use the `question` tool to clarify before acting.
-Do NOT proceed with assumptions. Do NOT skip this step.
+Do NOT start drafting until you understand what the user needs. Ask clarifying questions first, then write.
 </GATE>
 
 ## Workflow
 
-1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+1. **Clarify** - Ask the user what they need before writing anything.
 2. **Execute** - Extract the facts, choose the right structure, and draft in the requested tone.
 3. **Verify** - Check the draft for factual fidelity, tone, and usability.
 
 ## Step 1: Clarify
 
-Always ask these questions before acting:
+Ask the user the following before acting:
 
-```json
-{
-  "questions": [
-    {
-      "question": "What kind of writing do you need?",
-      "header": "Content type",
-      "options": [
-        { "label": "Email", "description": "Draft or revise an email" },
-        { "label": "Report/memo", "description": "Write a report, memo, or internal brief" },
-        { "label": "Announcement", "description": "Prepare an update or announcement" },
-        { "label": "Plan/proposal", "description": "Draft a plan, proposal, or recommendation" }
-      ]
-    },
-    {
-      "question": "What tone should I use?",
-      "header": "Tone",
-      "options": [
-        { "label": "Formal", "description": "Professional and polished" },
-        { "label": "Conversational", "description": "Natural and approachable" },
-        { "label": "Concise/direct", "description": "Short, clear, and to the point" },
-        { "label": "Persuasive", "description": "Structured to convince the reader" }
-      ]
-    },
-    {
-      "question": "How should I handle the key points?",
-      "header": "Key points",
-      "options": [
-        { "label": "I'll provide details now", "description": "Wait for me to give the facts or bullet points" },
-        { "label": "Draft from what I've said", "description": "Use the details already in the conversation" },
-        { "label": "Ask me more first", "description": "Collect more facts before drafting" }
-      ]
-    }
-  ]
-}
-```
+- **Content type** — Email, report or memo, announcement, or plan/proposal?
+- **Tone** — Formal, conversational, concise and direct, or persuasive?
+- **Key points** — Will they provide details now, should you draft from what they already said, or should you ask more questions first? Always ask this, even when input seems sufficient.
+- **Constraints** — Any length, audience, structure, or deadline requirements.
 
-Also confirm any length, audience, structure, or deadline constraints that affect the final draft.
+If the user chooses to provide details later, wait for their next message before proceeding to draft.
 
 ## Step 2: Execute
 

--- a/skills/writing-assistant/SKILL.md
+++ b/skills/writing-assistant/SKILL.md
@@ -5,36 +5,84 @@ description: Use when user wants to draft or revise work writing like emails, re
 
 # Writing Assistant
 
-Draft and revise business content. If the request is mostly file transformation or analysis, finish that first, use this skill only for the writing pass.
+Draft or revise business writing without inventing facts, commitments, or details.
 
-## Clarify Before Acting
-
-Use `question` if ambiguous. Skip when the request is already specific.
-
-- Content type (email, report, announcement, plan, copy)
-- Audience
-- Tone (concise, warm, formal, direct, persuasive)
-- Length or structure constraints
-
-If source notes are thin, ask for missing facts before drafting.
+<GATE>
+ALWAYS use the `question` tool to clarify before acting.
+Do NOT proceed with assumptions. Do NOT skip this step.
+</GATE>
 
 ## Workflow
 
-1. Identify content type and audience
-2. Extract facts, constraints, deadlines from user's notes
-3. If input is thin, propose structure before writing long-form
-4. Draft in requested tone
-5. Tighten: remove filler, verify every claim is from provided material
+1. **Clarify** - Use the `question` tool and ask the predefined questions in one call.
+2. **Execute** - Extract the facts, choose the right structure, and draft in the requested tone.
+3. **Verify** - Check the draft for factual fidelity, tone, and usability.
 
-## Working Rules
+## Step 1: Clarify
 
-- Default: clear wording, short paragraphs
-- Preserve facts from source notes, tighten wording
-- Never invent facts, names, numbers, or commitments
-- Return polished copy, not brainstorming fragments (unless user asks for outline)
+Always ask these questions before acting:
 
-## Guardrails
+```json
+{
+  "questions": [
+    {
+      "question": "What kind of writing do you need?",
+      "header": "Content type",
+      "options": [
+        { "label": "Email", "description": "Draft or revise an email" },
+        { "label": "Report/memo", "description": "Write a report, memo, or internal brief" },
+        { "label": "Announcement", "description": "Prepare an update or announcement" },
+        { "label": "Plan/proposal", "description": "Draft a plan, proposal, or recommendation" }
+      ]
+    },
+    {
+      "question": "What tone should I use?",
+      "header": "Tone",
+      "options": [
+        { "label": "Formal", "description": "Professional and polished" },
+        { "label": "Conversational", "description": "Natural and approachable" },
+        { "label": "Concise/direct", "description": "Short, clear, and to the point" },
+        { "label": "Persuasive", "description": "Structured to convince the reader" }
+      ]
+    },
+    {
+      "question": "How should I handle the key points?",
+      "header": "Key points",
+      "options": [
+        { "label": "I'll provide details now", "description": "Wait for me to give the facts or bullet points" },
+        { "label": "Draft from what I've said", "description": "Use the details already in the conversation" },
+        { "label": "Ask me more first", "description": "Collect more facts before drafting" }
+      ]
+    }
+  ]
+}
+```
 
-- Missing facts → ask, don't hallucinate
-- Two plausible tones → give stronger default first, mention alternative
-- Mixed drafting + strategy → separate final copy from advice so output is immediately usable
+Also confirm any length, audience, structure, or deadline constraints that affect the final draft.
+
+## Step 2: Execute
+
+| Situation | Approach |
+| --- | --- |
+| User already provided complete notes | Draft directly from the provided facts |
+| Existing draft needs revision | Preserve the facts, tighten wording, improve structure |
+| Notes are thin or incomplete | Ask follow-up questions before writing full copy |
+
+Execution rules:
+- Extract all facts, constraints, deadlines, names, and commitments from the user's material.
+- Preserve facts from the source and improve clarity, structure, and tone.
+- Do not invent missing facts, names, numbers, or commitments.
+- Return usable copy unless the user explicitly asked for an outline or options.
+
+## Step 3: Verify
+
+Before reporting back:
+- Check that every concrete claim comes from the user's material.
+- Re-read for the requested tone, audience, and structure.
+- Remove filler, repetition, and vague phrasing.
+- If facts are still missing, say what is missing instead of guessing.
+
+## Language
+
+Reply in the user's locale (shown in system environment as "User locale").
+If no locale is shown, match the language used in the user's request.


### PR DESCRIPTION
## Summary
- split the desktop session side panel into separate Files and Review header toggles, defaulting desktop sessions to Files
- thread user locale from the app through prompt submit, followups, commands, resumed loops, and built-in skill launches
- rewrite the built-in document-processing, data-analysis, and writing-assistant skills to use mandatory question-first flows with locale-aware guidance
- add regression tests for panel behavior, locale threading, skill content, skill launch locale, and SDK config model-id typing

## Verification
- `packages/app`: `bun test --preload ./happydom.ts ./src/context/layout.test.ts ./src/components/prompt-input/submit.test.ts ./src/components/session/session-new-view.test.ts`
- `packages/app`: `bun x playwright test e2e/commands/panels.spec.ts`
- `packages/opencode`: `bun test ./test/session/system.test.ts ./test/session/prompt.test.ts ./test/skill/skill.test.ts --timeout 30000`
- `packages/opencode`: `bun run typecheck`
- `packages/sdk/js`: `bun run typecheck`

## Notes
- `packages/app` `bun run typecheck` in this worktree still resolves `@opencode-ai/sdk` through the shared borrowed `node_modules` from the main checkout, so it reports stale pre-locale request types instead of the regenerated SDK types in this branch.