### PR TITLE
fix: avoid first message render crash

### DIFF
--- a/packages/app/e2e/prompt/first-message-reply.spec.ts
+++ b/packages/app/e2e/prompt/first-message-reply.spec.ts
@@ -1,0 +1,39 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { assistantText } from "../actions"
+
+const pageErrors = (page: Page) => {
+  const hits: string[] = []
+  const onPageError = (err: Error) => {
+    hits.push(err.stack || err.message || String(err))
+  }
+  page.on("pageerror", onPageError)
+  return {
+    hits,
+    dispose: () => page.off("pageerror", onPageError),
+  }
+}
+
+test("first replied message in a new session renders without page errors", async ({ page, project, assistant }) => {
+  test.setTimeout(120_000)
+
+  const token = `FIRST_REPLY_${Date.now()}`
+  const errors = pageErrors(page)
+
+  try {
+    await project.open()
+    await assistant.reply(token)
+    const sessionID = await project.prompt(`Reply with exactly: ${token}`)
+    const assistantReply = page
+      .locator('[data-slot="session-turn-assistant-content"]')
+      .getByText(token, { exact: true })
+      .first()
+
+    await expect.poll(() => assistantText(project.sdk, sessionID), { timeout: 30_000 }).toContain(token)
+    await expect(assistantReply).toBeVisible({ timeout: 30_000 })
+    await page.waitForTimeout(250)
+    expect(errors.hits).toEqual([])
+  } finally {
+    errors.dispose()
+  }
+})

--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -44,19 +44,14 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   })
   const messages = createMemo(() => (params.id ? (sync.data.message[params.id] ?? []) : []))
 
-  const usd = createMemo(
-    () =>
-      new Intl.NumberFormat(language.intl(), {
-        style: "currency",
-        currency: "USD",
-      }),
-  )
-
   const metrics = createMemo(() => getSessionContextMetrics(messages(), providers.all()))
   const context = createMemo(() => metrics().context)
