### PR TITLE
refactor: sync desktop app slice

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -128,6 +128,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       if (started) return run
       started = true
       run = (async () => {
+        // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
         while (!abort.signal.aborted && started) {
           attempt = new AbortController()
           lastEventAt = Date.now()
@@ -155,7 +156,10 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
               resetHeartbeat()
               streamErrorLogged = false
               const directory = event.directory ?? "global"
-              const payload = event.payload
+              const payload = event.payload as Event | { type: "sync" }
+              if (payload.type === "sync") {
+                continue
+              }
               const k = key(directory, payload)
               if (k) {
                 const i = coalesced.get(k)

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -26,6 +26,7 @@ import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
 import { sanitizeProject } from "./global-sync/utils"
 import { formatServerError } from "@/utils/server-errors"
+import { queryOptions, skipToken, useQueryClient } from "@tanstack/solid-query"
 
 type GlobalStore = {
   ready: boolean
@@ -40,6 +41,9 @@ type GlobalStore = {
   config: Config
   reload: undefined | "pending" | "complete"
 }
+
+export const loadSessionsQuery = (directory: string) =>
+  queryOptions<null>({ queryKey: [directory, "loadSessions"], queryFn: skipToken })
 
 function createGlobalSync() {
   const globalSDK = useGlobalSDK()
@@ -67,6 +71,7 @@ function createGlobalSync() {
     config: {},
     reload: undefined,
   })
+  const queryClient = useQueryClient()
 
   let active = true
   let projectWritten = false
@@ -198,46 +203,53 @@ function createGlobalSync() {
     }
 
     const limit = Math.max(store.limit + SESSION_RECENT_LIMIT, SESSION_RECENT_LIMIT)
-    const promise = loadRootSessionsWithFallback({
-      directory,
-      limit,
-      list: (query) => globalSDK.client.session.list(query),
-    })
-      .then((x) => {
-        const nonArchived = (x.data ?? [])
-          .filter((s) => !!s?.id)
-          .filter((s) => !s.time?.archived)
-          .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
-        const limit = store.limit
-        const childSessions = store.session.filter((s) => !!s.parentID)
-        const sessions = trimSessions([...nonArchived, ...childSessions], {
-          limit,
-          permission: store.permission,
-        })
-        setStore(
-          "sessionTotal",
-          estimateRootSessionTotal({
-            count: nonArchived.length,
-            limit: x.limit,
-            limited: x.limited,
-          }),
-        )
-        setStore("session", reconcile(sessions, { key: "id" }))
-        cleanupDroppedSessionCaches(store, setStore, sessions, setSessionTodo)
-        sessionMeta.set(directory, { limit })
+    const promise = queryClient
+      .fetchQuery({
+        ...loadSessionsQuery(directory),
+        queryFn: () =>
+          loadRootSessionsWithFallback({
+            directory,
+            limit,
+            list: (query) => globalSDK.client.session.list(query),
+          })
+            .then((x) => {
+              const nonArchived = (x.data ?? [])
+                .filter((s) => !!s?.id)
+                .filter((s) => !s.time?.archived)
+                .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+              const limit = store.limit
+              const childSessions = store.session.filter((s) => !!s.parentID)
+              const sessions = trimSessions([...nonArchived, ...childSessions], {
+                limit,
+                permission: store.permission,
+              })
+              setStore(
+                "sessionTotal",
+                estimateRootSessionTotal({
+                  count: nonArchived.length,
+                  limit: x.limit,
+                  limited: x.limited,
+                }),
+              )
+              setStore("session", reconcile(sessions, { key: "id" }))
+              cleanupDroppedSessionCaches(store, setStore, sessions, setSessionTodo)
+              sessionMeta.set(directory, { limit })
+            })
+            .catch((err) => {
+              console.error("Failed to load sessions", err)
+              const project = getFilename(directory)
+              showToast({
+                variant: "error",
+                title: language.t("toast.session.listFailed.title", { project }),
+                description: formatServerError(err, language.t),
+              })
+            })
+            .then(() => null),
       })
-      .catch((err) => {
-        console.error("Failed to load sessions", err)
-        const project = getFilename(directory)
-        showToast({
-          variant: "error",
-          title: language.t("toast.session.listFailed.title", { project }),
-          description: formatServerError(err, language.t),
-        })
-      })
+      .then(() => {})
 
     sessionLoads.set(directory, promise)
-    promise.finally(() => {
+    void promise.finally(() => {
       sessionLoads.delete(directory)
       children.unpin(directory)
     })
@@ -250,7 +262,7 @@ function createGlobalSync() {
     if (pending) return pending
 
     children.pin(directory)
-    const promise = (async () => {
+    const promise = Promise.resolve().then(async () => {
       const child = children.ensureChild(directory)
       const cache = children.vcsCache.get(directory)
       if (!cache) return
@@ -269,11 +281,12 @@ function createGlobalSync() {
         vcsCache: cache,
         loadSessions,
         translate: language.t,
+        queryClient,
       })
-    })()
+    })
 
     booting.set(directory, promise)
-    promise.finally(() => {
+    void promise.finally(() => {
       booting.delete(directory)
       children.unpin(directory)
     })
@@ -317,7 +330,7 @@ function createGlobalSync() {
       setSessionTodo,
       vcsCache: children.vcsCache.get(directory),
       loadLsp: () => {
-        sdkFor(directory)
+        void sdkFor(directory)
           .lsp.status()
           .then((x) => {
             setStore("lsp", x.data ?? [])
@@ -346,6 +359,7 @@ function createGlobalSync() {
         translate: language.t,
         formatMoreCount: (count) => language.t("common.moreCountSuffix", { count }),
         setGlobalStore: setBootStore,
+        queryClient,
       })
       bootedAt = Date.now()
     } finally {
@@ -359,13 +373,13 @@ function createGlobalSync() {
         eventFrame = undefined
         eventTimer = setTimeout(() => {
           eventTimer = undefined
-          globalSDK.event.start()
+          void globalSDK.event.start()
         }, 0)
       })
     } else {
       eventTimer = setTimeout(() => {
         eventTimer = undefined
-        globalSDK.event.start()
+        void globalSDK.event.start()
       }, 0)
     }
     void bootstrap()

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test"
+import type { Config, Path, Project, ProviderListResponse, VcsInfo } from "@opencode-ai/sdk/v2/client"
+import { QueryClient } from "@tanstack/solid-query"
+import { createStore } from "solid-js/store"
+import { bootstrapDirectory } from "./bootstrap"
+import { loadSessionsQuery } from "../global-sync"
+import type { State, VcsCache } from "./types"
+
+function createState(): State {
+  return {
+    status: "loading",
+    agent: [],
+    command: [],
+    project: "",
+    projectMeta: undefined,
+    icon: undefined,
+    provider_ready: false,
+    provider: { all: [], connected: [], default: {} },
+    config: {},
+    path: { state: "", config: "", worktree: "", directory: "", home: "" },
+    session: [],
+    sessionTotal: 0,
+    session_status: {},
+    session_diff: {},
+    todo: {},
+    permission: {},
+    question: {},
+    mcp_ready: false,
+    mcp: {},
+    lsp_ready: false,
+    lsp: [],
+    vcs: undefined,
+    limit: 5,
+    message: {},
+    part: {},
+  }
+}
+
+function createVcsCache(): VcsCache {
+  const [store, setStore] = createStore({ value: undefined as VcsInfo | undefined })
+  return {
+    store,
+    setStore,
+    ready: () => true,
+  }
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 300) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error("timed out waiting for condition")
+}
+
+describe("bootstrapDirectory", () => {
+  test("refreshes directory providers even when sessions query cache is already populated", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(loadSessionsQuery(directory).queryKey, null)
+
+    const [store, setStore] = createStore(createState())
+    const providers = [
+      {
+        all: [{ id: "dir-provider-a", name: "Dir Provider A", source: "custom", env: [], options: {}, models: {} }],
+        connected: ["dir-provider-a"],
+        default: {},
+      },
+      {
+        all: [{ id: "dir-provider-b", name: "Dir Provider B", source: "custom", env: [], options: {}, models: {} }],
+        connected: ["dir-provider-b"],
+        default: {},
+      },
+    ] satisfies ProviderListResponse[]
+
+    let providerCalls = 0
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: {
+        list: async () => {
+          const next = providers[Math.min(providerCalls, providers.length - 1)]
+          providerCalls += 1
+          return { data: next }
+        },
+      },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => providerCalls === 1)
+
+    expect(store.provider_ready).toBe(true)
+    expect(store.provider).toEqual(providers[0])
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => providerCalls === 2)
+
+    expect(providerCalls).toBe(2)
+    expect(store.provider_ready).toBe(true)
+    expect(store.provider).toEqual(providers[1])
+  })
+})

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -18,6 +18,8 @@ import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
+import { QueryClient, queryOptions, skipToken } from "@tanstack/solid-query"
+import { loadSessionsQuery } from "../global-sync"
 
 type GlobalStore = {
   ready: boolean
@@ -65,28 +67,13 @@ function runAll(list: Array<() => Promise<unknown>>) {
   return Promise.allSettled(list.map((item) => item()))
 }
 
-function showErrors(input: {
-  errors: unknown[]
-  title: string
-  translate: (key: string, vars?: Record<string, string | number>) => string
-  formatMoreCount: (count: number) => string
-}) {
-  if (input.errors.length === 0) return
-  const message = formatServerError(input.errors[0], input.translate)
-  const more = input.errors.length > 1 ? input.formatMoreCount(input.errors.length - 1) : ""
-  showToast({
-    variant: "error",
-    title: input.title,
-    description: message + more,
-  })
-}
-
 export async function bootstrapGlobal(input: {
   globalSDK: OpencodeClient
   requestFailedTitle: string
   translate: (key: string, vars?: Record<string, string | number>) => string
   formatMoreCount: (count: number) => string
   setGlobalStore: SetStoreFunction<GlobalStore>
+  queryClient: QueryClient
 }) {
   const fast = [
     () =>
@@ -96,11 +83,16 @@ export async function bootstrapGlobal(input: {
         }),
       ),
     () =>
-      retry(() =>
-        input.globalSDK.provider.list().then((x) => {
-          input.setGlobalStore("provider", normalizeProviderList(x.data!))
-        }),
-      ),
+      input.queryClient.fetchQuery({
+        ...loadProvidersQuery(null),
+        queryFn: () =>
+          retry(() =>
+            input.globalSDK.provider.list().then((x) => {
+              input.setGlobalStore("provider", normalizeProviderList(x.data!))
+              return null
+            }),
+          ),
+      }),
   ]
 
   const slow = [
@@ -122,10 +114,7 @@ export async function bootstrapGlobal(input: {
         }),
       ),
   ]
-  const fastErrs = errors(await runAll(fast))
-  if (fastErrs.length > 0) {
-    console.error("Failed to bootstrap global sync", fastErrs[0])
-  }
+  await runAll(fast)
   // showErrors({
   //   errors: errors(await runAll(fast)),
   //   title: input.requestFailedTitle,
@@ -133,10 +122,7 @@ export async function bootstrapGlobal(input: {
   //   formatMoreCount: input.formatMoreCount,
   // })
   await waitForPaint()
-  const slowErrs = errors(await runAll(slow))
-  if (slowErrs.length > 0) {
-    console.error("Failed to finish global sync bootstrap", slowErrs[0])
-  }
+  await runAll(slow)
   // showErrors({
   //   errors: errors(),
   //   title: input.requestFailedTitle,
@@ -194,6 +180,12 @@ function warmSessions(input: {
   ).then(() => undefined)
 }
 
+export const loadProvidersQuery = (directory: string | null) =>
+  queryOptions<null>({ queryKey: [directory, "providers"], queryFn: skipToken })
+
+export const loadAgentsQuery = (directory: string | null) =>
+  queryOptions<null>({ queryKey: [directory, "agents"], queryFn: skipToken })
+
 export async function bootstrapDirectory(input: {
   directory: string
   sdk: OpencodeClient
@@ -208,6 +200,7 @@ export async function bootstrapDirectory(input: {
     project: Project[]
     provider: ProviderListResponse
   }
+  queryClient: QueryClient
 }) {
   const loading = input.store.status !== "complete"
   const seededProject = projectID(input.directory, input.global.project)
@@ -229,97 +222,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("lsp", [])
   if (loading) input.setStore("status", "partial")
 
-  const fast = [
-    () => retry(() => input.sdk.app.agents().then((x) => input.setStore("agent", normalizeAgentList(x.data)))),
-    () => retry(() => input.sdk.config.get().then((x) => input.setStore("config", x.data!))),
-    () => retry(() => input.sdk.session.status().then((x) => input.setStore("session_status", x.data!))),
-  ]
-
-  const slow = [
-    () =>
-      seededProject
-        ? Promise.resolve()
-        : retry(() => input.sdk.project.current()).then((x) => input.setStore("project", x.data!.id)),
-    () =>
-      seededPath
-        ? Promise.resolve()
-        : retry(() =>
-            input.sdk.path.get().then((x) => {
-              input.setStore("path", x.data!)
-              const next = projectID(x.data?.directory ?? input.directory, input.global.project)
-              if (next) input.setStore("project", next)
-            }),
-          ),
-    () =>
-      retry(() =>
-        input.sdk.vcs.get().then((x) => {
-          const next = x.data ?? input.store.vcs
-          input.setStore("vcs", next)
-          if (next) input.vcsCache.setStore("value", next)
-        }),
-      ),
-    () => retry(() => input.sdk.command.list().then((x) => input.setStore("command", x.data ?? []))),
-    () =>
-      retry(() =>
-        input.sdk.permission.list().then((x) => {
-          const ids = (x.data ?? []).map((perm) => perm?.sessionID).filter((id): id is string => !!id)
-          const grouped = groupBySession(
-            (x.data ?? []).filter((perm): perm is PermissionRequest => !!perm?.id && !!perm.sessionID),
-          )
-          return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
-            batch(() => {
-              for (const sessionID of Object.keys(input.store.permission)) {
-                if (grouped[sessionID]) continue
-                input.setStore("permission", sessionID, [])
-              }
-              for (const [sessionID, permissions] of Object.entries(grouped)) {
-                input.setStore(
-                  "permission",
-                  sessionID,
-                  reconcile(
-                    permissions.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id)),
-                    { key: "id" },
-                  ),
-                )
-              }
-            }),
-          )
-        }),
-      ),
-    () =>
-      retry(() =>
-        input.sdk.question.list().then((x) => {
-          const ids = (x.data ?? []).map((question) => question?.sessionID).filter((id): id is string => !!id)
-          const grouped = groupBySession((x.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID))
-          return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
-            batch(() => {
-              for (const sessionID of Object.keys(input.store.question)) {
-                if (grouped[sessionID]) continue
-                input.setStore("question", sessionID, [])
-              }
-              for (const [sessionID, questions] of Object.entries(grouped)) {
-                input.setStore(
-                  "question",
-                  sessionID,
-                  reconcile(
-                    questions.filter((q) => !!q?.id).sort((a, b) => cmp(a.id, b.id)),
-                    { key: "id" },
-                  ),
-                )
-              }
-            }),
-          )
-        }),
-      ),
-    () => Promise.resolve(input.loadSessions(input.directory)),
-    () =>
-      retry(() =>
-        input.sdk.mcp.status().then((x) => {
-          input.setStore("mcp", x.data!)
-          input.setStore("mcp_ready", true)
-        }),
-      ),
-  ]
+  const fast = [() => Promise.resolve(input.loadSessions(input.directory))]
 
   const errs = errors(await runAll(fast))
   if (errs.length > 0) {
@@ -332,36 +235,138 @@ export async function bootstrapDirectory(input: {
     })
   }
 
-  await waitForPaint()
-  const slowErrs = errors(await runAll(slow))
-  if (slowErrs.length > 0) {
-    console.error("Failed to finish bootstrap instance", slowErrs[0])
-    const project = getFilename(input.directory)
-    showToast({
-      variant: "error",
-      title: input.translate("toast.project.reloadFailed.title", { project }),
-      description: formatServerError(slowErrs[0], input.translate),
-    })
-  }
+  ;(async () => {
+    const slow = [
+      () =>
+        input.queryClient.ensureQueryData({
+          ...loadAgentsQuery(input.directory),
+          queryFn: () =>
+            retry(() => input.sdk.app.agents().then((x) => input.setStore("agent", normalizeAgentList(x.data)))).then(
+              () => null,
+            ),
+        }),
+      () => retry(() => input.sdk.config.get().then((x) => input.setStore("config", x.data!))),
+      () => retry(() => input.sdk.session.status().then((x) => input.setStore("session_status", x.data!))),
+      () =>
+        seededProject
+          ? Promise.resolve()
+          : retry(() => input.sdk.project.current()).then((x) => input.setStore("project", x.data!.id)),
+      () =>
+        seededPath
+          ? Promise.resolve()
+          : retry(() =>
+              input.sdk.path.get().then((x) => {
+                input.setStore("path", x.data!)
+                const next = projectID(x.data?.directory ?? input.directory, input.global.project)
+                if (next) input.setStore("project", next)
+              }),
+            ),
+      () =>
+        retry(() =>
+          input.sdk.vcs.get().then((x) => {
+            const next = x.data ?? input.store.vcs
+            input.setStore("vcs", next)
+            if (next) input.vcsCache.setStore("value", next)
+          }),
+        ),
+      () => retry(() => input.sdk.command.list().then((x) => input.setStore("command", x.data ?? []))),
+      () =>
+        retry(() =>
+          input.sdk.permission.list().then((x) => {
+            const ids = (x.data ?? []).map((perm) => perm?.sessionID).filter((id): id is string => !!id)
+            const grouped = groupBySession(
+              (x.data ?? []).filter((perm): perm is PermissionRequest => !!perm?.id && !!perm.sessionID),
+            )
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
+              batch(() => {
+                for (const sessionID of Object.keys(input.store.permission)) {
+                  if (grouped[sessionID]) continue
+                  input.setStore("permission", sessionID, [])
+                }
+                for (const [sessionID, permissions] of Object.entries(grouped)) {
+                  input.setStore(
+                    "permission",
+                    sessionID,
+                    reconcile(
+                      permissions.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id)),
+                      { key: "id" },
+                    ),
+                  )
+                }
+              }),
+            )
+          }),
+        ),
+      () =>
+        retry(() =>
+          input.sdk.question.list().then((x) => {
+            const ids = (x.data ?? []).map((question) => question?.sessionID).filter((id): id is string => !!id)
+            const grouped = groupBySession((x.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID))
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
+              batch(() => {
+                for (const sessionID of Object.keys(input.store.question)) {
+                  if (grouped[sessionID]) continue
+                  input.setStore("question", sessionID, [])
+                }
+                for (const [sessionID, questions] of Object.entries(grouped)) {
+                  input.setStore(
+                    "question",
+                    sessionID,
+                    reconcile(
+                      questions.filter((q) => !!q?.id).sort((a, b) => cmp(a.id, b.id)),
+                      { key: "id" },
+                    ),
+                  )
+                }
+              }),
+            )
+          }),
+        ),
+      () => Promise.resolve(input.loadSessions(input.directory)),
+      () =>
+        retry(() =>
+          input.sdk.mcp.status().then((x) => {
+            input.setStore("mcp", x.data!)
+            input.setStore("mcp_ready", true)
+          }),
+        ),
+    ]
 
-  if (loading && errs.length === 0 && slowErrs.length === 0) input.setStore("status", "complete")
-
-  const rev = (providerRev.get(input.directory) ?? 0) + 1
-  providerRev.set(input.directory, rev)
-  void retry(() => input.sdk.provider.list())
-    .then((x) => {
-      if (providerRev.get(input.directory) !== rev) return
-      input.setStore("provider", normalizeProviderList(x.data!))
-      input.setStore("provider_ready", true)
-    })
-    .catch((err) => {
-      if (providerRev.get(input.directory) !== rev) return
-      console.error("Failed to refresh provider list", err)
+    await waitForPaint()
+    const slowErrs = errors(await runAll(slow))
+    if (slowErrs.length > 0) {
+      console.error("Failed to finish bootstrap instance", slowErrs[0])
       const project = getFilename(input.directory)
       showToast({
         variant: "error",
         title: input.translate("toast.project.reloadFailed.title", { project }),
-        description: formatServerError(err, input.translate),
+        description: formatServerError(slowErrs[0], input.translate),
       })
+    }
+
+    if (loading && errs.length === 0 && slowErrs.length === 0) input.setStore("status", "complete")
+
+    const rev = (providerRev.get(input.directory) ?? 0) + 1
+    providerRev.set(input.directory, rev)
+    void input.queryClient.fetchQuery({
+      ...loadProvidersQuery(input.directory),
+      queryFn: () =>
+        retry(() => input.sdk.provider.list())
+          .then((x) => {
+            if (providerRev.get(input.directory) !== rev) return
+            input.setStore("provider", normalizeProviderList(x.data!))
+            input.setStore("provider_ready", true)
+          })
+          .catch((err) => {
+            if (providerRev.get(input.directory) !== rev) console.error("Failed to refresh provider list", err)
+            const project = getFilename(input.directory)
+            showToast({
+              variant: "error",
+              title: input.translate("toast.project.reloadFailed.title", { project }),
+              description: formatServerError(err, input.translate),
+            })
+          })
+          .then(() => null),
     })
+  })()
 }

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -243,8 +243,8 @@ export function createChildStoreManager(input: {
     const cached = metaCache.get(directory)
     if (!cached) return
     const previous = store.projectMeta ?? {}
-    const icon = patch.icon ? { ...(previous.icon ?? {}), ...patch.icon } : previous.icon
-    const commands = patch.commands ? { ...(previous.commands ?? {}), ...patch.commands } : previous.commands
+    const icon = patch.icon ? { ...previous.icon, ...patch.icon } : previous.icon
+    const commands = patch.commands ? { ...previous.commands, ...patch.commands } : previous.commands
     const next = {
       ...previous,
       ...patch,

--- a/packages/app/src/context/global-sync/queue.ts
+++ b/packages/app/src/context/global-sync/queue.ts
@@ -63,6 +63,7 @@ export function createRefreshQueue(input: QueueInput) {
       }
     } finally {
       running = false
+      // oxlint-disable-next-line no-unsafe-finally -- intentional: early return skips schedule() when paused
       if (input.paused()) return
       if (root || queued.size) schedule()
     }

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -8,7 +8,6 @@ import type {
   Part,
   Path,
   PermissionRequest,
-  Project,
   ProviderListResponse,
   QuestionRequest,
   Session,

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -363,7 +363,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           return
         }
 
-        setStore("sessionView", sessionKey, "scroll", (prev) => ({ ...(prev ?? {}), ...next }))
+        setStore("sessionView", sessionKey, "scroll", (prev) => ({ ...prev, ...next }))
         prune(keep)
       },
     })
@@ -418,7 +418,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         local?.icon?.color !== undefined
 
       const base = {
-        ...(metadata ?? {}),
+        ...metadata,
         ...project,
         icon: {
           url: metadata?.icon?.url,
@@ -601,7 +601,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         open(directory: string) {
           const root = rootFor(directory)
           if (server.projects.list().find((x) => x.worktree === root)) return
-          globalSync.project.loadSessions(root)
+          void globalSync.project.loadSessions(root)
           server.projects.open(root)
         },
         close(directory: string) {

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -23,6 +23,11 @@ export interface Settings {
     autoSave: boolean
     releaseNotes: boolean
     followup: "queue" | "steer"
+    showFileTree: boolean
+    showNavigation: boolean
+    showSearch: boolean
+    showStatus: boolean
+    showTerminal: boolean
     showReasoningSummaries: boolean
     shellToolPartsExpanded: boolean
     editToolPartsExpanded: boolean
@@ -97,6 +102,11 @@ const defaultSettings: Settings = {
     autoSave: true,
     releaseNotes: true,
     followup: "steer",
+    showFileTree: false,
+    showNavigation: false,
+    showSearch: false,
+    showStatus: false,
+    showTerminal: false,
     showReasoningSummaries: false,
     shellToolPartsExpanded: false,
     editToolPartsExpanded: false,
@@ -186,6 +196,26 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setFollowup(value: "queue" | "steer") {
           setStore("general", "followup", value === "queue" ? "steer" : value)
+        },
+        showFileTree: withFallback(() => store.general?.showFileTree, defaultSettings.general.showFileTree),
+        setShowFileTree(value: boolean) {
+          setStore("general", "showFileTree", value)
+        },
+        showNavigation: withFallback(() => store.general?.showNavigation, defaultSettings.general.showNavigation),
+        setShowNavigation(value: boolean) {
+          setStore("general", "showNavigation", value)
+        },
+        showSearch: withFallback(() => store.general?.showSearch, defaultSettings.general.showSearch),
+        setShowSearch(value: boolean) {
+          setStore("general", "showSearch", value)
+        },
+        showStatus: withFallback(() => store.general?.showStatus, defaultSettings.general.showStatus),
+        setShowStatus(value: boolean) {
+          setStore("general", "showStatus", value)
+        },
+        showTerminal: withFallback(() => store.general?.showTerminal, defaultSettings.general.showTerminal),
+        setShowTerminal(value: boolean) {
+          setStore("general", "showTerminal", value)
         },
         showReasoningSummaries: withFallback(
           () => store.general?.showReasoningSummaries,

--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -140,7 +140,7 @@ export function clearWorkspaceTerminals(dir: string, sessionIDs?: string[], plat
     entry?.value.clear()
   }
 
-  removePersisted(Persist.workspace(dir, "terminal"), platform)
+  void removePersisted(Persist.workspace(dir, "terminal"), platform)
 
   const legacy = new Set(getLegacyTerminalStorageKeys(dir))
   for (const id of sessionIDs ?? []) {
@@ -149,7 +149,7 @@ export function clearWorkspaceTerminals(dir: string, sessionIDs?: string[], plat
     }
   }
   for (const key of legacy) {
-    removePersisted({ key }, platform)
+    void removePersisted({ key }, platform)
   }
 }
 

--- a/packages/desktop-electron/electron.vite.config.ts
+++ b/packages/desktop-electron/electron.vite.config.ts
@@ -75,6 +75,9 @@ export default defineConfig({
     plugins: [appPlugin],
     publicDir: "../../../app/public",
     root: "src/renderer",
+    define: {
+      "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+    },
     ...rendererWorkspaceConfig,
     build: {
       rollupOptions: {

--- a/packages/desktop-electron/src/main/apps.ts
+++ b/packages/desktop-electron/src/main/apps.ts
@@ -20,7 +20,7 @@ export function wslPath(path: string, mode: "windows" | "linux" | null): string 
   try {
     if (path.startsWith("~")) {
       const suffix = path.slice(1)
-      const cmd = `wslpath ${flag} \"$HOME${suffix.replace(/\"/g, '\\"')}\"`
+      const cmd = `wslpath ${flag} "$HOME${suffix.replace(/"/g, '\\"')}"`
       const output = execFileSync("wsl", ["-e", "sh", "-lc", cmd])
       return output.toString().trim()
     }
@@ -28,7 +28,7 @@ export function wslPath(path: string, mode: "windows" | "linux" | null): string 
     const output = execFileSync("wsl", ["-e", "wslpath", flag, path])
     return output.toString().trim()
   } catch (error) {
-    throw new Error(`Failed to run wslpath: ${String(error)}`)
+    throw new Error(`Failed to run wslpath: ${String(error)}`, { cause: error })
   }
 }
 


### PR DESCRIPTION
## Summary

- sync the PR 9c `packages/app/src/{context,types}/**` and `packages/desktop-electron/**` lane to upstream `v1.4.11`
- move global and directory bootstrap work onto TanStack Query-backed session, agent, and provider loading, including a regression test for directory provider refresh after sessions are already cached
- carry the upstream app-context settings and event-stream handling changes needed by the desktop shell
- align the Electron renderer channel define and Windows app-path helper updates without touching the UI rewrite carve-out

## Why

This keeps the `sync/desktop-app` slice in lockstep with upstream as part of PR 9c under `#27`, while keeping the boundary tight to app context and desktop shell infrastructure. The goal is to reduce foundation drift without widening into `packages/app/src/{components,pages,styles,theme,i18n}`.

## Related Issue

Part of #27

## How To Verify

```bash
cd packages/app && bun test --preload ./happydom.ts ./src/context/global-sync/bootstrap.test.ts
bun turbo typecheck --filter=@opencode-ai/app
```

Manual checks: none, no visible UI changes in this slice.

## Screenshots or Recordings

N/A

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
