### PR TITLE
fix(config): harden scoped dependency loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
         with:
           bun-version: "1.3.11"
 
+      # Restoring Bun's download cache on Windows was empirically slower than a cold install
+      # and consumed enough of the 30-minute job budget to starve opencode:test:ci.
       - uses: actions/cache@v4
+        if: runner.os != 'Windows'
         with:
           path: |
             ~/.bun/install/cache

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -27,7 +27,6 @@ import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Glob } from "../util/glob"
-import { iife } from "@/util/iife"
 import { Account } from "@/account"
 import { isRecord } from "@/util/record"
 import { ConfigPaths } from "./paths"
@@ -1417,6 +1416,9 @@ export namespace Config {
           }
 
           const deps: Promise<void>[] = []
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(() => Promise.allSettled(deps).then(() => undefined)),
+          )
 
           for (const dir of unique(directories)) {
             if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -1430,9 +1432,7 @@ export namespace Config {
               }
             }
 
-            const dep = iife(async () => {
-              await installDependencies(dir)
-            })
+            const dep = installDependencies(dir)
             void dep.catch((err) => {
               log.warn("background dependency install failed", { dir, error: err })
             })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1073,7 +1073,10 @@ export namespace Config {
   type State = {
     config: Info
     directories: string[]
-    deps: Fiber.Fiber<Exit.Exit<void, unknown>, never>[]
+    deps: {
+      dir: string
+      fiber: Fiber.Fiber<Exit.Exit<void, unknown>, never>
+    }[]
     consoleState: ConsoleState
   }
 
@@ -1086,7 +1089,7 @@ export namespace Config {
     readonly updateGlobal: (config: Info) => Effect.Effect<Info>
     readonly invalidate: (wait?: boolean) => Effect.Effect<void>
     readonly directories: () => Effect.Effect<string[]>
-    readonly waitForDependencies: () => Effect.Effect<void, unknown>
+    readonly waitForDependencies: (directories?: string[]) => Effect.Effect<void, unknown>
   }
 
   export class Service extends Context.Service<Service, Interface>()("@opencode/Config") {}
@@ -1346,10 +1349,12 @@ export namespace Config {
                 ).pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort()))),
               ).pipe(
                 Effect.flatMap((lease) =>
-                  Effect.gen(function* () {
-                    input?.signal?.throwIfAborted()
-                    yield* install(dir).pipe(Effect.uninterruptible)
-                  }).pipe(
+                  restore(
+                    Effect.gen(function* () {
+                      input?.signal?.throwIfAborted()
+                      yield* install(dir)
+                    }),
+                  ).pipe(
                     Effect.ensuring(Effect.promise(() => lease.release())),
                   ),
                 ),
@@ -1444,7 +1449,7 @@ export namespace Config {
             log.debug("loading config from OPENCODE_CONFIG_DIR", { path: Flag.OPENCODE_CONFIG_DIR })
           }
 
-          const deps: Fiber.Fiber<Exit.Exit<void, unknown>, never>[] = []
+          const deps: State["deps"] = []
 
           for (const dir of unique(directories)) {
             if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -1469,7 +1474,7 @@ export namespace Config {
               ),
               Effect.forkScoped,
             )
-            deps.push(dep)
+            deps.push({ dir, fiber: dep })
 
             result.command = mergeDeep(result.command ?? {}, yield* Effect.promise(() => loadCommand(dir)))
             result.agent = mergeDeep(result.agent, yield* Effect.promise(() => loadAgent(dir)))
@@ -1604,9 +1609,14 @@ export namespace Config {
           return yield* InstanceState.use(state, (s) => s.consoleState)
         })
 
-        const waitForDependencies = Effect.fn("Config.waitForDependencies")(function* () {
+        const waitForDependencies = Effect.fn("Config.waitForDependencies")(function* (directories?: string[]) {
+          const filter = directories ? new Set(directories.map((dir) => Filesystem.resolve(dir))) : undefined
           yield* InstanceState.useEffect(state, (s) =>
-            Effect.forEach(s.deps, Fiber.join, { concurrency: "unbounded" }).pipe(
+            Effect.forEach(
+              s.deps.filter((dep) => !filter || filter.has(Filesystem.resolve(dep.dir))),
+              ({ fiber }) => Fiber.join(fiber),
+              { concurrency: "unbounded" },
+            ).pipe(
               Effect.flatMap((exits) => Effect.forEach(exits, (exit) => exit, { discard: true })),
             ),
           )
@@ -1710,7 +1720,7 @@ export namespace Config {
     return runPromise((svc) => svc.directories())
   }
 
-  export async function waitForDependencies() {
-    return runPromise((svc) => svc.waitForDependencies())
+  export async function waitForDependencies(directories?: string[]) {
+    return runPromise((svc) => svc.waitForDependencies(directories))
   }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1329,41 +1329,42 @@ export namespace Config {
             const key = process.platform === "win32" ? "config-install:win32" : `config-install:${Filesystem.resolve(dir)}`
             const controller = new AbortController()
             const onAbort = () => controller.abort(input?.signal?.reason)
-            if (input?.signal) {
-              if (input.signal.aborted) controller.abort(input.signal.reason)
-              else input.signal.addEventListener("abort", onAbort, { once: true })
-            }
-            yield* Effect.uninterruptibleMask((restore) =>
-              restore(
-                Effect.promise(() =>
-                  Flock.acquire(key, {
-                    signal: controller.signal,
-                    onWait: (tick) =>
-                      input?.waitTick?.({
-                        dir,
-                        attempt: tick.attempt,
-                        delay: tick.delay,
-                        waited: tick.waited,
+            yield* Effect.acquireUseRelease(
+              Effect.sync(() => {
+                if (!input?.signal) return
+                if (input.signal.aborted) controller.abort(input.signal.reason)
+                else input.signal.addEventListener("abort", onAbort, { once: true })
+              }),
+              () =>
+                Effect.scoped(
+                  Effect.gen(function* () {
+                    yield* Effect.acquireRelease(
+                      Effect.tryPromise({
+                        try: (signal) =>
+                          Flock.acquire(key, {
+                            signal: AbortSignal.any([controller.signal, signal]),
+                            onWait: (tick) =>
+                              input?.waitTick?.({
+                                dir,
+                                attempt: tick.attempt,
+                                delay: tick.delay,
+                                waited: tick.waited,
+                              }),
+                          }),
+                        catch: (cause) => cause,
                       }),
-                  }),
-                ).pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort()))),
-              ).pipe(
-                Effect.flatMap((lease) =>
-                  restore(
-                    Effect.gen(function* () {
-                      input?.signal?.throwIfAborted()
-                      yield* install(dir)
-                    }),
-                  ).pipe(
-                    Effect.ensuring(Effect.promise(() => lease.release())),
-                  ),
-                ),
-                Effect.ensuring(
-                  Effect.sync(() => {
-                    input?.signal?.removeEventListener("abort", onAbort)
+                      (lease) => Effect.promise(() => lease.release()),
+                      { interruptible: true },
+                    )
+
+                    input?.signal?.throwIfAborted()
+                    yield* install(dir)
                   }),
                 ),
-              ),
+              () =>
+                Effect.sync(() => {
+                  input?.signal?.removeEventListener("abort", onAbort)
+                }),
             )
           })
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -22,7 +22,7 @@ import { Instance, type InstanceContext } from "../project/instance"
 import { LSPServer } from "../lsp/server"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
-import { constants, existsSync } from "fs"
+import { existsSync } from "fs"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
@@ -35,7 +35,7 @@ import type { ConsoleState } from "./console-state"
 import { AppFileSystem } from "@/filesystem"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
-import { Duration, Effect, Layer, Option, Context } from "effect"
+import { Duration, Effect, Layer, Option, Context, Exit, Fiber } from "effect"
 import { Flock } from "@/util/flock"
 import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "@/plugin/shared"
 import { Npm } from "@/npm"
@@ -148,58 +148,7 @@ export namespace Config {
   }
 
   export async function installDependencies(dir: string, input?: InstallInput) {
-    if (!(await isWritable(dir))) return
-    const key = process.platform === "win32" ? "config-install:win32" : `config-install:${Filesystem.resolve(dir)}`
-    await using _ = await Flock.acquire(key, {
-      signal: input?.signal,
-      onWait: (tick) =>
-        input?.waitTick?.({
-          dir,
-          attempt: tick.attempt,
-          delay: tick.delay,
-          waited: tick.waited,
-        }),
-    })
-    input?.signal?.throwIfAborted()
-
-    const pkg = path.join(dir, "package.json")
-    const plugin = path.join(dir, "node_modules", "@opencode-ai", "plugin", "package.json")
-    const target = Installation.isLocal() ? "*" : Installation.VERSION
-    const json = await Filesystem.readJson<Package>(pkg).catch(
-      (): Package => ({
-        dependencies: {},
-      }),
-    )
-    const dependencies: Record<string, string> = json.dependencies ?? {}
-    const hasDep = dependencies["@opencode-ai/plugin"] === target
-    json.dependencies = {
-      ...dependencies,
-      "@opencode-ai/plugin": target,
-    }
-
-    const gitignore = path.join(dir, ".gitignore")
-    const ignore = await Filesystem.exists(gitignore)
-    const hasPkg = await Filesystem.exists(plugin)
-    if (!hasDep) {
-      await Filesystem.writeJson(pkg, json)
-    }
-    if (!ignore) {
-      await Filesystem.write(
-        gitignore,
-        ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
-      )
-    }
-    if (hasDep && ignore && hasPkg) return
-    await Npm.install(dir)
-  }
-
-  async function isWritable(dir: string) {
-    try {
-      await fsNode.access(dir, constants.W_OK)
-      return true
-    } catch {
-      return false
-    }
+    return runPromise((svc) => svc.installDependencies(dir, input))
   }
 
   function rel(item: string, patterns: string[]) {
@@ -1124,7 +1073,7 @@ export namespace Config {
   type State = {
     config: Info
     directories: string[]
-    deps: Promise<void>[]
+    deps: Fiber.Fiber<Exit.Exit<void, unknown>, never>[]
     consoleState: ConsoleState
   }
 
@@ -1132,11 +1081,12 @@ export namespace Config {
     readonly get: () => Effect.Effect<Info>
     readonly getGlobal: () => Effect.Effect<Info>
     readonly getConsoleState: () => Effect.Effect<ConsoleState>
+    readonly installDependencies: (dir: string, input?: InstallInput) => Effect.Effect<void, unknown>
     readonly update: (config: Info) => Effect.Effect<void>
     readonly updateGlobal: (config: Info) => Effect.Effect<Info>
     readonly invalidate: (wait?: boolean) => Effect.Effect<void>
     readonly directories: () => Effect.Effect<string[]>
-    readonly waitForDependencies: () => Effect.Effect<void>
+    readonly waitForDependencies: () => Effect.Effect<void, unknown>
   }
 
   export class Service extends Context.Service<Service, Interface>()("@opencode/Config") {}
@@ -1333,6 +1283,85 @@ export namespace Config {
           return yield* cachedGlobal
         })
 
+        const install = Effect.fnUntraced(function* (dir: string) {
+          const pkg = path.join(dir, "package.json")
+          const plugin = path.join(dir, "node_modules", "@opencode-ai", "plugin", "package.json")
+          const target = Installation.isLocal() ? "*" : Installation.VERSION
+          const json = yield* fs.readJson(pkg).pipe(
+            Effect.catch(() => Effect.succeed({} satisfies Package)),
+            Effect.map((x): Package => (isRecord(x) ? (x as Package) : {})),
+          )
+          const dependencies: Record<string, string> = json.dependencies ?? {}
+          const hasDep = dependencies["@opencode-ai/plugin"] === target
+          const gitignore = path.join(dir, ".gitignore")
+          const ignore = yield* fs.existsSafe(gitignore)
+          const hasPkg = yield* fs.existsSafe(plugin)
+          if (!hasDep) {
+            yield* fs.writeJson(pkg, {
+              ...json,
+              dependencies: {
+                ...dependencies,
+                "@opencode-ai/plugin": target,
+              },
+            })
+          }
+          if (!ignore) {
+            yield* fs.writeFileString(
+              gitignore,
+              ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+            )
+          }
+          if (hasDep && ignore && hasPkg) return
+          yield* Effect.promise(() => Npm.install(dir))
+        })
+
+        const installDependencies = (dir: string, input?: InstallInput) =>
+          Effect.gen(function* () {
+            const writable = yield* fs.access(dir, { writable: true }).pipe(
+              Effect.as(true),
+              Effect.catch(() => Effect.succeed(false)),
+            )
+            if (!writable) return
+
+            const key = process.platform === "win32" ? "config-install:win32" : `config-install:${Filesystem.resolve(dir)}`
+            const controller = new AbortController()
+            const onAbort = () => controller.abort(input?.signal?.reason)
+            if (input?.signal) {
+              if (input.signal.aborted) controller.abort(input.signal.reason)
+              else input.signal.addEventListener("abort", onAbort, { once: true })
+            }
+            yield* Effect.uninterruptibleMask((restore) =>
+              restore(
+                Effect.promise(() =>
+                  Flock.acquire(key, {
+                    signal: controller.signal,
+                    onWait: (tick) =>
+                      input?.waitTick?.({
+                        dir,
+                        attempt: tick.attempt,
+                        delay: tick.delay,
+                        waited: tick.waited,
+                      }),
+                  }),
+                ).pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort()))),
+              ).pipe(
+                Effect.flatMap((lease) =>
+                  Effect.gen(function* () {
+                    input?.signal?.throwIfAborted()
+                    yield* install(dir).pipe(Effect.uninterruptible)
+                  }).pipe(
+                    Effect.ensuring(Effect.promise(() => lease.release())),
+                  ),
+                ),
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    input?.signal?.removeEventListener("abort", onAbort)
+                  }),
+                ),
+              ),
+            )
+          })
+
         const loadInstanceState = Effect.fnUntraced(function* (ctx: InstanceContext) {
           const auth = yield* authSvc.all().pipe(Effect.orDie)
 
@@ -1415,10 +1444,7 @@ export namespace Config {
             log.debug("loading config from OPENCODE_CONFIG_DIR", { path: Flag.OPENCODE_CONFIG_DIR })
           }
 
-          const deps: Promise<void>[] = []
-          yield* Effect.addFinalizer(() =>
-            Effect.promise(() => Promise.allSettled(deps).then(() => undefined)),
-          )
+          const deps: Fiber.Fiber<Exit.Exit<void, unknown>, never>[] = []
 
           for (const dir of unique(directories)) {
             if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -1432,10 +1458,17 @@ export namespace Config {
               }
             }
 
-            const dep = installDependencies(dir)
-            void dep.catch((err) => {
-              log.warn("background dependency install failed", { dir, error: err })
-            })
+            const dep = yield* installDependencies(dir).pipe(
+              Effect.exit,
+              Effect.tap((exit) =>
+                Exit.isFailure(exit)
+                  ? Effect.sync(() => {
+                      log.warn("background dependency install failed", { dir, error: String(exit.cause) })
+                    })
+                  : Effect.void,
+              ),
+              Effect.forkScoped,
+            )
             deps.push(dep)
 
             result.command = mergeDeep(result.command ?? {}, yield* Effect.promise(() => loadCommand(dir)))
@@ -1572,7 +1605,11 @@ export namespace Config {
         })
 
         const waitForDependencies = Effect.fn("Config.waitForDependencies")(function* () {
-          yield* InstanceState.useEffect(state, (s) => Effect.promise(() => Promise.all(s.deps).then(() => undefined)))
+          yield* InstanceState.useEffect(state, (s) =>
+            Effect.forEach(s.deps, Fiber.join, { concurrency: "unbounded" }).pipe(
+              Effect.flatMap((exits) => Effect.forEach(exits, (exit) => exit, { discard: true })),
+            ),
+          )
         })
 
         const update = Effect.fn("Config.update")(function* (config: Info) {
@@ -1627,6 +1664,7 @@ export namespace Config {
           get,
           getGlobal,
           getConsoleState,
+          installDependencies,
           update,
           updateGlobal,
           invalidate,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -141,6 +141,7 @@ export namespace Config {
   export type InstallInput = {
     signal?: AbortSignal
     waitTick?: (input: { dir: string; attempt: number; delay: number; waited: number }) => void | Promise<void>
+    queueKey?: string | false
   }
 
   type Package = {
@@ -1326,9 +1327,32 @@ export namespace Config {
             )
             if (!writable) return
 
-            const key = process.platform === "win32" ? "config-install:win32" : `config-install:${Filesystem.resolve(dir)}`
             const controller = new AbortController()
             const onAbort = () => controller.abort(input?.signal?.reason)
+            const scopedKey = `config-install:${Filesystem.resolve(dir)}`
+            const queueKey = input?.queueKey ?? (process.platform === "win32" ? "config-install:win32" : false)
+            const signal = (inner: AbortSignal) => AbortSignal.any([controller.signal, inner])
+            const acquire = (key: string, waitTick = false) =>
+              Effect.acquireRelease(
+                Effect.tryPromise({
+                  try: (inner) =>
+                    Flock.acquire(key, {
+                      signal: signal(inner),
+                      onWait: waitTick
+                        ? (tick) =>
+                            input?.waitTick?.({
+                              dir,
+                              attempt: tick.attempt,
+                              delay: tick.delay,
+                              waited: tick.waited,
+                            })
+                        : undefined,
+                    }),
+                  catch: (cause) => cause,
+                }),
+                (lease) => Effect.promise(() => lease.release()),
+                { interruptible: true },
+              )
             yield* Effect.acquireUseRelease(
               Effect.sync(() => {
                 if (!input?.signal) return
@@ -1338,25 +1362,10 @@ export namespace Config {
               () =>
                 Effect.scoped(
                   Effect.gen(function* () {
-                    yield* Effect.acquireRelease(
-                      Effect.tryPromise({
-                        try: (signal) =>
-                          Flock.acquire(key, {
-                            signal: AbortSignal.any([controller.signal, signal]),
-                            onWait: (tick) =>
-                              input?.waitTick?.({
-                                dir,
-                                attempt: tick.attempt,
-                                delay: tick.delay,
-                                waited: tick.waited,
-                              }),
-                          }),
-                        catch: (cause) => cause,
-                      }),
-                      (lease) => Effect.promise(() => lease.release()),
-                      { interruptible: true },
-                    )
-
+                    if (queueKey) {
+                      yield* acquire(queueKey, true)
+                    }
+                    yield* acquire(scopedKey, !queueKey)
                     input?.signal?.throwIfAborted()
                     yield* install(dir)
                   }),
@@ -1451,6 +1460,10 @@ export namespace Config {
           }
 
           const deps: State["deps"] = []
+          const queueKey = (dir: string) => {
+            if (process.platform !== "win32") return false
+            return dir.endsWith(".opencode") ? "config-install:win32:local" : "config-install:win32"
+          }
 
           for (const dir of unique(directories)) {
             if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -1464,7 +1477,7 @@ export namespace Config {
               }
             }
 
-            const dep = yield* installDependencies(dir).pipe(
+            const dep = yield* installDependencies(dir, { queueKey: queueKey(dir) }).pipe(
               Effect.exit,
               Effect.tap((exit) =>
                 Exit.isFailure(exit)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1289,7 +1289,6 @@ export namespace Config {
 
         const install = Effect.fnUntraced(function* (dir: string) {
           const pkg = path.join(dir, "package.json")
-          const plugin = path.join(dir, "node_modules", "@opencode-ai", "plugin", "package.json")
           const target = Installation.isLocal() ? "*" : Installation.VERSION
           const json = yield* fs.readJson(pkg).pipe(
             Effect.catch(() => Effect.succeed({} satisfies Package)),
@@ -1297,16 +1296,21 @@ export namespace Config {
           )
           const dependencies: Record<string, string> = json.dependencies ?? {}
           const hasDep = dependencies["@opencode-ai/plugin"] === target
+          const required = {
+            ...dependencies,
+            "@opencode-ai/plugin": target,
+          }
           const gitignore = path.join(dir, ".gitignore")
           const ignore = yield* fs.existsSafe(gitignore)
-          const hasPkg = yield* fs.existsSafe(plugin)
+          const installed = yield* Effect.forEach(
+            Object.keys(required),
+            (name) => fs.existsSafe(path.join(dir, "node_modules", ...name.split("/"), "package.json")),
+            { concurrency: "unbounded" },
+          )
           if (!hasDep) {
             yield* fs.writeJson(pkg, {
               ...json,
-              dependencies: {
-                ...dependencies,
-                "@opencode-ai/plugin": target,
-              },
+              dependencies: required,
             })
           }
           if (!ignore) {
@@ -1315,7 +1319,7 @@ export namespace Config {
               ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
             )
           }
-          if (hasDep && ignore && hasPkg) return
+          if (hasDep && ignore && installed.every(Boolean)) return
           yield* Effect.promise(() => Npm.install(dir))
         })
 

--- a/packages/opencode/src/config/dependency.ts
+++ b/packages/opencode/src/config/dependency.ts
@@ -1,0 +1,57 @@
+import path from "path"
+import { builtinModules, isBuiltin } from "module"
+import { Filesystem } from "@/util/filesystem"
+
+const DEPENDENCY_IMPORT =
+  /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']([^./"'`][^"'`]*)["']|import\s*\(\s*["']([^./"'`][^"'`]*)["']\s*\)|require\(\s*["']([^./"'`][^"'`]*)["']\s*\)/gm
+const LOCAL_IMPORT =
+  /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']((?:\.\.?\/)[^"'`]*)["']|import\s*\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)|require\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)/gm
+const BUILTIN_MODULES = new Set(builtinModules)
+const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
+
+function packageName(spec: string) {
+  if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
+  if (spec.startsWith("@")) {
+    const [scope, name] = spec.split("/")
+    if (!scope || !name) return
+    return `${scope}/${name}`
+  }
+  return spec.split("/")[0]
+}
+
+async function resolveLocalImport(file: string, spec: string) {
+  const target = path.resolve(path.dirname(file), spec)
+  const candidates = path.extname(target)
+    ? [target]
+    : [
+        ...LOCAL_IMPORT_EXTENSIONS.map((ext) => `${target}${ext}`),
+        ...LOCAL_IMPORT_EXTENSIONS.map((ext) => path.join(target, `index${ext}`)),
+      ]
+  for (const candidate of candidates) {
+    if (await Filesystem.exists(candidate)) return candidate
+  }
+}
+
+export async function needsConfigDependencies(file: string, configDir: string, visited = new Set<string>()) {
+  const resolved = path.resolve(file)
+  if (visited.has(resolved)) return false
+  visited.add(resolved)
+  const text = await Filesystem.readText(resolved).catch(() => "")
+  for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
+    const spec = match[1] ?? match[2] ?? match[3]
+    if (!spec) continue
+    const pkg = packageName(spec)
+    if (!pkg) continue
+    const pkgPath = path.join(configDir, "node_modules", ...pkg.split("/"))
+    if (await Filesystem.exists(path.join(pkgPath, "package.json"))) continue
+    return true
+  }
+  for (const match of text.matchAll(LOCAL_IMPORT)) {
+    const spec = match[1] ?? match[2] ?? match[3]
+    if (!spec) continue
+    const next = await resolveLocalImport(resolved, spec)
+    if (!next) continue
+    if (await needsConfigDependencies(next, configDir, visited)) return true
+  }
+  return false
+}

--- a/packages/opencode/src/config/dependency.ts
+++ b/packages/opencode/src/config/dependency.ts
@@ -9,6 +9,19 @@ const LOCAL_IMPORT =
 const BUILTIN_MODULES = new Set(builtinModules)
 const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
 
+function isTypeOnlyImport(statement: string) {
+  const normalized = statement.trimStart()
+  if (/^(?:import|export)\s+type\b/s.test(normalized)) return true
+
+  const named = normalized.match(/^(?:import|export)\s*\{([^}]*)\}\s+from\b/s)
+  if (!named) return false
+  const specifiers = named[1]
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+  return specifiers.length > 0 && specifiers.every((part) => /^type\s+(?!as\b)\S/s.test(part))
+}
+
 function packageName(spec: string) {
   if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
   if (spec.startsWith("@")) {
@@ -38,6 +51,7 @@ export async function needsConfigDependencies(file: string, configDir: string, v
   visited.add(resolved)
   const text = await Filesystem.readText(resolved).catch(() => "")
   for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
+    if (isTypeOnlyImport(match[0])) continue
     const spec = match[1] ?? match[2] ?? match[3]
     if (!spec) continue
     const pkg = packageName(spec)
@@ -47,6 +61,7 @@ export async function needsConfigDependencies(file: string, configDir: string, v
     return true
   }
   for (const match of text.matchAll(LOCAL_IMPORT)) {
+    if (isTypeOnlyImport(match[0])) continue
     const spec = match[1] ?? match[2] ?? match[3]
     if (!spec) continue
     const next = await resolveLocalImport(resolved, spec)

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -27,7 +27,10 @@ export namespace Plugin {
   const log = Log.create({ service: "plugin" })
   const DEPENDENCY_IMPORT =
     /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']([^./"'`][^"'`]*)["']|import\s*\(\s*["']([^./"'`][^"'`]*)["']\s*\)|require\(\s*["']([^./"'`][^"'`]*)["']\s*\)/gm
+  const LOCAL_IMPORT =
+    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']((?:\.\.?\/)[^"'`]*)["']|import\s*\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)|require\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)/gm
   const BUILTIN_MODULES = new Set(builtinModules)
+  const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
 
   function packageName(spec: string) {
     if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
@@ -45,8 +48,24 @@ export namespace Plugin {
     return source
   }
 
-  async function needsConfigDependencies(file: string, source: string, projectDir: string) {
-    const text = await Filesystem.readText(file).catch(() => "")
+  async function resolveLocalImport(file: string, spec: string) {
+    const target = path.resolve(path.dirname(file), spec)
+    const candidates = path.extname(target)
+      ? [target]
+      : [
+          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => `${target}${ext}`),
+          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => path.join(target, `index${ext}`)),
+        ]
+    for (const candidate of candidates) {
+      if (await Filesystem.exists(candidate)) return candidate
+    }
+  }
+
+  async function needsConfigDependencies(file: string, source: string, projectDir: string, visited = new Set<string>()) {
+    const resolved = path.resolve(file)
+    if (visited.has(resolved)) return false
+    visited.add(resolved)
+    const text = await Filesystem.readText(resolved).catch(() => "")
     const configDir = dependencyDir(source, projectDir)
     for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
       const spec = match[1] ?? match[2] ?? match[3]
@@ -56,6 +75,13 @@ export namespace Plugin {
       const pkgPath = path.join(configDir, "node_modules", ...pkg.split("/"))
       if (await Filesystem.exists(path.join(pkgPath, "package.json"))) continue
       return true
+    }
+    for (const match of text.matchAll(LOCAL_IMPORT)) {
+      const spec = match[1] ?? match[2] ?? match[3]
+      if (!spec) continue
+      const next = await resolveLocalImport(resolved, spec)
+      if (!next) continue
+      if (await needsConfigDependencies(next, source, projectDir, visited)) return true
     }
     return false
   }
@@ -191,6 +217,17 @@ export namespace Plugin {
           const plugins = Flag.OPENCODE_PURE ? [] : (cfg.plugin_origins ?? [])
           if (Flag.OPENCODE_PURE && cfg.plugin_origins?.length) {
             log.info("skipping external plugins in pure mode", { count: cfg.plugin_origins.length })
+          }
+          const readyDirs = new Set<string>()
+          for (const origin of plugins) {
+            const spec = Config.pluginSpecifier(origin.spec)
+            if (!spec.startsWith("file://")) continue
+            const dir = dependencyDir(origin.source, ctx.directory)
+            if (readyDirs.has(dir)) continue
+            const needsDeps = yield* Effect.promise(() => needsConfigDependencies(fileURLToPath(spec), origin.source, ctx.directory))
+            if (!needsDeps) continue
+            readyDirs.add(dir)
+            yield* Effect.promise(() => Config.waitForDependencies([dir]).catch(() => undefined))
           }
 
           const loaded = yield* Effect.promise(() =>

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -18,72 +18,17 @@ import { EffectLogger } from "@/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { errorMessage } from "@/util/error"
-import { Filesystem } from "@/util/filesystem"
+import { needsConfigDependencies } from "@/config/dependency"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
-import { builtinModules, isBuiltin } from "module"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
-  const DEPENDENCY_IMPORT =
-    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']([^./"'`][^"'`]*)["']|import\s*\(\s*["']([^./"'`][^"'`]*)["']\s*\)|require\(\s*["']([^./"'`][^"'`]*)["']\s*\)/gm
-  const LOCAL_IMPORT =
-    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']((?:\.\.?\/)[^"'`]*)["']|import\s*\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)|require\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)/gm
-  const BUILTIN_MODULES = new Set(builtinModules)
-  const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
-
-  function packageName(spec: string) {
-    if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
-    if (spec.startsWith("@")) {
-      const [scope, name] = spec.split("/")
-      if (!scope || !name) return
-      return `${scope}/${name}`
-    }
-    return spec.split("/")[0]
-  }
 
   function dependencyDir(source: string, projectDir: string) {
     if (source === "OPENCODE_CONFIG_CONTENT") return projectDir
     if (source.endsWith(".json") || source.endsWith(".jsonc")) return path.dirname(source)
     return source
-  }
-
-  async function resolveLocalImport(file: string, spec: string) {
-    const target = path.resolve(path.dirname(file), spec)
-    const candidates = path.extname(target)
-      ? [target]
-      : [
-          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => `${target}${ext}`),
-          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => path.join(target, `index${ext}`)),
-        ]
-    for (const candidate of candidates) {
-      if (await Filesystem.exists(candidate)) return candidate
-    }
-  }
-
-  async function needsConfigDependencies(file: string, source: string, projectDir: string, visited = new Set<string>()) {
-    const resolved = path.resolve(file)
-    if (visited.has(resolved)) return false
-    visited.add(resolved)
-    const text = await Filesystem.readText(resolved).catch(() => "")
-    const configDir = dependencyDir(source, projectDir)
-    for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
-      const spec = match[1] ?? match[2] ?? match[3]
-      if (!spec) continue
-      const pkg = packageName(spec)
-      if (!pkg) continue
-      const pkgPath = path.join(configDir, "node_modules", ...pkg.split("/"))
-      if (await Filesystem.exists(path.join(pkgPath, "package.json"))) continue
-      return true
-    }
-    for (const match of text.matchAll(LOCAL_IMPORT)) {
-      const spec = match[1] ?? match[2] ?? match[3]
-      if (!spec) continue
-      const next = await resolveLocalImport(resolved, spec)
-      if (!next) continue
-      if (await needsConfigDependencies(next, source, projectDir, visited)) return true
-    }
-    return false
   }
 
   type State = {
@@ -224,7 +169,7 @@ export namespace Plugin {
             if (!spec.startsWith("file://")) continue
             const dir = dependencyDir(origin.source, ctx.directory)
             if (readyDirs.has(dir)) continue
-            const needsDeps = yield* Effect.promise(() => needsConfigDependencies(fileURLToPath(spec), origin.source, ctx.directory))
+            const needsDeps = yield* Effect.promise(() => needsConfigDependencies(fileURLToPath(spec), dir))
             if (!needsDeps) continue
             readyDirs.add(dir)
             yield* Effect.promise(() => Config.waitForDependencies([dir]).catch(() => undefined))
@@ -238,7 +183,7 @@ export namespace Plugin {
               shouldRetry: (origin) => {
                 const spec = Config.pluginSpecifier(origin.spec)
                 if (!spec.startsWith("file://")) return Promise.resolve(false)
-                return needsConfigDependencies(fileURLToPath(spec), origin.source, ctx.directory)
+                return needsConfigDependencies(fileURLToPath(spec), dependencyDir(origin.source, ctx.directory))
               },
               report: {
                 start(candidate) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -49,64 +49,10 @@ import { AppFileSystem } from "../filesystem"
 import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
-import { builtinModules, isBuiltin } from "module"
-import { Filesystem } from "../util/filesystem"
+import { needsConfigDependencies } from "../config/dependency"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
-  const DEPENDENCY_IMPORT =
-    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']([^./"'`][^"'`]*)["']|import\s*\(\s*["']([^./"'`][^"'`]*)["']\s*\)|require\(\s*["']([^./"'`][^"'`]*)["']\s*\)/gm
-  const LOCAL_IMPORT =
-    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']((?:\.\.?\/)[^"'`]*)["']|import\s*\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)|require\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)/gm
-  const BUILTIN_MODULES = new Set(builtinModules)
-  const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
-
-  function packageName(spec: string) {
-    if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
-    if (spec.startsWith("@")) {
-      const [scope, name] = spec.split("/")
-      if (!scope || !name) return
-      return `${scope}/${name}`
-    }
-    return spec.split("/")[0]
-  }
-
-  async function resolveLocalImport(file: string, spec: string) {
-    const target = path.resolve(path.dirname(file), spec)
-    const candidates = path.extname(target)
-      ? [target]
-      : [
-          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => `${target}${ext}`),
-          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => path.join(target, `index${ext}`)),
-        ]
-    for (const candidate of candidates) {
-      if (await Filesystem.exists(candidate)) return candidate
-    }
-  }
-
-  async function needsConfigDependencies(file: string, dir: string, visited = new Set<string>()) {
-    const resolved = path.resolve(file)
-    if (visited.has(resolved)) return false
-    visited.add(resolved)
-    const text = await Filesystem.readText(resolved).catch(() => "")
-    for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
-      const spec = match[1] ?? match[2] ?? match[3]
-      if (!spec) continue
-      const pkg = packageName(spec)
-      if (!pkg) continue
-      const pkgPath = path.join(dir, "node_modules", ...pkg.split("/"))
-      if (await Filesystem.exists(path.join(pkgPath, "package.json"))) continue
-      return true
-    }
-    for (const match of text.matchAll(LOCAL_IMPORT)) {
-      const spec = match[1] ?? match[2] ?? match[3]
-      if (!spec) continue
-      const next = await resolveLocalImport(resolved, spec)
-      if (!next) continue
-      if (await needsConfigDependencies(next, dir, visited)) return true
-    }
-    return false
-  }
 
   type TaskDef = Tool.InferDef<typeof TaskTool>
   type ReadDef = Tool.InferDef<typeof ReadTool>

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -191,7 +191,7 @@ export namespace ToolRegistry {
           )
           const cfg = yield* config.get()
           const rules = Permission.fromConfig(cfg.permission ?? {})
-          let depsReady = false
+          const readyDirs = new Set<string>()
           for (const match of matches) {
             const namespace = path.basename(match, path.extname(match))
             const text = yield* Effect.promise(() => Bun.file(match).text())
@@ -206,9 +206,10 @@ export namespace ToolRegistry {
             ])
             if (ids.length && ids.every((id) => disabled.has(id))) continue
             const spec = process.platform === "win32" ? match : pathToFileURL(match).href
-            if (!depsReady && (yield* Effect.promise(() => needsConfigDependencies(text, path.dirname(path.dirname(match)))))) {
-              depsReady = true
-              yield* config.waitForDependencies().pipe(Effect.orDie)
+            const toolDir = path.dirname(path.dirname(match))
+            if (!readyDirs.has(toolDir) && (yield* Effect.promise(() => needsConfigDependencies(text, toolDir)))) {
+              readyDirs.add(toolDir)
+              yield* config.waitForDependencies([toolDir]).pipe(Effect.orDie)
             }
             const mod = yield* Effect.promise(() => import(spec))
             for (const [id, def] of Object.entries<ToolDefinition>(mod)) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -56,7 +56,10 @@ export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
   const DEPENDENCY_IMPORT =
     /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']([^./"'`][^"'`]*)["']|import\s*\(\s*["']([^./"'`][^"'`]*)["']\s*\)|require\(\s*["']([^./"'`][^"'`]*)["']\s*\)/gm
+  const LOCAL_IMPORT =
+    /(?:^|\n)\s*(?:import\s+(?:[^"'`]+\s+from\s+)?|export\s+[^"'`]+\s+from\s+)["']((?:\.\.?\/)[^"'`]*)["']|import\s*\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)|require\(\s*["']((?:\.\.?\/)[^"'`]*)["']\s*\)/gm
   const BUILTIN_MODULES = new Set(builtinModules)
+  const LOCAL_IMPORT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
 
   function packageName(spec: string) {
     if (spec.startsWith("node:") || isBuiltin(spec) || BUILTIN_MODULES.has(spec)) return
@@ -68,7 +71,24 @@ export namespace ToolRegistry {
     return spec.split("/")[0]
   }
 
-  async function needsConfigDependencies(text: string, dir: string) {
+  async function resolveLocalImport(file: string, spec: string) {
+    const target = path.resolve(path.dirname(file), spec)
+    const candidates = path.extname(target)
+      ? [target]
+      : [
+          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => `${target}${ext}`),
+          ...LOCAL_IMPORT_EXTENSIONS.map((ext) => path.join(target, `index${ext}`)),
+        ]
+    for (const candidate of candidates) {
+      if (await Filesystem.exists(candidate)) return candidate
+    }
+  }
+
+  async function needsConfigDependencies(file: string, dir: string, visited = new Set<string>()) {
+    const resolved = path.resolve(file)
+    if (visited.has(resolved)) return false
+    visited.add(resolved)
+    const text = await Filesystem.readText(resolved).catch(() => "")
     for (const match of text.matchAll(DEPENDENCY_IMPORT)) {
       const spec = match[1] ?? match[2] ?? match[3]
       if (!spec) continue
@@ -77,6 +97,13 @@ export namespace ToolRegistry {
       const pkgPath = path.join(dir, "node_modules", ...pkg.split("/"))
       if (await Filesystem.exists(path.join(pkgPath, "package.json"))) continue
       return true
+    }
+    for (const match of text.matchAll(LOCAL_IMPORT)) {
+      const spec = match[1] ?? match[2] ?? match[3]
+      if (!spec) continue
+      const next = await resolveLocalImport(resolved, spec)
+      if (!next) continue
+      if (await needsConfigDependencies(next, dir, visited)) return true
     }
     return false
   }
@@ -207,7 +234,7 @@ export namespace ToolRegistry {
             if (ids.length && ids.every((id) => disabled.has(id))) continue
             const spec = process.platform === "win32" ? match : pathToFileURL(match).href
             const toolDir = path.dirname(path.dirname(match))
-            if (!readyDirs.has(toolDir) && (yield* Effect.promise(() => needsConfigDependencies(text, toolDir)))) {
+            if (!readyDirs.has(toolDir) && (yield* Effect.promise(() => needsConfigDependencies(match, toolDir)))) {
               readyDirs.add(toolDir)
               yield* config.waitForDependencies([toolDir]).pipe(Effect.orDie)
             }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -208,7 +208,7 @@ export namespace ToolRegistry {
             const spec = process.platform === "win32" ? match : pathToFileURL(match).href
             if (!depsReady && (yield* Effect.promise(() => needsConfigDependencies(text, path.dirname(path.dirname(match)))))) {
               depsReady = true
-              yield* config.waitForDependencies()
+              yield* config.waitForDependencies().pipe(Effect.orDie)
             }
             const mod = yield* Effect.promise(() => import(spec))
             for (const [id, def] of Object.entries<ToolDefinition>(mod)) {

--- a/packages/opencode/src/util/flock.ts
+++ b/packages/opencode/src/util/flock.ts
@@ -86,6 +86,30 @@ export namespace Flock {
     })
   }
 
+  function retryableReleaseError(err: unknown) {
+    const errCode = code(err)
+    return errCode === "EBUSY" || errCode === "ENOTEMPTY" || errCode === "EPERM"
+  }
+
+  async function removeLockDir(lockDir: string) {
+    let delay = 10
+
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rm(lockDir, { recursive: true, force: true })
+        return
+      } catch (err) {
+        if (!retryableReleaseError(err) || attempt >= 4) {
+          throw err
+        }
+      }
+
+      // Windows can briefly report the lock dir as still in use after heartbeat cleanup.
+      await sleep(delay)
+      delay *= 2
+    }
+  }
+
   function jitter(ms: number) {
     const j = Math.floor(ms * 0.3)
     const d = Math.floor(Math.random() * (2 * j + 1)) - j
@@ -247,7 +271,7 @@ export namespace Flock {
         throw new Error("Refusing to release: lock token mismatch (not the owner).")
       }
 
-      await rm(lockDir, { recursive: true, force: true })
+      await removeLockDir(lockDir)
     }
 
     return {

--- a/packages/opencode/src/util/flock.ts
+++ b/packages/opencode/src/util/flock.ts
@@ -338,9 +338,34 @@ export namespace Flock {
       },
       cfg,
     )
+    let abortReason: unknown
+    const onAbort = () => {
+      abortReason = input.signal?.reason ?? new Error("Aborted")
+    }
+    let released: Promise<void> | undefined
+    const release = () => {
+      input.signal?.removeEventListener("abort", onAbort)
+      return (released ??= lock.release())
+    }
+
+    input.signal?.addEventListener("abort", onAbort, { once: true })
+    if (input.signal?.aborted) {
+      abortReason = input.signal.reason ?? new Error("Aborted")
+    }
+
     lock.startHeartbeat()
 
-    const release = () => lock.release()
+    // Hold the abort hook through the handoff microtask so callers can
+    // register their own finalizer without leaking a just-acquired lock.
+    if (input.signal) {
+      await Promise.resolve()
+      if (abortReason !== undefined || input.signal.aborted) {
+        await release()
+        throw (abortReason ?? input.signal.reason ?? new Error("Aborted"))
+      }
+      input.signal.removeEventListener("abort", onAbort)
+    }
+
     return {
       release,
       [Symbol.asyncDispose]() {

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -152,6 +152,18 @@ export namespace Worktree {
     )
   }
 
+  function removeErrorCode(error: unknown) {
+    if (typeof error !== "object" || error === null || !("code" in error)) return
+    const value = error.code
+    if (typeof value !== "string") return
+    return value
+  }
+
+  function retryableRemoveError(error: unknown) {
+    const code = removeErrorCode(error)
+    return code === "EBUSY" || code === "ENOTEMPTY" || code === "EPERM"
+  }
+
   // ---------------------------------------------------------------------------
   // Effect service
   // ---------------------------------------------------------------------------
@@ -358,14 +370,25 @@ export namespace Worktree {
       }
 
       function cleanDirectory(target: string) {
-        return Effect.promise(() =>
-          import("fs/promises")
-            .then((fsp) => fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }))
-            .catch((error) => {
+        return Effect.promise(async () => {
+          const fsp = await import("fs/promises")
+          let delay = 50
+
+          for (let attempt = 0; ; attempt += 1) {
+            try {
+              await fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+              return
+            } catch (error) {
+              if (retryableRemoveError(error) && attempt < 7) {
+                await new Promise((resolve) => setTimeout(resolve, delay))
+                delay = Math.min(delay * 2, 1_000)
+                continue
+              }
               const message = errorMessage(error)
               throw new RemoveFailedError({ message: message || "Failed to remove git worktree directory" })
-            }),
-        )
+            }
+          }
+        })
       }
 
       const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -953,6 +953,87 @@ test("skips reinstall when config dependencies are already bootstrapped", async 
   }
 })
 
+test("Instance.disposeAll waits for background config dependency installs to finish", async () => {
+  await using tmp = await tmpdir<string>({
+    init: async (dir) => {
+      const cfg = path.join(dir, "configdir")
+      await fs.mkdir(cfg, { recursive: true })
+      return cfg
+    },
+  })
+
+  const prev = process.env.OPENCODE_CONFIG_DIR
+  process.env.OPENCODE_CONFIG_DIR = tmp.extra
+  const secondDir = path.join(tmp.path, "other-config")
+  await fs.mkdir(secondDir, { recursive: true })
+
+  const platform = process.platform
+  Object.defineProperty(process, "platform", {
+    value: "win32",
+    configurable: true,
+  })
+
+  let release = () => {}
+  let started = () => {}
+  const installing = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  const online = spyOn(Network, "online").mockReturnValue(false)
+  const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+    if (path.normalize(dir) === path.normalize(tmp.extra)) {
+      started()
+      await installing
+    }
+    await writeMockConfigInstall(dir)
+  })
+
+  let disposing: Promise<void> | undefined
+  let waited = false
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+      },
+    })
+    await ready
+
+    let done = false
+    disposing = Instance.disposeAll().then(() => {
+      done = true
+    })
+    const afterDispose = disposing.then(() =>
+      Config.installDependencies(secondDir, {
+        waitTick: () => {
+          waited = true
+        },
+      }),
+    )
+    await Bun.sleep(50)
+
+    expect(done).toBe(false)
+    expect(waited).toBe(false)
+
+    release()
+    await afterDispose
+    expect(done).toBe(true)
+  } finally {
+    release()
+    await disposing?.catch(() => undefined)
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+    })
+    online.mockRestore()
+    install.mockRestore()
+    if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = prev
+  }
+})
+
 test("resolves scoped npm plugins in config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -24,6 +24,7 @@ import * as Network from "../../src/util/network"
 import { Npm } from "../../src/npm"
 import { writeMockConfigInstall } from "../shared/mock-npm-install"
 import { Installation } from "../../src/installation"
+import { Flock } from "../../src/util/flock"
 
 const emptyAccount = Layer.mock(Account.Service)({
   active: () => Effect.succeed(Option.none()),
@@ -763,9 +764,16 @@ test("does not try to install dependencies in read-only OPENCODE_CONFIG_DIR", as
   })
 
   const prev = process.env.OPENCODE_CONFIG_DIR
-  process.env.OPENCODE_CONFIG_DIR = tmp.extra
+  const prevGlobal = Global.Path.config
+  let globalDir = ""
 
   try {
+    globalDir = path.join(tmp.path, "global")
+    await fs.mkdir(globalDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = tmp.extra
+    ;(Global.Path as { config: string }).config = globalDir
+    await Config.invalidate()
+
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -775,6 +783,8 @@ test("does not try to install dependencies in read-only OPENCODE_CONFIG_DIR", as
   } finally {
     if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
     else process.env.OPENCODE_CONFIG_DIR = prev
+    ;(Global.Path as { config: string }).config = prevGlobal
+    await Config.invalidate()
   }
 })
 
@@ -788,11 +798,18 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
   })
 
   const prev = process.env.OPENCODE_CONFIG_DIR
-  process.env.OPENCODE_CONFIG_DIR = tmp.extra
+  const prevGlobal = Global.Path.config
+  let globalDir = ""
   const online = spyOn(Network, "online").mockReturnValue(false)
   const install = spyOn(Npm, "install").mockImplementation((dir: string) => writeMockConfigInstall(dir))
 
   try {
+    globalDir = path.join(tmp.path, "global")
+    await fs.mkdir(globalDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = tmp.extra
+    ;(Global.Path as { config: string }).config = globalDir
+    await Config.invalidate()
+
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -809,6 +826,8 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
     install.mockRestore()
     if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
     else process.env.OPENCODE_CONFIG_DIR = prev
+    ;(Global.Path as { config: string }).config = prevGlobal
+    await Config.invalidate()
   }
 })
 
@@ -953,7 +972,7 @@ test("skips reinstall when config dependencies are already bootstrapped", async 
   }
 })
 
-test("Instance.disposeAll waits for background config dependency installs to finish", async () => {
+test("Instance.disposeAll interrupts waiting background config installs without leaking Windows lock", async () => {
   await using tmp = await tmpdir<string>({
     init: async (dir) => {
       const cfg = path.join(dir, "configdir")
@@ -963,8 +982,112 @@ test("Instance.disposeAll waits for background config dependency installs to fin
   })
 
   const prev = process.env.OPENCODE_CONFIG_DIR
-  process.env.OPENCODE_CONFIG_DIR = tmp.extra
+  const prevGlobal = Global.Path.config
   const secondDir = path.join(tmp.path, "other-config")
+  let globalDir = ""
+
+  const platform = process.platform
+  Object.defineProperty(process, "platform", {
+    value: "win32",
+    configurable: true,
+  })
+
+  let release = () => {}
+  let started = () => {}
+  let waiting = () => {}
+  const installing = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  const waitStarted = new Promise<void>((resolve) => {
+    waiting = resolve
+  })
+  const online = spyOn(Network, "online").mockReturnValue(false)
+  let secondCalls = 0
+  const originalAcquire = Flock.acquire
+  let configAcquireCalls = 0
+  const acquire = spyOn(Flock, "acquire").mockImplementation(async (key, input = {}) => {
+    if (key === "config-install:win32") {
+      configAcquireCalls += 1
+      if (configAcquireCalls > 1) {
+        const onWait = input.onWait
+        input = {
+          ...input,
+          onWait: async (tick) => {
+            waiting()
+            await onWait?.(tick)
+          },
+        }
+      }
+    }
+    return originalAcquire(key, input)
+  })
+  const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+    if (path.normalize(dir) === path.normalize(tmp.extra)) {
+      started()
+      await installing
+    }
+    if (path.normalize(dir) === path.normalize(secondDir)) {
+      secondCalls += 1
+    }
+    await writeMockConfigInstall(dir)
+  })
+
+  try {
+    globalDir = path.join(tmp.path, "global")
+    process.env.OPENCODE_CONFIG_DIR = secondDir
+    await fs.mkdir(globalDir, { recursive: true })
+    ;(Global.Path as { config: string }).config = globalDir
+    await Config.invalidate()
+    await fs.mkdir(secondDir, { recursive: true })
+
+    const first = Config.installDependencies(tmp.extra)
+    await ready
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+      },
+    })
+    await waitStarted
+    const dispose = Promise.race([
+      Instance.disposeAll().then(() => "done" as const),
+      Bun.sleep(200).then(() => "timeout" as const),
+    ])
+
+    expect(await dispose).toBe("done")
+
+    release()
+    await first
+    await Bun.sleep(50)
+    expect(secondCalls).toBe(0)
+
+    await Config.installDependencies(secondDir)
+    expect(secondCalls).toBe(1)
+  } finally {
+    release()
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+    })
+    online.mockRestore()
+    acquire.mockRestore()
+    install.mockRestore()
+    if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = prev
+    ;(Global.Path as { config: string }).config = prevGlobal
+    await Config.invalidate()
+  }
+})
+
+test("config dependency install aborts while waiting for Windows lock", async () => {
+  await using tmp = await tmpdir()
+  const firstDir = path.join(tmp.path, "a")
+  const secondDir = path.join(tmp.path, "b")
+  await fs.mkdir(firstDir, { recursive: true })
   await fs.mkdir(secondDir, { recursive: true })
 
   const platform = process.platform
@@ -982,55 +1105,43 @@ test("Instance.disposeAll waits for background config dependency installs to fin
     started = resolve
   })
   const online = spyOn(Network, "online").mockReturnValue(false)
+  let secondCalls = 0
   const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
-    if (path.normalize(dir) === path.normalize(tmp.extra)) {
+    if (path.normalize(dir) === path.normalize(firstDir)) {
       started()
       await installing
+    }
+    if (path.normalize(dir) === path.normalize(secondDir)) {
+      secondCalls += 1
     }
     await writeMockConfigInstall(dir)
   })
 
-  let disposing: Promise<void> | undefined
-  let waited = false
   try {
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await Config.get()
-      },
-    })
+    const first = Config.installDependencies(firstDir)
     await ready
 
