### PR TITLE
feat(plugin): bridge workspace adaptors into opencode

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,15 +1,14 @@
 import { test, expect } from "../fixtures"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
+import { serverNamePattern } from "../utils"
 
 test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
   await page.goto("/")
 
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
-  await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
-  await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
-  await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
-  await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
-  await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
+  await expect(page.getByRole("button", { name: serverNamePattern })).toBeVisible()
+  await expect(page.getByText("No recent projects")).toBeVisible()
+  await expect(page.getByText("Get started by opening a local project")).toBeVisible()
 })
 
 test("@smoke home renders the hero composer and starter cards", async ({ page, project }) => {
@@ -28,7 +27,7 @@ test("@smoke home renders the hero composer and starter cards", async ({ page, p
   await expect(firstCard).toBeVisible()
   await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
   await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
-  await expect(page.getByRole("button", { name: "Status" })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Right utility panel" })).toBeVisible()
 
   const cardBox = await firstCard.boundingBox()
   const composerBox = await composer.boundingBox()
@@ -55,7 +54,7 @@ test("@smoke home hero prompt starts a session", async ({ page, project, assista
 
 test("@smoke project home status panel can open the server picker dialog", async ({ page, project }) => {
   await project.open()
-  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const statusButton = page.getByRole("button", { name: "Right utility panel" }).first()
   const rightPanel = page.locator("#right-panel")
 
   await statusButton.click()

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,14 +1,15 @@
 import { test, expect } from "../fixtures"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
-import { serverNamePattern } from "../utils"
 
 test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
   await page.goto("/")
 
   await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
-  await expect(page.getByRole("button", { name: serverNamePattern })).toBeVisible()
-  await expect(page.getByText("No recent projects")).toBeVisible()
-  await expect(page.getByText("Get started by opening a local project")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Process documents/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Analyze data/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /Write faster/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Right utility panel" })).toBeVisible()
 })
 
 test("@smoke home renders the hero composer and starter cards", async ({ page, project }) => {

--- a/packages/app/e2e/app/server-default.spec.ts
+++ b/packages/app/e2e/app/server-default.spec.ts
@@ -15,18 +15,18 @@ test("can set a default server on web", async ({ page, gotoSession }) => {
 
   await gotoSession()
 
-  const status = page.getByRole("button", { name: "Status" })
-  await expect(status).toBeVisible()
-  const popover = page.locator('[data-component="popover-content"]').filter({ hasText: "Manage servers" })
+  const statusPanel = page.getByRole("button", { name: "Right utility panel" })
+  await expect(statusPanel).toBeVisible()
+  const rightPanel = page.locator("#right-panel")
 
-  const ensurePopoverOpen = async () => {
-    if (await popover.isVisible()) return
-    await status.click()
-    await expect(popover).toBeVisible()
+  const ensureStatusPanelOpen = async () => {
+    if ((await rightPanel.getAttribute("aria-hidden")) === "false") return
+    await statusPanel.click()
+    await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
   }
 
-  await ensurePopoverOpen()
-  await popover.getByRole("button", { name: "Manage servers" }).click()
+  await ensureStatusPanelOpen()
+  await rightPanel.getByRole("button", { name: "Manage servers" }).click()
 
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()
@@ -50,9 +50,9 @@ test("can set a default server on web", async ({ page, gotoSession }) => {
 
   await closeDialog(page, dialog)
 
-  await ensurePopoverOpen()
+  await ensureStatusPanelOpen()
 
-  const serverRow = popover.locator("button").filter({ hasText: serverNamePattern }).first()
+  const serverRow = rightPanel.locator("button").filter({ hasText: serverNamePattern }).first()
   await expect(serverRow).toBeVisible()
   await expect(serverRow.getByText("Default", { exact: true })).toBeVisible()
 })

--- a/packages/opencode/migration/20260419092854_workspace-owner-directory/migration.sql
+++ b/packages/opencode/migration/20260419092854_workspace-owner-directory/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workspace` ADD `owner_directory` text;

--- a/packages/opencode/migration/20260419092854_workspace-owner-directory/snapshot.json
+++ b/packages/opencode/migration/20260419092854_workspace-owner-directory/snapshot.json
@@ -1,0 +1,1357 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "57c01470-eb95-4288-a184-3cdb8c353c99",
+  "prevIds": [
+    "6badfa56-8d38-45c7-ac9a-ab488d72b608"
+  ],
+  "ddl": [
+    {
+      "name": "account_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "name": "event_sequence",
+      "entityType": "tables"
+    },
+    {
+      "name": "event",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_account_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_org_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "owner_directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "skill",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "active_account_id"
+      ],
+      "tableTo": "account",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_account_state_active_account_id_account_id_fk",
+      "entityType": "fks",
+      "table": "account_state"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "workspace"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "tableTo": "event_sequence",
+      "columnsTo": [
+        "aggregate_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_event_aggregate_id_event_sequence_aggregate_id_fk",
+      "entityType": "fks",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_state_pk",
+      "table": "account_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_pk",
+      "table": "workspace",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "nameExplicit": false,
+      "name": "event_sequence_pk",
+      "table": "event_sequence",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_pk",
+      "table": "event",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "time_created",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_time_created_id_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_id_id_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_workspace_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -6,16 +6,20 @@ const BUILTIN: Record<string, () => Promise<Adaptor>> = {
   worktree: lazy(async () => (await import("./worktree")).WorktreeAdaptor),
 }
 
-type CustomAdaptor = {
-  adaptor: Adaptor
-  refs: number
-}
+const CUSTOM = new Map<ProjectID, Map<string, Map<string, Adaptor>>>()
 
-const CUSTOM = new Map<ProjectID, Map<string, CustomAdaptor>>()
+export async function getAdaptor(projectID: ProjectID, type: string, owner?: string): Promise<Adaptor> {
+  const project = CUSTOM.get(projectID)?.get(type)
+  if (project) {
+    if (owner) {
+      const exact = project.get(owner)
+      if (exact) return exact
+    }
 
-export async function getAdaptor(projectID: ProjectID, type: string): Promise<Adaptor> {
-  const custom = CUSTOM.get(projectID)?.get(type)
-  if (custom) return custom.adaptor
+    const adaptors = [...project.values()]
+    const latest = adaptors.at(-1)
+    if (latest) return latest
+  }
 
   const builtin = BUILTIN[type]
   if (builtin) return builtin()
@@ -23,35 +27,27 @@ export async function getAdaptor(projectID: ProjectID, type: string): Promise<Ad
   throw new Error(`Unknown workspace adaptor: ${type}`)
 }
 
-export function installAdaptor(projectID: ProjectID, type: string, adaptor: Adaptor) {
+export function installAdaptor(projectID: ProjectID, owner: string, type: string, adaptor: Adaptor) {
   // This is experimental: mostly used for testing right now, but we
   // will likely allow this in the future. Need to figure out the
   // TypeScript story
 
-  const project = CUSTOM.get(projectID) ?? new Map<string, CustomAdaptor>()
-  const current = project.get(type)
-  project.set(type, {
-    adaptor,
-    refs: (current?.refs ?? 0) + 1,
-  })
+  const project = CUSTOM.get(projectID) ?? new Map<string, Map<string, Adaptor>>()
+  const adaptors = project.get(type) ?? new Map<string, Adaptor>()
+  if (adaptors.has(owner)) adaptors.delete(owner)
+  adaptors.set(owner, adaptor)
+  project.set(type, adaptors)
   CUSTOM.set(projectID, project)
 }
 
-export function uninstallAdaptor(projectID: ProjectID, type: string) {
+export function uninstallAdaptor(projectID: ProjectID, owner: string, type: string) {
   const project = CUSTOM.get(projectID)
   if (!project) return
 
-  const current = project.get(type)
-  if (!current) return
+  const adaptors = project.get(type)
+  if (!adaptors) return
 
-  if (current.refs > 1) {
-    project.set(type, {
-      adaptor: current.adaptor,
-      refs: current.refs - 1,
-    })
-    return
-  }
-
-  project.delete(type)
+  adaptors.delete(owner)
+  if (adaptors.size === 0) project.delete(type)
   if (project.size === 0) CUSTOM.delete(projectID)
 }

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -14,6 +14,7 @@ export async function getAdaptor(projectID: ProjectID, type: string, owner?: str
     if (owner) {
       const exact = project.get(owner)
       if (exact) return exact
+      throw new Error(`Unknown workspace adaptor owner: ${owner} (${type})`)
     }
 
     const adaptors = [...project.values()]

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -8,6 +8,14 @@ const BUILTIN: Record<string, () => Promise<Adaptor>> = {
 
 const CUSTOM = new Map<ProjectID, Map<string, Map<string, Adaptor>>>()
 
+export function ownerKey(directory: string, worktree: string) {
+  return worktree === "/" ? directory : worktree
+}
+
+export function getBuiltinAdaptor(type: string) {
+  return BUILTIN[type]
+}
+
 export async function getAdaptor(projectID: ProjectID, type: string, owner?: string): Promise<Adaptor> {
   const project = CUSTOM.get(projectID)?.get(type)
   if (project) {

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -1,20 +1,57 @@
 import { lazy } from "@/util/lazy"
+import type { ProjectID } from "@/project/schema"
 import type { Adaptor } from "../types"
 
-const ADAPTORS: Record<string, () => Promise<Adaptor>> = {
+const BUILTIN: Record<string, () => Promise<Adaptor>> = {
   worktree: lazy(async () => (await import("./worktree")).WorktreeAdaptor),
 }
 
-export function getAdaptor(type: string): Promise<Adaptor> {
-  return ADAPTORS[type]()
+type CustomAdaptor = {
+  adaptor: Adaptor
+  refs: number
 }
 
-export function installAdaptor(type: string, adaptor: Adaptor) {
+const CUSTOM = new Map<ProjectID, Map<string, CustomAdaptor>>()
+
+export async function getAdaptor(projectID: ProjectID, type: string): Promise<Adaptor> {
+  const custom = CUSTOM.get(projectID)?.get(type)
+  if (custom) return custom.adaptor
+
+  const builtin = BUILTIN[type]
+  if (builtin) return builtin()
+
+  throw new Error(`Unknown workspace adaptor: ${type}`)
+}
+
+export function installAdaptor(projectID: ProjectID, type: string, adaptor: Adaptor) {
   // This is experimental: mostly used for testing right now, but we
   // will likely allow this in the future. Need to figure out the
   // TypeScript story
 
-  // @ts-expect-error we force the builtin types right now, but we
-  // will implement a way to extend the types for custom adaptors
-  ADAPTORS[type] = () => adaptor
+  const project = CUSTOM.get(projectID) ?? new Map<string, CustomAdaptor>()
+  const current = project.get(type)
+  project.set(type, {
+    adaptor,
+    refs: (current?.refs ?? 0) + 1,
+  })
+  CUSTOM.set(projectID, project)
+}
+
+export function uninstallAdaptor(projectID: ProjectID, type: string) {
+  const project = CUSTOM.get(projectID)
+  if (!project) return
+
+  const current = project.get(type)
+  if (!current) return
+
+  if (current.refs > 1) {
+    project.set(type, {
+      adaptor: current.adaptor,
+      refs: current.refs - 1,
+    })
+    return
+  }
+
+  project.delete(type)
+  if (project.size === 0) CUSTOM.delete(projectID)
 }

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -40,6 +40,9 @@ export function installAdaptor(projectID: ProjectID, owner: string, type: string
   // This is experimental: mostly used for testing right now, but we
   // will likely allow this in the future. Need to figure out the
   // TypeScript story
+  if (type in BUILTIN) {
+    throw new Error(`Cannot register built-in workspace adaptor: ${type}`)
+  }
 
   const project = CUSTOM.get(projectID) ?? new Map<string, Map<string, Adaptor>>()
   const adaptors = project.get(type) ?? new Map<string, Adaptor>()

--- a/packages/opencode/src/control-plane/workspace.sql.ts
+++ b/packages/opencode/src/control-plane/workspace.sql.ts
@@ -9,6 +9,7 @@ export const WorkspaceTable = sqliteTable("workspace", {
   branch: text(),
   name: text(),
   directory: text(),
+  owner_directory: text(),
   extra: text({ mode: "json" }),
   project_id: text()
     .$type<ProjectID>()

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -82,13 +82,18 @@ export namespace Workspace {
     extra: Info.shape.extra,
   })
 
-  async function bootstrapAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner">, error: unknown) {
+  async function bootstrapAdaptor(
+    input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null },
+    error: unknown,
+  ) {
     const project = Project.get(input.projectID)
     if (!project) throw error
 
     const candidates = [
       ...new Set(
-        [input.owner, project.worktree, ...project.sandboxes].filter((value): value is string => Boolean(value)),
+        [input.hint, input.owner, project.worktree, ...project.sandboxes].filter(
+          (value): value is string => Boolean(value),
+        ),
       ),
     ]
     let lastError = error
@@ -131,7 +136,7 @@ export namespace Workspace {
     throw lastError
   }
 
-  export async function resolveAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner">) {
+  export async function resolveAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null }) {
     if (input.owner) {
       try {
         return await getAdaptor(input.projectID, input.type, input.owner)
@@ -214,7 +219,7 @@ export namespace Workspace {
       stopSync(id)
 
       const adaptor = await resolveAdaptor(info)
-      adaptor.remove(info)
+      await adaptor.remove(info)
       Database.use((db) => db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run())
       return toInfo(info)
     }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -222,6 +222,7 @@ export namespace Workspace {
 
   const connections = new Map<WorkspaceID, ConnectionStatus>()
   const aborts = new Map<WorkspaceID, AbortController>()
+  const pending = new Map<WorkspaceID, StoredInfo>()
 
   function setStatus(id: WorkspaceID, status: ConnectionStatus["status"], error?: string) {
     const prev = connections.get(id)
@@ -254,7 +255,11 @@ export namespace Workspace {
       const adaptor = await resolveAdaptor(space)
       const target = await adaptor.target(space)
 
-      if (target.type === "local") return
+      if (target.type === "local") {
+        const exists = await Filesystem.exists(target.directory)
+        setStatus(space.id, exists ? "connected" : "error", exists ? undefined : "directory does not exist")
+        return
+      }
 
       const res = await fetch(target.url + "/sync/event", { method: "GET", signal }).catch((err: unknown) => {
         setStatus(space.id, "error", String(err))
@@ -296,24 +301,37 @@ export namespace Workspace {
       return
     }
 
-    if (aborts.has(space.id)) return
+    if (aborts.has(space.id)) {
+      pending.set(space.id, space)
+      return
+    }
     const abort = new AbortController()
     aborts.set(space.id, abort)
     setStatus(space.id, "disconnected")
 
-    void workspaceEventLoop(space, abort.signal).catch((error) => {
-      aborts.delete(space.id)
-      setStatus(space.id, "error", String(error))
-      log.warn("workspace sync listener failed", {
-        workspaceID: space.id,
-        error,
+    void workspaceEventLoop(space, abort.signal)
+      .catch((error) => {
+        setStatus(space.id, "error", String(error))
+        log.warn("workspace sync listener failed", {
+          workspaceID: space.id,
+          error,
+        })
       })
-    })
+      .finally(() => {
+        if (aborts.get(space.id) === abort) {
+          aborts.delete(space.id)
+        }
+        const next = pending.get(space.id)
+        if (!next) return
+        pending.delete(space.id)
+        startSync(next)
+      })
   }
 
   function stopSync(id: WorkspaceID) {
     aborts.get(id)?.abort()
     aborts.delete(id)
+    pending.delete(id)
     connections.delete(id)
   }
 }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -9,6 +9,7 @@ import { SyncEvent } from "@/sync"
 import { Log } from "@/util/log"
 import { Filesystem } from "@/util/filesystem"
 import { ProjectID } from "@/project/schema"
+import { Instance } from "@/project/instance"
 import { WorkspaceTable } from "./workspace.sql"
 import { getAdaptor } from "./adaptors"
 import { WorkspaceInfo } from "./types"
@@ -66,7 +67,7 @@ export namespace Workspace {
 
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
-    const adaptor = await getAdaptor(input.projectID, input.type)
+    const adaptor = await getAdaptor(input.projectID, input.type, Instance.directory)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })
 

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -66,7 +66,7 @@ export namespace Workspace {
 
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
-    const adaptor = await getAdaptor(input.type)
+    const adaptor = await getAdaptor(input.projectID, input.type)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })
 
@@ -124,7 +124,7 @@ export namespace Workspace {
       stopSync(id)
 
       const info = fromRow(row)
-      const adaptor = await getAdaptor(row.type)
+      const adaptor = await getAdaptor(info.projectID, row.type)
       adaptor.remove(info)
       Database.use((db) => db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run())
       return info
@@ -162,7 +162,7 @@ export namespace Workspace {
       log.info("connecting to sync: " + space.id)
 
       setStatus(space.id, "connecting")
-      const adaptor = await getAdaptor(space.type)
+      const adaptor = await getAdaptor(space.projectID, space.type)
       const target = await adaptor.target(space)
 
       if (target.type === "local") return

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -10,6 +10,7 @@ import { Log } from "@/util/log"
 import { Filesystem } from "@/util/filesystem"
 import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { WorkspaceTable } from "./workspace.sql"
 import { getAdaptor } from "./adaptors"
 import { WorkspaceInfo } from "./types"
@@ -21,6 +22,9 @@ export namespace Workspace {
     ref: "Workspace",
   })
   export type Info = z.infer<typeof Info>
+  type StoredInfo = Info & {
+    owner: string | null
+  }
 
   export const ConnectionStatus = z.object({
     workspaceID: WorkspaceID.zod,
@@ -45,7 +49,20 @@ export namespace Workspace {
     Status: BusEvent.define("workspace.status", ConnectionStatus),
   }
 
-  function fromRow(row: typeof WorkspaceTable.$inferSelect): Info {
+  function fromRow(row: typeof WorkspaceTable.$inferSelect): StoredInfo {
+    return {
+      id: row.id,
+      type: row.type,
+      branch: row.branch,
+      name: row.name,
+      directory: row.directory,
+      owner: row.owner_directory,
+      extra: row.extra,
+      projectID: row.project_id,
+    }
+  }
+
+  function toInfo(row: StoredInfo): Info {
     return {
       id: row.id,
       type: row.type,
@@ -53,7 +70,7 @@ export namespace Workspace {
       name: row.name,
       directory: row.directory,
       extra: row.extra,
-      projectID: row.project_id,
+      projectID: row.projectID,
     }
   }
 
@@ -65,18 +82,54 @@ export namespace Workspace {
     extra: Info.shape.extra,
   })
 
+  async function bootstrapAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner">, error: unknown) {
+    const project = Project.get(input.projectID)
+    if (!project) throw error
+
+    const candidates = [
+      ...new Set(
+        [input.owner, project.worktree, ...project.sandboxes].filter((value): value is string => Boolean(value)),
+      ),
+    ]
+    let lastError = error
+
+    for (const directory of candidates) {
+      try {
+        return await Instance.provide({
+          directory,
+          init: InstanceBootstrap,
+          fn: () => getAdaptor(input.projectID, input.type, directory),
+        })
+      } catch (candidateError) {
+        lastError = candidateError
+      }
+    }
+
+    throw lastError
+  }
+
+  export async function resolveAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner">) {
+    try {
+      return await getAdaptor(input.projectID, input.type, input.owner ?? undefined)
+    } catch (error) {
+      return bootstrapAdaptor(input, error)
+    }
+  }
+
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
-    const adaptor = await getAdaptor(input.projectID, input.type, Instance.directory)
+    const owner = Instance.directory
+    const adaptor = await getAdaptor(input.projectID, input.type, owner)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })
 
-    const info: Info = {
+    const info: StoredInfo = {
       id,
       type: config.type,
       branch: config.branch ?? null,
       name: config.name ?? null,
       directory: config.directory ?? null,
+      owner,
       extra: config.extra ?? null,
       projectID: input.projectID,
     }
@@ -89,6 +142,7 @@ export namespace Workspace {
           branch: info.branch,
           name: info.name,
           directory: info.directory,
+          owner_directory: info.owner,
           extra: info.extra,
           project_id: info.projectID,
         })
@@ -99,7 +153,7 @@ export namespace Workspace {
 
     startSync(info)
 
-    return info
+    return toInfo(info)
   })
 
   export function list(project: Project.Info) {
@@ -108,27 +162,31 @@ export namespace Workspace {
     )
     const spaces = rows.map(fromRow).sort((a, b) => a.id.localeCompare(b.id))
     for (const space of spaces) startSync(space)
-    return spaces
+    return spaces.map(toInfo)
   }
 
-  export const get = fn(WorkspaceID.zod, async (id) => {
+  export const record = fn(WorkspaceID.zod, async (id) => {
     const row = Database.use((db) => db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, id)).get())
     if (!row) return
-    const space = fromRow(row)
+    return fromRow(row)
+  })
+
+  export const get = fn(WorkspaceID.zod, async (id) => {
+    const space = await record(id)
+    if (!space) return
     startSync(space)
-    return space
+    return toInfo(space)
   })
 
   export const remove = fn(WorkspaceID.zod, async (id) => {
-    const row = Database.use((db) => db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, id)).get())
-    if (row) {
+    const info = await record(id)
+    if (info) {
       stopSync(id)
 
-      const info = fromRow(row)
-      const adaptor = await getAdaptor(info.projectID, row.type)
+      const adaptor = await resolveAdaptor(info)
       adaptor.remove(info)
       Database.use((db) => db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run())
-      return info
+      return toInfo(info)
     }
   })
 
@@ -156,14 +214,14 @@ export namespace Workspace {
 
   const log = Log.create({ service: "workspace-sync" })
 
-  async function workspaceEventLoop(space: Info, signal: AbortSignal) {
+  async function workspaceEventLoop(space: StoredInfo, signal: AbortSignal) {
     log.info("starting sync: " + space.id)
 
     while (!signal.aborted) {
       log.info("connecting to sync: " + space.id)
 
       setStatus(space.id, "connecting")
-      const adaptor = await getAdaptor(space.projectID, space.type)
+      const adaptor = await resolveAdaptor(space)
       const target = await adaptor.target(space)
 
       if (target.type === "local") return
@@ -200,7 +258,7 @@ export namespace Workspace {
     }
   }
 
-  function startSync(space: Info) {
+  function startSync(space: StoredInfo) {
     if (space.type === "worktree") {
       void Filesystem.exists(space.directory!).then((exists) => {
         setStatus(space.id, exists ? "connected" : "error", exists ? undefined : "directory does not exist")
@@ -214,6 +272,7 @@ export namespace Workspace {
     setStatus(space.id, "disconnected")
 
     void workspaceEventLoop(space, abort.signal).catch((error) => {
+      aborts.delete(space.id)
       setStatus(space.id, "error", String(error))
       log.warn("workspace sync listener failed", {
         workspaceID: space.id,

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -10,7 +10,7 @@ import { Log } from "@/util/log"
 import { Filesystem } from "@/util/filesystem"
 import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
-import { InstanceBootstrap } from "@/project/bootstrap"
+import { Plugin } from "@/plugin"
 import { WorkspaceTable } from "./workspace.sql"
 import { getAdaptor, getBuiltinAdaptor, ownerKey } from "./adaptors"
 import { WorkspaceInfo } from "./types"
@@ -103,8 +103,8 @@ export namespace Workspace {
       try {
         const match = await Instance.provide({
           directory,
-          init: InstanceBootstrap,
           fn: async () => {
+            await Plugin.init()
             const owner = ownerKey(Instance.directory, Instance.worktree)
             return {
               owner,
@@ -137,18 +137,33 @@ export namespace Workspace {
   }
 
   export async function resolveAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null }) {
+    const hint =
+      input.hint ??
+      (() => {
+        try {
+          return ownerKey(Instance.directory, Instance.worktree)
+        } catch {
+          return undefined
+        }
+      })()
+
     if (input.owner) {
       try {
         return await getAdaptor(input.projectID, input.type, input.owner)
       } catch (error) {
-        return bootstrapAdaptor(input, error)
+        return bootstrapAdaptor({ ...input, hint }, error)
       }
     }
 
     const builtin = getBuiltinAdaptor(input.type)
     if (builtin) return builtin()
 
-    return bootstrapAdaptor(input, new Error(`Missing workspace owner for adaptor: ${input.type}`))
+    const project = Project.get(input.projectID)
+    if (project?.worktree === "/" && !hint) {
+      throw new Error(`Missing workspace owner for non-git adaptor: ${input.type}`)
+    }
+
+    return bootstrapAdaptor({ ...input, hint }, new Error(`Missing workspace owner for adaptor: ${input.type}`))
   }
 
   export const create = fn(CreateInput, async (input) => {

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -118,7 +118,7 @@ export namespace Workspace {
 
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
-    const owner = Instance.directory
+    const owner = Instance.worktree
     const adaptor = await getAdaptor(input.projectID, input.type, owner)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -12,7 +12,7 @@ import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
 import { WorkspaceTable } from "./workspace.sql"
-import { getAdaptor } from "./adaptors"
+import { getAdaptor, getBuiltinAdaptor, ownerKey } from "./adaptors"
 import { WorkspaceInfo } from "./types"
 import { WorkspaceID } from "./schema"
 import { parseSSE } from "./sse"
@@ -92,16 +92,39 @@ export namespace Workspace {
       ),
     ]
     let lastError = error
+    const resolved: { owner: string; adaptor: Awaited<ReturnType<typeof getAdaptor>> }[] = []
 
     for (const directory of candidates) {
       try {
-        return await Instance.provide({
+        const match = await Instance.provide({
           directory,
           init: InstanceBootstrap,
-          fn: () => getAdaptor(input.projectID, input.type, directory),
+          fn: async () => {
+            const owner = ownerKey(Instance.directory, Instance.worktree)
+            return {
+              owner,
+              adaptor: await getAdaptor(input.projectID, input.type, owner),
+            }
+          },
         })
+
+        if (input.owner) {
+          if (match.owner === input.owner) return match.adaptor
+          continue
+        }
+
+        if (!resolved.some((item) => item.owner === match.owner)) {
+          resolved.push(match)
+        }
       } catch (candidateError) {
         lastError = candidateError
+      }
+    }
+
+    if (!input.owner) {
+      if (resolved.length === 1) return resolved[0]!.adaptor
+      if (resolved.length > 1) {
+        throw new Error(`Ambiguous workspace adaptor owner for ${input.type}`)
       }
     }
 
@@ -109,16 +132,23 @@ export namespace Workspace {
   }
 
   export async function resolveAdaptor(input: Pick<StoredInfo, "projectID" | "type" | "owner">) {
-    try {
-      return await getAdaptor(input.projectID, input.type, input.owner ?? undefined)
-    } catch (error) {
-      return bootstrapAdaptor(input, error)
+    if (input.owner) {
+      try {
+        return await getAdaptor(input.projectID, input.type, input.owner)
+      } catch (error) {
+        return bootstrapAdaptor(input, error)
+      }
     }
+
+    const builtin = getBuiltinAdaptor(input.type)
+    if (builtin) return builtin()
+
+    return bootstrapAdaptor(input, new Error(`Missing workspace owner for adaptor: ${input.type}`))
   }
 
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
-    const owner = Instance.worktree
+    const owner = ownerKey(Instance.directory, Instance.worktree)
     const adaptor = await getAdaptor(input.projectID, input.type, owner)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -88,10 +88,11 @@ export namespace Workspace {
   ) {
     const project = Project.get(input.projectID)
     if (!project) throw error
+    const projectWorktree = project.worktree === "/" ? undefined : project.worktree
 
     const candidates = [
       ...new Set(
-        [input.hint, input.owner, project.worktree, ...project.sandboxes].filter(
+        [input.hint, input.owner, projectWorktree, ...project.sandboxes].filter(
           (value): value is string => Boolean(value),
         ),
       ),
@@ -201,7 +202,7 @@ export namespace Workspace {
 
     await adaptor.create(config)
 
-    startSync(info)
+    startSync({ space: info })
 
     return toInfo(info)
   })
@@ -211,7 +212,7 @@ export namespace Workspace {
       db.select().from(WorkspaceTable).where(eq(WorkspaceTable.project_id, project.id)).all(),
     )
     const spaces = rows.map(fromRow).sort((a, b) => a.id.localeCompare(b.id))
-    for (const space of spaces) startSync(space)
+    for (const space of spaces) startSync({ space })
     return spaces.map(toInfo)
   }
 
@@ -224,13 +225,13 @@ export namespace Workspace {
   export const get = fn(WorkspaceID.zod, async (id) => {
     const space = await record(id)
     if (!space) return
-    startSync(space)
+    startSync({ space })
     return toInfo(space)
   })
 
-  export function ensureSync(space: Awaited<ReturnType<typeof record>> | undefined) {
+  export function ensureSync(space: Awaited<ReturnType<typeof record>> | undefined, hint?: string | null) {
     if (!space) return
-    startSync(space)
+    startSync({ space, hint })
   }
 
   export const remove = fn(WorkspaceID.zod, async (id) => {
@@ -246,8 +247,13 @@ export namespace Workspace {
   })
 
   const connections = new Map<WorkspaceID, ConnectionStatus>()
+  type SyncRequest = {
+    space: StoredInfo
+    hint?: string | null
+  }
+
   const aborts = new Map<WorkspaceID, AbortController>()
-  const pending = new Map<WorkspaceID, StoredInfo>()
+  const pending = new Map<WorkspaceID, SyncRequest>()
 
   function setStatus(id: WorkspaceID, status: ConnectionStatus["status"], error?: string) {
     const prev = connections.get(id)
@@ -270,14 +276,15 @@ export namespace Workspace {
 
   const log = Log.create({ service: "workspace-sync" })
 
-  async function workspaceEventLoop(space: StoredInfo, signal: AbortSignal) {
+  async function workspaceEventLoop(input: SyncRequest, signal: AbortSignal) {
+    const space = input.space
     log.info("starting sync: " + space.id)
 
     while (!signal.aborted) {
       log.info("connecting to sync: " + space.id)
 
       setStatus(space.id, "connecting")
-      const adaptor = await resolveAdaptor(space)
+      const adaptor = await resolveAdaptor({ ...space, hint: input.hint })
       const target = await adaptor.target(space)
 
       if (target.type === "local") {
@@ -318,7 +325,8 @@ export namespace Workspace {
     }
   }
 
-  function startSync(space: StoredInfo) {
+  function startSync(input: SyncRequest) {
+    const space = input.space
     if (space.type === "worktree") {
       void Filesystem.exists(space.directory!).then((exists) => {
         setStatus(space.id, exists ? "connected" : "error", exists ? undefined : "directory does not exist")
@@ -327,14 +335,14 @@ export namespace Workspace {
     }
 
     if (aborts.has(space.id)) {
-      pending.set(space.id, space)
+      pending.set(space.id, input)
       return
     }
     const abort = new AbortController()
     aborts.set(space.id, abort)
     setStatus(space.id, "disconnected")
 
-    void workspaceEventLoop(space, abort.signal)
+    void workspaceEventLoop(input, abort.signal)
       .catch((error) => {
         setStatus(space.id, "error", String(error))
         log.warn("workspace sync listener failed", {

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -228,6 +228,11 @@ export namespace Workspace {
     return toInfo(space)
   })
 
+  export function ensureSync(space: Awaited<ReturnType<typeof record>> | undefined) {
+    if (!space) return
+    startSync(space)
+  }
+
   export const remove = fn(WorkspaceID.zod, async (id) => {
     const info = await record(id)
     if (info) {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -1,4 +1,10 @@
-import type { Hooks, PluginInput, Plugin as PluginInstance, PluginModule } from "@opencode-ai/plugin"
+import type {
+  Hooks,
+  PluginInput,
+  Plugin as PluginInstance,
+  PluginModule,
+  WorkspaceAdaptor as PluginWorkspaceAdaptor,
+} from "@opencode-ai/plugin"
 import { fileURLToPath } from "url"
 import path from "path"
 import { Config } from "../config/config"
@@ -21,6 +27,8 @@ import { errorMessage } from "@/util/error"
 import { needsConfigDependencies } from "@/config/dependency"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
+import { installAdaptor } from "@/control-plane/adaptors"
+import type { Adaptor } from "@/control-plane/types"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -141,6 +149,11 @@ export namespace Plugin {
             project: ctx.project,
             worktree: ctx.worktree,
             directory: ctx.directory,
+            experimental_workspace: {
+              register(type: string, adaptor: PluginWorkspaceAdaptor) {
+                installAdaptor(type, adaptor as unknown as Adaptor)
+              },
+            },
             get serverUrl(): URL {
               return Server.url ?? new URL("http://localhost:4096")
             },

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -27,7 +27,7 @@ import { errorMessage } from "@/util/error"
 import { needsConfigDependencies } from "@/config/dependency"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
-import { installAdaptor, uninstallAdaptor } from "@/control-plane/adaptors"
+import { installAdaptor, ownerKey, uninstallAdaptor } from "@/control-plane/adaptors"
 import type { Adaptor } from "@/control-plane/types"
 
 export namespace Plugin {
@@ -152,7 +152,7 @@ export namespace Plugin {
             directory: ctx.directory,
             experimental_workspace: {
               register(type: string, adaptor: PluginWorkspaceAdaptor) {
-                installAdaptor(ctx.project.id, ctx.worktree, type, adaptor as unknown as Adaptor)
+                installAdaptor(ctx.project.id, ownerKey(ctx.directory, ctx.worktree), type, adaptor as unknown as Adaptor)
                 registeredAdaptors.add(type)
               },
             },
@@ -285,7 +285,7 @@ export namespace Plugin {
           yield* Effect.addFinalizer(() =>
             Effect.sync(() => {
               for (const type of registeredAdaptors) {
-                uninstallAdaptor(ctx.project.id, ctx.worktree, type)
+                uninstallAdaptor(ctx.project.id, ownerKey(ctx.directory, ctx.worktree), type)
               }
             }),
           )

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -152,7 +152,7 @@ export namespace Plugin {
             directory: ctx.directory,
             experimental_workspace: {
               register(type: string, adaptor: PluginWorkspaceAdaptor) {
-                installAdaptor(ctx.project.id, type, adaptor as unknown as Adaptor)
+                installAdaptor(ctx.project.id, ctx.directory, type, adaptor as unknown as Adaptor)
                 registeredAdaptors.add(type)
               },
             },
@@ -285,7 +285,7 @@ export namespace Plugin {
           yield* Effect.addFinalizer(() =>
             Effect.sync(() => {
               for (const type of registeredAdaptors) {
-                uninstallAdaptor(ctx.project.id, type)
+                uninstallAdaptor(ctx.project.id, ctx.directory, type)
               }
             }),
           )

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -27,7 +27,7 @@ import { errorMessage } from "@/util/error"
 import { needsConfigDependencies } from "@/config/dependency"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
-import { installAdaptor } from "@/control-plane/adaptors"
+import { installAdaptor, uninstallAdaptor } from "@/control-plane/adaptors"
 import type { Adaptor } from "@/control-plane/types"
 
 export namespace Plugin {
@@ -130,6 +130,7 @@ export namespace Plugin {
       const state = yield* InstanceState.make<State>(
         Effect.fn("Plugin.state")(function* (ctx) {
           const hooks: Hooks[] = []
+          const registeredAdaptors = new Set<string>()
 
           const { Server } = yield* Effect.promise(() => import("../server/server"))
 
@@ -151,7 +152,8 @@ export namespace Plugin {
             directory: ctx.directory,
             experimental_workspace: {
               register(type: string, adaptor: PluginWorkspaceAdaptor) {
-                installAdaptor(type, adaptor as unknown as Adaptor)
+                installAdaptor(ctx.project.id, type, adaptor as unknown as Adaptor)
+                registeredAdaptors.add(type)
               },
             },
             get serverUrl(): URL {
@@ -278,6 +280,14 @@ export namespace Plugin {
               }),
             ),
             Effect.forkScoped,
+          )
+
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              for (const type of registeredAdaptors) {
+                uninstallAdaptor(ctx.project.id, type)
+              }
+            }),
           )
 
           return { hooks }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -152,7 +152,7 @@ export namespace Plugin {
             directory: ctx.directory,
             experimental_workspace: {
               register(type: string, adaptor: PluginWorkspaceAdaptor) {
-                installAdaptor(ctx.project.id, ctx.directory, type, adaptor as unknown as Adaptor)
+                installAdaptor(ctx.project.id, ctx.worktree, type, adaptor as unknown as Adaptor)
                 registeredAdaptors.add(type)
               },
             },
@@ -285,7 +285,7 @@ export namespace Plugin {
           yield* Effect.addFinalizer(() =>
             Effect.sync(() => {
               for (const type of registeredAdaptors) {
-                uninstallAdaptor(ctx.project.id, ctx.directory, type)
+                uninstallAdaptor(ctx.project.id, ctx.worktree, type)
               }
             }),
           )

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -105,7 +105,10 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    const adaptor = await Workspace.resolveAdaptor(workspace)
+    const adaptor = await Workspace.resolveAdaptor({
+      ...workspace,
+      hint: directory,
+    })
     const target = await adaptor.target(workspace)
 
     if (target.type === "local") {

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -10,6 +10,7 @@ import { ServerProxy } from "../proxy"
 import { Filesystem } from "@/util/filesystem"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
+import { Project } from "@/project/project"
 import { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
@@ -45,6 +46,21 @@ async function getSessionWorkspace(url: URL) {
 
   const session = await Session.get(id).catch(() => undefined)
   return session?.workspaceID
+}
+
+async function getWorkspaceAdaptor(workspace: Workspace.Info) {
+  try {
+    return await getAdaptor(workspace.projectID, workspace.type)
+  } catch (error) {
+    const project = Project.get(workspace.projectID)
+    if (!project) throw error
+
+    return Instance.provide({
+      directory: project.worktree,
+      init: InstanceBootstrap,
+      fn: () => getAdaptor(workspace.projectID, workspace.type),
+    })
+  }
 }
 
 export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): MiddlewareHandler {
@@ -106,7 +122,7 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    const adaptor = await getAdaptor(workspace.type)
+    const adaptor = await getWorkspaceAdaptor(workspace)
     const target = await adaptor.target(workspace)
 
     if (target.type === "local") {

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -3,14 +3,12 @@ import type { UpgradeWebSocket } from "hono/ws"
 import { mkdirSync } from "fs"
 import os from "os"
 import path from "path"
-import { getAdaptor } from "@/control-plane/adaptors"
 import { WorkspaceID } from "@/control-plane/schema"
 import { Workspace } from "@/control-plane/workspace"
 import { ServerProxy } from "../proxy"
 import { Filesystem } from "@/util/filesystem"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
-import { Project } from "@/project/project"
 import { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
@@ -46,32 +44,6 @@ async function getSessionWorkspace(url: URL) {
 
   const session = await Session.get(id).catch(() => undefined)
   return session?.workspaceID
-}
-
-async function getWorkspaceAdaptor(workspace: Workspace.Info) {
-  try {
-    return await getAdaptor(workspace.projectID, workspace.type)
-  } catch (error) {
-    const project = Project.get(workspace.projectID)
-    if (!project) throw error
-
-    const candidates = [...new Set([project.worktree, ...project.sandboxes])]
-    let lastError = error
-
-    for (const directory of candidates) {
-      try {
-        return await Instance.provide({
-          directory,
-          init: InstanceBootstrap,
-          fn: () => getAdaptor(workspace.projectID, workspace.type, directory),
-        })
-      } catch (candidateError) {
-        lastError = candidateError
-      }
-    }
-
-    throw lastError
-  }
 }
 
 export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): MiddlewareHandler {
@@ -112,7 +84,7 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    const workspace = await Workspace.get(WorkspaceID.make(workspaceID))
+    const workspace = await Workspace.record(WorkspaceID.make(workspaceID))
 
     if (!workspace) {
       // Special-case deleting a session in case user's data in a
@@ -133,7 +105,7 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    const adaptor = await getWorkspaceAdaptor(workspace)
+    const adaptor = await Workspace.resolveAdaptor(workspace)
     const target = await adaptor.target(workspace)
 
     if (target.type === "local") {

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -55,11 +55,22 @@ async function getWorkspaceAdaptor(workspace: Workspace.Info) {
     const project = Project.get(workspace.projectID)
     if (!project) throw error
 
-    return Instance.provide({
-      directory: project.worktree,
-      init: InstanceBootstrap,
-      fn: () => getAdaptor(workspace.projectID, workspace.type),
-    })
+    const candidates = [...new Set([project.worktree, ...project.sandboxes])]
+    let lastError = error
+
+    for (const directory of candidates) {
+      try {
+        return await Instance.provide({
+          directory,
+          init: InstanceBootstrap,
+          fn: () => getAdaptor(workspace.projectID, workspace.type, directory),
+        })
+      } catch (candidateError) {
+        lastError = candidateError
+      }
+    }
+
+    throw lastError
   }
 }
 

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -105,7 +105,7 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    Workspace.ensureSync(workspace)
+    Workspace.ensureSync(workspace, directory)
 
     const adaptor = await Workspace.resolveAdaptor({
       ...workspace,

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -105,6 +105,8 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
+    Workspace.ensureSync(workspace)
+
     const adaptor = await Workspace.resolveAdaptor({
       ...workspace,
       hint: directory,

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -125,6 +125,9 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
     project: {} as never,
     directory: "",
     worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
     serverUrl: new URL("https://example.com"),
     $: {} as never,
   })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -357,4 +357,63 @@ describe("plugin.workspace", () => {
     const status = Workspace.status().find((item) => item.workspaceID === workspace.id)
     expect(status?.error).toContain("target unavailable")
   })
+
+  test("plugin cannot shadow the built-in worktree adaptor", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            '  experimental_workspace.register("worktree", {',
+            '    name: "shadow",',
+            '    description: "shadow builtin",',
+            '    configure(input) { return { ...input, name: "shadow", branch: "shadow/main", directory: input.directory } },',
+            "    async create() {},",
+            "    async remove() {},",
+            '    target(input) { return { type: "local", directory: input.directory } },',
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+      },
+    })
+
+    const info = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type: "worktree",
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+
+    expect(info.name).not.toBe("shadow")
+    expect(info.branch).not.toBe("shadow/main")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Workspace.remove(info.id),
+    })
+  })
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { tmpdir } from "../fixture/fixture"
+
+const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Flag } = await import("../../src/flag/flag")
+const { Plugin } = await import("../../src/plugin/index")
+const { Workspace } = await import("../../src/control-plane/workspace")
+const { Instance } = await import("../../src/project/instance")
+
+const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
+// @ts-expect-error test-only flag override
+Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+afterAll(() => {
+  if (disableDefault === undefined) delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  else process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+  // @ts-expect-error test-only flag override
+  Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = experimental
+})
+
+describe("plugin.workspace", () => {
+  test("plugin can install a workspace adaptor", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        const mark = path.join(dir, "created.json")
+        const space = path.join(dir, "space")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "plug",',
+            '    description: "plugin workspace adaptor",',
+            "    configure(input) {",
+            `      return { ...input, name: "plug", branch: "plug/main", directory: ${JSON.stringify(space)} }`,
+            "    },",
+            "    async create(input) {",
+            `      await Bun.write(${JSON.stringify(mark)}, JSON.stringify(input))`,
+            "    },",
+            "    async remove() {},",
+            "    target(input) {",
+            '      return { type: "local", directory: input.directory }',
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { mark, space, type }
+      },
+    })
+
+    const info = await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const plugin = yield* Plugin.Service
+          yield* plugin.init()
+          return Workspace.create({
+            type: tmp.extra.type,
+            branch: null,
+            extra: { key: "value" },
+            projectID: Instance.project.id,
+          })
+        }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
+    })
+
+    expect(info.type).toBe(tmp.extra.type)
+    expect(info.name).toBe("plug")
+    expect(info.branch).toBe("plug/main")
+    expect(info.directory).toBe(tmp.extra.space)
+    expect(info.extra).toEqual({ key: "value" })
+    expect(JSON.parse(await Bun.file(tmp.extra.mark).text())).toMatchObject({
+      type: tmp.extra.type,
+      name: "plug",
+      branch: "plug/main",
+      directory: tmp.extra.space,
+      extra: { key: "value" },
+    })
+  })
+})

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -28,6 +28,10 @@ afterAll(() => {
   Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = experimental
 })
 
+function wait(ms = 50) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 async function pluginProject() {
   return tmpdir({
     git: true,
@@ -272,5 +276,81 @@ describe("plugin.workspace", () => {
         .quiet()
         .catch(() => {})
     }
+  })
+
+  test("cold-start Workspace.get retries sync after owner bootstrap for remote adaptors", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        const counter = path.join(dir, "target-count.txt")
+        await Bun.write(counter, "0")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: "remote/main", directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            "    async target() {",
+            `      const file = Bun.file(${JSON.stringify(counter)})`,
+            '      const count = Number((await file.text()) || "0") + 1',
+            `      await Bun.write(${JSON.stringify(counter)}, String(count))`,
+            '      throw new Error("target unavailable")',
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { counter, type }
+      },
+    })
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type: tmp.extra.type,
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+
+    await Instance.disposeAll()
+
+    await Workspace.get(workspace.id)
+    await wait(100)
+    const first = Number(await Bun.file(tmp.extra.counter).text())
+    expect(first).toBeGreaterThan(0)
+
+    await Workspace.get(workspace.id)
+    await wait(100)
+    const second = Number(await Bun.file(tmp.extra.counter).text())
+    expect(second).toBeGreaterThan(first)
+
+    const status = Workspace.status().find((item) => item.workspaceID === workspace.id)
+    expect(status?.error).toContain("target unavailable")
   })
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
@@ -141,5 +142,135 @@ describe("plugin.workspace", () => {
           }),
       }),
     ).rejects.toThrow(/workspace adaptor/i)
+  })
+
+  test("disposing one checkout restores the previous adaptor for the same project and type", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const type = "shared"
+    const rootPlugin = path.join(root.path, "plugin.ts")
+    const rootSpace = path.join(root.path, "root-space")
+    await Bun.write(
+      rootPlugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "root",',
+        '    description: "root adaptor",',
+        "    configure(input) {",
+        `      return { ...input, name: "root", branch: "root/main", directory: ${JSON.stringify(rootSpace)} }`,
+        "    },",
+        "    async create() {},",
+        "    async remove() {},",
+        "    target(input) {",
+        '      return { type: "local", directory: input.directory }',
+        "    },",
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(root.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(rootPlugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const worktreePath = path.join(root.path, "..", path.basename(root.path) + "-plugin-wt")
+    const worktreePlugin = path.join(worktreePath, "plugin.ts")
+    const worktreeSpace = path.join(worktreePath, "worktree-space")
+
+    try {
+      await $`git worktree add ${worktreePath} -b test-plugin-${Date.now()}`.cwd(root.path).quiet()
+      await Bun.write(
+        worktreePlugin,
+        [
+          "export default async ({ experimental_workspace }) => {",
+          `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+          '    name: "worktree",',
+          '    description: "worktree adaptor",',
+          "    configure(input) {",
+          `      return { ...input, name: "worktree", branch: "worktree/main", directory: ${JSON.stringify(worktreeSpace)} }`,
+          "    },",
+          "    async create() {},",
+          "    async remove() {},",
+          "    target(input) {",
+          '      return { type: "local", directory: input.directory }',
+          "    },",
+          "  })",
+          "  return {}",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(worktreePath, "opencode.json"),
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(worktreePlugin).href],
+          },
+          null,
+          2,
+        ),
+      )
+
+      const fromRoot = await Instance.provide({
+        directory: root.path,
+        fn: async () => {
+          await Plugin.init()
+          return Workspace.create({
+            type,
+            branch: null,
+            extra: null,
+            projectID: Instance.project.id,
+          })
+        },
+      })
+      expect(fromRoot.directory).toBe(rootSpace)
+
+      const fromWorktree = await Instance.provide({
+        directory: worktreePath,
+        fn: async () => {
+          await Plugin.init()
+          return Workspace.create({
+            type,
+            branch: null,
+            extra: null,
+            projectID: Instance.project.id,
+          })
+        },
+      })
+      expect(fromWorktree.directory).toBe(worktreeSpace)
+
+      await Instance.provide({
+        directory: worktreePath,
+        fn: async () => Instance.dispose(),
+      })
+
+      const restored = await Instance.provide({
+        directory: root.path,
+        fn: async () =>
+          Workspace.create({
+            type,
+            branch: null,
+            extra: null,
+            projectID: Instance.project.id,
+          }),
+      })
+      expect(restored.directory).toBe(rootSpace)
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(root.path)
+        .quiet()
+        .catch(() => {})
+    }
   })
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -1,6 +1,7 @@
 import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { mkdir } from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
 import { tmpdir } from "../fixture/fixture"
@@ -84,6 +85,7 @@ async function pluginProject() {
 describe("plugin.workspace", () => {
   test("plugin can install a workspace adaptor", async () => {
     await using tmp = await pluginProject()
+    await mkdir(tmp.extra.space, { recursive: true })
 
     const info = await Instance.provide({
       directory: tmp.path,
@@ -112,6 +114,8 @@ describe("plugin.workspace", () => {
       directory: tmp.extra.space,
       extra: { key: "value" },
     })
+    await wait(100)
+    expect(Workspace.status().find((item) => item.workspaceID === info.id)?.status).not.toBe("connecting")
   })
 
   test("plugin workspace adaptor registration does not survive instance disposal", async () => {

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect"
 import { mkdir } from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
+import { eq } from "../../src/storage/db"
 import { tmpdir } from "../fixture/fixture"
+import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
+import { Database } from "../../src/storage/db"
 
 const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
 process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
@@ -415,5 +418,39 @@ describe("plugin.workspace", () => {
       directory: tmp.path,
       fn: async () => Workspace.remove(info.id),
     })
+  })
+
+  test("Workspace.get recovers a null-owner non-git workspace when called from its original directory", async () => {
+    await using tmp = await pluginProject()
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type: tmp.extra.type,
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+
+    Database.use((db) =>
+      db.update(WorkspaceTable).set({ owner_directory: null }).where(eq(WorkspaceTable.id, workspace.id)).run(),
+    )
+    await Instance.disposeAll()
+
+    const reloaded = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Workspace.get(workspace.id),
+    })
+
+    expect(reloaded?.id).toBe(workspace.id)
+    expect(
+      Workspace.status()
+        .find((item) => item.workspaceID === workspace.id)
+        ?.error?.includes("Unknown workspace adaptor") ?? false,
+    ).toBe(false)
   })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -194,7 +194,7 @@ describe("workspace router", () => {
     }
   })
 
-  test("routes a persisted workspace through its original checkout when the same type is registered elsewhere", async () => {
+  test("routes a persisted workspace through its original checkout after the owner instance is disposed", async () => {
     await using root = await tmpdir({ git: true })
 
     const type = "shared"
@@ -288,6 +288,11 @@ describe("workspace router", () => {
       await Instance.provide({
         directory: worktreePath,
         fn: async () => Plugin.init(),
+      })
+
+      await Instance.provide({
+        directory: root.path,
+        fn: async () => Instance.dispose(),
       })
 
       const app = Server.Default().app

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -193,4 +193,119 @@ describe("workspace router", () => {
         .catch(() => {})
     }
   })
+
+  test("routes a persisted workspace through its original checkout when the same type is registered elsewhere", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const type = "shared"
+    const rootPlugin = path.join(root.path, "plugin.ts")
+    const rootSpace = path.join(root.path, "root-space")
+    await Bun.write(
+      rootPlugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "root",',
+        '    description: "root adaptor",',
+        "    configure(input) {",
+        `      return { ...input, name: "root", branch: "root/main", directory: ${JSON.stringify(rootSpace)} }`,
+        "    },",
+        "    async create() {},",
+        "    async remove() {},",
+        "    target() {",
+        `      return { type: "local", directory: ${JSON.stringify(rootSpace)} }`,
+        "    },",
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(root.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(rootPlugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const worktreePath = path.join(root.path, "..", path.basename(root.path) + "-router-shared")
+    const worktreePlugin = path.join(worktreePath, "plugin.ts")
+    const worktreeSpace = path.join(worktreePath, "worktree-space")
+
+    try {
+      await $`git worktree add ${worktreePath} -b test-shared-${Date.now()}`.cwd(root.path).quiet()
+      await Bun.write(
+        worktreePlugin,
+        [
+          "export default async ({ experimental_workspace }) => {",
+          `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+          '    name: "worktree",',
+          '    description: "worktree adaptor",',
+          "    configure(input) {",
+          `      return { ...input, name: "worktree", branch: "worktree/main", directory: ${JSON.stringify(worktreeSpace)} }`,
+          "    },",
+          "    async create() {},",
+          "    async remove() {},",
+          "    target() {",
+          `      return { type: "local", directory: ${JSON.stringify(worktreeSpace)} }`,
+          "    },",
+          "  })",
+          "  return {}",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(worktreePath, "opencode.json"),
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(worktreePlugin).href],
+          },
+          null,
+          2,
+        ),
+      )
+
+      const workspace = await Instance.provide({
+        directory: root.path,
+        fn: async () => {
+          await Plugin.init()
+          return Workspace.create({
+            type,
+            branch: null,
+            extra: null,
+            projectID: Instance.project.id,
+          })
+        },
+      })
+
+      await Instance.provide({
+        directory: worktreePath,
+        fn: async () => Plugin.init(),
+      })
+
+      const app = Server.Default().app
+      const response = await app.request(`/path?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": worktreePath,
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        directory: rootSpace,
+      })
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(root.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
@@ -110,5 +111,86 @@ describe("workspace router", () => {
     expect(await response.json()).toMatchObject({
       directory: tmp.extra.space,
     })
+  })
+
+  test("tries project sandboxes when the plugin only exists in a secondary worktree", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const worktreePath = path.join(root.path, "..", path.basename(root.path) + "-router-wt")
+    const type = `plug-${Math.random().toString(36).slice(2)}`
+    const plugin = path.join(worktreePath, "plugin.ts")
+    const space = path.join(worktreePath, "space")
+
+    try {
+      await $`git worktree add ${worktreePath} -b test-router-${Date.now()}`.cwd(root.path).quiet()
+
+      await Bun.write(
+        plugin,
+        [
+          "export default async ({ experimental_workspace }) => {",
+          `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+          '    name: "plug",',
+          '    description: "worktree-only adaptor",',
+          "    configure(input) {",
+          `      return { ...input, name: "plug", branch: "plug/main", directory: ${JSON.stringify(space)} }`,
+          "    },",
+          "    async create() {},",
+          "    async remove() {},",
+          "    target(input) {",
+          '      return { type: "local", directory: input.directory }',
+          "    },",
+          "  })",
+          "  return {}",
+          "}",
+          "",
+        ].join("\n"),
+      )
+
+      await Bun.write(
+        path.join(worktreePath, "opencode.json"),
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(plugin).href],
+          },
+          null,
+          2,
+        ),
+      )
+
+      const workspace = await Instance.provide({
+        directory: worktreePath,
+        fn: async () =>
+          Effect.gen(function* () {
+            const plugin = yield* Plugin.Service
+            yield* plugin.init()
+            return Workspace.create({
+              type,
+              branch: null,
+              extra: null,
+              projectID: Instance.project.id,
+            })
+          }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
+      })
+
+      await Instance.disposeAll()
+
+      const app = Server.Default().app
+      const response = await app.request(`/path?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": root.path,
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        directory: space,
+      })
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(root.path)
+        .quiet()
+        .catch(() => {})
+    }
   })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -2,22 +2,27 @@ import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Instance } from "../../src/project/instance"
+import { Plugin } from "../../src/plugin"
+import { Server } from "../../src/server/server"
+import { Workspace } from "../../src/control-plane/workspace"
+import { Log } from "../../src/util/log"
+import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
 
 const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
 process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
 
 const { Flag } = await import("../../src/flag/flag")
-const { Plugin } = await import("../../src/plugin/index")
-const { Workspace } = await import("../../src/control-plane/workspace")
-const { Instance } = await import("../../src/project/instance")
-
 const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 // @ts-expect-error test-only flag override
 Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
 
 afterEach(async () => {
   await Instance.disposeAll()
+  await resetDatabase()
 })
 
 afterAll(() => {
@@ -33,7 +38,6 @@ async function pluginProject() {
     init: async (dir) => {
       const type = `plug-${Math.random().toString(36).slice(2)}`
       const file = path.join(dir, "plugin.ts")
-      const mark = path.join(dir, "created.json")
       const space = path.join(dir, "space")
       await Bun.write(
         file,
@@ -45,9 +49,7 @@ async function pluginProject() {
           "    configure(input) {",
           `      return { ...input, name: "plug", branch: "plug/main", directory: ${JSON.stringify(space)} }`,
           "    },",
-          "    async create(input) {",
-          `      await Bun.write(${JSON.stringify(mark)}, JSON.stringify(input))`,
-          "    },",
+          "    async create() {},",
           "    async remove() {},",
           "    target(input) {",
           '      return { type: "local", directory: input.directory }',
@@ -71,16 +73,16 @@ async function pluginProject() {
         ),
       )
 
-      return { mark, space, type }
+      return { space, type }
     },
   })
 }
 
-describe("plugin.workspace", () => {
-  test("plugin can install a workspace adaptor", async () => {
+describe("workspace router", () => {
+  test("bootstraps the owning project before routing a persisted plugin workspace", async () => {
     await using tmp = await pluginProject()
 
-    const info = await Instance.provide({
+    const workspace = await Instance.provide({
       directory: tmp.path,
       fn: async () =>
         Effect.gen(function* () {
@@ -88,38 +90,6 @@ describe("plugin.workspace", () => {
           yield* plugin.init()
           return Workspace.create({
             type: tmp.extra.type,
-            branch: null,
-            extra: { key: "value" },
-            projectID: Instance.project.id,
-          })
-        }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
-    })
-
-    expect(info.type).toBe(tmp.extra.type)
-    expect(info.name).toBe("plug")
-    expect(info.branch).toBe("plug/main")
-    expect(info.directory).toBe(tmp.extra.space)
-    expect(info.extra).toEqual({ key: "value" })
-    expect(JSON.parse(await Bun.file(tmp.extra.mark).text())).toMatchObject({
-      type: tmp.extra.type,
-      name: "plug",
-      branch: "plug/main",
-      directory: tmp.extra.space,
-      extra: { key: "value" },
-    })
-  })
-
-  test("plugin workspace adaptor registration does not survive instance disposal", async () => {
-    await using source = await pluginProject()
-
-    await Instance.provide({
-      directory: source.path,
-      fn: async () =>
-        Effect.gen(function* () {
-          const plugin = yield* Plugin.Service
-          yield* plugin.init()
-          return Workspace.create({
-            type: source.extra.type,
             branch: null,
             extra: null,
             projectID: Instance.project.id,
@@ -129,17 +99,16 @@ describe("plugin.workspace", () => {
 
     await Instance.disposeAll()
 
-    await expect(
-      Instance.provide({
-        directory: source.path,
-        fn: async () =>
-          Workspace.create({
-            type: source.extra.type,
-            branch: null,
-            extra: null,
-            projectID: Instance.project.id,
-          }),
-      }),
-    ).rejects.toThrow(/workspace adaptor/i)
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      directory: tmp.extra.space,
+    })
   })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -3,10 +3,13 @@ import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
+import { eq } from "../../src/storage/db"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Server } from "../../src/server/server"
 import { Workspace } from "../../src/control-plane/workspace"
+import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
+import { Database } from "../../src/storage/db"
 import { Log } from "../../src/util/log"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
@@ -306,6 +309,223 @@ describe("workspace router", () => {
       expect(await response.json()).toMatchObject({
         directory: rootSpace,
       })
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(root.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
+
+  test("keeps non-git workspace ownership separate by directory", async () => {
+    await using first = await tmpdir()
+    await using second = await tmpdir()
+
+    const type = "shared"
+    const firstPlugin = path.join(first.path, "plugin.ts")
+    const firstSpace = path.join(first.path, "first-space")
+    await Bun.write(
+      firstPlugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "first",',
+        '    description: "first adaptor",',
+        "    configure(input) {",
+        `      return { ...input, name: "first", branch: null, directory: ${JSON.stringify(firstSpace)} }`,
+        "    },",
+        "    async create() {},",
+        "    async remove() {},",
+        "    target() {",
+        `      return { type: "local", directory: ${JSON.stringify(firstSpace)} }`,
+        "    },",
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(first.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(firstPlugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const secondPlugin = path.join(second.path, "plugin.ts")
+    const secondSpace = path.join(second.path, "second-space")
+    await Bun.write(
+      secondPlugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "second",',
+        '    description: "second adaptor",',
+        "    configure(input) {",
+        `      return { ...input, name: "second", branch: null, directory: ${JSON.stringify(secondSpace)} }`,
+        "    },",
+        "    async create() {},",
+        "    async remove() {},",
+        "    target() {",
+        `      return { type: "local", directory: ${JSON.stringify(secondSpace)} }`,
+        "    },",
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(second.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(secondPlugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const workspace = await Instance.provide({
+      directory: first.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type,
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+
+    await Instance.provide({
+      directory: second.path,
+      fn: async () => Plugin.init(),
+    })
+
+    await Instance.provide({
+      directory: first.path,
+      fn: async () => Instance.dispose(),
+    })
+
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": second.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      directory: firstSpace,
+    })
+  })
+
+  test("fails explicitly when an upgraded workspace has no owner and multiple checkouts register the same type", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const type = "shared"
+    const rootPlugin = path.join(root.path, "plugin.ts")
+    await Bun.write(
+      rootPlugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "root",',
+        '    description: "root adaptor",',
+        '    configure(input) { return { ...input, name: "root", branch: "root/main", directory: null } },',
+        "    async create() {},",
+        "    async remove() {},",
+        '    target() { return { type: "local", directory: "/tmp/root-space" } },',
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(root.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(rootPlugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const worktreePath = path.join(root.path, "..", path.basename(root.path) + "-router-null-owner")
+    const worktreePlugin = path.join(worktreePath, "plugin.ts")
+
+    try {
+      await $`git worktree add ${worktreePath} -b test-null-owner-${Date.now()}`.cwd(root.path).quiet()
+      await Bun.write(
+        worktreePlugin,
+        [
+          "export default async ({ experimental_workspace }) => {",
+          `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+          '    name: "worktree",',
+          '    description: "worktree adaptor",',
+          '    configure(input) { return { ...input, name: "worktree", branch: "worktree/main", directory: null } },',
+          "    async create() {},",
+          "    async remove() {},",
+          '    target() { return { type: "local", directory: "/tmp/worktree-space" } },',
+          "  })",
+          "  return {}",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(worktreePath, "opencode.json"),
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(worktreePlugin).href],
+          },
+          null,
+          2,
+        ),
+      )
+
+      const workspace = await Instance.provide({
+        directory: root.path,
+        fn: async () => {
+          await Plugin.init()
+          return Workspace.create({
+            type,
+            branch: null,
+            extra: null,
+            projectID: Instance.project.id,
+          })
+        },
+      })
+
+      Database.use((db) =>
+        db.update(WorkspaceTable).set({ owner_directory: null }).where(eq(WorkspaceTable.id, workspace.id)).run(),
+      )
+
+      await Instance.provide({
+        directory: worktreePath,
+        fn: async () => Plugin.init(),
+      })
+
+      const app = Server.Default().app
+      const response = await app.request(`/path?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": worktreePath,
+        },
+      })
+
+      expect(response.status).toBe(500)
     } finally {
       await $`git worktree remove ${worktreePath}`
         .cwd(root.path)

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -533,4 +533,70 @@ describe("workspace router", () => {
         .catch(() => {})
     }
   })
+
+  test("recovers a null-owner non-git workspace from the request directory when there is only one candidate", async () => {
+    await using tmp = await tmpdir()
+
+    const type = "shared"
+    const plugin = path.join(tmp.path, "plugin.ts")
+    const space = path.join(tmp.path, "space")
+    await Bun.write(
+      plugin,
+      [
+        "export default async ({ experimental_workspace }) => {",
+        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+        '    name: "single",',
+        '    description: "single adaptor",',
+        `    configure(input) { return { ...input, name: "single", branch: null, directory: ${JSON.stringify(space)} } },`,
+        "    async create() {},",
+        "    async remove() {},",
+        `    target() { return { type: "local", directory: ${JSON.stringify(space)} } },`,
+        "  })",
+        "  return {}",
+        "}",
+        "",
+      ].join("\n"),
+    )
+    await Bun.write(
+      path.join(tmp.path, "opencode.json"),
+      JSON.stringify(
+        {
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(plugin).href],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type,
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+
+    Database.use((db) =>
+      db.update(WorkspaceTable).set({ owner_directory: null }).where(eq(WorkspaceTable.id, workspace.id)).run(),
+    )
+    await Instance.disposeAll()
+
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      directory: space,
+    })
+  })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -7,6 +7,7 @@ import { eq } from "../../src/storage/db"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Server } from "../../src/server/server"
+import { WorkspaceID } from "../../src/control-plane/schema"
 import { Workspace } from "../../src/control-plane/workspace"
 import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
 import { Database } from "../../src/storage/db"
@@ -35,6 +36,10 @@ afterAll(() => {
   // @ts-expect-error test-only flag override
   Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = experimental
 })
+
+function wait(ms = 50) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 async function pluginProject() {
   return tmpdir({
@@ -426,6 +431,121 @@ describe("workspace router", () => {
     expect(await response.json()).toMatchObject({
       directory: firstSpace,
     })
+  })
+
+  test("routing a persisted remote workspace restarts background sync after cold start", async () => {
+    let syncHits = 0
+    let pathHits = 0
+
+    await using remote = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (url.pathname === "/sync/event") {
+          syncHits++
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.close()
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "text/event-stream",
+              },
+            },
+          )
+        }
+
+        if (url.pathname !== "/sync/event") {
+          pathHits++
+          return Response.json({ ok: true })
+        }
+      },
+    })
+
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: "remote/main", directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            "    target() {",
+            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        const id = WorkspaceID.ascending()
+        Database.use((db) =>
+          db.insert(WorkspaceTable)
+            .values({
+              id,
+              type: tmp.extra.type,
+              branch: "remote/main",
+              name: "remote",
+              directory: null,
+              owner_directory: tmp.path,
+              extra: null,
+              project_id: Instance.project.id,
+            })
+            .run(),
+        )
+        return { id }
+      },
+    })
+
+    const before = syncHits
+
+    await Instance.disposeAll()
+
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true })
+
+    await wait(100)
+    expect(pathHits).toBe(1)
+    expect(syncHits).toBeGreaterThan(before)
   })
 
   test("fails explicitly when an upgraded workspace has no owner and multiple checkouts register the same type", async () => {

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -717,4 +717,114 @@ describe("workspace router", () => {
       directory: space,
     })
   })
+
+  test("routing an ownerless non-git remote workspace restarts sync with the request directory hint", async () => {
+    let syncHits = 0
+    let pathHits = 0
+
+    await using remote = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (url.pathname === "/sync/event") {
+          syncHits++
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.close()
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "text/event-stream",
+              },
+            },
+          )
+        }
+
+        pathHits++
+        return Response.json({ ok: true })
+      },
+    })
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            "    target() {",
+            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        const id = WorkspaceID.ascending()
+        Database.use((db) =>
+          db.insert(WorkspaceTable)
+            .values({
+              id,
+              type: tmp.extra.type,
+              branch: null,
+              name: "remote",
+              directory: null,
+              owner_directory: null,
+              extra: null,
+              project_id: Instance.project.id,
+            })
+            .run(),
+        )
+        return { id }
+      },
+    })
+
+    await Instance.disposeAll()
+
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true })
+
+    await wait(100)
+    expect(pathHits).toBe(1)
+    expect(syncHits).toBeGreaterThan(0)
+  })
 })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -458,10 +458,8 @@ describe("workspace router", () => {
           )
         }
 
-        if (url.pathname !== "/sync/event") {
-          pathHits++
-          return Response.json({ ok: true })
-        }
+        pathHits++
+        return Response.json({ ok: true })
       },
     })
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -24,11 +24,44 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type WorkspaceInfo = {
+  id: string
+  type: string
+  name: string | null
+  branch: string | null
+  directory: string | null
+  extra: unknown | null
+  projectID: string
+}
+
+export type WorkspaceTarget =
+  | {
+      type: "local"
+      directory: string
+    }
+  | {
+      type: "remote"
+      url: string | URL
+      headers?: HeadersInit
+    }
+
+export type WorkspaceAdaptor = {
+  name: string
+  description: string
+  configure(config: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
+  create(config: WorkspaceInfo, from?: WorkspaceInfo): Promise<void>
+  remove(config: WorkspaceInfo): Promise<void>
+  target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
   directory: string
   worktree: string
+  experimental_workspace: {
+    register(type: string, adaptor: WorkspaceAdaptor): void
+  }
   serverUrl: URL
   $: BunShell
 }


### PR DESCRIPTION
## Summary

- expose plugin-side experimental workspace adaptor registration
- scope custom workspace adaptors by project and checkout owner
- persist workspace adaptor owners and recover them across cold starts, worktrees, and upgraded ownerless rows
- restart routed cold-start sync, including ownerless non-git remote workspaces
- add regression coverage for owner persistence, null-owner recovery, and routed sync restart

## Why

Issue #27 needs a runtime bridge so plugin-defined workspace adaptors keep working after disposal, checkout switches, and cold starts. Before this slice, adaptor registration was effectively instance-local, persisted workspaces could resolve to the wrong checkout, upgraded rows with missing owner metadata had fragile recovery, and router-based cold starts could serve a request without actually restoring background sync.

## Related Issue

Part of #27

## How To Verify

```bash
bun test test/plugin/workspace-adaptor.test.ts test/plugin/loader-shared.test.ts test/plugin/meta.test.ts test/plugin/trigger.test.ts test/project/project.test.ts test/project/worktree.test.ts test/project/worktree-remove.test.ts test/server/workspace-router.test.ts test/plugin/github-copilot-models.test.ts --timeout 30000
bun run typecheck
bun run script/check-migrations.ts
bun --cwd packages/plugin run typecheck
bun turbo typecheck
```

Manual checks: none, no visible UI changes in this slice.

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
