### PR TITLE
docs: add contributing and github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report something that is broken or behaving incorrectly
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please keep the report concrete. Screenshots or screen recordings are very helpful for desktop issues.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the actual problem in one or two short paragraphs.
+      placeholder: When I tried to export a PDF, the app got stuck on loading and never finished.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the shortest path to reproduce the issue.
+      placeholder: |
+        1. Open PawWork
+        2. Click ...
+        3. Import ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: The file should export successfully.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: PawWork version
+      description: "Example: v0.2.2"
+      placeholder: v0.2.2
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS version
+      description: "Example: macOS 15.4.1"
+      placeholder: macOS ...
+    validations:
+      required: true
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Can you reproduce it again?
+      options:
+        - Yes, every time
+        - Sometimes
+        - Only once so far
+    validations:
+      required: true
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots, recordings, or extra context
+      description: Drag files into the issue, or paste any extra details here.
+      placeholder: Attach screenshots, recordings, logs, or sample files if helpful.

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a workflow improvement or new capability
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+
+        PawWork is built for non-technical knowledge workers, so the most useful requests describe the real task and why the current workflow is not enough.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What task are you trying to do?
+      description: Describe the real workflow or job to be done.
+      placeholder: I want to summarize a spreadsheet and turn it into a shareable report without leaving the app.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: What do you do today?
+      description: Explain the current workaround or why the current flow is painful.
+      placeholder: Today I export the file, switch to another tool, then copy the result back manually.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What would a good result look like?
+      description: Describe the outcome you want, not only the implementation you have in mind.
+      placeholder: I can open a file, ask for a summary, and get a clean report in one place.
+    validations:
+      required: true
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Which audience does this matter to most?
+      options:
+        - Chinese market users
+        - Global users
+        - Both
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context
+      description: Add screenshots, references, or examples if useful.
+      placeholder: Similar workflows, screenshots, or example files.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe what changed.
+
+## Why
+
+Explain the problem, goal, or context for this pull request.
+
+## Related Issue
+
+Link the issue if there is one.
+
+## How To Verify
+
+List the commands you ran and any manual checks you performed.
+
+```bash
+bun turbo typecheck
+bun turbo test:ci
+```
+
+## Screenshots or Recordings
+
+Required for visible UI changes.
+
+## Checklist
+
+- [ ] I ran the relevant verification steps
+- [ ] I tested visible changes manually when needed
+- [ ] I am targeting the `dev` branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to PawWork
+
+Thanks for contributing to PawWork.
+
+PawWork is a desktop AI workstation for non-technical knowledge workers. When making changes, optimize for clarity, reversibility, and out-of-the-box usability.
+
+## Before You Start
+
+- Read [README.md](README.md) for local setup.
+- Check existing issues and pull requests before starting work.
+- Read recent pull requests to understand current conventions and priorities.
+
+## What We Welcome
+
+- Bug fixes
+- Small UX improvements
+- Documentation improvements
+- New ideas that fit the product direction
+
+Please open an issue first for larger feature proposals or changes that affect product scope.
+
+## Ground Rules
+
+- Keep changes focused. Do not bundle unrelated work.
+- Prefer the smallest change that solves the problem well.
+- Preserve the product's bilingual direction.
+- Optimize for non-technical users, not developer convenience alone.
+- Do not rewrite broad areas of the fork without prior discussion.
+
+## Development Setup
+
+PawWork uses Bun and requires Node 24 in CI.
+
+```bash
+bun install --frozen-lockfile
+```
+
+For local development:
+
+```bash
+cd packages/desktop-electron
+bun run dev
+```
+
+## Branches and Commits
+
+- Open pull requests against `dev`
+- Use small, reversible commits
+- Use Conventional Commits in English, such as `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
+
+## Verification
+
+Run the checks relevant to your change before opening a pull request:
+
+```bash
+bun turbo typecheck
+bun turbo test:ci
+```
+
+If your change affects the desktop app or UI, also do a quick manual check in the app and include screenshots or a short recording in the pull request.
+
+## Pull Requests
+
+- Explain what changed and why
+- Link the related issue when there is one
+- Keep the pull request small enough to review comfortably
+- Include verification steps
+- Include screenshots for visible UI changes
+
+## Reporting Bugs and Requesting Features
+
+- Use the bug report form for broken behavior
+- Use the feature request form for new capabilities or workflow improvements
+- You may write in English or Chinese
+
+## Questions
+
+If you are unsure whether something fits the roadmap, open an issue before investing in implementation.


### PR DESCRIPTION
## Summary

Add the initial GitHub community contribution flow:
- root `CONTRIBUTING.md`
- issue forms for bug reports and feature requests
- issue template `config.yml`
- PR template

## Why

The repo was missing the basic community contribution files that GitHub surfaces for public projects. This adds a minimal setup that matches PawWork's current stage and keeps the forms lightweight.

## How to verify

```bash
git diff --check
ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
```

## Notes

- Targets `dev`
- Uses existing labels: `bug`, `enhancement`
- Keeps blank issues enabled for now because the project is early and Discussions is not enabled
- Fresh-eyes review found one broken-link issue in `CONTRIBUTING.md`; that was fixed before opening this PR
