### PR TITLE
[Feature] Add CodeQL workflow for JS/TS PR scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: codeql
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+  schedule:
+    - cron: "0 2 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-js-ts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # github/codeql-action@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Analyze with CodeQL
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # github/codeql-action@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/packages/opencode/test/github/codeql-workflow.test.ts
+++ b/packages/opencode/test/github/codeql-workflow.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseWorkflow, readWorkflow } from "./workflow-parser"
+
+const repoRoot = path.join(import.meta.dir, "../../../..")
+const workflowPath = path.join(repoRoot, ".github", "workflows", "codeql.yml")
+
+describe("codeql workflow", () => {
+  test("defines a JS/TS code scanning workflow for dev pushes, PRs, and weekly scans", () => {
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
+    const jobs = parsed.jobs ?? {}
+    const job = jobs["analyze-js-ts"]
+    const steps = job?.steps ?? []
+
+    expect(parsed.name).toBe("codeql")
+    expect(parsed.on?.push).toEqual({ branches: ["dev"] })
+    expect(parsed.on?.pull_request).toEqual({ branches: ["dev"] })
+    expect(parsed.on?.schedule).toEqual([{ cron: "0 2 * * 1" }])
+    expect(parsed.on?.workflow_dispatch).toBeUndefined()
+    expect(parsed.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      "security-events": "write",
+    })
+    expect(Object.keys(jobs)).toEqual(["analyze-js-ts"])
+    expect(Object.keys(job ?? {}).sort()).toEqual(["runs-on", "steps", "timeout-minutes"])
+    expect(job?.["runs-on"]).toBe("ubuntu-latest")
+    expect(job?.["timeout-minutes"]).toBe(30)
+    expect(steps).toHaveLength(3)
+    expect(steps.map((step) => ({ name: step.name, uses: step.uses }))).toEqual([
+      {
+        name: undefined,
+        uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+      },
+      {
+        name: "Initialize CodeQL",
+        uses: "github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225",
+      },
+      {
+        name: "Analyze with CodeQL",
+        uses: "github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225",
+      },
+    ])
+
+    expect(steps[0]?.with).toEqual({ "persist-credentials": false })
+    expect(steps[1]?.with).toEqual({ languages: "javascript-typescript" })
+    expect(steps[2]?.with).toEqual({ category: "/language:javascript-typescript" })
+    expect(steps.every((step) => step.run === undefined && step.env === undefined)).toBe(true)
+
+    expect(workflow).toContain("group: codeql-${{ github.ref }}")
+    expect(workflow).toContain("cancel-in-progress: true")
+    expect(workflow).not.toContain("pull_request_target")
+    expect(workflow).not.toContain("persist-credentials: true")
+    expect(workflow).not.toContain("strategy:")
+    expect(workflow).not.toContain("matrix:")
+    expect(workflow).not.toContain("autobuild")
+    expect(workflow).not.toContain("secrets.")
+  })
+})

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -19,6 +19,7 @@ export type WorkflowJob = {
   outputs?: Record<string, string>
   permissions?: Record<string, string>
   steps?: WorkflowStep[]
+  "timeout-minutes"?: number
 }
 
 export type Workflow = {


### PR DESCRIPTION
## Summary

Add a dedicated `codeql.yml` workflow for JavaScript and TypeScript scanning on `dev` pull requests, pushes, and a weekly schedule.
Add a workflow contract test that locks the intended workflow shape, including triggers, permissions, pinned action SHAs, exact step order, and the absence of `matrix`, `autobuild`, and `pull_request_target`.

## Why

PawWork already has a clear CI split for code checks, desktop smoke, and non-blocking diagnostics.
This change adds one more trustworthy layer for security-oriented code scanning without widening the responsibilities of the existing workflows.

I initially explored a dependency review gate as well, but removed it after verifying GitHub's dependency graph support does not currently make that check trustworthy enough for this Bun-based repo.
Keeping only CodeQL avoids adding a check that could look reassuring while still missing part of the real dependency surface.

## Related Issue

Follow-up to #38.

## How To Verify

```bash
bun install --frozen-lockfile
cd packages/opencode
bun test test/github
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
