### PR TITLE
feat: unify session right utility panel

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "../fixtures"
-import { openStatusPopover } from "../actions"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
 
 test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
@@ -54,10 +53,14 @@ test("@smoke home hero prompt starts a session", async ({ page, project, assista
   await expect(page.getByText("home hero reply")).toBeVisible()
 })
 
-test("@smoke home route server picker dialog opens", async ({ page, project }) => {
+test("@smoke project home status panel can open the server picker dialog", async ({ page, project }) => {
   await project.open()
-  const { popoverBody } = await openStatusPopover(page)
-  await popoverBody.getByRole("button", { name: "Manage servers" }).click()
+  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightPanel = page.locator("#right-panel")
+
+  await statusButton.click()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await rightPanel.getByRole("button", { name: "Manage servers" }).click()
 
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()

--- a/packages/app/e2e/app/shell-frame.spec.ts
+++ b/packages/app/e2e/app/shell-frame.spec.ts
@@ -32,3 +32,19 @@ test("@smoke shell frame exposes stable desktop hooks", async ({ page, gotoSessi
   const palette = await openPalette(page)
   await closeDialog(page, palette)
 })
+
+test("session titlebar center keeps a project-directory affordance next to file search", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await gotoSession()
+
+  const center = page.locator(titlebarCenterSelector)
+  const buttons = center.getByRole("button")
+  const openProject = buttons.first()
+  const searchFiles = center.getByRole("button", { name: /search files/i })
+
+  await expect(buttons).toHaveCount(2)
+  await expect(openProject).toBeVisible()
+  await expect(openProject).toHaveAttribute("title", /.+/)
+  await expect(openProject).toContainText(/.+/)
+  await expect(searchFiles).toBeVisible()
+})

--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -51,3 +51,59 @@ test("desktop side-panel buttons switch between review and files within a unifie
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
   await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
 })
+
+test("legacy changes side-panel state restores into the review tab", async ({ page, gotoSession, slug }) => {
+  await page.addInitScript(({ slug }) => {
+    const key = "opencode.global.dat:layout"
+    const raw = localStorage.getItem(key)
+    const parsed = (() => {
+      if (!raw) return {}
+      try {
+        return JSON.parse(raw) as Record<string, unknown>
+      } catch {
+        return {}
+      }
+    })()
+
+    const review =
+      parsed.review && typeof parsed.review === "object"
+        ? (parsed.review as Record<string, unknown>)
+        : {}
+
+    const sessionView =
+      parsed.sessionView && typeof parsed.sessionView === "object"
+        ? (parsed.sessionView as Record<string, unknown>)
+        : {}
+
+    const current =
+      sessionView[slug] && typeof sessionView[slug] === "object"
+        ? (sessionView[slug] as Record<string, unknown>)
+        : {}
+
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ...parsed,
+        review: { ...review, panelOpened: true },
+        sessionView: {
+          ...sessionView,
+          [slug]: {
+            ...current,
+            scroll: current.scroll && typeof current.scroll === "object" ? current.scroll : {},
+            sidePanelTab: "changes",
+          },
+        },
+      }),
+    )
+  }, { slug })
+
+  await gotoSession()
+
+  const rightPanel = page.locator("#right-panel")
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const reviewToggle = page.getByRole("button", { name: "Toggle review" }).first()
+
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
+})

--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -1,55 +1,141 @@
 import { test, expect } from "../fixtures"
+import { titlebarRightSelector } from "../selectors"
 import { modKey } from "../utils"
 
-const expanded = async (el: { getAttribute: (name: string) => Promise<string | null> }) => {
-  const value = await el.getAttribute("aria-expanded")
-  if (value !== "true" && value !== "false") throw new Error(`Expected aria-expanded to be true|false, got: ${value}`)
-  return value === "true"
-}
-
-test("desktop side-panel buttons switch between review and files within a unified right-panel tab shell", async ({
-  page,
-  gotoSession,
-}) => {
+test("desktop right-panel tabs switch between review and files within a unified utility shell", async ({ page, gotoSession }) => {
   await gotoSession()
 
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
   const rightPanel = page.locator("#right-panel")
-  const reviewToggle = page.getByRole("button", { name: "Toggle review" }).first()
-  const fileToggle = page.getByRole("button", { name: "Toggle file tree" }).first()
+  await expect(rightToggle).toBeVisible()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
-  await expect(reviewToggle).toBeVisible()
-  await expect(fileToggle).toBeVisible()
-
-  if (await expanded(reviewToggle)) await reviewToggle.click()
-  if (await expanded(fileToggle)) await fileToggle.click()
-
-  await reviewToggle.click()
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
-  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
+  await rightToggle.click()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
   const shellTabList = rightPanel.getByRole("tablist").first()
+  const reviewTab = shellTabList.getByRole("tab", { name: "Review", exact: true })
+  const filesTab = shellTabList.getByRole("tab", { name: "Files", exact: true })
   await expect(shellTabList.getByRole("tab", { name: "Status", exact: true })).toBeVisible()
-  await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toBeVisible()
-  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toBeVisible()
+  await expect(filesTab).toBeVisible()
+  await expect(reviewTab).toBeVisible()
   await expect(shellTabList.getByRole("tab", { name: "Terminal", exact: true })).toBeVisible()
-  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
+  await expect(shellTabList.getByRole("tab", { name: "Status", exact: true })).toHaveAttribute("aria-selected", "true")
 
-  await fileToggle.click()
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
-  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
-  await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
+  await reviewTab.click()
+  await expect(reviewTab).toHaveAttribute("aria-selected", "true")
 
-  await fileToggle.click()
-  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
+  await filesTab.click()
+  await expect(filesTab).toHaveAttribute("aria-selected", "true")
+
+  await rightToggle.click()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
   await page.keyboard.press(`${modKey}+Shift+R`)
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
-  await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
-  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
+  await expect(reviewTab).toHaveAttribute("aria-selected", "true")
+})
+
+test("desktop session keeps a single right-panel toggle and icon-first utility tabs", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightChrome = page.locator(titlebarRightSelector)
+  const rightPanel = page.locator("#right-panel")
+
+  await expect(rightChrome.getByRole("button")).toHaveCount(1)
+  await expect(rightChrome.getByRole("button", { name: /copy path/i })).toHaveCount(0)
+  await expect(rightChrome.getByRole("button", { name: /toggle review/i })).toHaveCount(0)
+  await expect(rightChrome.getByRole("button", { name: /toggle file tree/i })).toHaveCount(0)
+  await expect(rightChrome.getByRole("button", { name: /toggle terminal/i })).toHaveCount(0)
+  await expect(rightChrome.getByRole("button", { name: /status/i })).toHaveCount(0)
+
+  await page.keyboard.press(`${modKey}+Shift+R`)
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  await expect(shellTabList.locator('[data-component="icon"]')).toHaveCount(4)
+
+  const widths = await shellTabList.locator('[data-slot="tabs-trigger"]').evaluateAll((els) =>
+    els.map((el) => Math.round(el.getBoundingClientRect().width)),
+  )
+
+  expect(new Set(widths).size).toBe(1)
+})
+
+test("desktop session uses the design paneR icon for the right-panel toggle", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightToggleIcon = page.locator(`${titlebarRightSelector} button [data-slot="icon-svg"]`).first()
+  const iconMarkup = await rightToggleIcon.evaluate((el) => el.outerHTML)
+
+  expect(iconMarkup).toContain('data-slot="icon-svg"')
+  expect(iconMarkup).toContain('d="M8.5 2.5v9"')
+})
+
+test("desktop right-panel uses the design icon set for utility tabs", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightPanel = page.locator("#right-panel")
+
+  await page.keyboard.press(`${modKey}+Shift+R`)
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const icons = await shellTabList.locator('[data-slot="tabs-trigger"] [data-slot="icon-svg"]').evaluateAll((els) =>
+    els.map((el) => el.innerHTML),
+  )
+
+  expect(icons[0]).toContain('M2.5 3.5h8M2.5 6.5h8M2.5 9.5h5')
+  expect(icons[1]).toContain('M1.5 3.5A1 1 0 012.5 2.5H5l1 1h3.5a1 1 0 011 1V9a1 1 0 01-1 1h-7a1 1 0 01-1-1V3.5z')
+  expect(icons[2]).toContain('M2 6.5l2.5 2.5L11 3.5')
+  expect(icons[3]).toContain('x="1.5" y="2.5" width="9" height="7"')
+})
+
+test("desktop review root shows a simple toolbar before opening files", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightPanel = page.locator("#right-panel")
+  await page.keyboard.press(`${modKey}+Shift+R`)
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const reviewTab = shellTabList.getByRole("tab", { name: "Review", exact: true })
+  await reviewTab.click()
+  await expect(reviewTab).toHaveAttribute("aria-selected", "true")
+
+  await expect(rightPanel.getByRole("tablist")).toHaveCount(2)
+
+  const openFile = rightPanel.getByRole("button", { name: /^Open file$/i }).first()
+  await expect(openFile).toBeVisible()
+})
+
+test("desktop right-panel collapses shell tab labels below the compact threshold", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightPanel = page.locator("#right-panel")
+
+  await page.keyboard.press(`${modKey}+Shift+R`)
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const tabLabels = () =>
+    shellTabList
+      .locator('[data-slot="tabs-trigger"]')
+      .evaluateAll((els) => els.map((el) => el.textContent?.trim() ?? ""))
+
+  await expect.poll(tabLabels).toEqual(["", "", "", ""])
+
+  await rightPanel.evaluate((el) => {
+    ;(el as HTMLElement).style.width = "400px"
+  })
+
+  await expect.poll(tabLabels).toEqual(["Status", "Files", "Review", "Terminal"])
+
+  await rightPanel.evaluate((el) => {
+    ;(el as HTMLElement).style.width = "320px"
+  })
+
+  await expect.poll(tabLabels).toEqual(["", "", "", ""])
 })
 
 test("legacy changes side-panel state restores into the review tab", async ({ page, gotoSession, slug }) => {
@@ -101,9 +187,7 @@ test("legacy changes side-panel state restores into the review tab", async ({ pa
 
   const rightPanel = page.locator("#right-panel")
   const shellTabList = rightPanel.getByRole("tablist").first()
-  const reviewToggle = page.getByRole("button", { name: "Toggle review" }).first()
 
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
-  await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
   await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
 })

--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -7,13 +7,13 @@ const expanded = async (el: { getAttribute: (name: string) => Promise<string | n
   return value === "true"
 }
 
-test("desktop side-panel buttons switch between review and files without an in-panel tab strip", async ({
+test("desktop side-panel buttons switch between review and files within a unified right-panel tab shell", async ({
   page,
   gotoSession,
 }) => {
   await gotoSession()
 
-  const reviewPanel = page.locator("#review-panel")
+  const rightPanel = page.locator("#right-panel")
   const reviewToggle = page.getByRole("button", { name: "Toggle review" }).first()
   const fileToggle = page.getByRole("button", { name: "Toggle file tree" }).first()
 
@@ -23,26 +23,31 @@ test("desktop side-panel buttons switch between review and files without an in-p
   if (await expanded(reviewToggle)) await reviewToggle.click()
   if (await expanded(fileToggle)) await fileToggle.click()
 
-  await expect(reviewPanel.getByRole("tab", { name: "Files" })).toHaveCount(0)
-  await expect(reviewPanel.getByRole("tab", { name: "Changes" })).toHaveCount(0)
-
   await reviewToggle.click()
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
   await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  await expect(shellTabList.getByRole("tab", { name: "Status", exact: true })).toBeVisible()
+  await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toBeVisible()
+  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toBeVisible()
+  await expect(shellTabList.getByRole("tab", { name: "Terminal", exact: true })).toBeVisible()
+  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
 
   await fileToggle.click()
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
   await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
-  await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
 
   await fileToggle.click()
   await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(reviewPanel).toHaveAttribute("aria-hidden", "true")
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
   await page.keyboard.press(`${modKey}+Shift+R`)
   await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
   await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
-  await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
 })

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -1,65 +1,59 @@
 import { test, expect } from "../fixtures"
 import { withSession } from "../actions"
+import { titlebarRightSelector } from "../selectors"
 
-test("@smoke file tree entrypoints can open the panel and a file", async ({ page, project }) => {
+test("@smoke review keeps the persistent file-tree pane for review navigation", async ({ page, project }) => {
   await project.open()
 
   await withSession(project.sdk, `e2e file tree smoke ${Date.now()}`, async (session) => {
     await project.gotoSession(session.id)
 
-    const fileToggle = page.getByRole("button", { name: "Toggle file tree" })
-    const reviewToggle = page.getByRole("button", { name: "Toggle review" })
+    const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
     const rightPanel = page.locator("#right-panel")
     const panel = page.locator("#file-tree-panel")
     const shellTabList = rightPanel.getByRole("tablist").first()
-    const treeTabs = panel.locator('[data-component="tabs"][data-variant="pill"][data-scope="filetree"]')
 
-    await expect(fileToggle).toBeVisible()
-    if ((await fileToggle.getAttribute("aria-expanded")) !== "true") await fileToggle.click()
-    await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
+    await expect(rightToggle).toBeVisible()
+    await rightToggle.click()
     await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
     await expect(rightPanel).toBeVisible()
-    await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
-    await expect(rightPanel).toContainText("No files")
-
-    await expect(reviewToggle).toBeVisible()
-    await reviewToggle.click()
-    await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
-    await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
-    await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
+    const reviewTab = shellTabList.getByRole("tab", { name: "Review", exact: true })
+    await reviewTab.click()
+    await expect(reviewTab).toHaveAttribute("aria-selected", "true")
     await expect(panel).toBeVisible()
-    await expect(treeTabs).toBeVisible()
+    await expect(panel.getByRole("tab", { name: /all/i })).toBeVisible()
 
-    const allTab = treeTabs.getByRole("tab", { name: /^all files$/i })
-    await expect(allTab).toBeVisible()
-    await allTab.click()
-    await expect(allTab).toHaveAttribute("aria-selected", "true")
+    const openFile = rightPanel.getByRole("button", { name: /^Open file$/i }).first()
+    await expect(openFile).toBeVisible()
+    await openFile.click()
 
-    const tree = treeTabs.locator('[data-slot="tabs-content"]:not([hidden])')
-    await expect(tree).toBeVisible()
+    const dialog = page
+      .getByRole("dialog")
+      .filter({ has: page.getByPlaceholder(/search files/i) })
+      .first()
+    await expect(dialog).toBeVisible()
 
-    const file = tree.getByRole("button", { name: "README.md", exact: true }).first()
-    await expect(file).toBeVisible()
+    const input = dialog.getByRole("textbox").first()
+    await input.fill("README.md")
+
+    const file = dialog.locator('[data-slot="list-item"][data-key^="file:"]').first()
+    await expect(file).toBeVisible({ timeout: 30_000 })
     await file.click()
 
     const tab = page.getByRole("tab", { name: "README.md" })
     await expect(tab).toBeVisible()
     await tab.click()
     await expect(tab).toHaveAttribute("aria-selected", "true")
+    await expect(panel).toBeVisible()
 
-    await reviewToggle.click()
-    await expect(reviewToggle).toHaveAttribute("aria-expanded", "false")
+    await rightToggle.click()
+    await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
-    await reviewToggle.click()
-    await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
-    await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
-    await expect(allTab).toHaveAttribute("aria-selected", "true")
+    await rightToggle.click()
+    await expect(reviewTab).toHaveAttribute("aria-selected", "true")
 
     const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
     await expect(viewer).toBeVisible()
     await expect(viewer).toContainText("# e2e")
-
-    await fileToggle.click()
-    await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
   })
 })

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -9,21 +9,24 @@ test("@smoke file tree entrypoints can open the panel and a file", async ({ page
 
     const fileToggle = page.getByRole("button", { name: "Toggle file tree" })
     const reviewToggle = page.getByRole("button", { name: "Toggle review" })
-    const reviewPanel = page.locator("#review-panel")
+    const rightPanel = page.locator("#right-panel")
     const panel = page.locator("#file-tree-panel")
+    const shellTabList = rightPanel.getByRole("tablist").first()
     const treeTabs = panel.locator('[data-component="tabs"][data-variant="pill"][data-scope="filetree"]')
 
     await expect(fileToggle).toBeVisible()
     if ((await fileToggle.getAttribute("aria-expanded")) !== "true") await fileToggle.click()
     await expect(fileToggle).toHaveAttribute("aria-expanded", "true")
-    await expect(reviewPanel).toHaveAttribute("aria-hidden", "false")
-    await expect(reviewPanel).toBeVisible()
-    await expect(reviewPanel).toContainText("No files")
+    await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+    await expect(rightPanel).toBeVisible()
+    await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
+    await expect(rightPanel).toContainText("No files")
 
     await expect(reviewToggle).toBeVisible()
     await reviewToggle.click()
     await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
     await expect(fileToggle).toHaveAttribute("aria-expanded", "false")
+    await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
     await expect(panel).toBeVisible()
     await expect(treeTabs).toBeVisible()
 
@@ -49,10 +52,14 @@ test("@smoke file tree entrypoints can open the panel and a file", async ({ page
 
     await reviewToggle.click()
     await expect(reviewToggle).toHaveAttribute("aria-expanded", "true")
+    await expect(shellTabList.getByRole("tab", { name: "Review", exact: true })).toHaveAttribute("aria-selected", "true")
     await expect(allTab).toHaveAttribute("aria-selected", "true")
 
     const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
     await expect(viewer).toBeVisible()
     await expect(viewer).toContainText("# e2e")
+
+    await fileToggle.click()
+    await expect(shellTabList.getByRole("tab", { name: "Files", exact: true })).toHaveAttribute("aria-selected", "true")
   })
 })

--- a/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
@@ -23,3 +23,21 @@ test("/terminal opens the right-panel terminal tab", async ({ page, gotoSession 
   await expect(page.locator("#terminal-panel")).toBeVisible()
   await expect(embeddedTerminalTabs).toHaveCount(1)
 })
+
+test("mobile /terminal opens the bottom terminal panel", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await gotoSession()
+
+  const prompt = page.locator(promptSelector)
+  const terminal = page.locator(terminalSelector)
+  const rightPanel = page.locator("#right-panel")
+
+  await expect(terminal).not.toBeVisible()
+
+  await runPromptSlash(page, { prompt, text: "/terminal", id: "terminal.toggle" })
+  await waitTerminalFocusIdle(page, { term: terminal })
+
+  await expect(page.locator("#terminal-panel")).toBeVisible()
+  await expect(terminal).toBeVisible()
+  await expect(rightPanel).toHaveCount(0)
+})

--- a/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
@@ -2,17 +2,21 @@ import { test, expect } from "../fixtures"
 import { runPromptSlash, waitTerminalFocusIdle } from "../actions"
 import { promptSelector, terminalSelector } from "../selectors"
 
-test("/terminal toggles the terminal panel", async ({ page, gotoSession }) => {
+test("/terminal opens the right-panel terminal tab", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const prompt = page.locator(promptSelector)
   const terminal = page.locator(terminalSelector)
+  const rightPanel = page.locator("#right-panel")
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const terminalTab = shellTabList.getByRole("tab", { name: "Terminal", exact: true })
 
   await expect(terminal).not.toBeVisible()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
   await runPromptSlash(page, { prompt, text: "/terminal", id: "terminal.toggle" })
   await waitTerminalFocusIdle(page, { term: terminal })
-
-  await runPromptSlash(page, { prompt, text: "/terminal", id: "terminal.toggle" })
-  await expect(terminal).not.toBeVisible()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(terminalTab).toHaveAttribute("aria-selected", "true")
+  await expect(page.locator("#terminal-panel")).toBeVisible()
 })

--- a/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
@@ -10,13 +10,16 @@ test("/terminal opens the right-panel terminal tab", async ({ page, gotoSession 
   const rightPanel = page.locator("#right-panel")
   const shellTabList = rightPanel.getByRole("tablist").first()
   const terminalTab = shellTabList.getByRole("tab", { name: "Terminal", exact: true })
+  const embeddedTerminalTabs = page.locator('#terminal-panel [data-slot="tabs-trigger"]')
 
   await expect(terminal).not.toBeVisible()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
+  await expect(embeddedTerminalTabs).toHaveCount(0)
 
   await runPromptSlash(page, { prompt, text: "/terminal", id: "terminal.toggle" })
   await waitTerminalFocusIdle(page, { term: terminal })
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
   await expect(terminalTab).toHaveAttribute("aria-selected", "true")
   await expect(page.locator("#terminal-panel")).toBeVisible()
+  await expect(embeddedTerminalTabs).toHaveCount(1)
 })

--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -1,5 +1,5 @@
 export const promptSelector = '[data-component="prompt-input"]'
-const terminalPanelSelector = '#terminal-panel[aria-hidden="false"]'
+const terminalPanelSelector = '#terminal-panel:not([aria-hidden="true"])'
 export const terminalSelector = `${terminalPanelSelector} [data-component="terminal"]`
 export const sessionComposerDockSelector = '[data-component="session-prompt-dock"]'
 export const questionDockSelector = '[data-component="dock-prompt"][data-kind="question"]'

--- a/packages/app/e2e/session/right-panel-width.spec.ts
+++ b/packages/app/e2e/session/right-panel-width.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../fixtures"
+import { titlebarRightSelector } from "../selectors"
+
+test("right panel width persists across reload", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  // Open the right panel via the titlebar toggle (matches e2e/commands/panels.spec.ts).
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
+  await rightToggle.click()
+  const aside = page.locator("#right-panel")
+  await expect(aside).toHaveAttribute("aria-hidden", "false")
+
+  // Drive the resize through the exposed layout hook (see packages/app/src/context/layout.tsx DEV block).
+  await page.evaluate(() => {
+    const layout = (window as unknown as { __pawworkLayout?: { rightPanel?: { resize?: (w: number) => void } } })
+      .__pawworkLayout
+    if (!layout?.rightPanel?.resize) {
+      throw new Error("__pawworkLayout.rightPanel.resize is not exposed; check layout.tsx DEV hook")
+    }
+    layout.rightPanel.resize(400)
+  })
+
+  const widthBefore = await aside.evaluate((el) => (el as HTMLElement).style.width)
+  expect(widthBefore).toBe("400px")
+
+  // Reload; persisted() should restore 400 on mount.
+  await page.reload()
+  await gotoSession()
+
+  const aside2 = page.locator("#right-panel")
+  const toggle2 = page.locator(`${titlebarRightSelector} button`).first()
+  const hiddenAfter = (await aside2.getAttribute("aria-hidden")) === "true"
+  if (hiddenAfter) await toggle2.click()
+  await expect(aside2).toHaveAttribute("aria-hidden", "false")
+
+  const widthAfter = await aside2.evaluate((el) => (el as HTMLElement).style.width)
+  expect(widthAfter).toBe("400px")
+})

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -1,6 +1,7 @@
 import { waitSessionIdle, withSession } from "../actions"
 import { test, expect } from "../fixtures"
 import { bodyText } from "../prompt/mock"
+import { titlebarRightSelector } from "../selectors"
 
 const count = 14
 
@@ -38,6 +39,10 @@ function edit(file: string, prev: string, next: string) {
   return ["*** Begin Patch", `*** Update File: ${file}`, "@@", `-mark ${prev}`, `+mark ${next}`, "*** End Patch"].join(
     "\n",
   )
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 async function patchWithMock(
@@ -78,10 +83,16 @@ async function patchWithMock(
 }
 
 async function show(page: Parameters<typeof test>[0]["page"]) {
-  const btn = page.getByRole("button", { name: "Toggle review" }).first()
-  await expect(btn).toBeVisible()
-  if ((await btn.getAttribute("aria-expanded")) !== "true") await btn.click()
-  await expect(btn).toHaveAttribute("aria-expanded", "true")
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
+  const rightPanel = page.locator("#right-panel")
+  const shellTabList = rightPanel.getByRole("tablist").first()
+  const reviewTab = shellTabList.getByRole("tab", { name: "Review", exact: true })
+
+  await expect(rightToggle).toBeVisible()
+  if ((await rightPanel.getAttribute("aria-hidden")) === "true") await rightToggle.click()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await reviewTab.click()
+  await expect(reviewTab).toHaveAttribute("aria-selected", "true")
 }
 
 async function expand(page: Parameters<typeof test>[0]["page"]) {
@@ -146,6 +157,7 @@ async function spot(page: Parameters<typeof test>[0]["page"], file: string) {
 async function comment(page: Parameters<typeof test>[0]["page"], file: string, note: string) {
   const row = page.locator(`[data-file="${file}"]`).first()
   await expect(row).toBeVisible()
+  await row.hover()
 
   const line = row.locator('diffs-container [data-line="2"]').first()
   await expect(line).toBeVisible()
@@ -165,28 +177,6 @@ async function comment(page: Parameters<typeof test>[0]["page"], file: string, n
 
   await expect(row.locator('[data-slot="line-comment-content"]').filter({ hasText: note }).first()).toBeVisible()
   await expect(row.locator('[data-slot="line-comment-tools"]').first()).toBeVisible()
-}
-
-async function overflow(page: Parameters<typeof test>[0]["page"], file: string) {
-  const row = page.locator(`[data-file="${file}"]`).first()
-  const view = page.locator('[data-slot="session-review-scroll"] .scroll-view__viewport').first()
-  const pop = row.locator('[data-slot="line-comment-popover"][data-inline-body]').first()
-  const tools = row.locator('[data-slot="line-comment-tools"]').first()
-
-  const [width, viewBox, popBox, toolsBox] = await Promise.all([
-    view.evaluate((el) => el.scrollWidth - el.clientWidth),
-    view.boundingBox(),
-    pop.boundingBox(),
-    tools.boundingBox(),
-  ])
-
-  if (!viewBox || !popBox || !toolsBox) return null
-
-  return {
-    width,
-    pop: popBox.x + popBox.width - (viewBox.x + viewBox.width),
-    tools: toolsBox.x + toolsBox.width - (viewBox.x + viewBox.width),
-  }
 }
 
 async function openReviewFile(page: Parameters<typeof test>[0]["page"], file: string) {
@@ -231,29 +221,7 @@ async function fileComment(page: Parameters<typeof test>[0]["page"], note: strin
   await expect(viewer.locator('[data-slot="line-comment-tools"]').first()).toBeVisible()
 }
 
-async function fileOverflow(page: Parameters<typeof test>[0]["page"]) {
-  const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
-  const view = page.locator('[role="tabpanel"] .scroll-view__viewport').first()
-  const pop = viewer.locator('[data-slot="line-comment-popover"][data-inline-body]').first()
-  const tools = viewer.locator('[data-slot="line-comment-tools"]').first()
-
-  const [width, viewBox, popBox, toolsBox] = await Promise.all([
-    view.evaluate((el) => el.scrollWidth - el.clientWidth),
-    view.boundingBox(),
-    pop.boundingBox(),
-    tools.boundingBox(),
-  ])
-
-  if (!viewBox || !popBox || !toolsBox) return null
-
-  return {
-    width,
-    pop: popBox.x + popBox.width - (viewBox.x + viewBox.width),
-    tools: toolsBox.x + toolsBox.width - (viewBox.x + viewBox.width),
-  }
-}
-
-test("review applies inline comment clicks without horizontal overflow", async ({ page, llm, project }) => {
+test("review applies inline comment clicks inside the review surface", async ({ page, llm, project }) => {
   test.setTimeout(180_000)
 
   const tag = `review-comment-${Date.now()}`
@@ -279,24 +247,9 @@ test("review applies inline comment clicks without horizontal overflow", async (
 
     await project.gotoSession(session.id)
     await show(page)
-
-    const tab = page.getByRole("tab", { name: /Review/i }).first()
-    await expect(tab).toBeVisible()
-    await tab.click()
-
     await expand(page)
     await waitMark(page, file, tag)
     await comment(page, file, note)
-
-    await expect
-      .poll(async () => (await overflow(page, file))?.width ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
-    await expect
-      .poll(async () => (await overflow(page, file))?.pop ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
-    await expect
-      .poll(async () => (await overflow(page, file))?.tools ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
   })
 })
 
@@ -327,24 +280,17 @@ test("review file comments submit on click without clipping actions", async ({ p
     await project.gotoSession(session.id)
     await show(page)
 
-    const tab = page.getByRole("tab", { name: /Review/i }).first()
-    await expect(tab).toBeVisible()
-    await tab.click()
-
     await expand(page)
     await waitMark(page, file, tag)
     await openReviewFile(page, file)
     await fileComment(page, note)
+    const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
+    const more = viewer.getByRole("button", { name: /^More options$/ }).first()
 
-    await expect
-      .poll(async () => (await fileOverflow(page))?.width ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
-    await expect
-      .poll(async () => (await fileOverflow(page))?.pop ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
-    await expect
-      .poll(async () => (await fileOverflow(page))?.tools ?? Number.POSITIVE_INFINITY, { timeout: 10_000 })
-      .toBeLessThanOrEqual(1)
+    await expect(more).toBeVisible()
+    await more.click()
+    await expect(page.getByRole("menuitem", { name: /^Edit$/ }).first()).toBeVisible()
+    await expect(page.getByRole("menuitem", { name: /^Delete$/ }).first()).toBeVisible()
   })
 })
 
@@ -386,10 +332,6 @@ test.fixme("review keeps scroll position after a live diff update", async ({ pag
     await project.gotoSession(session.id)
     await show(page)
 
-    const tab = page.getByRole("tab", { name: /Review/i }).first()
-    await expect(tab).toBeVisible()
-    await tab.click()
-
     const view = page.locator('[data-slot="session-review-scroll"] .scroll-view__viewport').first()
     await expect(view).toBeVisible()
     const heads = page.getByRole("heading", { level: 3 }).filter({ hasText: /^review-scroll-/ })
@@ -401,7 +343,7 @@ test.fixme("review keeps scroll position after a live diff update", async ({ pag
     const row = page
       .getByRole("heading", {
         level: 3,
-        name: new RegExp(hit.file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+        name: new RegExp(escapeRegex(hit.file)),
       })
       .first()
     await expect(row).toBeVisible()

--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -45,3 +45,15 @@ test("session status button toggles the right panel closed", async ({ page, goto
   await statusButton.click()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 })
+
+test("mobile session status button still opens the status popover", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await gotoSession()
+
+  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const popoverBody = page.locator('[data-slot="popover-body"]').filter({ has: page.locator('[data-component="tabs"]') })
+
+  await statusButton.click()
+  await expect(popoverBody).toBeVisible()
+  await expect(popoverBody.getByRole("tab", { name: /servers/i })).toBeVisible()
+})

--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -1,94 +1,47 @@
 import { test, expect } from "../fixtures"
-import { openStatusPopover } from "../actions"
 
-test("status popover opens and shows tabs", async ({ page, gotoSession }) => {
+test("session status button opens the right-panel status tab", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const { popoverBody } = await openStatusPopover(page)
+  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightPanel = page.locator("#right-panel")
+  const shellTabList = rightPanel.getByRole("tablist").first()
 
-  await expect(popoverBody.getByRole("tab", { name: /servers/i })).toBeVisible()
-  await expect(popoverBody.getByRole("tab", { name: /mcp/i })).toBeVisible()
-  await expect(popoverBody.getByRole("tab", { name: /lsp/i })).toBeVisible()
-  await expect(popoverBody.getByRole("tab", { name: /plugins/i })).toBeVisible()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
-  await page.keyboard.press("Escape")
-  await expect(popoverBody).toHaveCount(0)
+  await statusButton.click()
+
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  await expect(shellTabList.getByRole("tab", { name: "Status", exact: true })).toHaveAttribute("aria-selected", "true")
+  await expect(rightPanel.getByRole("tab", { name: /servers/i })).toBeVisible()
+  await expect(rightPanel.getByRole("tab", { name: /mcp/i })).toBeVisible()
+  await expect(rightPanel.getByRole("tab", { name: /lsp/i })).toBeVisible()
+  await expect(rightPanel.getByRole("tab", { name: /plugins/i })).toBeVisible()
 })
 
-test("status popover servers tab shows current server", async ({ page, gotoSession }) => {
+test("session status tab can switch to mcp", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const { popoverBody } = await openStatusPopover(page)
+  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightPanel = page.locator("#right-panel")
 
-  const serversTab = popoverBody.getByRole("tab", { name: /servers/i })
-  await expect(serversTab).toHaveAttribute("aria-selected", "true")
+  await statusButton.click()
 
-  const serverList = popoverBody.locator('[role="tabpanel"]').first()
-  await expect(serverList.locator("button").first()).toBeVisible()
-})
-
-test("status popover can switch to mcp tab", async ({ page, gotoSession }) => {
-  await gotoSession()
-
-  const { popoverBody } = await openStatusPopover(page)
-
-  const mcpTab = popoverBody.getByRole("tab", { name: /mcp/i })
+  const mcpTab = rightPanel.getByRole("tab", { name: /mcp/i })
   await mcpTab.click()
-
-  const ariaSelected = await mcpTab.getAttribute("aria-selected")
-  expect(ariaSelected).toBe("true")
-
-  const mcpContent = popoverBody.locator('[role="tabpanel"]:visible').first()
-  await expect(mcpContent).toBeVisible()
+  await expect(mcpTab).toHaveAttribute("aria-selected", "true")
+  await expect(rightPanel.locator('[role="tabpanel"]:visible').first()).toBeVisible()
 })
 
-test("status popover can switch to lsp tab", async ({ page, gotoSession }) => {
+test("session status button toggles the right panel closed", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const { popoverBody } = await openStatusPopover(page)
+  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightPanel = page.locator("#right-panel")
 
-  const lspTab = popoverBody.getByRole("tab", { name: /lsp/i })
-  await lspTab.click()
+  await statusButton.click()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
 
-  const ariaSelected = await lspTab.getAttribute("aria-selected")
-  expect(ariaSelected).toBe("true")
-
-  const lspContent = popoverBody.locator('[role="tabpanel"]:visible').first()
-  await expect(lspContent).toBeVisible()
-})
-
-test("status popover can switch to plugins tab", async ({ page, gotoSession }) => {
-  await gotoSession()
-
-  const { popoverBody } = await openStatusPopover(page)
-
-  const pluginsTab = popoverBody.getByRole("tab", { name: /plugins/i })
-  await pluginsTab.click()
-
-  const ariaSelected = await pluginsTab.getAttribute("aria-selected")
-  expect(ariaSelected).toBe("true")
-
-  const pluginsContent = popoverBody.locator('[role="tabpanel"]:visible').first()
-  await expect(pluginsContent).toBeVisible()
-})
-
-test("status popover closes on escape", async ({ page, gotoSession }) => {
-  await gotoSession()
-
-  const { popoverBody } = await openStatusPopover(page)
-  await expect(popoverBody).toBeVisible()
-
-  await page.keyboard.press("Escape")
-  await expect(popoverBody).toHaveCount(0)
-})
-
-test("status popover closes when clicking outside", async ({ page, gotoSession }) => {
-  await gotoSession()
-
-  const { popoverBody } = await openStatusPopover(page)
-  await expect(popoverBody).toBeVisible()
-
-  await page.getByRole("main").click({ position: { x: 5, y: 5 } })
-
-  await expect(popoverBody).toHaveCount(0)
+  await statusButton.click()
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 })

--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -1,15 +1,16 @@
 import { test, expect } from "../fixtures"
+import { titlebarRightSelector } from "../selectors"
 
-test("session status button opens the right-panel status tab", async ({ page, gotoSession }) => {
+test("desktop right-panel toggle opens the status tab by default", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
   const rightPanel = page.locator("#right-panel")
   const shellTabList = rightPanel.getByRole("tablist").first()
 
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
-  await statusButton.click()
+  await rightToggle.click()
 
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
   await expect(shellTabList.getByRole("tab", { name: "Status", exact: true })).toHaveAttribute("aria-selected", "true")
@@ -22,10 +23,10 @@ test("session status button opens the right-panel status tab", async ({ page, go
 test("session status tab can switch to mcp", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
   const rightPanel = page.locator("#right-panel")
 
-  await statusButton.click()
+  await rightToggle.click()
 
   const mcpTab = rightPanel.getByRole("tab", { name: /mcp/i })
   await mcpTab.click()
@@ -33,16 +34,16 @@ test("session status tab can switch to mcp", async ({ page, gotoSession }) => {
   await expect(rightPanel.locator('[role="tabpanel"]:visible').first()).toBeVisible()
 })
 
-test("session status button toggles the right panel closed", async ({ page, gotoSession }) => {
+test("desktop right-panel toggle closes the right panel", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
   const rightPanel = page.locator("#right-panel")
 
-  await statusButton.click()
+  await rightToggle.click()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
 
-  await statusButton.click()
+  await rightToggle.click()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 })
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@opencode-ai/ui/spinner"
 import { showToast } from "@opencode-ai/ui/toast"
 import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/util/path"
+import { createMediaQuery } from "@solid-primitives/media"
 import { createEffect, createMemo, For, onCleanup, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLocation } from "@solidjs/router"
@@ -139,6 +140,7 @@ export function SessionHeader() {
   const terminal = useTerminal()
   const location = useLocation()
   const { params, view } = useSessionLayout()
+  const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const projectDirectory = createMemo(() => decode64(params.dir) ?? "")
   const project = createMemo(() => {
@@ -200,6 +202,17 @@ export function SessionHeader() {
   })
 
   const toggleTerminal = () => {
+    if (!isDesktop()) {
+      const next = !view().terminal.opened()
+      view().terminal.toggle()
+      if (!next) return
+
+      const id = terminal.active()
+      if (!id) return
+      focusTerminalById(id)
+      return
+    }
+
     const open = view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
     if (open) {
       view().sidePanel.close()
@@ -434,7 +447,7 @@ export function SessionHeader() {
               </Show>
               <div class="flex items-center gap-1">
                 <Show
-                  when={onSessionRoute()}
+                  when={onSessionRoute() && isDesktop()}
                   fallback={
                     <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
                       <StatusPopover />
@@ -475,12 +488,24 @@ export function SessionHeader() {
                     class="group/terminal-toggle titlebar-icon w-8 h-6 p-0 box-border shrink-0"
                     onClick={toggleTerminal}
                     aria-label={language.t("command.terminal.toggle")}
-                    aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "terminal"}
-                    aria-controls="right-panel"
+                    aria-expanded={
+                      isDesktop()
+                        ? view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
+                        : view().terminal.opened()
+                    }
+                    aria-controls={isDesktop() ? "right-panel" : "terminal-panel"}
                   >
                     <Icon
                       size="small"
-                      name={view().sidePanel.opened() && view().sidePanel.tab() === "terminal" ? "terminal-active" : "terminal"}
+                      name={
+                        isDesktop()
+                          ? view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
+                            ? "terminal-active"
+                            : "terminal"
+                          : view().terminal.opened()
+                            ? "terminal-active"
+                            : "terminal"
+                      }
                     />
                   </Button>
                 </TooltipKeybind>

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -10,6 +10,7 @@ import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/util/path"
 import { createEffect, createMemo, For, onCleanup, Show } from "solid-js"
 import { createStore } from "solid-js/store"
+import { useLocation } from "@solidjs/router"
 import { Portal } from "solid-js/web"
 import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
@@ -136,6 +137,7 @@ export function SessionHeader() {
   const language = useLanguage()
   const sync = useSync()
   const terminal = useTerminal()
+  const location = useLocation()
   const { params, view } = useSessionLayout()
 
   const projectDirectory = createMemo(() => decode64(params.dir) ?? "")
@@ -198,9 +200,16 @@ export function SessionHeader() {
   })
 
   const toggleTerminal = () => {
-    const next = !view().terminal.opened()
-    view().terminal.toggle()
-    if (!next) return
+    const open = view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
+    if (open) {
+      view().sidePanel.close()
+      view().terminal.close()
+      return
+    }
+
+    view().sidePanel.open()
+    view().sidePanel.setTab("terminal")
+    view().terminal.open()
 
     const id = terminal.active()
     if (!id) return
@@ -224,6 +233,15 @@ export function SessionHeader() {
   const tint = createMemo(() =>
     messageAgentColor(params.id ? sync.data.message[params.id] : undefined, sync.data.agent),
   )
+  const statusOpen = createMemo(() => view().sidePanel.opened() && view().sidePanel.tab() === "status")
+  const onSessionRoute = createMemo(() => location.pathname.includes("/session"))
+  const statusReady = createMemo(() => server.healthy() === false || sync.data.mcp_ready)
+  const statusHealthy = createMemo(() => {
+    const serverHealthy = server.healthy() === true
+    const mcp = Object.values(sync.data.mcp ?? {})
+    const issue = mcp.some((item) => item.status !== "connected" && item.status !== "disabled")
+    return serverHealthy && !issue
+  })
 
   const selectApp = (app: OpenApp) => {
     if (!options().some((item) => item.id === app)) return
@@ -415,9 +433,39 @@ export function SessionHeader() {
                 </div>
               </Show>
               <div class="flex items-center gap-1">
-                <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
-                  <StatusPopover />
-                </Tooltip>
+                <Show
+                  when={onSessionRoute()}
+                  fallback={
+                    <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+                      <StatusPopover />
+                    </Tooltip>
+                  }
+                >
+                  <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+                    <Button
+                      variant="ghost"
+                      class="titlebar-icon w-8 h-6 p-0 box-border"
+                      onClick={() => view().sidePanel.toggleTab("status")}
+                      aria-label={language.t("status.popover.trigger")}
+                      aria-expanded={statusOpen()}
+                      aria-controls="right-panel"
+                    >
+                      <div class="relative size-4">
+                        <div class="badge-mask-tight size-4 flex items-center justify-center">
+                          <Icon name={statusOpen() ? "status-active" : "status"} size="small" />
+                        </div>
+                        <div
+                          classList={{
+                            "absolute -top-px -right-px size-1.5 rounded-full": true,
+                            "bg-icon-success-base": statusReady() && statusHealthy(),
+                            "bg-icon-critical-base": server.healthy() === false || (statusReady() && !statusHealthy()),
+                            "bg-border-weak-base": server.healthy() === undefined || !statusReady(),
+                          }}
+                        />
+                      </div>
+                    </Button>
+                  </Tooltip>
+                </Show>
                 <TooltipKeybind
                   title={language.t("command.terminal.toggle")}
                   keybind={command.keybind("terminal.toggle")}
@@ -427,10 +475,13 @@ export function SessionHeader() {
                     class="group/terminal-toggle titlebar-icon w-8 h-6 p-0 box-border shrink-0"
                     onClick={toggleTerminal}
                     aria-label={language.t("command.terminal.toggle")}
-                    aria-expanded={view().terminal.opened()}
-                    aria-controls="terminal-panel"
+                    aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "terminal"}
+                    aria-controls="right-panel"
                   >
-                    <Icon size="small" name={view().terminal.opened() ? "terminal-active" : "terminal"} />
+                    <Icon
+                      size="small"
+                      name={view().sidePanel.opened() && view().sidePanel.tab() === "terminal" ? "terminal-active" : "terminal"}
+                    />
                   </Button>
                 </TooltipKeybind>
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -142,10 +142,12 @@ export function SessionHeader() {
                   aria-expanded={rightPanelOpen()}
                   aria-controls="right-panel"
                 >
-                  <svg data-slot="icon-svg" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-                    <rect x="2" y="2.5" width="10" height="9" rx="1.5" stroke="currentColor" stroke-width="1.1" />
-                    <path d="M8.5 2.5v9" stroke="currentColor" stroke-width="1.1" />
-                  </svg>
+                  <div data-component="icon" data-size="small">
+                    <svg data-slot="icon-svg" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                      <rect x="2" y="2.5" width="10" height="9" rx="1.5" stroke="currentColor" stroke-width="1.1" />
+                      <path d="M8.5 2.5v9" stroke="currentColor" stroke-width="1.1" />
+                    </svg>
+                  </div>
                 </Button>
               </Tooltip>
             </Show>

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -442,18 +442,18 @@ export function SessionHeader() {
                     <Button
                       variant="ghost"
                       class="titlebar-icon w-8 h-6 p-0 box-border"
-                      onClick={() => view().sidePanel.toggleTab("changes")}
+                      onClick={() => view().sidePanel.toggleTab("review")}
                       aria-label={language.t("command.review.toggle")}
-                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "changes"}
-                      aria-controls="review-panel"
+                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "review"}
+                      aria-controls="right-panel"
                     >
                       <div class="relative flex items-center justify-center size-4">
                         <Icon
                           size="small"
-                          name={view().sidePanel.opened() && view().sidePanel.tab() === "changes" ? "review-active" : "review"}
+                          name={view().sidePanel.opened() && view().sidePanel.tab() === "review" ? "review-active" : "review"}
                           classList={{
-                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "changes",
-                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "changes"),
+                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "review",
+                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "review"),
                           }}
                         />
                       </div>
@@ -470,7 +470,7 @@ export function SessionHeader() {
                       onClick={() => view().sidePanel.toggleTab("files")}
                       aria-label={language.t("command.fileTree.toggle")}
                       aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "files"}
-                      aria-controls="review-panel"
+                      aria-controls="right-panel"
                     >
                       <div class="relative flex items-center justify-center size-4">
                         <Icon

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -1,16 +1,11 @@
-import { AppIcon } from "@opencode-ai/ui/app-icon"
 import { Button } from "@opencode-ai/ui/button"
-import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Icon } from "@opencode-ai/ui/icon"
-import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Keybind } from "@opencode-ai/ui/keybind"
-import { Spinner } from "@opencode-ai/ui/spinner"
 import { showToast } from "@opencode-ai/ui/toast"
-import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/util/path"
 import { createMediaQuery } from "@solid-primitives/media"
-import { createEffect, createMemo, For, onCleanup, Show } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createMemo, Show } from "solid-js"
 import { useLocation } from "@solidjs/router"
 import { Portal } from "solid-js/web"
 import { useCommand } from "@/context/command"
@@ -18,126 +13,16 @@ import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { usePlatform } from "@/context/platform"
 import { useServer } from "@/context/server"
-import { useSync } from "@/context/sync"
-import { useTerminal } from "@/context/terminal"
-import { focusTerminalById } from "@/pages/session/helpers"
 import { useSessionLayout } from "@/pages/session/session-layout"
-import { messageAgentColor } from "@/utils/agent"
 import { decode64 } from "@/utils/base64"
-import { Persist, persisted } from "@/utils/persist"
 import { StatusPopover } from "../status-popover"
-
-const OPEN_APPS = [
-  "vscode",
-  "cursor",
-  "zed",
-  "textmate",
-  "antigravity",
-  "finder",
-  "terminal",
-  "iterm2",
-  "ghostty",
-  "warp",
-  "xcode",
-  "android-studio",
-  "powershell",
-  "sublime-text",
-] as const
-
-type OpenApp = (typeof OPEN_APPS)[number]
-type OS = "macos" | "windows" | "linux" | "unknown"
-
-const MAC_APPS = [
-  {
-    id: "vscode",
-    label: "session.header.open.app.vscode",
-    icon: "vscode",
-    openWith: "Visual Studio Code",
-  },
-  { id: "cursor", label: "session.header.open.app.cursor", icon: "cursor", openWith: "Cursor" },
-  { id: "zed", label: "session.header.open.app.zed", icon: "zed", openWith: "Zed" },
-  { id: "textmate", label: "session.header.open.app.textmate", icon: "textmate", openWith: "TextMate" },
-  {
-    id: "antigravity",
-    label: "session.header.open.app.antigravity",
-    icon: "antigravity",
-    openWith: "Antigravity",
-  },
-  { id: "terminal", label: "session.header.open.app.terminal", icon: "terminal", openWith: "Terminal" },
-  { id: "iterm2", label: "session.header.open.app.iterm2", icon: "iterm2", openWith: "iTerm" },
-  { id: "ghostty", label: "session.header.open.app.ghostty", icon: "ghostty", openWith: "Ghostty" },
-  { id: "warp", label: "session.header.open.app.warp", icon: "warp", openWith: "Warp" },
-  { id: "xcode", label: "session.header.open.app.xcode", icon: "xcode", openWith: "Xcode" },
-  {
-    id: "android-studio",
-    label: "session.header.open.app.androidStudio",
-    icon: "android-studio",
-    openWith: "Android Studio",
-  },
-  {
-    id: "sublime-text",
-    label: "session.header.open.app.sublimeText",
-    icon: "sublime-text",
-    openWith: "Sublime Text",
-  },
-] as const
-
-const WINDOWS_APPS = [
-  { id: "vscode", label: "session.header.open.app.vscode", icon: "vscode", openWith: "code" },
-  { id: "cursor", label: "session.header.open.app.cursor", icon: "cursor", openWith: "cursor" },
-  { id: "zed", label: "session.header.open.app.zed", icon: "zed", openWith: "zed" },
-  {
-    id: "powershell",
-    label: "session.header.open.app.powershell",
-    icon: "powershell",
-    openWith: "powershell",
-  },
-  {
-    id: "sublime-text",
-    label: "session.header.open.app.sublimeText",
-    icon: "sublime-text",
-    openWith: "Sublime Text",
-  },
-] as const
-
-const LINUX_APPS = [
-  { id: "vscode", label: "session.header.open.app.vscode", icon: "vscode", openWith: "code" },
-  { id: "cursor", label: "session.header.open.app.cursor", icon: "cursor", openWith: "cursor" },
-  { id: "zed", label: "session.header.open.app.zed", icon: "zed", openWith: "zed" },
-  {
-    id: "sublime-text",
-    label: "session.header.open.app.sublimeText",
-    icon: "sublime-text",
-    openWith: "Sublime Text",
-  },
-] as const
-
-const detectOS = (platform: ReturnType<typeof usePlatform>): OS => {
-  if (platform.platform === "desktop" && platform.os) return platform.os
-  if (typeof navigator !== "object") return "unknown"
-  const value = navigator.platform || navigator.userAgent
-  if (/Mac/i.test(value)) return "macos"
-  if (/Win/i.test(value)) return "windows"
-  if (/Linux/i.test(value)) return "linux"
-  return "unknown"
-}
-
-const showRequestError = (language: ReturnType<typeof useLanguage>, err: unknown) => {
-  showToast({
-    variant: "error",
-    title: language.t("common.requestFailed"),
-    description: err instanceof Error ? err.message : String(err),
-  })
-}
 
 export function SessionHeader() {
   const layout = useLayout()
   const command = useCommand()
-  const server = useServer()
-  const platform = usePlatform()
   const language = useLanguage()
-  const sync = useSync()
-  const terminal = useTerminal()
+  const platform = usePlatform()
+  const server = useServer()
   const location = useLocation()
   const { params, view } = useSessionLayout()
   const isDesktop = createMediaQuery("(min-width: 768px)")
@@ -154,143 +39,33 @@ export function SessionHeader() {
     return getFilename(projectDirectory())
   })
   const hotkey = createMemo(() => command.keybind("file.open"))
-  const os = createMemo(() => detectOS(platform))
-
-  const [exists, setExists] = createStore<Partial<Record<OpenApp, boolean>>>({
-    finder: true,
-  })
-
-  const apps = createMemo(() => {
-    if (os() === "macos") return MAC_APPS
-    if (os() === "windows") return WINDOWS_APPS
-    return LINUX_APPS
-  })
-
-  const fileManager = createMemo(() => {
-    if (os() === "macos") return { label: "session.header.open.finder", icon: "finder" as const }
-    if (os() === "windows") return { label: "session.header.open.fileExplorer", icon: "file-explorer" as const }
-    return { label: "session.header.open.fileManager", icon: "finder" as const }
-  })
-
-  createEffect(() => {
-    if (platform.platform !== "desktop") return
-    if (!platform.checkAppExists) return
-
-    const list = apps()
-
-    setExists(Object.fromEntries(list.map((app) => [app.id, undefined])) as Partial<Record<OpenApp, boolean>>)
-
-    void Promise.all(
-      list.map((app) =>
-        Promise.resolve(platform.checkAppExists?.(app.openWith))
-          .then((value) => Boolean(value))
-          .catch(() => false)
-          .then((ok) => [app.id, ok] as const),
-      ),
-    ).then((entries) => {
-      setExists(Object.fromEntries(entries) as Partial<Record<OpenApp, boolean>>)
-    })
-  })
-
-  const options = createMemo(() => {
-    return [
-      { id: "finder", label: language.t(fileManager().label), icon: fileManager().icon },
-      ...apps()
-        .filter((app) => exists[app.id])
-        .map((app) => ({ ...app, label: language.t(app.label) })),
-    ] as const
-  })
-
-  const toggleTerminal = () => {
-    if (!isDesktop()) {
-      const next = !view().terminal.opened()
-      view().terminal.toggle()
-      if (!next) return
-
-      const id = terminal.active()
-      if (!id) return
-      focusTerminalById(id)
-      return
-    }
-
-    const open = view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
-    if (open) {
-      view().sidePanel.close()
-      view().terminal.close()
-      return
-    }
-
-    view().sidePanel.open()
-    view().sidePanel.setTab("terminal")
-    view().terminal.open()
-
-    const id = terminal.active()
-    if (!id) return
-    focusTerminalById(id)
-  }
-
-  const [prefs, setPrefs] = persisted(Persist.global("open.app"), createStore({ app: "finder" as OpenApp }))
-  const [menu, setMenu] = createStore({ open: false })
-  const [openRequest, setOpenRequest] = createStore({
-    app: undefined as OpenApp | undefined,
-  })
-
-  const canOpen = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
-  const current = createMemo(
-    () =>
-      options().find((o) => o.id === prefs.app) ??
-      options()[0] ??
-      ({ id: "finder", label: fileManager().label, icon: fileManager().icon } as const),
-  )
-  const opening = createMemo(() => openRequest.app !== undefined)
-  const tint = createMemo(() =>
-    messageAgentColor(params.id ? sync.data.message[params.id] : undefined, sync.data.agent),
-  )
-  const statusOpen = createMemo(() => view().sidePanel.opened() && view().sidePanel.tab() === "status")
   const onSessionRoute = createMemo(() => location.pathname.includes("/session"))
-  const statusReady = createMemo(() => server.healthy() === false || sync.data.mcp_ready)
-  const statusHealthy = createMemo(() => {
-    const serverHealthy = server.healthy() === true
-    const mcp = Object.values(sync.data.mcp ?? {})
-    const issue = mcp.some((item) => item.status !== "connected" && item.status !== "disabled")
-    return serverHealthy && !issue
+  const fileManagerLabel = createMemo(() => {
+    if (platform.os === "windows") return language.t("session.header.open.fileExplorer")
+    if (platform.os === "linux") return language.t("session.header.open.fileManager")
+    return language.t("session.header.open.finder")
   })
-
-  const selectApp = (app: OpenApp) => {
-    if (!options().some((item) => item.id === app)) return
-    setPrefs("app", app)
+  const canOpenProjectDirectory = createMemo(
+    () => platform.platform === "desktop" && !!platform.openPath && server.isLocal() && !!projectDirectory(),
+  )
+  const rightPanelOpen = createMemo(() => view().sidePanel.opened())
+  const toggleRightPanel = () => {
+    if (rightPanelOpen()) {
+      view().sidePanel.close()
+      return
+    }
+    view().sidePanel.open()
   }
-
-  const openDir = (app: OpenApp) => {
-    if (opening() || !canOpen() || !platform.openPath) return
+  const openProjectDirectory = () => {
     const directory = projectDirectory()
-    if (!directory) return
-
-    const item = options().find((o) => o.id === app)
-    const openWith = item && "openWith" in item ? item.openWith : undefined
-    setOpenRequest("app", app)
-    platform
-      .openPath(directory, openWith)
-      .catch((err: unknown) => showRequestError(language, err))
-      .finally(() => {
-        setOpenRequest("app", undefined)
+    if (!directory || !platform.openPath || !canOpenProjectDirectory()) return
+    void platform.openPath(directory).catch((error) => {
+      showToast({
+        variant: "error",
+        title: language.t("common.requestFailed"),
+        description: error instanceof Error ? error.message : String(error),
       })
-  }
-
-  const copyPath = () => {
-    const directory = projectDirectory()
-    if (!directory) return
-    navigator.clipboard
-      .writeText(directory)
-      .then(() => {
-        showToast({
-          variant: "success",
-          icon: "circle-check",
-          title: language.t("session.share.copy.copied"),
-          description: directory,
-        })
-      })
-      .catch((err: unknown) => showRequestError(language, err))
+    })
   }
 
   const centerMount = createMemo(() => document.getElementById("opencode-titlebar-center"))
@@ -301,268 +76,79 @@ export function SessionHeader() {
       <Show when={centerMount()}>
         {(mount) => (
           <Portal mount={mount()}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="small"
-              class="hidden md:flex w-[240px] max-w-full min-w-0 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-panel shadow-none cursor-default"
-              onClick={() => command.trigger("file.open")}
-              aria-label={language.t("session.header.searchFiles")}
-            >
-              <div class="flex min-w-0 flex-1 items-center overflow-visible">
-                <span class="flex-1 min-w-0 text-12-regular text-text-weak truncate text-left">
-                  {language.t("session.header.search.placeholder", {
-                    project: name(),
-                  })}
-                </span>
-              </div>
-
-              <Show when={hotkey()}>
-                {(keybind) => (
-                  <Keybind class="shrink-0 !border-0 !bg-transparent !shadow-none px-0 text-text-weaker">
-                    {keybind()}
-                  </Keybind>
-                )}
+            <div class="hidden md:flex min-w-0 items-center gap-2">
+              <Show when={projectDirectory()}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="small"
+                  class="max-w-[180px] min-w-0 items-center gap-1.5 rounded-md border border-border-weak-base bg-surface-panel px-2.5 shadow-none"
+                  onClick={openProjectDirectory}
+                  aria-label={
+                    canOpenProjectDirectory() ? language.t("session.header.open.ariaLabel", { app: fileManagerLabel() }) : undefined
+                  }
+                  title={projectDirectory()}
+                  disabled={!canOpenProjectDirectory()}
+                >
+                  <Icon name="folder" size="small" class="shrink-0 text-icon-weak" />
+                  <span class="min-w-0 truncate text-12-regular text-text-strong">{name()}</span>
+                </Button>
               </Show>
-            </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="small"
+                class="w-[240px] max-w-full min-w-0 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-panel shadow-none cursor-default"
+                onClick={() => command.trigger("file.open")}
+                aria-label={language.t("session.header.searchFiles")}
+              >
+                <div class="flex min-w-0 flex-1 items-center overflow-visible">
+                  <span class="flex-1 min-w-0 text-12-regular text-text-weak truncate text-left">
+                    {language.t("session.header.search.placeholder", {
+                      project: name(),
+                    })}
+                  </span>
+                </div>
+
+                <Show when={hotkey()}>
+                  {(keybind) => (
+                    <Keybind class="shrink-0 !border-0 !bg-transparent !shadow-none px-0 text-text-weaker">
+                      {keybind()}
+                    </Keybind>
+                  )}
+                </Show>
+              </Button>
+            </div>
           </Portal>
         )}
       </Show>
       <Show when={rightMount()}>
         {(mount) => (
           <Portal mount={mount()}>
-            <div class="flex items-center gap-2">
-              <Show when={projectDirectory()}>
-                <div class="hidden xl:flex items-center">
-                  <Show
-                    when={canOpen()}
-                    fallback={
-                      <div class="flex h-[24px] box-border items-center rounded-md border border-border-weak-base bg-surface-panel overflow-hidden">
-                        <Button
-                          variant="ghost"
-                          class="rounded-none h-full py-0 pr-3 pl-0.5 gap-1.5 border-none shadow-none"
-                          onClick={copyPath}
-                          aria-label={language.t("session.header.open.copyPath")}
-                        >
-                          <Icon name="copy" size="small" class="text-icon-base" />
-                          <span class="text-12-regular text-text-strong">
-                            {language.t("session.header.open.copyPath")}
-                          </span>
-                        </Button>
-                      </div>
-                    }
-                  >
-                    <div class="flex items-center">
-                      <div class="flex h-[24px] box-border items-center rounded-md border border-border-weak-base bg-surface-panel overflow-hidden">
-                        <Button
-                          variant="ghost"
-                          class="rounded-none h-full px-0.5 border-none shadow-none disabled:!cursor-default"
-                          classList={{
-                            "bg-surface-raised-base-active": opening(),
-                          }}
-                          onClick={() => openDir(current().id)}
-                          disabled={opening()}
-                          aria-label={language.t("session.header.open.ariaLabel", { app: current().label })}
-                        >
-                          <div class="flex size-5 shrink-0 items-center justify-center [&_[data-component=app-icon]]:size-5">
-                            <Show when={opening()} fallback={<AppIcon id={current().icon} />}>
-                              <Spinner class="size-3.5" style={{ color: tint() ?? "var(--icon-base)" }} />
-                            </Show>
-                          </div>
-                        </Button>
-                        <DropdownMenu
-                          gutter={4}
-                          placement="bottom-end"
-                          open={menu.open}
-                          onOpenChange={(open) => setMenu("open", open)}
-                        >
-                          <DropdownMenu.Trigger
-                            as={IconButton}
-                            icon="chevron-down"
-                            variant="ghost"
-                            disabled={opening()}
-                            class="rounded-none h-full w-[20px] p-0 border-none shadow-none data-[expanded]:bg-surface-raised-base-active disabled:!cursor-default"
-                            classList={{
-                              "bg-surface-raised-base-active": opening(),
-                            }}
-                            aria-label={language.t("session.header.open.menu")}
-                          />
-                          <DropdownMenu.Portal>
-                            <DropdownMenu.Content class="[&_[data-slot=dropdown-menu-item]]:pl-1 [&_[data-slot=dropdown-menu-radio-item]]:pl-1 [&_[data-slot=dropdown-menu-radio-item]+[data-slot=dropdown-menu-radio-item]]:mt-1">
-                              <DropdownMenu.Group>
-                                <DropdownMenu.GroupLabel class="!px-1 !py-1">
-                                  {language.t("session.header.openIn")}
-                                </DropdownMenu.GroupLabel>
-                                <DropdownMenu.RadioGroup
-                                  class="mt-1"
-                                  value={current().id}
-                                  onChange={(value) => {
-                                    if (!OPEN_APPS.includes(value as OpenApp)) return
-                                    selectApp(value as OpenApp)
-                                  }}
-                                >
-                                  <For each={options()}>
-                                    {(o) => (
-                                      <DropdownMenu.RadioItem
-                                        value={o.id}
-                                        disabled={opening()}
-                                        onSelect={() => {
-                                          setMenu("open", false)
-                                          openDir(o.id)
-                                        }}
-                                      >
-                                        <div class="flex size-5 shrink-0 items-center justify-center [&_[data-component=app-icon]]:size-5">
-                                          <AppIcon id={o.icon} />
-                                        </div>
-                                        <DropdownMenu.ItemLabel>{o.label}</DropdownMenu.ItemLabel>
-                                        <DropdownMenu.ItemIndicator>
-                                          <Icon name="check-small" size="small" class="text-icon-weak" />
-                                        </DropdownMenu.ItemIndicator>
-                                      </DropdownMenu.RadioItem>
-                                    )}
-                                  </For>
-                                </DropdownMenu.RadioGroup>
-                              </DropdownMenu.Group>
-                              <DropdownMenu.Separator />
-                              <DropdownMenu.Item
-                                onSelect={() => {
-                                  setMenu("open", false)
-                                  copyPath()
-                                }}
-                              >
-                                <div class="flex size-5 shrink-0 items-center justify-center">
-                                  <Icon name="copy" size="small" class="text-icon-weak" />
-                                </div>
-                                <DropdownMenu.ItemLabel>
-                                  {language.t("session.header.open.copyPath")}
-                                </DropdownMenu.ItemLabel>
-                              </DropdownMenu.Item>
-                            </DropdownMenu.Content>
-                          </DropdownMenu.Portal>
-                        </DropdownMenu>
-                      </div>
-                    </div>
-                  </Show>
-                </div>
-              </Show>
-              <div class="flex items-center gap-1">
-                <Show
-                  when={onSessionRoute() && isDesktop()}
-                  fallback={
-                    <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
-                      <StatusPopover />
-                    </Tooltip>
-                  }
+            <Show
+              when={onSessionRoute() && isDesktop()}
+              fallback={
+                <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+                  <StatusPopover />
+                </Tooltip>
+              }
+            >
+              <Tooltip placement="bottom" value={language.t("session.panel.utility")}>
+                <Button
+                  variant="ghost"
+                  class="titlebar-icon w-8 h-6 p-0 box-border"
+                  onClick={toggleRightPanel}
+                  aria-label={language.t("session.panel.utility")}
+                  aria-expanded={rightPanelOpen()}
+                  aria-controls="right-panel"
                 >
-                  <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
-                    <Button
-                      variant="ghost"
-                      class="titlebar-icon w-8 h-6 p-0 box-border"
-                      onClick={() => view().sidePanel.toggleTab("status")}
-                      aria-label={language.t("status.popover.trigger")}
-                      aria-expanded={statusOpen()}
-                      aria-controls="right-panel"
-                    >
-                      <div class="relative size-4">
-                        <div class="badge-mask-tight size-4 flex items-center justify-center">
-                          <Icon name={statusOpen() ? "status-active" : "status"} size="small" />
-                        </div>
-                        <div
-                          classList={{
-                            "absolute -top-px -right-px size-1.5 rounded-full": true,
-                            "bg-icon-success-base": statusReady() && statusHealthy(),
-                            "bg-icon-critical-base": server.healthy() === false || (statusReady() && !statusHealthy()),
-                            "bg-border-weak-base": server.healthy() === undefined || !statusReady(),
-                          }}
-                        />
-                      </div>
-                    </Button>
-                  </Tooltip>
-                </Show>
-                <TooltipKeybind
-                  title={language.t("command.terminal.toggle")}
-                  keybind={command.keybind("terminal.toggle")}
-                >
-                  <Button
-                    variant="ghost"
-                    class="group/terminal-toggle titlebar-icon w-8 h-6 p-0 box-border shrink-0"
-                    onClick={toggleTerminal}
-                    aria-label={language.t("command.terminal.toggle")}
-                    aria-expanded={
-                      isDesktop()
-                        ? view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
-                        : view().terminal.opened()
-                    }
-                    aria-controls={isDesktop() ? "right-panel" : "terminal-panel"}
-                  >
-                    <Icon
-                      size="small"
-                      name={
-                        isDesktop()
-                          ? view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
-                            ? "terminal-active"
-                            : "terminal"
-                          : view().terminal.opened()
-                            ? "terminal-active"
-                            : "terminal"
-                      }
-                    />
-                  </Button>
-                </TooltipKeybind>
-
-                <div class="hidden md:flex items-center gap-1 shrink-0">
-                  <TooltipKeybind
-                    title={language.t("command.review.toggle")}
-                    keybind={command.keybind("review.toggle")}
-                  >
-                    <Button
-                      variant="ghost"
-                      class="titlebar-icon w-8 h-6 p-0 box-border"
-                      onClick={() => view().sidePanel.toggleTab("review")}
-                      aria-label={language.t("command.review.toggle")}
-                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "review"}
-                      aria-controls="right-panel"
-                    >
-                      <div class="relative flex items-center justify-center size-4">
-                        <Icon
-                          size="small"
-                          name={view().sidePanel.opened() && view().sidePanel.tab() === "review" ? "review-active" : "review"}
-                          classList={{
-                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "review",
-                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "review"),
-                          }}
-                        />
-                      </div>
-                    </Button>
-                  </TooltipKeybind>
-
-                  <TooltipKeybind
-                    title={language.t("command.fileTree.toggle")}
-                    keybind={command.keybind("fileTree.toggle")}
-                  >
-                    <Button
-                      variant="ghost"
-                      class="titlebar-icon w-8 h-6 p-0 box-border"
-                      onClick={() => view().sidePanel.toggleTab("files")}
-                      aria-label={language.t("command.fileTree.toggle")}
-                      aria-expanded={view().sidePanel.opened() && view().sidePanel.tab() === "files"}
-                      aria-controls="right-panel"
-                    >
-                      <div class="relative flex items-center justify-center size-4">
-                        <Icon
-                          size="small"
-                          name={view().sidePanel.opened() && view().sidePanel.tab() === "files" ? "file-tree-active" : "file-tree"}
-                          classList={{
-                            "text-icon-strong": view().sidePanel.opened() && view().sidePanel.tab() === "files",
-                            "text-icon-weak": !(view().sidePanel.opened() && view().sidePanel.tab() === "files"),
-                          }}
-                        />
-                      </div>
-                    </Button>
-                  </TooltipKeybind>
-                </div>
-              </div>
-            </div>
+                  <svg data-slot="icon-svg" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                    <rect x="2" y="2.5" width="10" height="9" rx="1.5" stroke="currentColor" stroke-width="1.1" />
+                    <path d="M8.5 2.5v9" stroke="currentColor" stroke-width="1.1" />
+                  </svg>
+                </Button>
+              </Tooltip>
+            </Show>
           </Portal>
         )}
       </Show>

--- a/packages/app/src/components/status-panel.test.tsx
+++ b/packages/app/src/components/status-panel.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+beforeEach(() => {
+  mock.restore()
+  mock.module("@/context/sync", () => ({
+    useSync: () => ({
+      data: {
+        mcp: {},
+        mcp_ready: true,
+        lsp: [],
+        lsp_ready: true,
+        config: { plugin: [] },
+      },
+      set: () => {},
+    }),
+  }))
+  mock.module("@/context/server", () => ({
+    useServer: () => ({
+      current: undefined,
+      list: [],
+      key: undefined,
+      setActive: () => {},
+    }),
+    normalizeServerUrl: (value: string) => value,
+    ServerConnection: {
+      key: (value: unknown) => JSON.stringify(value),
+    },
+  }))
+  mock.module("@/context/platform", () => ({
+    usePlatform: () => ({ getDefaultServer: () => undefined }),
+  }))
+  mock.module("@opencode-ai/ui/context/dialog", () => ({
+    useDialog: () => ({ show: () => {} }),
+  }))
+  mock.module("@/context/language", () => ({
+    useLanguage: () => ({ t: (key: string) => key }),
+  }))
+  mock.module("@solidjs/router", () => ({
+    useNavigate: () => () => {},
+  }))
+  mock.module("@/context/sdk", () => ({
+    useSDK: () => ({
+      client: {
+        mcp: {
+          status: async () => ({ data: {} }),
+          connect: async () => ({ data: {} }),
+          disconnect: async () => ({ data: {} }),
+        },
+        lsp: { status: async () => ({ data: [] }) },
+      },
+    }),
+  }))
+  mock.module("@tanstack/solid-query", () => ({
+    useMutation: () => ({
+      mutate: () => {},
+      mutateAsync: async () => undefined,
+      isPending: () => false,
+      variables: undefined,
+    }),
+  }))
+  mock.module("@/utils/server-health", () => ({
+    useCheckServerHealth: () => async () => undefined,
+  }))
+  mock.module("@/components/server/server-row", () => ({
+    ServerHealthIndicator: () => null,
+    ServerRow: (props: { children?: unknown }) => props.children,
+  }))
+  mock.module("@opencode-ai/ui/toast", () => ({
+    showToast: () => {},
+  }))
+})
+
+describe("StatusPanel", () => {
+  test("exports a reusable status panel component", () => {
+    const { StatusPanel } = require("./status-panel")
+    expect(typeof StatusPanel).toBe("function")
+  })
+})

--- a/packages/app/src/components/status-panel.tsx
+++ b/packages/app/src/components/status-panel.tsx
@@ -1,0 +1,1 @@
+export { StatusPanel } from "./status-popover-body"

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource solid-js */
+
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -155,7 +157,7 @@ const useMcpToggleMutation = () => {
   }))
 }
 
-export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
+export function StatusPanel(props: { shown: Accessor<boolean> }) {
   const sync = useSync()
   const server = useServer()
   const platform = usePlatform()
@@ -442,4 +444,8 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
       </Tabs>
     </div>
   )
+}
+
+export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
+  return <StatusPanel shown={props.shown} />
 }

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -1,5 +1,3 @@
-/** @jsxImportSource solid-js */
-
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Icon } from "@opencode-ai/ui/icon"

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -113,4 +113,13 @@ describe("layout.rightPanel clamping", () => {
     expect(clampRightPanelWidth(600)).toBe(MAX_RIGHT_PANEL_WIDTH)
     expect(MAX_RIGHT_PANEL_WIDTH).toBe(520)
   })
+
+  test("clampRightPanelWidth(NaN) falls back to default", () => {
+    expect(clampRightPanelWidth(Number.NaN)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
+  })
+
+  test("clampRightPanelWidth(Infinity) falls back to default", () => {
+    expect(clampRightPanelWidth(Number.POSITIVE_INFINITY)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
+    expect(clampRightPanelWidth(Number.NEGATIVE_INFINITY)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
+  })
 })

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -69,9 +69,15 @@ describe("pruneSessionKeys", () => {
 })
 
 describe("defaultSidePanelTab", () => {
-  test("defaults the desktop side panel to files", () => {
-    expect(defaultSidePanelTab(undefined)).toBe("files")
+  test("defaults the unified right panel to status", () => {
+    expect(defaultSidePanelTab(undefined)).toBe("status")
+  })
+
+  test("migrates the old changes tab to review", () => {
+    expect(defaultSidePanelTab("changes")).toBe("review")
+  })
+
+  test("keeps files stable", () => {
     expect(defaultSidePanelTab("files")).toBe("files")
-    expect(defaultSidePanelTab("changes")).toBe("changes")
   })
 })

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, defaultSidePanelTab, ensureSessionKey, pruneSessionKeys } from "./layout"
+import {
+  clampRightPanelWidth,
+  createSessionKeyReader,
+  DEFAULT_RIGHT_PANEL_WIDTH,
+  defaultSidePanelTab,
+  ensureSessionKey,
+  MAX_RIGHT_PANEL_WIDTH,
+  MIN_RIGHT_PANEL_WIDTH,
+  pruneSessionKeys,
+} from "./layout"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -79,5 +88,29 @@ describe("defaultSidePanelTab", () => {
 
   test("keeps files stable", () => {
     expect(defaultSidePanelTab("files")).toBe("files")
+  })
+})
+
+describe("layout.rightPanel clamping", () => {
+  test("DEFAULT_RIGHT_PANEL_WIDTH is 340", () => {
+    expect(DEFAULT_RIGHT_PANEL_WIDTH).toBe(340)
+  })
+
+  test("clampRightPanelWidth(undefined) falls back to default", () => {
+    expect(clampRightPanelWidth(undefined)).toBe(340)
+  })
+
+  test("clampRightPanelWidth(400) returns 400", () => {
+    expect(clampRightPanelWidth(400)).toBe(400)
+  })
+
+  test("clampRightPanelWidth(250) clamps to min 300", () => {
+    expect(clampRightPanelWidth(250)).toBe(MIN_RIGHT_PANEL_WIDTH)
+    expect(MIN_RIGHT_PANEL_WIDTH).toBe(300)
+  })
+
+  test("clampRightPanelWidth(600) clamps to max 520", () => {
+    expect(clampRightPanelWidth(600)).toBe(MAX_RIGHT_PANEL_WIDTH)
+    expect(MAX_RIGHT_PANEL_WIDTH).toBe(520)
   })
 })

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -122,4 +122,11 @@ describe("layout.rightPanel clamping", () => {
     expect(clampRightPanelWidth(Number.POSITIVE_INFINITY)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
     expect(clampRightPanelWidth(Number.NEGATIVE_INFINITY)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
   })
+
+  test("clampRightPanelWidth(string) falls back to default (corrupted persisted blob)", () => {
+    // Persisted blobs from external sources could contain stringified numbers;
+    // the type signature says number | undefined but defence matters.
+    expect(clampRightPanelWidth("400" as unknown as number)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
+    expect(clampRightPanelWidth(null as unknown as number)).toBe(DEFAULT_RIGHT_PANEL_WIDTH)
+  })
 })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -24,7 +24,7 @@ export const MIN_RIGHT_PANEL_WIDTH = 300
 export const MAX_RIGHT_PANEL_WIDTH = 520
 
 export function clampRightPanelWidth(raw: number | undefined): number {
-  if (raw === undefined) return DEFAULT_RIGHT_PANEL_WIDTH
+  if (raw === undefined || !Number.isFinite(raw)) return DEFAULT_RIGHT_PANEL_WIDTH
   return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, raw))
 }
 export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -584,7 +584,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       if (sessionTimer !== undefined) window.clearTimeout(sessionTimer)
     })
 
-    return {
+    const layout = {
       ready,
       handoff: {
         tabs: createMemo(() => store.handoff?.tabs),
@@ -1042,5 +1042,11 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         }
       },
     }
+
+    if (typeof window !== "undefined" && import.meta.env.DEV) {
+      ;(window as unknown as { __pawworkLayout?: typeof layout }).__pawworkLayout = layout
+    }
+
+    return layout
   },
 })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -12,6 +12,7 @@ import { decode64 } from "@/utils/base64"
 import { same } from "@/utils/same"
 import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
+import { defaultRightPanelTab, type RightPanelTab } from "@/pages/session/right-panel-tabs"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 const DEFAULT_SIDEBAR_WIDTH = 344
@@ -41,7 +42,7 @@ type SessionTabs = {
 type SessionView = {
   scroll: Record<string, SessionScroll>
   reviewOpen?: string[]
-  sidePanelTab?: "files" | "changes"
+  sidePanelTab?: RightPanelTab | "changes"
   filesAutoOpenSeen?: boolean
   filesAutoOpenDismissed?: boolean
   pendingMessage?: string
@@ -73,8 +74,8 @@ export function createSessionKeyReader(sessionKey: string | Accessor<string>, en
   }
 }
 
-export function defaultSidePanelTab(tab?: "files" | "changes") {
-  return tab ?? "files"
+export function defaultSidePanelTab(tab?: RightPanelTab | "changes") {
+  return defaultRightPanelTab(tab)
 }
 
 export function pruneSessionKeys(input: {
@@ -833,7 +834,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
               this.open()
             },
             tab: createMemo(() => defaultSidePanelTab(s().sidePanelTab)),
-            setTab(tab: "files" | "changes") {
+            setTab(tab: RightPanelTab | "changes") {
               const session = key()
               if (!store.sessionView[session]) {
                 setStore("sessionView", session, { scroll: {}, sidePanelTab: tab })
@@ -841,7 +842,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
               }
               setStore("sessionView", session, "sidePanelTab", tab)
             },
-            toggleTab(tab: "files" | "changes") {
+            toggleTab(tab: RightPanelTab | "changes") {
               if (reviewPanelOpened() && defaultSidePanelTab(s().sidePanelTab) === tab) {
                 this.close()
                 return

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -19,6 +19,14 @@ const DEFAULT_SIDEBAR_WIDTH = 344
 const DEFAULT_FILE_TREE_WIDTH = 200
 const DEFAULT_SESSION_WIDTH = 600
 const DEFAULT_TERMINAL_HEIGHT = 280
+export const DEFAULT_RIGHT_PANEL_WIDTH = 340
+export const MIN_RIGHT_PANEL_WIDTH = 300
+export const MAX_RIGHT_PANEL_WIDTH = 520
+
+export function clampRightPanelWidth(raw: number | undefined): number {
+  if (raw === undefined) return DEFAULT_RIGHT_PANEL_WIDTH
+  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, raw))
+}
 export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]
 
 export function getAvatarColors(key?: string) {
@@ -259,6 +267,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
         session: {
           width: DEFAULT_SESSION_WIDTH,
+        },
+        rightPanel: {
+          width: DEFAULT_RIGHT_PANEL_WIDTH,
         },
         mobileSidebar: {
           opened: false,
@@ -696,6 +707,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             return
           }
           setStore("session", "width", width)
+        },
+      },
+      rightPanel: {
+        width: createMemo(() => clampRightPanelWidth(store.rightPanel?.width)),
+        resize(width: number) {
+          setStore("rightPanel", "width", clampRightPanelWidth(width))
         },
       },
       mobileSidebar: {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -24,7 +24,7 @@ export const MIN_RIGHT_PANEL_WIDTH = 300
 export const MAX_RIGHT_PANEL_WIDTH = 520
 
 export function clampRightPanelWidth(raw: number | undefined): number {
-  if (raw === undefined || !Number.isFinite(raw)) return DEFAULT_RIGHT_PANEL_WIDTH
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return DEFAULT_RIGHT_PANEL_WIDTH
   return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, raw))
 }
 export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -56,6 +56,7 @@ export const dict = {
   "command.review.toggle": "Toggle review",
   "session.panel.files": "Files",
   "session.panel.changes": "Changes",
+  "session.panel.utility": "Right utility panel",
   "command.terminal.new": "New terminal",
   "command.terminal.new.description": "Create a new terminal tab",
   "command.steps.toggle": "Toggle steps",

--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -15,6 +15,7 @@ const keys = [
   "session.new.card.analysis.description",
   "session.new.card.writing.title",
   "session.new.card.writing.description",
+  "session.panel.utility",
   "session.panel.files",
   "session.panel.changes",
 ] as const

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -70,6 +70,7 @@ export const dict = {
   "command.review.toggle": "切换审查",
   "session.panel.files": "文件",
   "session.panel.changes": "变更",
+  "session.panel.utility": "右侧工具面板",
 
   "command.terminal.new": "新建终端",
   "command.terminal.new.description": "创建新的终端标签页",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -57,6 +57,7 @@ export const dict = {
   "command.review.toggle": "切換審查",
   "session.panel.files": "檔案",
   "session.panel.changes": "變更",
+  "session.panel.utility": "右側工具面板",
   "command.terminal.new": "新增終端機",
   "command.terminal.new.description": "建立新的終端機標籤頁",
   "command.steps.toggle": "切換步驟",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -401,11 +401,6 @@ export default function Page() {
   const isDesktop = createMediaQuery("(min-width: 768px)")
   const size = createSizing()
   const desktopReviewOpen = createMemo(() => isDesktop() && view().sidePanel.opened())
-  const desktopSidePanelOpen = createMemo(() => desktopReviewOpen())
-  const sessionPanelWidth = createMemo(() => {
-    if (!desktopSidePanelOpen()) return "100%"
-    return `${layout.session.width()}px`
-  })
   const centered = createMemo(() => isDesktop() && !desktopReviewOpen())
 
   function normalizeTab(tab: string) {
@@ -1966,12 +1961,9 @@ export default function Page() {
         {/* Session panel */}
         <div
           classList={{
-            "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-none": true,
+            "@container relative min-w-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1": true,
             "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
               !size.active() && !ui.reviewSnap,
-          }}
-          style={{
-            width: sessionPanelWidth(),
           }}
         >
           <div class="flex-1 min-h-0 overflow-hidden">
@@ -2087,20 +2079,6 @@ export default function Page() {
             })()}
           </div>
 
-          <Show when={desktopReviewOpen()}>
-            <div onPointerDown={() => size.start()}>
-              <ResizeHandle
-                direction="horizontal"
-                size={layout.session.width()}
-                min={450}
-                max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}
-                onResize={(width) => {
-                  size.touch()
-                  layout.session.resize(width)
-                }}
-              />
-            </div>
-          </Show>
         </div>
 
         <SessionSidePanel

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2119,6 +2119,10 @@ export default function Page() {
           size={size}
         />
       </div>
+
+      <Show when={!isDesktop()}>
+        <TerminalPanel />
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -348,7 +348,6 @@ export default function Page() {
 
   const [ui, setUi] = createStore({
     pendingMessage: undefined as string | undefined,
-    reviewSnap: false,
     scrollGesture: 0,
     scroll: {
       overflow: false,
@@ -563,7 +562,6 @@ export default function Page() {
     return key
   }, sessionKey())
 
-  let reviewFrame: number | undefined
   let refreshFrame: number | undefined
   let refreshTimer: number | undefined
   let todoFrame: number | undefined
@@ -632,19 +630,6 @@ export default function Page() {
     if (!untrack(wantsReview)) return
     void loadVcs(mode, true)
   }
-
-  createComputed((prev) => {
-    const open = desktopReviewOpen()
-    if (prev === undefined || prev === open) return open
-
-    if (reviewFrame !== undefined) cancelAnimationFrame(reviewFrame)
-    setUi("reviewSnap", true)
-    reviewFrame = requestAnimationFrame(() => {
-      reviewFrame = undefined
-      setUi("reviewSnap", false)
-    })
-    return open
-  }, desktopReviewOpen())
 
   const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
   const [artifactHistory, { refetch: refetchArtifactHistory }] = createResource(
@@ -1918,7 +1903,6 @@ export default function Page() {
   })
 
   onCleanup(() => {
-    if (reviewFrame !== undefined) cancelAnimationFrame(reviewFrame)
     if (refreshFrame !== undefined) cancelAnimationFrame(refreshFrame)
     if (refreshTimer !== undefined) window.clearTimeout(refreshTimer)
     if (todoFrame !== undefined) cancelAnimationFrame(todoFrame)
@@ -2087,7 +2071,6 @@ export default function Page() {
           terminalPanel={() => <TerminalPanel embedded />}
           activeDiff={tree.activeDiff}
           focusReviewDiff={focusReviewDiff}
-          reviewSnap={ui.reviewSnap}
           size={size}
         />
       </div>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1959,13 +1959,7 @@ export default function Page() {
         </Show>
 
         {/* Session panel */}
-        <div
-          classList={{
-            "@container relative min-w-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1": true,
-            "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
-              !size.active() && !ui.reviewSnap,
-          }}
-        >
+        <div class="@container relative min-w-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1">
           <div class="flex-1 min-h-0 overflow-hidden">
             {(() => {
               const renderComposerRegion = (variant: "session" | "home") => (

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -427,7 +427,7 @@ export default function Page() {
 
   const openReviewPanel = () => {
     if (!view().sidePanel.opened()) view().sidePanel.open()
-    if (view().sidePanel.tab() !== "changes") view().sidePanel.setTab("changes")
+    if (view().sidePanel.tab() !== "review") view().sidePanel.setTab("review")
   }
 
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
@@ -1074,7 +1074,7 @@ export default function Page() {
 
   const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
   const wantsReview = createMemo(() =>
-    isDesktop() ? desktopReviewOpen() && view().sidePanel.tab() === "changes" && activeTab() === "review" : store.mobileTab === "changes",
+    isDesktop() ? desktopReviewOpen() && view().sidePanel.tab() === "review" && activeTab() === "review" : store.mobileTab === "changes",
   )
 
   createEffect(() => {
@@ -1440,7 +1440,7 @@ export default function Page() {
     const dir = sdk.directory
     if (!isDesktop()) return
     if (!view().sidePanel.opened()) return
-    if (view().sidePanel.tab() !== "changes") return
+    if (view().sidePanel.tab() !== "review") return
     if (sync.status === "loading") return
 
     fileTreeTab()

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2112,14 +2112,13 @@ export default function Page() {
           reviewCount={reviewCount}
           reviewPanel={reviewPanel}
           files={artifactFiles}
+          terminalPanel={() => <TerminalPanel embedded />}
           activeDiff={tree.activeDiff}
           focusReviewDiff={focusReviewDiff}
           reviewSnap={ui.reviewSnap}
           size={size}
         />
       </div>
-
-      <TerminalPanel />
     </div>
   )
 }

--- a/packages/app/src/pages/session/right-panel-tabs.test.ts
+++ b/packages/app/src/pages/session/right-panel-tabs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+import { defaultRightPanelTab, migrateLegacyRightPanelTab, type RightPanelTab } from "./right-panel-tabs"
+
+describe("right panel tab helpers", () => {
+  test("defaults to status for sessions without stored tab", () => {
+    expect(defaultRightPanelTab()).toBe("status")
+  })
+
+  test("migrates old changes tab to review", () => {
+    expect(migrateLegacyRightPanelTab("changes")).toBe("review")
+  })
+
+  test("migrates old files tab to files", () => {
+    expect(migrateLegacyRightPanelTab("files")).toBe("files")
+  })
+
+  test("keeps new right panel tabs stable", () => {
+    const tabs: RightPanelTab[] = ["status", "files", "review", "terminal"]
+    expect(tabs.map((tab) => migrateLegacyRightPanelTab(tab))).toEqual(tabs)
+  })
+})

--- a/packages/app/src/pages/session/right-panel-tabs.ts
+++ b/packages/app/src/pages/session/right-panel-tabs.ts
@@ -1,0 +1,10 @@
+export type RightPanelTab = "status" | "files" | "review" | "terminal"
+
+export const migrateLegacyRightPanelTab = (tab?: string): RightPanelTab => {
+  if (tab === "changes") return "review"
+  if (tab === "files") return "files"
+  if (tab === "review" || tab === "status" || tab === "terminal") return tab
+  return "status"
+}
+
+export const defaultRightPanelTab = (tab?: string) => migrateLegacyRightPanelTab(tab)

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -100,3 +100,17 @@ describe("SessionSidePanel", () => {
     expect(typeof fileTabScroll.nextTabListScrollLeft).toBe("function")
   })
 })
+
+describe("formatRightPanelWidth", () => {
+  test("returns \"0px\" when closed", async () => {
+    const { formatRightPanelWidth } = await import("./session-side-panel")
+    expect(formatRightPanelWidth(false, 340)).toBe("0px")
+    expect(formatRightPanelWidth(false, 520)).toBe("0px")
+  })
+
+  test("returns px-suffixed width when open", async () => {
+    const { formatRightPanelWidth } = await import("./session-side-panel")
+    expect(formatRightPanelWidth(true, 340)).toBe("340px")
+    expect(formatRightPanelWidth(true, 520)).toBe("520px")
+  })
+})

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -114,3 +114,27 @@ describe("formatRightPanelWidth", () => {
     expect(formatRightPanelWidth(true, 520)).toBe("520px")
   })
 })
+
+describe("makeRightPanelResizeHandler", () => {
+  test("calls size.touch() then layout.rightPanel.resize(width) in order", async () => {
+    const { makeRightPanelResizeHandler } = await import("./session-side-panel")
+    const calls: string[] = []
+    const handler = makeRightPanelResizeHandler(
+      { touch: () => calls.push("touch") },
+      { rightPanel: { resize: (w: number) => calls.push(`resize:${w}`) } },
+    )
+    handler(350)
+    expect(calls).toEqual(["touch", "resize:350"])
+  })
+
+  test("passes width through unchanged (clamping is the store's job)", async () => {
+    const { makeRightPanelResizeHandler } = await import("./session-side-panel")
+    let received = 0
+    const handler = makeRightPanelResizeHandler(
+      { touch: () => undefined },
+      { rightPanel: { resize: (w: number) => (received = w) } },
+    )
+    handler(280) // below MIN; handler doesn't clamp, store.resize clamps internally
+    expect(received).toBe(280)
+  })
+})

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -52,19 +52,8 @@ beforeAll(async () => {
   }))
   mock.module("@/context/language", () => ({ useLanguage: () => ({ t: (key: string) => key }) }))
   mock.module("@/context/layout", () => ({ useLayout: () => ({ session: { width: () => 720 } }) }))
-  mock.module("@/pages/session/file-tab-scroll", () => ({ createFileTabListSync: () => () => undefined }))
   mock.module("@/pages/session/file-tabs", () => ({ FileTabContent: () => null }))
   mock.module("@/pages/session/files-tab", () => ({ FilesTab: () => null }))
-  mock.module("@/pages/session/helpers", () => ({
-    createOpenSessionFileTab: () => () => undefined,
-    createSessionTabs: () => ({
-      contextOpen: () => false,
-      openedTabs: () => [],
-      activeTab: () => "review",
-      activeFileTab: () => undefined,
-    }),
-    getTabReorderIndex: () => undefined,
-  }))
   mock.module("@/pages/session/handoff", () => ({ setSessionHandoff: () => undefined }))
   mock.module("@/pages/session/session-layout", () => ({
     useSessionLayout: () => ({
@@ -101,5 +90,13 @@ afterAll(() => {
 describe("SessionSidePanel", () => {
   test("exports a reusable unified right-panel component", () => {
     expect(typeof SessionSidePanel).toBe("function")
+  })
+
+  test("preserves helper exports for later session tests", async () => {
+    const helpers = await import("./helpers")
+    const fileTabScroll = await import("./file-tab-scroll")
+
+    expect(typeof helpers.createOpenReviewFile).toBe("function")
+    expect(typeof fileTabScroll.nextTabListScrollLeft).toBe("function")
   })
 })

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
+
+let SessionSidePanel: typeof import("./session-side-panel").SessionSidePanel
+
+beforeAll(async () => {
+  mock.module("@solid-primitives/media", () => ({
+    createMediaQuery: () => () => true,
+  }))
+
+  mock.module("@opencode-ai/ui/tabs", () => {
+    const Tabs = (_props: any) => null
+    Tabs.List = (_props: any) => null
+    Tabs.Trigger = (_props: any) => null
+    Tabs.Content = (_props: any) => null
+    return { Tabs }
+  })
+
+  mock.module("@opencode-ai/ui/icon-button", () => ({ IconButton: () => null }))
+  mock.module("@opencode-ai/ui/tooltip", () => ({ TooltipKeybind: (_props: any) => null }))
+  mock.module("@opencode-ai/ui/resize-handle", () => ({ ResizeHandle: () => null }))
+  mock.module("@opencode-ai/ui/logo", () => ({ Mark: () => null }))
+  mock.module("@thisbeyond/solid-dnd", () => ({
+    DragDropProvider: (_props: any) => null,
+    DragDropSensors: () => null,
+    DragOverlay: (_props: any) => null,
+    SortableProvider: (_props: any) => null,
+    closestCenter: () => null,
+  }))
+  mock.module("@/utils/solid-dnd", () => ({
+    ConstrainDragYAxis: () => null,
+    getDraggableId: () => undefined,
+  }))
+  mock.module("@opencode-ai/ui/context/dialog", () => ({ useDialog: () => ({ show: () => undefined }) }))
+  mock.module("@/components/file-tree", () => ({ default: () => null }))
+  mock.module("@/components/session-context-usage", () => ({ SessionContextUsage: () => null }))
+  mock.module("@/components/session", () => ({
+    SessionContextTab: () => null,
+    SortableTab: () => null,
+    FileVisual: () => null,
+  }))
+  mock.module("@/components/status-panel", () => ({ StatusPanel: () => null }))
+  mock.module("@/context/command", () => ({ useCommand: () => ({ keybind: () => "" }) }))
+  mock.module("@/context/file", () => ({
+    useFile: () => ({
+      ready: () => true,
+      tree: { state: () => ({ loaded: true }), children: () => [] },
+      tab: (path: string) => `file://${path}`,
+      pathFromTab: () => undefined,
+      selectedLines: () => null,
+      load: async () => undefined,
+    }),
+  }))
+  mock.module("@/context/language", () => ({ useLanguage: () => ({ t: (key: string) => key }) }))
+  mock.module("@/context/layout", () => ({ useLayout: () => ({ session: { width: () => 720 } }) }))
+  mock.module("@/pages/session/file-tab-scroll", () => ({ createFileTabListSync: () => () => undefined }))
+  mock.module("@/pages/session/file-tabs", () => ({ FileTabContent: () => null }))
+  mock.module("@/pages/session/files-tab", () => ({ FilesTab: () => null }))
+  mock.module("@/pages/session/helpers", () => ({
+    createOpenSessionFileTab: () => () => undefined,
+    createSessionTabs: () => ({
+      contextOpen: () => false,
+      openedTabs: () => [],
+      activeTab: () => "review",
+      activeFileTab: () => undefined,
+    }),
+    getTabReorderIndex: () => undefined,
+  }))
+  mock.module("@/pages/session/handoff", () => ({ setSessionHandoff: () => undefined }))
+  mock.module("@/pages/session/session-layout", () => ({
+    useSessionLayout: () => ({
+      sessionKey: () => "dir/demo",
+      tabs: () => ({
+        all: () => [],
+        open: () => undefined,
+        setActive: () => undefined,
+        close: () => undefined,
+        move: () => undefined,
+      }),
+      view: () => ({
+        sidePanel: {
+          opened: () => true,
+          tab: () => "status",
+          setTab: () => undefined,
+          open: () => undefined,
+          toggleTab: () => undefined,
+          explorer: { width: () => 240, tab: () => "changes", setTab: () => undefined, resize: () => undefined },
+        },
+        reviewPanel: { opened: () => true, open: () => undefined },
+        terminal: { opened: () => false, open: () => undefined, close: () => undefined },
+      }),
+    }),
+  }))
+
+  SessionSidePanel = (await import("./session-side-panel")).SessionSidePanel
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("SessionSidePanel", () => {
+  test("exports a reusable unified right-panel component", () => {
+    expect(typeof SessionSidePanel).toBe("function")
+  })
+})

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -20,7 +20,7 @@ import { StatusPanel } from "@/components/status-panel"
 import { useCommand } from "@/context/command"
 import { useFile, type SelectedLineRange } from "@/context/file"
 import { useLanguage } from "@/context/language"
-import { useLayout } from "@/context/layout"
+import { MAX_RIGHT_PANEL_WIDTH, MIN_RIGHT_PANEL_WIDTH, useLayout } from "@/context/layout"
 import { createFileTabListSync } from "@/pages/session/file-tab-scroll"
 import { FileTabContent } from "@/pages/session/file-tabs"
 import { FilesTab } from "@/pages/session/files-tab"
@@ -32,6 +32,16 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 
 export function formatRightPanelWidth(open: boolean, width: number): string {
   return open ? `${width}px` : "0px"
+}
+
+export function makeRightPanelResizeHandler(
+  size: { touch: () => void },
+  layout: { rightPanel: { resize: (width: number) => void } },
+): (width: number) => void {
+  return (width) => {
+    size.touch()
+    layout.rightPanel.resize(width)
+  }
 }
 
 type RightPanelShellIconName = "summary" | "folder" | "review" | "terminal"
@@ -307,6 +317,20 @@ export function SessionSidePanel(props: {
         }}
         style={{ width: panelWidth() }}
       >
+        <div
+          data-testid="right-panel-resize-wrapper"
+          onPointerDown={() => props.size.start()}
+          class="absolute top-0 left-0 h-full z-10"
+        >
+          <ResizeHandle
+            direction="horizontal"
+            edge="start"
+            size={layout.rightPanel.width()}
+            min={MIN_RIGHT_PANEL_WIDTH}
+            max={MAX_RIGHT_PANEL_WIDTH}
+            onResize={makeRightPanelResizeHandler(props.size, layout)}
+          />
+        </div>
         <div class="size-full border-l border-border-weaker-base">
           <Tabs
             variant="sidepanel"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -30,6 +30,10 @@ import { setSessionHandoff } from "@/pages/session/handoff"
 import type { RightPanelTab } from "@/pages/session/right-panel-tabs"
 import { useSessionLayout } from "@/pages/session/session-layout"
 
+export function formatRightPanelWidth(open: boolean, width: number): string {
+  return open ? `${width}px` : "0px"
+}
+
 type RightPanelShellIconName = "summary" | "folder" | "review" | "terminal"
 
 function RightPanelShellIcon(props: { icon: RightPanelShellIconName }) {
@@ -107,10 +111,7 @@ export function SessionSidePanel(props: {
   const open = createMemo(() => isDesktop() && view().sidePanel.opened())
   const reviewTab = createMemo(() => isDesktop())
   const sidePanelTab = createMemo(() => view().sidePanel.tab())
-  const panelWidth = createMemo(() => {
-    if (!open()) return "0px"
-    return `calc(100% - ${layout.session.width()}px)`
-  })
+  const panelWidth = createMemo(() => formatRightPanelWidth(open(), layout.rightPanel.width()))
   const treeWidth = createMemo(() => `${view().sidePanel.explorer.width()}px`)
 
   const diffFiles = createMemo(() => props.diffs().map((d) => d.file))
@@ -308,7 +309,7 @@ export function SessionSidePanel(props: {
       >
         <div class="size-full border-l border-border-weaker-base">
           <Tabs
-            variant="pill"
+            variant="sidepanel"
             value={sidePanelTab()}
             onChange={setSidePanelTabValue}
             class="h-full flex flex-col"
@@ -337,6 +338,7 @@ export function SessionSidePanel(props: {
                 )}
               </For>
               <div class="flex-1" />
+              <div class="w-10 shrink-0" aria-hidden />
             </Tabs.List>
 
             <Tabs.Content value="status" class="min-h-0 flex-1 overflow-hidden">

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -474,11 +474,13 @@ export function SessionSidePanel(props: {
             </Tabs.Content>
 
             <Tabs.Content value="terminal" class="min-h-0 flex-1 overflow-hidden">
-              <Show
-                when={props.terminalPanel}
-                fallback={<div class="px-4 py-3 text-14-regular text-text-weak">{language.t("terminal.loading")}</div>}
-              >
-                {(renderTerminal) => renderTerminal()()}
+              <Show when={sidePanelTab() === "terminal"}>
+                <Show
+                  when={props.terminalPanel}
+                  fallback={<div class="px-4 py-3 text-14-regular text-text-weak">{language.t("terminal.loading")}</div>}
+                >
+                  {(renderTerminal) => renderTerminal()()}
+                </Show>
               </Show>
             </Tabs.Content>
           </Tabs>

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -1,6 +1,7 @@
-import { For, Match, Show, Switch, createEffect, createMemo, onCleanup, type JSX } from "solid-js"
+import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createMediaQuery } from "@solid-primitives/media"
+import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
@@ -29,6 +30,54 @@ import { setSessionHandoff } from "@/pages/session/handoff"
 import type { RightPanelTab } from "@/pages/session/right-panel-tabs"
 import { useSessionLayout } from "@/pages/session/session-layout"
 
+type RightPanelShellIconName = "summary" | "folder" | "review" | "terminal"
+
+function RightPanelShellIcon(props: { icon: RightPanelShellIconName }) {
+  return (
+    <div data-component="icon" data-size="small">
+      <Switch>
+        <Match when={props.icon === "summary"}>
+          <svg data-slot="icon-svg" viewBox="0 0 13 13" fill="none" aria-hidden="true" class="text-text-weaker">
+            <path d="M2.5 3.5h8M2.5 6.5h8M2.5 9.5h5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" />
+          </svg>
+        </Match>
+        <Match when={props.icon === "folder"}>
+          <svg data-slot="icon-svg" viewBox="0 0 12 12" fill="none" aria-hidden="true" class="text-text-weaker">
+            <path
+              d="M1.5 3.5A1 1 0 012.5 2.5H5l1 1h3.5a1 1 0 011 1V9a1 1 0 01-1 1h-7a1 1 0 01-1-1V3.5z"
+              stroke="currentColor"
+              stroke-width="1"
+            />
+          </svg>
+        </Match>
+        <Match when={props.icon === "review"}>
+          <svg data-slot="icon-svg" viewBox="0 0 13 13" fill="none" aria-hidden="true" class="text-text-weaker">
+            <path
+              d="M2 6.5l2.5 2.5L11 3.5"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </Match>
+        <Match when={props.icon === "terminal"}>
+          <svg data-slot="icon-svg" viewBox="0 0 12 12" fill="none" aria-hidden="true" class="text-text-weaker">
+            <rect x="1.5" y="2.5" width="9" height="7" rx="1" stroke="currentColor" stroke-width="1" />
+            <path
+              d="M3.5 5l1.5 1L3.5 7M6.5 7.5h2.5"
+              stroke="currentColor"
+              stroke-width="1"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </Match>
+      </Switch>
+    </div>
+  )
+}
+
 export function SessionSidePanel(props: {
   canReview: () => boolean
   diffs: () => (SnapshotFileDiff | VcsFileDiff)[]
@@ -50,6 +99,8 @@ export function SessionSidePanel(props: {
   const command = useCommand()
   const dialog = useDialog()
   const { sessionKey, tabs, view } = useSessionLayout()
+  const [panelRef, setPanelRef] = createSignal<HTMLElement>()
+  const [compactShellTabs, setCompactShellTabs] = createSignal(false)
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
@@ -87,6 +138,15 @@ export function SessionSidePanel(props: {
       }
     }
     return out
+  })
+
+  createEffect(() => {
+    const el = panelRef()
+    if (!el) return
+
+    const updateCompactShellTabs = () => setCompactShellTabs(el.getBoundingClientRect().width < 360)
+    createResizeObserver(el, updateCompactShellTabs)
+    updateCompactShellTabs()
   })
 
   const empty = (msg: string) => (
@@ -133,19 +193,31 @@ export function SessionSidePanel(props: {
   const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
+  const showSecondaryReviewTabs = createMemo(() => contextOpen() || openedTabs().length > 0)
+  const shellTabs = createMemo(
+    () =>
+      [
+        { value: "status", label: language.t("status.popover.trigger"), icon: "summary" as const },
+        { value: "files", label: language.t("session.panel.files"), icon: "folder" as const },
+        { value: "review", label: language.t("session.tab.review"), icon: "review" as const },
+        { value: "terminal", label: language.t("terminal.title"), icon: "terminal" as const },
+      ] satisfies Array<{
+        value: RightPanelTab
+        label: string
+        icon: RightPanelShellIconName
+      }>,
+  )
 
-  const fileTreeTab = () => view().sidePanel.explorer.tab()
   const setSidePanelTabValue = (value: string) => {
     if (value !== "status" && value !== "files" && value !== "review" && value !== "terminal") return
     view().sidePanel.setTab(value as RightPanelTab)
     view().sidePanel.open()
   }
-
+  const fileTreeTab = () => view().sidePanel.explorer.tab()
   const setFileTreeTabValue = (value: string) => {
     if (value !== "changes" && value !== "all") return
     view().sidePanel.explorer.setTab(value)
   }
-
   const showAllFiles = () => {
     if (fileTreeTab() !== "changes") return
     view().sidePanel.explorer.setTab("all")
@@ -191,6 +263,12 @@ export function SessionSidePanel(props: {
     setStore("activeDraggable", undefined)
   }
 
+  const openFilePicker = (onOpenFile?: () => void) => {
+    void import("@/components/dialog-select-file").then((x) => {
+      dialog.show(() => <x.DialogSelectFile mode="files" onOpenFile={onOpenFile} />)
+    })
+  }
+
   createEffect(() => {
     if (!file.ready()) return
 
@@ -216,6 +294,7 @@ export function SessionSidePanel(props: {
     <Show when={isDesktop()}>
       <aside
         id="right-panel"
+        ref={setPanelRef}
         aria-label={language.t("session.panel.utility")}
         aria-hidden={!open()}
         inert={!open()}
@@ -229,24 +308,35 @@ export function SessionSidePanel(props: {
       >
         <div class="size-full border-l border-border-weaker-base">
           <Tabs
+            variant="pill"
             value={sidePanelTab()}
             onChange={setSidePanelTabValue}
             class="h-full flex flex-col"
             data-scope="right-panel"
           >
-            <Tabs.List class="h-11 shrink-0 px-2 border-b border-border-weaker-base gap-1">
-              <Tabs.Trigger value="status" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("status.popover.trigger")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="files" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("session.panel.files")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="review" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("session.tab.review")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="terminal" class="flex-1" classes={{ button: "w-full" }}>
-                {language.t("terminal.title")}
-              </Tabs.Trigger>
+            <Tabs.List class="h-11 shrink-0 px-2 py-0 border-b border-border-weaker-base gap-1 items-center">
+              <For each={shellTabs()}>
+                {(tab) => (
+                  <Tabs.Trigger
+                    value={tab.value}
+                    class="shrink-0 h-7"
+                    title={compactShellTabs() ? tab.label : undefined}
+                    aria-label={compactShellTabs() ? tab.label : undefined}
+                    classes={{
+                      button:
+                        `h-7 min-h-7 inline-flex items-center whitespace-nowrap rounded-md text-12-medium text-text-weak ${
+                          compactShellTabs() ? "gap-0 px-2" : "gap-1.5 px-2.5"
+                        }`,
+                    }}
+                  >
+                    <RightPanelShellIcon icon={tab.icon} />
+                    <Show when={!compactShellTabs()}>
+                      <span>{tab.label}</span>
+                    </Show>
+                  </Tabs.Trigger>
+                )}
+              </For>
+              <div class="flex-1" />
             </Tabs.List>
 
             <Tabs.Content value="status" class="min-h-0 flex-1 overflow-hidden">
@@ -271,74 +361,92 @@ export function SessionSidePanel(props: {
                       <ConstrainDragYAxis />
                       <Tabs value={activeTab()} onChange={openTab}>
                         <div class="sticky top-0 shrink-0 flex">
-                          <Tabs.List
-                            ref={(el: HTMLDivElement) => {
-                              const stop = createFileTabListSync({ el, contextOpen })
-                              onCleanup(stop)
-                            }}
+                          <Show
+                            when={showSecondaryReviewTabs()}
+                            fallback={
+                              <div class="w-full bg-background-stronger flex items-center justify-end px-3 py-1.5">
+                                <TooltipKeybind
+                                  title={language.t("command.file.open")}
+                                  keybind={command.keybind("file.open")}
+                                  class="flex items-center"
+                                >
+                                  <IconButton
+                                    icon="plus-small"
+                                    variant="ghost"
+                                    iconSize="large"
+                                    class="!rounded-md"
+                                    onClick={() => openFilePicker(showAllFiles)}
+                                    aria-label={language.t("command.file.open")}
+                                  />
+                                </TooltipKeybind>
+                              </div>
+                            }
                           >
-                            <Show when={reviewTab() && props.canReview()}>
-                              <Tabs.Trigger value="review">
-                                <div class="flex items-center gap-1.5">
-                                  <div>{language.t("session.tab.review")}</div>
-                                  <Show when={props.hasReview()}>
-                                    <div>{props.reviewCount()}</div>
-                                  </Show>
-                                </div>
-                              </Tabs.Trigger>
-                            </Show>
-                            <Show when={contextOpen()}>
-                              <Tabs.Trigger
-                                value="context"
-                                closeButton={
-                                  <TooltipKeybind
-                                    title={language.t("common.closeTab")}
-                                    keybind={command.keybind("tab.close")}
-                                    placement="bottom"
-                                    gutter={10}
-                                  >
-                                    <IconButton
-                                      icon="close-small"
-                                      variant="ghost"
-                                      class="h-5 w-5"
-                                      onClick={() => tabs().close("context")}
-                                      aria-label={language.t("common.closeTab")}
-                                    />
-                                  </TooltipKeybind>
-                                }
-                                hideCloseButton
-                                onMiddleClick={() => tabs().close("context")}
-                              >
-                                <div class="flex items-center gap-2">
-                                  <SessionContextUsage variant="indicator" />
-                                  <div>{language.t("session.tab.context")}</div>
-                                </div>
-                              </Tabs.Trigger>
-                            </Show>
-                            <SortableProvider ids={openedTabs()}>
-                              <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
-                            </SortableProvider>
-                            <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
-                              <TooltipKeybind
-                                title={language.t("command.file.open")}
-                                keybind={command.keybind("file.open")}
-                                class="flex items-center"
-                              >
-                                <IconButton
-                                  icon="plus-small"
-                                  variant="ghost"
-                                  iconSize="large"
-                                  class="!rounded-md"
-                                  onClick={() => {
-                                    void import("@/components/dialog-select-file").then((x) => {
-                                      dialog.show(() => <x.DialogSelectFile mode="files" onOpenFile={showAllFiles} />)
-                                    })
-                                  }}
-                                  aria-label={language.t("command.file.open")}
-                                />
-                              </TooltipKeybind>
-                            </div>
-                          </Tabs.List>
+                            <Tabs.List
+                              ref={(el: HTMLDivElement) => {
+                                const stop = createFileTabListSync({ el, contextOpen })
+                                onCleanup(stop)
+                              }}
+                            >
+                              <Show when={reviewTab() && props.canReview()}>
+                                <Tabs.Trigger value="review">
+                                  <div class="flex items-center gap-1.5">
+                                    <div>{language.t("session.tab.review")}</div>
+                                    <Show when={props.hasReview()}>
+                                      <div>{props.reviewCount()}</div>
+                                    </Show>
+                                  </div>
+                                </Tabs.Trigger>
+                              </Show>
+                              <Show when={contextOpen()}>
+                                <Tabs.Trigger
+                                  value="context"
+                                  closeButton={
+                                    <TooltipKeybind
+                                      title={language.t("common.closeTab")}
+                                      keybind={command.keybind("tab.close")}
+                                      placement="bottom"
+                                      gutter={10}
+                                    >
+                                      <IconButton
+                                        icon="close-small"
+                                        variant="ghost"
+                                        class="h-5 w-5"
+                                        onClick={() => tabs().close("context")}
+                                        aria-label={language.t("common.closeTab")}
+                                      />
+                                    </TooltipKeybind>
+                                  }
+                                  hideCloseButton
+                                  onMiddleClick={() => tabs().close("context")}
+                                >
+                                  <div class="flex items-center gap-2">
+                                    <SessionContextUsage variant="indicator" />
+                                    <div>{language.t("session.tab.context")}</div>
+                                  </div>
+                                </Tabs.Trigger>
+                              </Show>
+                              <SortableProvider ids={openedTabs()}>
+                                <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
+                              </SortableProvider>
+                              <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
+                                <TooltipKeybind
+                                  title={language.t("command.file.open")}
+                                  keybind={command.keybind("file.open")}
+                                  class="flex items-center"
+                                >
+                                  <IconButton
+                                    icon="plus-small"
+                                    variant="ghost"
+                                    iconSize="large"
+                                    class="!rounded-md"
+                                    onClick={() => openFilePicker(showAllFiles)}
+                                    aria-label={language.t("command.file.open")}
+                                  />
+                                </TooltipKeybind>
+                              </div>
+                            </Tabs.List>
+                          </Show>
                         </div>
 
                         <Show when={reviewTab() && props.canReview()}>
@@ -389,7 +497,6 @@ export function SessionSidePanel(props: {
                     </DragDropProvider>
                   </div>
                 </div>
-
                 <div
                   id="file-tree-panel"
                   class="relative min-w-0 h-full shrink-0 overflow-hidden border-l border-border-weaker-base"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -362,6 +362,8 @@ export function SessionSidePanel(props: {
                 )}
               </For>
               <div class="flex-1" />
+              {/* 40px right-gutter reserve — matches docs/design/src/rightpanel.jsx,
+                  gives the tab row breathing room against the panel edge. */}
               <div class="w-10 shrink-0" aria-hidden />
             </Tabs.List>
 

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -104,7 +104,6 @@ export function SessionSidePanel(props: {
   terminalPanel?: () => JSX.Element
   activeDiff?: string
   focusReviewDiff: (path: string) => void
-  reviewSnap: boolean
   size: Sizing
 }) {
   const layout = useLayout()
@@ -313,7 +312,7 @@ export function SessionSidePanel(props: {
         classList={{
           "pointer-events-none": !open(),
           "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
-            !props.size.active() && !props.reviewSnap,
+            !props.size.active(),
         }}
         style={{ width: panelWidth() }}
       >

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -155,6 +155,22 @@ export function SessionSidePanel(props: {
     activeDraggable: undefined as string | undefined,
   })
 
+  createEffect(() => {
+    if (!isDesktop()) return
+
+    if (!open()) {
+      if (view().terminal.opened()) view().terminal.close()
+      return
+    }
+
+    if (sidePanelTab() === "terminal") {
+      if (!view().terminal.opened()) view().terminal.open()
+      return
+    }
+
+    if (view().terminal.opened()) view().terminal.close()
+  })
+
   const handleDragStart = (event: unknown) => {
     const id = getDraggableId(event)
     if (!id) return
@@ -200,7 +216,7 @@ export function SessionSidePanel(props: {
     <Show when={isDesktop()}>
       <aside
         id="right-panel"
-        aria-label={language.t("session.panel.reviewAndFiles")}
+        aria-label={language.t("session.panel.utility")}
         aria-hidden={!open()}
         inert={!open()}
         class="relative min-w-0 h-full flex shrink-0 overflow-hidden bg-background-base"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -15,6 +15,7 @@ import { useDialog } from "@opencode-ai/ui/context/dialog"
 import FileTree from "@/components/file-tree"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
+import { StatusPanel } from "@/components/status-panel"
 import { useCommand } from "@/context/command"
 import { useFile, type SelectedLineRange } from "@/context/file"
 import { useLanguage } from "@/context/language"
@@ -25,6 +26,7 @@ import { FilesTab } from "@/pages/session/files-tab"
 import type { FilesTabEntry } from "@/pages/session/files-tab-state"
 import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type Sizing } from "@/pages/session/helpers"
 import { setSessionHandoff } from "@/pages/session/handoff"
+import type { RightPanelTab } from "@/pages/session/right-panel-tabs"
 import { useSessionLayout } from "@/pages/session/session-layout"
 
 export function SessionSidePanel(props: {
@@ -36,6 +38,7 @@ export function SessionSidePanel(props: {
   reviewCount: () => number
   reviewPanel: () => JSX.Element
   files: () => FilesTabEntry[]
+  terminalPanel?: () => JSX.Element
   activeDiff?: string
   focusReviewDiff: (path: string) => void
   reviewSnap: boolean
@@ -132,6 +135,11 @@ export function SessionSidePanel(props: {
   const activeFileTab = tabState.activeFileTab
 
   const fileTreeTab = () => view().sidePanel.explorer.tab()
+  const setSidePanelTabValue = (value: string) => {
+    if (value !== "status" && value !== "files" && value !== "review" && value !== "terminal") return
+    view().sidePanel.setTab(value as RightPanelTab)
+    view().sidePanel.open()
+  }
 
   const setFileTreeTabValue = (value: string) => {
     if (value !== "changes" && value !== "all") return
@@ -191,7 +199,7 @@ export function SessionSidePanel(props: {
   return (
     <Show when={isDesktop()}>
       <aside
-        id="review-panel"
+        id="right-panel"
         aria-label={language.t("session.panel.reviewAndFiles")}
         aria-hidden={!open()}
         inert={!open()}
@@ -204,229 +212,260 @@ export function SessionSidePanel(props: {
         style={{ width: panelWidth() }}
       >
         <div class="size-full border-l border-border-weaker-base">
-          <Show when={sidePanelTab() === "files"}>
-            <div class="h-full min-h-0 overflow-hidden">
-            <FilesTab files={props.files()} />
-            </div>
-          </Show>
+          <Tabs
+            value={sidePanelTab()}
+            onChange={setSidePanelTabValue}
+            class="h-full flex flex-col"
+            data-scope="right-panel"
+          >
+            <Tabs.List class="h-11 shrink-0 px-2 border-b border-border-weaker-base gap-1">
+              <Tabs.Trigger value="status" class="flex-1" classes={{ button: "w-full" }}>
+                {language.t("status.popover.trigger")}
+              </Tabs.Trigger>
+              <Tabs.Trigger value="files" class="flex-1" classes={{ button: "w-full" }}>
+                {language.t("session.panel.files")}
+              </Tabs.Trigger>
+              <Tabs.Trigger value="review" class="flex-1" classes={{ button: "w-full" }}>
+                {language.t("session.tab.review")}
+              </Tabs.Trigger>
+              <Tabs.Trigger value="terminal" class="flex-1" classes={{ button: "w-full" }}>
+                {language.t("terminal.title")}
+              </Tabs.Trigger>
+            </Tabs.List>
 
-          <Show when={sidePanelTab() === "changes"}>
-            <div class="h-full min-h-0 overflow-hidden">
-            <div class="size-full flex">
-              <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-background-base">
-                <div class="size-full min-w-0 h-full bg-background-base">
-                  <DragDropProvider
-                    onDragStart={handleDragStart}
-                    onDragEnd={handleDragEnd}
-                    onDragOver={handleDragOver}
-                    collisionDetector={closestCenter}
-                  >
-                    <DragDropSensors />
-                    <ConstrainDragYAxis />
-                    <Tabs value={activeTab()} onChange={openTab}>
-                      <div class="sticky top-0 shrink-0 flex">
-                        <Tabs.List
-                          ref={(el: HTMLDivElement) => {
-                            const stop = createFileTabListSync({ el, contextOpen })
-                            onCleanup(stop)
-                          }}
-                        >
-                          <Show when={reviewTab() && props.canReview()}>
-                            <Tabs.Trigger value="review">
-                              <div class="flex items-center gap-1.5">
-                                <div>{language.t("session.tab.review")}</div>
-                                <Show when={props.hasReview()}>
-                                  <div>{props.reviewCount()}</div>
-                                </Show>
-                              </div>
-                            </Tabs.Trigger>
-                          </Show>
-                          <Show when={contextOpen()}>
-                            <Tabs.Trigger
-                              value="context"
-                              closeButton={
-                                <TooltipKeybind
-                                  title={language.t("common.closeTab")}
-                                  keybind={command.keybind("tab.close")}
-                                  placement="bottom"
-                                  gutter={10}
-                                >
-                                  <IconButton
-                                    icon="close-small"
-                                    variant="ghost"
-                                    class="h-5 w-5"
-                                    onClick={() => tabs().close("context")}
-                                    aria-label={language.t("common.closeTab")}
-                                  />
-                                </TooltipKeybind>
-                              }
-                              hideCloseButton
-                              onMiddleClick={() => tabs().close("context")}
-                            >
-                              <div class="flex items-center gap-2">
-                                <SessionContextUsage variant="indicator" />
-                                <div>{language.t("session.tab.context")}</div>
-                              </div>
-                            </Tabs.Trigger>
-                          </Show>
-                          <SortableProvider ids={openedTabs()}>
-                            <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
-                          </SortableProvider>
-                          <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
-                            <TooltipKeybind
-                              title={language.t("command.file.open")}
-                              keybind={command.keybind("file.open")}
-                              class="flex items-center"
-                            >
-                              <IconButton
-                                icon="plus-small"
-                                variant="ghost"
-                                iconSize="large"
-                                class="!rounded-md"
-                                onClick={() => {
-                                  void import("@/components/dialog-select-file").then((x) => {
-                                    dialog.show(() => <x.DialogSelectFile mode="files" onOpenFile={showAllFiles} />)
-                                  })
-                                }}
-                                aria-label={language.t("command.file.open")}
-                              />
-                            </TooltipKeybind>
-                          </div>
-                        </Tabs.List>
-                      </div>
+            <Tabs.Content value="status" class="min-h-0 flex-1 overflow-hidden">
+              <StatusPanel shown={open} />
+            </Tabs.Content>
 
-                      <Show when={reviewTab() && props.canReview()}>
-                        <Tabs.Content value="review" class="flex flex-col h-full overflow-hidden contain-strict">
-                          <Show when={activeTab() === "review"}>{props.reviewPanel()}</Show>
-                        </Tabs.Content>
-                      </Show>
+            <Tabs.Content value="files" class="min-h-0 flex-1 overflow-hidden">
+              <FilesTab files={props.files()} />
+            </Tabs.Content>
 
-                      <Tabs.Content value="empty" class="flex flex-col h-full overflow-hidden contain-strict">
-                        <Show when={activeTab() === "empty"}>
-                          <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
-                            <div class="h-full px-6 pb-42 -mt-4 flex flex-col items-center justify-center text-center gap-6">
-                              <Mark class="w-14 opacity-10" />
-                              <div class="text-14-regular text-text-weak max-w-56">
-                                {language.t("session.files.selectToOpen")}
-                              </div>
-                            </div>
-                          </div>
-                        </Show>
-                      </Tabs.Content>
-
-                      <Show when={contextOpen()}>
-                        <Tabs.Content value="context" class="flex flex-col h-full overflow-hidden contain-strict">
-                          <Show when={activeTab() === "context"}>
-                            <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
-                              <SessionContextTab />
-                            </div>
-                          </Show>
-                        </Tabs.Content>
-                      </Show>
-
-                      <Show when={activeFileTab()} keyed>
-                        {(tab) => <FileTabContent tab={tab} />}
-                      </Show>
-                    </Tabs>
-                    <DragOverlay>
-                      <Show when={store.activeDraggable} keyed>
-                        {(tab) => {
-                          const path = file.pathFromTab(tab)
-                          return (
-                            <div data-component="tabs-drag-preview">
-                              <Show when={path}>{(p) => <FileVisual active path={p()} />}</Show>
-                            </div>
-                          )
-                        }}
-                      </Show>
-                    </DragOverlay>
-                  </DragDropProvider>
-                </div>
-              </div>
-
-              <div
-                id="file-tree-panel"
-                class="relative min-w-0 h-full shrink-0 overflow-hidden border-l border-border-weaker-base"
-                style={{ width: treeWidth() }}
-              >
-                <div class="h-full flex flex-col overflow-hidden group/filetree">
-                  <Tabs
-                    variant="pill"
-                    value={fileTreeTab()}
-                    onChange={setFileTreeTabValue}
-                    class="h-full"
-                    data-scope="filetree"
-                  >
-                    <Tabs.List>
-                      <Tabs.Trigger value="changes" class="flex-1" classes={{ button: "w-full" }}>
-                        {props.reviewCount()}{" "}
-                        {language.t(
-                          props.reviewCount() === 1 ? "session.review.change.one" : "session.review.change.other",
-                        )}
-                      </Tabs.Trigger>
-                      <Tabs.Trigger value="all" class="flex-1" classes={{ button: "w-full" }}>
-                        {language.t("session.files.all")}
-                      </Tabs.Trigger>
-                    </Tabs.List>
-                    <Tabs.Content value="changes" class="bg-background-stronger px-3 py-0">
-                      <Switch>
-                        <Match when={props.hasReview() || !props.diffsReady()}>
-                          <Show
-                            when={props.diffsReady()}
-                            fallback={
-                              <div class="px-2 py-2 text-12-regular text-text-weak">
-                                {language.t("common.loading")}
-                                {language.t("common.loading.ellipsis")}
-                              </div>
-                            }
+            <Tabs.Content value="review" class="min-h-0 flex-1 overflow-hidden">
+              <div class="size-full flex">
+                <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-background-base">
+                  <div class="size-full min-w-0 h-full bg-background-base">
+                    <DragDropProvider
+                      onDragStart={handleDragStart}
+                      onDragEnd={handleDragEnd}
+                      onDragOver={handleDragOver}
+                      collisionDetector={closestCenter}
+                    >
+                      <DragDropSensors />
+                      <ConstrainDragYAxis />
+                      <Tabs value={activeTab()} onChange={openTab}>
+                        <div class="sticky top-0 shrink-0 flex">
+                          <Tabs.List
+                            ref={(el: HTMLDivElement) => {
+                              const stop = createFileTabListSync({ el, contextOpen })
+                              onCleanup(stop)
+                            }}
                           >
+                            <Show when={reviewTab() && props.canReview()}>
+                              <Tabs.Trigger value="review">
+                                <div class="flex items-center gap-1.5">
+                                  <div>{language.t("session.tab.review")}</div>
+                                  <Show when={props.hasReview()}>
+                                    <div>{props.reviewCount()}</div>
+                                  </Show>
+                                </div>
+                              </Tabs.Trigger>
+                            </Show>
+                            <Show when={contextOpen()}>
+                              <Tabs.Trigger
+                                value="context"
+                                closeButton={
+                                  <TooltipKeybind
+                                    title={language.t("common.closeTab")}
+                                    keybind={command.keybind("tab.close")}
+                                    placement="bottom"
+                                    gutter={10}
+                                  >
+                                    <IconButton
+                                      icon="close-small"
+                                      variant="ghost"
+                                      class="h-5 w-5"
+                                      onClick={() => tabs().close("context")}
+                                      aria-label={language.t("common.closeTab")}
+                                    />
+                                  </TooltipKeybind>
+                                }
+                                hideCloseButton
+                                onMiddleClick={() => tabs().close("context")}
+                              >
+                                <div class="flex items-center gap-2">
+                                  <SessionContextUsage variant="indicator" />
+                                  <div>{language.t("session.tab.context")}</div>
+                                </div>
+                              </Tabs.Trigger>
+                            </Show>
+                            <SortableProvider ids={openedTabs()}>
+                              <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
+                            </SortableProvider>
+                            <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
+                              <TooltipKeybind
+                                title={language.t("command.file.open")}
+                                keybind={command.keybind("file.open")}
+                                class="flex items-center"
+                              >
+                                <IconButton
+                                  icon="plus-small"
+                                  variant="ghost"
+                                  iconSize="large"
+                                  class="!rounded-md"
+                                  onClick={() => {
+                                    void import("@/components/dialog-select-file").then((x) => {
+                                      dialog.show(() => <x.DialogSelectFile mode="files" onOpenFile={showAllFiles} />)
+                                    })
+                                  }}
+                                  aria-label={language.t("command.file.open")}
+                                />
+                              </TooltipKeybind>
+                            </div>
+                          </Tabs.List>
+                        </div>
+
+                        <Show when={reviewTab() && props.canReview()}>
+                          <Tabs.Content value="review" class="flex flex-col h-full overflow-hidden contain-strict">
+                            <Show when={activeTab() === "review"}>{props.reviewPanel()}</Show>
+                          </Tabs.Content>
+                        </Show>
+
+                        <Tabs.Content value="empty" class="flex flex-col h-full overflow-hidden contain-strict">
+                          <Show when={activeTab() === "empty"}>
+                            <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
+                              <div class="h-full px-6 pb-42 -mt-4 flex flex-col items-center justify-center text-center gap-6">
+                                <Mark class="w-14 opacity-10" />
+                                <div class="text-14-regular text-text-weak max-w-56">
+                                  {language.t("session.files.selectToOpen")}
+                                </div>
+                              </div>
+                            </div>
+                          </Show>
+                        </Tabs.Content>
+
+                        <Show when={contextOpen()}>
+                          <Tabs.Content value="context" class="flex flex-col h-full overflow-hidden contain-strict">
+                            <Show when={activeTab() === "context"}>
+                              <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
+                                <SessionContextTab />
+                              </div>
+                            </Show>
+                          </Tabs.Content>
+                        </Show>
+
+                        <Show when={activeFileTab()} keyed>
+                          {(tab) => <FileTabContent tab={tab} />}
+                        </Show>
+                      </Tabs>
+                      <DragOverlay>
+                        <Show when={store.activeDraggable} keyed>
+                          {(tab) => {
+                            const path = file.pathFromTab(tab)
+                            return (
+                              <div data-component="tabs-drag-preview">
+                                <Show when={path}>{(p) => <FileVisual active path={p()} />}</Show>
+                              </div>
+                            )
+                          }}
+                        </Show>
+                      </DragOverlay>
+                    </DragDropProvider>
+                  </div>
+                </div>
+
+                <div
+                  id="file-tree-panel"
+                  class="relative min-w-0 h-full shrink-0 overflow-hidden border-l border-border-weaker-base"
+                  style={{ width: treeWidth() }}
+                >
+                  <div class="h-full flex flex-col overflow-hidden group/filetree">
+                    <Tabs
+                      variant="pill"
+                      value={fileTreeTab()}
+                      onChange={setFileTreeTabValue}
+                      class="h-full"
+                      data-scope="filetree"
+                    >
+                      <Tabs.List>
+                        <Tabs.Trigger value="changes" class="flex-1" classes={{ button: "w-full" }}>
+                          {props.reviewCount()}{" "}
+                          {language.t(
+                            props.reviewCount() === 1 ? "session.review.change.one" : "session.review.change.other",
+                          )}
+                        </Tabs.Trigger>
+                        <Tabs.Trigger value="all" class="flex-1" classes={{ button: "w-full" }}>
+                          {language.t("session.files.all")}
+                        </Tabs.Trigger>
+                      </Tabs.List>
+                      <Tabs.Content value="changes" class="bg-background-stronger px-3 py-0">
+                        <Switch>
+                          <Match when={props.hasReview() || !props.diffsReady()}>
+                            <Show
+                              when={props.diffsReady()}
+                              fallback={
+                                <div class="px-2 py-2 text-12-regular text-text-weak">
+                                  {language.t("common.loading")}
+                                  {language.t("common.loading.ellipsis")}
+                                </div>
+                              }
+                            >
+                              <FileTree
+                                path=""
+                                class="pt-3"
+                                allowed={diffFiles()}
+                                kinds={kinds()}
+                                draggable={false}
+                                active={props.activeDiff}
+                                onFileClick={(node) => props.focusReviewDiff(node.path)}
+                              />
+                            </Show>
+                          </Match>
+                          <Match when={true}>{empty(props.empty())}</Match>
+                        </Switch>
+                      </Tabs.Content>
+                      <Tabs.Content value="all" class="bg-background-stronger px-3 py-0">
+                        <Switch>
+                          <Match when={nofiles()}>{empty(language.t("session.files.empty"))}</Match>
+                          <Match when={true}>
                             <FileTree
                               path=""
                               class="pt-3"
-                              allowed={diffFiles()}
+                              modified={diffFiles()}
                               kinds={kinds()}
-                              draggable={false}
-                              active={props.activeDiff}
-                              onFileClick={(node) => props.focusReviewDiff(node.path)}
+                              onFileClick={(node) => openTab(file.tab(node.path))}
                             />
-                          </Show>
-                        </Match>
-                        <Match when={true}>{empty(props.empty())}</Match>
-                      </Switch>
-                    </Tabs.Content>
-                    <Tabs.Content value="all" class="bg-background-stronger px-3 py-0">
-                      <Switch>
-                        <Match when={nofiles()}>{empty(language.t("session.files.empty"))}</Match>
-                        <Match when={true}>
-                          <FileTree
-                            path=""
-                            class="pt-3"
-                            modified={diffFiles()}
-                            kinds={kinds()}
-                            onFileClick={(node) => openTab(file.tab(node.path))}
-                          />
-                        </Match>
-                      </Switch>
-                    </Tabs.Content>
-                  </Tabs>
-                </div>
-                <div onPointerDown={() => props.size.start()}>
-                  <ResizeHandle
-                    direction="horizontal"
-                    edge="start"
-                    size={view().sidePanel.explorer.width()}
-                    min={200}
-                    max={480}
-                    onResize={(width) => {
-                      props.size.touch()
-                      view().sidePanel.explorer.resize(width)
-                    }}
-                  />
+                          </Match>
+                        </Switch>
+                      </Tabs.Content>
+                    </Tabs>
+                  </div>
+                  <div onPointerDown={() => props.size.start()}>
+                    <ResizeHandle
+                      direction="horizontal"
+                      edge="start"
+                      size={view().sidePanel.explorer.width()}
+                      min={200}
+                      max={480}
+                      onResize={(width) => {
+                        props.size.touch()
+                        view().sidePanel.explorer.resize(width)
+                      }}
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            </div>
-          </Show>
+            </Tabs.Content>
+
+            <Tabs.Content value="terminal" class="min-h-0 flex-1 overflow-hidden">
+              <Show
+                when={props.terminalPanel}
+                fallback={<div class="px-4 py-3 text-14-regular text-text-weak">{language.t("terminal.loading")}</div>}
+              >
+                {(renderTerminal) => renderTerminal()()}
+              </Show>
+            </Tabs.Content>
+          </Tabs>
         </div>
       </aside>
     </Show>

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -21,7 +21,7 @@ import { getTerminalHandoff, setTerminalHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { terminalProbe } from "@/testing/terminal"
 
-export function TerminalPanel() {
+export function TerminalPanel(props: { embedded?: boolean }) {
   const delays = [120, 240]
   const layout = useLayout()
   const terminal = useTerminal()
@@ -29,7 +29,7 @@ export function TerminalPanel() {
   const command = useCommand()
   const { params, view } = useSessionLayout()
 
-  const opened = createMemo(() => view().terminal.opened())
+  const opened = createMemo(() => (props.embedded ? true : view().terminal.opened()))
   const size = createSizing()
   const height = createMemo(() => layout.terminal.height())
   const close = () => view().terminal.close()
@@ -186,22 +186,22 @@ export function TerminalPanel() {
       id="terminal-panel"
       role="region"
       aria-label={language.t("terminal.title")}
-      aria-hidden={!opened()}
-      inert={!opened()}
-      class="relative w-full shrink-0 overflow-hidden bg-background-stronger"
+      aria-hidden={props.embedded ? undefined : !opened()}
+      inert={props.embedded ? undefined : !opened()}
+      class={props.embedded ? "h-full min-h-0 flex flex-col bg-background-stronger" : "relative w-full shrink-0 overflow-hidden bg-background-stronger"}
       classList={{
-        "border-t border-border-weak-base": opened(),
+        "border-t border-border-weak-base": !props.embedded && opened(),
         "transition-[height] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[height] motion-reduce:transition-none":
-          !size.active(),
+          !props.embedded && !size.active(),
       }}
-      style={{ height: opened() ? `${pane()}px` : "0px" }}
+      style={props.embedded ? undefined : { height: opened() ? `${pane()}px` : "0px" }}
     >
       <div
-        class="absolute inset-x-0 top-0 flex flex-col"
+        class={props.embedded ? "size-full flex flex-col" : "absolute inset-x-0 top-0 flex flex-col"}
         classList={{
-          "pointer-events-none": !opened(),
+          "pointer-events-none": !props.embedded && !opened(),
         }}
-        style={{ height: `${pane()}px` }}
+        style={props.embedded ? undefined : { height: `${pane()}px` }}
       >
         <div class="hidden md:block" onPointerDown={() => size.start()}>
           <ResizeHandle

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -29,7 +29,7 @@ export function TerminalPanel(props: { embedded?: boolean }) {
   const command = useCommand()
   const { params, view } = useSessionLayout()
 
-  const opened = createMemo(() => (props.embedded ? true : view().terminal.opened()))
+  const opened = createMemo(() => view().terminal.opened())
   const size = createSizing()
   const height = createMemo(() => layout.terminal.height())
   const close = () => view().terminal.close()

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@solidjs/router"
+import { createMediaQuery } from "@solid-primitives/media"
 import { useCommand, type CommandOption } from "@/context/command"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
@@ -46,6 +47,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const layout = useLayout()
   const navigate = useNavigate()
   const { params, tabs, view } = useSessionLayout()
+  const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const info = () => {
     const id = params.id
@@ -245,12 +247,20 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
 
   const openTerminal = () => {
     if (terminal.all().length > 0) terminal.new()
+    if (!isDesktop()) {
+      view().terminal.open()
+      return
+    }
     view().sidePanel.open()
     view().sidePanel.setTab("terminal")
     view().terminal.open()
   }
 
   const toggleTerminal = () => {
+    if (!isDesktop()) {
+      view().terminal.toggle()
+      return
+    }
     const open = view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
     if (open) {
       view().sidePanel.close()

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -245,6 +245,20 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
 
   const openTerminal = () => {
     if (terminal.all().length > 0) terminal.new()
+    view().sidePanel.open()
+    view().sidePanel.setTab("terminal")
+    view().terminal.open()
+  }
+
+  const toggleTerminal = () => {
+    const open = view().sidePanel.opened() && view().sidePanel.tab() === "terminal"
+    if (open) {
+      view().sidePanel.close()
+      view().terminal.close()
+      return
+    }
+    view().sidePanel.open()
+    view().sidePanel.setTab("terminal")
     view().terminal.open()
   }
 
@@ -449,7 +463,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       title: language.t("command.terminal.toggle"),
       keybind: "ctrl+`",
       slash: "terminal",
-      onSelect: () => view().terminal.toggle(),
+      onSelect: toggleTerminal,
     }),
     viewCommand({
       id: "review.toggle",

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -455,7 +455,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       id: "review.toggle",
       title: language.t("command.review.toggle"),
       keybind: "mod+shift+r",
-      onSelect: () => view().sidePanel.toggleTab("changes"),
+      onSelect: () => view().sidePanel.toggleTab("review"),
     }),
     viewCommand({
       id: "fileTree.toggle",

--- a/packages/desktop-electron/electron-vite.config.test.ts
+++ b/packages/desktop-electron/electron-vite.config.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { realpathSync } from "node:fs"
+import path from "node:path"
+import { createRendererWorkspaceConfig } from "./renderer-workspace-config"
+
+test("renderer dev server allows the resolved workspace node_modules path", () => {
+  const expected = realpathSync(path.resolve(import.meta.dir, "../../node_modules"))
+  const allow = createRendererWorkspaceConfig(import.meta.dir).server.fs.allow
+
+  expect(allow).toContain(expected)
+})
+
+test("renderer dedupes the ui workspace package", () => {
+  const dedupe = createRendererWorkspaceConfig(import.meta.dir).resolve.dedupe
+
+  expect(dedupe).toContain("@opencode-ai/ui")
+})

--- a/packages/desktop-electron/electron.vite.config.ts
+++ b/packages/desktop-electron/electron.vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "electron-vite"
 import appPlugin from "@opencode-ai/app/vite"
-import { existsSync } from "node:fs"
+import { existsSync, realpathSync } from "node:fs"
 import * as fs from "node:fs/promises"
 import path from "node:path"
 import {
@@ -8,6 +8,7 @@ import {
   embeddedServerMissingArtifacts,
   embeddedServerMissingArtifactsMessage,
 } from "./src/main/embedded-server-contract"
+import { createRendererWorkspaceConfig } from "./renderer-workspace-config"
 
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
@@ -24,6 +25,7 @@ if (missingArtifacts.length > 0) {
 }
 
 const nodePtyPkg = `@lydell/node-pty-${process.platform}-${process.arch}`
+const rendererWorkspaceConfig = createRendererWorkspaceConfig(process.cwd(), realpathSync)
 
 export default defineConfig({
   main: {
@@ -73,6 +75,7 @@ export default defineConfig({
     plugins: [appPlugin],
     publicDir: "../../../app/public",
     root: "src/renderer",
+    ...rendererWorkspaceConfig,
     build: {
       rollupOptions: {
         input: {

--- a/packages/desktop-electron/renderer-workspace-config.ts
+++ b/packages/desktop-electron/renderer-workspace-config.ts
@@ -1,0 +1,21 @@
+import { realpathSync } from "node:fs"
+import path from "node:path"
+
+export function createRendererWorkspaceConfig(
+  cwd: string,
+  resolveRealpath: (file: string) => string = realpathSync,
+) {
+  const workspaceRoot = path.resolve(cwd, "../..")
+  const workspaceNodeModules = resolveRealpath(path.resolve(cwd, "../../node_modules"))
+
+  return {
+    resolve: {
+      dedupe: ["@opencode-ai/ui"],
+    },
+    server: {
+      fs: {
+        allow: [workspaceRoot, workspaceNodeModules],
+      },
+    },
+  }
+}

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -23,7 +23,7 @@ import { initI18n, t } from "./i18n"
 import { UPDATER_ENABLED } from "./updater"
 import { webviewZoom } from "./webview-zoom"
 import "./styles.css"
-import { useTheme } from "@opencode-ai/ui/theme"
+import { useTheme } from "@opencode-ai/ui/theme/context"
 
 const root = document.getElementById("root")
 if (import.meta.env.DEV && !(root instanceof HTMLElement)) {

--- a/packages/desktop-electron/src/renderer/theme-context.test.ts
+++ b/packages/desktop-electron/src/renderer/theme-context.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const source = readFileSync(join(import.meta.dir, "index.tsx"), "utf8")
+
+test("renderer uses the direct theme context import for useTheme", () => {
+  expect(source).toContain('import { useTheme } from "@opencode-ai/ui/theme/context"')
+  expect(source).not.toContain('import { useTheme } from "@opencode-ai/ui/theme"')
+})

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -6,11 +6,11 @@ const repoRoot = path.resolve(import.meta.dir, "../../../../")
 const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke home hero prompt starts a session",
   "packages/app/e2e/app/home.spec.ts:@smoke home renders the hero composer and starter cards",
-  "packages/app/e2e/app/home.spec.ts:@smoke home route server picker dialog opens",
+  "packages/app/e2e/app/home.spec.ts:@smoke project home status panel can open the server picker dialog",
   "packages/app/e2e/app/home.spec.ts:@smoke root route renders seeded home entrypoints",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
-  "packages/app/e2e/files/file-tree.spec.ts:@smoke file tree entrypoints can open the panel and a file",
+  "packages/app/e2e/files/file-tree.spec.ts:@smoke review keeps the persistent file-tree pane for review navigation",
   "packages/app/e2e/projects/projects-switch.spec.ts:@smoke can switch between projects from sidebar",
   "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",
   "packages/app/e2e/prompt/prompt.spec.ts:@smoke can send a prompt and receive a reply",

--- a/packages/ui/src/components/tabs.css
+++ b/packages/ui/src/components/tabs.css
@@ -400,8 +400,15 @@
   }
 
   &[data-variant="sidepanel"] {
-    [data-slot="tabs-list"]::after {
-      display: none;
+    [data-slot="tabs-list"] {
+      /* Override the base 48px so the consumer's h-11 (44px) is honored.
+         Tailwind class (0,1,0) would lose to the base nested selector (0,2,0)
+         without this explicit override. */
+      height: 44px;
+
+      &::after {
+        display: none;
+      }
     }
 
     /* Neutralize the base tabs-trigger-wrapper chrome (borders, bg, selected-state tint). */

--- a/packages/ui/src/components/tabs.css
+++ b/packages/ui/src/components/tabs.css
@@ -399,6 +399,49 @@
     }
   }
 
+  &[data-variant="sidepanel"] {
+    [data-slot="tabs-list"]::after {
+      display: none;
+    }
+
+    /* Neutralize the base tabs-trigger-wrapper chrome (borders, bg, selected-state tint). */
+    [data-slot="tabs-trigger-wrapper"] {
+      border-bottom: none;
+      border-right: none;
+      background-color: transparent;
+      color: inherit;
+      font: inherit;
+      height: auto;
+      max-width: none;
+      gap: 0;
+
+      &:has([data-selected]),
+      &:hover:not(:disabled):not([data-selected]) {
+        color: inherit;
+        background-color: transparent;
+        border-bottom-color: transparent;
+      }
+    }
+
+    /* Sidepanel trigger visuals — geometry (height/padding/gap/border-radius) is set by the
+       consumer via Tailwind classes; this block only owns the color/bg/state contract. */
+    [data-slot="tabs-trigger"] {
+      border: 1px solid transparent;
+      color: var(--text-weak);
+      background-color: transparent;
+      transition: background-color 120ms ease;
+
+      &:hover {
+        background-color: var(--surface-base-hover);
+      }
+
+      &[data-selected] {
+        background-color: var(--surface-raised-base);
+        color: var(--text-base);
+      }
+    }
+  }
+
   &[data-variant="pill"][data-orientation="horizontal"][data-scope="filetree"] {
     [data-slot="tabs-list"] {
       height: 48px;

--- a/packages/ui/src/components/tabs.test.tsx
+++ b/packages/ui/src/components/tabs.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import type { TabsProps } from "./tabs"
+
+describe("Tabs variant union", () => {
+  test("accepts \"sidepanel\"", () => {
+    // Compile-time: typecheck fails if the union drops "sidepanel".
+    // Runtime: trivially passes (bun strips TS types).
+    const variant: TabsProps["variant"] = "sidepanel"
+    expect(variant).toBe("sidepanel")
+  })
+
+  test("accepts existing variants", () => {
+    const normal: TabsProps["variant"] = "normal"
+    const alt: TabsProps["variant"] = "alt"
+    const pill: TabsProps["variant"] = "pill"
+    const settings: TabsProps["variant"] = "settings"
+    expect([normal, alt, pill, settings]).toEqual(["normal", "alt", "pill", "settings"])
+  })
+})

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -3,7 +3,7 @@ import { Show, splitProps, type JSX } from "solid-js"
 import type { ComponentProps, ParentProps, Component } from "solid-js"
 
 export interface TabsProps extends ComponentProps<typeof Kobalte> {
-  variant?: "normal" | "alt" | "pill" | "settings"
+  variant?: "normal" | "alt" | "pill" | "settings" | "sidepanel"
   orientation?: "horizontal" | "vertical"
 }
 export interface TabsListProps extends ComponentProps<typeof Kobalte.List> {}


### PR DESCRIPTION
## Summary

- unify the desktop session right utility panel into four top-level tabs: Status, Files, Review, and Terminal
- move terminal rendering into the right panel on desktop while preserving the existing bottom terminal flow on mobile
- keep Status routed to the right panel on desktop, preserve the existing status popover on mobile, and add legacy restore coverage for old `sidePanelTab: "changes"` state

## Why

This slice lands the next phase of the PawWork desktop UI tracked in `#26`. The goal is to replace split session utilities with one consistent right-side surface without regressing terminal access, status access, or old persisted layout state.

## Related Issue

Part of #26

## How To Verify

```bash
cd packages/app
bun test --preload ./happydom.ts ./src/pages/session/right-panel-tabs.test.ts ./src/context/layout.test.ts ./src/components/status-panel.test.tsx ./src/pages/session/session-side-panel.test.tsx ./src/i18n/parity.test.ts
bun run typecheck
bun x playwright test e2e/files/file-tree.spec.ts e2e/commands/panels.spec.ts e2e/status/status-popover.spec.ts e2e/prompt/prompt-slash-terminal.spec.ts e2e/terminal/terminal-init.spec.ts -g "(@smoke file tree entrypoints can open the panel and a file|desktop side-panel buttons switch between review and files within a unified right-panel tab shell|legacy changes side-panel state restores into the review tab|session status button opens the right-panel status tab|session status tab can switch to mcp|session status button toggles the right panel closed|mobile session status button still opens the status popover|/terminal opens the right-panel terminal tab|mobile /terminal opens the bottom terminal panel|@smoke terminal mounts and can create a second tab)"
```

## Screenshots or Recordings

- Not attached in CLI flow. Visible behavior is covered by the targeted Playwright checks above.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


---

## Phase 2 — shell geometry refine (added 2026-04-19)

Reworks the outer shell introduced above. The first pass left the panel growing with the viewport and using the wrong tab chrome; this follow-up anchors it at a fixed width, rebuilds the tab row per `docs/design/src/rightpanel.jsx`, deletes the zombie middle splitter, and wires a real left-edge resize handle.

### Changes

- Right panel anchors at 340px default, resizes 300–520 via a left-edge `ResizeHandle`. Session column flips to `flex-1` and claims the gap.
- New `variant="sidepanel"` on `@opencode-ai/ui/tabs` with scoped CSS: disables the base `::after` flex-grow filler so the 40px right-gutter reserve stays flush; neutralizes wrapper chrome; owns trigger color/bg/selected contract (consumer keeps geometry via Tailwind).
- Global `layout.rightPanel.width` (sibling of `layout.sidebar`, `layout.fileTree`, `layout.session`). `clampRightPanelWidth` guards undefined / non-number / non-finite inputs and defaults to 340. Width persists across sessions and reloads.
- Deletes `sessionPanelWidth` + `desktopSidePanelOpen` memos and the middle splitter `<Show>` block in `session.tsx` (0 remaining readers). Removes `transition-[width]` on the now-flex session column (no-op on `flex-1`).
- `size.start/touch` threaded through the new handle to preserve transition suppression during drag, matching the sidebar + file-tree handles.

### Test coverage

- `clampRightPanelWidth` pure-factory: default / inside-range / below-min / above-max / NaN / ±Infinity / string / null → 9 cases.
- `formatRightPanelWidth` + `makeRightPanelResizeHandler` helpers: closed/open, touch-before-resize, clamping delegation.
- `tabs.test.tsx` type-level: union includes `"sidepanel"` (typecheck gates regression; bun strips types at runtime).
- E2E `e2e/session/right-panel-width.spec.ts`: open via titlebar → drive `layout.rightPanel.resize(400)` via DEV-only `window.__pawworkLayout` hook → reload → assert 400px persisted.

### Review

Three rounds of multi-model crosscheck (Claude + Codex) converged:
- R1 fixed: clamp non-finite guard, tabs-list specificity override (base `[data-slot="tabs-list"] { height: 48px }` at (0,2,0) was winning over consumer's `h-11` at (0,1,0)), removed dead `transition-[width]` on `flex-1`.
- R2 strengthened: `typeof !== "number"` guard on clamp, inline comment on the 40px reserve spacer.
- R3 only surfaced pre-existing `wantsReview` tab-gating (out of scope; this PR only renames `"changes"` → `"review"` in that expression) and false-positives disproved by code reading.

### Known tradeoffs

- Tests at the component layer stay at the null-mock pattern (`session-side-panel.test.tsx`). `bun test` compiles JSX with the React transform, not Solid's — real DOM rendering would require adding `@solidjs/testing-library` + harness setup to `packages/ui` and `packages/app`, which is scope creep on the upstream-synced test infra. Coverage shifts to pure helpers (`formatRightPanelWidth`, `makeRightPanelResizeHandler`, `clampRightPanelWidth`) + typecheck + e2e.
- E2E drives the store via `window.__pawworkLayout` (DEV-gated), not the pointer drag path. Playwright webServer always runs in DEV, so the hook is always present in practice; a real-drag test would be more brittle and cover less surface than the persistence round-trip.
- `layout.session.width` is still persisted as a store field even though nothing reads it anymore — kept for layout.v6 blob back-compat; a future migration can strip it.

### Scope deferred

- `wantsReview` / `openReviewPanel` change-tab behavior (pre-existing; flagged by both reviewers but unchanged by this diff).
- Sidepanel variant's trigger selectors are not scoped to direct-child `Tabs.List` — consistent with the existing `pill` variant, which has the same descendant-leakage pattern; fixing both belongs in a broader tabs primitive refactor.

