### PR TITLE
feat(ci): add e2e artifacts workflow

### DIFF
--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -4,9 +4,18 @@ on:
   pull_request:
     branches: [dev]
   workflow_dispatch:
+    inputs:
+      suite:
+        description: E2E suite to run
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - smoke
 
 concurrency:
-  group: e2e-artifacts-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-artifacts-${{ github.event.pull_request.number || github.ref }}-${{ inputs.suite || 'pr-smoke' }}
   cancel-in-progress: true
 
 permissions:
@@ -54,8 +63,15 @@ jobs:
       - name: Run e2e
         env:
           CI: "true"
+          EVENT_NAME: ${{ github.event_name }}
+          E2E_SUITE: ${{ inputs.suite || '' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
-        run: bun --cwd packages/app test:e2e:local
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
+            bun --cwd packages/app test:e2e:local -- --grep @smoke
+          else
+            bun --cwd packages/app test:e2e:local
+          fi
 
       - name: Upload e2e artifacts
         if: always()

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -1,0 +1,70 @@
+name: e2e-artifacts
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-artifacts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+
+jobs:
+  e2e-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.playwright-browsers
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: packages/app
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run e2e
+        env:
+          CI: "true"
+          PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
+        run: bun --cwd packages/app test:e2e:local
+
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-linux-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            packages/app/e2e/junit-linux.xml
+            packages/app/e2e/playwright-report
+            packages/app/e2e/test-results

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { serverNamePattern } from "../utils"
+import { openStatusPopover } from "../actions"
 
 test("@smoke home renders and shows core entrypoints", async ({ page }) => {
   await page.goto("/")
@@ -8,15 +8,13 @@ test("@smoke home renders and shows core entrypoints", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
   await expect(nav.getByText("No projects open")).toBeVisible()
   await expect(nav.getByText("Open a project to get started")).toBeVisible()
-  await expect(page.getByRole("button", { name: serverNamePattern })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
 })
 
 test("@smoke server picker dialog opens from home", async ({ page }) => {
   await page.goto("/")
-
-  const trigger = page.getByRole("button", { name: serverNamePattern })
-  await expect(trigger).toBeVisible()
-  await trigger.click()
+  const { popoverBody } = await openStatusPopover(page)
+  await popoverBody.getByRole("button", { name: "Manage servers" }).click()
 
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures"
 import { serverNamePattern } from "../utils"
 
-test("home renders and shows core entrypoints", async ({ page }) => {
+test("@smoke home renders and shows core entrypoints", async ({ page }) => {
   await page.goto("/")
   const nav = page.locator('[data-component="sidebar-nav-desktop"]')
 
@@ -11,7 +11,7 @@ test("home renders and shows core entrypoints", async ({ page }) => {
   await expect(page.getByRole("button", { name: serverNamePattern })).toBeVisible()
 })
 
-test("server picker dialog opens from home", async ({ page }) => {
+test("@smoke server picker dialog opens from home", async ({ page }) => {
   await page.goto("/")
 
   const trigger = page.getByRole("button", { name: serverNamePattern })

--- a/packages/app/e2e/app/navigation.spec.ts
+++ b/packages/app/e2e/app/navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { dirPath } from "../utils"
 
-test("project route redirects to /session", async ({ page, directory, slug }) => {
+test("@smoke project route redirects to /session", async ({ page, directory, slug }) => {
   await page.goto(dirPath(directory))
 
   await expect(page).toHaveURL(new RegExp(`/${slug}/session`))

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -1,56 +1,58 @@
 import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
 
-test("@smoke file tree can expand folders and open a file", async ({ page, gotoSession }) => {
-  await gotoSession()
+test("@smoke file tree entrypoints can open the panel and a file", async ({ page, project }) => {
+  await project.open()
 
-  const toggle = page.getByRole("button", { name: "Toggle file tree" })
-  const panel = page.locator("#file-tree-panel")
-  const treeTabs = panel.locator('[data-component="tabs"][data-variant="pill"][data-scope="filetree"]')
+  await withSession(project.sdk, `e2e file tree smoke ${Date.now()}`, async (session) => {
+    await project.gotoSession(session.id)
 
-  await expect(toggle).toBeVisible()
-  if ((await toggle.getAttribute("aria-expanded")) !== "true") await toggle.click()
-  await expect(toggle).toHaveAttribute("aria-expanded", "true")
-  await expect(panel).toBeVisible()
-  await expect(treeTabs).toBeVisible()
+    const fileToggle = page.getByRole("button", { name: "Toggle file tree" })
+    const reviewToggle = page.getByRole("button", { name: "Toggle review" })
+    const reviewPanel = page.locator("#review-panel")
+    const panel = page.locator("#file-tree-panel")
+    const treeTabs = panel.locator('[data-component="tabs"][data-variant="pill"][data-scope="filetree"]')
 
-  const allTab = treeTabs.getByRole("tab", { name: /^all files$/i })
-  await expect(allTab).toBeVisible()
-  await allTab.click()
-  await expect(allTab).toHaveAttribute("aria-selected", "true")
+    await expect(fileToggle).toBeVisible()
+    if ((await fileToggle.getAttribute("aria-expanded")) !== "true") await fileToggle.click()
+    await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
+    await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+    await expect(reviewPanel).toBeVisible()
+    await expect(reviewPanel).toContainText("No files")
 
-  const tree = treeTabs.locator('[data-slot="tabs-content"]:not([hidden])')
-  await expect(tree).toBeVisible()
+    await expect(reviewToggle).toBeVisible()
+    await reviewToggle.click()
+    await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+    await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
+    await expect(panel).toBeVisible()
+    await expect(treeTabs).toBeVisible()
 
-  const expand = async (name: string) => {
-    const folder = tree.getByRole("button", { name, exact: true }).first()
-    await expect(folder).toBeVisible()
-    await expect(folder).toHaveAttribute("aria-expanded", /true|false/)
-    if ((await folder.getAttribute("aria-expanded")) === "false") await folder.click()
-    await expect(folder).toHaveAttribute("aria-expanded", "true")
-  }
+    const allTab = treeTabs.getByRole("tab", { name: /^all files$/i })
+    await expect(allTab).toBeVisible()
+    await allTab.click()
+    await expect(allTab).toHaveAttribute("aria-selected", "true")
 
-  await expand("packages")
-  await expand("app")
-  await expand("src")
-  await expand("components")
+    const tree = treeTabs.locator('[data-slot="tabs-content"]:not([hidden])')
+    await expect(tree).toBeVisible()
 
-  const file = tree.getByRole("button", { name: "file-tree.tsx", exact: true }).first()
-  await expect(file).toBeVisible()
-  await file.click()
+    const file = tree.getByRole("button", { name: "README.md", exact: true }).first()
+    await expect(file).toBeVisible()
+    await file.click()
 
-  const tab = page.getByRole("tab", { name: "file-tree.tsx" })
-  await expect(tab).toBeVisible()
-  await tab.click()
-  await expect(tab).toHaveAttribute("aria-selected", "true")
+    const tab = page.getByRole("tab", { name: "README.md" })
+    await expect(tab).toBeVisible()
+    await tab.click()
+    await expect(tab).toHaveAttribute("aria-selected", "true")
 
-  await toggle.click()
-  await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await reviewToggle.click()
+    await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
 
-  await toggle.click()
-  await expect(toggle).toHaveAttribute("aria-expanded", "true")
-  await expect(allTab).toHaveAttribute("aria-selected", "true")
+    await reviewToggle.click()
+    await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+    await expect(allTab).toHaveAttribute("aria-selected", "true")
 
-  const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
-  await expect(viewer).toBeVisible()
-  await expect(viewer).toContainText("export default function FileTree")
+    const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
+    await expect(viewer).toBeVisible()
+    await expect(viewer).toContainText("# e2e")
+  })
 })

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "../fixtures"
 
-test("file tree can expand folders and open a file", async ({ page, gotoSession }) => {
+test("@smoke file tree can expand folders and open a file", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const toggle = page.getByRole("button", { name: "Toggle file tree" })

--- a/packages/app/e2e/files/file-viewer.spec.ts
+++ b/packages/app/e2e/files/file-viewer.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { modKey } from "../utils"
 
-test("smoke file viewer renders real file content", async ({ page, gotoSession }) => {
+test("file viewer renders real file content", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.locator(promptSelector).click()

--- a/packages/app/e2e/models/model-picker.spec.ts
+++ b/packages/app/e2e/models/model-picker.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { clickListItem } from "../actions"
 
-test.fixme("smoke model selection updates prompt footer", async ({ page, gotoSession }) => {
+test.fixme("model selection updates prompt footer", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.locator(promptSelector).click()

--- a/packages/app/e2e/projects/projects-switch.spec.ts
+++ b/packages/app/e2e/projects/projects-switch.spec.ts
@@ -12,7 +12,7 @@ import {
 import { projectSwitchSelector, workspaceItemSelector, workspaceNewSessionSelector } from "../selectors"
 import { dirSlug, resolveDirectory } from "../utils"
 
-test("can switch between projects from sidebar", async ({ page, project }) => {
+test("@smoke can switch between projects from sidebar", async ({ page, project }) => {
   await page.setViewportSize({ width: 1400, height: 800 })
 
   const other = await createTestProject()

--- a/packages/app/e2e/prompt/first-message-reply.spec.ts
+++ b/packages/app/e2e/prompt/first-message-reply.spec.ts
@@ -14,7 +14,11 @@ const pageErrors = (page: Page) => {
   }
 }
 
-test("first replied message in a new session renders without page errors", async ({ page, project, assistant }) => {
+test("@smoke first replied message in a new session renders without page errors", async ({
+  page,
+  project,
+  assistant,
+}) => {
   test.setTimeout(120_000)
 
   const token = `FIRST_REPLY_${Date.now()}`

--- a/packages/app/e2e/prompt/prompt-mention.spec.ts
+++ b/packages/app/e2e/prompt/prompt-mention.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
-test("smoke @mention inserts file pill token", async ({ page, gotoSession }) => {
+test("@mention inserts file pill token", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.locator(promptSelector).click()

--- a/packages/app/e2e/prompt/prompt-slash-open.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-open.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
-test("smoke /open opens file picker dialog", async ({ page, gotoSession }) => {
+test("/open opens file picker dialog", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.locator(promptSelector).click()

--- a/packages/app/e2e/prompt/prompt.spec.ts
+++ b/packages/app/e2e/prompt/prompt.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures"
 import { assistantText } from "../actions"
 
-test("can send a prompt and receive a reply", async ({ page, project, assistant }) => {
+test("@smoke can send a prompt and receive a reply", async ({ page, project, assistant }) => {
   test.setTimeout(120_000)
 
   const pageErrors: string[] = []

--- a/packages/app/e2e/settings/settings.spec.ts
+++ b/packages/app/e2e/settings/settings.spec.ts
@@ -16,7 +16,7 @@ import {
   settingsUpdatesStartupSelector,
 } from "../selectors"
 
-test("new installs start with the PawWork theme", async ({ page, gotoSession }) => {
+test("@smoke new installs start with the PawWork theme", async ({ page, gotoSession }) => {
   await page.addInitScript(() => {
     localStorage.removeItem("opencode-theme-id")
     localStorage.removeItem("opencode-color-scheme")
@@ -28,7 +28,7 @@ test("new installs start with the PawWork theme", async ({ page, gotoSession }) 
   await expect(page.locator("html")).toHaveAttribute("data-color-scheme", "light")
 })
 
-test("smoke settings dialog opens, switches tabs, closes", async ({ page, gotoSession }) => {
+test("@smoke settings dialog opens, switches tabs, closes", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const dialog = await openSettings(page)

--- a/packages/app/e2e/sidebar/sidebar.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures"
 import { openSidebar, toggleSidebar, withSession } from "../actions"
 
-test("sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
+test("@smoke sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await openSidebar(page)

--- a/packages/app/e2e/terminal/terminal-init.spec.ts
+++ b/packages/app/e2e/terminal/terminal-init.spec.ts
@@ -3,7 +3,7 @@ import { waitTerminalFocusIdle, waitTerminalReady } from "../actions"
 import { promptSelector, terminalSelector } from "../selectors"
 import { terminalToggleKey } from "../utils"
 
-test("smoke terminal mounts and can create a second tab", async ({ page, gotoSession }) => {
+test("@smoke terminal mounts and can create a second tab", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const terminals = page.locator(terminalSelector)

--- a/packages/app/e2e/thinking-level.spec.ts
+++ b/packages/app/e2e/thinking-level.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./fixtures"
 import { modelVariantCycleSelector } from "./selectors"
 
-test("smoke model variant cycle updates label", async ({ page, gotoSession }) => {
+test("model variant cycle updates label", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.addStyleTag({

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,9 @@
     "test:unit": "bun test --preload ./happydom.ts ./src",
     "test:unit:watch": "bun test --watch --preload ./happydom.ts ./src",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:local": "bun script/e2e-local.ts",
+    "test:e2e:local:smoke": "bun script/e2e-local.ts -- --grep @smoke",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e/playwright-report"
   },

--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -15,7 +15,6 @@ const seed = async () => {
   const { MessageID, PartID } = await import("../src/session/schema")
   const { Project } = await import("../src/project/project")
   const { ModelID, ProviderID } = await import("../src/provider/schema")
-  const { ToolRegistry } = await import("../src/tool/registry")
 
   try {
     await Instance.provide({
@@ -23,7 +22,6 @@ const seed = async () => {
       init: InstanceBootstrap,
       fn: async () => {
         await Config.waitForDependencies()
-        await ToolRegistry.ids()
 
         const session = await Session.create({ title })
         const messageID = MessageID.ascending()

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+const workflowPath = path.resolve(import.meta.dir, "../../../../.github/workflows/e2e-artifacts.yml")
+
+async function readWorkflow() {
+  return await fs.readFile(workflowPath, "utf8")
+}
+
+describe("e2e artifacts workflow", () => {
+  test("exists as a dedicated non-blocking PR diagnostics workflow", async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toContain("name: e2e-artifacts")
+    expect(workflow).toContain("pull_request:")
+    expect(workflow).toContain("branches: [dev]")
+    expect(workflow).toContain("workflow_dispatch:")
+    expect(workflow).toContain("permissions:")
+    expect(workflow).toContain("contents: read")
+    expect(workflow).not.toContain("pull_request_target:")
+    expect(workflow).not.toContain("/Users/yuhan/")
+    expect(workflow).toContain("runs-on: ubuntu-latest")
+    expect(workflow).toContain("continue-on-error: true")
+    expect(workflow).toContain("persist-credentials: false")
+    expect(workflow).toContain("bun install --frozen-lockfile")
+    expect(workflow).toContain("bunx playwright install --with-deps chromium")
+    expect(workflow).toContain("bun --cwd packages/app test:e2e:local")
+    expect(workflow).toContain("if: always()")
+    expect(workflow).toContain("actions/upload-artifact@v4")
+    expect(workflow).toContain("retention-days: 7")
+    expect(workflow).toContain("packages/app/e2e/playwright-report")
+    expect(workflow).toContain("packages/app/e2e/test-results")
+    expect(workflow).toContain("packages/app/e2e/junit-linux.xml")
+  })
+})

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -8,6 +8,9 @@ async function readWorkflow() {
   return await fs.readFile(workflowPath, "utf8")
 }
 
+const runBlockPattern =
+  /run: \|\n\s+if \[ "\$EVENT_NAME" = "pull_request" \] \|\| \[ "\$E2E_SUITE" = "smoke" \]; then\n\s+bun --cwd packages\/app test:e2e:local -- --grep @smoke\n\s+else\n\s+bun --cwd packages\/app test:e2e:local\n\s+fi/
+
 describe("e2e artifacts workflow", () => {
   test("exists as a dedicated non-blocking PR diagnostics workflow", async () => {
     const workflow = await readWorkflow()
@@ -16,6 +19,13 @@ describe("e2e artifacts workflow", () => {
     expect(workflow).toContain("pull_request:")
     expect(workflow).toContain("branches: [dev]")
     expect(workflow).toContain("workflow_dispatch:")
+    expect(workflow).toContain("suite:")
+    expect(workflow).toContain("default: full")
+    expect(workflow).toContain("- smoke")
+    expect(workflow).toContain("- full")
+    expect(workflow).toContain(
+      "group: e2e-artifacts-${{ github.event.pull_request.number || github.ref }}-${{ inputs.suite || 'pr-smoke' }}",
+    )
     expect(workflow).toContain("permissions:")
     expect(workflow).toContain("contents: read")
     expect(workflow).not.toContain("pull_request_target:")
@@ -25,7 +35,7 @@ describe("e2e artifacts workflow", () => {
     expect(workflow).toContain("persist-credentials: false")
     expect(workflow).toContain("bun install --frozen-lockfile")
     expect(workflow).toContain("bunx playwright install --with-deps chromium")
-    expect(workflow).toContain("bun --cwd packages/app test:e2e:local")
+    expect(workflow).toMatch(runBlockPattern)
     expect(workflow).toContain("if: always()")
     expect(workflow).toContain("actions/upload-artifact@v4")
     expect(workflow).toContain("retention-days: 7")

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+const repoRoot = path.resolve(import.meta.dir, "../../../../")
+const expectedSmokeTests = [
+  "packages/app/e2e/app/home.spec.ts:@smoke home renders and shows core entrypoints",
+  "packages/app/e2e/app/home.spec.ts:@smoke server picker dialog opens from home",
+  "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
+  "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree can expand folders and open a file",
+  "packages/app/e2e/projects/projects-switch.spec.ts:@smoke can switch between projects from sidebar",
+  "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",
+  "packages/app/e2e/prompt/prompt.spec.ts:@smoke can send a prompt and receive a reply",
+  "packages/app/e2e/settings/settings.spec.ts:@smoke new installs start with the PawWork theme",
+  "packages/app/e2e/settings/settings.spec.ts:@smoke settings dialog opens, switches tabs, closes",
+  "packages/app/e2e/sidebar/sidebar.spec.ts:@smoke sidebar can be collapsed and expanded",
+  "packages/app/e2e/terminal/terminal-init.spec.ts:@smoke terminal mounts and can create a second tab",
+]
+
+describe("e2e smoke tagging", () => {
+  test("uses the expected @smoke inventory without legacy smoke titles", async () => {
+    const legacy: string[] = []
+    const tagged: string[] = []
+
+    for await (const file of new Bun.Glob("packages/app/e2e/**/*.spec.ts").scan({
+      cwd: repoRoot,
+      absolute: true,
+    })) {
+      const text = await fs.readFile(file, "utf8")
+      const relative = path.relative(repoRoot, file)
+
+      for (const match of text.matchAll(/test(?:\.fixme)?\(\s*["']smoke\b/g)) {
+        legacy.push(`${relative}:${match.index ?? 0}`)
+      }
+
+      for (const match of text.matchAll(/test(?:\.fixme)?\(\s*["']([^"']+)["']/g)) {
+        const title = match[1]
+        if (!title?.startsWith("@smoke ")) continue
+        tagged.push(`${relative}:${title}`)
+      }
+    }
+
+    expect(legacy).toEqual([])
+    expect(tagged.toSorted()).toEqual(expectedSmokeTests)
+  })
+})

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -7,7 +7,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke home renders and shows core entrypoints",
   "packages/app/e2e/app/home.spec.ts:@smoke server picker dialog opens from home",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
-  "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree can expand folders and open a file",
+  "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree entrypoints can open the panel and a file",
   "packages/app/e2e/projects/projects-switch.spec.ts:@smoke can switch between projects from sidebar",
   "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",
   "packages/app/e2e/prompt/prompt.spec.ts:@smoke can send a prompt and receive a reply",

--- a/packages/opencode/test/config/seed-e2e.test.ts
+++ b/packages/opencode/test/config/seed-e2e.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { Process } from "../../src/util/process"
+
+const packageRoot = path.resolve(import.meta.dir, "../..")
+const repoRoot = path.resolve(import.meta.dir, "../../../../")
+
+async function mkdir(name: string) {
+  return await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`))
+}
+
+describe("seed e2e script", () => {
+  test("exits cleanly after creating the seeded session", async () => {
+    const [home, data, cache, config, state] = await Promise.all([
+      mkdir("opencode-seed-home"),
+      mkdir("opencode-seed-data"),
+      mkdir("opencode-seed-cache"),
+      mkdir("opencode-seed-config"),
+      mkdir("opencode-seed-state"),
+    ])
+
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), 5_000)
+
+    try {
+      const out = await Process.run(["bun", "script/seed-e2e.ts"], {
+        cwd: packageRoot,
+        abort: abort.signal,
+        timeout: 100,
+        nothrow: true,
+        env: {
+          OPENCODE_CLIENT: "app",
+          OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+          OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
+          OPENCODE_DISABLE_SHARE: "true",
+          OPENCODE_E2E_PROJECT_DIR: repoRoot,
+          OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+          OPENCODE_STRICT_CONFIG_DEPS: "true",
+          OPENCODE_TEST_HOME: home,
+          XDG_CACHE_HOME: cache,
+          XDG_CONFIG_HOME: config,
+          XDG_DATA_HOME: data,
+          XDG_STATE_HOME: state,
+        },
+      })
+
+      expect(out.code).toBe(0)
+    } finally {
+      clearTimeout(timer)
+      await Promise.allSettled(
+        [home, data, cache, config, state].map((dir) => fs.rm(dir, { recursive: true, force: true })),
+      )
+    }
+  }, 15_000)
+})


### PR DESCRIPTION
## Summary
- Adds a dedicated `e2e-artifacts.yml` workflow instead of extending the main `ci.yml` gate.
- Runs Linux Playwright E2E in a non-blocking job, always uploading `playwright-report`, `test-results`, and `junit-linux.xml` for debugging.
- Splits the suite into `@smoke` and `full`: PRs run smoke automatically, `workflow_dispatch` can run either suite and defaults to `full`.
- Keeps the first rollout fork-safe with `pull_request`, `contents: read`, and `persist-credentials: false`.
- Adds contract tests for workflow shape, smoke inventory, and the `seed-e2e.ts` exit behavior.

## Why
The goal of this first workflow is better failure diagnosis, not stronger merge gating. Keeping it separate from `ci.yml` lets us preserve failure artifacts without changing required checks, adding release logic, or broadening permissions.

## Notes
- `continue-on-error: true` is intentional for the first rollout. The workflow is non-blocking by design, while still surfacing failing job status and retaining artifacts.
- `packages/opencode/script/seed-e2e.ts` no longer calls `ToolRegistry.ids()`. That warmup call was causing the seed script to hang after seeding. The new `seed-e2e.test.ts` locks in the expected contract that the script exits cleanly after creating the seeded session.

## Test plan
- [x] `bun test --preload ./test/preload.ts ./test/config/e2e-artifacts-workflow.test.ts ./test/config/e2e-smoke-tagging.test.ts ./test/config/seed-e2e.test.ts`
- [x] `bun --cwd packages/app test:e2e:local:smoke -- --project=chromium`
- [x] `git diff --check`
- [x] Fresh-eyes review on the final diff, no remaining findings
- [x] First real GitHub Actions run on this PR uploads `playwright-report`, `test-results`, and `junit-linux.xml`