-    let done = false
-    disposing = Instance.disposeAll().then(() => {
-      done = true
-    })
-    const afterDispose = disposing.then(() =>
+    const controller = new AbortController()
+    await expect(
       Config.installDependencies(secondDir, {
+        signal: controller.signal,
         waitTick: () => {
-          waited = true
+          controller.abort(new Error("stop waiting"))
         },
       }),
-    )
-    await Bun.sleep(50)
-
-    expect(done).toBe(false)
-    expect(waited).toBe(false)
+    ).rejects.toThrow("stop waiting")
 
     release()
-    await afterDispose
-    expect(done).toBe(true)
+    await first
+    expect(secondCalls).toBe(0)
   } finally {
     release()
-    await disposing?.catch(() => undefined)
     Object.defineProperty(process, "platform", {
       value: platform,
       configurable: true,
     })
     online.mockRestore()
     install.mockRestore()
-    if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
-    else process.env.OPENCODE_CONFIG_DIR = prev
   }
 })
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -972,6 +972,68 @@ test("skips reinstall when config dependencies are already bootstrapped", async 
   }
 })
 
+test("Instance.disposeAll interrupts Config.get background installs for global config on Windows", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  const prevGlobal = Global.Path.config
+  let globalDir = ""
+
+  const platform = process.platform
+  Object.defineProperty(process, "platform", {
+    value: "win32",
+    configurable: true,
+  })
+
+  let release = () => {}
+  let started = () => {}
+  const installing = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  const online = spyOn(Network, "online").mockReturnValue(false)
+  const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+    if (path.normalize(dir) === path.normalize(globalDir)) {
+      started()
+      await installing
+    }
+    await writeMockConfigInstall(dir)
+  })
+
+  try {
+    globalDir = path.join(tmp.path, "global")
+    await fs.mkdir(globalDir, { recursive: true })
+    ;(Global.Path as { config: string }).config = globalDir
+    await Config.invalidate()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+      },
+    })
+    await ready
+
+    const dispose = Promise.race([
+      Instance.disposeAll().then(() => "done" as const),
+      Bun.sleep(200).then(() => "timeout" as const),
+    ])
+
+    expect(await dispose).toBe("done")
+  } finally {
+    release()
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+    })
+    online.mockRestore()
+    install.mockRestore()
+    ;(Global.Path as { config: string }).config = prevGlobal
+    await Config.invalidate()
+  }
+})
+
 test("Instance.disposeAll interrupts waiting background config installs without leaking Windows lock", async () => {
   await using tmp = await tmpdir<string>({
     init: async (dir) => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -972,6 +972,46 @@ test("skips reinstall when config dependencies are already bootstrapped", async 
   }
 })
 
+test("reinstalls when declared config dependencies are missing from node_modules", async () => {
+  await using tmp = await tmpdir()
+  const dir = path.join(tmp.path, "configdir")
+  await fs.mkdir(path.join(dir, "node_modules", "@opencode-ai", "plugin"), { recursive: true })
+  const target = Installation.isLocal() ? "*" : Installation.VERSION
+
+  await Filesystem.writeJson(path.join(dir, "package.json"), {
+    dependencies: {
+      "@opencode-ai/plugin": target,
+      "late-dep": "1.0.0",
+    },
+  })
+  await Filesystem.write(
+    path.join(dir, ".gitignore"),
+    ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+  )
+  await Filesystem.writeJson(path.join(dir, "node_modules", "@opencode-ai", "plugin", "package.json"), {
+    name: "@opencode-ai/plugin",
+    version: "1.0.0",
+  })
+
+  const install = spyOn(Npm, "install").mockImplementation(async (cwd: string) => {
+    await fs.mkdir(path.join(cwd, "node_modules", "late-dep"), { recursive: true })
+    await Filesystem.writeJson(path.join(cwd, "node_modules", "late-dep", "package.json"), {
+      name: "late-dep",
+      version: "1.0.0",
+      type: "module",
+      exports: "./index.js",
+    })
+  })
+
+  try {
+    await Config.installDependencies(dir)
+    expect(install).toHaveBeenCalledTimes(1)
+    expect(await Filesystem.exists(path.join(dir, "node_modules", "late-dep", "package.json"))).toBe(true)
+  } finally {
+    install.mockRestore()
+  }
+})
+
 test("Instance.disposeAll interrupts Config.get background installs for global config on Windows", async () => {
   await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
-import { tmpdir } from "../fixture/fixture"
+import { tmpdir as baseTmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Config } from "../../src/config/config"
 import { TuiConfig } from "../../src/config/tui"
@@ -10,6 +10,27 @@ import { Filesystem } from "../../src/util/filesystem"
 
 const managedConfigDir = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR!
 const wintest = process.platform === "win32" ? test : test.skip
+
+type TestTmpdirOptions<T> = {
+  git?: boolean
+  config?: Partial<Config.Info>
+  init?: (dir: string) => Promise<T>
+  dispose?: (dir: string) => Promise<T>
+}
+
+async function tmpdir<T>(options?: TestTmpdirOptions<T>) {
+  return baseTmpdir<T>({
+    ...options,
+    dispose: async (dir) => {
+      await Instance.provide({
+        directory: dir,
+        fn: () => TuiConfig.waitForDependencies(),
+      })
+      await Config.invalidate(true)
+      return (await options?.dispose?.(dir)) as T
+    },
+  })
+}
 
 beforeEach(async () => {
   await Config.invalidate(true)
@@ -80,6 +101,7 @@ test("keeps server and tui plugin merge semantics aligned", async () => {
     directory: tmp.path,
     fn: async () => {
       const server = await Config.get()
+      await Config.waitForDependencies()
       const tui = await TuiConfig.get()
       const serverPlugins = (server.plugin ?? []).map((item) => Config.pluginSpecifier(item))
       const tuiPlugins = (tui.plugin ?? []).map((item) => Config.pluginSpecifier(item))

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
 import { tmpdir } from "../fixture/fixture"
+import { writeMockConfigInstall } from "../shared/mock-npm-install"
 import { Filesystem } from "../../src/util/filesystem"
 
 const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
@@ -745,6 +746,51 @@ describe("plugin.loader.shared", () => {
       expect(await Bun.file(tmp.extra.mark).text()).toBe("ok")
     } finally {
       wait.mockRestore()
+    }
+  })
+
+  test("waits for auto-discovered file plugins that reach config deps through helper imports", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const configDir = path.join(dir, ".opencode")
+        const pluginsDir = path.join(configDir, "plugins")
+        const pluginFile = path.join(pluginsDir, "demo.ts")
+        const mark = path.join(dir, "demo.txt")
+
+        await fs.mkdir(pluginsDir, { recursive: true })
+        await Bun.write(
+          path.join(pluginsDir, "helper.ts"),
+          ["import { ready } from 'late-dep'", "export { ready }", ""].join("\n"),
+        )
+        await Bun.write(
+          pluginFile,
+          [
+            'import { ready } from "./helper"',
+            "export default {",
+            '  id: "demo.helper",',
+            "  server: async () => {",
+            `    await Bun.write(${JSON.stringify(mark)}, ready)`,
+            "    return {}",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        return { mark, configDir }
+      },
+    })
+
+    const install = spyOn(Npm, "install").mockImplementation((dir: string) => writeMockConfigInstall(dir))
+
+    try {
+      await load(tmp.path)
+      expect(
+        install.mock.calls.some(([dir]) => path.normalize(dir) === path.normalize(tmp.extra.configDir)),
+      ).toBe(true)
+      expect(await Bun.file(tmp.extra.mark).text()).toBe("hello")
+    } finally {
+      install.mockRestore()
     }
   })
 

--- a/packages/opencode/test/project/worktree-cleanup.test.ts
+++ b/packages/opencode/test/project/worktree-cleanup.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test"
+import { $ } from "bun"
+import { promises as nodeFs } from "node:fs"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Filesystem } from "../../src/util/filesystem"
+import { tmpdir } from "../fixture/fixture"
+
+let rmCalls = 0
+let failBusyTimes = 0
+
+mock.module("fs/promises", () => {
+  return {
+    ...nodeFs,
+    rm: async (...args: Parameters<typeof nodeFs.rm>) => {
+      rmCalls += 1
+      if (failBusyTimes > 0) {
+        failBusyTimes -= 1
+        const error = new Error("resource busy or locked")
+        ;(error as NodeJS.ErrnoException).code = "EBUSY"
+        throw error
+      }
+      return nodeFs.rm(...args)
+    },
+  }
+})
+
+const { Worktree } = await import("../../src/worktree")
+
+describe("Worktree.remove cleanup", () => {
+  test("retries transient busy directory cleanup after git worktree removal", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const root = tmp.path
+    const name = `remove-busy-${Date.now().toString(36)}`
+    const branch = `opencode/${name}`
+    const dir = path.join(root, "..", name)
+
+    await $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet()
+    await $`git reset --hard`.cwd(dir).quiet()
+
+    failBusyTimes = 2
+    rmCalls = 0
+
+    const ok = await Instance.provide({
+      directory: root,
+      fn: () => Worktree.remove({ directory: dir }),
+    })
+
+    expect(ok).toBe(true)
+    expect(rmCalls).toBeGreaterThanOrEqual(3)
+    expect(await Filesystem.exists(dir)).toBe(false)
+  })
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -7,6 +7,7 @@ import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
 import { Npm } from "../../src/npm"
 import { Config } from "../../src/config/config"
+import { needsConfigDependencies } from "../../src/config/dependency"
 import { Global } from "../../src/global"
 import { withTimeout } from "../../src/util/timeout"
 
@@ -254,6 +255,125 @@ describe("tool.registry", () => {
     } finally {
       install.mockRestore()
     }
+  })
+
+  test("does not wait on local config installs for helper files with type-only imports or exports", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolsDir = path.join(dir, ".opencode", "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "helper.ts"),
+          [
+            "import type { Missing } from 'late-dep'",
+            "export type { Missing } from 'late-dep'",
+            "import { type Missing as InlineImport } from 'late-dep'",
+            "export { type Missing as InlineExport } from 'late-dep'",
+            "export const ready = 'local'",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(toolsDir, "late.ts"),
+          [
+            "import { ready } from './helper'",
+            "export default {",
+            "  description: 'tool with helper type-only imports or exports',",
+            "  args: {},",
+            "  execute: async () => ready,",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    let release = () => {}
+    let started = () => {}
+    let idsTask: Promise<string[]> | undefined
+    const installing = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const ready = new Promise<void>((resolve) => {
+      started = resolve
+    })
+    const localConfigDir = path.join(tmp.path, ".opencode")
+    const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+      if (path.normalize(dir) === path.normalize(localConfigDir)) {
+        started()
+        await installing
+      }
+      await writeMockConfigInstall(dir)
+    })
+
+    try {
+      idsTask = Instance.provide({
+        directory: tmp.path,
+        fn: () => ToolRegistry.ids(),
+      }).then((ids) => ids)
+
+      await ready
+
+      await expect(withTimeout(idsTask, 2_000)).resolves.toContain("late")
+    } finally {
+      release()
+      await idsTask?.catch(() => undefined)
+      install.mockRestore()
+    }
+  })
+
+  test("ignores multiline type-only dependency imports and exports when scanning config dependencies", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolsDir = path.join(dir, ".opencode", "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "helper.ts"),
+          [
+            "import type",
+            "  { Missing as MultilineImport } from 'late-dep'",
+            "export type",
+            "  { Missing as MultilineExport } from 'late-dep'",
+            "import { type",
+            "  Missing as InlineMultilineImport } from 'late-dep'",
+            "export { type",
+            "  Missing as InlineMultilineExport } from 'late-dep'",
+            "export const ready = 'local'",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await expect(
+      needsConfigDependencies(path.join(tmp.path, ".opencode", "tools", "helper.ts"), path.join(tmp.path, ".opencode")),
+    ).resolves.toBe(false)
+  })
+
+  test("keeps runtime imports and exports for bindings literally named type", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolsDir = path.join(dir, ".opencode", "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "helper.ts"),
+          [
+            "import { type as RuntimeImport } from 'late-dep'",
+            "export { type as RuntimeExport } from 'late-dep'",
+            "export const ready = 'local'",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await expect(
+      needsConfigDependencies(path.join(tmp.path, ".opencode", "tools", "helper.ts"), path.join(tmp.path, ".opencode")),
+    ).resolves.toBe(true)
   })
 
   test("does not wait for unrelated global config installs before importing local tools with bare imports", async () => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -215,6 +215,47 @@ describe("tool.registry", () => {
     }
   })
 
+  test("waits for config-scoped dependencies used through local helper imports", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolsDir = path.join(dir, ".opencode", "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(path.join(toolsDir, "helper.ts"), ["import { ready } from 'late-dep'", "export { ready }", ""].join("\n"))
+
+        await Bun.write(
+          path.join(toolsDir, "late.ts"),
+          [
+            "import { ready } from './helper'",
+            "export default {",
+            "  description: 'tool that reaches deps through helper imports',",
+            "  args: {},",
+            "  execute: async () => ready,",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    const install = spyOn(Npm, "install").mockImplementation((dir: string) => writeMockConfigInstall(dir))
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).toContain("late")
+        },
+      })
+      expect(
+        install.mock.calls.some(([dir]) => path.normalize(dir) === path.normalize(path.join(tmp.path, ".opencode"))),
+      ).toBe(true)
+    } finally {
+      install.mockRestore()
+    }
+  })
+
   test("does not wait for unrelated global config installs before importing local tools with bare imports", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -6,6 +6,8 @@ import { writeMockConfigInstall } from "../shared/mock-npm-install"
 import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
 import { Npm } from "../../src/npm"
+import { Config } from "../../src/config/config"
+import { Global } from "../../src/global"
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -193,6 +195,74 @@ describe("tool.registry", () => {
       ).toBe(true)
     } finally {
       install.mockRestore()
+    }
+  })
+
+  test("does not wait for unrelated global config installs before importing local tools with bare imports", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolsDir = path.join(dir, ".opencode", "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "late.ts"),
+          [
+            "import { ready } from 'late-dep'",
+            "export default {",
+            "  description: 'tool that only needs local config deps',",
+            "  args: {},",
+            "  execute: async () => ready,",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    const prevGlobal = Global.Path.config
+    let globalDir = ""
+    let release = () => {}
+    let started = () => {}
+    let idsTask: Promise<string[]> | undefined
+    const installing = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const ready = new Promise<void>((resolve) => {
+      started = resolve
+    })
+    const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+      if (path.normalize(dir) === path.normalize(globalDir)) {
+        started()
+        await installing
+      }
+      await writeMockConfigInstall(dir)
+    })
+
+    try {
+      globalDir = path.join(tmp.path, "global")
+      await fs.mkdir(globalDir, { recursive: true })
+      ;(Global.Path as { config: string }).config = globalDir
+      await Config.invalidate(true)
+
+      idsTask = Instance.provide({
+        directory: tmp.path,
+        fn: async () => ToolRegistry.ids(),
+      })
+
+      await ready
+
+      const result = await Promise.race([
+        idsTask.then((ids) => (ids.includes("late") ? "done" : "missing")),
+        Bun.sleep(200).then(() => "timeout"),
+      ])
+
+      expect(result).toBe("done")
+    } finally {
+      release()
+      await idsTask?.catch(() => undefined)
+      install.mockRestore()
+      ;(Global.Path as { config: string }).config = prevGlobal
+      await Config.invalidate(true)
     }
   })
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -8,6 +8,7 @@ import { ToolRegistry } from "../../src/tool/registry"
 import { Npm } from "../../src/npm"
 import { Config } from "../../src/config/config"
 import { Global } from "../../src/global"
+import { withTimeout } from "../../src/util/timeout"
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -251,12 +252,7 @@ describe("tool.registry", () => {
 
       await ready
 
-      const result = await Promise.race([
-        idsTask.then((ids) => (ids.includes("late") ? "done" : "missing")),
-        Bun.sleep(200).then(() => "timeout"),
-      ])
-
-      expect(result).toBe("done")
+      await expect(withTimeout(idsTask, 2_000)).resolves.toContain("late")
     } finally {
       release()
       await idsTask?.catch(() => undefined)

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -246,8 +246,8 @@ describe("tool.registry", () => {
 
       idsTask = Instance.provide({
         directory: tmp.path,
-        fn: async () => ToolRegistry.ids(),
-      })
+        fn: () => ToolRegistry.ids(),
+      }).then((ids) => ids)
 
       await ready
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -14,6 +14,22 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+async function withPlatform<T>(value: NodeJS.Platform, fn: () => Promise<T>) {
+  const previous = process.platform
+  Object.defineProperty(process, "platform", {
+    value,
+    configurable: true,
+  })
+  try {
+    return await fn()
+  } finally {
+    Object.defineProperty(process, "platform", {
+      value: previous,
+      configurable: true,
+    })
+  }
+}
+
 describe("tool.registry", () => {
   test("loads tools from .opencode/tool (singular)", async () => {
     await using tmp = await tmpdir({
@@ -260,6 +276,157 @@ describe("tool.registry", () => {
       ;(Global.Path as { config: string }).config = prevGlobal
       await Config.invalidate(true)
     }
+  })
+
+  test("does not wait for unrelated global config installs on Windows before importing local tools with bare imports", async () => {
+    await withPlatform("win32", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const toolsDir = path.join(dir, ".opencode", "tools")
+          await fs.mkdir(toolsDir, { recursive: true })
+
+          await Bun.write(
+            path.join(toolsDir, "late.ts"),
+            [
+              "import { ready } from 'late-dep'",
+              "export default {",
+              "  description: 'tool that only needs local config deps',",
+              "  args: {},",
+              "  execute: async () => ready,",
+              "}",
+              "",
+            ].join("\n"),
+          )
+        },
+      })
+
+      const prevGlobal = Global.Path.config
+      let globalDir = ""
+      let release = () => {}
+      let started = () => {}
+      let idsTask: Promise<string[]> | undefined
+      const installing = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const ready = new Promise<void>((resolve) => {
+        started = resolve
+      })
+      const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+        if (path.normalize(dir) === path.normalize(globalDir)) {
+          started()
+          await installing
+        }
+        await writeMockConfigInstall(dir)
+      })
+
+      try {
+        globalDir = path.join(tmp.path, "global")
+        await fs.mkdir(globalDir, { recursive: true })
+        ;(Global.Path as { config: string }).config = globalDir
+        await Config.invalidate(true)
+
+        idsTask = Instance.provide({
+          directory: tmp.path,
+          fn: () => ToolRegistry.ids(),
+        }).then((ids) => ids)
+
+        await ready
+
+        await expect(withTimeout(idsTask, 2_000)).resolves.toContain("late")
+      } finally {
+        release()
+        await idsTask?.catch(() => undefined)
+        install.mockRestore()
+        ;(Global.Path as { config: string }).config = prevGlobal
+        await Config.invalidate(true)
+      }
+    })
+  })
+
+  test("serializes concurrent Windows local tool dependency installs across directories", async () => {
+    await withPlatform("win32", async () => {
+      async function createToolProject() {
+        return await tmpdir({
+          init: async (dir) => {
+            const toolsDir = path.join(dir, ".opencode", "tools")
+            await fs.mkdir(toolsDir, { recursive: true })
+            await Bun.write(
+              path.join(toolsDir, "late.ts"),
+              [
+                "import { ready } from 'late-dep'",
+                "export default {",
+                "  description: 'tool that needs local config deps',",
+                "  args: {},",
+                "  execute: async () => ready,",
+                "}",
+                "",
+              ].join("\n"),
+            )
+          },
+        })
+      }
+
+      await using first = await createToolProject()
+      await using second = await createToolProject()
+
+      const targets = new Set([
+        path.normalize(path.join(first.path, ".opencode")),
+        path.normalize(path.join(second.path, ".opencode")),
+      ])
+      let open = 0
+      let peak = 0
+      let calls = 0
+      let release = () => {}
+      let started = () => {}
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const firstInstall = new Promise<void>((resolve) => {
+        started = resolve
+      })
+      const install = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+        const key = path.normalize(dir)
+        const hit = targets.has(key)
+        if (hit) {
+          calls += 1
+          open += 1
+          peak = Math.max(peak, open)
+          if (calls === 1) {
+            started()
+            await gate
+          }
+        }
+        await writeMockConfigInstall(dir)
+        if (hit) {
+          open -= 1
+        }
+      })
+
+      try {
+        const firstIds = Instance.provide({
+          directory: first.path,
+          fn: () => ToolRegistry.ids(),
+        })
+        await firstInstall
+
+        const secondIds = Instance.provide({
+          directory: second.path,
+          fn: () => ToolRegistry.ids(),
+        })
+        await Bun.sleep(100)
+        release()
+
+        await expect(firstIds).resolves.toContain("late")
+        await expect(secondIds).resolves.toContain("late")
+      } finally {
+        release()
+        install.mockRestore()
+        await Config.invalidate(true)
+      }
+
+      expect(calls).toBe(2)
+      expect(peak).toBe(1)
+    })
   })
 
   test("skips disabled tools before importing them", async () => {

--- a/packages/opencode/test/util/flock-release-retry.test.ts
+++ b/packages/opencode/test/util/flock-release-retry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import { tmpdir } from "../fixture/fixture"
+
+async function importFlockWithTransientReleaseFailure(root: string, tempDir: string) {
+  const source = path.join(root, "src", "util", "flock.ts")
+  await fs.mkdir(tempDir, { recursive: true })
+
+  const mockFsPath = path.join(tempDir, "mock-fs-promises.ts")
+  const flockPath = path.join(tempDir, "flock-under-test.ts")
+  const original = await fs.readFile(source, "utf8")
+  const globalUrl = pathToFileURL(path.join(root, "src", "global", "index.ts")).href
+  const hashUrl = pathToFileURL(path.join(root, "src", "util", "hash.ts")).href
+
+  await fs.writeFile(
+    mockFsPath,
+    [
+      'import * as real from "fs/promises"',
+      'export const mkdir = real.mkdir',
+      'export const readFile = real.readFile',
+      'export const stat = real.stat',
+      'export const utimes = real.utimes',
+      'export const writeFile = real.writeFile',
+      "",
+      "let failed = false",
+      "",
+      "export async function rm(target: Parameters<typeof real.rm>[0], options?: Parameters<typeof real.rm>[1]) {",
+      '  if (!failed && typeof target === "string" && target.endsWith(".lock")) {',
+      "    failed = true",
+      '    const error = new Error("transient lock-dir removal failure") as Error & { code?: string }',
+      '    error.code = "ENOTEMPTY"',
+      "    throw error",
+      "  }",
+      "  return real.rm(target, options)",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+
+  await fs.writeFile(
+    flockPath,
+    original
+      .replace('from "fs/promises"', 'from "./mock-fs-promises.ts"')
+      .replace('from "@/global"', `from "${globalUrl}"`)
+      .replace('from "@/util/hash"', `from "${hashUrl}"`),
+    "utf8",
+  )
+
+  return import(pathToFileURL(flockPath).href + `?t=${Date.now()}`)
+}
+
+describe("util.flock release retry", () => {
+  test("retries transient lock-dir removal failures during release", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(import.meta.dir, "../..")
+    const { Flock } = await importFlockWithTransientReleaseFailure(root, path.join(tmp.path, "module-fixtures"))
+    const dir = path.join(tmp.path, "locks")
+    const key = "flock:release-retry"
+
+    const lease = await Flock.acquire(key, {
+      dir,
+      staleMs: 1_000,
+      timeoutMs: 1_000,
+      baseDelayMs: 10,
+      maxDelayMs: 20,
+    })
+
+    await expect(lease.release()).resolves.toBeUndefined()
+
+    let reacquired = false
+    await Flock.withLock(
+      key,
+      async () => {
+        reacquired = true
+      },
+      {
+        dir,
+        staleMs: 1_000,
+        timeoutMs: 1_000,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+      },
+    )
+
+    expect(reacquired).toBe(true)
+  })
+})

--- a/packages/opencode/test/util/flock.test.ts
+++ b/packages/opencode/test/util/flock.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import { pathToFileURL } from "url"
 import { Flock } from "../../src/util/flock"
 import { Hash } from "../../src/util/hash"
 import { Process } from "../../src/util/process"
@@ -64,6 +65,49 @@ function spawn(msg: Msg) {
     stdout: "pipe",
     stderr: "pipe",
   })
+}
+
+async function importFlockWithAfterAcquireHook(root: string, tempDir: string) {
+  const source = path.join(root, "src", "util", "flock.ts")
+  await fs.mkdir(tempDir, { recursive: true })
+
+  const hookPath = path.join(tempDir, "after-acquire.ts")
+  const flockPath = path.join(tempDir, "flock-under-test.ts")
+  const original = await fs.readFile(source, "utf8")
+  const globalUrl = pathToFileURL(path.join(root, "src", "global", "index.ts")).href
+  const hashUrl = pathToFileURL(path.join(root, "src", "util", "hash.ts")).href
+
+  await fs.writeFile(
+    hookPath,
+    [
+      "let hook: (() => Promise<void>) | undefined",
+      "",
+      "export function setAfterAcquire(next: (() => Promise<void>) | undefined) {",
+      "  hook = next",
+      "}",
+      "",
+      "export function afterAcquire() {",
+      "  return hook?.()",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+
+  await fs.writeFile(
+    flockPath,
+    original
+      .replace('import { Global } from "@/global"', `import { Global } from "${globalUrl}"`)
+      .replace('import { Hash } from "@/util/hash"', `import { Hash } from "${hashUrl}"\nimport { afterAcquire } from "./after-acquire.ts"`)
+      .replace("    lock.startHeartbeat()", "    await afterAcquire()\n    lock.startHeartbeat()")
+      .concat('\nexport { setAfterAcquire } from "./after-acquire.ts"\n'),
+    "utf8",
+  )
+
+  return import(pathToFileURL(flockPath).href + `?t=${Date.now()}`) as Promise<{
+    Flock: typeof Flock
+    setAfterAcquire: (next: (() => Promise<void>) | undefined) => void
+  }>
 }
 
 describe("util.flock", () => {
@@ -312,6 +356,52 @@ describe("util.flock", () => {
     }
 
     expect(await exists(lockDir)).toBe(false)
+  })
+
+  test("releases the lock when aborted immediately after acquisition", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(import.meta.dir, "../..")
+    const { Flock, setAfterAcquire } = await importFlockWithAfterAcquireHook(root, path.join(tmp.path, "module-fixtures"))
+    const dir = path.join(tmp.path, "locks")
+    const key = "flock:post-acquire-abort"
+    const lockDir = lock(dir, key)
+    const controller = new AbortController()
+
+    setAfterAcquire(async () => {
+      controller.abort(new Error("stop"))
+      await Promise.resolve()
+    })
+
+    const err = await Flock.acquire(key, {
+      dir,
+      signal: controller.signal,
+      staleMs: 1_000,
+      timeoutMs: 1_000,
+      baseDelayMs: 10,
+      maxDelayMs: 20,
+    }).catch((err) => err)
+
+    expect(err).toBeInstanceOf(Error)
+    if (!(err instanceof Error)) throw err
+    expect(err.message).toContain("stop")
+    expect(await exists(lockDir)).toBe(false)
+
+    let reacquired = false
+    await Flock.withLock(
+      key,
+      async () => {
+        reacquired = true
+      },
+      {
+        dir,
+        staleMs: 1_000,
+        timeoutMs: 1_000,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+      },
+    )
+
+    expect(reacquired).toBe(true)
   })
 
   test("refuses token mismatch release and recovers from stale", async () => {


### PR DESCRIPTION
## Summary
- harden config-scoped dependency installs and waiting behavior
- follow transitive config dependencies across local tool and plugin helpers
- ignore type-only dependency signals while preserving runtime aliases
- include the supporting Windows cleanup and lock reliability fixes already in this branch stack

## Verification
- bun test --timeout 30000 test/config/config.test.ts test/tool/registry.test.ts test/plugin/loader-shared.test.ts
- git diff --check

## Notes
- This PR is the clean replacement for PR #3 so review can happen against a single branch-level diff.