### PR TITLE
fix: tighten desktop shell frame contracts

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -3,11 +3,12 @@ import { openStatusPopover } from "../actions"
 
 test("@smoke home renders and shows core entrypoints", async ({ page }) => {
   await page.goto("/")
-  const nav = page.locator('[data-component="sidebar-nav-desktop"]')
 
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
-  await expect(nav.getByText("No projects open")).toBeVisible()
-  await expect(nav.getByText("Open a project to get started")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
   await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
 })
 

--- a/packages/app/e2e/app/shell-frame.spec.ts
+++ b/packages/app/e2e/app/shell-frame.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "../fixtures"
+import { closeDialog, openPalette, openSettings } from "../actions"
+import {
+  desktopShellFrameSelector,
+  desktopShellMainSelector,
+  desktopShellSelector,
+  titlebarCenterSelector,
+  titlebarLeftSelector,
+  titlebarRightSelector,
+  titlebarShellSelector,
+} from "../selectors"
+
+test("@smoke shell frame exposes stable desktop hooks", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await gotoSession()
+
+  await expect(page.locator(desktopShellSelector)).toBeVisible()
+  await expect(page.locator(desktopShellFrameSelector)).toBeVisible()
+  await expect(page.locator(titlebarShellSelector)).toBeVisible()
+  await expect(page.locator(desktopShellMainSelector)).toBeVisible()
+  await expect(page.locator(titlebarLeftSelector)).toHaveCount(1)
+  await expect(page.locator(`${titlebarCenterSelector} button`).first()).toBeVisible()
+  await expect(page.locator(`${titlebarRightSelector} button`).first()).toBeVisible()
+  await expect(page.getByRole("button", { name: /toggle sidebar/i }).first()).toBeVisible()
+  await expect(page.getByRole("button", { name: /navigate back/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /navigate forward/i })).toBeVisible()
+
+  const settings = await openSettings(page)
+  await expect(settings.getByRole("heading", { level: 2 })).toBeVisible()
+  await closeDialog(page, settings)
+
+  const palette = await openPalette(page)
+  await closeDialog(page, palette)
+})

--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -23,6 +23,12 @@ export const settingsSoundsPermissionsSelector = '[data-action="settings-sounds-
 export const settingsSoundsErrorsSelector = '[data-action="settings-sounds-errors"]'
 export const settingsUpdatesStartupSelector = '[data-action="settings-updates-startup"]'
 export const settingsReleaseNotesSelector = '[data-action="settings-release-notes"]'
+export const desktopShellSelector = '[data-component="desktop-shell"]'
+export const desktopShellFrameSelector = '[data-component="desktop-shell-frame"]'
+export const desktopShellMainSelector = '[data-component="desktop-shell-main"]'
+export const titlebarShellSelector = '[data-component="titlebar-shell"]'
+export const titlebarLeftSelector = "#opencode-titlebar-left"
+export const titlebarCenterSelector = "#opencode-titlebar-center"
 
 const sidebarNavSelector = '[data-component="sidebar-nav-desktop"]'
 
@@ -38,6 +44,7 @@ export const projectWorkspacesToggleSelector = (slug: string) =>
   `[data-action="project-workspaces-toggle"][data-project="${slug}"]`
 
 export const titlebarRightSelector = "#opencode-titlebar-right"
+export const sidebarNavMobileSelector = '[data-component="sidebar-nav-mobile"]'
 
 export const popoverBodySelector = '[data-slot="popover-body"]'
 

--- a/packages/app/e2e/sidebar/sidebar.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures"
 import { openSidebar, toggleSidebar, withSession } from "../actions"
+import { sidebarNavMobileSelector, titlebarShellSelector } from "../selectors"
 
 test("@smoke sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -37,4 +38,21 @@ test("sidebar collapsed state persists across navigation and reload", async ({ p
       await expect(opened).toBe(false)
     })
   })
