### PR TITLE
Sync provider/plugin upstream behaviors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2232,7 +2232,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361", "sha512-dW0nwaiBBcun9y5WJSvm3HxDLe5o9V0xLCndQvWonRVubU8CS1PHxZpLffyPt1YujPWC13ez03aWxcuKBPYYGQ=="],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#main",
+    "ghostty-web": "github:anomalyco/ghostty-web#20bd3613f59dfc0f088a9aec498db2fa1a08b768",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/opencode/src/plugin/cloudflare.ts
+++ b/packages/opencode/src/plugin/cloudflare.ts
@@ -63,5 +63,11 @@ export async function CloudflareAIGatewayAuthPlugin(_input: PluginInput): Promis
         },
       ],
     },
+    "chat.params": async (input, output) => {
+      if (input.model.providerID !== "cloudflare-ai-gateway") return
+      if (!input.model.api.id.toLowerCase().startsWith("openai/")) return
+      if (!input.model.capabilities.reasoning) return
+      output.maxOutputTokens = undefined
+    },
   }
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -959,7 +959,7 @@ export namespace Provider {
       family: model.family,
       api: {
         id: model.id,
-        url: model.provider?.api ?? provider.api!,
+        url: model.provider?.api ?? provider.api ?? "",
         npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
       },
       status: model.status ?? "active",
@@ -972,10 +972,10 @@ export namespace Provider {
         output: model.limit.output,
       },
       capabilities: {
-        temperature: model.temperature,
-        reasoning: model.reasoning,
-        attachment: model.attachment,
-        toolcall: model.tool_call,
+        temperature: model.temperature ?? false,
+        reasoning: model.reasoning ?? false,
+        attachment: model.attachment ?? false,
+        toolcall: model.tool_call ?? true,
         input: {
           text: model.modalities?.input?.includes("text") ?? false,
           audio: model.modalities?.input?.includes("audio") ?? false,
@@ -992,7 +992,7 @@ export namespace Provider {
         },
         interleaved: model.interleaved ?? false,
       },
-      release_date: model.release_date,
+      release_date: model.release_date ?? "",
       variants: {},
     }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -75,7 +75,7 @@ export namespace ProviderTransform {
 
     if (model.api.id.includes("claude")) {
       const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
-      return msgs.map((msg) => {
+      msgs = msgs.map((msg) => {
         if (msg.role === "assistant" && Array.isArray(msg.content)) {
           return {
             ...msg,
@@ -99,6 +99,21 @@ export namespace ProviderTransform {
           }
         }
         return msg
+      })
+    }
+    if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
+      msgs = msgs.flatMap((msg) => {
+        if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
+
+        const parts = msg.content
+        const firstToolCall = parts.findIndex((part) => part.type === "tool-call")
+        if (firstToolCall === -1) return [msg]
+        if (!parts.slice(firstToolCall).some((part) => part.type !== "tool-call")) return [msg]
+
+        return [
+          { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
+          { ...msg, content: parts.filter((part) => part.type === "tool-call") },
+        ]
       })
     }
     if (
@@ -373,10 +388,17 @@ export namespace ProviderTransform {
     if (!model.capabilities.reasoning) return {}
 
     const id = model.id.toLowerCase()
-    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) =>
-      model.api.id.includes(v),
-    )
-    const adaptiveEfforts = ["low", "medium", "high", "max"]
+    const adaptiveEfforts = ["opus-4-7", "opus-4.7"].some((v) => model.api.id.includes(v))
+      ? ["low", "medium", "high", "xhigh", "max"]
+      : ["low", "medium", "high", "max"]
+    const isAnthropicAdaptive = [
+      "opus-4-7",
+      "opus-4.7",
+      "opus-4-6",
+      "opus-4.6",
+      "sonnet-4-6",
+      "sonnet-4.6",
+    ].some((v) => model.api.id.includes(v))
     if (
       id.includes("deepseek") ||
       id.includes("minimax") ||
@@ -567,6 +589,9 @@ export namespace ProviderTransform {
               {
                 thinking: {
                   type: "adaptive",
+                  ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
+                    ? { display: "summarized" }
+                    : {}),
                 },
                 effort,
               },
@@ -764,6 +789,10 @@ export namespace ProviderTransform {
       input.model.api.npm === "@ai-sdk/github-copilot"
     ) {
       result["store"] = false
+    }
+
+    if (input.model.providerID === "azure" || input.model.api.npm === "@ai-sdk/azure") {
+      result["store"] = true
     }
 
     if (input.model.api.npm === "@openrouter/ai-sdk-provider") {

--- a/packages/opencode/test/plugin/cloudflare.test.ts
+++ b/packages/opencode/test/plugin/cloudflare.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { CloudflareAIGatewayAuthPlugin } from "@/plugin/cloudflare"
+
+const pluginInput = {
+  client: {} as never,
+  project: {} as never,
+  directory: "",
+  worktree: "",
+  serverUrl: new URL("https://example.com"),
+  $: {} as never,
+}
+
+function makeHookInput(overrides?: { providerID?: string; apiId?: string; reasoning?: boolean }) {
+  return {
+    sessionID: "s",
+    agent: "a",
+    provider: {} as never,
+    message: {} as never,
+    model: {
+      providerID: overrides?.providerID ?? "cloudflare-ai-gateway",
+      api: { id: overrides?.apiId ?? "openai/gpt-5.2-codex", url: "", npm: "ai-gateway-provider" },
+      capabilities: {
+        reasoning: overrides?.reasoning ?? true,
+        temperature: false,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+    } as never,
+  }
+}
+
+test("omits maxOutputTokens for openai reasoning models on cloudflare-ai-gateway", async () => {
+  const hooks = await CloudflareAIGatewayAuthPlugin(pluginInput as never)
+  const out = { temperature: 0, topP: 1, topK: 0, maxOutputTokens: 32_000 as number | undefined, options: {} }
+  await hooks["chat.params"]?.(makeHookInput(), out)
+  expect(out.maxOutputTokens).toBeUndefined()
+})
+
+test("keeps maxOutputTokens for openai non-reasoning models", async () => {
+  const hooks = await CloudflareAIGatewayAuthPlugin(pluginInput as never)
+  const out = { temperature: 0, topP: 1, topK: 0, maxOutputTokens: 32_000 as number | undefined, options: {} }
+  await hooks["chat.params"]?.(makeHookInput({ apiId: "openai/gpt-4-turbo", reasoning: false }), out)
+  expect(out.maxOutputTokens).toBe(32_000)
+})
+
+test("keeps maxOutputTokens for non-openai reasoning models on cloudflare-ai-gateway", async () => {
+  const hooks = await CloudflareAIGatewayAuthPlugin(pluginInput as never)
+  const out = { temperature: 0, topP: 1, topK: 0, maxOutputTokens: 32_000 as number | undefined, options: {} }
+  await hooks["chat.params"]?.(makeHookInput({ apiId: "anthropic/claude-sonnet-4-5", reasoning: true }), out)
+  expect(out.maxOutputTokens).toBe(32_000)
+})
+
+test("ignores non-cloudflare-ai-gateway providers", async () => {
+  const hooks = await CloudflareAIGatewayAuthPlugin(pluginInput as never)
+  const out = { temperature: 0, topP: 1, topK: 0, maxOutputTokens: 32_000 as number | undefined, options: {} }
+  await hooks["chat.params"]?.(makeHookInput({ providerID: "openai", apiId: "gpt-5.2-codex", reasoning: true }), out)
+  expect(out.maxOutputTokens).toBe(32_000)
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1891,6 +1891,38 @@ test("mode cost preserves over-200k pricing from base model", () => {
   })
 })
 
+test("models.dev normalization fills required response fields", () => {
+  const provider = {
+    id: "gateway",
+    name: "Gateway",
+    env: [],
+    models: {
+      "gpt-5.4": {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        family: "gpt",
+        cost: {
+          input: 2.5,
+          output: 15,
+        },
+        limit: {
+          context: 1_050_000,
+          input: 922_000,
+          output: 128_000,
+        },
+      },
+    },
+  } as unknown as ModelsDev.Provider
+
+  const model = Provider.fromModelsDevProvider(provider).models["gpt-5.4"]
+  expect(model.api.url).toBe("")
+  expect(model.capabilities.temperature).toBe(false)
+  expect(model.capabilities.reasoning).toBe(false)
+  expect(model.capabilities.attachment).toBe(false)
+  expect(model.capabilities.toolcall).toBe(true)
+  expect(model.release_date).toBe("")
+})
+
 test("model variants are generated for reasoning models", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -102,6 +102,24 @@ describe("ProviderTransform.options - setCacheKey", () => {
     })
     expect(result.store).toBe(false)
   })
+
+  test("should set store=true for azure provider by default", () => {
+    const azureModel = {
+      ...mockModel,
+      providerID: "azure",
+      api: {
+        id: "gpt-4",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    }
+    const result = ProviderTransform.options({
+      model: azureModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBe(true)
+  })
 })
 
 describe("ProviderTransform.options - zai/zhipuai thinking", () => {
@@ -1287,6 +1305,106 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[0].content).toBe("")
     expect(result[1].content).toHaveLength(1)
   })
+
+  test("splits anthropic assistant messages when text trails tool calls", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Check my home directory for PDFs" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+          { type: "text", text: "I checked your home directory and looked for PDF files." },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+          {
+            type: "tool-result",
+            toolCallId: "toolu_2",
+            toolName: "glob",
+            output: { type: "text", value: "No files found" },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    expect(result).toHaveLength(4)
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
+    })
+    expect(result[2]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+        { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+      ],
+    })
+  })
+
+  test("leaves valid anthropic assistant tool ordering unchanged", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I checked your home directory and looked for PDF files." },
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toMatchObject([
+      { type: "text", text: "I checked your home directory and looked for PDF files." },
+      { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+      { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+    ])
+  })
+
+  test("splits vertex anthropic assistant messages when text trails tool calls", () => {
+    const model = {
+      ...anthropicModel,
+      providerID: "google-vertex-anthropic",
+      api: {
+        id: "claude-sonnet-4@20250514",
+        url: "https://us-central1-aiplatform.googleapis.com",
+        npm: "@ai-sdk/google-vertex/anthropic",
+      },
+    }
+
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+          { type: "text", text: "I checked your home directory and looked for PDF files." },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toMatchObject([
+      { type: "text", text: "I checked your home directory and looked for PDF files." },
+    ])
+    expect(result[1].content).toMatchObject([
+      { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+      { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+    ])
+  })
 })
 
 describe("ProviderTransform.message - strip openai metadata when store=false", () => {
@@ -2150,6 +2268,46 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("anthropic opus 4.7 models return adaptive thinking options with xhigh", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-7",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4-7",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.xhigh).toEqual({
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "xhigh",
+      })
+      expect(result.max).toEqual({
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "max",
+      })
+    })
+
+    test("anthropic opus 4.7 dot-format models return adaptive thinking options with xhigh", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-7",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4.7",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    })
+
     test("anthropic models return anthropic thinking options", () => {
       const model = createMockModel({
         id: "anthropic/claude-sonnet-4",
@@ -2559,6 +2717,34 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("opus 4.7 returns adaptive thinking options with summarized display", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-7",
+        providerID: "anthropic",
+        api: {
+          id: "claude-opus-4-7",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.xhigh).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "xhigh",
+      })
+      expect(result.max).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "max",
+      })
+    })
+
     test("returns high and max with thinking config", () => {
       const model = createMockModel({
         id: "anthropic/claude-4",
@@ -2599,6 +2785,32 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.max).toEqual({
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "max",
+        },
+      })
+    })
+
+    test("anthropic opus 4.7 returns adaptive reasoning options with xhigh", () => {
+      const model = createMockModel({
+        id: "bedrock/anthropic-claude-opus-4-7",
+        providerID: "bedrock",
+        api: {
+          id: "anthropic.claude-opus-4-7",
+          url: "https://bedrock.amazonaws.com",
+          npm: "@ai-sdk/amazon-bedrock",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.xhigh).toEqual({
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "xhigh",
+        },
+      })
       expect(result.max).toEqual({
         reasoningConfig: {
           type: "adaptive",


### PR DESCRIPTION
## Summary

Align the PR3 provider/plugin slice of issue #27 with upstream `v1.4.11` behavior, while keeping the diff inside provider/plugin-owned files and tests.

This PR:
- omits `maxOutputTokens` for OpenAI reasoning models on `cloudflare-ai-gateway`
- normalizes sparse `models.dev` provider entries so required response fields get safe defaults
- normalizes Anthropic and Vertex Anthropic assistant messages when text trails tool calls
- adds Opus 4.7 adaptive reasoning coverage for gateway, Anthropic, and Bedrock
- carries the upstream Azure `store=true` provider behavior and locks it with a regression test so this sync item is explicit in PR3 instead of implicit in later drift
- pins `ghostty-web` to an immutable Git commit so `bun install --frozen-lockfile` stays reproducible in CI

## Why

Issue #27 was split so PR3 only owns provider/plugin behavior work and directly owned tests. This keeps the review surface honest after PR #31 instead of hiding runtime bridge migration inside a provider/plugin-named PR.

The CI follow-up is intentionally small: this repo cannot use a moving Git dependency ref like `github:anomalyco/ghostty-web#main` while enforcing a frozen lockfile, because upstream branch movement makes installs non-reproducible.

## Related Issue

Refs #27

## How To Verify

```bash
bun install --frozen-lockfile
bun --cwd packages/opencode test test/provider test/plugin
bun run --cwd packages/opencode typecheck
bun run --cwd packages/opencode build
bun turbo typecheck
bun turbo test:ci
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
