### PR TITLE
feat: add home composer entrypoint

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,19 +1,52 @@
 import { test, expect } from "../fixtures"
 import { openStatusPopover } from "../actions"
+import { promptSelector, sessionComposerDockSelector } from "../selectors"
 
-test("@smoke home renders and shows core entrypoints", async ({ page }) => {
+test("@smoke cold-start root route still renders home entrypoints", async ({ page }) => {
   await page.goto("/")
 
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
+  await expect(page.getByText("No projects open").first()).toBeVisible()
+  await expect(page.getByText("Open a project to get started").first()).toBeVisible()
+  await expect(page.getByText("No recent projects")).toBeVisible()
+  await expect(page.getByText("Get started by opening a local project")).toBeVisible()
+})
+
+test("@smoke home renders the hero composer and starter cards", async ({ page, project }) => {
+  await project.open()
+
+  const home = page.locator('[data-component="session-new-home"]')
+  await expect(home).toBeVisible()
+  await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
   await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
+  await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
+  await expect(home.locator(sessionComposerDockSelector)).toHaveCount(1)
+  await expect(home.locator(sessionComposerDockSelector)).toHaveCSS("text-align", "left")
+  await expect(home.locator(promptSelector)).toBeVisible()
   await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
   await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
   await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
   await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
 })
 
-test("@smoke server picker dialog opens from home", async ({ page }) => {
-  await page.goto("/")
+test("@smoke home hero prompt starts a session", async ({ page, project, assistant }) => {
+  await project.open()
+
+  const home = page.locator('[data-component="session-new-home"]')
+  const prompt = home.locator(sessionComposerDockSelector).locator(promptSelector)
+  await expect(prompt).toBeVisible()
+  await assistant.reply("home hero reply")
+  await page.keyboard.type("Use the home hero prompt")
+  await page.keyboard.press("Enter")
+
+  await expect.poll(() => page.url(), { timeout: 30_000 }).toContain("/session/")
+  await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
+  await expect(page.locator(promptSelector)).toHaveCount(1)
+  await expect(page.getByText("home hero reply")).toBeVisible()
+})
+
+test("@smoke home route server picker dialog opens", async ({ page, project }) => {
+  await project.open()
   const { popoverBody } = await openStatusPopover(page)
   await popoverBody.getByRole("button", { name: "Manage servers" }).click()
 

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -2,14 +2,15 @@ import { test, expect } from "../fixtures"
 import { openStatusPopover } from "../actions"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
 
-test("@smoke cold-start root route still renders home entrypoints", async ({ page }) => {
+test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
   await page.goto("/")
 
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
-  await expect(page.getByText("No projects open").first()).toBeVisible()
-  await expect(page.getByText("Open a project to get started").first()).toBeVisible()
-  await expect(page.getByText("No recent projects")).toBeVisible()
-  await expect(page.getByText("Get started by opening a local project")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
 })
 
 test("@smoke home renders the hero composer and starter cards", async ({ page, project }) => {

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -17,17 +17,25 @@ test("@smoke home renders the hero composer and starter cards", async ({ page, p
   await project.open()
 
   const home = page.locator('[data-component="session-new-home"]')
+  const composer = home.locator(sessionComposerDockSelector)
+  const firstCard = home.getByRole("button", { name: /Process documents/i })
   await expect(home).toBeVisible()
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
   await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
   await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
-  await expect(home.locator(sessionComposerDockSelector)).toHaveCount(1)
-  await expect(home.locator(sessionComposerDockSelector)).toHaveCSS("text-align", "left")
+  await expect(composer).toHaveCount(1)
+  await expect(composer).toHaveCSS("text-align", "left")
   await expect(home.locator(promptSelector)).toBeVisible()
-  await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
+  await expect(firstCard).toBeVisible()
   await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
   await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
   await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
+
+  const cardBox = await firstCard.boundingBox()
+  const composerBox = await composer.boundingBox()
+  expect(cardBox).not.toBeNull()
+  expect(composerBox).not.toBeNull()
+  expect(cardBox!.y).toBeLessThan(composerBox!.y)
 })
 
 test("@smoke home hero prompt starts a session", async ({ page, project, assistant }) => {

--- a/packages/app/src/components/session/session-new-view-start.ts
+++ b/packages/app/src/components/session/session-new-view-start.ts
@@ -1,0 +1,45 @@
+import { base64Encode } from "@opencode-ai/util/encode"
+import type { PawworkSkillName } from "./pawwork-skill-meta"
+import { buildSkillSessionCommandInput } from "./session-new-view-command"
+
+export async function startPawworkSkillSession(input: {
+  name: PawworkSkillName
+  client: {
+    session: {
+      create: (input: { skill: PawworkSkillName }) => Promise<{ data?: { id: string } }>
+      command: (input: ReturnType<typeof buildSkillSessionCommandInput>) => Promise<unknown>
+      delete: (input: { sessionID: string }) => Promise<unknown>
+    }
+  }
+  directory: string
+  agent: string
+  model: string
+  variant?: string
+  locale?: string
+  promote: (directory: string, sessionID: string) => void
+  navigate: (href: string) => void
+  onSessionCreateFailed: () => never
+}) {
+  const created = await input.client.session.create({ skill: input.name }).then((res) => res.data)
+  if (!created) input.onSessionCreateFailed()
+
+  try {
+    input.promote(input.directory, created.id)
+    input.navigate(`/${base64Encode(input.directory)}/session/${created.id}`)
+
+    await input.client.session.command(
+      buildSkillSessionCommandInput({
+        sessionID: created.id,
+        command: input.name,
+        agent: input.agent,
+        model: input.model,
+        variant: input.variant,
+        locale: input.locale,
+      }),
+    )
+  } catch (error) {
+    await input.client.session.delete({ sessionID: created.id }).catch(() => undefined)
+    input.navigate(`/${base64Encode(input.directory)}/session`)
+    throw error
+  }
+}

--- a/packages/app/src/components/session/session-new-view.test.ts
+++ b/packages/app/src/components/session/session-new-view.test.ts
@@ -1,26 +1,86 @@
-import { describe, expect, test } from "bun:test"
-import { buildSkillSessionCommandInput } from "./session-new-view-command"
+import { describe, expect, mock, test } from "bun:test"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { pawworkSkillCards } from "./pawwork-skill-meta"
+import { startPawworkSkillSession } from "./session-new-view-start"
 
 describe("new session skill cards", () => {
-  test("passes locale through the built-in skill launch command", () => {
-    expect(
-      buildSkillSessionCommandInput({
-        sessionID: "session-1",
-        command: "document-processing",
+  test("all starter cards create a session and dispatch the expected built-in command", async () => {
+    for (const card of pawworkSkillCards) {
+      const create = mock(async () => ({ data: { id: `session-${card.name}` } }))
+      const command = mock(async () => ({ data: undefined }))
+      const remove = mock(async () => ({ data: undefined }))
+      const promote = mock(() => undefined)
+      const navigate = mock(() => undefined)
+
+      await startPawworkSkillSession({
+        name: card.name,
+        client: {
+          session: {
+            create,
+            command,
+            delete: remove,
+          },
+        },
+        directory: "repo",
         agent: "build",
         model: "openai/gpt-5",
         variant: "fast",
         locale: "pt-BR",
-      }),
-    ).toEqual({
-      sessionID: "session-1",
-      command: "document-processing",
-      arguments: "",
-      agent: "build",
-      model: "openai/gpt-5",
-      variant: "fast",
-      locale: "pt-BR",
-      parts: [],
+        promote,
+        navigate,
+        onSessionCreateFailed: () => {
+          throw new Error("session create should not fail")
+        },
+      })
+
+      expect(create).toHaveBeenCalledWith({ skill: card.name })
+      expect(command).toHaveBeenCalledWith({
+        sessionID: `session-${card.name}`,
+        command: card.name,
+        arguments: "",
+        agent: "build",
+        model: "openai/gpt-5",
+        variant: "fast",
+        locale: "pt-BR",
+        parts: [],
+      })
+      expect(promote).toHaveBeenCalledWith("repo", `session-${card.name}`)
+      expect(navigate).toHaveBeenCalledWith(`/${base64Encode("repo")}/session/session-${card.name}`)
+      expect(remove).not.toHaveBeenCalled()
+    }
+  })
+
+  test("deletes the created session and navigates back when command dispatch fails", async () => {
+    const create = mock(async () => ({ data: { id: "session-document-processing" } }))
+    const command = mock(async () => {
+      throw new Error("boom")
     })
+    const remove = mock(async () => ({ data: undefined }))
+    const promote = mock(() => undefined)
+    const navigate = mock(() => undefined)
+
+    await expect(
+      startPawworkSkillSession({
+        name: "document-processing",
+        client: {
+          session: {
+            create,
+            command,
+            delete: remove,
+          },
+        },
+        directory: "repo",
+        agent: "build",
+        model: "openai/gpt-5",
+        promote,
+        navigate,
+        onSessionCreateFailed: () => {
+          throw new Error("session create should not fail")
+        },
+      }),
+    ).rejects.toThrow("boom")
+
+    expect(remove).toHaveBeenCalledWith({ sessionID: "session-document-processing" })
+    expect(navigate).toHaveBeenLastCalledWith(`/${base64Encode("repo")}/session`)
   })
 })

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -1,15 +1,14 @@
-import { For, createSignal } from "solid-js"
+import { For, Show, createSignal, type JSX } from "solid-js"
 import { useSDK } from "@/context/sdk"
 import { useLocal } from "@/context/local"
 import { useLanguage } from "@/context/language"
 import { useNavigate } from "@solidjs/router"
-import { base64Encode } from "@opencode-ai/util/encode"
 import { showToast } from "@opencode-ai/ui/toast"
 import { Mark } from "@opencode-ai/ui/logo"
 import { pawworkSkillCards, type PawworkSkillName } from "./pawwork-skill-meta"
-import { buildSkillSessionCommandInput } from "./session-new-view-command"
+import { startPawworkSkillSession } from "./session-new-view-start"
 
-export function NewSessionView() {
+export function NewSessionView(props: { composer?: JSX.Element }) {
   const sdk = useSDK()
   const local = useLocal()
   const language = useLanguage()
@@ -31,31 +30,23 @@ export function NewSessionView() {
     }
 
     setPending(name)
-    let created: { id: string } | undefined
 
     try {
-      created = await sdk.client.session.create({ skill: name }).then((res) => res.data ?? undefined)
-      if (!created) throw new Error(language.t("prompt.toast.sessionCreateFailed.description"))
-
-      local.session.promote(sdk.directory, created.id)
-      navigate(`/${base64Encode(sdk.directory)}/session/${created.id}`)
-
-      await sdk.client.session.command(
-        buildSkillSessionCommandInput({
-          sessionID: created.id,
-          command: name,
-          agent: agent.name,
-          model: `${model.provider.id}/${model.id}`,
-          variant: local.model.variant.current() ?? undefined,
-          locale: language.intl(),
-        }),
-      )
+      await startPawworkSkillSession({
+        name,
+        client: sdk.client,
+        directory: sdk.directory,
+        agent: agent.name,
+        model: `${model.provider.id}/${model.id}`,
+        variant: local.model.variant.current() ?? undefined,
+        locale: language.intl(),
+        promote: local.session.promote,
+        navigate,
+        onSessionCreateFailed: () => {
+          throw new Error(language.t("prompt.toast.sessionCreateFailed.description"))
+        },
+      })
     } catch (error) {
-      if (created?.id) {
-        await sdk.client.session.delete({ sessionID: created.id }).catch(() => undefined)
-        navigate(`/${base64Encode(sdk.directory)}/session`)
-      }
-
       showToast({
         title: language.t("prompt.toast.commandSendFailed.title"),
         description: error instanceof Error ? error.message : language.t("common.requestFailed"),
@@ -66,13 +57,16 @@ export function NewSessionView() {
   }
 
   return (
-    <div class="size-full flex items-center justify-center px-6 pb-30">
-      <div class="w-full max-w-200 flex flex-col items-center gap-6 text-center">
+    <div data-component="session-new-home" class="size-full overflow-y-auto px-6 py-8 md:px-8 md:py-10">
+      <div class="mx-auto flex w-full max-w-200 flex-col items-center gap-6 text-center">
         <Mark class="w-10" />
         <div class="flex flex-col gap-2">
           <h1 class="text-24-medium text-text-strong">{language.t("session.new.title")}</h1>
           <p class="text-14-regular text-text-weak">{language.t("session.new.subtitle")}</p>
         </div>
+        <Show when={props.composer}>
+          <div class="w-full max-w-170">{props.composer}</div>
+        </Show>
         <div class="grid w-full max-w-170 gap-3 md:grid-cols-3">
           <For each={pawworkSkillCards}>
             {(card) => (

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -64,9 +64,6 @@ export function NewSessionView(props: { composer?: JSX.Element }) {
           <h1 class="text-24-medium text-text-strong">{language.t("session.new.title")}</h1>
           <p class="text-14-regular text-text-weak">{language.t("session.new.subtitle")}</p>
         </div>
-        <Show when={props.composer}>
-          <div class="w-full max-w-170">{props.composer}</div>
-        </Show>
         <div class="grid w-full max-w-170 gap-3 md:grid-cols-3">
           <For each={pawworkSkillCards}>
             {(card) => (
@@ -84,6 +81,9 @@ export function NewSessionView(props: { composer?: JSX.Element }) {
             )}
           </For>
         </div>
+        <Show when={props.composer}>
+          <div class="w-full max-w-170">{props.composer}</div>
+        </Show>
       </div>
     </div>
   )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1975,106 +1975,117 @@ export default function Page() {
           }}
         >
           <div class="flex-1 min-h-0 overflow-hidden">
-            <Switch>
-              <Match when={params.id}>
-                <Show when={messagesReady()}>
-                  <MessageTimeline
-                    mobileChanges={mobileChanges()}
-                    mobileFallback={reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-8",
-                        header: "px-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                    actions={actions}
-                    scroll={ui.scroll}
-                    onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
-                    onScheduleScrollState={scheduleScrollState}
-                    onAutoScrollHandleScroll={autoScroll.handleScroll}
-                    onMarkScrollGesture={markScrollGesture}
-                    hasScrollGesture={hasScrollGesture}
-                    onUserScroll={markUserScroll}
-                    onTurnBackfillScroll={historyWindow.onScrollerScroll}
-                    onAutoScrollInteraction={autoScroll.handleInteraction}
-                    centered={centered()}
-                    setContentRef={(el) => {
-                      content = el
-                      autoScroll.contentRef(el)
+            {(() => {
+              const renderComposerRegion = (variant: "session" | "home") => (
+                <SessionComposerRegion
+                  variant={variant}
+                  state={composer}
+                  ready={!store.deferRender && messagesReady()}
+                  centered={centered()}
+                  inputRef={(el) => {
+                    inputRef = el
+                  }}
+                  newSessionWorktree={newSessionWorktree()}
+                  onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
+                  onSubmit={() => {
+                    comments.clear()
+                    resumeScroll()
+                  }}
+                  onResponseSubmit={resumeScroll}
+                  followup={
+                    params.id && !isChildSession()
+                      ? {
+                          queue: queueEnabled,
+                          items: followupDock(),
+                          sending: sendingFollowup(),
+                          edit: editingFollowup(),
+                          onQueue: queueFollowup,
+                          onAbort: () => {
+                            const id = params.id
+                            if (!id) return
+                            setFollowup("paused", id, true)
+                          },
+                          onSend: (id) => {
+                            void sendFollowup(params.id!, id, { manual: true })
+                          },
+                          onEdit: editFollowup,
+                          onEditLoaded: clearFollowupEdit,
+                        }
+                      : undefined
+                  }
+                  revert={
+                    rolled().length > 0
+                      ? {
+                          items: rolled(),
+                          restoring: restoring(),
+                          disabled: reverting(),
+                          onRestore: restore,
+                        }
+                      : undefined
+                  }
+                  setPromptDockRef={(el) => {
+                    promptDock = el
+                  }}
+                />
+              )
 
-                      const root = scroller
-                      if (root) scheduleScrollState(root)
-                    }}
-                    turnStart={historyWindow.turnStart()}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
-                      void historyWindow.loadAndReveal()
-                    }}
-                    renderedUserMessages={historyWindow.renderedUserMessages()}
-                    anchor={anchor}
-                  />
-                </Show>
-              </Match>
-              <Match when={true}>
-                <NewSessionView />
-              </Match>
-            </Switch>
+              return (
+                <>
+                  <Switch>
+                    <Match when={params.id}>
+                      <Show when={messagesReady()}>
+                        <MessageTimeline
+                          mobileChanges={mobileChanges()}
+                          mobileFallback={reviewContent({
+                            diffStyle: "unified",
+                            classes: {
+                              root: "pb-8",
+                              header: "px-4",
+                              container: "px-4",
+                            },
+                            loadingClass: "px-4 py-4 text-text-weak",
+                            emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+                          })}
+                          actions={actions}
+                          scroll={ui.scroll}
+                          onResumeScroll={resumeScroll}
+                          setScrollRef={setScrollRef}
+                          onScheduleScrollState={scheduleScrollState}
+                          onAutoScrollHandleScroll={autoScroll.handleScroll}
+                          onMarkScrollGesture={markScrollGesture}
+                          hasScrollGesture={hasScrollGesture}
+                          onUserScroll={markUserScroll}
+                          onTurnBackfillScroll={historyWindow.onScrollerScroll}
+                          onAutoScrollInteraction={autoScroll.handleInteraction}
+                          centered={centered()}
+                          setContentRef={(el) => {
+                            content = el
+                            autoScroll.contentRef(el)
+
+                            const root = scroller
+                            if (root) scheduleScrollState(root)
+                          }}
+                          turnStart={historyWindow.turnStart()}
+                          historyMore={historyMore()}
+                          historyLoading={historyLoading()}
+                          onLoadEarlier={() => {
+                            void historyWindow.loadAndReveal()
+                          }}
+                          renderedUserMessages={historyWindow.renderedUserMessages()}
+                          anchor={anchor}
+                        />
+                      </Show>
+                    </Match>
+                    <Match when={true}>
+                      <NewSessionView composer={renderComposerRegion("home")} />
+                    </Match>
+                  </Switch>
+
+                  <Show when={params.id}>{renderComposerRegion("session")}</Show>
+                </>
+              )
+            })()}
           </div>
-
-          <SessionComposerRegion
-            state={composer}
-            ready={!store.deferRender && messagesReady()}
-            centered={centered()}
-            inputRef={(el) => {
-              inputRef = el
-            }}
-            newSessionWorktree={newSessionWorktree()}
-            onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
-            onSubmit={() => {
-              comments.clear()
-              resumeScroll()
-            }}
-            onResponseSubmit={resumeScroll}
-            followup={
-              params.id && !isChildSession()
-                ? {
-                    queue: queueEnabled,
-                    items: followupDock(),
-                    sending: sendingFollowup(),
-                    edit: editingFollowup(),
-                    onQueue: queueFollowup,
-                    onAbort: () => {
-                      const id = params.id
-                      if (!id) return
-                      setFollowup("paused", id, true)
-                    },
-                    onSend: (id) => {
-                      void sendFollowup(params.id!, id, { manual: true })
-                    },
-                    onEdit: editFollowup,
-                    onEditLoaded: clearFollowupEdit,
-                  }
-                : undefined
-            }
-            revert={
-              rolled().length > 0
-                ? {
-                    items: rolled(),
-                    restoring: restoring(),
-                    disabled: reverting(),
-                    onRestore: restore,
-                  }
-                : undefined
-            }
-            setPromptDockRef={(el) => {
-              promptDock = el
-            }}
-          />
 
           <Show when={desktopReviewOpen()}>
             <div onPointerDown={() => size.start()}>

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -18,6 +18,7 @@ import type { FollowupDraft } from "@/components/prompt-input/submit"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 
 export function SessionComposerRegion(props: {
+  variant?: "session" | "home"
   state: SessionComposerState
   ready: boolean
   centered: boolean
@@ -55,6 +56,7 @@ export function SessionComposerRegion(props: {
   const info = createMemo(() => (route.params.id ? sync.session.get(route.params.id) : undefined))
   const parentID = createMemo(() => info()?.parentID)
   const child = createMemo(() => !!parentID())
+  const home = createMemo(() => props.variant === "home")
   const showComposer = createMemo(() => !props.state.blocked() || child())
 
   const previewPrompt = () =>
@@ -139,12 +141,19 @@ export function SessionComposerRegion(props: {
     <div
       ref={props.setPromptDockRef}
       data-component="session-prompt-dock"
-      class="shrink-0 w-full pb-3 flex flex-col justify-center items-center bg-background-stronger pointer-events-none"
+      data-variant={home() ? "home" : "session"}
+      classList={{
+        "w-full flex flex-col justify-center items-center pointer-events-none": true,
+        "shrink-0 pb-3 bg-background-stronger": !home(),
+        "py-0 bg-transparent": home(),
+        "text-left": home(),
+      }}
     >
       <div
         classList={{
           "w-full px-3 pointer-events-auto": true,
-          "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+          "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered && !home(),
+          "mx-auto max-w-170": home(),
         }}
       >
         <Show when={props.state.questionRequest()} keyed>

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -4,8 +4,10 @@ import path from "node:path"
 
 const repoRoot = path.resolve(import.meta.dir, "../../../../")
 const expectedSmokeTests = [
-  "packages/app/e2e/app/home.spec.ts:@smoke home renders and shows core entrypoints",
-  "packages/app/e2e/app/home.spec.ts:@smoke server picker dialog opens from home",
+  "packages/app/e2e/app/home.spec.ts:@smoke cold-start root route still renders home entrypoints",
+  "packages/app/e2e/app/home.spec.ts:@smoke home hero prompt starts a session",
+  "packages/app/e2e/app/home.spec.ts:@smoke home renders the hero composer and starter cards",
+  "packages/app/e2e/app/home.spec.ts:@smoke home route server picker dialog opens",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree entrypoints can open the panel and a file",

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -4,10 +4,10 @@ import path from "node:path"
 
 const repoRoot = path.resolve(import.meta.dir, "../../../../")
 const expectedSmokeTests = [
-  "packages/app/e2e/app/home.spec.ts:@smoke cold-start root route still renders home entrypoints",
   "packages/app/e2e/app/home.spec.ts:@smoke home hero prompt starts a session",
   "packages/app/e2e/app/home.spec.ts:@smoke home renders the hero composer and starter cards",
   "packages/app/e2e/app/home.spec.ts:@smoke home route server picker dialog opens",
+  "packages/app/e2e/app/home.spec.ts:@smoke root route renders seeded home entrypoints",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree entrypoints can open the panel and a file",


### PR DESCRIPTION
## Summary

- move the empty cold-start UI to the root `/` route only
- render the home hero composer inside the in-project no-session view
- keep a single composer surface per route by only mounting the session dock for active sessions
- extract starter-card session bootstrapping into a dedicated helper and cover the new flow with tests
- update smoke inventory expectations for the new home coverage

## Why

Issue #26 is landing the new PawWork desktop UI in phased PRs. This slice wires the new home composer entrypoint into the app without changing the root cold-start experience, and keeps the routing and starter-card behavior small enough to review in isolation.

## Related Issue

Part of #26

## How To Verify

```bash
bun test --preload ./happydom.ts ./src/components/session/session-new-view.test.ts
bun x playwright test e2e/app/home.spec.ts
bun x playwright test e2e/app/shell-frame.spec.ts e2e/sidebar/sidebar.spec.ts
bun turbo typecheck
bun turbo test:ci
```

Manual checks:
- open an existing project and confirm the no-session home route shows the hero composer and starter cards
- submit a prompt from the home hero and confirm it creates a session and shows the assistant reply
- open the Status popover from the home route and confirm the Manage servers dialog still opens

## Screenshots or Recordings

<img width="933" height="677" alt="pawwork-home-composer-e2e" src="https://github.com/user-attachments/assets/2feb5d0a-0e46-432b-9b6a-e1b50027b597" />

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