-  const cost = createMemo(() => {
-    return usd().format(metrics().totalCost)
-  })
+  const cost = createMemo(() =>
+    new Intl.NumberFormat(language.intl(), {
+      style: "currency",
+      currency: "USD",
+    }).format(metrics().totalCost),
+  )
 
   const openContext = () => {
     if (!params.id) return

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -249,17 +249,21 @@ export function MessageTimeline(props: {
     if (!id) return emptyMessages
     return sync.data.message[id] ?? emptyMessages
   })
-  const pending = createMemo(() =>
-    sessionMessages().findLast(
+  const pending = createMemo(() => {
+    const messages = sessionMessages() ?? emptyMessages
+    return messages.findLast(
       (item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number",
-    ),
-  )
+    )
+  })
   const sessionStatus = createMemo(() => {
     const id = sessionID()
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
+  const working = createMemo(() => {
+    const status = sessionStatus() ?? idle
+    return !!pending() || status.type !== "idle"
+  })
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 
   const [timeoutDone, setTimeoutDone] = createSignal(true)
@@ -286,7 +290,7 @@ export function MessageTimeline(props: {
       if (message && message.role === "user") return message.id
     }
 
-    const status = sessionStatus()
+    const status = sessionStatus() ?? idle
     if (status.type !== "idle") {
       const messages = sessionMessages()
       for (let i = messages.length - 1; i >= 0; i--) {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -800,23 +800,19 @@ export function registerPartComponent(type: string, component: PartComponent) {
 
 export function Message(props: MessageProps) {
   return (
-    <Switch>
-      <Match when={props.message.role === "user" && props.message}>
-        {(userMessage) => (
-          <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} actions={props.actions} />
-        )}
-      </Match>
-      <Match when={props.message.role === "assistant" && props.message}>
-        {(assistantMessage) => (
-          <AssistantMessageDisplay
-            message={assistantMessage() as AssistantMessage}
-            parts={props.parts}
-            showAssistantCopyPartID={props.showAssistantCopyPartID}
-            showReasoningSummaries={props.showReasoningSummaries}
-          />
-        )}
-      </Match>
-    </Switch>
+    <>
+      <Show when={props.message.role === "user"}>
+        <UserMessageDisplay message={props.message as UserMessage} parts={props.parts} actions={props.actions} />
+      </Show>
+      <Show when={props.message.role === "assistant"}>
+        <AssistantMessageDisplay
+          message={props.message as AssistantMessage}
+          parts={props.parts}
+          showAssistantCopyPartID={props.showAssistantCopyPartID}
+          showReasoningSummaries={props.showReasoningSummaries}
+        />
+      </Show>
+    </>
   )
 }
 
@@ -1026,12 +1022,10 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
     const match = data.store.provider?.all?.find((p) => p.id === providerID)
     return match?.models?.[modelID]?.name ?? modelID
   })
-  const timefmt = createMemo(() => new Intl.DateTimeFormat(i18n.locale(), { timeStyle: "short" }))
-
   const stamp = createMemo(() => {
     const created = props.message.time?.created
     if (typeof created !== "number") return ""
-    return timefmt().format(created)
+    return new Intl.DateTimeFormat(i18n.locale(), { timeStyle: "short" }).format(created)
   })
 
   const metaHead = createMemo(() => {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -384,147 +384,149 @@ export function SessionTurn(
         class={props.classes?.content}
       >
         <div onClick={autoScroll.handleInteraction}>
-          <Show when={message()}>
-            <div
-              ref={autoScroll.contentRef}
-              data-message={message()!.id}
-              data-slot="session-turn-message-container"
-              class={props.classes?.container}
-            >
-              <div data-slot="session-turn-message-content" aria-live="off">
-                <Message message={message()!} parts={parts()} actions={props.actions} />
-              </div>
-              <Show when={divider()}>
-                <div data-slot="session-turn-compaction">
-                  <MessageDivider label={divider()} />
+          <Show when={message()} keyed>
+            {(message) => (
+              <div
+                ref={autoScroll.contentRef}
+                data-message={message.id}
+                data-slot="session-turn-message-container"
+                class={props.classes?.container}
+              >
+                <div data-slot="session-turn-message-content" aria-live="off">
+                  <Message message={message} parts={parts()} actions={props.actions} />
                 </div>
-              </Show>
-              <Show when={assistantMessages().length > 0}>
-                <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
-                  <AssistantParts
-                    messages={assistantMessages()}
-                    showAssistantCopyPartID={assistantCopyPartID()}
-                    turnDurationMs={turnDurationMs()}
-                    working={working()}
-                    showReasoningSummaries={showReasoningSummaries()}
-                    shellToolDefaultOpen={props.shellToolDefaultOpen}
-                    editToolDefaultOpen={props.editToolDefaultOpen}
-                  />
-                </div>
-              </Show>
-              <Show when={showThinking()}>
-                <div data-slot="session-turn-thinking">
-                  <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} />
-                  <Show when={!showReasoningSummaries()}>
-                    <TextReveal
-                      text={reasoningHeading()}
-                      class="session-turn-thinking-heading"
-                      travel={25}
-                      duration={700}
+                <Show when={divider()}>
+                  <div data-slot="session-turn-compaction">
+                    <MessageDivider label={divider()} />
+                  </div>
+                </Show>
+                <Show when={assistantMessages().length > 0}>
+                  <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
+                    <AssistantParts
+                      messages={assistantMessages()}
+                      showAssistantCopyPartID={assistantCopyPartID()}
+                      turnDurationMs={turnDurationMs()}
+                      working={working()}
+                      showReasoningSummaries={showReasoningSummaries()}
+                      shellToolDefaultOpen={props.shellToolDefaultOpen}
+                      editToolDefaultOpen={props.editToolDefaultOpen}
                     />
-                  </Show>
-                </div>
-              </Show>
-              <SessionRetry status={status()} show={active()} />
-              <Show when={edited() > 0 && !working()}>
-                <div
-                  data-slot="session-turn-diffs"
-                  data-component="session-turn-diffs-group"
-                  data-show-all={showAll() || undefined}
-                >
-                  <div data-slot="session-turn-diffs-header">
-                    <span data-slot="session-turn-diffs-label">
-                      {edited()} {i18n.t("ui.sessionTurn.diffs.changed")}{" "}
-                      {i18n.t(edited() === 1 ? "ui.common.file.one" : "ui.common.file.other")}
-                    </span>
-                    <DiffChanges changes={diffs()} />
-                    <Show when={overflow() > 0}>
-                      <span data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
-                        {showAll() ? i18n.t("ui.sessionTurn.diffs.showLess") : i18n.t("ui.sessionTurn.diffs.showAll")}
+                  </div>
+                </Show>
+                <Show when={showThinking()}>
+                  <div data-slot="session-turn-thinking">
+                    <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} />
+                    <Show when={!showReasoningSummaries()}>
+                      <TextReveal
+                        text={reasoningHeading()}
+                        class="session-turn-thinking-heading"
+                        travel={25}
+                        duration={700}
+                      />
+                    </Show>
+                  </div>
+                </Show>
+                <SessionRetry status={status()} show={active()} />
+                <Show when={edited() > 0 && !working()}>
+                  <div
+                    data-slot="session-turn-diffs"
+                    data-component="session-turn-diffs-group"
+                    data-show-all={showAll() || undefined}
+                  >
+                    <div data-slot="session-turn-diffs-header">
+                      <span data-slot="session-turn-diffs-label">
+                        {edited()} {i18n.t("ui.sessionTurn.diffs.changed")}{" "}
+                        {i18n.t(edited() === 1 ? "ui.common.file.one" : "ui.common.file.other")}
                       </span>
-                    </Show>
-                  </div>
-                  <div data-component="session-turn-diffs-content">
-                    <Accordion
-                      multiple
-                      style={{ "--sticky-accordion-offset": "44px" }}
-                      value={expanded()}
-                      onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
-                    >
-                      <For each={visible()}>
-                        {(diff) => {
-                          const view = normalize(diff)
-                          const active = createMemo(() => expanded().includes(diff.file))
-                          const [shown, setShown] = createSignal(false)
+                      <DiffChanges changes={diffs()} />
+                      <Show when={overflow() > 0}>
+                        <span data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
+                          {showAll() ? i18n.t("ui.sessionTurn.diffs.showLess") : i18n.t("ui.sessionTurn.diffs.showAll")}
+                        </span>
+                      </Show>
+                    </div>
+                    <div data-component="session-turn-diffs-content">
+                      <Accordion
+                        multiple
+                        style={{ "--sticky-accordion-offset": "44px" }}
+                        value={expanded()}
+                        onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
+                      >
+                        <For each={visible()}>
+                          {(diff) => {
+                            const view = normalize(diff)
+                            const active = createMemo(() => expanded().includes(diff.file))
+                            const [shown, setShown] = createSignal(false)
 
-                          createEffect(
-                            on(
-                              active,
-                              (value) => {
-                                if (!value) {
-                                  setShown(false)
-                                  return
-                                }
+                            createEffect(
+                              on(
+                                active,
+                                (value) => {
+                                  if (!value) {
+                                    setShown(false)
+                                    return
+                                  }
 
-                                requestAnimationFrame(() => {
-                                  if (!active()) return
-                                  setShown(true)
-                                })
-                              },
-                              { defer: true },
-                            ),
-                          )
+                                  requestAnimationFrame(() => {
+                                    if (!active()) return
+                                    setShown(true)
+                                  })
+                                },
+                                { defer: true },
+                              ),
+                            )
 
-                          return (
-                            <Accordion.Item value={diff.file}>
-                              <StickyAccordionHeader>
-                                <Accordion.Trigger>
-                                  <div data-slot="session-turn-diff-trigger">
-                                    <span data-slot="session-turn-diff-path">
-                                      <Show when={diff.file.includes("/")}>
-                                        <span data-slot="session-turn-diff-directory">
-                                          {`\u202A${getDirectory(diff.file)}\u202C`}
+                            return (
+                              <Accordion.Item value={diff.file}>
+                                <StickyAccordionHeader>
+                                  <Accordion.Trigger>
+                                    <div data-slot="session-turn-diff-trigger">
+                                      <span data-slot="session-turn-diff-path">
+                                        <Show when={diff.file.includes("/")}>
+                                          <span data-slot="session-turn-diff-directory">
+                                            {`\u202A${getDirectory(diff.file)}\u202C`}
+                                          </span>
+                                        </Show>
+                                        <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
+                                      </span>
+                                      <div data-slot="session-turn-diff-meta">
+                                        <span data-slot="session-turn-diff-changes">
+                                          <DiffChanges changes={diff} />
                                         </span>
-                                      </Show>
-                                      <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
-                                    </span>
-                                    <div data-slot="session-turn-diff-meta">
-                                      <span data-slot="session-turn-diff-changes">
-                                        <DiffChanges changes={diff} />
-                                      </span>
-                                      <span data-slot="session-turn-diff-chevron">
-                                        <Icon name="chevron-down" size="small" />
-                                      </span>
+                                        <span data-slot="session-turn-diff-chevron">
+                                          <Icon name="chevron-down" size="small" />
+                                        </span>
+                                      </div>
                                     </div>
-                                  </div>
-                                </Accordion.Trigger>
-                              </StickyAccordionHeader>
-                              <Accordion.Content>
-                                <Show when={shown()}>
-                                  <div data-slot="session-turn-diff-view" data-scrollable>
-                                    <Dynamic component={fileComponent} mode="diff" fileDiff={view.fileDiff} />
-                                  </div>
-                                </Show>
-                              </Accordion.Content>
-                            </Accordion.Item>
-                          )
-                        }}
-                      </For>
-                    </Accordion>
-                    <Show when={!showAll() && overflow() > 0}>
-                      <div data-slot="session-turn-diffs-more" onClick={toggleAll}>
-                        {i18n.t("ui.sessionTurn.diffs.more", { count: String(overflow()) })}
-                      </div>
-                    </Show>
+                                  </Accordion.Trigger>
+                                </StickyAccordionHeader>
+                                <Accordion.Content>
+                                  <Show when={shown()}>
+                                    <div data-slot="session-turn-diff-view" data-scrollable>
+                                      <Dynamic component={fileComponent} mode="diff" fileDiff={view.fileDiff} />
+                                    </div>
+                                  </Show>
+                                </Accordion.Content>
+                              </Accordion.Item>
+                            )
+                          }}
+                        </For>
+                      </Accordion>
+                      <Show when={!showAll() && overflow() > 0}>
+                        <div data-slot="session-turn-diffs-more" onClick={toggleAll}>
+                          {i18n.t("ui.sessionTurn.diffs.more", { count: String(overflow()) })}
+                        </div>
+                      </Show>
+                    </div>
                   </div>
-                </div>
-              </Show>
-              <Show when={error()}>
-                <Card variant="error" class="error-card">
-                  {errorText()}
-                </Card>
-              </Show>
-            </div>
+                </Show>
+                <Show when={error()}>
+                  <Card variant="error" class="error-card">
+                    {errorText()}
+                  </Card>
+                </Show>
+              </div>
+            )}
           </Show>
           {props.children}
         </div>


### PR DESCRIPTION
## Summary
- Adds a regression spec for the crash path where a brand new session sends its first prompt and receives its first reply.
- Fixes the render-layer lifecycle/nullability crashes in `message-part`, `session-turn`, `session-context-usage`, and `message-timeline`.
- Tightens the new E2E assertion so it matches the assistant reply inside `session-turn-assistant-content`, not the user prompt text.

## Why
A new session could crash as soon as the first reply rendered. This was fixed with TDD: the regression test was written first, then each production hunk was validated by reverting it against the same test. The remaining production changes are the minimal set that kept the regression green.

## Test plan
- [x] `bun x playwright test e2e/prompt/first-message-reply.spec.ts`
- [x] `bun x playwright test e2e/prompt/first-message-reply.spec.ts e2e/prompt/prompt.spec.ts e2e/prompt/prompt-history.spec.ts --grep "first replied message in a new session renders without page errors|can send a prompt and receive a reply|prompt history restores unsent draft with arrow navigation"`
- [x] Manual dev-mode verification on PawWork Dev: a new session can continue chatting after the first reply without crashing