### PR TITLE
feat: make CI a trustworthy PR quality gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: filter
         env:
@@ -92,12 +93,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
@@ -131,12 +134,14 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
@@ -167,7 +172,7 @@ jobs:
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository
           )
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
         with:
           report_paths: packages/*/.artifacts/unit/junit.xml
           check_name: unit results

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: filter
         env:
@@ -92,12 +93,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
@@ -125,6 +128,10 @@ jobs:
         working-directory: packages/desktop-electron
         env:
           OPENCODE_CHANNEL: dev
+
+      - name: Launch desktop smoke app
+        run: bun run smoke:ci
+        working-directory: packages/desktop-electron
 
       - name: Package desktop app
         run: npx electron-builder --mac dir --arm64 --publish never --config electron-builder.config.ts --config.mac.identity=- --config.mac.notarize=false

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: "24"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
@@ -61,6 +61,7 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Run e2e
+        id: run_e2e
         env:
           CI: "true"
           EVENT_NAME: ${{ github.event_name }}
@@ -68,10 +69,15 @@ jobs:
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
         run: |
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
-            bun --cwd packages/app test:e2e:local -- --grep @smoke
+            bun --cwd packages/app test:e2e:local:smoke
           else
             bun --cwd packages/app test:e2e:local
           fi
+
+      - name: Warn on smoke failure
+        if: failure()
+        run: |
+          echo "::warning::Non-blocking e2e-artifacts failed. Download the uploaded artifacts for the Playwright report and junit output."
 
       - name: Upload e2e artifacts
         if: always()

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsgo -b",
     "test": "bun test",
     "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "smoke:ci": "bun ./scripts/ci-smoke.ts",
     "predev": "bun ./scripts/predev.ts",
     "dev": "electron-vite dev",
     "prebuild": "bun ./scripts/prebuild.ts",

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
+import { buildSmokeEnv, requiredSelectors, resolveCiSmokeReadyFile, resolveMainEntry } from "./ci-smoke"
+
+describe("ci smoke helpers", () => {
+  test("resolveMainEntry points at the built Electron main process bundle", () => {
+    expect(resolveMainEntry()).toMatch(/packages\/desktop-electron\/out\/main\/index\.js$/)
+  })
+
+  test("buildSmokeEnv isolates the app state in a temporary home", () => {
+    const env = buildSmokeEnv("/tmp/pawwork-ci-smoke")
+
+    expect(env.OPENCODE_CHANNEL).toBe("dev")
+    expect(env.PAWWORK_CI_SMOKE).toBe("true")
+    expect(env.PAWWORK_CI_SMOKE_HOME).toBe("/tmp/pawwork-ci-smoke")
+    expect(env.HOME).toBe("/tmp/pawwork-ci-smoke")
+    expect(env.XDG_DATA_HOME).toBe("/tmp/pawwork-ci-smoke")
+    expect(env.CI).toBe("true")
+  })
+
+  test("required selectors lock one real renderer affordance", () => {
+    expect(requiredSelectors).toEqual([titlebarShellSelector, desktopShellMainSelector])
+  })
+
+  test("resolveCiSmokeReadyFile points at the CI-ready marker inside the isolated user data dir", () => {
+    expect(resolveCiSmokeReadyFile("/tmp/pawwork-ci-smoke")).toBe(
+      "/tmp/pawwork-ci-smoke/ai.pawwork.desktop.dev/ci-smoke-ready.json",
+    )
+  })
+})

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -1,0 +1,113 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { once } from "node:events"
+import { existsSync, mkdtempSync } from "node:fs"
+import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import process from "node:process"
+import readline from "node:readline"
+import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
+
+export const requiredSelectors = [titlebarShellSelector, desktopShellMainSelector]
+const require = createRequire(import.meta.url)
+
+export function resolveMainEntry() {
+  return resolve(import.meta.dir, "../out/main/index.js")
+}
+
+export function buildSmokeEnv(homeDir: string) {
+  return {
+    ...process.env,
+    CI: "true",
+    HOME: homeDir,
+    PAWWORK_CI_SMOKE: "true",
+    PAWWORK_CI_SMOKE_HOME: homeDir,
+    XDG_DATA_HOME: homeDir,
+    OPENCODE_CHANNEL: "dev",
+  }
+}
+
+export function resolveCiSmokeReadyFile(homeDir: string) {
+  return join(homeDir, "ai.pawwork.desktop.dev", "ci-smoke-ready.json")
+}
+
+function resolveElectronBinary() {
+  return require("electron/index.js") as string
+}
+
+function watchChildLogs(child: ChildProcessWithoutNullStreams) {
+  const stdout = readline.createInterface({ input: child.stdout })
+  const stderr = readline.createInterface({ input: child.stderr })
+  const recent: string[] = []
+
+  const remember = (line: string) => {
+    recent.push(line)
+    if (recent.length > 40) recent.shift()
+  }
+
+  stdout.on("line", remember)
+  stderr.on("line", remember)
+
+  return {
+    recent,
+    close() {
+      stdout.close()
+      stderr.close()
+    },
+  }
+}
+
+async function waitForCiSmokeReady(homeDir: string, child: ChildProcessWithoutNullStreams, recent: string[]) {
+  const readyFile = resolveCiSmokeReadyFile(homeDir)
+  const timeoutAt = Date.now() + 60_000
+
+  while (Date.now() < timeoutAt) {
+    if (existsSync(readyFile)) return
+
+    if (child.exitCode !== null || child.signalCode !== null) {
+      const tail = recent.length ? `\nRecent app output:\n${recent.join("\n")}` : ""
+      throw new Error(`Electron exited before reporting CI smoke readiness${tail}`)
+    }
+
+    await Bun.sleep(250)
+  }
+
+  const tail = recent.length ? `\nRecent app output:\n${recent.join("\n")}` : ""
+  throw new Error(`Timed out waiting for the desktop app to report CI smoke readiness${tail}`)
+}
+
+function launchApp(homeDir: string) {
+  return spawn(resolveElectronBinary(), [resolveMainEntry()], {
+    env: buildSmokeEnv(homeDir),
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+
+  child.kill("SIGTERM")
+  const result = await Promise.race([once(child, "exit").then(() => "exit"), Bun.sleep(5_000).then(() => "timeout")])
+
+  if (result === "timeout" && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL")
+    await once(child, "exit").catch(() => undefined)
+  }
+}
+
+async function main() {
+  const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
+  const child = launchApp(homeDir)
+  const logs = watchChildLogs(child)
+
+  try {
+    await waitForCiSmokeReady(homeDir, child, logs.recent)
+  } finally {
+    logs.close()
+    await stopChild(child)
+  }
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -76,6 +76,8 @@ function setupApp() {
   ensureLoopbackNoProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
 
+  // CI smoke should not fail just because a local desktop instance already holds
+  // the singleton lock on the runner or developer machine.
   if (!CI_SMOKE_ENABLED && !app.requestSingleInstanceLock()) {
     app.quit()
     return
@@ -138,6 +140,8 @@ function setInitStep(step: InitStep) {
 }
 
 async function initialize() {
+  // CI smoke only verifies that the desktop shell boots and the embedded
+  // sidecar is healthy; sqlite migration coverage stays outside this gate.
   const needsMigration = !CI_SMOKE_ENABLED && !sqliteFileExists()
   const sqliteDone = needsMigration ? defer<void>() : undefined
   let overlay: BrowserWindow | null = null

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto"
 import { EventEmitter } from "node:events"
-import { existsSync } from "node:fs"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { createServer } from "node:net"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import type { Event } from "electron"
 import { app, BrowserWindow, dialog } from "electron"
 import pkg from "electron-updater"
@@ -30,8 +30,16 @@ const APP_IDS: Record<string, string> = {
   beta: "ai.pawwork.desktop.beta",
   prod: "ai.pawwork.desktop",
 }
+const CI_SMOKE_HOME = process.env.PAWWORK_CI_SMOKE_HOME
+const CI_SMOKE_ENABLED = process.env.PAWWORK_CI_SMOKE === "true"
+const userDataRoot = CI_SMOKE_HOME ?? app.getPath("appData")
+
 app.setName(app.isPackaged ? APP_NAMES[CHANNEL] : "PawWork Dev")
-app.setPath("userData", join(app.getPath("appData"), app.isPackaged ? APP_IDS[CHANNEL] : "ai.pawwork.desktop.dev"))
+if (CI_SMOKE_HOME) {
+  app.setPath("appData", CI_SMOKE_HOME)
+}
+app.setPath("userData", join(userDataRoot, app.isPackaged ? APP_IDS[CHANNEL] : "ai.pawwork.desktop.dev"))
+const CI_SMOKE_READY_FILE = join(app.getPath("userData"), "ci-smoke-ready.json")
 const { autoUpdater } = pkg
 
 import type { InitStep, ServerReadyData, SqliteMigrationProgress, WslConfig } from "../preload/types"
@@ -68,7 +76,7 @@ function setupApp() {
   ensureLoopbackNoProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
 
-  if (!app.requestSingleInstanceLock()) {
+  if (!CI_SMOKE_ENABLED && !app.requestSingleInstanceLock()) {
     app.quit()
     return
   }
@@ -130,7 +138,7 @@ function setInitStep(step: InitStep) {
 }
 
 async function initialize() {
-  const needsMigration = !sqliteFileExists()
+  const needsMigration = !CI_SMOKE_ENABLED && !sqliteFileExists()
   const sqliteDone = needsMigration ? defer<void>() : undefined
   let overlay: BrowserWindow | null = null
 
@@ -246,12 +254,19 @@ registerIpcHandlers({
   checkUpdate: async () => checkUpdate(),
   installUpdate: async () => installUpdate(),
   setBackgroundColor: (color) => setBackgroundColor(color),
+  reportCiSmokeReady: () => reportCiSmokeReady(),
 })
 
 function killSidecar() {
   if (!server) return
   server.stop()
   server = null
+}
+
+function reportCiSmokeReady() {
+  if (!CI_SMOKE_ENABLED) return
+  mkdirSync(dirname(CI_SMOKE_READY_FILE), { recursive: true })
+  writeFileSync(CI_SMOKE_READY_FILE, JSON.stringify({ readyAt: new Date().toISOString() }), "utf8")
 }
 
 function ensureLoopbackNoProxy() {

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -30,6 +30,7 @@ type Deps = {
   checkUpdate: () => Promise<{ updateAvailable: boolean; version?: string }>
   installUpdate: () => Promise<void> | void
   setBackgroundColor: (color: string) => void
+  reportCiSmokeReady: () => Promise<void> | void
 }
 
 export function registerIpcHandlers(deps: Deps) {
@@ -82,6 +83,7 @@ export function registerIpcHandlers(deps: Deps) {
     const store = getStore(name)
     return Object.keys(store.store).length
   })
+  ipcMain.handle("report-ci-smoke-ready", () => deps.reportCiSmokeReady())
 
   ipcMain.handle(
     "open-directory-picker",

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -1,7 +1,11 @@
 import { contextBridge, ipcRenderer } from "electron"
 import type { ElectronAPI, InitStep, SqliteMigrationProgress } from "./types"
+import { getRuntimeFlags } from "./runtime-flags"
+
+const runtimeFlags = getRuntimeFlags(process.env)
 
 const api: ElectronAPI = {
+  ciSmokeEnabled: runtimeFlags.ciSmokeEnabled,
   killSidecar: () => ipcRenderer.invoke("kill-sidecar"),
   installCli: () => ipcRenderer.invoke("install-cli"),
   awaitInitialization: (onStep) => {
@@ -27,6 +31,7 @@ const api: ElectronAPI = {
   storeClear: (name) => ipcRenderer.invoke("store-clear", name),
   storeKeys: (name) => ipcRenderer.invoke("store-keys", name),
   storeLength: (name) => ipcRenderer.invoke("store-length", name),
+  reportCiSmokeReady: () => ipcRenderer.invoke("report-ci-smoke-ready"),
 
   getWindowCount: () => ipcRenderer.invoke("get-window-count"),
   onSqliteMigrationProgress: (cb) => {

--- a/packages/desktop-electron/src/preload/runtime-flags.test.ts
+++ b/packages/desktop-electron/src/preload/runtime-flags.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test"
+import { getRuntimeFlags } from "./runtime-flags"
+
+describe("runtime flags", () => {
+  test("ci smoke is enabled only for explicit true", () => {
+    expect(getRuntimeFlags({ PAWWORK_CI_SMOKE: "true" }).ciSmokeEnabled).toBe(true)
+    expect(getRuntimeFlags({ PAWWORK_CI_SMOKE: "false" }).ciSmokeEnabled).toBe(false)
+    expect(getRuntimeFlags({}).ciSmokeEnabled).toBe(false)
+  })
+})

--- a/packages/desktop-electron/src/preload/runtime-flags.ts
+++ b/packages/desktop-electron/src/preload/runtime-flags.ts
@@ -1,0 +1,5 @@
+export function getRuntimeFlags(env: NodeJS.ProcessEnv) {
+  return {
+    ciSmokeEnabled: env.PAWWORK_CI_SMOKE === "true",
+  }
+}

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -16,6 +16,7 @@ export type TitlebarTheme = {
 }
 
 export type ElectronAPI = {
+  ciSmokeEnabled: boolean
   killSidecar: () => Promise<void>
   installCli: () => Promise<string>
   awaitInitialization: (onStep: (step: InitStep) => void) => Promise<ServerReadyData>
@@ -35,6 +36,7 @@ export type ElectronAPI = {
   storeClear: (name: string) => Promise<void>
   storeKeys: (name: string) => Promise<string[]>
   storeLength: (name: string) => Promise<number>
+  reportCiSmokeReady: () => Promise<void>
 
   getWindowCount: () => Promise<number>
   onSqliteMigrationProgress: (cb: (progress: SqliteMigrationProgress) => void) => () => void

--- a/packages/desktop-electron/src/renderer/ci-smoke-selectors.test.ts
+++ b/packages/desktop-electron/src/renderer/ci-smoke-selectors.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import {
+  desktopShellMainSelector as appDesktopShellMainSelector,
+  titlebarShellSelector as appTitlebarShellSelector,
+} from "../../../app/e2e/selectors"
+import { desktopShellMainSelector, titlebarShellSelector } from "./ci-smoke-selectors"
+
+test("desktop CI smoke selectors stay aligned with the app e2e contract", () => {
+  expect({ titlebarShellSelector, desktopShellMainSelector }).toEqual({
+    titlebarShellSelector: appTitlebarShellSelector,
+    desktopShellMainSelector: appDesktopShellMainSelector,
+  })
+})

--- a/packages/desktop-electron/src/renderer/ci-smoke-selectors.ts
+++ b/packages/desktop-electron/src/renderer/ci-smoke-selectors.ts
@@ -1,0 +1,2 @@
+export const titlebarShellSelector = '[data-component="titlebar-shell"]'
+export const desktopShellMainSelector = '[data-component="desktop-shell-main"]'

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -19,6 +19,7 @@ import { MemoryRouter } from "@solidjs/router"
 import { createEffect, createResource, onCleanup, onMount, Show } from "solid-js"
 import { render } from "solid-js/web"
 import pkg from "../../package.json"
+import { desktopShellMainSelector, titlebarShellSelector } from "./ci-smoke-selectors"
 import { initI18n, t } from "./i18n"
 import { UPDATER_ENABLED } from "./updater"
 import { webviewZoom } from "./webview-zoom"
@@ -33,13 +34,32 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
 void initI18n()
 
 const deepLinkEvent = "opencode:deep-link"
-
 const emitDeepLinks = (urls: string[]) => {
   if (urls.length === 0) return
   window.__OPENCODE__ ??= {}
   const pending = window.__OPENCODE__.deepLinks ?? []
   window.__OPENCODE__.deepLinks = [...pending, ...urls]
   window.dispatchEvent(new CustomEvent(deepLinkEvent, { detail: { urls } }))
+}
+
+async function reportCiSmokeReady(sidecar: { url: string; username?: string | null; password?: string | null }) {
+  if (document.title !== "PawWork") return false
+  if (!document.querySelector(titlebarShellSelector)) return false
+  if (!document.querySelector(desktopShellMainSelector)) return false
+
+  const windowCount = await window.api.getWindowCount().catch(() => 0)
+  if (windowCount !== 1) return false
+
+  const auth = btoa(`${sidecar.username ?? "opencode"}:${sidecar.password ?? ""}`)
+  const res = await fetch(new URL("/global/health", sidecar.url), {
+    headers: {
+      authorization: `Basic ${auth}`,
+    },
+  }).catch(() => null)
+  if (!res?.ok) return false
+
+  await window.api.reportCiSmokeReady()
+  return true
 }
 
 const listenForDeepLinks = () => {
@@ -296,6 +316,7 @@ render(() => {
     }),
   )
   const [locale] = createResource(loadLocale)
+  let ciSmokeTaskStarted = false
 
   const servers = () => {
     const data = sidecar()
@@ -338,6 +359,25 @@ render(() => {
 
     return null
   }
+
+  createEffect(() => {
+    if (!window.api.ciSmokeEnabled) return
+    if (ciSmokeTaskStarted) return
+    if (defaultServer.loading || sidecar.loading || windowCount.loading || locale.loading) return
+
+    const readySidecar = sidecar.latest
+    if (!readySidecar) return
+
+    ciSmokeTaskStarted = true
+    void (async () => {
+      const timeoutAt = Date.now() + 15_000
+      while (Date.now() < timeoutAt) {
+        if (await reportCiSmokeReady(readySidecar)) return
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      }
+      ciSmokeTaskStarted = false
+    })()
+  })
 
   onMount(() => {
     document.addEventListener("click", handleClick)

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -375,7 +375,6 @@ render(() => {
         if (await reportCiSmokeReady(readySidecar)) return
         await new Promise((resolve) => setTimeout(resolve, 250))
       }
-      ciSmokeTaskStarted = false
     })()
   })
 

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -1,44 +1,56 @@
 import { describe, expect, test } from "bun:test"
-import fs from "node:fs/promises"
 import path from "node:path"
+import { parseWorkflow, readWorkflow } from "../github/workflow-parser"
 
-const workflowPath = path.resolve(import.meta.dir, "../../../../.github/workflows/e2e-artifacts.yml")
-
-async function readWorkflow() {
-  return await fs.readFile(workflowPath, "utf8")
-}
-
-const runBlockPattern =
-  /run: \|\n\s+if \[ "\$EVENT_NAME" = "pull_request" \] \|\| \[ "\$E2E_SUITE" = "smoke" \]; then\n\s+bun --cwd packages\/app test:e2e:local -- --grep @smoke\n\s+else\n\s+bun --cwd packages\/app test:e2e:local\n\s+fi/
+const repoRoot = path.join(import.meta.dir, "../../../..")
+const workflowPath = path.join(repoRoot, ".github", "workflows", "e2e-artifacts.yml")
 
 describe("e2e artifacts workflow", () => {
-  test("exists as a dedicated non-blocking PR diagnostics workflow", async () => {
-    const workflow = await readWorkflow()
+  test("defines a visible but non-blocking PR diagnostics workflow", () => {
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
+    const job = parsed.jobs?.["e2e-artifacts"]
+    const steps = job?.steps ?? []
+    const checkoutStep = steps.find((step) => step.uses === "actions/checkout@v4")
+    const bunStep = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
+    const runStep = steps.find((step) => step.name === "Run e2e")
+    const warnStep = steps.find((step) => step.name === "Warn on smoke failure")
+    const uploadStep = steps.find((step) => step.name === "Upload e2e artifacts")
 
-    expect(workflow).toContain("name: e2e-artifacts")
-    expect(workflow).toContain("pull_request:")
-    expect(workflow).toContain("branches: [dev]")
-    expect(workflow).toContain("workflow_dispatch:")
-    expect(workflow).toContain("suite:")
-    expect(workflow).toContain("default: full")
-    expect(workflow).toContain("- smoke")
-    expect(workflow).toContain("- full")
+    expect(parsed.name).toBe("e2e-artifacts")
+    expect(parsed.on?.pull_request).toEqual({ branches: ["dev"] })
+    expect(parsed.on?.workflow_dispatch).toEqual({
+      inputs: {
+        suite: {
+          description: "E2E suite to run",
+          required: true,
+          default: "full",
+          type: "choice",
+          options: ["full", "smoke"],
+        },
+      },
+    })
     expect(workflow).toContain(
       "group: e2e-artifacts-${{ github.event.pull_request.number || github.ref }}-${{ inputs.suite || 'pr-smoke' }}",
     )
-    expect(workflow).toContain("permissions:")
-    expect(workflow).toContain("contents: read")
+    expect(parsed.permissions).toEqual({ contents: "read" })
+    expect(job?.["runs-on"]).toBe("ubuntu-latest")
+    expect(job?.["continue-on-error"]).toBe(true)
+    expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
+    expect(bunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
+    expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
+    expect(warnStep?.if).toBe("failure()")
+    expect(warnStep?.run).toContain("::warning::")
+    expect(uploadStep?.uses).toBe("actions/upload-artifact@v4")
+    expect(uploadStep?.with?.name).toBe("e2e-artifacts-linux-${{ github.run_attempt }}")
+    expect(uploadStep?.with?.["if-no-files-found"]).toBe("ignore")
+    expect(uploadStep?.with?.["retention-days"]).toBe(7)
     expect(workflow).not.toContain("pull_request_target:")
-    expect(workflow).not.toContain("/Users/yuhan/")
-    expect(workflow).toContain("runs-on: ubuntu-latest")
-    expect(workflow).toContain("continue-on-error: true")
-    expect(workflow).toContain("persist-credentials: false")
+    expect(workflow).not.toMatch(/\/Users\/[^/]+\//)
+    expect(workflow).not.toMatch(/\/home\/[^/]+\//)
     expect(workflow).toContain("bun install --frozen-lockfile")
-    expect(workflow).toContain("bunx playwright install --with-deps chromium")
-    expect(workflow).toMatch(runBlockPattern)
-    expect(workflow).toContain("if: always()")
-    expect(workflow).toContain("actions/upload-artifact@v4")
-    expect(workflow).toContain("retention-days: 7")
     expect(workflow).toContain("packages/app/e2e/playwright-report")
     expect(workflow).toContain("packages/app/e2e/test-results")
     expect(workflow).toContain("packages/app/e2e/junit-linux.xml")

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseWorkflow, readWorkflow } from "./workflow-parser"
+
+const repoRoot = path.join(import.meta.dir, "../../../..")
+const workflowPath = path.join(repoRoot, ".github", "workflows", "ci.yml")
+
+describe("ci workflow", () => {
+  test("pins third-party actions and disables checkout credential persistence", () => {
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
+    const jobs = parsed.jobs ?? {}
+    const changesSteps = jobs.changes?.steps ?? []
+    const typecheckSteps = jobs.typecheck?.steps ?? []
+    const unitSteps = jobs.unit?.steps ?? []
+    const changesCheckoutStep = changesSteps.find((step) => step.uses === "actions/checkout@v4")
+    const typecheckCheckoutStep = typecheckSteps.find((step) => step.uses === "actions/checkout@v4")
+    const unitCheckoutStep = unitSteps.find((step) => step.uses === "actions/checkout@v4")
+    const typecheckBunStep = typecheckSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const unitBunStep = unitSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const junitStep = unitSteps.find((step) => step.name === "Publish unit reports")
+
+    expect(parsed.name).toBe("ci")
+    expect(parsed.permissions).toEqual({ contents: "read" })
+
+    expect(changesCheckoutStep?.with).toEqual({
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    })
+
+    expect(typecheckCheckoutStep?.with).toEqual({ "persist-credentials": false })
+    expect(typecheckBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+
+    expect(unitCheckoutStep?.with).toEqual({ "persist-credentials": false })
+    expect(unitBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+    expect(junitStep?.uses).toBe("mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386")
+
+    expect(workflow).not.toContain("pull_request_target")
+    expect(workflow).not.toContain("persist-credentials: true")
+  })
+})

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -1,69 +1,24 @@
 import { describe, expect, test } from "bun:test"
-import { execFileSync } from "node:child_process"
-import fs from "node:fs"
 import path from "node:path"
+import { parseWorkflow, readWorkflow } from "./workflow-parser"
 
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const workflowPath = path.join(repoRoot, ".github", "workflows", "desktop-smoke.yml")
 
-function readWorkflow() {
-  expect(fs.existsSync(workflowPath)).toBe(true)
-  return fs.readFileSync(workflowPath, "utf8")
-}
-
-type WorkflowStep = {
-  name?: string
-  run?: string
-  uses?: string
-  with?: Record<string, unknown>
-  env?: Record<string, string>
-}
-
-type WorkflowJob = {
-  if?: string
-  needs?: string | string[]
-  "runs-on"?: string
-  outputs?: Record<string, string>
-  steps?: WorkflowStep[]
-}
-
-type Workflow = {
-  name?: string
-  on?: Record<string, unknown>
-  permissions?: Record<string, string>
-  jobs?: Record<string, WorkflowJob>
-}
-
-function parseWorkflow() {
-  const parsed = execFileSync(
-    "ruby",
-    [
-      "-e",
-      `
-        require "json"
-        require "yaml"
-
-        data = YAML.load_file(ARGV[0])
-        data["on"] = data.delete(true) if data.key?(true)
-        puts JSON.generate(data)
-      `,
-      workflowPath,
-    ],
-    { encoding: "utf8" },
-  )
-
-  return JSON.parse(parsed) as Workflow
-}
-
 describe("desktop smoke workflow", () => {
   test("defines a PR-safe macOS arm64 smoke build", () => {
-    const workflow = readWorkflow()
-    const parsed = parseWorkflow()
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
     const jobs = parsed.jobs ?? {}
     const changes = jobs.changes
     const smoke = jobs["smoke-macos-arm64"]
     const check = jobs.check
+    const changesSteps = changes?.steps ?? []
     const smokeSteps = smoke?.steps ?? []
+    const changesCheckoutStep = changesSteps.find((step) => step.uses === "actions/checkout@v4")
+    const smokeCheckoutStep = smokeSteps.find((step) => step.uses === "actions/checkout@v4")
+    const smokeBunStep = smokeSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const appSmokeStep = smokeSteps.find((step) => step.name === "Launch desktop smoke app")
     const packageStep = smokeSteps.find((step) => step.name === "Package desktop app")
     const smokeStep = smokeSteps.find((step) => step.name === "Smoke check app bundle")
 
@@ -75,6 +30,10 @@ describe("desktop smoke workflow", () => {
     expect(Object.keys(jobs).sort()).toEqual(["changes", "check", "smoke-macos-arm64"])
 
     expect(changes?.outputs).toEqual({ docs_only: "${{ steps.filter.outputs.docs_only }}" })
+    expect(changesCheckoutStep?.with).toEqual({
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    })
     expect(smoke?.needs).toBe("changes")
     expect(smoke?.if).toBe("needs.changes.outputs.docs_only != 'true'")
     expect(smoke?.["runs-on"]).toBe("macos-14")
@@ -84,8 +43,13 @@ describe("desktop smoke workflow", () => {
     expect(workflow).not.toContain("strategy:")
     expect(workflow).not.toContain("matrix:")
 
+    expect(smokeCheckoutStep?.with).toEqual({ "persist-credentials": false })
+    expect(smokeBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
     expect(workflow).toContain("bun install --frozen-lockfile")
     expect(workflow).toContain("bun run build")
+    expect(appSmokeStep?.run).toBe("bun run smoke:ci")
+    expect(workflow).toContain("Launch desktop smoke app")
+    expect(workflow).toContain("bun run smoke:ci")
     expect(packageStep?.run).toContain(
       "npx electron-builder --mac dir --arm64 --publish never --config electron-builder.config.ts",
     )

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process"
+import fs from "node:fs"
+
+export type WorkflowStep = {
+  id?: string
+  if?: string
+  name?: string
+  run?: string
+  uses?: string
+  with?: Record<string, unknown>
+  env?: Record<string, string>
+}
+
+export type WorkflowJob = {
+  "continue-on-error"?: boolean
+  if?: string
+  needs?: string | string[]
+  "runs-on"?: string
+  outputs?: Record<string, string>
+  permissions?: Record<string, string>
+  steps?: WorkflowStep[]
+}
+
+export type Workflow = {
+  name?: string
+  on?: Record<string, unknown>
+  permissions?: Record<string, string>
+  jobs?: Record<string, WorkflowJob>
+}
+
+export function readWorkflow(workflowPath: string) {
+  if (!fs.existsSync(workflowPath)) {
+    throw new Error(`Missing workflow: ${workflowPath}`)
+  }
+  return fs.readFileSync(workflowPath, "utf8")
+}
+
+export function parseWorkflow(workflowPath: string) {
+  const parsed = execFileSync(
+    "ruby",
+    [
+      "-e",
+      `
+        require "json"
+        require "yaml"
+
+        data = YAML.load_file(ARGV[0])
+        data["on"] = data.delete(true) if data.key?(true)
+        puts JSON.generate(data)
+      `,
+      workflowPath,
+    ],
+    { encoding: "utf8" },
+  )
+
+  return JSON.parse(parsed) as Workflow
+}


### PR DESCRIPTION
## Summary

- pin third-party GitHub Actions and disable checkout credential persistence in blocking workflows
- add a real macOS desktop smoke gate that launches the Electron app and waits for a CI-ready signal
- keep the non-blocking e2e artifacts workflow useful, and add Dependabot coverage plus workflow contract tests

## Why

The goal of #38 is to make CI a trustworthy PR quality gate instead of a loose collection of workflows. This PR hardens the blocking checks, makes the desktop smoke workflow validate an actual app launch path, and keeps diagnostic e2e coverage visible without turning it into a flaky merge blocker.

## Related Issue

Closes #38

## How To Verify

```bash
bun test scripts/ci-smoke.test.ts src/preload/runtime-flags.test.ts src/renderer/ci-smoke-selectors.test.ts
bun test test/github/desktop-smoke-workflow.test.ts test/github/ci-workflow.test.ts test/config/e2e-artifacts-workflow.test.ts
bun --cwd packages/app test:e2e:local:smoke
bun run build
bun run smoke:ci
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