+})
+
+test("narrow desktop sidebar starts below the shell titlebar", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 1180, height: 900 })
+  await gotoSession()
+
+  const menuButton = page.getByRole("button", { name: /toggle menu/i }).first()
+  await expect(menuButton).toBeVisible()
+  await menuButton.click()
+  await expect(menuButton).toHaveAttribute("aria-expanded", "true")
+
+  const titlebar = await page.locator(titlebarShellSelector).boundingBox()
+  const mobileSidebar = await page.locator(sidebarNavMobileSelector).boundingBox()
+
+  expect(titlebar).not.toBeNull()
+  expect(mobileSidebar).not.toBeNull()
+  expect(Math.round(mobileSidebar!.y)).toBeGreaterThanOrEqual(Math.round(titlebar!.height) - 1)
 })

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -49,7 +49,8 @@ export function Titlebar() {
   const windows = createMemo(() => platform.platform === "desktop" && platform.os === "windows")
   const web = createMemo(() => platform.platform === "web")
   const zoom = () => platform.webviewZoom?.() ?? 1
-  const minHeight = () => (mac() ? `${40 / zoom()}px` : undefined)
+  const currentTitlebarHeight = () =>
+    mac() ? "var(--shell-titlebar-current-height, var(--shell-titlebar-height, 40px))" : undefined
 
   const [history, setHistory] = createStore({
     stack: [] as string[],
@@ -162,8 +163,12 @@ export function Titlebar() {
 
   return (
     <header
-      class="h-10 shrink-0 bg-background-base relative grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center"
-      style={{ "min-height": minHeight() }}
+      data-component="titlebar-shell"
+      data-platform={platform.platform}
+      data-os={platform.os}
+      class="shrink-0 bg-background-base relative grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center"
+      classList={{ "h-10": !mac() }}
+      style={{ height: currentTitlebarHeight(), "min-height": currentTitlebarHeight() }}
       data-tauri-drag-region
       onMouseDown={drag}
       onDblClick={maximize}
@@ -286,7 +291,7 @@ export function Titlebar() {
             </Show>
           </div>
         </div>
-        <div id="opencode-titlebar-left" class="flex items-center gap-3 min-w-0 px-2" />
+        <div id="opencode-titlebar-left" data-shell-slot="left-portal" class="flex items-center gap-3 min-w-0 px-2" />
       </div>
 
       <div class="min-w-0 flex items-center justify-center pointer-events-none">
@@ -301,7 +306,11 @@ export function Titlebar() {
         data-tauri-drag-region
         onMouseDown={drag}
       >
-        <div id="opencode-titlebar-right" class="flex items-center gap-1 shrink-0 justify-end" />
+        <div
+          id="opencode-titlebar-right"
+          data-shell-slot="right-portal"
+          class="flex items-center gap-1 shrink-0 justify-end"
+        />
         <Show when={windows()}>
           {!tauriApi() && <div class="w-36 shrink-0" />}
           <div data-tauri-decorum-tb class="flex flex-row" />

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -66,4 +66,90 @@
       width: auto;
     }
   }
+
+  [data-component="desktop-shell"][data-platform="desktop"] {
+    --shell-titlebar-height: 40px;
+    --shell-frame-margin: 12px;
+    --shell-frame-radius: 18px;
+    --shell-background-base: #F4EFE9;
+    --shell-background-weak: #EEE6DE;
+    --shell-surface-base: #FBF8F4;
+    --shell-surface-raised: #F7F1EA;
+    --shell-surface-strong: #FEFBF8;
+    --shell-border-base: #D8CFC6;
+    --shell-border-weak: #E7DED6;
+    --shell-frame-border: color-mix(in srgb, var(--shell-border-base) 78%, #c4b5a8 22%);
+    --shell-frame-shadow:
+      0 24px 64px -36px rgb(33 26 22 / 0.34),
+      0 10px 28px -20px rgb(33 26 22 / 0.2);
+    --shell-frame-surface: linear-gradient(180deg, var(--shell-surface-strong) 0%, var(--shell-surface-base) 100%);
+    --shell-titlebar-border: color-mix(in srgb, var(--shell-border-weak) 72%, var(--shell-border-base) 28%);
+    background:
+      radial-gradient(circle at top, rgb(255 255 255 / 0.72), transparent 52%),
+      linear-gradient(180deg, var(--shell-background-base), var(--shell-background-weak));
+  }
+
+  [data-component="desktop-shell"][data-platform="desktop"][data-os="macos"] {
+    --shell-titlebar-height: 48px;
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"] {
+    padding-inline: 8px;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--shell-surface-raised) 84%, white 16%) 0%,
+      var(--shell-surface-raised) 100%
+    );
+    border-bottom: 1px solid var(--shell-titlebar-border);
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"] [data-shell-slot="left-portal"] {
+    padding-inline: 12px;
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"] {
+    border-radius: 10px;
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"]:hover:not(:disabled) {
+    background-color: color-mix(in srgb, var(--shell-surface-strong) 90%, var(--shell-background-base) 10%);
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-expanded="true"],
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-current="page"] {
+    background-color: color-mix(in srgb, var(--shell-surface-strong) 82%, var(--shell-background-base) 18%);
+  }
+
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-expanded="true"]
+    [data-slot="icon-svg"],
+  [data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-current="page"]
+    [data-slot="icon-svg"] {
+    color: var(--color-text-strong);
+  }
+
+  [data-component="desktop-shell-main"][data-platform="desktop"][data-os="macos"] {
+    border-top-width: 0;
+  }
+
+  @media (min-width: 1280px) {
+    [data-component="desktop-shell-frame"][data-platform="desktop"] {
+      margin: var(--shell-frame-margin);
+      border: 1px solid var(--shell-frame-border);
+      border-radius: var(--shell-frame-radius);
+      background: var(--shell-frame-surface);
+      box-shadow: var(--shell-frame-shadow);
+      overflow: hidden;
+    }
+
+    [data-component="desktop-shell-main"][data-platform="desktop"] {
+      background: color-mix(in srgb, var(--shell-background-base) 92%, white 8%);
+    }
+
+  }
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2364,150 +2364,173 @@ export default function Layout(props: ParentProps) {
   )
 
   return (
-    <div class="relative bg-background-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text">
-      <Titlebar />
-      <div class="flex-1 min-h-0 min-w-0 flex">
-        <div class="flex-1 min-h-0 relative">
-          <div class="size-full relative overflow-x-hidden">
-            <nav
-              aria-label={language.t("sidebar.nav.projectsAndSessions")}
-              data-component="sidebar-nav-desktop"
-              classList={{
-                "hidden xl:block": true,
-                "absolute inset-y-0 left-0": true,
-                "z-10": true,
-              }}
-              style={{ width: `${side()}px` }}
-              ref={(el) => {
-                setState("nav", el)
-              }}
-              onMouseEnter={() => {
-                disarm()
-              }}
-              onMouseLeave={() => {
-                aim.reset()
-                if (!sidebarHovering()) return
-
-                arm()
-              }}
-            >
-              <div class="@container w-full h-full contain-strict">{sidebarContent()}</div>
-            </nav>
-
-            <Show when={layout.sidebar.opened()}>
-              <div
-                class="hidden xl:block absolute inset-y-0 z-30 w-0 overflow-visible"
-                style={{ left: `${side()}px` }}
-                onPointerDown={() => setState("sizing", true)}
-              >
-                <ResizeHandle
-                  direction="horizontal"
-                  size={layout.sidebar.width()}
-                  min={244}
-                  max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}
-                  onResize={(w) => {
-                    setState("sizing", true)
-                    if (sizet !== undefined) clearTimeout(sizet)
-                    sizet = window.setTimeout(() => setState("sizing", false), 120)
-                    layout.sidebar.resize(w)
-                  }}
-                />
-              </div>
-            </Show>
-
-            <div
-              class="hidden xl:block pointer-events-none absolute top-0 right-0 z-0 border-t border-border-weaker-base"
-              style={{ left: "calc(4rem + 12px)" }}
-            />
-
-            <div class="xl:hidden">
-              <div
-                classList={{
-                  "fixed inset-x-0 top-10 bottom-0 z-40 transition-opacity duration-200": true,
-                  "opacity-100 pointer-events-auto": layout.mobileSidebar.opened(),
-                  "opacity-0 pointer-events-none": !layout.mobileSidebar.opened(),
-                }}
-                onClick={(e) => {
-                  if (e.target === e.currentTarget) layout.mobileSidebar.hide()
-                }}
-              />
+    <div
+      data-component="desktop-shell"
+      data-platform={platform.platform}
+      data-os={platform.os}
+      class="relative bg-background-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
+      style={{
+        "--shell-titlebar-current-height":
+          platform.platform === "desktop" && platform.os === "macos"
+            ? `calc(var(--shell-titlebar-height, 40px) / ${platform.webviewZoom?.() ?? 1})`
+            : "var(--shell-titlebar-height, 40px)",
+      }}
+    >
+      <div
+        data-component="desktop-shell-frame"
+        data-platform={platform.platform}
+        data-os={platform.os}
+        class="flex flex-1 min-h-0 min-w-0 flex-col"
+      >
+        <Titlebar />
+        <div class="flex-1 min-h-0 min-w-0 flex">
+          <div class="flex-1 min-h-0 relative">
+            <div class="size-full relative overflow-x-hidden">
               <nav
                 aria-label={language.t("sidebar.nav.projectsAndSessions")}
-                data-component="sidebar-nav-mobile"
+                data-component="sidebar-nav-desktop"
                 classList={{
-                  "@container fixed top-10 bottom-0 left-0 z-50 w-full max-w-[400px] overflow-hidden border-r border-border-weaker-base bg-background-base transition-transform duration-200 ease-out": true,
-                  "translate-x-0": layout.mobileSidebar.opened(),
-                  "-translate-x-full": !layout.mobileSidebar.opened(),
+                  "hidden xl:block": true,
+                  "absolute inset-y-0 left-0": true,
+                  "z-10": true,
                 }}
-                onClick={(e) => e.stopPropagation()}
+                style={{ width: `${side()}px` }}
+                ref={(el) => {
+                  setState("nav", el)
+                }}
+                onMouseEnter={() => {
+                  disarm()
+                }}
+                onMouseLeave={() => {
+                  aim.reset()
+                  if (!sidebarHovering()) return
+
+                  arm()
+                }}
               >
-                {sidebarContent(true)}
+                <div class="@container w-full h-full contain-strict">{sidebarContent()}</div>
               </nav>
-            </div>
 
-            <div
-              classList={{
-                "absolute inset-0": true,
-                "xl:inset-y-0 xl:right-0 xl:left-[var(--main-left)]": true,
-                "z-20": true,
-                "transition-[left] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[left] motion-reduce:transition-none":
-                  !state.sizing,
-              }}
-              style={{
-                "--main-left": layout.sidebar.opened() ? `${side()}px` : "4rem",
-              }}
-            >
-              <main
+              <Show when={layout.sidebar.opened()}>
+                <div
+                  class="hidden xl:block absolute inset-y-0 z-30 w-0 overflow-visible"
+                  style={{ left: `${side()}px` }}
+                  onPointerDown={() => setState("sizing", true)}
+                >
+                  <ResizeHandle
+                    direction="horizontal"
+                    size={layout.sidebar.width()}
+                    min={244}
+                    max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}
+                    onResize={(w) => {
+                      setState("sizing", true)
+                      if (sizet !== undefined) clearTimeout(sizet)
+                      sizet = window.setTimeout(() => setState("sizing", false), 120)
+                      layout.sidebar.resize(w)
+                    }}
+                  />
+                </div>
+              </Show>
+
+              <div
+                class="hidden xl:block pointer-events-none absolute top-0 right-0 z-0 border-t border-border-weaker-base"
+                style={{ left: "calc(4rem + 12px)" }}
+              />
+
+              <div class="xl:hidden">
+                <div
+                  classList={{
+                    "fixed inset-x-0 bottom-0 z-40 transition-opacity duration-200": true,
+                    "opacity-100 pointer-events-auto": layout.mobileSidebar.opened(),
+                    "opacity-0 pointer-events-none": !layout.mobileSidebar.opened(),
+                  }}
+                  style={{ top: "var(--shell-titlebar-current-height, var(--shell-titlebar-height, 2.5rem))" }}
+                  onClick={(e) => {
+                    if (e.target === e.currentTarget) layout.mobileSidebar.hide()
+                  }}
+                />
+                <nav
+                  aria-label={language.t("sidebar.nav.projectsAndSessions")}
+                  data-component="sidebar-nav-mobile"
+                  classList={{
+                    "@container fixed bottom-0 left-0 z-50 w-full max-w-[400px] overflow-hidden border-r border-border-weaker-base bg-background-base transition-transform duration-200 ease-out": true,
+                    "translate-x-0": layout.mobileSidebar.opened(),
+                    "-translate-x-full": !layout.mobileSidebar.opened(),
+                  }}
+                  style={{ top: "var(--shell-titlebar-current-height, var(--shell-titlebar-height, 2.5rem))" }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {sidebarContent(true)}
+                </nav>
+              </div>
+
+              <div
                 classList={{
-                  "size-full overflow-x-hidden flex flex-col items-start contain-strict border-t border-border-weak-base bg-background-base xl:border-l xl:rounded-tl-[12px]": true,
+                  "absolute inset-0": true,
+                  "xl:inset-y-0 xl:right-0 xl:left-[var(--main-left)]": true,
+                  "z-20": true,
+                  "transition-[left] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[left] motion-reduce:transition-none":
+                    !state.sizing,
+                }}
+                style={{
+                  "--main-left": layout.sidebar.opened() ? `${side()}px` : "4rem",
                 }}
               >
-                <Show when={!autoselecting.loading} fallback={<div class="size-full" />}>
-                  {props.children}
+                <main
+                  data-component="desktop-shell-main"
+                  data-platform={platform.platform}
+                  data-os={platform.os}
+                  classList={{
+                    "size-full overflow-x-hidden flex flex-col items-start contain-strict border-t border-border-weak-base bg-background-base xl:border-l xl:rounded-tl-[12px]": true,
+                  }}
+                >
+                  <Show when={!autoselecting.loading} fallback={<div class="size-full" />}>
+                    {props.children}
+                  </Show>
+                </main>
+              </div>
+
+              <div
+                classList={{
+                  "hidden xl:flex absolute inset-y-0 left-16 z-30": true,
+                  "opacity-100 translate-x-0 pointer-events-auto": state.peeked && !layout.sidebar.opened(),
+                  "opacity-0 -translate-x-2 pointer-events-none": !state.peeked || layout.sidebar.opened(),
+                  "transition-[opacity,transform] motion-reduce:transition-none": true,
+                  "duration-180 ease-out": state.peeked && !layout.sidebar.opened(),
+                  "duration-120 ease-in": !state.peeked || layout.sidebar.opened(),
+                }}
+                onMouseMove={disarm}
+                onMouseEnter={() => {
+                  disarm()
+                  aim.reset()
+                }}
+                onPointerDown={disarm}
+                onMouseLeave={() => {
+                  arm()
+                }}
+              >
+                <Show when={peekProject()}>
+                  <SidebarPanel project={peekProject} merged={false} />
                 </Show>
-              </main>
-            </div>
+              </div>
 
-            <div
-              classList={{
-                "hidden xl:flex absolute inset-y-0 left-16 z-30": true,
-                "opacity-100 translate-x-0 pointer-events-auto": state.peeked && !layout.sidebar.opened(),
-                "opacity-0 -translate-x-2 pointer-events-none": !state.peeked || layout.sidebar.opened(),
-                "transition-[opacity,transform] motion-reduce:transition-none": true,
-                "duration-180 ease-out": state.peeked && !layout.sidebar.opened(),
-                "duration-120 ease-in": !state.peeked || layout.sidebar.opened(),
-              }}
-              onMouseMove={disarm}
-              onMouseEnter={() => {
-                disarm()
-                aim.reset()
-              }}
-              onPointerDown={disarm}
-              onMouseLeave={() => {
-                arm()
-              }}
-            >
-              <Show when={peekProject()}>
-                <SidebarPanel project={peekProject} merged={false} />
-              </Show>
-            </div>
-
-            <div
-              classList={{
-                "hidden xl:block pointer-events-none absolute inset-y-0 right-0 z-25 overflow-hidden": true,
-                "opacity-100 translate-x-0": state.peeked && !layout.sidebar.opened(),
-                "opacity-0 -translate-x-2": !state.peeked || layout.sidebar.opened(),
-                "transition-[opacity,transform] motion-reduce:transition-none": true,
-                "duration-180 ease-out": state.peeked && !layout.sidebar.opened(),
-                "duration-120 ease-in": !state.peeked || layout.sidebar.opened(),
-              }}
-              style={{ left: `calc(4rem + ${panel()}px)` }}
-            >
-              <div class="h-full w-px" style={{ "box-shadow": "var(--shadow-sidebar-overlay)" }} />
+              <div
+                classList={{
+                  "hidden xl:block pointer-events-none absolute inset-y-0 right-0 z-25 overflow-hidden": true,
+                  "opacity-100 translate-x-0": state.peeked && !layout.sidebar.opened(),
+                  "opacity-0 -translate-x-2": !state.peeked || layout.sidebar.opened(),
+                  "transition-[opacity,transform] motion-reduce:transition-none": true,
+                  "duration-180 ease-out": state.peeked && !layout.sidebar.opened(),
+                  "duration-120 ease-in": !state.peeked || layout.sidebar.opened(),
+                }}
+                style={{ left: `calc(4rem + ${panel()}px)` }}
+              >
+                <div class="h-full w-px" style={{ "box-shadow": "var(--shadow-sidebar-overlay)" }} />
+              </div>
             </div>
           </div>
+          {import.meta.env.DEV && <DebugBar />}
         </div>
-        {import.meta.env.DEV && <DebugBar />}
       </div>
       <Toast.Region />
     </div>

--- a/packages/app/src/shell-frame-contract.test.ts
+++ b/packages/app/src/shell-frame-contract.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(import.meta.dir, relativePath), "utf8")
+}
+
+test("desktop shell shares titlebar height across titlebar and narrow sidebar geometry", () => {
+  const css = read("./index.css")
+  const layout = read("./pages/layout.tsx")
+  const titlebar = read("./components/titlebar.tsx")
+  const sessionHeader = read("./components/session/session-header.tsx")
+  const wideDesktopQuery = css.indexOf("@media (min-width: 1280px)")
+  const macMainSeamRule = css.indexOf('[data-component="desktop-shell-main"][data-platform="desktop"][data-os="macos"] {')
+
+  expect(css).toContain('[data-component="desktop-shell"][data-platform="desktop"] {')
+  expect(css).toContain("--shell-titlebar-height: 40px;")
+  expect(css).toContain('[data-component="desktop-shell"][data-platform="desktop"][data-os="macos"] {')
+  expect(css).toContain("--shell-titlebar-height: 48px;")
+  expect(wideDesktopQuery).toBeGreaterThan(-1)
+  expect(macMainSeamRule).toBeGreaterThan(-1)
+  expect(macMainSeamRule).toBeLessThan(wideDesktopQuery)
+  expect(layout).toContain('"--shell-titlebar-current-height"')
+  expect(layout).toContain('platform.os === "macos"')
+  expect(layout).toContain('top: "var(--shell-titlebar-current-height, var(--shell-titlebar-height, 2.5rem))"')
+  expect(layout).not.toContain("top-10")
+  expect(titlebar).toContain('style={{ height: currentTitlebarHeight(), "min-height": currentTitlebarHeight() }}')
+  expect(sessionHeader).toContain('document.getElementById("opencode-titlebar-center")')
+  expect(sessionHeader).toContain('document.getElementById("opencode-titlebar-right")')
+})

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -10,6 +10,8 @@
   },
   "scripts": {
     "typecheck": "tsgo -b",
+    "test": "bun test",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "predev": "bun ./scripts/predev.ts",
     "dev": "electron-vite dev",
     "prebuild": "bun ./scripts/prebuild.ts",

--- a/packages/desktop-electron/src/main/window-chrome.test.ts
+++ b/packages/desktop-electron/src/main/window-chrome.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+import {
+  LEGACY_MACOS_TITLEBAR_HEIGHT,
+  LEGACY_MACOS_TRAFFIC_LIGHT_Y,
+  MACOS_SHELL_TITLEBAR_HEIGHT,
+  WINDOWS_TITLEBAR_OVERLAY_HEIGHT,
+  macTrafficLightPosition,
+} from "./window-chrome"
+
+function appIndexCss() {
+  return fs.readFileSync(path.join(import.meta.dir, "..", "..", "..", "app", "src", "index.css"), "utf8")
+}
+
+test("macOS traffic lights stay centered when shell titlebar height increases", () => {
+  const css = appIndexCss()
+  const wideDesktopQuery = css.indexOf("@media (min-width: 1280px)")
+  const macTitlebarBlock = css.indexOf('[data-component="titlebar-shell"][data-platform="desktop"][data-os="macos"] {')
+
+  expect(wideDesktopQuery).toBeGreaterThan(-1)
+  expect(css).toContain('[data-component="desktop-shell"][data-platform="desktop"] {')
+  expect(css).toContain("--shell-titlebar-height: 40px;")
+  expect(css).toContain('[data-component="desktop-shell"][data-platform="desktop"][data-os="macos"] {')
+  expect(macTitlebarBlock).toBeGreaterThan(-1)
+  expect(macTitlebarBlock).toBeLessThan(wideDesktopQuery)
+  expect(css).toContain("--shell-titlebar-height: 48px;")
+  expect(WINDOWS_TITLEBAR_OVERLAY_HEIGHT).toBe(40)
+  expect(macTrafficLightPosition()).toEqual({
+    x: 12,
+    y: LEGACY_MACOS_TRAFFIC_LIGHT_Y + (MACOS_SHELL_TITLEBAR_HEIGHT - LEGACY_MACOS_TITLEBAR_HEIGHT) / 2,
+  })
+})

--- a/packages/desktop-electron/src/main/window-chrome.ts
+++ b/packages/desktop-electron/src/main/window-chrome.ts
@@ -1,0 +1,11 @@
+export const WINDOWS_TITLEBAR_OVERLAY_HEIGHT = 40
+export const MACOS_SHELL_TITLEBAR_HEIGHT = 48
+export const LEGACY_MACOS_TITLEBAR_HEIGHT = 40
+export const LEGACY_MACOS_TRAFFIC_LIGHT_Y = 14
+
+export function macTrafficLightPosition() {
+  return {
+    x: 12,
+    y: LEGACY_MACOS_TRAFFIC_LIGHT_Y + (MACOS_SHELL_TITLEBAR_HEIGHT - LEGACY_MACOS_TITLEBAR_HEIGHT) / 2,
+  }
+}

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow, nativeImage, nativeTheme } from "electron"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { TitlebarTheme } from "../preload/types"
+import { WINDOWS_TITLEBAR_OVERLAY_HEIGHT, macTrafficLightPosition } from "./window-chrome"
 
 type Globals = {
   updaterEnabled: boolean
@@ -39,7 +40,7 @@ function overlay(theme: Partial<TitlebarTheme> = {}) {
   return {
     color: "#00000000",
     symbolColor: mode === "dark" ? "white" : "black",
-    height: 40,
+    height: WINDOWS_TITLEBAR_OVERLAY_HEIGHT,
   }
 }
 
@@ -73,7 +74,7 @@ export function createMainWindow(globals: Globals) {
     ...(process.platform === "darwin"
       ? {
           titleBarStyle: "hidden" as const,
-          trafficLightPosition: { x: 12, y: 14 },
+          trafficLightPosition: macTrafficLightPosition(),
         }
       : {}),
     ...(process.platform === "win32"

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -7,6 +7,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke home renders and shows core entrypoints",
   "packages/app/e2e/app/home.spec.ts:@smoke server picker dialog opens from home",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
+  "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree entrypoints can open the panel and a file",
   "packages/app/e2e/projects/projects-switch.spec.ts:@smoke can switch between projects from sidebar",
   "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,15 @@
       "dependsOn": ["^build"],
       "outputs": [".artifacts/unit/junit.xml"],
       "passThroughEnv": ["*"]
+    },
+    "@opencode-ai/desktop-electron#test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@opencode-ai/desktop-electron#test:ci": {
+      "dependsOn": ["^build"],
+      "outputs": [".artifacts/unit/junit.xml"],
+      "passThroughEnv": ["*"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
   "tasks": {
     "typecheck": {},
     "build": {
-      "dependsOn": [],
+      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
     "opencode#test": {


### PR DESCRIPTION
## Summary

- add stable desktop shell hooks plus shell-frame regression coverage
- localize shell chrome styling to app-level shell CSS and tighten macOS shell geometry contracts
- wire desktop-electron shell geometry tests into package scripts and `turbo test:ci`

## Why

This pull request finishes the shell-frame polish work without leaking styling into shared inner-page theme tokens.

It also fixes the main regression risks found during repeated fresh-eyes review: macOS traffic-light alignment, narrow-shell seam ownership, and zoom-dependent titlebar/sidebar offset drift.

## Related Issue

Part of #26.

This PR lands the first slice of Phase 1 for the desktop UI redesign, focused on shell polish and shell-frame contract hardening. It does not complete #26.

## How To Verify

```bash
cd packages/app && bun test src/shell-frame-contract.test.ts
cd packages/app && bun run test:e2e -- e2e/app/shell-frame.spec.ts e2e/app/titlebar-history.spec.ts e2e/app/palette.spec.ts e2e/settings/settings.spec.ts e2e/sidebar/sidebar.spec.ts
cd packages/app && bun run typecheck
cd packages/desktop-electron && bun test src/main/window-chrome.test.ts
cd packages/desktop-electron && bun run typecheck
bun turbo test:ci --filter=@opencode-ai/desktop-electron
```

## Screenshots or Recordings

Not attached from this CLI session.
Visible shell changes were covered by the verification commands above, including the shell-frame and sidebar regressions.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
