### PR TITLE
ci(windows): DISABLE_FILEWATCHER env (match upstream)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -43,17 +43,6 @@ jobs:
         run: bun turbo typecheck
 
       - name: test
-        if: runner.os != 'Windows'
         run: bun turbo test:ci
-
-      # Windows GitHub runners have intermittent resource jitter that causes
-      # timing-sensitive shell/loop tests (3000ms bound) to cross the threshold
-      # by ~16ms. One retry absorbs this without masking stable bugs.
-      - name: test (windows, with retry)
-        if: runner.os == 'Windows'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          command: bun turbo test:ci
-          shell: pwsh
+        env:
+          OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -43,4 +43,17 @@ jobs:
         run: bun turbo typecheck
 
       - name: test
+        if: runner.os != 'Windows'
         run: bun turbo test:ci
+
+      # Windows GitHub runners have intermittent resource jitter that causes
+      # timing-sensitive shell/loop tests (3000ms bound) to cross the threshold
+      # by ~16ms. One retry absorbs this without masking stable bugs.
+      - name: test (windows, with retry)
+        if: runner.os == 'Windows'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command: bun turbo test:ci
+          shell: pwsh


### PR DESCRIPTION
## Summary
- Replaces the retry wrapper approach with `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: true` on Windows only (matches upstream OpenCode's [test.yml](https://github.com/anomalyco/opencode/blob/dev/.github/workflows/test.yml)).
- Ubuntu unchanged.
- Reverts job `timeout-minutes` 45 → 30 (not needed without retry).
- Drops the inline comment documenting the narrower "16ms edge case" diagnosis.

## Why
The retry approach (first version of this PR) was validated with 5 reruns on the same SHA: 4/4 completed reruns FAILED. Both inner retry attempts fail each time, on DIFFERENT tests from a ~10-test pool (config-deps 30s timeouts, shell/loop 3s, skill discovery, node server bootstrap, multiple file ops). The flake surface is far broader than the initial "16ms shell/loop" hypothesis.

Upstream OpenCode hit the same problem and uses `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true` on Windows. The flag already exists in our code (`packages/opencode/src/flag/flag.ts:57`, 13 call sites); the fork just never wired it in CI.

Related cleanup recorded in `docs/TODO.md`:
- Merge `publish.yml` (dead in fork, gated to `anomalyco/opencode`) + `build.yml` (only active for macOS arm64) into a single release workflow. Out of scope for this PR.

## Test plan
- [ ] CI on this PR: Ubuntu + Windows both green
- [ ] Trigger 4 more reruns on this commit via `gh run rerun`; collect 5 data points
- [ ] Failure rate < 20% on Windows acceptable; if higher, escalate to tier-2 (OS-scaled timeouts / bun test --jobs / split unit vs e2e)