### PR TITLE
fix: finalize cancelled shell runs

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -4,7 +4,7 @@ export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
-  readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly startShell: (work: Effect.Effect<A, E>, options?: { ready?: Deferred.Deferred<void> }) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
 }
 
@@ -18,6 +18,7 @@ interface RunHandle<A, E> {
 
 interface ShellHandle<A, E> {
   id: number
+  ready: Deferred.Deferred<void>
   fiber: Fiber.Fiber<A, E>
 }
 
@@ -100,6 +101,9 @@ export const make = <A, E = never>(
 
   const stopShell = (shell: ShellHandle<A, E>) => Fiber.interrupt(shell.fiber)
 
+  const awaitShellReady = (shell: ShellHandle<A, E>) =>
+    Deferred.await(shell.ready).pipe(Effect.raceFirst(Fiber.await(shell.fiber).pipe(Effect.asVoid)), Effect.ignore)
+
   const ensureRunning = (work: Effect.Effect<A, E>) =>
     SynchronizedRef.modifyEffect(
       ref,
@@ -130,7 +134,7 @@ export const make = <A, E = never>(
       ),
     )
 
-  const startShell = (work: Effect.Effect<A, E>) =>
+  const startShell = (work: Effect.Effect<A, E>, options?: { ready?: Deferred.Deferred<void> }) =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
@@ -145,8 +149,13 @@ export const make = <A, E = never>(
         }
         yield* busy
         const id = next()
+        const ready =
+          options?.ready ??
+          (yield* Deferred.make<void>().pipe(
+            Effect.tap((ready) => Deferred.succeed(ready, undefined)),
+          ))
         const fiber = yield* work.pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
-        const shell = { id, fiber } satisfies ShellHandle<A, E>
+        const shell = { id, ready, fiber } satisfies ShellHandle<A, E>
         return [
           Effect.gen(function* () {
             const exit = yield* Fiber.await(fiber)
@@ -175,6 +184,7 @@ export const make = <A, E = never>(
       case "Shell":
         return [
           Effect.gen(function* () {
+            yield* awaitShellReady(st.shell)
             yield* stopShell(st.shell)
             yield* idleIfCurrent()
           }),
@@ -184,6 +194,7 @@ export const make = <A, E = never>(
         return [
           Effect.gen(function* () {
             yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
+            yield* awaitShellReady(st.shell)
             yield* stopShell(st.shell)
             yield* idleIfCurrent()
           }),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,7 +42,7 @@ import { AppFileSystem } from "@/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
-import { Cause, Effect, Exit, Layer, Option, Scope, Context } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer, Option, Scope, Context } from "effect"
 import { EffectLogger } from "@/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
@@ -721,7 +721,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         } satisfies MessageV2.TextPart)
       })
 
-      const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput) {
+      const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput, ready: Deferred.Deferred<void>) {
         let output = ""
         let aborted = false
         const { run, msg, part, cmd, finish } = yield* Effect.uninterruptibleMask((restore) =>
@@ -789,6 +789,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               },
             }
             yield* sessions.updatePart(part)
+            yield* Deferred.succeed(ready, undefined).pipe(Effect.ignore)
 
             const sh = Shell.preferred()
             const shellName = (
@@ -1602,7 +1603,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
         function* (input: ShellInput) {
-          return yield* state.startShell(input.sessionID, shellCancelledAssistant(input.sessionID), shellImpl(input))
+          const ready = yield* Deferred.make<void>()
+          return yield* state.startShell(input.sessionID, shellCancelledAssistant(input.sessionID), shellImpl(input, ready), ready)
         },
       )
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -722,148 +722,153 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
 
       const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput) {
-        const ctx = yield* InstanceState.context
-        const run = yield* runner()
-        const session = yield* sessions.get(input.sessionID)
-        if (session.revert) {
-          yield* revert.cleanup(session)
-        }
-        const agent = yield* agents.get(input.agent)
-        if (!agent) {
-          const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
-          const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
-          const error = new NamedError.Unknown({ message: `Agent not found: "${input.agent}".${hint}` })
-          yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
-          throw error
-        }
-        const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
-        const userMsg: MessageV2.User = {
-          id: input.messageID ?? MessageID.ascending(),
-          sessionID: input.sessionID,
-          time: { created: Date.now() },
-          role: "user",
-          agent: input.agent,
-          model: { providerID: model.providerID, modelID: model.modelID },
-        }
-        yield* sessions.updateMessage(userMsg)
-        const userPart: MessageV2.Part = {
-          type: "text",
-          id: PartID.ascending(),
-          messageID: userMsg.id,
-          sessionID: input.sessionID,
-          text: "The following tool was executed by the user",
-          synthetic: true,
-        }
-        yield* sessions.updatePart(userPart)
-
-        const msg: MessageV2.Assistant = {
-          id: MessageID.ascending(),
-          sessionID: input.sessionID,
-          parentID: userMsg.id,
-          mode: input.agent,
-          agent: input.agent,
-          cost: 0,
-          path: { cwd: ctx.directory, root: ctx.worktree },
-          time: { created: Date.now() },
-          role: "assistant",
-          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-          modelID: model.modelID,
-          providerID: model.providerID,
-        }
-        yield* sessions.updateMessage(msg)
-        const part: MessageV2.ToolPart = {
-          type: "tool",
-          id: PartID.ascending(),
-          messageID: msg.id,
-          sessionID: input.sessionID,
-          tool: "bash",
-          callID: ulid(),
-          state: {
-            status: "running",
-            time: { start: Date.now() },
-            input: { command: input.command },
-          },
-        }
-        yield* sessions.updatePart(part)
-
-        const sh = Shell.preferred()
-        const shellName = (
-          process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
-        ).toLowerCase()
-        const invocations: Record<string, { args: string[] }> = {
-          nu: { args: ["-c", input.command] },
-          fish: { args: ["-c", input.command] },
-          zsh: {
-            args: [
-              "-l",
-              "-c",
-              `
-                __oc_cwd=$PWD
-                [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
-                [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-                cd "$__oc_cwd"
-                eval ${JSON.stringify(input.command)}
-              `,
-            ],
-          },
-          bash: {
-            args: [
-              "-l",
-              "-c",
-              `
-                __oc_cwd=$PWD
-                shopt -s expand_aliases
-                [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-                cd "$__oc_cwd"
-                eval ${JSON.stringify(input.command)}
-              `,
-            ],
-          },
-          cmd: { args: ["/c", input.command] },
-          powershell: { args: ["-NoProfile", "-Command", input.command] },
-          pwsh: { args: ["-NoProfile", "-Command", input.command] },
-          "": { args: ["-c", input.command] },
-        }
-
-        const args = (invocations[shellName] ?? invocations[""]).args
-        const cwd = ctx.directory
-        const shellEnv = yield* plugin.trigger(
-          "shell.env",
-          { cwd, sessionID: input.sessionID, callID: part.callID },
-          { env: {} },
-        )
-
-        const cmd = ChildProcess.make(sh, args, {
-          cwd,
-          extendEnv: true,
-          env: { ...shellEnv.env, TERM: "dumb" },
-          stdin: "ignore",
-          forceKillAfter: "3 seconds",
-        })
-
         let output = ""
         let aborted = false
-
-        const finish = Effect.uninterruptible(
+        const { run, msg, part, cmd, finish } = yield* Effect.uninterruptible(
           Effect.gen(function* () {
-            if (aborted) {
-              output += "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+            const ctx = yield* InstanceState.context
+            const run = yield* runner()
+            const session = yield* sessions.get(input.sessionID)
+            if (session.revert) {
+              yield* revert.cleanup(session)
             }
-            if (!msg.time.completed) {
-              msg.time.completed = Date.now()
-              yield* sessions.updateMessage(msg)
+            const agent = yield* agents.get(input.agent)
+            if (!agent) {
+              const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
+              const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
+              const error = new NamedError.Unknown({ message: `Agent not found: "${input.agent}".${hint}` })
+              yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
+              throw error
             }
-            if (part.state.status === "running") {
-              part.state = {
-                status: "completed",
-                time: { ...part.state.time, end: Date.now() },
-                input: part.state.input,
-                title: "",
-                metadata: { output, description: "" },
-                output,
-              }
-              yield* sessions.updatePart(part)
+            const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
+            const userMsg: MessageV2.User = {
+              id: input.messageID ?? MessageID.ascending(),
+              sessionID: input.sessionID,
+              time: { created: Date.now() },
+              role: "user",
+              agent: input.agent,
+              model: { providerID: model.providerID, modelID: model.modelID },
             }
+            yield* sessions.updateMessage(userMsg)
+            const userPart: MessageV2.Part = {
+              type: "text",
+              id: PartID.ascending(),
+              messageID: userMsg.id,
+              sessionID: input.sessionID,
+              text: "The following tool was executed by the user",
+              synthetic: true,
+            }
+            yield* sessions.updatePart(userPart)
+
+            const msg: MessageV2.Assistant = {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              parentID: userMsg.id,
+              mode: input.agent,
+              agent: input.agent,
+              cost: 0,
+              path: { cwd: ctx.directory, root: ctx.worktree },
+              time: { created: Date.now() },
+              role: "assistant",
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: model.modelID,
+              providerID: model.providerID,
+            }
+            yield* sessions.updateMessage(msg)
+            const part: MessageV2.ToolPart = {
+              type: "tool",
+              id: PartID.ascending(),
+              messageID: msg.id,
+              sessionID: input.sessionID,
+              tool: "bash",
+              callID: ulid(),
+              state: {
+                status: "running",
+                time: { start: Date.now() },
+                input: { command: input.command },
+              },
+            }
+            yield* sessions.updatePart(part)
+
+            const sh = Shell.preferred()
+            const shellName = (
+              process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
+            ).toLowerCase()
+            const invocations: Record<string, { args: string[] }> = {
+              nu: { args: ["-c", input.command] },
+              fish: { args: ["-c", input.command] },
+              zsh: {
+                args: [
+                  "-l",
+                  "-c",
+                  `
+                    __oc_cwd=$PWD
+                    [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
+                    [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
+                    cd "$__oc_cwd"
+                    eval ${JSON.stringify(input.command)}
+                  `,
+                ],
+              },
+              bash: {
+                args: [
+                  "-l",
+                  "-c",
+                  `
+                    __oc_cwd=$PWD
+                    shopt -s expand_aliases
+                    [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
+                    cd "$__oc_cwd"
+                    eval ${JSON.stringify(input.command)}
+                  `,
+                ],
+              },
+              cmd: { args: ["/c", input.command] },
+              powershell: { args: ["-NoProfile", "-Command", input.command] },
+              pwsh: { args: ["-NoProfile", "-Command", input.command] },
+              "": { args: ["-c", input.command] },
+            }
+
+            const args = (invocations[shellName] ?? invocations[""]).args
+            const cwd = ctx.directory
+            const shellEnv = yield* plugin.trigger(
+              "shell.env",
+              { cwd, sessionID: input.sessionID, callID: part.callID },
+              { env: {} },
+            )
+
+            const cmd = ChildProcess.make(sh, args, {
+              cwd,
+              extendEnv: true,
+              env: { ...shellEnv.env, TERM: "dumb" },
+              stdin: "ignore",
+              forceKillAfter: "3 seconds",
+            })
+
+            const finish = Effect.uninterruptible(
+              Effect.gen(function* () {
+                if (aborted) {
+                  output += "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+                }
+                if (!msg.time.completed) {
+                  msg.time.completed = Date.now()
+                  yield* sessions.updateMessage(msg)
+                }
+                if (part.state.status === "running") {
+                  part.state = {
+                    status: "completed",
+                    time: { ...part.state.time, end: Date.now() },
+                    input: part.state.input,
+                    title: "",
+                    metadata: { output, description: "" },
+                    output,
+                  }
+                  yield* sessions.updatePart(part)
+                }
+              }),
+            )
+
+            return { run, msg, part, cmd, finish }
           }),
         )
 
@@ -1311,6 +1316,52 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         throw new Error("Impossible")
       })
 
+      const shellCancelledAssistant = Effect.fnUntraced(function* (sessionID: SessionID) {
+        const message = yield* lastAssistant(sessionID)
+        if (message.info.role !== "assistant") return message
+
+        const runningTool = message.parts.find(
+          (
+            part,
+          ): part is MessageV2.ToolPart & {
+            state: MessageV2.ToolStateRunning
+          } => part.type === "tool" && part.tool === "bash" && part.state.status === "running",
+        )
+        if (!runningTool) return message
+
+        const output = "\n\n<metadata>\nUser aborted the command\n</metadata>"
+        const info = message.info.time.completed
+          ? message.info
+          : {
+              ...message.info,
+              time: {
+                ...message.info.time,
+                completed: Date.now(),
+              },
+            }
+        const part: MessageV2.ToolPart = {
+          ...runningTool,
+          state: {
+            status: "completed",
+            time: { ...runningTool.state.time, end: Date.now() },
+            input: runningTool.state.input,
+            title: "",
+            metadata: { output, description: "" },
+            output,
+          },
+        }
+
+        if (info !== message.info) {
+          yield* sessions.updateMessage(info)
+        }
+        yield* sessions.updatePart(part)
+
+        return {
+          info,
+          parts: message.parts.map((item) => (item.id === part.id ? part : item)),
+        }
+      })
+
       const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
         function* (sessionID: SessionID) {
           const ctx = yield* InstanceState.context
@@ -1548,7 +1599,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
         function* (input: ShellInput) {
-          return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), shellImpl(input))
+          return yield* state.startShell(input.sessionID, shellCancelledAssistant(input.sessionID), shellImpl(input))
         },
       )
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1329,7 +1329,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
         if (!runningTool) return message
 
-        const output = "\n\n<metadata>\nUser aborted the command\n</metadata>"
+        const output = (typeof runningTool.state.metadata?.output === "string" ? runningTool.state.metadata.output : "")
+          .concat("\n\n<metadata>\nUser aborted the command\n</metadata>")
         const info = message.info.time.completed
           ? message.info
           : {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -724,7 +724,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput) {
         let output = ""
         let aborted = false
-        const { run, msg, part, cmd, finish } = yield* Effect.uninterruptible(
+        const { run, msg, part, cmd, finish } = yield* Effect.uninterruptibleMask((restore) =>
           Effect.gen(function* () {
             const ctx = yield* InstanceState.context
             const run = yield* runner()
@@ -831,10 +831,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             const args = (invocations[shellName] ?? invocations[""]).args
             const cwd = ctx.directory
-            const shellEnv = yield* plugin.trigger(
-              "shell.env",
-              { cwd, sessionID: input.sessionID, callID: part.callID },
-              { env: {} },
+            const shellEnv = yield* restore(
+              plugin.trigger(
+                "shell.env",
+                { cwd, sessionID: input.sessionID, callID: part.callID },
+                { env: {} },
+              ),
             )
 
             const cmd = ChildProcess.make(sh, args, {

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,6 +1,6 @@
 import { InstanceState } from "@/effect/instance-state"
 import { Runner } from "@/effect/runner"
-import { Effect, Layer, Scope, Context } from "effect"
+import { Deferred, Effect, Layer, Scope, Context } from "effect"
 import { Session } from "."
 import { MessageV2 } from "./message-v2"
 import { SessionID } from "./schema"
@@ -19,6 +19,7 @@ export namespace SessionRunState {
       sessionID: SessionID,
       onInterrupt: Effect.Effect<MessageV2.WithParts>,
       work: Effect.Effect<MessageV2.WithParts>,
+      ready?: Deferred.Deferred<void>,
     ) => Effect.Effect<MessageV2.WithParts>
   }
 
@@ -96,8 +97,9 @@ export namespace SessionRunState {
         sessionID: SessionID,
         onInterrupt: Effect.Effect<MessageV2.WithParts>,
         work: Effect.Effect<MessageV2.WithParts>,
+        ready?: Deferred.Deferred<void>,
       ) {
-        return yield* (yield* runner(sessionID, onInterrupt)).startShell(work)
+        return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
       })
 
       return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1346,6 +1346,39 @@ unix(
 )
 
 unix(
+  "cancel preserves partial shell output when fallback finalizes the run",
+  () =>
+    withSh(() =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const { prompt, chat } = yield* boot()
+
+            const sh = yield* prompt
+              .shell({ sessionID: chat.id, agent: "build", command: "printf 'partial output'; trap '' TERM; sleep 30" })
+              .pipe(Effect.forkChild)
+            yield* Effect.sleep(50)
+
+            yield* prompt.cancel(chat.id)
+
+            const exit = yield* Fiber.await(sh)
+            expect(Exit.isSuccess(exit)).toBe(true)
+            if (Exit.isSuccess(exit)) {
+              expect(exit.value.info.role).toBe("assistant")
+              const tool = completedTool(exit.value.parts)
+              if (tool) {
+                expect(tool.state.output).toContain("partial output")
+                expect(tool.state.output).toContain("User aborted the command")
+              }
+            }
+          }),
+        { git: true, config: cfg },
+      ),
+    ),
+  30_000,
+)
+
+unix(
   "cancel finalizes interrupted bash tool output through normal truncation",
   () =>
     provideTmpdirServer(

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1329,6 +1329,41 @@ unix(
 )
 
 unix(
+  "cancel immediately after shell start resolves cleanly",
+  () =>
+    withSh(() =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const { prompt, run, chat } = yield* boot()
+
+            const sh = yield* prompt
+              .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
+              .pipe(Effect.forkChild)
+            yield* Effect.yieldNow
+
+            yield* prompt.cancel(chat.id)
+
+            const busy = yield* run.assertNotBusy(chat.id).pipe(Effect.exit)
+            expect(Exit.isSuccess(busy)).toBe(true)
+
+            const exit = yield* Fiber.await(sh)
+            expect(Exit.isSuccess(exit)).toBe(true)
+            if (Exit.isSuccess(exit)) {
+              expect(exit.value.info.role).toBe("assistant")
+              const tool = completedTool(exit.value.parts)
+              if (tool) {
+                expect(tool.state.output).toContain("User aborted the command")
+              }
+            }
+          }),
+        { git: true, config: cfg },
+      ),
+    ),
+  30_000,
+)
+
+unix(
   "cancel persists aborted shell result when shell ignores TERM",
   () =>
     withSh(() =>

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -141,7 +141,7 @@ const lsp = Layer.succeed(
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-function makeHttp() {
+function makeHttp(plugin = Plugin.defaultLayer) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -149,7 +149,7 @@ function makeHttp() {
     AgentSvc.defaultLayer,
     Command.defaultLayer,
     Permission.defaultLayer,
-    Plugin.defaultLayer,
+    plugin,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,
@@ -190,6 +190,21 @@ function makeHttp() {
 
 const it = testEffect(makeHttp())
 const unix = process.platform !== "win32" ? it.live : it.live.skip
+const unixWithPlugin = (plugin: typeof Plugin.defaultLayer) => {
+  const effect = testEffect(makeHttp(plugin))
+  return process.platform !== "win32" ? effect.live : effect.live.skip
+}
+
+function hangingShellEnvPlugin(ready: { promise: Promise<void>; resolve: (value: void | PromiseLike<void>) => void }) {
+  return Layer.mock(Plugin.Service)({
+    trigger: <Name extends string, Input, Output>(name: Name, _input: Input, output: Output) => {
+      if (name !== "shell.env") return Effect.succeed(output)
+      return Effect.sync(() => ready.resolve(undefined)).pipe(Effect.andThen(Effect.never), Effect.as(output))
+    },
+    list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+}
 
 // Config that registers a custom "test" provider with a "test-model" model
 // so Provider.getModel("test", "test-model") succeeds inside the loop.
@@ -1377,6 +1392,46 @@ unix(
     ),
   30_000,
 )
+
+{
+  const ready = defer<void>()
+  unixWithPlugin(hangingShellEnvPlugin(ready))(
+    "cancel interrupts shell setup waiting on shell env hook",
+    () =>
+      withSh(() =>
+        provideTmpdirInstance(
+          (dir) =>
+            Effect.gen(function* () {
+              const { prompt, run, chat } = yield* boot()
+
+              const sh = yield* prompt
+                .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
+                .pipe(Effect.forkChild)
+              yield* Effect.promise(() => ready.promise)
+
+              const stop = yield* prompt.cancel(chat.id).pipe(Effect.forkChild)
+              const stopExit = yield* Fiber.await(stop).pipe(Effect.timeout("250 millis"))
+              expect(Exit.isSuccess(stopExit)).toBe(true)
+
+              const busy = yield* run.assertNotBusy(chat.id).pipe(Effect.exit)
+              expect(Exit.isSuccess(busy)).toBe(true)
+
+              const exit = yield* Fiber.await(sh).pipe(Effect.timeout("250 millis"))
+              expect(Exit.isSuccess(exit)).toBe(true)
+              if (Exit.isSuccess(exit)) {
+                expect(exit.value.info.role).toBe("assistant")
+                const tool = completedTool(exit.value.parts)
+                if (tool) {
+                  expect(tool.state.output).toContain("User aborted the command")
+                }
+              }
+            }),
+          { git: true, config: cfg },
+        ),
+      ),
+    30_000,
+  )
+}
 
 unix(
   "cancel finalizes interrupted bash tool output through normal truncation",


### PR DESCRIPTION
## Summary

- make the shell prompt setup uninterruptible until the assistant and running bash tool scaffolding exist
- finalize shell cancel fallback into a completed aborted bash result instead of reusing a running snapshot
- preserve partial streamed shell output when cancellation falls back to the interrupted path
- add regression coverage for ignored `TERM` and partial-output preservation

## Why

After PR #36 merged, CI run #107 started failing in `prompt-effect` cancellation coverage. Early shell cancellation could race ahead of the normal finalization path, which either threw `Impossible` while looking up the last assistant message or reused a still-running bash tool snapshot. The fallback path also dropped already-streamed shell output.

## Related Issue

Follow-up to #36. Triggered by CI run #107 after merge.

## How To Verify

```bash
cd packages/opencode && bun test test/session/prompt-effect.test.ts --timeout 30000
cd packages/opencode && bun run typecheck
cd packages/opencode && bun run build
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
