### PR TITLE
feat: sync opencode foundation tail

### DIFF
--- a/packages/opencode/src/env/index.ts
+++ b/packages/opencode/src/env/index.ts
@@ -1,28 +1,73 @@
-import { Instance } from "../project/instance"
+import { Context, Effect, Layer } from "effect"
+import { InstanceState } from "@/effect"
+import { makeRuntime } from "../effect/run-service"
+
+type State = Record<string, string | undefined>
+
+export interface Interface {
+  readonly get: (key: string) => Effect.Effect<string | undefined>
+  readonly all: () => Effect.Effect<State>
+  readonly set: (key: string, value: string) => Effect.Effect<void>
+  readonly remove: (key: string) => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Env") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const state = yield* InstanceState.make<State>(Effect.fn("Env.state")(() => Effect.succeed({ ...process.env })))
+
+    const get = Effect.fn("Env.get")((key: string) => InstanceState.use(state, (env) => env[key]))
+    const all = Effect.fn("Env.all")(() => InstanceState.get(state))
+    const set = Effect.fn("Env.set")(function* (key: string, value: string) {
+      const env = yield* InstanceState.get(state)
+      env[key] = value
+    })
+    const remove = Effect.fn("Env.remove")(function* (key: string) {
+      const env = yield* InstanceState.get(state)
+      delete env[key]
+    })
+
+    return Service.of({ get, all, set, remove })
+  }),
+)
+
+export const defaultLayer = layer
+
+const { runSync } = makeRuntime(Service, defaultLayer)
+
+export function get(key: string) {
+  return runSync((svc) => svc.get(key))
+}
+
+export function all() {
+  return runSync((svc) => svc.all())
+}
+
+export function set(key: string, value: string) {
+  return runSync((svc) => svc.set(key, value))
+}
+
+export function remove(key: string) {
+  return runSync((svc) => svc.remove(key))
+}
+
+const EnvServiceValue = Service
+const EnvLayerValue = layer
+const EnvDefaultLayerValue = defaultLayer
+const EnvGetValue = get
+const EnvAllValue = all
+const EnvSetValue = set
+const EnvRemoveValue = remove
 
 export namespace Env {
-  const state = Instance.state(() => {
-    // Create a shallow copy to isolate environment per instance
-    // Prevents parallel tests from interfering with each other's env vars
-    return { ...process.env } as Record<string, string | undefined>
-  })
-
-  export function get(key: string) {
-    const env = state()
-    return env[key]
-  }
-
-  export function all() {
-    return state()
-  }
-
-  export function set(key: string, value: string) {
-    const env = state()
-    env[key] = value
-  }
-
-  export function remove(key: string) {
-    const env = state()
-    delete env[key]
-  }
+  export type Service = import("./index").Service
+  export const Service = EnvServiceValue
+  export const layer = EnvLayerValue
+  export const defaultLayer = EnvDefaultLayerValue
+  export const get = EnvGetValue
+  export const all = EnvAllValue
+  export const set = EnvSetValue
+  export const remove = EnvRemoveValue
 }

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -21,6 +21,17 @@ import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { Log } from "@/util/log"
 
 export namespace Ripgrep {
+  type SearchItems = z.infer<typeof Match.shape.data>[]
+  type SearchResultJson = {
+    items: SearchItems
+    partial: boolean
+  }
+  type SearchResult = SearchItems & {
+    items: SearchItems
+    partial: boolean
+    toJSON: () => SearchResultJson
+  }
+
   const log = Log.create({ service: "ripgrep" })
   const Stats = z.object({
     elapsed: z.object({
@@ -225,6 +236,17 @@ export namespace Ripgrep {
     } satisfies NodeJS.ProcessEnv
   }
 
+  function searchResult(items: SearchItems, partial: boolean): SearchResult {
+    return Object.assign(items, {
+      items,
+      partial,
+      toJSON: () => ({
+        items: [...items],
+        partial,
+      }),
+    })
+  }
+
   export async function* files(input: {
     cwd: string
     glob?: string[]
@@ -417,7 +439,7 @@ export namespace Ripgrep {
       nothrow: true,
     })
     if (result.code === 1) {
-      return []
+      return searchResult([], false)
     }
 
     if (result.code !== 0 && result.code !== 2) {
@@ -432,10 +454,13 @@ export namespace Ripgrep {
     const lines = result.text.trim().split(/\r?\n/).filter(Boolean)
     // Parse JSON lines from ripgrep output
 
-    return lines
-      .map((line) => JSON.parse(line))
-      .map((parsed) => Result.parse(parsed))
-      .filter((r) => r.type === "match")
-      .map((r) => r.data)
+    return searchResult(
+      lines
+        .map((line) => JSON.parse(line))
+        .map((parsed) => Result.parse(parsed))
+        .filter((r) => r.type === "match")
+        .map((r) => r.data),
+      result.code === 2,
+    )
   }
 }

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -1,234 +1,267 @@
 import type { AuthOAuthResult, Hooks } from "@opencode-ai/plugin"
 import { NamedError } from "@opencode-ai/util/error"
 import { Auth } from "@/auth"
-import { InstanceState } from "@/effect/instance-state"
+import { InstanceState } from "@/effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 import { Plugin } from "../plugin"
 import { ProviderID } from "./schema"
-import { Array as Arr, Effect, Layer, Record, Result, Context } from "effect"
+import { Array as Arr, Effect, Layer, Record, Result, Context, Schema } from "effect"
 import z from "zod"
 
-export namespace ProviderAuth {
-  export const Method = z
-    .object({
-      type: z.union([z.literal("oauth"), z.literal("api")]),
-      label: z.string(),
-      prompts: z
-        .array(
-          z.union([
-            z.object({
-              type: z.literal("text"),
-              key: z.string(),
-              message: z.string(),
-              placeholder: z.string().optional(),
-              when: z
-                .object({
-                  key: z.string(),
-                  op: z.union([z.literal("eq"), z.literal("neq")]),
-                  value: z.string(),
-                })
-                .optional(),
-            }),
-            z.object({
-              type: z.literal("select"),
-              key: z.string(),
-              message: z.string(),
-              options: z.array(
-                z.object({
-                  label: z.string(),
-                  value: z.string(),
-                  hint: z.string().optional(),
-                }),
-              ),
-              when: z
-                .object({
-                  key: z.string(),
-                  op: z.union([z.literal("eq"), z.literal("neq")]),
-                  value: z.string(),
-                })
-                .optional(),
-            }),
-          ]),
-        )
-        .optional(),
-    })
-    .meta({
-      ref: "ProviderAuthMethod",
-    })
-  export type Method = z.infer<typeof Method>
+const When = Schema.Struct({
+  key: Schema.String,
+  op: Schema.Literals(["eq", "neq"]),
+  value: Schema.String,
+})
 
-  export const Authorization = z
-    .object({
-      url: z.string(),
-      method: z.union([z.literal("auto"), z.literal("code")]),
-      instructions: z.string(),
-    })
-    .meta({
-      ref: "ProviderAuthAuthorization",
-    })
-  export type Authorization = z.infer<typeof Authorization>
+const TextPrompt = Schema.Struct({
+  type: Schema.Literal("text"),
+  key: Schema.String,
+  message: Schema.String,
+  placeholder: Schema.optional(Schema.String),
+  when: Schema.optional(When),
+})
 
-  export const OauthMissing = NamedError.create("ProviderAuthOauthMissing", z.object({ providerID: ProviderID.zod }))
+const SelectOption = Schema.Struct({
+  label: Schema.String,
+  value: Schema.String,
+  hint: Schema.optional(Schema.String),
+})
 
-  export const OauthCodeMissing = NamedError.create(
-    "ProviderAuthOauthCodeMissing",
-    z.object({ providerID: ProviderID.zod }),
-  )
+const SelectPrompt = Schema.Struct({
+  type: Schema.Literal("select"),
+  key: Schema.String,
+  message: Schema.String,
+  options: Schema.Array(SelectOption),
+  when: Schema.optional(When),
+})
 
-  export const OauthCallbackFailed = NamedError.create("ProviderAuthOauthCallbackFailed", z.object({}))
+const Prompt = Schema.Union([TextPrompt, SelectPrompt])
 
-  export const ValidationFailed = NamedError.create(
-    "ProviderAuthValidationFailed",
-    z.object({
-      field: z.string(),
-      message: z.string(),
-    }),
-  )
+export class Method extends Schema.Class<Method>("ProviderAuthMethod")({
+  type: Schema.Literals(["oauth", "api"]),
+  label: Schema.String,
+  prompts: Schema.optional(Schema.Array(Prompt)),
+}) {
+  static readonly zod = zod(this)
+}
 
-  export type Error =
-    | Auth.AuthError
-    | InstanceType<typeof OauthMissing>
-    | InstanceType<typeof OauthCodeMissing>
-    | InstanceType<typeof OauthCallbackFailed>
-    | InstanceType<typeof ValidationFailed>
+export const Methods = Schema.Record(Schema.String, Schema.Array(Method)).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Methods = typeof Methods.Type
 
-  type Hook = NonNullable<Hooks["auth"]>
+export class Authorization extends Schema.Class<Authorization>("ProviderAuthAuthorization")({
+  url: Schema.String,
+  method: Schema.Literals(["auto", "code"]),
+  instructions: Schema.String,
+}) {
+  static readonly zod = zod(this)
+}
 
-  export interface Interface {
-    readonly methods: () => Effect.Effect<Record<ProviderID, Method[]>>
-    readonly authorize: (input: {
+export const AuthorizeInput = Schema.Struct({
+  method: Schema.Number.annotate({ description: "Auth method index" }),
+  inputs: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({ description: "Prompt inputs" }),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type AuthorizeInput = Schema.Schema.Type<typeof AuthorizeInput>
+
+export const CallbackInput = Schema.Struct({
+  method: Schema.Number.annotate({ description: "Auth method index" }),
+  code: Schema.optional(Schema.String).annotate({ description: "OAuth authorization code" }),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type CallbackInput = Schema.Schema.Type<typeof CallbackInput>
+
+export const OauthMissing = NamedError.create("ProviderAuthOauthMissing", z.object({ providerID: ProviderID.zod }))
+
+export const OauthCodeMissing = NamedError.create(
+  "ProviderAuthOauthCodeMissing",
+  z.object({ providerID: ProviderID.zod }),
+)
+
+export const OauthCallbackFailed = NamedError.create("ProviderAuthOauthCallbackFailed", z.object({}))
+
+export const ValidationFailed = NamedError.create(
+  "ProviderAuthValidationFailed",
+  z.object({
+    field: z.string(),
+    message: z.string(),
+  }),
+)
+
+export type Error =
+  | Auth.AuthError
+  | InstanceType<typeof OauthMissing>
+  | InstanceType<typeof OauthCodeMissing>
+  | InstanceType<typeof OauthCallbackFailed>
+  | InstanceType<typeof ValidationFailed>
+
+type Hook = NonNullable<Hooks["auth"]>
+
+export interface Interface {
+  readonly methods: () => Effect.Effect<Methods>
+  readonly authorize: (
+    input: {
       providerID: ProviderID
-      method: number
-      inputs?: Record<string, string>
-    }) => Effect.Effect<Authorization | undefined, Error>
-    readonly callback: (input: { providerID: ProviderID; method: number; code?: string }) => Effect.Effect<void, Error>
-  }
+    } & AuthorizeInput,
+  ) => Effect.Effect<Authorization | undefined, Error>
+  readonly callback: (input: { providerID: ProviderID } & CallbackInput) => Effect.Effect<void, Error>
+}
 
-  interface State {
-    hooks: Record<ProviderID, Hook>
-    pending: Map<ProviderID, AuthOAuthResult>
-  }
+interface State {
+  hooks: Record<ProviderID, Hook>
+  pending: Map<ProviderID, AuthOAuthResult>
+}
 
-  export class Service extends Context.Service<Service, Interface>()("@opencode/ProviderAuth") {}
+export class Service extends Context.Service<Service, Interface>()("@opencode/ProviderAuth") {}
 
-  export const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> = Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const auth = yield* Auth.Service
-      const plugin = yield* Plugin.Service
-      const state = yield* InstanceState.make<State>(
-        Effect.fn("ProviderAuth.state")(function* () {
-          const plugins = yield* plugin.list()
-          return {
-            hooks: Record.fromEntries(
-              Arr.filterMap(plugins, (x) =>
-                x.auth?.provider !== undefined
-                  ? Result.succeed([ProviderID.make(x.auth.provider), x.auth] as const)
-                  : Result.failVoid,
-              ),
+export const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const auth = yield* Auth.Service
+    const plugin = yield* Plugin.Service
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("ProviderAuth.state")(function* () {
+        const plugins = yield* plugin.list()
+        return {
+          hooks: Record.fromEntries(
+            Arr.filterMap(plugins, (x) =>
+              x.auth?.provider !== undefined
+                ? Result.succeed([ProviderID.make(x.auth.provider), x.auth] as const)
+                : Result.failVoid,
             ),
-            pending: new Map<ProviderID, AuthOAuthResult>(),
-          }
-        }),
-      )
+          ),
+          pending: new Map<ProviderID, AuthOAuthResult>(),
+        }
+      }),
+    )
 
-      const methods = Effect.fn("ProviderAuth.methods")(function* () {
-        const hooks = (yield* InstanceState.get(state)).hooks
-        return Record.map(hooks, (item) =>
-          item.methods.map(
-            (method): Method => ({
-              type: method.type,
-              label: method.label,
-              prompts: method.prompts?.map((prompt) => {
-                if (prompt.type === "select") {
-                  return {
-                    type: "select" as const,
-                    key: prompt.key,
-                    message: prompt.message,
-                    options: prompt.options,
-                    when: prompt.when,
-                  }
-                }
+    const decode = Schema.decodeUnknownSync(Methods)
+    const methods = Effect.fn("ProviderAuth.methods")(function* () {
+      const hooks = (yield* InstanceState.get(state)).hooks
+      return decode(
+        Record.map(hooks, (item) =>
+          item.methods.map((method) => ({
+            type: method.type,
+            label: method.label,
+            prompts: method.prompts?.map((prompt) => {
+              if (prompt.type === "select") {
                 return {
-                  type: "text" as const,
+                  type: "select" as const,
                   key: prompt.key,
                   message: prompt.message,
-                  placeholder: prompt.placeholder,
+                  options: prompt.options,
                   when: prompt.when,
                 }
-              }),
+              }
+              return {
+                type: "text" as const,
+                key: prompt.key,
+                message: prompt.message,
+                placeholder: prompt.placeholder,
+                when: prompt.when,
+              }
             }),
-          ),
-        )
-      })
+          })),
+        ),
+      )
+    })
 
-      const authorize = Effect.fn("ProviderAuth.authorize")(function* (input: {
-        providerID: ProviderID
-        method: number
-        inputs?: Record<string, string>
-      }) {
-        const { hooks, pending } = yield* InstanceState.get(state)
-        const method = hooks[input.providerID].methods[input.method]
-        if (method.type !== "oauth") return
+    const authorize = Effect.fn("ProviderAuth.authorize")(function* (
+      input: { providerID: ProviderID } & AuthorizeInput,
+    ) {
+      const { hooks, pending } = yield* InstanceState.get(state)
+      const method = hooks[input.providerID].methods[input.method]
+      if (method.type !== "oauth") return
 
-        if (method.prompts && input.inputs) {
-          for (const prompt of method.prompts) {
-            if (prompt.type === "text" && prompt.validate && input.inputs[prompt.key] !== undefined) {
-              const error = prompt.validate(input.inputs[prompt.key])
-              if (error) return yield* Effect.fail(new ValidationFailed({ field: prompt.key, message: error }))
-            }
+      if (method.prompts && input.inputs) {
+        for (const prompt of method.prompts) {
+          if (prompt.type === "text" && prompt.validate && input.inputs[prompt.key] !== undefined) {
+            const error = prompt.validate(input.inputs[prompt.key])
+            if (error) return yield* Effect.fail(new ValidationFailed({ field: prompt.key, message: error }))
           }
         }
+      }
 
-        const result = yield* Effect.promise(() => method.authorize(input.inputs))
-        pending.set(input.providerID, result)
-        return {
-          url: result.url,
-          method: result.method,
-          instructions: result.instructions,
-        }
-      })
+      const result = yield* Effect.promise(() => method.authorize(input.inputs))
+      pending.set(input.providerID, result)
+      return {
+        url: result.url,
+        method: result.method,
+        instructions: result.instructions,
+      }
+    })
 
-      const callback = Effect.fn("ProviderAuth.callback")(function* (input: {
-        providerID: ProviderID
-        method: number
-        code?: string
-      }) {
-        const pending = (yield* InstanceState.get(state)).pending
-        const match = pending.get(input.providerID)
-        if (!match) return yield* Effect.fail(new OauthMissing({ providerID: input.providerID }))
-        if (match.method === "code" && !input.code) {
-          return yield* Effect.fail(new OauthCodeMissing({ providerID: input.providerID }))
-        }
+    const callback = Effect.fn("ProviderAuth.callback")(function* (input: { providerID: ProviderID } & CallbackInput) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const match = pending.get(input.providerID)
+      if (!match) return yield* Effect.fail(new OauthMissing({ providerID: input.providerID }))
+      if (match.method === "code" && !input.code) {
+        return yield* Effect.fail(new OauthCodeMissing({ providerID: input.providerID }))
+      }
 
-        const result = yield* Effect.promise(() =>
-          match.method === "code" ? match.callback(input.code!) : match.callback(),
-        )
-        if (!result || result.type !== "success") return yield* Effect.fail(new OauthCallbackFailed({}))
+      const result = yield* Effect.promise(() =>
+        match.method === "code" ? match.callback(input.code!) : match.callback(),
+      )
+      if (!result || result.type !== "success") return yield* Effect.fail(new OauthCallbackFailed({}))
 
-        if ("key" in result) {
-          yield* auth.set(input.providerID, {
-            type: "api",
-            key: result.key,
-          })
-        }
+      if ("key" in result) {
+        yield* auth.set(input.providerID, {
+          type: "api",
+          key: result.key,
+        })
+      }
 
-        if ("refresh" in result) {
-          const { type: _, provider: __, refresh, access, expires, ...extra } = result
-          yield* auth.set(input.providerID, {
-            type: "oauth",
-            access,
-            refresh,
-            expires,
-            ...extra,
-          })
-        }
-      })
+      if ("refresh" in result) {
+        const { type: _, provider: __, refresh, access, expires, ...extra } = result
+        yield* auth.set(input.providerID, {
+          type: "oauth",
+          access,
+          refresh,
+          expires,
+          ...extra,
+        })
+      }
+    })
 
-      return Service.of({ methods, authorize, callback })
-    }),
-  )
+    return Service.of({ methods, authorize, callback })
+  }),
+)
 
-  export const defaultLayer = Layer.suspend(() =>
-    layer.pipe(Layer.provide(Auth.defaultLayer), Layer.provide(Plugin.defaultLayer)),
-  )
+export const defaultLayer = Layer.suspend(() =>
+  layer.pipe(Layer.provide(Auth.defaultLayer), Layer.provide(Plugin.defaultLayer)),
+)
+
+const ProviderAuthServiceValue = Service
+const ProviderAuthLayerValue = layer
+const ProviderAuthDefaultLayerValue = defaultLayer
+const ProviderAuthMethodValue = Method
+const ProviderAuthMethodsValue = Methods
+const ProviderAuthAuthorizationValue = Authorization
+const ProviderAuthAuthorizeInputValue = AuthorizeInput
+const ProviderAuthCallbackInputValue = CallbackInput
+const ProviderAuthOauthMissingValue = OauthMissing
+const ProviderAuthOauthCodeMissingValue = OauthCodeMissing
+const ProviderAuthOauthCallbackFailedValue = OauthCallbackFailed
+const ProviderAuthValidationFailedValue = ValidationFailed
+
+export namespace ProviderAuth {
+  export type Interface = import("./auth").Interface
+  export type Service = import("./auth").Service
+  export type Method = import("./auth").Method
+  export type Methods = import("./auth").Methods
+  export type Authorization = import("./auth").Authorization
+  export type AuthorizeInput = import("./auth").AuthorizeInput
+  export type CallbackInput = import("./auth").CallbackInput
+  export type Error = import("./auth").Error
+  export const Method = ProviderAuthMethodValue.zod
+  export const Methods = ProviderAuthMethodsValue.zod
+  export const Authorization = ProviderAuthAuthorizationValue.zod
+  export const AuthorizeInput = ProviderAuthAuthorizeInputValue.zod
+  export const CallbackInput = ProviderAuthCallbackInputValue.zod
+  export const OauthMissing = ProviderAuthOauthMissingValue
+  export const OauthCodeMissing = ProviderAuthOauthCodeMissingValue
+  export const OauthCallbackFailed = ProviderAuthOauthCallbackFailedValue
+  export const ValidationFailed = ProviderAuthValidationFailedValue
+  export const Service = ProviderAuthServiceValue
+  export const layer = ProviderAuthLayerValue
+  export const defaultLayer = ProviderAuthDefaultLayerValue
 }

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -3,195 +3,202 @@ import { STATUS_CODES } from "http"
 import { iife } from "@/util/iife"
 import type { ProviderID } from "./schema"
 
-export namespace ProviderError {
-  // Adapted from overflow detection patterns in:
-  // https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
-  const OVERFLOW_PATTERNS = [
-    /prompt is too long/i, // Anthropic
-    /input is too long for requested model/i, // Amazon Bedrock
-    /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
-    /input token count.*exceeds the maximum/i, // Google (Gemini)
-    /maximum prompt length is \d+/i, // xAI (Grok)
-    /reduce the length of the messages/i, // Groq
-    /maximum context length is \d+ tokens/i, // OpenRouter, DeepSeek, vLLM
-    /exceeds the limit of \d+/i, // GitHub Copilot
-    /exceeds the available context size/i, // llama.cpp server
-    /greater than the context length/i, // LM Studio
-    /context window exceeds limit/i, // MiniMax
-    /exceeded model token limit/i, // Kimi For Coding, Moonshot
-    /context[_ ]length[_ ]exceeded/i, // Generic fallback
-    /request entity too large/i, // HTTP 413
-    /context length is only \d+ tokens/i, // vLLM
-    /input length.*exceeds.*context length/i, // vLLM
-    /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
-    /too large for model with \d+ maximum context length/i, // Mistral
-    /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
-  ]
+// Adapted from overflow detection patterns in:
+// https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
+const OVERFLOW_PATTERNS = [
+  /prompt is too long/i, // Anthropic
+  /input is too long for requested model/i, // Amazon Bedrock
+  /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
+  /input token count.*exceeds the maximum/i, // Google (Gemini)
+  /maximum prompt length is \d+/i, // xAI (Grok)
+  /reduce the length of the messages/i, // Groq
+  /maximum context length is \d+ tokens/i, // OpenRouter, DeepSeek, vLLM
+  /exceeds the limit of \d+/i, // GitHub Copilot
+  /exceeds the available context size/i, // llama.cpp server
+  /greater than the context length/i, // LM Studio
+  /context window exceeds limit/i, // MiniMax
+  /exceeded model token limit/i, // Kimi For Coding, Moonshot
+  /context[_ ]length[_ ]exceeded/i, // Generic fallback
+  /request entity too large/i, // HTTP 413
+  /context length is only \d+ tokens/i, // vLLM
+  /input length.*exceeds.*context length/i, // vLLM
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+]
 
-  function isOpenAiErrorRetryable(e: APICallError) {
-    const status = e.statusCode
-    if (!status) return e.isRetryable
-    // openai sometimes returns 404 for models that are actually available
-    return status === 404 || e.isRetryable
-  }
+function isOpenAiErrorRetryable(e: APICallError) {
+  const status = e.statusCode
+  if (!status) return e.isRetryable
+  // openai sometimes returns 404 for models that are actually available
+  return status === 404 || e.isRetryable
+}
 
-  // Providers not reliably handled in this function:
-  // - z.ai: can accept overflow silently (needs token-count/context-window checks)
-  function isOverflow(message: string) {
-    if (OVERFLOW_PATTERNS.some((p) => p.test(message))) return true
+// Providers not reliably handled in this function:
+// - z.ai: can accept overflow silently (needs token-count/context-window checks)
+function isOverflow(message: string) {
+  if (OVERFLOW_PATTERNS.some((p) => p.test(message))) return true
 
-    // Providers/status patterns handled outside of regex list:
-    // - Cerebras: often returns "400 (no body)" / "413 (no body)"
-    // - Mistral: often returns "400 (no body)" / "413 (no body)"
-    return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
-  }
+  // Providers/status patterns handled outside of regex list:
+  // - Cerebras: often returns "400 (no body)" / "413 (no body)"
+  // - Mistral: often returns "400 (no body)" / "413 (no body)"
+  return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
+}
 
-  function message(providerID: ProviderID, e: APICallError) {
-    return iife(() => {
-      const msg = e.message
-      if (msg === "") {
-        if (e.responseBody) return e.responseBody
-        if (e.statusCode) {
-          const err = STATUS_CODES[e.statusCode]
-          if (err) return err
-        }
-        return "Unknown error"
+function message(providerID: ProviderID, e: APICallError) {
+  return iife(() => {
+    const msg = e.message
+    if (msg === "") {
+      if (e.responseBody) return e.responseBody
+      if (e.statusCode) {
+        const err = STATUS_CODES[e.statusCode]
+        if (err) return err
       }
-
-      if (!e.responseBody || (e.statusCode && msg !== STATUS_CODES[e.statusCode])) {
-        return msg
-      }
-
-      try {
-        const body = JSON.parse(e.responseBody)
-        // try to extract common error message fields
-        const errMsg = body.message || body.error || body.error?.message
-        if (errMsg && typeof errMsg === "string") {
-          return `${msg}: ${errMsg}`
-        }
-      } catch {}
-
-      // If responseBody is HTML (e.g. from a gateway or proxy error page),
-      // provide a human-readable message instead of dumping raw markup
-      if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) {
-        if (e.statusCode === 401) {
-          return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
-        }
-        if (e.statusCode === 403) {
-          return "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings."
-        }
-        return msg
-      }
-
-      return `${msg}: ${e.responseBody}`
-    }).trim()
-  }
-
-  function json(input: unknown) {
-    if (typeof input === "string") {
-      try {
-        const result = JSON.parse(input)
-        if (result && typeof result === "object") return result
-        return undefined
-      } catch {
-        return undefined
-      }
+      return "Unknown error"
     }
-    if (typeof input === "object" && input !== null) {
-      return input
+
+    if (!e.responseBody || (e.statusCode && msg !== STATUS_CODES[e.statusCode])) {
+      return msg
     }
-    return undefined
-  }
 
-  export type ParsedStreamError =
-    | {
-        type: "context_overflow"
-        message: string
-        responseBody: string
+    try {
+      const body = JSON.parse(e.responseBody)
+      // try to extract common error message fields
+      const errMsg = body.message || body.error || body.error?.message
+      if (errMsg && typeof errMsg === "string") {
+        return `${msg}: ${errMsg}`
       }
-    | {
-        type: "api_error"
-        message: string
-        isRetryable: false
-        responseBody: string
+    } catch {}
+
+    // If responseBody is HTML (e.g. from a gateway or proxy error page),
+    // provide a human-readable message instead of dumping raw markup
+    if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) {
+      if (e.statusCode === 401) {
+        return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
       }
+      if (e.statusCode === 403) {
+        return "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings."
+      }
+      return msg
+    }
 
-  export function parseStreamError(input: unknown): ParsedStreamError | undefined {
-    const body = json(input)
-    if (!body) return
+    return `${msg}: ${e.responseBody}`
+  }).trim()
+}
 
-    const responseBody = JSON.stringify(body)
-    if (body.type !== "error") return
-
-    switch (body?.error?.code) {
-      case "context_length_exceeded":
-        return {
-          type: "context_overflow",
-          message: "Input exceeds context window of this model",
-          responseBody,
-        }
-      case "insufficient_quota":
-        return {
-          type: "api_error",
-          message: "Quota exceeded. Check your plan and billing details.",
-          isRetryable: false,
-          responseBody,
-        }
-      case "usage_not_included":
-        return {
-          type: "api_error",
-          message: "To use Codex with your ChatGPT plan, upgrade to Plus: https://chatgpt.com/explore/plus.",
-          isRetryable: false,
-          responseBody,
-        }
-      case "invalid_prompt":
-        return {
-          type: "api_error",
-          message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
-          isRetryable: false,
-          responseBody,
-        }
+function json(input: unknown) {
+  if (typeof input === "string") {
+    try {
+      const result = JSON.parse(input)
+      if (result && typeof result === "object") return result
+      return undefined
+    } catch {
+      return undefined
     }
   }
+  if (typeof input === "object" && input !== null) {
+    return input
+  }
+  return undefined
+}
 
-  export type ParsedAPICallError =
-    | {
-        type: "context_overflow"
-        message: string
-        responseBody?: string
-      }
-    | {
-        type: "api_error"
-        message: string
-        statusCode?: number
-        isRetryable: boolean
-        responseHeaders?: Record<string, string>
-        responseBody?: string
-        metadata?: Record<string, string>
-      }
+export type ParsedStreamError =
+  | {
+      type: "context_overflow"
+      message: string
+      responseBody: string
+    }
+  | {
+      type: "api_error"
+      message: string
+      isRetryable: false
+      responseBody: string
+    }
 
-  export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
-    const m = message(input.providerID, input.error)
-    const body = json(input.error.responseBody)
-    if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
+export function parseStreamError(input: unknown): ParsedStreamError | undefined {
+  const body = json(input)
+  if (!body) return
+
+  const responseBody = JSON.stringify(body)
+  if (body.type !== "error") return
+
+  switch (body?.error?.code) {
+    case "context_length_exceeded":
       return {
         type: "context_overflow",
-        message: m,
-        responseBody: input.error.responseBody,
+        message: "Input exceeds context window of this model",
+        responseBody,
       }
+    case "insufficient_quota":
+      return {
+        type: "api_error",
+        message: "Quota exceeded. Check your plan and billing details.",
+        isRetryable: false,
+        responseBody,
+      }
+    case "usage_not_included":
+      return {
+        type: "api_error",
+        message: "To use Codex with your ChatGPT plan, upgrade to Plus: https://chatgpt.com/explore/plus.",
+        isRetryable: false,
+        responseBody,
+      }
+    case "invalid_prompt":
+      return {
+        type: "api_error",
+        message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
+        isRetryable: false,
+        responseBody,
+      }
+  }
+}
+
+export type ParsedAPICallError =
+  | {
+      type: "context_overflow"
+      message: string
+      responseBody?: string
+    }
+  | {
+      type: "api_error"
+      message: string
+      statusCode?: number
+      isRetryable: boolean
+      responseHeaders?: Record<string, string>
+      responseBody?: string
+      metadata?: Record<string, string>
     }
 
-    const metadata = input.error.url ? { url: input.error.url } : undefined
+export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
+  const m = message(input.providerID, input.error)
+  const body = json(input.error.responseBody)
+  if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
     return {
-      type: "api_error",
+      type: "context_overflow",
       message: m,
-      statusCode: input.error.statusCode,
-      isRetryable: input.providerID.startsWith("openai")
-        ? isOpenAiErrorRetryable(input.error)
-        : input.error.isRetryable,
-      responseHeaders: input.error.responseHeaders,
       responseBody: input.error.responseBody,
-      metadata,
     }
   }
+
+  const metadata = input.error.url ? { url: input.error.url } : undefined
+  return {
+    type: "api_error",
+    message: m,
+    statusCode: input.error.statusCode,
+    isRetryable: input.providerID.startsWith("openai") ? isOpenAiErrorRetryable(input.error) : input.error.isRetryable,
+    responseHeaders: input.error.responseHeaders,
+    responseBody: input.error.responseBody,
+    metadata,
+  }
+}
+
+const ProviderErrorParseStreamErrorValue = parseStreamError
+const ProviderErrorParseAPICallErrorValue = parseAPICallError
+
+export namespace ProviderError {
+  export type ParsedStreamError = import("./error").ParsedStreamError
+  export type ParsedAPICallError = import("./error").ParsedAPICallError
+
+  export const parseStreamError = ProviderErrorParseStreamErrorValue
+  export const parseAPICallError = ProviderErrorParseAPICallErrorValue
 }

--- a/packages/opencode/src/provider/index.ts
+++ b/packages/opencode/src/provider/index.ts
@@ -1,1 +1,5 @@
-export { Provider } from "./provider"
+export * as Provider from "./provider"
+export * as ProviderAuth from "./auth"
+export * as ProviderError from "./error"
+export * as ModelsDev from "./models"
+export * as ProviderTransform from "./transform"

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -1,181 +1,196 @@
 import { Global } from "../global"
-import { Log } from "../util/log"
+import { Log } from "../util"
 import path from "path"
 import z from "zod"
 import { Installation } from "../installation"
 import { Flag } from "../flag/flag"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
-import { Flock } from "@/util/flock"
-import { Hash } from "@/util/hash"
+import { Flock } from "../util/flock"
+import { Hash } from "../util/hash"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
 /* @ts-ignore */
 
-export namespace ModelsDev {
-  const log = Log.create({ service: "models.dev" })
-  const source = url()
-  const filepath = path.join(
-    Global.Path.cache,
-    source === "https://models.dev" ? "models.json" : `models-${Hash.fast(source)}.json`,
-  )
-  const ttl = 5 * 60 * 1000
+const log = Log.create({ service: "models.dev" })
+const source = url()
+const filepath = path.join(
+  Global.Path.cache,
+  source === "https://models.dev" ? "models.json" : `models-${Hash.fast(source)}.json`,
+)
+const ttl = 5 * 60 * 1000
 
-  type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[]
+type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[]
 
-  const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
-    z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(JsonValue), z.record(z.string(), JsonValue)]),
-  )
+const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(JsonValue), z.record(z.string(), JsonValue)]),
+)
 
-  const Cost = z.object({
-    input: z.number(),
-    output: z.number(),
-    cache_read: z.number().optional(),
-    cache_write: z.number().optional(),
-    context_over_200k: z
-      .object({
-        input: z.number(),
-        output: z.number(),
-        cache_read: z.number().optional(),
-        cache_write: z.number().optional(),
-      })
-      .optional(),
-  })
-
-  export const Model = z.object({
-    id: z.string(),
-    name: z.string(),
-    family: z.string().optional(),
-    release_date: z.string(),
-    attachment: z.boolean(),
-    reasoning: z.boolean(),
-    temperature: z.boolean(),
-    tool_call: z.boolean(),
-    interleaved: z
-      .union([
-        z.literal(true),
-        z
-          .object({
-            field: z.enum(["reasoning_content", "reasoning_details"]),
-          })
-          .strict(),
-      ])
-      .optional(),
-    cost: Cost.optional(),
-    limit: z.object({
-      context: z.number(),
-      input: z.number().optional(),
+const Cost = z.object({
+  input: z.number(),
+  output: z.number(),
+  cache_read: z.number().optional(),
+  cache_write: z.number().optional(),
+  context_over_200k: z
+    .object({
+      input: z.number(),
       output: z.number(),
-    }),
-    modalities: z
-      .object({
-        input: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
-        output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
-      })
-      .optional(),
-    experimental: z
-      .object({
-        modes: z
-          .record(
-            z.string(),
-            z.object({
-              cost: Cost.optional(),
-              provider: z
-                .object({
-                  body: z.record(z.string(), JsonValue).optional(),
-                  headers: z.record(z.string(), z.string()).optional(),
-                })
-                .optional(),
-            }),
-          )
-          .optional(),
-      })
-      .optional(),
-    status: z.enum(["alpha", "beta", "deprecated"]).optional(),
-    provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
-  })
-  export type Model = z.infer<typeof Model>
-
-  export const Provider = z.object({
-    api: z.string().optional(),
-    name: z.string(),
-    env: z.array(z.string()),
-    id: z.string(),
-    npm: z.string().optional(),
-    models: z.record(z.string(), Model),
-  })
-
-  export type Provider = z.infer<typeof Provider>
-
-  function url() {
-    return Flag.OPENCODE_MODELS_URL || "https://models.dev"
-  }
-
-  function fresh() {
-    return Date.now() - Number(Filesystem.stat(filepath)?.mtimeMs ?? 0) < ttl
-  }
-
-  function skip(force: boolean) {
-    return !force && fresh()
-  }
-
-  const fetchApi = async () => {
-    const result = await fetch(`${url()}/api.json`, {
-      headers: { "User-Agent": Installation.USER_AGENT },
-      signal: AbortSignal.timeout(10000),
+      cache_read: z.number().optional(),
+      cache_write: z.number().optional(),
     })
-    return { ok: result.ok, text: await result.text() }
-  }
+    .optional(),
+})
 
-  export const Data = lazy(async () => {
+export const Model = z.object({
+  id: z.string(),
+  name: z.string(),
+  family: z.string().optional(),
+  release_date: z.string(),
+  attachment: z.boolean(),
+  reasoning: z.boolean(),
+  temperature: z.boolean(),
+  tool_call: z.boolean(),
+  interleaved: z
+    .union([
+      z.literal(true),
+      z
+        .object({
+          field: z.enum(["reasoning_content", "reasoning_details"]),
+        })
+        .strict(),
+    ])
+    .optional(),
+  cost: Cost.optional(),
+  limit: z.object({
+    context: z.number(),
+    input: z.number().optional(),
+    output: z.number(),
+  }),
+  modalities: z
+    .object({
+      input: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+      output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+    })
+    .optional(),
+  experimental: z
+    .object({
+      modes: z
+        .record(
+          z.string(),
+          z.object({
+            cost: Cost.optional(),
+            provider: z
+              .object({
+                body: z.record(z.string(), JsonValue).optional(),
+                headers: z.record(z.string(), z.string()).optional(),
+              })
+              .optional(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+  status: z.enum(["alpha", "beta", "deprecated"]).optional(),
+  provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
+})
+export type Model = z.infer<typeof Model>
+
+export const Provider = z.object({
+  api: z.string().optional(),
+  name: z.string(),
+  env: z.array(z.string()),
+  id: z.string(),
+  npm: z.string().optional(),
+  models: z.record(z.string(), Model),
+})
+
+export type Provider = z.infer<typeof Provider>
+
+function url() {
+  return Flag.OPENCODE_MODELS_URL || "https://models.dev"
+}
+
+function fresh() {
+  return Date.now() - Number(Filesystem.stat(filepath)?.mtimeMs ?? 0) < ttl
+}
+
+function skip(force: boolean) {
+  return !force && fresh()
+}
+
+const fetchApi = async () => {
+  const result = await fetch(`${url()}/api.json`, {
+    headers: { "User-Agent": Installation.USER_AGENT },
+    signal: AbortSignal.timeout(10000),
+  })
+  return { ok: result.ok, text: await result.text() }
+}
+
+export const Data = lazy(async () => {
+  const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+  if (result) return result
+  // @ts-ignore
+  const snapshot = await import("./models-snapshot.js")
+    .then((m) => m.snapshot as Record<string, unknown>)
+    .catch(() => undefined)
+  if (snapshot) return snapshot
+  if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
+  return Flock.withLock(`models-dev:${filepath}`, async () => {
     const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
     if (result) return result
-    // @ts-ignore
-    const snapshot = await import("./models-snapshot.js")
-      .then((m) => m.snapshot as Record<string, unknown>)
-      .catch(() => undefined)
-    if (snapshot) return snapshot
-    if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-    return Flock.withLock(`models-dev:${filepath}`, async () => {
-      const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
-      if (result) return result
-      const result2 = await fetchApi()
-      if (result2.ok) {
-        await Filesystem.write(filepath, result2.text).catch((e) => {
-          log.error("Failed to write models cache", { error: e })
-        })
-      }
-      return JSON.parse(result2.text)
+    const result2 = await fetchApi()
+    if (result2.ok) {
+      await Filesystem.write(filepath, result2.text).catch((e) => {
+        log.error("Failed to write models cache", { error: e })
+      })
+    }
+    return JSON.parse(result2.text)
+  })
+})
+
+export async function get() {
+  const result = await Data()
+  return result as Record<string, Provider>
+}
+
+export async function refresh(force = false) {
+  if (skip(force)) return Data.reset()
+  await Flock.withLock(`models-dev:${filepath}`, async () => {
+    if (skip(force)) return Data.reset()
+    const result = await fetchApi()
+    if (!result.ok) return
+    await Filesystem.write(filepath, result.text)
+    Data.reset()
+  }).catch((e) => {
+    log.error("Failed to fetch models.dev", {
+      error: e,
     })
   })
+}
 
-  export async function get() {
-    const result = await Data()
-    return result as Record<string, Provider>
-  }
+const ModelsDevModelValue = Model
+const ModelsDevProviderValue = Provider
+const ModelsDevDataValue = Data
+const ModelsDevGetValue = get
+const ModelsDevRefreshValue = refresh
 
-  export async function refresh(force = false) {
-    if (skip(force)) return ModelsDev.Data.reset()
-    await Flock.withLock(`models-dev:${filepath}`, async () => {
-      if (skip(force)) return ModelsDev.Data.reset()
-      const result = await fetchApi()
-      if (!result.ok) return
-      await Filesystem.write(filepath, result.text)
-      ModelsDev.Data.reset()
-    }).catch((e) => {
-      log.error("Failed to fetch models.dev", {
-        error: e,
-      })
-    })
-  }
+export namespace ModelsDev {
+  export type Model = import("./models").Model
+  export type Provider = import("./models").Provider
+
+  export const Model = ModelsDevModelValue
+  export const Provider = ModelsDevProviderValue
+  export const Data = ModelsDevDataValue
+  export const get = ModelsDevGetValue
+  export const refresh = ModelsDevRefreshValue
 }
 
 if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
-  ModelsDev.refresh()
+  void refresh()
   setInterval(
     async () => {
-      await ModelsDev.refresh()
+      await refresh()
     },
     60 * 1000 * 60,
   ).unref()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -39,6 +39,12 @@ function shouldUseCopilotResponsesApi(modelID: string): boolean {
   return Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")
 }
 
+function e2eLLMURL(envs: Record<string, string | undefined>) {
+  const url = envs.OPENCODE_E2E_LLM_URL
+  if (typeof url !== "string" || url === "") return
+  return url
+}
+
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
   if (!res.body) return res
@@ -89,6 +95,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
 
 type BundledSDK = {
   languageModel(modelId: string): LanguageModelV3
+  chatModel?(modelId: string): LanguageModelV3
 }
 
 const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>> = {
@@ -1544,6 +1551,19 @@ const layer: Layer.Layer<
       if (s.models.has(key)) return s.models.get(key)!
 
       return yield* Effect.promise(async () => {
+        const e2eURL = e2eLLMURL(envs)
+        if (e2eURL && model.providerID === "opencode") {
+          const createOpenAICompatible = await BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"]()
+          const sdk = createOpenAICompatible({
+            name: model.providerID,
+            apiKey: "test-key",
+            baseURL: e2eURL,
+          })
+          const language = sdk.chatModel ? sdk.chatModel(model.api.id) : sdk.languageModel(model.api.id)
+          s.models.set(key, language)
+          return language
+        }
+
         const provider = s.providers[model.providerID]
         const sdk = await resolveSDK(model, s, envs)
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,1737 +1,1799 @@
 import z from "zod"
 import os from "os"
 import fuzzysort from "fuzzysort"
-import { Config } from "../config/config"
+import { Config } from "../config"
 import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
 import { NoSuchModelError, type Provider as SDK } from "ai"
-import { Log } from "../util/log"
+import { Log } from "../util"
 import { Npm } from "../npm"
 import { Hash } from "../util/hash"
 import { Plugin } from "../plugin"
 import { NamedError } from "@opencode-ai/util/error"
 import { type LanguageModelV3 } from "@ai-sdk/provider"
-import { ModelsDev } from "./models"
+import * as ModelsDev from "./models"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { Instance } from "../project/instance"
+import { Installation } from "../installation"
 import { Flag } from "../flag/flag"
+import { zod } from "@/util/effect-zod"
 import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
-import { Filesystem } from "../util/filesystem"
-import { Effect, Layer, Context } from "effect"
-import { EffectLogger } from "@/effect/logger"
-import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
+import { Effect, Layer, Context, Schema, Types } from "effect"
+import { EffectBridge } from "@/effect"
+import { InstanceState } from "@/effect"
+import { AppFileSystem } from "../filesystem"
+import { isRecord } from "@/util/record"
+import { withStatics } from "@/util/schema"
+import { makeRuntime } from "../effect/run-service"
 
-// Direct imports for bundled providers
-import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
-import { createAnthropic } from "@ai-sdk/anthropic"
-import { createAzure } from "@ai-sdk/azure"
-import { createGoogleGenerativeAI } from "@ai-sdk/google"
-import { createVertex } from "@ai-sdk/google-vertex"
-import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
-import { createOpenAI } from "@ai-sdk/openai"
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
-import { createOpenRouter } from "@openrouter/ai-sdk-provider"
-import { createOpenaiCompatible as createGitHubCopilotOpenAICompatible } from "./sdk/copilot"
-import { createXai } from "@ai-sdk/xai"
-import { createMistral } from "@ai-sdk/mistral"
-import { createGroq } from "@ai-sdk/groq"
-import { createDeepInfra } from "@ai-sdk/deepinfra"
-import { createCerebras } from "@ai-sdk/cerebras"
-import { createCohere } from "@ai-sdk/cohere"
-import { createGateway } from "@ai-sdk/gateway"
-import { createTogetherAI } from "@ai-sdk/togetherai"
-import { createPerplexity } from "@ai-sdk/perplexity"
-import { createVercel } from "@ai-sdk/vercel"
-import { createVenice } from "venice-ai-sdk-provider"
-import { createAlibaba } from "@ai-sdk/alibaba"
-import {
-  createGitLab,
-  VERSION as GITLAB_PROVIDER_VERSION,
-  isWorkflowModel,
-  discoverWorkflowModels,
-} from "gitlab-ai-provider"
-import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
-import { GoogleAuth } from "google-auth-library"
-import { ProviderTransform } from "./transform"
-import { Installation } from "../installation"
+import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
 
-export namespace Provider {
-  const log = Log.create({ service: "provider" })
+const log = Log.create({ service: "provider" })
 
-  function shouldUseCopilotResponsesApi(modelID: string): boolean {
-    const match = /^gpt-(\d+)/.exec(modelID)
-    if (!match) return false
-    return Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")
-  }
+function shouldUseCopilotResponsesApi(modelID: string): boolean {
+  const match = /^gpt-(\d+)/.exec(modelID)
+  if (!match) return false
+  return Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")
+}
 
-  function wrapSSE(res: Response, ms: number, ctl: AbortController) {
-    if (typeof ms !== "number" || ms <= 0) return res
-    if (!res.body) return res
-    if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+function wrapSSE(res: Response, ms: number, ctl: AbortController) {
+  if (typeof ms !== "number" || ms <= 0) return res
+  if (!res.body) return res
+  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
 
-    const reader = res.body.getReader()
-    const body = new ReadableStream<Uint8Array>({
-      async pull(ctrl) {
-        const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-          const id = setTimeout(() => {
-            const err = new Error("SSE read timed out")
-            ctl.abort(err)
-            void reader.cancel(err)
+  const reader = res.body.getReader()
+  const body = new ReadableStream<Uint8Array>({
+    async pull(ctrl) {
+      const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
+        const id = setTimeout(() => {
+          const err = new Error("SSE read timed out")
+          ctl.abort(err)
+          void reader.cancel(err)
+          reject(err)
+        }, ms)
+
+        reader.read().then(
+          (part) => {
+            clearTimeout(id)
+            resolve(part)
+          },
+          (err) => {
+            clearTimeout(id)
             reject(err)
-          }, ms)
-
-          reader.read().then(
-            (part) => {
-              clearTimeout(id)
-              resolve(part)
-            },
-            (err) => {
-              clearTimeout(id)
-              reject(err)
-            },
-          )
-        })
-
-        if (part.done) {
-          ctrl.close()
-          return
-        }
-
-        ctrl.enqueue(part.value)
-      },
-      async cancel(reason) {
-        ctl.abort(reason)
-        await reader.cancel(reason)
-      },
-    })
-
-    return new Response(body, {
-      headers: new Headers(res.headers),
-      status: res.status,
-      statusText: res.statusText,
-    })
-  }
-
-  function e2eURL() {
-    const url = Env.get("OPENCODE_E2E_LLM_URL")
-    if (typeof url !== "string" || url === "") return
-    return url
-  }
-
-  type BundledSDK = {
-    languageModel(modelId: string): LanguageModelV3
-  }
-
-  const BUNDLED_PROVIDERS: Record<string, (options: any) => BundledSDK> = {
-    "@ai-sdk/amazon-bedrock": createAmazonBedrock,
-    "@ai-sdk/anthropic": createAnthropic,
-    "@ai-sdk/azure": createAzure,
-    "@ai-sdk/google": createGoogleGenerativeAI,
-    "@ai-sdk/google-vertex": createVertex,
-    "@ai-sdk/google-vertex/anthropic": createVertexAnthropic,
-    "@ai-sdk/openai": createOpenAI,
-    "@ai-sdk/openai-compatible": createOpenAICompatible,
-    "@openrouter/ai-sdk-provider": createOpenRouter,
-    "@ai-sdk/xai": createXai,
-    "@ai-sdk/mistral": createMistral,
-    "@ai-sdk/groq": createGroq,
-    "@ai-sdk/deepinfra": createDeepInfra,
-    "@ai-sdk/cerebras": createCerebras,
-    "@ai-sdk/cohere": createCohere,
-    "@ai-sdk/gateway": createGateway,
-    "@ai-sdk/togetherai": createTogetherAI,
-    "@ai-sdk/perplexity": createPerplexity,
-    "@ai-sdk/vercel": createVercel,
-    "@ai-sdk/alibaba": createAlibaba,
-    "gitlab-ai-provider": createGitLab,
-    "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
-    "venice-ai-sdk-provider": createVenice,
-  }
-
-  type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
-  type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
-  type CustomDiscoverModels = () => Promise<Record<string, Model>>
-  type CustomLoader = (provider: Info) => Effect.Effect<{
-    autoload: boolean
-    getModel?: CustomModelLoader
-    vars?: CustomVarsLoader
-    options?: Record<string, any>
-    discoverModels?: CustomDiscoverModels
-  }>
-
-  type CustomDep = {
-    auth: (id: string) => Effect.Effect<Auth.Info | undefined>
-    config: () => Effect.Effect<Config.Info>
-  }
-
-  function useLanguageModel(sdk: any) {
-    return sdk.responses === undefined && sdk.chat === undefined
-  }
-
-  function custom(dep: CustomDep): Record<string, CustomLoader> {
-    return {
-      anthropic: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
-            },
           },
-        }),
-      opencode: Effect.fnUntraced(function* (input: Info) {
-        const env = Env.all()
-        const hasKey = iife(() => {
-          if (input.env.some((item) => env[item])) return true
-          return false
-        })
-        const ok =
-          hasKey ||
-          Boolean(yield* dep.auth(input.id)) ||
-          Boolean((yield* dep.config()).provider?.["opencode"]?.options?.apiKey)
-
-        if (!ok) {
-          for (const [key, value] of Object.entries(input.models)) {
-            if (value.cost.input === 0) continue
-            delete input.models[key]
-          }
-        }
-
-        return {
-          autoload: Object.keys(input.models).length > 0,
-          options: ok ? {} : { apiKey: "public" },
-        }
-      }),
-      openai: () =>
-        Effect.succeed({
-          autoload: false,
-          async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-            return sdk.responses(modelID)
-          },
-          options: {},
-        }),
-      xai: () =>
-        Effect.succeed({
-          autoload: false,
-          async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-            return sdk.responses(modelID)
-          },
-          options: {},
-        }),
-      "github-copilot": () =>
-        Effect.succeed({
-          autoload: false,
-          async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-            if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-            return shouldUseCopilotResponsesApi(modelID) ? sdk.responses(modelID) : sdk.chat(modelID)
-          },
-          options: {},
-        }),
-      azure: (provider) => {
-        const resource = iife(() => {
-          const name = provider.options?.resourceName
-          if (typeof name === "string" && name.trim() !== "") return name
-          return Env.get("AZURE_RESOURCE_NAME")
-        })
-
-        return Effect.succeed({
-          autoload: false,
-          async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-            if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-            if (options?.["useCompletionUrls"]) {
-              return sdk.chat(modelID)
-            } else {
-              return sdk.responses(modelID)
-            }
-          },
-          options: {},
-          vars(_options) {
-            return {
-              ...(resource && { AZURE_RESOURCE_NAME: resource }),
-            }
-          },
-        })
-      },
-      "azure-cognitive-services": () => {
-        const resourceName = Env.get("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME")
-        return Effect.succeed({
-          autoload: false,
-          async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-            if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-            if (options?.["useCompletionUrls"]) {
-              return sdk.chat(modelID)
-            } else {
-              return sdk.responses(modelID)
-            }
-          },
-          options: {
-            baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,
-          },
-        })
-      },
-      "amazon-bedrock": Effect.fnUntraced(function* () {
-        const providerConfig = (yield* dep.config()).provider?.["amazon-bedrock"]
-        const auth = yield* dep.auth("amazon-bedrock")
-
-        // Region precedence: 1) config file, 2) env var, 3) default
-        const configRegion = providerConfig?.options?.region
-        const envRegion = Env.get("AWS_REGION")
-        const defaultRegion = configRegion ?? envRegion ?? "us-east-1"
-
-        // Profile: config file takes precedence over env var
-        const configProfile = providerConfig?.options?.profile
-        const envProfile = Env.get("AWS_PROFILE")
-        const profile = configProfile ?? envProfile
-
-        const awsAccessKeyId = Env.get("AWS_ACCESS_KEY_ID")
-
-        // TODO: Using process.env directly because Env.set only updates a process.env shallow copy,
-        // until the scope of the Env API is clarified (test only or runtime?)
-        const awsBearerToken = iife(() => {
-          const envToken = process.env.AWS_BEARER_TOKEN_BEDROCK
-          if (envToken) return envToken
-          if (auth?.type === "api") {
-            process.env.AWS_BEARER_TOKEN_BEDROCK = auth.key
-            return auth.key
-          }
-          return undefined
-        })
-
-        const awsWebIdentityTokenFile = Env.get("AWS_WEB_IDENTITY_TOKEN_FILE")
-
-        const containerCreds = Boolean(
-          process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
         )
+      })
 
-        if (!profile && !awsAccessKeyId && !awsBearerToken && !awsWebIdentityTokenFile && !containerCreds)
-          return { autoload: false }
+      if (part.done) {
+        ctrl.close()
+        return
+      }
 
-        const providerOptions: AmazonBedrockProviderSettings = {
-          region: defaultRegion,
+      ctrl.enqueue(part.value)
+    },
+    async cancel(reason) {
+      ctl.abort(reason)
+      await reader.cancel(reason)
+    },
+  })
+
+  return new Response(body, {
+    headers: new Headers(res.headers),
+    status: res.status,
+    statusText: res.statusText,
+  })
+}
+
+type BundledSDK = {
+  languageModel(modelId: string): LanguageModelV3
+}
+
+const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>> = {
+  "@ai-sdk/amazon-bedrock": () => import("@ai-sdk/amazon-bedrock").then((m) => m.createAmazonBedrock),
+  "@ai-sdk/anthropic": () => import("@ai-sdk/anthropic").then((m) => m.createAnthropic),
+  "@ai-sdk/azure": () => import("@ai-sdk/azure").then((m) => m.createAzure),
+  "@ai-sdk/google": () => import("@ai-sdk/google").then((m) => m.createGoogleGenerativeAI),
+  "@ai-sdk/google-vertex": () => import("@ai-sdk/google-vertex").then((m) => m.createVertex),
+  "@ai-sdk/google-vertex/anthropic": () =>
+    import("@ai-sdk/google-vertex/anthropic").then((m) => m.createVertexAnthropic),
+  "@ai-sdk/openai": () => import("@ai-sdk/openai").then((m) => m.createOpenAI),
+  "@ai-sdk/openai-compatible": () => import("@ai-sdk/openai-compatible").then((m) => m.createOpenAICompatible),
+  "@openrouter/ai-sdk-provider": () => import("@openrouter/ai-sdk-provider").then((m) => m.createOpenRouter),
+  "@ai-sdk/xai": () => import("@ai-sdk/xai").then((m) => m.createXai),
+  "@ai-sdk/mistral": () => import("@ai-sdk/mistral").then((m) => m.createMistral),
+  "@ai-sdk/groq": () => import("@ai-sdk/groq").then((m) => m.createGroq),
+  "@ai-sdk/deepinfra": () => import("@ai-sdk/deepinfra").then((m) => m.createDeepInfra),
+  "@ai-sdk/cerebras": () => import("@ai-sdk/cerebras").then((m) => m.createCerebras),
+  "@ai-sdk/cohere": () => import("@ai-sdk/cohere").then((m) => m.createCohere),
+  "@ai-sdk/gateway": () => import("@ai-sdk/gateway").then((m) => m.createGateway),
+  "@ai-sdk/togetherai": () => import("@ai-sdk/togetherai").then((m) => m.createTogetherAI),
+  "@ai-sdk/perplexity": () => import("@ai-sdk/perplexity").then((m) => m.createPerplexity),
+  "@ai-sdk/vercel": () => import("@ai-sdk/vercel").then((m) => m.createVercel),
+  "@ai-sdk/alibaba": () => import("@ai-sdk/alibaba").then((m) => m.createAlibaba),
+  "gitlab-ai-provider": () => import("gitlab-ai-provider").then((m) => m.createGitLab),
+  "@ai-sdk/github-copilot": () => import("./sdk/copilot").then((m) => m.createOpenaiCompatible),
+  "venice-ai-sdk-provider": () => import("venice-ai-sdk-provider").then((m) => m.createVenice),
+}
+
+type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
+type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
+type CustomDiscoverModels = () => Promise<Record<string, Model>>
+type CustomLoader = (provider: Info) => Effect.Effect<{
+  autoload: boolean
+  getModel?: CustomModelLoader
+  vars?: CustomVarsLoader
+  options?: Record<string, any>
+  discoverModels?: CustomDiscoverModels
+}>
+
+type CustomDep = {
+  auth: (id: string) => Effect.Effect<Auth.Info | undefined>
+  config: () => Effect.Effect<Config.Info>
+  env: () => Effect.Effect<Record<string, string | undefined>>
+  get: (key: string) => Effect.Effect<string | undefined>
+}
+
+function useLanguageModel(sdk: any) {
+  return sdk.responses === undefined && sdk.chat === undefined
+}
+
+function custom(dep: CustomDep): Record<string, CustomLoader> {
+  return {
+    anthropic: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+          },
+        },
+      }),
+    opencode: Effect.fnUntraced(function* (input: Info) {
+      const env = yield* dep.env()
+      const hasKey = iife(() => {
+        if (input.env.some((item) => env[item])) return true
+        return false
+      })
+      const ok =
+        hasKey ||
+        Boolean(yield* dep.auth(input.id)) ||
+        Boolean((yield* dep.config()).provider?.["opencode"]?.options?.apiKey)
+
+      if (!ok) {
+        for (const [key, value] of Object.entries(input.models)) {
+          if (value.cost.input === 0) continue
+          delete input.models[key]
         }
+      }
 
-        // Only use credential chain if no bearer token exists
-        // Bearer token takes precedence over credential chain (profiles, access keys, IAM roles, web identity tokens)
-        if (!awsBearerToken) {
-          // Build credential provider options (only pass profile if specified)
-          const credentialProviderOptions = profile ? { profile } : {}
+      return {
+        autoload: Object.keys(input.models).length > 0,
+        options: ok ? {} : { apiKey: "public" },
+      }
+    }),
+    openai: () =>
+      Effect.succeed({
+        autoload: false,
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          return sdk.responses(modelID)
+        },
+        options: {},
+      }),
+    xai: () =>
+      Effect.succeed({
+        autoload: false,
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          return sdk.responses(modelID)
+        },
+        options: {},
+      }),
+    "github-copilot": () =>
+      Effect.succeed({
+        autoload: false,
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          return shouldUseCopilotResponsesApi(modelID) ? sdk.responses(modelID) : sdk.chat(modelID)
+        },
+        options: {},
+      }),
+    azure: Effect.fnUntraced(function* (provider: Info) {
+      const env = yield* dep.env()
+      const resource = iife(() => {
+        const name = provider.options?.resourceName
+        if (typeof name === "string" && name.trim() !== "") return name
+        return env["AZURE_RESOURCE_NAME"]
+      })
 
-          providerOptions.credentialProvider = fromNodeProviderChain(credentialProviderOptions)
+      return {
+        autoload: false,
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          if (options?.["useCompletionUrls"]) {
+            return sdk.chat(modelID)
+          } else {
+            return sdk.responses(modelID)
+          }
+        },
+        options: {},
+        vars(_options) {
+          return {
+            ...(resource && { AZURE_RESOURCE_NAME: resource }),
+          }
+        },
+      }
+    }),
+    "azure-cognitive-services": Effect.fnUntraced(function* () {
+      const resourceName = yield* dep.get("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME")
+      return {
+        autoload: false,
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          if (options?.["useCompletionUrls"]) {
+            return sdk.chat(modelID)
+          } else {
+            return sdk.responses(modelID)
+          }
+        },
+        options: {
+          baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,
+        },
+      }
+    }),
+    "amazon-bedrock": Effect.fnUntraced(function* () {
+      const providerConfig = (yield* dep.config()).provider?.["amazon-bedrock"]
+      const auth = yield* dep.auth("amazon-bedrock")
+      const env = yield* dep.env()
+
+      // Region precedence: 1) config file, 2) env var, 3) default
+      const configRegion = providerConfig?.options?.region
+      const envRegion = env["AWS_REGION"]
+      const defaultRegion = configRegion ?? envRegion ?? "us-east-1"
+
+      // Profile: config file takes precedence over env var
+      const configProfile = providerConfig?.options?.profile
+      const envProfile = env["AWS_PROFILE"]
+      const profile = configProfile ?? envProfile
+
+      const awsAccessKeyId = env["AWS_ACCESS_KEY_ID"]
+
+      // TODO: Using process.env directly because Env.set only updates a process.env shallow copy,
+      // until the scope of the Env API is clarified (test only or runtime?)
+      const awsBearerToken = iife(() => {
+        const envToken = process.env.AWS_BEARER_TOKEN_BEDROCK
+        if (envToken) return envToken
+        if (auth?.type === "api") {
+          process.env.AWS_BEARER_TOKEN_BEDROCK = auth.key
+          return auth.key
         }
+        return undefined
+      })
 
-        // Add custom endpoint if specified (endpoint takes precedence over baseURL)
-        const endpoint = providerConfig?.options?.endpoint ?? providerConfig?.options?.baseURL
-        if (endpoint) {
-          providerOptions.baseURL = endpoint
-        }
+      const awsWebIdentityTokenFile = env["AWS_WEB_IDENTITY_TOKEN_FILE"]
 
-        return {
-          autoload: true,
-          options: providerOptions,
-          async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-            // Skip region prefixing if model already has a cross-region inference profile prefix
-            // Models from models.dev may already include prefixes like us., eu., global., etc.
-            const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
-            if (crossRegionPrefixes.some((prefix) => modelID.startsWith(prefix))) {
-              return sdk.languageModel(modelID)
-            }
+      const containerCreds = Boolean(
+        process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+      )
 
-            // Region resolution precedence (highest to lowest):
-            // 1. options.region from opencode.json provider config
-            // 2. defaultRegion from AWS_REGION environment variable
-            // 3. Default "us-east-1" (baked into defaultRegion)
-            const region = options?.region ?? defaultRegion
+      if (!profile && !awsAccessKeyId && !awsBearerToken && !awsWebIdentityTokenFile && !containerCreds)
+        return { autoload: false }
 
-            let regionPrefix = region.split("-")[0]
+      const { fromNodeProviderChain } = yield* Effect.promise(() => import("@aws-sdk/credential-providers"))
 
-            switch (regionPrefix) {
-              case "us": {
-                const modelRequiresPrefix = [
-                  "nova-micro",
-                  "nova-lite",
-                  "nova-pro",
-                  "nova-premier",
-                  "nova-2",
-                  "claude",
-                  "deepseek",
-                ].some((m) => modelID.includes(m))
-                const isGovCloud = region.startsWith("us-gov")
-                if (modelRequiresPrefix && !isGovCloud) {
-                  modelID = `${regionPrefix}.${modelID}`
-                }
-                break
+      const providerOptions: Record<string, any> = {
+        region: defaultRegion,
+      }
+
+      // Only use credential chain if no bearer token exists
+      // Bearer token takes precedence over credential chain (profiles, access keys, IAM roles, web identity tokens)
+      if (!awsBearerToken) {
+        // Build credential provider options (only pass profile if specified)
+        const credentialProviderOptions = profile ? { profile } : {}
+
+        providerOptions.credentialProvider = fromNodeProviderChain(credentialProviderOptions)
+      }
+
+      // Add custom endpoint if specified (endpoint takes precedence over baseURL)
+      const endpoint = providerConfig?.options?.endpoint ?? providerConfig?.options?.baseURL
+      if (endpoint) {
+        providerOptions.baseURL = endpoint
+      }
+
+      return {
+        autoload: true,
+        options: providerOptions,
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          // Skip region prefixing if model already has a cross-region inference profile prefix
+          // Models from models.dev may already include prefixes like us., eu., global., etc.
+          const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
+          if (crossRegionPrefixes.some((prefix) => modelID.startsWith(prefix))) {
+            return sdk.languageModel(modelID)
+          }
+
+          // Region resolution precedence (highest to lowest):
+          // 1. options.region from opencode.json provider config
+          // 2. defaultRegion from AWS_REGION environment variable
+          // 3. Default "us-east-1" (baked into defaultRegion)
+          const region = options?.region ?? defaultRegion
+
+          let regionPrefix = region.split("-")[0]
+
+          switch (regionPrefix) {
+            case "us": {
+              const modelRequiresPrefix = [
+                "nova-micro",
+                "nova-lite",
+                "nova-pro",
+                "nova-premier",
+                "nova-2",
+                "claude",
+                "deepseek",
+              ].some((m) => modelID.includes(m))
+              const isGovCloud = region.startsWith("us-gov")
+              if (modelRequiresPrefix && !isGovCloud) {
+                modelID = `${regionPrefix}.${modelID}`
               }
-              case "eu": {
-                const regionRequiresPrefix = [
-                  "eu-west-1",
-                  "eu-west-2",
-                  "eu-west-3",
-                  "eu-north-1",
-                  "eu-central-1",
-                  "eu-south-1",
-                  "eu-south-2",
-                ].some((r) => region.includes(r))
-                const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "llama3", "pixtral"].some((m) =>
+              break
+            }
+            case "eu": {
+              const regionRequiresPrefix = [
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "eu-north-1",
+                "eu-central-1",
+                "eu-south-1",
+                "eu-south-2",
+              ].some((r) => region.includes(r))
+              const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "llama3", "pixtral"].some((m) =>
+                modelID.includes(m),
+              )
+              if (regionRequiresPrefix && modelRequiresPrefix) {
+                modelID = `${regionPrefix}.${modelID}`
+              }
+              break
+            }
+            case "ap": {
+              const isAustraliaRegion = ["ap-southeast-2", "ap-southeast-4"].includes(region)
+              const isTokyoRegion = region === "ap-northeast-1"
+              if (
+                isAustraliaRegion &&
+                ["anthropic.claude-sonnet-4-5", "anthropic.claude-haiku"].some((m) => modelID.includes(m))
+              ) {
+                regionPrefix = "au"
+                modelID = `${regionPrefix}.${modelID}`
+              } else if (isTokyoRegion) {
+                // Tokyo region uses jp. prefix for cross-region inference
+                const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
                   modelID.includes(m),
                 )
-                if (regionRequiresPrefix && modelRequiresPrefix) {
+                if (modelRequiresPrefix) {
+                  regionPrefix = "jp"
                   modelID = `${regionPrefix}.${modelID}`
                 }
-                break
-              }
-              case "ap": {
-                const isAustraliaRegion = ["ap-southeast-2", "ap-southeast-4"].includes(region)
-                const isTokyoRegion = region === "ap-northeast-1"
-                if (
-                  isAustraliaRegion &&
-                  ["anthropic.claude-sonnet-4-5", "anthropic.claude-haiku"].some((m) => modelID.includes(m))
-                ) {
-                  regionPrefix = "au"
+              } else {
+                // Other APAC regions use apac. prefix
+                const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
+                  modelID.includes(m),
+                )
+                if (modelRequiresPrefix) {
+                  regionPrefix = "apac"
                   modelID = `${regionPrefix}.${modelID}`
-                } else if (isTokyoRegion) {
-                  // Tokyo region uses jp. prefix for cross-region inference
-                  const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
-                    modelID.includes(m),
-                  )
-                  if (modelRequiresPrefix) {
-                    regionPrefix = "jp"
-                    modelID = `${regionPrefix}.${modelID}`
-                  }
-                } else {
-                  // Other APAC regions use apac. prefix
-                  const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
-                    modelID.includes(m),
-                  )
-                  if (modelRequiresPrefix) {
-                    regionPrefix = "apac"
-                    modelID = `${regionPrefix}.${modelID}`
-                  }
                 }
-                break
               }
+              break
             }
-
-            return sdk.languageModel(modelID)
-          },
-        }
-      }),
-      openrouter: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "HTTP-Referer": "https://opencode.ai/",
-              "X-Title": "opencode",
-            },
-          },
-        }),
-      vercel: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "http-referer": "https://opencode.ai/",
-              "x-title": "opencode",
-            },
-          },
-        }),
-      "google-vertex": (provider) => {
-        const project =
-          provider.options?.project ??
-          Env.get("GOOGLE_CLOUD_PROJECT") ??
-          Env.get("GCP_PROJECT") ??
-          Env.get("GCLOUD_PROJECT")
-
-        const location = String(
-          provider.options?.location ??
-            Env.get("GOOGLE_VERTEX_LOCATION") ??
-            Env.get("GOOGLE_CLOUD_LOCATION") ??
-            Env.get("VERTEX_LOCATION") ??
-            "us-central1",
-        )
-
-        const autoload = Boolean(project)
-        if (!autoload) return Effect.succeed({ autoload: false })
-        return Effect.succeed({
-          autoload: true,
-          vars(_options: Record<string, any>) {
-            const endpoint =
-              location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
-            return {
-              ...(project && { GOOGLE_VERTEX_PROJECT: project }),
-              GOOGLE_VERTEX_LOCATION: location,
-              GOOGLE_VERTEX_ENDPOINT: endpoint,
-            }
-          },
-          options: {
-            project,
-            location,
-            fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-              const auth = new GoogleAuth()
-              const client = await auth.getApplicationDefault()
-              const token = await client.credential.getAccessToken()
-
-              const headers = new Headers(init?.headers)
-              headers.set("Authorization", `Bearer ${token.token}`)
-
-              return fetch(input, { ...init, headers })
-            },
-          },
-          async getModel(sdk: any, modelID: string) {
-            const id = String(modelID).trim()
-            return sdk.languageModel(id)
-          },
-        })
-      },
-      "google-vertex-anthropic": () => {
-        const project = Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
-        const location = Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "global"
-        const autoload = Boolean(project)
-        if (!autoload) return Effect.succeed({ autoload: false })
-        return Effect.succeed({
-          autoload: true,
-          options: {
-            project,
-            location,
-          },
-          async getModel(sdk: any, modelID) {
-            const id = String(modelID).trim()
-            return sdk.languageModel(id)
-          },
-        })
-      },
-      "sap-ai-core": Effect.fnUntraced(function* () {
-        const auth = yield* dep.auth("sap-ai-core")
-        // TODO: Using process.env directly because Env.set only updates a shallow copy (not process.env),
-        // until the scope of the Env API is clarified (test only or runtime?)
-        const envServiceKey = iife(() => {
-          const envAICoreServiceKey = process.env.AICORE_SERVICE_KEY
-          if (envAICoreServiceKey) return envAICoreServiceKey
-          if (auth?.type === "api") {
-            process.env.AICORE_SERVICE_KEY = auth.key
-            return auth.key
           }
-          return undefined
-        })
-        const deploymentId = process.env.AICORE_DEPLOYMENT_ID
-        const resourceGroup = process.env.AICORE_RESOURCE_GROUP
 
-        return {
-          autoload: !!envServiceKey,
-          options: envServiceKey ? { deploymentId, resourceGroup } : {},
-          async getModel(sdk: any, modelID: string) {
-            return sdk(modelID)
+          return sdk.languageModel(modelID)
+        },
+      }
+    }),
+    llmgateway: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
+            "X-Source": "opencode",
           },
-        }
+        },
       }),
-      zenmux: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "HTTP-Referer": "https://opencode.ai/",
-              "X-Title": "opencode",
-            },
+    openrouter: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
           },
-        }),
-      gitlab: Effect.fnUntraced(function* (input: Info) {
-        const instanceUrl = Env.get("GITLAB_INSTANCE_URL") || "https://gitlab.com"
+        },
+      }),
+    vercel: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "http-referer": "https://opencode.ai/",
+            "x-title": "opencode",
+          },
+        },
+      }),
+    "google-vertex": Effect.fnUntraced(function* (provider: Info) {
+      const env = yield* dep.env()
+      const project =
+        provider.options?.project ?? env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
 
-        const auth = yield* dep.auth(input.id)
-        const apiKey = yield* Effect.sync(() => {
-          if (auth?.type === "oauth") return auth.access
-          if (auth?.type === "api") return auth.key
-          return Env.get("GITLAB_TOKEN")
-        })
+      const location = String(
+        provider.options?.location ??
+          env["GOOGLE_VERTEX_LOCATION"] ??
+          env["GOOGLE_CLOUD_LOCATION"] ??
+          env["VERTEX_LOCATION"] ??
+          "us-central1",
+      )
 
-        const providerConfig = (yield* dep.config()).provider?.["gitlab"]
+      const autoload = Boolean(project)
+      if (!autoload) return { autoload: false }
+      return {
+        autoload: true,
+        vars(_options: Record<string, any>) {
+          const endpoint = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
+          return {
+            ...(project && { GOOGLE_VERTEX_PROJECT: project }),
+            GOOGLE_VERTEX_LOCATION: location,
+            GOOGLE_VERTEX_ENDPOINT: endpoint,
+          }
+        },
+        options: {
+          project,
+          location,
+          fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+            const { GoogleAuth } = await import("google-auth-library")
+            const auth = new GoogleAuth()
+            const client = await auth.getApplicationDefault()
+            const token = await client.credential.getAccessToken()
 
-        const aiGatewayHeaders = {
-          "User-Agent": `opencode/${Installation.VERSION} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
-          "anthropic-beta": "context-1m-2025-08-07",
-          ...(providerConfig?.options?.aiGatewayHeaders || {}),
+            const headers = new Headers(init?.headers)
+            headers.set("Authorization", `Bearer ${token.token}`)
+
+            return fetch(input, { ...init, headers })
+          },
+        },
+        async getModel(sdk: any, modelID: string) {
+          const id = String(modelID).trim()
+          return sdk.languageModel(id)
+        },
+      }
+    }),
+    "google-vertex-anthropic": Effect.fnUntraced(function* () {
+      const env = yield* dep.env()
+      const project = env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
+      const location = env["GOOGLE_CLOUD_LOCATION"] ?? env["VERTEX_LOCATION"] ?? "global"
+      const autoload = Boolean(project)
+      if (!autoload) return { autoload: false }
+      return {
+        autoload: true,
+        options: {
+          project,
+          location,
+        },
+        async getModel(sdk: any, modelID) {
+          const id = String(modelID).trim()
+          return sdk.languageModel(id)
+        },
+      }
+    }),
+    "sap-ai-core": Effect.fnUntraced(function* () {
+      const auth = yield* dep.auth("sap-ai-core")
+      // TODO: Using process.env directly because Env.set only updates a shallow copy (not process.env),
+      // until the scope of the Env API is clarified (test only or runtime?)
+      const envServiceKey = iife(() => {
+        const envAICoreServiceKey = process.env.AICORE_SERVICE_KEY
+        if (envAICoreServiceKey) return envAICoreServiceKey
+        if (auth?.type === "api") {
+          process.env.AICORE_SERVICE_KEY = auth.key
+          return auth.key
         }
+        return undefined
+      })
+      const deploymentId = process.env.AICORE_DEPLOYMENT_ID
+      const resourceGroup = process.env.AICORE_RESOURCE_GROUP
 
-        const featureFlags = {
-          duo_agent_platform_agentic_chat: true,
-          duo_agent_platform: true,
-          ...(providerConfig?.options?.featureFlags || {}),
-        }
+      return {
+        autoload: !!envServiceKey,
+        options: envServiceKey ? { deploymentId, resourceGroup } : {},
+        async getModel(sdk: any, modelID: string) {
+          return sdk(modelID)
+        },
+      }
+    }),
+    zenmux: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
+          },
+        },
+      }),
+    gitlab: Effect.fnUntraced(function* (input: Info) {
+      const {
+        VERSION: GITLAB_PROVIDER_VERSION,
+        isWorkflowModel,
+        discoverWorkflowModels,
+      } = yield* Effect.promise(() => import("gitlab-ai-provider"))
 
-        return {
-          autoload: !!apiKey,
-          options: {
-            instanceUrl,
-            apiKey,
+      const instanceUrl = (yield* dep.get("GITLAB_INSTANCE_URL")) || "https://gitlab.com"
+
+      const auth = yield* dep.auth(input.id)
+      const apiKey = yield* Effect.sync(() => {
+        if (auth?.type === "oauth") return auth.access
+        if (auth?.type === "api") return auth.key
+        return undefined
+      })
+      const token = apiKey ?? (yield* dep.get("GITLAB_TOKEN"))
+
+      const providerConfig = (yield* dep.config()).provider?.["gitlab"]
+
+      const aiGatewayHeaders = {
+        "User-Agent": `opencode/${Installation.VERSION} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
+        "anthropic-beta": "context-1m-2025-08-07",
+        ...providerConfig?.options?.aiGatewayHeaders,
+      }
+
+      const featureFlags = {
+        duo_agent_platform_agentic_chat: true,
+        duo_agent_platform: true,
+        ...providerConfig?.options?.featureFlags,
+      }
+
+      return {
+        autoload: !!token,
+        options: {
+          instanceUrl,
+          apiKey: token,
+          aiGatewayHeaders,
+          featureFlags,
+        },
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (modelID.startsWith("duo-workflow-")) {
+            const workflowRef = typeof options?.workflowRef === "string" ? options.workflowRef : undefined
+            // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
+            const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
+            const workflowDefinition =
+              typeof options?.workflowDefinition === "string" ? options.workflowDefinition : undefined
+            const model = sdk.workflowChat(sdkModelID, {
+              featureFlags,
+              workflowDefinition,
+            })
+            if (workflowRef) {
+              model.selectedModelRef = workflowRef
+            }
+            return model
+          }
+          return sdk.agenticChat(modelID, {
             aiGatewayHeaders,
             featureFlags,
-          },
-          async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string, options?: Record<string, any>) {
-            if (modelID.startsWith("duo-workflow-")) {
-              const workflowRef = options?.workflowRef as string | undefined
-              // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
-              const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
-              const model = sdk.workflowChat(sdkModelID, {
-                featureFlags,
-                workflowDefinition: options?.workflowDefinition as string | undefined,
+          })
+        },
+        async discoverModels(): Promise<Record<string, Model>> {
+          if (!apiKey) {
+            log.info("gitlab model discovery skipped: no apiKey")
+            return {}
+          }
+
+          try {
+            const token = apiKey
+            const getHeaders = (): Record<string, string> =>
+              auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
+
+            log.info("gitlab model discovery starting", { instanceUrl })
+            const result = await discoverWorkflowModels(
+              { instanceUrl, getHeaders },
+              { workingDirectory: Instance.directory },
+            )
+
+            if (!result.models.length) {
+              log.info("gitlab model discovery skipped: no models found", {
+                project: result.project
+                  ? {
+                      id: result.project.id,
+                      path: result.project.pathWithNamespace,
+                    }
+                  : null,
               })
-              if (workflowRef) {
-                model.selectedModelRef = workflowRef
-              }
-              return model
-            }
-            return sdk.agenticChat(modelID, {
-              aiGatewayHeaders,
-              featureFlags,
-            })
-          },
-          async discoverModels(): Promise<Record<string, Model>> {
-            if (!apiKey) {
-              log.info("gitlab model discovery skipped: no apiKey")
               return {}
             }
 
-            try {
-              const token = apiKey
-              const getHeaders = (): Record<string, string> =>
-                auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
-
-              log.info("gitlab model discovery starting", { instanceUrl })
-              const result = await discoverWorkflowModels(
-                { instanceUrl, getHeaders },
-                { workingDirectory: Instance.directory },
-              )
-
-              if (!result.models.length) {
-                log.info("gitlab model discovery skipped: no models found", {
-                  project: result.project
-                    ? {
-                        id: result.project.id,
-                        path: result.project.pathWithNamespace,
-                      }
-                    : null,
-                })
-                return {}
-              }
-
-              const models: Record<string, Model> = {}
-              for (const m of result.models) {
-                if (!input.models[m.id]) {
-                  models[m.id] = {
-                    id: ModelID.make(m.id),
-                    providerID: ProviderID.make("gitlab"),
-                    name: `Agent Platform (${m.name})`,
-                    family: "",
-                    api: {
-                      id: m.id,
-                      url: instanceUrl,
-                      npm: "gitlab-ai-provider",
+            const models: Record<string, Model> = {}
+            for (const m of result.models) {
+              if (!input.models[m.id]) {
+                models[m.id] = {
+                  id: ModelID.make(m.id),
+                  providerID: ProviderID.make("gitlab"),
+                  name: `Agent Platform (${m.name})`,
+                  family: "",
+                  api: {
+                    id: m.id,
+                    url: instanceUrl,
+                    npm: "gitlab-ai-provider",
+                  },
+                  status: "active",
+                  headers: {},
+                  options: { workflowRef: m.ref },
+                  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+                  limit: { context: m.context, output: m.output },
+                  capabilities: {
+                    temperature: false,
+                    reasoning: true,
+                    attachment: true,
+                    toolcall: true,
+                    input: {
+                      text: true,
+                      audio: false,
+                      image: true,
+                      video: false,
+                      pdf: true,
                     },
-                    status: "active",
-                    headers: {},
-                    options: { workflowRef: m.ref },
-                    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-                    limit: { context: m.context, output: m.output },
-                    capabilities: {
-                      temperature: false,
-                      reasoning: true,
-                      attachment: true,
-                      toolcall: true,
-                      input: {
-                        text: true,
-                        audio: false,
-                        image: true,
-                        video: false,
-                        pdf: true,
-                      },
-                      output: {
-                        text: true,
-                        audio: false,
-                        image: false,
-                        video: false,
-                        pdf: false,
-                      },
-                      interleaved: false,
+                    output: {
+                      text: true,
+                      audio: false,
+                      image: false,
+                      video: false,
+                      pdf: false,
                     },
-                    release_date: "",
-                    variants: {},
-                  }
+                    interleaved: false,
+                  },
+                  release_date: "",
+                  variants: {},
                 }
               }
-
-              log.info("gitlab model discovery complete", {
-                count: Object.keys(models).length,
-                models: Object.keys(models),
-              })
-              return models
-            } catch (e) {
-              log.warn("gitlab model discovery failed", { error: e })
-              return {}
             }
-          },
-        }
-      }),
-      "cloudflare-workers-ai": Effect.fnUntraced(function* (input: Info) {
-        // When baseURL is already configured (e.g. corporate config routing through a proxy/gateway),
-        // skip the account ID check because the URL is already fully specified.
-        if (input.options?.baseURL) return { autoload: false }
 
-        const auth = yield* dep.auth(input.id)
-        const accountId =
-          Env.get("CLOUDFLARE_ACCOUNT_ID") || (auth?.type === "api" ? auth.metadata?.accountId : undefined)
-        if (!accountId)
-          return {
-            autoload: false,
-            async getModel() {
-              throw new Error(
-                "CLOUDFLARE_ACCOUNT_ID is missing. Set it with: export CLOUDFLARE_ACCOUNT_ID=<your-account-id>",
-              )
-            },
+            log.info("gitlab model discovery complete", {
+              count: Object.keys(models).length,
+              models: Object.keys(models),
+            })
+            return models
+          } catch (e) {
+            log.warn("gitlab model discovery failed", { error: e })
+            return {}
           }
+        },
+      }
+    }),
+    "cloudflare-workers-ai": Effect.fnUntraced(function* (input: Info) {
+      // When baseURL is already configured (e.g. corporate config routing through a proxy/gateway),
+      // skip the account ID check because the URL is already fully specified.
+      if (input.options?.baseURL) return { autoload: false }
 
-        const apiKey = yield* Effect.gen(function* () {
-          const envToken = Env.get("CLOUDFLARE_API_KEY")
-          if (envToken) return envToken
-          if (auth?.type === "api") return auth.key
-          return undefined
-        })
-
+      const auth = yield* dep.auth(input.id)
+      const env = yield* dep.env()
+      const accountId = env["CLOUDFLARE_ACCOUNT_ID"] || (auth?.type === "api" ? auth.metadata?.accountId : undefined)
+      if (!accountId)
         return {
-          autoload: !!apiKey,
-          options: {
-            apiKey,
-            headers: {
-              "User-Agent": `opencode/${Installation.VERSION} cloudflare-workers-ai (${os.platform()} ${os.release()}; ${os.arch()})`,
-            },
-          },
-          async getModel(sdk: any, modelID: string) {
-            return sdk.languageModel(modelID)
-          },
-          vars(_options) {
-            return {
-              CLOUDFLARE_ACCOUNT_ID: accountId,
-            }
+          autoload: false,
+          async getModel() {
+            throw new Error(
+              "CLOUDFLARE_ACCOUNT_ID is missing. Set it with: export CLOUDFLARE_ACCOUNT_ID=<your-account-id>",
+            )
           },
         }
-      }),
-      "cloudflare-ai-gateway": Effect.fnUntraced(function* (input: Info) {
-        // When baseURL is already configured (e.g. corporate config), skip the ID checks.
-        if (input.options?.baseURL) return { autoload: false }
 
-        const auth = yield* dep.auth(input.id)
-        const accountId =
-          Env.get("CLOUDFLARE_ACCOUNT_ID") || (auth?.type === "api" ? auth.metadata?.accountId : undefined)
-        const gateway =
-          Env.get("CLOUDFLARE_GATEWAY_ID") || (auth?.type === "api" ? auth.metadata?.gatewayId : undefined)
+      const apiKey = yield* Effect.gen(function* () {
+        const envToken = env["CLOUDFLARE_API_KEY"]
+        if (envToken) return envToken
+        if (auth?.type === "api") return auth.key
+        return undefined
+      })
 
-        if (!accountId || !gateway) {
-          const missing = [
-            !accountId ? "CLOUDFLARE_ACCOUNT_ID" : undefined,
-            !gateway ? "CLOUDFLARE_GATEWAY_ID" : undefined,
-          ].filter((x): x is string => Boolean(x))
-          return {
-            autoload: false,
-            async getModel() {
-              throw new Error(
-                `${missing.join(" and ")} missing. Set with: ${missing.map((x) => `export ${x}=<value>`).join(" && ")}`,
-              )
-            },
-          }
-        }
-
-        // Get API token from env or auth - required for authenticated gateways
-        const apiToken = yield* Effect.gen(function* () {
-          const envToken = Env.get("CLOUDFLARE_API_TOKEN") || Env.get("CF_AIG_TOKEN")
-          if (envToken) return envToken
-          if (auth?.type === "api") return auth.key
-          return undefined
-        })
-
-        if (!apiToken) {
-          throw new Error(
-            "CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway. " +
-              "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
-          )
-        }
-
-        // Use official ai-gateway-provider package (v2.x for AI SDK v5 compatibility)
-        const { createAiGateway } = yield* Effect.promise(() => import("ai-gateway-provider"))
-        const { createUnified } = yield* Effect.promise(() => import("ai-gateway-provider/providers/unified"))
-
-        const metadata = iife(() => {
-          if (input.options?.metadata) return input.options.metadata
-          try {
-            return JSON.parse(input.options?.headers?.["cf-aig-metadata"])
-          } catch {
-            return undefined
-          }
-        })
-        const opts = {
-          metadata,
-          cacheTtl: input.options?.cacheTtl,
-          cacheKey: input.options?.cacheKey,
-          skipCache: input.options?.skipCache,
-          collectLog: input.options?.collectLog,
+      return {
+        autoload: !!apiKey,
+        options: {
+          apiKey,
           headers: {
-            "User-Agent": `opencode/${Installation.VERSION} cloudflare-ai-gateway (${os.platform()} ${os.release()}; ${os.arch()})`,
+            "User-Agent": `opencode/${Installation.VERSION} cloudflare-workers-ai (${os.platform()} ${os.release()}; ${os.arch()})`,
           },
-        }
+        },
+        async getModel(sdk: any, modelID: string) {
+          return sdk.languageModel(modelID)
+        },
+        vars(_options) {
+          return {
+            CLOUDFLARE_ACCOUNT_ID: accountId,
+          }
+        },
+      }
+    }),
+    "cloudflare-ai-gateway": Effect.fnUntraced(function* (input: Info) {
+      // When baseURL is already configured (e.g. corporate config), skip the ID checks.
+      if (input.options?.baseURL) return { autoload: false }
 
-        const aigateway = createAiGateway({
-          accountId,
-          gateway,
-          apiKey: apiToken,
-          ...(Object.values(opts).some((v) => v !== undefined) ? { options: opts } : {}),
-        })
-        const unified = createUnified()
+      const auth = yield* dep.auth(input.id)
+      const env = yield* dep.env()
+      const accountId = env["CLOUDFLARE_ACCOUNT_ID"] || (auth?.type === "api" ? auth.metadata?.accountId : undefined)
+      const gateway = env["CLOUDFLARE_GATEWAY_ID"] || (auth?.type === "api" ? auth.metadata?.gatewayId : undefined)
 
+      if (!accountId || !gateway) {
+        const missing = [
+          !accountId ? "CLOUDFLARE_ACCOUNT_ID" : undefined,
+          !gateway ? "CLOUDFLARE_GATEWAY_ID" : undefined,
+        ].filter((x): x is string => Boolean(x))
         return {
-          autoload: true,
-          async getModel(_sdk: any, modelID: string, _options?: Record<string, any>) {
-            // Model IDs use Unified API format: provider/model (e.g., "anthropic/claude-sonnet-4-5")
-            return aigateway(unified(modelID))
+          autoload: false,
+          async getModel() {
+            throw new Error(
+              `${missing.join(" and ")} missing. Set with: ${missing.map((x) => `export ${x}=<value>`).join(" && ")}`,
+            )
           },
-          options: {},
         }
-      }),
-      cerebras: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "X-Cerebras-3rd-Party-Integration": "opencode",
-            },
+      }
+
+      // Get API token from env or auth - required for authenticated gateways
+      const apiToken = yield* Effect.gen(function* () {
+        const envToken = env["CLOUDFLARE_API_TOKEN"] || env["CF_AIG_TOKEN"]
+        if (envToken) return envToken
+        if (auth?.type === "api") return auth.key
+        return undefined
+      })
+
+      if (!apiToken) {
+        throw new Error(
+          "CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway. " +
+            "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
+        )
+      }
+
+      // Use official ai-gateway-provider package (v2.x for AI SDK v5 compatibility)
+      const { createAiGateway } = yield* Effect.promise(() => import("ai-gateway-provider"))
+      const { createUnified } = yield* Effect.promise(() => import("ai-gateway-provider/providers/unified"))
+
+      const metadata = iife(() => {
+        if (input.options?.metadata) return input.options.metadata
+        try {
+          return JSON.parse(input.options?.headers?.["cf-aig-metadata"])
+        } catch {
+          return undefined
+        }
+      })
+      const opts = {
+        metadata,
+        cacheTtl: input.options?.cacheTtl,
+        cacheKey: input.options?.cacheKey,
+        skipCache: input.options?.skipCache,
+        collectLog: input.options?.collectLog,
+        headers: {
+          "User-Agent": `opencode/${Installation.VERSION} cloudflare-ai-gateway (${os.platform()} ${os.release()}; ${os.arch()})`,
+        },
+      }
+
+      const aigateway = createAiGateway({
+        accountId,
+        gateway,
+        apiKey: apiToken,
+        ...(Object.values(opts).some((v) => v !== undefined) ? { options: opts } : {}),
+      })
+      const unified = createUnified()
+
+      return {
+        autoload: true,
+        async getModel(_sdk: any, modelID: string, _options?: Record<string, any>) {
+          // Model IDs use Unified API format: provider/model (e.g., "anthropic/claude-sonnet-4-5")
+          return aigateway(unified(modelID))
+        },
+        options: {},
+      }
+    }),
+    cerebras: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "X-Cerebras-3rd-Party-Integration": "opencode",
           },
-        }),
-      kilo: () =>
-        Effect.succeed({
-          autoload: false,
-          options: {
-            headers: {
-              "HTTP-Referer": "https://opencode.ai/",
-              "X-Title": "opencode",
-            },
+        },
+      }),
+    kilo: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
           },
-        }),
-    }
+        },
+      }),
   }
+}
 
-  export const Model = z
-    .object({
-      id: ModelID.zod,
-      providerID: ProviderID.zod,
-      api: z.object({
-        id: z.string(),
-        url: z.string(),
-        npm: z.string(),
-      }),
-      name: z.string(),
-      family: z.string().optional(),
-      capabilities: z.object({
-        temperature: z.boolean(),
-        reasoning: z.boolean(),
-        attachment: z.boolean(),
-        toolcall: z.boolean(),
-        input: z.object({
-          text: z.boolean(),
-          audio: z.boolean(),
-          image: z.boolean(),
-          video: z.boolean(),
-          pdf: z.boolean(),
-        }),
-        output: z.object({
-          text: z.boolean(),
-          audio: z.boolean(),
-          image: z.boolean(),
-          video: z.boolean(),
-          pdf: z.boolean(),
-        }),
-        interleaved: z.union([
-          z.boolean(),
-          z.object({
-            field: z.enum(["reasoning_content", "reasoning_details"]),
-          }),
-        ]),
-      }),
-      cost: z.object({
-        input: z.number(),
-        output: z.number(),
-        cache: z.object({
-          read: z.number(),
-          write: z.number(),
-        }),
-        experimentalOver200K: z
-          .object({
-            input: z.number(),
-            output: z.number(),
-            cache: z.object({
-              read: z.number(),
-              write: z.number(),
-            }),
-          })
-          .optional(),
-      }),
-      limit: z.object({
-        context: z.number(),
-        input: z.number().optional(),
-        output: z.number(),
-      }),
-      status: z.enum(["alpha", "beta", "deprecated", "active"]),
-      options: z.record(z.string(), z.any()),
-      headers: z.record(z.string(), z.string()),
-      release_date: z.string(),
-      variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
-    })
-    .meta({
-      ref: "Model",
-    })
-  export type Model = z.infer<typeof Model>
+const ProviderApiInfo = Schema.Struct({
+  id: Schema.String,
+  url: Schema.String,
+  npm: Schema.String,
+})
 
-  export const Info = z
-    .object({
-      id: ProviderID.zod,
-      name: z.string(),
-      source: z.enum(["env", "config", "custom", "api"]),
-      env: z.string().array(),
-      key: z.string().optional(),
-      options: z.record(z.string(), z.any()),
-      models: z.record(z.string(), Model),
-    })
-    .meta({
-      ref: "Provider",
-    })
-  export type Info = z.infer<typeof Info>
+const ProviderModalities = Schema.Struct({
+  text: Schema.Boolean,
+  audio: Schema.Boolean,
+  image: Schema.Boolean,
+  video: Schema.Boolean,
+  pdf: Schema.Boolean,
+})
 
-  export interface Interface {
-    readonly list: () => Effect.Effect<Record<ProviderID, Info>>
-    readonly getProvider: (providerID: ProviderID) => Effect.Effect<Info>
-    readonly getModel: (providerID: ProviderID, modelID: ModelID) => Effect.Effect<Model>
-    readonly getLanguage: (model: Model) => Effect.Effect<LanguageModelV3>
-    readonly closest: (
-      providerID: ProviderID,
-      query: string[],
-    ) => Effect.Effect<{ providerID: ProviderID; modelID: string } | undefined>
-    readonly getSmallModel: (providerID: ProviderID) => Effect.Effect<Model | undefined>
-    readonly defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }>
+const ProviderInterleaved = Schema.Union([
+  Schema.Boolean,
+  Schema.Struct({
+    field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+  }),
+])
+
+const ProviderCapabilities = Schema.Struct({
+  temperature: Schema.Boolean,
+  reasoning: Schema.Boolean,
+  attachment: Schema.Boolean,
+  toolcall: Schema.Boolean,
+  input: ProviderModalities,
+  output: ProviderModalities,
+  interleaved: ProviderInterleaved,
+})
+
+const ProviderCacheCost = Schema.Struct({
+  read: Schema.Number,
+  write: Schema.Number,
+})
+
+const ProviderCost = Schema.Struct({
+  input: Schema.Number,
+  output: Schema.Number,
+  cache: ProviderCacheCost,
+  experimentalOver200K: Schema.optional(
+    Schema.Struct({
+      input: Schema.Number,
+      output: Schema.Number,
+      cache: ProviderCacheCost,
+    }),
+  ),
+})
+
+const ProviderLimit = Schema.Struct({
+  context: Schema.Number,
+  input: Schema.optional(Schema.Number),
+  output: Schema.Number,
+})
+
+export const Model = Schema.Struct({
+  id: ModelID,
+  providerID: ProviderID,
+  api: ProviderApiInfo,
+  name: Schema.String,
+  family: Schema.optional(Schema.String),
+  capabilities: ProviderCapabilities,
+  cost: ProviderCost,
+  limit: ProviderLimit,
+  status: Schema.Literals(["alpha", "beta", "deprecated", "active"]),
+  options: Schema.Record(Schema.String, Schema.Any),
+  headers: Schema.Record(Schema.String, Schema.String),
+  release_date: Schema.String,
+  variants: Schema.optional(Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Any))),
+})
+  .annotate({ identifier: "Model" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Model = Types.DeepMutable<Schema.Schema.Type<typeof Model>>
+
+export const Info = Schema.Struct({
+  id: ProviderID,
+  name: Schema.String,
+  source: Schema.Literals(["env", "config", "custom", "api"]),
+  env: Schema.Array(Schema.String),
+  key: Schema.optional(Schema.String),
+  options: Schema.Record(Schema.String, Schema.Any),
+  models: Schema.Record(Schema.String, Model),
+})
+  .annotate({ identifier: "Provider" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
+
+const DefaultModelIDs = Schema.Record(Schema.String, Schema.String)
+
+export const ListResult = Schema.Struct({
+  all: Schema.Array(Info),
+  default: DefaultModelIDs,
+  connected: Schema.Array(Schema.String),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ListResult = Types.DeepMutable<Schema.Schema.Type<typeof ListResult>>
+
+export const ConfigProvidersResult = Schema.Struct({
+  providers: Schema.Array(Info),
+  default: DefaultModelIDs,
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ConfigProvidersResult = Types.DeepMutable<Schema.Schema.Type<typeof ConfigProvidersResult>>
+export type Language = LanguageModelV3
+
+export function defaultModelIDs<T extends { models: Record<string, { id: string }> }>(providers: Record<string, T>) {
+  return mapValues(providers, (item) => sort(Object.values(item.models))[0].id)
+}
+
+export interface Interface {
+  readonly list: () => Effect.Effect<Record<ProviderID, Info>>
+  readonly getProvider: (providerID: ProviderID) => Effect.Effect<Info>
+  readonly getModel: (providerID: ProviderID, modelID: ModelID) => Effect.Effect<Model>
+  readonly getLanguage: (model: Model) => Effect.Effect<LanguageModelV3>
+  readonly closest: (
+    providerID: ProviderID,
+    query: string[],
+  ) => Effect.Effect<{ providerID: ProviderID; modelID: string } | undefined>
+  readonly getSmallModel: (providerID: ProviderID) => Effect.Effect<Model | undefined>
+  readonly defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }>
+}
+
+interface State {
+  models: Map<string, LanguageModelV3>
+  providers: Record<ProviderID, Info>
+  sdk: Map<string, BundledSDK>
+  modelLoaders: Record<string, CustomModelLoader>
+  varsLoaders: Record<string, CustomVarsLoader>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") {}
+
+function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
+  const result: Model["cost"] = {
+    input: c?.input ?? 0,
+    output: c?.output ?? 0,
+    cache: {
+      read: c?.cache_read ?? 0,
+      write: c?.cache_write ?? 0,
+    },
   }
-
-  interface State {
-    models: Map<string, LanguageModelV3>
-    providers: Record<ProviderID, Info>
-    sdk: Map<string, BundledSDK>
-    modelLoaders: Record<string, CustomModelLoader>
-    varsLoaders: Record<string, CustomVarsLoader>
-  }
-
-  export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") {}
-
-  function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
-    const result: Model["cost"] = {
-      input: c?.input ?? 0,
-      output: c?.output ?? 0,
+  if (c?.context_over_200k) {
+    result.experimentalOver200K = {
       cache: {
-        read: c?.cache_read ?? 0,
-        write: c?.cache_write ?? 0,
+        read: c.context_over_200k.cache_read ?? 0,
+        write: c.context_over_200k.cache_write ?? 0,
       },
+      input: c.context_over_200k.input,
+      output: c.context_over_200k.output,
     }
-    if (c?.context_over_200k) {
-      result.experimentalOver200K = {
-        cache: {
-          read: c.context_over_200k.cache_read ?? 0,
-          write: c.context_over_200k.cache_write ?? 0,
-        },
-        input: c.context_over_200k.input,
-        output: c.context_over_200k.output,
+  }
+  return result
+}
+
+function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
+  const base: Model = {
+    id: ModelID.make(model.id),
+    providerID: ProviderID.make(provider.id),
+    name: model.name,
+    family: model.family,
+    api: {
+      id: model.id,
+      url: model.provider?.api ?? provider.api ?? "",
+      npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
+    },
+    status: model.status ?? "active",
+    headers: {},
+    options: {},
+    cost: cost(model.cost),
+    limit: {
+      context: model.limit.context,
+      input: model.limit.input,
+      output: model.limit.output,
+    },
+    capabilities: {
+      temperature: model.temperature ?? false,
+      reasoning: model.reasoning ?? false,
+      attachment: model.attachment ?? false,
+      toolcall: model.tool_call ?? true,
+      input: {
+        text: model.modalities?.input?.includes("text") ?? false,
+        audio: model.modalities?.input?.includes("audio") ?? false,
+        image: model.modalities?.input?.includes("image") ?? false,
+        video: model.modalities?.input?.includes("video") ?? false,
+        pdf: model.modalities?.input?.includes("pdf") ?? false,
+      },
+      output: {
+        text: model.modalities?.output?.includes("text") ?? false,
+        audio: model.modalities?.output?.includes("audio") ?? false,
+        image: model.modalities?.output?.includes("image") ?? false,
+        video: model.modalities?.output?.includes("video") ?? false,
+        pdf: model.modalities?.output?.includes("pdf") ?? false,
+      },
+      interleaved: model.interleaved ?? false,
+    },
+    release_date: model.release_date ?? "",
+    variants: {},
+  }
+
+  return {
+    ...base,
+    variants: mapValues(ProviderTransform.variants(base), (v) => v),
+  }
+}
+
+export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
+  const models: Record<string, Model> = {}
+  for (const [key, model] of Object.entries(provider.models)) {
+    models[key] = fromModelsDevModel(provider, model)
+    for (const [mode, opts] of Object.entries(model.experimental?.modes ?? {})) {
+      const id = `${model.id}-${mode}`
+      const base = fromModelsDevModel(provider, model)
+      models[id] = {
+        ...base,
+        id: ModelID.make(id),
+        name: `${model.name} ${mode[0].toUpperCase()}${mode.slice(1)}`,
+        cost: opts.cost ? mergeDeep(base.cost, cost(opts.cost)) : base.cost,
+        options: opts.provider?.body
+          ? Object.fromEntries(
+              Object.entries(opts.provider.body).map(([k, v]) => [
+                k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()),
+                v,
+              ]),
+            )
+          : base.options,
+        headers: opts.provider?.headers ?? base.headers,
       }
     }
-    return result
   }
-
-  function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
-    const m: Model = {
-      id: ModelID.make(model.id),
-      providerID: ProviderID.make(provider.id),
-      name: model.name,
-      family: model.family,
-      api: {
-        id: model.id,
-        url: model.provider?.api ?? provider.api ?? "",
-        npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
-      },
-      status: model.status ?? "active",
-      headers: {},
-      options: {},
-      cost: cost(model.cost),
-      limit: {
-        context: model.limit.context,
-        input: model.limit.input,
-        output: model.limit.output,
-      },
-      capabilities: {
-        temperature: model.temperature ?? false,
-        reasoning: model.reasoning ?? false,
-        attachment: model.attachment ?? false,
-        toolcall: model.tool_call ?? true,
-        input: {
-          text: model.modalities?.input?.includes("text") ?? false,
-          audio: model.modalities?.input?.includes("audio") ?? false,
-          image: model.modalities?.input?.includes("image") ?? false,
-          video: model.modalities?.input?.includes("video") ?? false,
-          pdf: model.modalities?.input?.includes("pdf") ?? false,
-        },
-        output: {
-          text: model.modalities?.output?.includes("text") ?? false,
-          audio: model.modalities?.output?.includes("audio") ?? false,
-          image: model.modalities?.output?.includes("image") ?? false,
-          video: model.modalities?.output?.includes("video") ?? false,
-          pdf: model.modalities?.output?.includes("pdf") ?? false,
-        },
-        interleaved: model.interleaved ?? false,
-      },
-      release_date: model.release_date ?? "",
-      variants: {},
-    }
-
-    m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
-
-    return m
+  return {
+    id: ProviderID.make(provider.id),
+    source: "custom",
+    name: provider.name,
+    env: provider.env ?? [],
+    options: {},
+    models,
   }
+}
 
-  export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
-    const models: Record<string, Model> = {}
-    for (const [key, model] of Object.entries(provider.models)) {
-      models[key] = fromModelsDevModel(provider, model)
-      for (const [mode, opts] of Object.entries(model.experimental?.modes ?? {})) {
-        const id = `${model.id}-${mode}`
-        const m = fromModelsDevModel(provider, model)
-        m.id = ModelID.make(id)
-        m.name = `${model.name} ${mode[0].toUpperCase()}${mode.slice(1)}`
-        if (opts.cost) m.cost = mergeDeep(m.cost, cost(opts.cost))
-        // convert body params to camelCase for ai sdk compatibility
-        if (opts.provider?.body)
-          m.options = Object.fromEntries(
-            Object.entries(opts.provider.body).map(([k, v]) => [k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()), v]),
-          )
-        if (opts.provider?.headers) m.headers = opts.provider.headers
-        models[id] = m
-      }
-    }
-    return {
-      id: ProviderID.make(provider.id),
-      source: "custom",
-      name: provider.name,
-      env: provider.env ?? [],
-      options: {},
-      models,
-    }
-  }
+const layer: Layer.Layer<
+  Service,
+  never,
+  Config.Service | Auth.Service | Plugin.Service | AppFileSystem.Service | Env.Service
+> = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+    const config = yield* Config.Service
+    const auth = yield* Auth.Service
+    const env = yield* Env.Service
+    const plugin = yield* Plugin.Service
 
-  const layer: Layer.Layer<Service, never, Config.Service | Auth.Service | Plugin.Service> = Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const config = yield* Config.Service
-      const auth = yield* Auth.Service
-      const plugin = yield* Plugin.Service
+    const state = yield* InstanceState.make<State>(() =>
+      Effect.gen(function* () {
+        using _ = log.time("state")
+        const bridge = yield* EffectBridge.make()
+        const cfg = yield* config.get()
+        const modelsDev = yield* Effect.promise(() => ModelsDev.get())
+        const database = mapValues(modelsDev, fromModelsDevProvider)
 
-      const state = yield* InstanceState.make<State>(() =>
-        Effect.gen(function* () {
-          using _ = log.time("state")
-          const cfg = yield* config.get()
-          const modelsDev = yield* Effect.promise(() => ModelsDev.get())
-          const database = mapValues(modelsDev, fromModelsDevProvider)
+        const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
+        const languages = new Map<string, LanguageModelV3>()
+        const modelLoaders: {
+          [providerID: string]: CustomModelLoader
+        } = {}
+        const varsLoaders: {
+          [providerID: string]: CustomVarsLoader
+        } = {}
+        const sdk = new Map<string, BundledSDK>()
+        const discoveryLoaders: {
+          [providerID: string]: CustomDiscoverModels
+        } = {}
+        const dep = {
+          auth: (id: string) => auth.get(id).pipe(Effect.orDie),
+          config: () => config.get(),
+          env: () => env.all(),
+          get: (key: string) => env.get(key),
+        }
 
-          const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
-          const languages = new Map<string, LanguageModelV3>()
-          const modelLoaders: {
-            [providerID: string]: CustomModelLoader
-          } = {}
-          const varsLoaders: {
-            [providerID: string]: CustomVarsLoader
-          } = {}
-          const sdk = new Map<string, BundledSDK>()
-          const discoveryLoaders: {
-            [providerID: string]: CustomDiscoverModels
-          } = {}
-          const dep = {
-            auth: (id: string) => auth.get(id).pipe(Effect.orDie),
-            config: () => config.get(),
-          }
+        log.info("init")
 
-          log.info("init")
-
-          function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
-            const existing = providers[providerID]
-            if (existing) {
-              // @ts-expect-error
-              providers[providerID] = mergeDeep(existing, provider)
-              return
-            }
-            const match = database[providerID]
-            if (!match) return
+        function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
+          const existing = providers[providerID]
+          if (existing) {
             // @ts-expect-error
-            providers[providerID] = mergeDeep(match, provider)
+            providers[providerID] = mergeDeep(existing, provider)
+            return
+          }
+          const match = database[providerID]
+          if (!match) return
+          // @ts-expect-error
+          providers[providerID] = mergeDeep(match, provider)
+        }
+
+        // load plugins first so config() hook runs before reading cfg.provider
+        const plugins = yield* plugin.list()
+
+        // now read config providers - includes any modifications from plugin config() hook
+        const configProviders = Object.entries(cfg.provider ?? {})
+        const disabled = new Set(cfg.disabled_providers ?? [])
+        const enabled = cfg.enabled_providers ? new Set(cfg.enabled_providers) : null
+
+        function isProviderAllowed(providerID: ProviderID): boolean {
+          if (enabled && !enabled.has(providerID)) return false
+          if (disabled.has(providerID)) return false
+          return true
+        }
+
+        // extend database from config
+        for (const [providerID, provider] of configProviders) {
+          const existing = database[providerID]
+          const parsed: Info = {
+            id: ProviderID.make(providerID),
+            name: provider.name ?? existing?.name ?? providerID,
+            env: provider.env ?? existing?.env ?? [],
+            options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
+            source: "config",
+            models: existing?.models ?? {},
           }
 
-          // load plugins first so config() hook runs before reading cfg.provider
-          const plugins = yield* plugin.list()
-
-          // now read config providers - includes any modifications from plugin config() hook
-          const configProviders = Object.entries(cfg.provider ?? {})
-          const disabled = new Set(cfg.disabled_providers ?? [])
-          const enabled = cfg.enabled_providers ? new Set(cfg.enabled_providers) : null
-
-          function isProviderAllowed(providerID: ProviderID): boolean {
-            if (enabled && !enabled.has(providerID)) return false
-            if (disabled.has(providerID)) return false
-            return true
-          }
-
-          // extend database from config
-          for (const [providerID, provider] of configProviders) {
-            const existing = database[providerID]
-            const parsed: Info = {
-              id: ProviderID.make(providerID),
-              name: provider.name ?? existing?.name ?? providerID,
-              env: provider.env ?? existing?.env ?? [],
-              options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
-              source: "config",
-              models: existing?.models ?? {},
+          for (const [modelID, model] of Object.entries(provider.models ?? {})) {
+            const existingModel = parsed.models[model.id ?? modelID]
+            const name = iife(() => {
+              if (model.name) return model.name
+              if (model.id && model.id !== modelID) return modelID
+              return existingModel?.name ?? modelID
+            })
+            const parsedModel: Model = {
+              id: ModelID.make(modelID),
+              api: {
+                id: model.id ?? existingModel?.api.id ?? modelID,
+                npm:
+                  model.provider?.npm ??
+                  provider.npm ??
+                  existingModel?.api.npm ??
+                  modelsDev[providerID]?.npm ??
+                  "@ai-sdk/openai-compatible",
+                url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api ?? "",
+              },
+              status: model.status ?? existingModel?.status ?? "active",
+              name,
+              providerID: ProviderID.make(providerID),
+              capabilities: {
+                temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
+                reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
+                attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
+                toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
+                input: {
+                  text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
+                  audio: model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
+                  image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
+                  video: model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
+                  pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
+                },
+                output: {
+                  text: model.modalities?.output?.includes("text") ?? existingModel?.capabilities.output.text ?? true,
+                  audio:
+                    model.modalities?.output?.includes("audio") ?? existingModel?.capabilities.output.audio ?? false,
+                  image:
+                    model.modalities?.output?.includes("image") ?? existingModel?.capabilities.output.image ?? false,
+                  video:
+                    model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
+                  pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
+                },
+                interleaved: model.interleaved ?? false,
+              },
+              cost: {
+                input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
+                output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
+                cache: {
+                  read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
+                  write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
+                },
+              },
+              options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
+              limit: {
+                context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
+                input: model.limit?.input ?? existingModel?.limit?.input,
+                output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+              },
+              headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
+              family: model.family ?? existingModel?.family ?? "",
+              release_date: model.release_date ?? existingModel?.release_date ?? "",
+              variants: {},
             }
-
-            for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-              const existingModel = parsed.models[model.id ?? modelID]
-              const name = iife(() => {
-                if (model.name) return model.name
-                if (model.id && model.id !== modelID) return modelID
-                return existingModel?.name ?? modelID
-              })
-              const parsedModel: Model = {
-                id: ModelID.make(modelID),
-                api: {
-                  id: model.id ?? existingModel?.api.id ?? modelID,
-                  npm:
-                    model.provider?.npm ??
-                    provider.npm ??
-                    existingModel?.api.npm ??
-                    modelsDev[providerID]?.npm ??
-                    "@ai-sdk/openai-compatible",
-                  url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api,
-                },
-                status: model.status ?? existingModel?.status ?? "active",
-                name,
-                providerID: ProviderID.make(providerID),
-                capabilities: {
-                  temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
-                  reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
-                  attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
-                  toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
-                  input: {
-                    text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
-                    audio:
-                      model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
-                    image:
-                      model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
-                    video:
-                      model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
-                    pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
-                  },
-                  output: {
-                    text: model.modalities?.output?.includes("text") ?? existingModel?.capabilities.output.text ?? true,
-                    audio:
-                      model.modalities?.output?.includes("audio") ?? existingModel?.capabilities.output.audio ?? false,
-                    image:
-                      model.modalities?.output?.includes("image") ?? existingModel?.capabilities.output.image ?? false,
-                    video:
-                      model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
-                    pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
-                  },
-                  interleaved: model.interleaved ?? false,
-                },
-                cost: {
-                  input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
-                  output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
-                  cache: {
-                    read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
-                    write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
-                  },
-                },
-                options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
-                limit: {
-                  context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
-                  input: model.limit?.input ?? existingModel?.limit?.input,
-                  output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
-                },
-                headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
-                family: model.family ?? existingModel?.family ?? "",
-                release_date: model.release_date ?? existingModel?.release_date ?? "",
-                variants: {},
-              }
-              const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
-              parsedModel.variants = mapValues(
-                pickBy(merged, (v) => !v.disabled),
-                (v) => omit(v, ["disabled"]),
-              )
-              parsed.models[modelID] = parsedModel
-            }
-            database[providerID] = parsed
+            const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
+            parsedModel.variants = mapValues(
+              pickBy(merged, (v) => !v.disabled),
+              (v) => omit(v, ["disabled"]),
+            )
+            parsed.models[modelID] = parsedModel
           }
+          database[providerID] = parsed
+        }
 
-          // load env
-          const env = Env.all()
-          for (const [id, provider] of Object.entries(database)) {
-            const providerID = ProviderID.make(id)
-            if (disabled.has(providerID)) continue
-            const apiKey = provider.env.map((item) => env[item]).find(Boolean)
-            if (!apiKey) continue
+        // load env
+        const envs = yield* env.all()
+        for (const [id, provider] of Object.entries(database)) {
+          const providerID = ProviderID.make(id)
+          if (disabled.has(providerID)) continue
+          const apiKey = provider.env.map((item) => envs[item]).find(Boolean)
+          if (!apiKey) continue
+          mergeProvider(providerID, {
+            source: "env",
+            key: provider.env.length === 1 ? apiKey : undefined,
+          })
+        }
+
+        // load apikeys
+        const auths = yield* auth.all().pipe(Effect.orDie)
+        for (const [id, provider] of Object.entries(auths)) {
+          const providerID = ProviderID.make(id)
+          if (disabled.has(providerID)) continue
+          if (provider.type === "api") {
             mergeProvider(providerID, {
-              source: "env",
-              key: provider.env.length === 1 ? apiKey : undefined,
+              source: "api",
+              key: provider.key,
             })
           }
+        }
 
-          // load apikeys
-          const auths = yield* auth.all().pipe(Effect.orDie)
-          for (const [id, provider] of Object.entries(auths)) {
-            const providerID = ProviderID.make(id)
-            if (disabled.has(providerID)) continue
-            if (provider.type === "api") {
-              mergeProvider(providerID, {
-                source: "api",
-                key: provider.key,
-              })
-            }
+        // plugin auth loader - database now has entries for config providers
+        for (const plugin of plugins) {
+          if (!plugin.auth) continue
+          const providerID = ProviderID.make(plugin.auth.provider)
+          if (disabled.has(providerID)) continue
+
+          const stored = yield* auth.get(providerID).pipe(Effect.orDie)
+          if (!stored) continue
+          if (!plugin.auth.loader) continue
+
+          const options = yield* Effect.promise(() =>
+            plugin.auth!.loader!(
+              () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
+              database[plugin.auth!.provider],
+            ),
+          )
+          const opts = options ?? {}
+          const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
+          mergeProvider(providerID, patch)
+        }
+
+        for (const [id, fn] of Object.entries(custom(dep))) {
+          const providerID = ProviderID.make(id)
+          if (disabled.has(providerID)) continue
+          const data = database[providerID]
+          if (!data) {
+            log.error("Provider does not exist in model list " + providerID)
+            continue
           }
-
-          // plugin auth loader - database now has entries for config providers
-          for (const plugin of plugins) {
-            if (!plugin.auth) continue
-            const providerID = ProviderID.make(plugin.auth.provider)
-            if (disabled.has(providerID)) continue
-
-            const stored = yield* auth.get(providerID).pipe(Effect.orDie)
-            if (!stored) continue
-            if (!plugin.auth.loader) continue
-
-            const options = yield* Effect.promise(() =>
-              plugin.auth!.loader!(
-                () =>
-                  Effect.runPromise(auth.get(providerID).pipe(Effect.orDie, Effect.provide(EffectLogger.layer))) as any,
-                database[plugin.auth!.provider],
-              ),
-            )
-            const opts = options ?? {}
+          const result = yield* fn(data)
+          if (result && (result.autoload || providers[providerID])) {
+            if (result.getModel) modelLoaders[providerID] = result.getModel
+            if (result.vars) varsLoaders[providerID] = result.vars
+            if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
+            const opts = result.options ?? {}
             const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
             mergeProvider(providerID, patch)
           }
+        }
 
-          for (const [id, fn] of Object.entries(custom(dep))) {
-            const providerID = ProviderID.make(id)
-            if (disabled.has(providerID)) continue
-            const data = database[providerID]
-            if (!data) {
-              log.error("Provider does not exist in model list " + providerID)
-              continue
-            }
-            const result = yield* fn(data)
-            if (result && (result.autoload || providers[providerID])) {
-              if (result.getModel) modelLoaders[providerID] = result.getModel
-              if (result.vars) varsLoaders[providerID] = result.vars
-              if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
-              const opts = result.options ?? {}
-              const patch: Partial<Info> = providers[providerID]
-                ? { options: opts }
-                : { source: "custom", options: opts }
-              mergeProvider(providerID, patch)
-            }
-          }
+        // load config - re-apply with updated data
+        for (const [id, provider] of configProviders) {
+          const providerID = ProviderID.make(id)
+          const partial: Partial<Info> = { source: "config" }
+          if (provider.env) partial.env = provider.env
+          if (provider.name) partial.name = provider.name
+          if (provider.options) partial.options = provider.options
+          mergeProvider(providerID, partial)
+        }
 
-          // load config - re-apply with updated data
-          for (const [id, provider] of configProviders) {
-            const providerID = ProviderID.make(id)
-            const partial: Partial<Info> = { source: "config" }
-            if (provider.env) partial.env = provider.env
-            if (provider.name) partial.name = provider.name
-            if (provider.options) partial.options = provider.options
-            mergeProvider(providerID, partial)
-          }
-
-          const gitlab = ProviderID.make("gitlab")
-          if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
-            yield* Effect.promise(async () => {
-              try {
-                const discovered = await discoveryLoaders[gitlab]()
-                for (const [modelID, model] of Object.entries(discovered)) {
-                  if (!providers[gitlab].models[modelID]) {
-                    providers[gitlab].models[modelID] = model
-                  }
+        const gitlab = ProviderID.make("gitlab")
+        if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
+          yield* Effect.promise(async () => {
+            try {
+              const discovered = await discoveryLoaders[gitlab]()
+              for (const [modelID, model] of Object.entries(discovered)) {
+                if (!providers[gitlab].models[modelID]) {
+                  providers[gitlab].models[modelID] = model
                 }
-              } catch (e) {
-                log.warn("state discovery error", { id: "gitlab", error: e })
               }
-            })
-          }
-
-          for (const hook of plugins) {
-            const p = hook.provider
-            const models = p?.models
-            if (!p || !models) continue
-
-            const providerID = ProviderID.make(p.id)
-            if (disabled.has(providerID)) continue
-
-            const provider = providers[providerID]
-            if (!provider) continue
-            const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
-
-            provider.models = yield* Effect.promise(async () => {
-              const next = await models(provider, { auth: pluginAuth })
-              return Object.fromEntries(
-                Object.entries(next).map(([id, model]) => [
-                  id,
-                  {
-                    ...model,
-                    id: ModelID.make(id),
-                    providerID,
-                  },
-                ]),
-              )
-            })
-          }
-
-          for (const [id, provider] of Object.entries(providers)) {
-            const providerID = ProviderID.make(id)
-            if (!isProviderAllowed(providerID)) {
-              delete providers[providerID]
-              continue
+            } catch (e) {
+              log.warn("state discovery error", { id: "gitlab", error: e })
             }
+          })
+        }
 
-            const configProvider = cfg.provider?.[providerID]
+        for (const hook of plugins) {
+          const p = hook.provider
+          const models = p?.models
+          if (!p || !models) continue
 
-            for (const [modelID, model] of Object.entries(provider.models)) {
-              model.api.id = model.api.id ?? model.id ?? modelID
-              if (
-                modelID === "gpt-5-chat-latest" ||
-                (providerID === ProviderID.openrouter && modelID === "openai/gpt-5-chat")
-              )
-                delete provider.models[modelID]
-              if (model.status === "alpha" && !Flag.OPENCODE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
-              if (model.status === "deprecated") delete provider.models[modelID]
-              if (
-                (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
-                (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
-              )
-                delete provider.models[modelID]
+          const providerID = ProviderID.make(p.id)
+          if (disabled.has(providerID)) continue
 
-              model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
+          const provider = providers[providerID]
+          if (!provider) continue
+          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
 
-              const configVariants = configProvider?.models?.[modelID]?.variants
-              if (configVariants && model.variants) {
-                const merged = mergeDeep(model.variants, configVariants)
-                model.variants = mapValues(
-                  pickBy(merged, (v) => !v.disabled),
-                  (v) => omit(v, ["disabled"]),
-                )
-              }
-            }
+          provider.models = yield* Effect.promise(async () => {
+            const next = await models(provider, { auth: pluginAuth })
+            return Object.fromEntries(
+              Object.entries(next).map(([id, model]) => [
+                id,
+                {
+                  ...model,
+                  id: ModelID.make(id),
+                  providerID,
+                },
+              ]),
+            )
+          })
+        }
 
-            if (Object.keys(provider.models).length === 0) {
-              delete providers[providerID]
-              continue
-            }
-
-            log.info("found", { providerID })
+        for (const [id, provider] of Object.entries(providers)) {
+          const providerID = ProviderID.make(id)
+          if (!isProviderAllowed(providerID)) {
+            delete providers[providerID]
+            continue
           }
 
-          return {
-            models: languages,
-            providers,
-            sdk,
-            modelLoaders,
-            varsLoaders,
+          const configProvider = cfg.provider?.[providerID]
+
+          for (const [modelID, model] of Object.entries(provider.models)) {
+            model.api.id = model.api.id ?? model.id ?? modelID
+            if (
+              modelID === "gpt-5-chat-latest" ||
+              (providerID === ProviderID.openrouter && modelID === "openai/gpt-5-chat")
+            )
+              delete provider.models[modelID]
+            if (model.status === "alpha" && !Flag.OPENCODE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
+            if (model.status === "deprecated") delete provider.models[modelID]
+            if (
+              (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
+              (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
+            )
+              delete provider.models[modelID]
+
+            model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
+
+            const configVariants = configProvider?.models?.[modelID]?.variants
+            if (configVariants && model.variants) {
+              const merged = mergeDeep(model.variants, configVariants)
+              model.variants = mapValues(
+                pickBy(merged, (v) => !v.disabled),
+                (v) => omit(v, ["disabled"]),
+              )
+            }
           }
-        }),
-      )
 
-      const list = Effect.fn("Provider.list")(() => InstanceState.use(state, (s) => s.providers))
+          if (Object.keys(provider.models).length === 0) {
+            delete providers[providerID]
+            continue
+          }
 
-      async function resolveSDK(model: Model, s: State) {
-        try {
-          using _ = log.time("getSDK", {
+          log.info("found", { providerID })
+        }
+
+        return {
+          models: languages,
+          providers,
+          sdk,
+          modelLoaders,
+          varsLoaders,
+        }
+      }),
+    )
+
+    const list = Effect.fn("Provider.list")(() => InstanceState.use(state, (s) => s.providers))
+
+    async function resolveSDK(model: Model, s: State, envs: Record<string, string | undefined>) {
+      try {
+        using _ = log.time("getSDK", {
+          providerID: model.providerID,
+        })
+        const provider = s.providers[model.providerID]
+        const options = { ...provider.options }
+
+        if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
+          delete options.fetch
+        }
+
+        if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
+          options["includeUsage"] = true
+        }
+
+        const baseURL = iife(() => {
+          let url =
+            typeof options["baseURL"] === "string" && options["baseURL"] !== "" ? options["baseURL"] : model.api.url
+          if (!url) return
+
+          const loader = s.varsLoaders[model.providerID]
+          if (loader) {
+            const vars = loader(options)
+            for (const [key, value] of Object.entries(vars)) {
+              const field = "${" + key + "}"
+              url = url.replaceAll(field, value)
+            }
+          }
+
+          url = url.replace(/\$\{([^}]+)\}/g, (item, key) => {
+            const val = envs[String(key)]
+            return val ?? item
+          })
+          return url
+        })
+
+        if (baseURL !== undefined) options["baseURL"] = baseURL
+        if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
+        if (model.headers)
+          options["headers"] = {
+            ...options["headers"],
+            ...model.headers,
+          }
+
+        const key = Hash.fast(
+          JSON.stringify({
             providerID: model.providerID,
-          })
-          const provider = s.providers[model.providerID]
-          const options = { ...provider.options }
+            npm: model.api.npm,
+            options,
+          }),
+        )
+        const existing = s.sdk.get(key)
+        if (existing) return existing
 
-          if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
-            delete options.fetch
-          }
+        const customFetch = options["fetch"]
+        const chunkTimeout = options["chunkTimeout"]
+        delete options["chunkTimeout"]
 
-          if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
-            options["includeUsage"] = true
-          }
+        options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
+          const fetchFn = customFetch ?? fetch
+          const opts = init ?? {}
+          const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
+          const signals: AbortSignal[] = []
 
-          const baseURL = iife(() => {
-            let url =
-              typeof options["baseURL"] === "string" && options["baseURL"] !== "" ? options["baseURL"] : model.api.url
-            if (!url) return
+          if (opts.signal) signals.push(opts.signal)
+          if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
+          if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
+            signals.push(AbortSignal.timeout(options["timeout"]))
 
-            const loader = s.varsLoaders[model.providerID]
-            if (loader) {
-              const vars = loader(options)
-              for (const [key, value] of Object.entries(vars)) {
-                const field = "${" + key + "}"
-                url = url.replaceAll(field, value)
-              }
-            }
+          const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
+          if (combined) opts.signal = combined
 
-            url = url.replace(/\$\{([^}]+)\}/g, (item, key) => {
-              const val = Env.get(String(key))
-              return val ?? item
-            })
-            return url
-          })
-
-          if (baseURL !== undefined) options["baseURL"] = baseURL
-          if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
-          if (model.headers)
-            options["headers"] = {
-              ...options["headers"],
-              ...model.headers,
-            }
-
-          const key = Hash.fast(
-            JSON.stringify({
-              providerID: model.providerID,
-              npm: model.api.npm,
-              options,
-            }),
-          )
-          const existing = s.sdk.get(key)
-          if (existing) return existing
-
-          const customFetch = options["fetch"]
-          const chunkTimeout = options["chunkTimeout"]
-          delete options["chunkTimeout"]
-
-          options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
-            const fetchFn = customFetch ?? fetch
-            const opts = init ?? {}
-            const chunkAbortCtl =
-              typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
-            const signals: AbortSignal[] = []
-
-            if (opts.signal) signals.push(opts.signal)
-            if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
-            if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
-              signals.push(AbortSignal.timeout(options["timeout"]))
-
-            const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
-            if (combined) opts.signal = combined
-
-            // Strip openai itemId metadata following what codex does
-            if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {
-              const body = JSON.parse(opts.body as string)
-              const isAzure = model.providerID.includes("azure")
-              const keepIds = isAzure && body.store === true
-              if (!keepIds && Array.isArray(body.input)) {
-                for (const item of body.input) {
-                  if ("id" in item) {
-                    delete item.id
-                  }
+          // Strip openai itemId metadata following what codex does
+          if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {
+            const body = JSON.parse(opts.body as string)
+            const isAzure = model.providerID.includes("azure")
+            const keepIds = isAzure && body.store === true
+            if (!keepIds && Array.isArray(body.input)) {
+              for (const item of body.input) {
+                if ("id" in item) {
+                  delete item.id
                 }
-                opts.body = JSON.stringify(body)
               }
+              opts.body = JSON.stringify(body)
             }
-
-            const res = await fetchFn(input, {
-              ...opts,
-              // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
-              timeout: false,
-            })
-
-            if (!chunkAbortCtl) return res
-            return wrapSSE(res, chunkTimeout, chunkAbortCtl)
           }
 
-          const bundledFn = BUNDLED_PROVIDERS[model.api.npm]
-          if (bundledFn) {
-            log.info("using bundled provider", {
-              providerID: model.providerID,
-              pkg: model.api.npm,
-            })
-            const loaded = bundledFn({
-              name: model.providerID,
-              ...options,
-            })
-            s.sdk.set(key, loaded)
-            return loaded as SDK
-          }
+          const res = await fetchFn(input, {
+            ...opts,
+            // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
+            timeout: false,
+          })
 
-          let installedPath: string
-          if (!model.api.npm.startsWith("file://")) {
-            const item = await Npm.add(model.api.npm)
-            if (!item.entrypoint) throw new Error(`Package ${model.api.npm} has no import entrypoint`)
-            installedPath = item.entrypoint
-          } else {
-            log.info("loading local provider", { pkg: model.api.npm })
-            installedPath = model.api.npm
-          }
+          if (!chunkAbortCtl) return res
+          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+        }
 
-          const mod = await import(installedPath)
-
-          const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
-          const loaded = fn({
+        const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]
+        if (bundledLoader) {
+          log.info("using bundled provider", {
+            providerID: model.providerID,
+            pkg: model.api.npm,
+          })
+          const factory = await bundledLoader()
+          const loaded = factory({
             name: model.providerID,
             ...options,
           })
           s.sdk.set(key, loaded)
           return loaded as SDK
+        }
+
+        let installedPath: string
+        if (!model.api.npm.startsWith("file://")) {
+          const item = await Npm.add(model.api.npm)
+          if (!item.entrypoint) throw new Error(`Package ${model.api.npm} has no import entrypoint`)
+          installedPath = item.entrypoint
+        } else {
+          log.info("loading local provider", { pkg: model.api.npm })
+          installedPath = model.api.npm
+        }
+
+        const mod = await import(installedPath)
+
+        const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
+        const loaded = fn({
+          name: model.providerID,
+          ...options,
+        })
+        s.sdk.set(key, loaded)
+        return loaded as SDK
+      } catch (e) {
+        throw new InitError({ providerID: model.providerID }, { cause: e })
+      }
+    }
+
+    const getProvider = Effect.fn("Provider.getProvider")((providerID: ProviderID) =>
+      InstanceState.use(state, (s) => s.providers[providerID]),
+    )
+
+    const getModel = Effect.fn("Provider.getModel")(function* (providerID: ProviderID, modelID: ModelID) {
+      const s = yield* InstanceState.get(state)
+      const provider = s.providers[providerID]
+      if (!provider) {
+        const available = Object.keys(s.providers)
+        const matches = fuzzysort.go(providerID, available, { limit: 3, threshold: -10000 })
+        throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })
+      }
+
+      const info = provider.models[modelID]
+      if (!info) {
+        const available = Object.keys(provider.models)
+        const matches = fuzzysort.go(modelID, available, { limit: 3, threshold: -10000 })
+        throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })
+      }
+      return info
+    })
+
+    const getLanguage = Effect.fn("Provider.getLanguage")(function* (model: Model) {
+      const s = yield* InstanceState.get(state)
+      const envs = yield* env.all()
+      const key = `${model.providerID}/${model.id}`
+      if (s.models.has(key)) return s.models.get(key)!
+
+      return yield* Effect.promise(async () => {
+        const provider = s.providers[model.providerID]
+        const sdk = await resolveSDK(model, s, envs)
+
+        try {
+          const language = s.modelLoaders[model.providerID]
+            ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
+                ...provider.options,
+                ...model.options,
+              })
+            : sdk.languageModel(model.api.id)
+          s.models.set(key, language)
+          return language
         } catch (e) {
-          throw new InitError({ providerID: model.providerID }, { cause: e })
+          if (e instanceof NoSuchModelError)
+            throw new ModelNotFoundError(
+              {
+                modelID: model.id,
+                providerID: model.providerID,
+              },
+              { cause: e },
+            )
+          throw e
+        }
+      })
+    })
+
+    const closest = Effect.fn("Provider.closest")(function* (providerID: ProviderID, query: string[]) {
+      const s = yield* InstanceState.get(state)
+      const provider = s.providers[providerID]
+      if (!provider) return undefined
+      for (const item of query) {
+        for (const modelID of Object.keys(provider.models)) {
+          if (modelID.includes(item)) return { providerID, modelID }
+        }
+      }
+      return undefined
+    })
+
+    const getSmallModel = Effect.fn("Provider.getSmallModel")(function* (providerID: ProviderID) {
+      const cfg = yield* config.get()
+
+      if (cfg.small_model) {
+        const parsed = parseModel(cfg.small_model)
+        return yield* getModel(parsed.providerID, parsed.modelID)
+      }
+
+      const s = yield* InstanceState.get(state)
+      const provider = s.providers[providerID]
+      if (!provider) return undefined
+
+      let priority = [
+        "claude-haiku-4-5",
+        "claude-haiku-4.5",
+        "3-5-haiku",
+        "3.5-haiku",
+        "gemini-3-flash",
+        "gemini-2.5-flash",
+        "gpt-5-nano",
+      ]
+      if (providerID.startsWith("opencode")) {
+        priority = ["gpt-5-nano"]
+      }
+      if (providerID.startsWith("github-copilot")) {
+        priority = ["gpt-5-mini", "claude-haiku-4.5", ...priority]
+      }
+      for (const item of priority) {
+        if (providerID === ProviderID.amazonBedrock) {
+          const crossRegionPrefixes = ["global.", "us.", "eu."]
+          const candidates = Object.keys(provider.models).filter((m) => m.includes(item))
+
+          const globalMatch = candidates.find((m) => m.startsWith("global."))
+          if (globalMatch) return yield* getModel(providerID, ModelID.make(globalMatch))
+
+          const region = provider.options?.region
+          if (region) {
+            const regionPrefix = region.split("-")[0]
+            if (regionPrefix === "us" || regionPrefix === "eu") {
+              const regionalMatch = candidates.find((m) => m.startsWith(`${regionPrefix}.`))
+              if (regionalMatch) return yield* getModel(providerID, ModelID.make(regionalMatch))
+            }
+          }
+
+          const unprefixed = candidates.find((m) => !crossRegionPrefixes.some((p) => m.startsWith(p)))
+          if (unprefixed) return yield* getModel(providerID, ModelID.make(unprefixed))
+        } else {
+          for (const model of Object.keys(provider.models)) {
+            if (model.includes(item)) return yield* getModel(providerID, ModelID.make(model))
+          }
         }
       }
 
-      const getProvider = Effect.fn("Provider.getProvider")((providerID: ProviderID) =>
-        InstanceState.use(state, (s) => s.providers[providerID]),
+      return undefined
+    })
+
+    const defaultModel = Effect.fn("Provider.defaultModel")(function* () {
+      const cfg = yield* config.get()
+      if (cfg.model) return parseModel(cfg.model)
+
+      const s = yield* InstanceState.get(state)
+      const recent = yield* fs.readJson(path.join(Global.Path.state, "model.json")).pipe(
+        Effect.map((x): { providerID: ProviderID; modelID: ModelID }[] => {
+          if (!isRecord(x) || !Array.isArray(x.recent)) return []
+          return x.recent.flatMap((item) => {
+            if (!isRecord(item)) return []
+            if (typeof item.providerID !== "string") return []
+            if (typeof item.modelID !== "string") return []
+            return [{ providerID: ProviderID.make(item.providerID), modelID: ModelID.make(item.modelID) }]
+          })
+        }),
+        Effect.catch(() => Effect.succeed([] as { providerID: ProviderID; modelID: ModelID }[])),
       )
+      for (const entry of recent) {
+        const provider = s.providers[entry.providerID]
+        if (!provider) continue
+        if (!provider.models[entry.modelID]) continue
+        return { providerID: entry.providerID, modelID: entry.modelID }
+      }
 
-      const getModel = Effect.fn("Provider.getModel")(function* (providerID: ProviderID, modelID: ModelID) {
-        const s = yield* InstanceState.get(state)
-        const provider = s.providers[providerID]
-        if (!provider) {
-          const available = Object.keys(s.providers)
-          const matches = fuzzysort.go(providerID, available, { limit: 3, threshold: -10000 })
-          throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })
-        }
+      const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
+      if (!provider) throw new Error("no providers found")
+      const [model] = sort(Object.values(provider.models))
+      if (!model) throw new Error("no models found")
+      return {
+        providerID: provider.id,
+        modelID: model.id,
+      }
+    })
 
-        const info = provider.models[modelID]
-        if (!info) {
-          const available = Object.keys(provider.models)
-          const matches = fuzzysort.go(modelID, available, { limit: 3, threshold: -10000 })
-          throw new ModelNotFoundError({ providerID, modelID, suggestions: matches.map((m) => m.target) })
-        }
-        return info
-      })
+    return Service.of({ list, getProvider, getModel, getLanguage, closest, getSmallModel, defaultModel })
+  }),
+)
 
-      const getLanguage = Effect.fn("Provider.getLanguage")(function* (model: Model) {
-        const s = yield* InstanceState.get(state)
-        const key = `${model.providerID}/${model.id}`
-        if (s.models.has(key)) return s.models.get(key)!
+export const defaultLayer = Layer.suspend(() =>
+  layer.pipe(
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(Env.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Plugin.defaultLayer),
+  ),
+)
 
-        return yield* Effect.promise(async () => {
-          const url = e2eURL()
-          if (url) {
-            const language = createOpenAICompatible({
-              name: model.providerID,
-              apiKey: "test-key",
-              baseURL: url,
-            }).chatModel(model.api.id)
-            s.models.set(key, language)
-            return language
-          }
+const { runPromise } = makeRuntime(Service, defaultLayer)
 
-          const provider = s.providers[model.providerID]
-          const sdk = await resolveSDK(model, s)
+export async function list() {
+  return runPromise((svc) => svc.list())
+}
 
-          try {
-            const language = s.modelLoaders[model.providerID]
-              ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
-                  ...provider.options,
-                  ...model.options,
-                })
-              : sdk.languageModel(model.api.id)
-            s.models.set(key, language)
-            return language
-          } catch (e) {
-            if (e instanceof NoSuchModelError)
-              throw new ModelNotFoundError(
-                {
-                  modelID: model.id,
-                  providerID: model.providerID,
-                },
-                { cause: e },
-              )
-            throw e
-          }
-        })
-      })
+export async function getProvider(providerID: ProviderID) {
+  return runPromise((svc) => svc.getProvider(providerID))
+}
 
-      const closest = Effect.fn("Provider.closest")(function* (providerID: ProviderID, query: string[]) {
-        const s = yield* InstanceState.get(state)
-        const provider = s.providers[providerID]
-        if (!provider) return undefined
-        for (const item of query) {
-          for (const modelID of Object.keys(provider.models)) {
-            if (modelID.includes(item)) return { providerID, modelID }
-          }
-        }
-        return undefined
-      })
+export async function getModel(providerID: ProviderID, modelID: ModelID) {
+  return runPromise((svc) => svc.getModel(providerID, modelID))
+}
 
-      const getSmallModel = Effect.fn("Provider.getSmallModel")(function* (providerID: ProviderID) {
-        const cfg = yield* config.get()
+export async function getLanguage(model: Model) {
+  return runPromise((svc) => svc.getLanguage(model))
+}
 
-        if (cfg.small_model) {
-          const parsed = parseModel(cfg.small_model)
-          return yield* getModel(parsed.providerID, parsed.modelID)
-        }
+export async function closest(providerID: ProviderID, query: string[]) {
+  return runPromise((svc) => svc.closest(providerID, query))
+}
 
-        const s = yield* InstanceState.get(state)
-        const provider = s.providers[providerID]
-        if (!provider) return undefined
+export async function getSmallModel(providerID: ProviderID) {
+  return runPromise((svc) => svc.getSmallModel(providerID))
+}
 
-        let priority = [
-          "claude-haiku-4-5",
-          "claude-haiku-4.5",
-          "3-5-haiku",
-          "3.5-haiku",
-          "gemini-3-flash",
-          "gemini-2.5-flash",
-          "gpt-5-nano",
-        ]
-        if (providerID.startsWith("opencode")) {
-          priority = ["gpt-5-nano"]
-        }
-        if (providerID.startsWith("github-copilot")) {
-          priority = ["gpt-5-mini", "claude-haiku-4.5", ...priority]
-        }
-        for (const item of priority) {
-          if (providerID === ProviderID.amazonBedrock) {
-            const crossRegionPrefixes = ["global.", "us.", "eu."]
-            const candidates = Object.keys(provider.models).filter((m) => m.includes(item))
+export async function defaultModel() {
+  return runPromise((svc) => svc.defaultModel())
+}
 
-            const globalMatch = candidates.find((m) => m.startsWith("global."))
-            if (globalMatch) return yield* getModel(providerID, ModelID.make(globalMatch))
-
-            const region = provider.options?.region
-            if (region) {
-              const regionPrefix = region.split("-")[0]
-              if (regionPrefix === "us" || regionPrefix === "eu") {
-                const regionalMatch = candidates.find((m) => m.startsWith(`${regionPrefix}.`))
-                if (regionalMatch) return yield* getModel(providerID, ModelID.make(regionalMatch))
-              }
-            }
-
-            const unprefixed = candidates.find((m) => !crossRegionPrefixes.some((p) => m.startsWith(p)))
-            if (unprefixed) return yield* getModel(providerID, ModelID.make(unprefixed))
-          } else {
-            for (const model of Object.keys(provider.models)) {
-              if (model.includes(item)) return yield* getModel(providerID, ModelID.make(model))
-            }
-          }
-        }
-
-        return undefined
-      })
-
-      const defaultModel = Effect.fn("Provider.defaultModel")(function* () {
-        const cfg = yield* config.get()
-        if (cfg.model) return parseModel(cfg.model)
-
-        const s = yield* InstanceState.get(state)
-        const recent = yield* Effect.promise(() =>
-          Filesystem.readJson<{
-            recent?: { providerID: ProviderID; modelID: ModelID }[]
-          }>(path.join(Global.Path.state, "model.json"))
-            .then((x): { providerID: ProviderID; modelID: ModelID }[] => (Array.isArray(x.recent) ? x.recent : []))
-            .catch((): { providerID: ProviderID; modelID: ModelID }[] => []),
-        )
-        for (const entry of recent) {
-          const provider = s.providers[entry.providerID]
-          if (!provider) continue
-          if (!provider.models[entry.modelID]) continue
-          return { providerID: entry.providerID, modelID: entry.modelID }
-        }
-
-        const provider = Object.values(s.providers).find(
-          (p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id),
-        )
-        if (!provider) throw new Error("no providers found")
-        const [model] = sort(Object.values(provider.models))
-        if (!model) throw new Error("no models found")
-        return {
-          providerID: provider.id,
-          modelID: model.id,
-        }
-      })
-
-      return Service.of({ list, getProvider, getModel, getLanguage, closest, getSmallModel, defaultModel })
-    }),
+const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]
+export function sort<T extends { id: string }>(models: T[]) {
+  return sortBy(
+    models,
+    [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
+    [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
+    [(model) => model.id, "desc"],
   )
+}
 
-  export const defaultLayer = Layer.suspend(() =>
-    layer.pipe(
-      Layer.provide(Config.defaultLayer),
-      Layer.provide(Auth.defaultLayer),
-      Layer.provide(Plugin.defaultLayer),
-    ),
-  )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function list() {
-    return runPromise((svc) => svc.list())
+export function parseModel(model: string) {
+  const [providerID, ...rest] = model.split("/")
+  return {
+    providerID: ProviderID.make(providerID),
+    modelID: ModelID.make(rest.join("/")),
   }
+}
 
-  export async function getProvider(providerID: ProviderID) {
-    return runPromise((svc) => svc.getProvider(providerID))
-  }
+export const ModelNotFoundError = NamedError.create(
+  "ProviderModelNotFoundError",
+  z.object({
+    providerID: ProviderID.zod,
+    modelID: ModelID.zod,
+    suggestions: z.array(z.string()).optional(),
+  }),
+)
 
-  export async function getModel(providerID: ProviderID, modelID: ModelID) {
-    return runPromise((svc) => svc.getModel(providerID, modelID))
-  }
+export const InitError = NamedError.create(
+  "ProviderInitError",
+  z.object({
+    providerID: ProviderID.zod,
+  }),
+)
 
-  export async function getLanguage(model: Model) {
-    return runPromise((svc) => svc.getLanguage(model))
-  }
+const ProviderServiceValue = Service
+const ProviderDefaultLayerValue = defaultLayer
+const ProviderModelValue = Model
+const ProviderInfoValue = Info
+const ProviderListResultValue = ListResult
+const ProviderConfigProvidersResultValue = ConfigProvidersResult
+const ProviderDefaultModelIDsValue = defaultModelIDs
+const ProviderFromModelsDevProviderValue = fromModelsDevProvider
+const ProviderListValue = list
+const ProviderGetProviderValue = getProvider
+const ProviderGetModelValue = getModel
+const ProviderGetLanguageValue = getLanguage
+const ProviderClosestValue = closest
+const ProviderGetSmallModelValue = getSmallModel
+const ProviderDefaultModelValue = defaultModel
+const ProviderSortValue = sort
+const ProviderParseModelValue = parseModel
+const ProviderModelNotFoundErrorValue = ModelNotFoundError
+const ProviderInitErrorValue = InitError
 
-  export async function closest(providerID: ProviderID, query: string[]) {
-    return runPromise((svc) => svc.closest(providerID, query))
-  }
+export namespace Provider {
+  export type Interface = import("./provider").Interface
+  export type Service = import("./provider").Service
+  export type Info = import("./provider").Info
+  export type Model = import("./provider").Model
+  export type Language = import("./provider").Language
 
-  export async function getSmallModel(providerID: ProviderID) {
-    return runPromise((svc) => svc.getSmallModel(providerID))
-  }
-
-  export async function defaultModel() {
-    return runPromise((svc) => svc.defaultModel())
-  }
-
-  const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]
-  export function sort<T extends { id: string }>(models: T[]) {
-    return sortBy(
-      models,
-      [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
-      [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
-      [(model) => model.id, "desc"],
-    )
-  }
-
-  export function parseModel(model: string) {
-    const [providerID, ...rest] = model.split("/")
-    return {
-      providerID: ProviderID.make(providerID),
-      modelID: ModelID.make(rest.join("/")),
-    }
-  }
-
-  export const ModelNotFoundError = NamedError.create(
-    "ProviderModelNotFoundError",
-    z.object({
-      providerID: ProviderID.zod,
-      modelID: ModelID.zod,
-      suggestions: z.array(z.string()).optional(),
-    }),
-  )
-
-  export const InitError = NamedError.create(
-    "ProviderInitError",
-    z.object({
-      providerID: ProviderID.zod,
-    }),
-  )
+  export const Service = ProviderServiceValue
+  export const defaultLayer = ProviderDefaultLayerValue
+  export const Model = ProviderModelValue.zod
+  export const Info = ProviderInfoValue.zod
+  export const ListResult = ProviderListResultValue.zod
+  export const ConfigProvidersResult = ProviderConfigProvidersResultValue.zod
+  export const defaultModelIDs = ProviderDefaultModelIDsValue
+  export const fromModelsDevProvider = ProviderFromModelsDevProviderValue
+  export const list = ProviderListValue
+  export const getProvider = ProviderGetProviderValue
+  export const getModel = ProviderGetModelValue
+  export const getLanguage = ProviderGetLanguageValue
+  export const closest = ProviderClosestValue
+  export const getSmallModel = ProviderGetSmallModelValue
+  export const defaultModel = ProviderDefaultModelValue
+  export const sort = ProviderSortValue
+  export const parseModel = ProviderParseModelValue
+  export const ModelNotFoundError = ProviderModelNotFoundErrorValue
+  export const InitError = ProviderInitErrorValue
 }

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -30,7 +30,7 @@ const modelIdSchema = Schema.String.pipe(Schema.brand("ModelID"))
 export type ModelID = typeof modelIdSchema.Type
 
 export const ModelID = modelIdSchema.pipe(
-  withStatics((schema: typeof modelIdSchema) => ({
+  withStatics((_schema: typeof modelIdSchema) => ({
     zod: z.string().pipe(z.custom<ModelID>()),
   })),
 )

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -354,7 +354,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
         details: "flex processing is only available for o3, o4-mini, and gpt-5 models",
       })
       // Remove from args if not supported
-      delete (baseArgs as any).service_tier
+      baseArgs.service_tier = undefined
     }
 
     // Validate priority processing support
@@ -366,7 +366,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           "priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported",
       })
       // Remove from args if not supported
-      delete (baseArgs as any).service_tier
+      baseArgs.service_tier = undefined
     }
 
     const {
@@ -793,6 +793,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     })
 
+    // oxlint-disable-next-line no-this-alias -- needed for closure scope inside generator
     const self = this
 
     let finishReason: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -2,8 +2,8 @@ import type { ModelMessage } from "ai"
 import { mergeDeep, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type { JSONSchema } from "zod/v4/core"
-import type { Provider } from "./provider"
-import type { ModelsDev } from "./models"
+import type * as Provider from "./provider"
+import type * as ModelsDev from "./models"
 import { iife } from "@/util/iife"
 import { Flag } from "@/flag/flag"
 
@@ -17,653 +17,456 @@ function mimeToModality(mime: string): Modality | undefined {
   return undefined
 }
 
-export namespace ProviderTransform {
-  export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
+export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
-  // Maps npm package to the key the AI SDK expects for providerOptions
-  function sdkKey(npm: string): string | undefined {
-    switch (npm) {
-      case "@ai-sdk/github-copilot":
-        return "copilot"
-      case "@ai-sdk/azure":
-        return "azure"
-      case "@ai-sdk/openai":
-        return "openai"
-      case "@ai-sdk/amazon-bedrock":
-        return "bedrock"
-      case "@ai-sdk/anthropic":
-      case "@ai-sdk/google-vertex/anthropic":
-        return "anthropic"
-      case "@ai-sdk/google-vertex":
-        return "vertex"
-      case "@ai-sdk/google":
-        return "google"
-      case "@ai-sdk/gateway":
-        return "gateway"
-      case "@openrouter/ai-sdk-provider":
-        return "openrouter"
-    }
-    return undefined
+// Maps npm package to the key the AI SDK expects for providerOptions
+function sdkKey(npm: string): string | undefined {
+  switch (npm) {
+    case "@ai-sdk/github-copilot":
+      return "copilot"
+    case "@ai-sdk/azure":
+      return "azure"
+    case "@ai-sdk/openai":
+      return "openai"
+    case "@ai-sdk/amazon-bedrock":
+      return "bedrock"
+    case "@ai-sdk/anthropic":
+    case "@ai-sdk/google-vertex/anthropic":
+      return "anthropic"
+    case "@ai-sdk/google-vertex":
+      return "vertex"
+    case "@ai-sdk/google":
+      return "google"
+    case "@ai-sdk/gateway":
+      return "gateway"
+    case "@openrouter/ai-sdk-provider":
+      return "openrouter"
+  }
+  return undefined
+}
+
+function normalizeMessages(
+  msgs: ModelMessage[],
+  model: Provider.Model,
+  _options: Record<string, unknown>,
+): ModelMessage[] {
+  // Anthropic rejects messages with empty content - filter out empty string messages
+  // and remove empty text/reasoning parts from array content
+  if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {
+    msgs = msgs
+      .map((msg) => {
+        if (typeof msg.content === "string") {
+          if (msg.content === "") return undefined
+          return msg
+        }
+        if (!Array.isArray(msg.content)) return msg
+        const filtered = msg.content.filter((part) => {
+          if (part.type === "text" || part.type === "reasoning") {
+            return part.text !== ""
+          }
+          return true
+        })
+        if (filtered.length === 0) return undefined
+        return { ...msg, content: filtered }
+      })
+      .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
-  function normalizeMessages(
-    msgs: ModelMessage[],
-    model: Provider.Model,
-    options: Record<string, unknown>,
-  ): ModelMessage[] {
-    // Anthropic rejects messages with empty content - filter out empty string messages
-    // and remove empty text/reasoning parts from array content
-    if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {
-      msgs = msgs
-        .map((msg) => {
-          if (typeof msg.content === "string") {
-            if (msg.content === "") return undefined
-            return msg
-          }
-          if (!Array.isArray(msg.content)) return msg
-          const filtered = msg.content.filter((part) => {
-            if (part.type === "text" || part.type === "reasoning") {
-              return part.text !== ""
-            }
-            return true
-          })
-          if (filtered.length === 0) return undefined
-          return { ...msg, content: filtered }
-        })
-        .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
-    }
-
-    if (model.api.id.includes("claude")) {
-      const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
-      msgs = msgs.map((msg) => {
-        if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          return {
-            ...msg,
-            content: msg.content.map((part) => {
-              if (part.type === "tool-call" || part.type === "tool-result") {
-                return { ...part, toolCallId: scrub(part.toolCallId) }
-              }
-              return part
-            }),
-          }
-        }
-        if (msg.role === "tool" && Array.isArray(msg.content)) {
-          return {
-            ...msg,
-            content: msg.content.map((part) => {
-              if (part.type === "tool-result") {
-                return { ...part, toolCallId: scrub(part.toolCallId) }
-              }
-              return part
-            }),
-          }
-        }
-        return msg
-      })
-    }
-    if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
-      msgs = msgs.flatMap((msg) => {
-        if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
-
-        const parts = msg.content
-        const firstToolCall = parts.findIndex((part) => part.type === "tool-call")
-        if (firstToolCall === -1) return [msg]
-        if (!parts.slice(firstToolCall).some((part) => part.type !== "tool-call")) return [msg]
-
-        return [
-          { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
-          { ...msg, content: parts.filter((part) => part.type === "tool-call") },
-        ]
-      })
-    }
-    if (
-      model.providerID === "mistral" ||
-      model.api.id.toLowerCase().includes("mistral") ||
-      model.api.id.toLocaleLowerCase().includes("devstral")
-    ) {
-      const scrub = (id: string) => {
-        return id
-          .replace(/[^a-zA-Z0-9]/g, "") // Remove non-alphanumeric characters
-          .substring(0, 9) // Take first 9 characters
-          .padEnd(9, "0") // Pad with zeros if less than 9 characters
-      }
-      const result: ModelMessage[] = []
-      for (let i = 0; i < msgs.length; i++) {
-        const msg = msgs[i]
-        const nextMsg = msgs[i + 1]
-
-        if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          msg.content = msg.content.map((part) => {
+  if (model.api.id.includes("claude")) {
+    const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
+    msgs = msgs.map((msg) => {
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        return {
+          ...msg,
+          content: msg.content.map((part) => {
             if (part.type === "tool-call" || part.type === "tool-result") {
               return { ...part, toolCallId: scrub(part.toolCallId) }
             }
             return part
-          })
+          }),
         }
-        if (msg.role === "tool" && Array.isArray(msg.content)) {
-          msg.content = msg.content.map((part) => {
+      }
+      if (msg.role === "tool" && Array.isArray(msg.content)) {
+        return {
+          ...msg,
+          content: msg.content.map((part) => {
             if (part.type === "tool-result") {
               return { ...part, toolCallId: scrub(part.toolCallId) }
             }
             return part
-          })
-        }
-        result.push(msg)
-
-        // Fix message sequence: tool messages cannot be followed by user messages
-        if (msg.role === "tool" && nextMsg?.role === "user") {
-          result.push({
-            role: "assistant",
-            content: [
-              {
-                type: "text",
-                text: "Done.",
-              },
-            ],
-          })
+          }),
         }
       }
-      return result
+      return msg
+    })
+  }
+  if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
+    // Anthropic rejects assistant turns where tool_use blocks are followed by non-tool
+    // content, e.g. [tool_use, tool_use, text], with:
+    // `tool_use` ids were found without `tool_result` blocks immediately after...
+    //
+    // Reorder that invalid shape into [text] + [tool_use, tool_use]. Consecutive
+    // assistant messages are later merged by the provider/SDK, so preserving the
+    // original [tool_use...] then [text] order still produces the invalid payload.
+    //
+    // The root cause appears to be somewhere upstream where the stream is originally
+    // processed. We were unable to locate an exact narrower reproduction elsewhere,
+    // so we keep this transform in place for the time being.
+    msgs = msgs.flatMap((msg) => {
+      if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
+
+      const parts = msg.content
+      const first = parts.findIndex((part) => part.type === "tool-call")
+      if (first === -1) return [msg]
+      if (!parts.slice(first).some((part) => part.type !== "tool-call")) return [msg]
+      return [
+        { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
+        { ...msg, content: parts.filter((part) => part.type === "tool-call") },
+      ]
+    })
+  }
+  if (
+    model.providerID === "mistral" ||
+    model.api.id.toLowerCase().includes("mistral") ||
+    model.api.id.toLocaleLowerCase().includes("devstral")
+  ) {
+    const scrub = (id: string) => {
+      return id
+        .replace(/[^a-zA-Z0-9]/g, "") // Remove non-alphanumeric characters
+        .substring(0, 9) // Take first 9 characters
+        .padEnd(9, "0") // Pad with zeros if less than 9 characters
     }
+    const result: ModelMessage[] = []
+    for (let i = 0; i < msgs.length; i++) {
+      const msg = msgs[i]
+      const nextMsg = msgs[i + 1]
 
-    if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
-      const field = model.capabilities.interleaved.field
-      return msgs.map((msg) => {
-        if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
-          const reasoningText = reasoningParts.map((part: any) => part.text).join("")
-
-          // Filter out reasoning parts from content
-          const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
-
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
-            return {
-              ...msg,
-              content: filteredContent,
-              providerOptions: {
-                ...msg.providerOptions,
-                openaiCompatible: {
-                  ...(msg.providerOptions as any)?.openaiCompatible,
-                  [field]: reasoningText,
-                },
-              },
-            }
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        msg.content = msg.content.map((part) => {
+          if (part.type === "tool-call" || part.type === "tool-result") {
+            return { ...part, toolCallId: scrub(part.toolCallId) }
           }
+          return part
+        })
+      }
+      if (msg.role === "tool" && Array.isArray(msg.content)) {
+        msg.content = msg.content.map((part) => {
+          if (part.type === "tool-result") {
+            return { ...part, toolCallId: scrub(part.toolCallId) }
+          }
+          return part
+        })
+      }
+      result.push(msg)
 
+      // Fix message sequence: tool messages cannot be followed by user messages
+      if (msg.role === "tool" && nextMsg?.role === "user") {
+        result.push({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Done.",
+            },
+          ],
+        })
+      }
+    }
+    return result
+  }
+
+  if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
+    const field = model.capabilities.interleaved.field
+    return msgs.map((msg) => {
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
+        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+
+        // Filter out reasoning parts from content
+        const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+
+        // Include reasoning_content | reasoning_details directly on the message for all assistant messages
+        if (reasoningText) {
           return {
             ...msg,
             content: filteredContent,
+            providerOptions: {
+              ...msg.providerOptions,
+              openaiCompatible: {
+                ...msg.providerOptions?.openaiCompatible,
+                [field]: reasoningText,
+              },
+            },
           }
         }
 
-        return msg
-      })
-    }
-
-    return msgs
-  }
-
-  function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
-    const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
-    const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
-
-    const providerOptions = {
-      anthropic: {
-        cacheControl: { type: "ephemeral" },
-      },
-      openrouter: {
-        cacheControl: { type: "ephemeral" },
-      },
-      bedrock: {
-        cachePoint: { type: "default" },
-      },
-      openaiCompatible: {
-        cache_control: { type: "ephemeral" },
-      },
-      copilot: {
-        copilot_cache_control: { type: "ephemeral" },
-      },
-      ...(model.api.npm === "@ai-sdk/alibaba"
-        ? {
-            alibaba: {
-              cacheControl: { type: "ephemeral" },
-            },
-          }
-        : {}),
-    }
-
-    for (const msg of unique([...system, ...final])) {
-      const useMessageLevelOptions =
-        model.providerID === "anthropic" ||
-        model.providerID.includes("bedrock") ||
-        model.api.npm === "@ai-sdk/amazon-bedrock"
-      const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
-
-      if (shouldUseContentOptions) {
-        const lastContent = msg.content[msg.content.length - 1]
-        if (
-          lastContent &&
-          typeof lastContent === "object" &&
-          lastContent.type !== "tool-approval-request" &&
-          lastContent.type !== "tool-approval-response"
-        ) {
-          lastContent.providerOptions = mergeDeep(lastContent.providerOptions ?? {}, providerOptions)
-          continue
+        return {
+          ...msg,
+          content: filteredContent,
         }
       }
 
-      msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, providerOptions)
-    }
-
-    return msgs
-  }
-
-  function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
-    return msgs.map((msg) => {
-      if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
-
-      const filtered = msg.content.map((part) => {
-        if (part.type !== "file" && part.type !== "image") return part
-
-        // Check for empty base64 image data
-        if (part.type === "image") {
-          const imageStr = part.image.toString()
-          if (imageStr.startsWith("data:")) {
-            const match = imageStr.match(/^data:([^;]+);base64,(.*)$/)
-            if (match && (!match[2] || match[2].length === 0)) {
-              return {
-                type: "text" as const,
-                text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
-              }
-            }
-          }
-        }
-
-        const mime = part.type === "image" ? part.image.toString().split(";")[0].replace("data:", "") : part.mediaType
-        const filename = part.type === "file" ? part.filename : undefined
-        const modality = mimeToModality(mime)
-        if (!modality) return part
-        if (model.capabilities.input[modality]) return part
-
-        const name = filename ? `"${filename}"` : modality
-        return {
-          type: "text" as const,
-          text: `ERROR: Cannot read ${name} (this model does not support ${modality} input). Inform the user.`,
-        }
-      })
-
-      return { ...msg, content: filtered }
+      return msg
     })
   }
 
-  export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
-    msgs = unsupportedParts(msgs, model)
-    msgs = normalizeMessages(msgs, model, options)
-    if (
-      (model.providerID === "anthropic" ||
-        model.providerID === "google-vertex-anthropic" ||
-        model.api.id.includes("anthropic") ||
-        model.api.id.includes("claude") ||
-        model.id.includes("anthropic") ||
-        model.id.includes("claude") ||
-        model.api.npm === "@ai-sdk/anthropic" ||
-        model.api.npm === "@ai-sdk/alibaba") &&
-      model.api.npm !== "@ai-sdk/gateway"
-    ) {
-      msgs = applyCaching(msgs, model)
-    }
+  return msgs
+}
 
-    // Remap providerOptions keys from stored providerID to expected SDK key
-    const key = sdkKey(model.api.npm)
-    if (key && key !== model.providerID) {
-      const remap = (opts: Record<string, any> | undefined) => {
-        if (!opts) return opts
-        if (!(model.providerID in opts)) return opts
-        const result = { ...opts }
-        result[key] = result[model.providerID]
-        delete result[model.providerID]
-        return result
-      }
+function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
+  const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
 
-      msgs = msgs.map((msg) => {
-        if (!Array.isArray(msg.content)) return { ...msg, providerOptions: remap(msg.providerOptions) }
-        return {
-          ...msg,
-          providerOptions: remap(msg.providerOptions),
-          content: msg.content.map((part) => {
-            if (part.type === "tool-approval-request" || part.type === "tool-approval-response") {
-              return { ...part }
-            }
-            return { ...part, providerOptions: remap(part.providerOptions) }
-          }),
-        } as typeof msg
-      })
-    }
-
-    return msgs
+  const providerOptions = {
+    anthropic: {
+      cacheControl: { type: "ephemeral" },
+    },
+    openrouter: {
+      cacheControl: { type: "ephemeral" },
+    },
+    bedrock: {
+      cachePoint: { type: "default" },
+    },
+    openaiCompatible: {
+      cache_control: { type: "ephemeral" },
+    },
+    copilot: {
+      copilot_cache_control: { type: "ephemeral" },
+    },
+    alibaba: {
+      cacheControl: { type: "ephemeral" },
+    },
   }
 
-  export function temperature(model: Provider.Model) {
-    const id = model.id.toLowerCase()
-    if (id.includes("qwen")) return 0.55
-    if (id.includes("claude")) return undefined
-    if (id.includes("gemini")) return 1.0
-    if (id.includes("glm-4.6")) return 1.0
-    if (id.includes("glm-4.7")) return 1.0
-    if (id.includes("minimax-m2")) return 1.0
-    if (id.includes("kimi-k2")) {
-      // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
-      if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
-        return 1.0
-      }
-      return 0.6
-    }
-    return undefined
-  }
+  for (const msg of unique([...system, ...final])) {
+    const useMessageLevelOptions =
+      model.providerID === "anthropic" ||
+      model.providerID.includes("bedrock") ||
+      model.api.npm === "@ai-sdk/amazon-bedrock"
+    const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
 
-  export function topP(model: Provider.Model) {
-    const id = model.id.toLowerCase()
-    if (id.includes("qwen")) return 1
-    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
-      return 0.95
-    }
-    return undefined
-  }
-
-  export function topK(model: Provider.Model) {
-    const id = model.id.toLowerCase()
-    if (id.includes("minimax-m2")) {
-      if (["m2.", "m25", "m21"].some((s) => id.includes(s))) return 40
-      return 20
-    }
-    if (id.includes("gemini")) return 64
-    return undefined
-  }
-
-  const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
-  const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-
-  export function variants(model: Provider.Model): Record<string, Record<string, any>> {
-    if (!model.capabilities.reasoning) return {}
-
-    const id = model.id.toLowerCase()
-    const adaptiveEfforts = ["opus-4-7", "opus-4.7"].some((v) => model.api.id.includes(v))
-      ? ["low", "medium", "high", "xhigh", "max"]
-      : ["low", "medium", "high", "max"]
-    const isAnthropicAdaptive = [
-      "opus-4-7",
-      "opus-4.7",
-      "opus-4-6",
-      "opus-4.6",
-      "sonnet-4-6",
-      "sonnet-4.6",
-    ].some((v) => model.api.id.includes(v))
-    if (
-      id.includes("deepseek") ||
-      id.includes("minimax") ||
-      id.includes("glm") ||
-      id.includes("mistral") ||
-      id.includes("kimi") ||
-      id.includes("k2p5") ||
-      id.includes("qwen") ||
-      id.includes("big-pickle")
-    )
-      return {}
-
-    // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
-    if (id.includes("grok") && id.includes("grok-3-mini")) {
-      if (model.api.npm === "@openrouter/ai-sdk-provider") {
-        return {
-          low: { reasoning: { effort: "low" } },
-          high: { reasoning: { effort: "high" } },
-        }
-      }
-      return {
-        low: { reasoningEffort: "low" },
-        high: { reasoningEffort: "high" },
+    if (shouldUseContentOptions) {
+      const lastContent = msg.content[msg.content.length - 1]
+      if (
+        lastContent &&
+        typeof lastContent === "object" &&
+        lastContent.type !== "tool-approval-request" &&
+        lastContent.type !== "tool-approval-response"
+      ) {
+        lastContent.providerOptions = mergeDeep(lastContent.providerOptions ?? {}, providerOptions)
+        continue
       }
     }
-    if (id.includes("grok")) return {}
 
-    switch (model.api.npm) {
-      case "@openrouter/ai-sdk-provider":
-        if (!model.id.includes("gpt") && !model.id.includes("gemini-3") && !model.id.includes("claude")) return {}
-        return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
+    msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, providerOptions)
+  }
 
-      case "@ai-sdk/gateway":
-        if (model.id.includes("anthropic")) {
-          if (isAnthropicAdaptive) {
-            return Object.fromEntries(
-              adaptiveEfforts.map((effort) => [
-                effort,
-                {
-                  thinking: {
-                    type: "adaptive",
-                  },
-                  effort,
-                },
-              ]),
-            )
-          }
-          return {
-            high: {
-              thinking: {
-                type: "enabled",
-                budgetTokens: 16000,
-              },
-            },
-            max: {
-              thinking: {
-                type: "enabled",
-                budgetTokens: 31999,
-              },
-            },
-          }
-        }
-        if (model.id.includes("google")) {
-          if (id.includes("2.5")) {
+  return msgs
+}
+
+function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  return msgs.map((msg) => {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
+
+    const filtered = msg.content.map((part) => {
+      if (part.type !== "file" && part.type !== "image") return part
+
+      // Check for empty base64 image data
+      if (part.type === "image") {
+        const imageStr = String(part.image)
+        if (imageStr.startsWith("data:")) {
+          const match = imageStr.match(/^data:([^;]+);base64,(.*)$/)
+          if (match && (!match[2] || match[2].length === 0)) {
             return {
-              high: {
-                thinkingConfig: {
-                  includeThoughts: true,
-                  thinkingBudget: 16000,
-                },
-              },
-              max: {
-                thinkingConfig: {
-                  includeThoughts: true,
-                  thinkingBudget: 24576,
-                },
-              },
+              type: "text" as const,
+              text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
             }
           }
-          return Object.fromEntries(
-            ["low", "high"].map((effort) => [
-              effort,
-              {
-                includeThoughts: true,
-                thinkingLevel: effort,
-              },
-            ]),
-          )
         }
-        return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      }
 
-      case "@ai-sdk/github-copilot":
-        if (model.id.includes("gemini")) {
-          // currently github copilot only returns thinking
-          return {}
-        }
-        if (model.id.includes("claude")) {
-          return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
-        }
-        const copilotEfforts = iife(() => {
-          if (id.includes("5.1-codex-max") || id.includes("5.2") || id.includes("5.3"))
-            return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-          const arr = [...WIDELY_SUPPORTED_EFFORTS]
-          if (id.includes("gpt-5") && model.release_date >= "2025-12-04") arr.push("xhigh")
-          return arr
-        })
-        return Object.fromEntries(
-          copilotEfforts.map((effort) => [
-            effort,
-            {
-              reasoningEffort: effort,
-              reasoningSummary: "auto",
-              include: ["reasoning.encrypted_content"],
-            },
-          ]),
-        )
+      const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
+      const filename = part.type === "file" ? part.filename : undefined
+      const modality = mimeToModality(mime)
+      if (!modality) return part
+      if (model.capabilities.input[modality]) return part
 
-      case "@ai-sdk/cerebras":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cerebras
-      case "@ai-sdk/togetherai":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/togetherai
-      case "@ai-sdk/xai":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/xai
-      case "@ai-sdk/deepinfra":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/deepinfra
-      case "venice-ai-sdk-provider":
-      // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
-      case "@ai-sdk/openai-compatible":
-        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      const name = filename ? `"${filename}"` : modality
+      return {
+        type: "text" as const,
+        text: `ERROR: Cannot read ${name} (this model does not support ${modality} input). Inform the user.`,
+      }
+    })
 
-      case "@ai-sdk/azure":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
-        if (id === "o1-mini") return {}
-        const azureEfforts = ["low", "medium", "high"]
-        if (id.includes("gpt-5-") || id === "gpt-5") {
-          azureEfforts.unshift("minimal")
-        }
-        return Object.fromEntries(
-          azureEfforts.map((effort) => [
-            effort,
-            {
-              reasoningEffort: effort,
-              reasoningSummary: "auto",
-              include: ["reasoning.encrypted_content"],
-            },
-          ]),
-        )
-      case "@ai-sdk/openai":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
-        if (id === "gpt-5-pro") return {}
-        const openaiEfforts = iife(() => {
-          if (id.includes("codex")) {
-            if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-            return WIDELY_SUPPORTED_EFFORTS
+    return { ...msg, content: filtered }
+  })
+}
+
+export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
+  msgs = unsupportedParts(msgs, model)
+  msgs = normalizeMessages(msgs, model, options)
+  if (
+    (model.providerID === "anthropic" ||
+      model.providerID === "google-vertex-anthropic" ||
+      model.api.id.includes("anthropic") ||
+      model.api.id.includes("claude") ||
+      model.id.includes("anthropic") ||
+      model.id.includes("claude") ||
+      model.api.npm === "@ai-sdk/anthropic" ||
+      model.api.npm === "@ai-sdk/alibaba") &&
+    model.api.npm !== "@ai-sdk/gateway"
+  ) {
+    msgs = applyCaching(msgs, model)
+  }
+
+  // Remap providerOptions keys from stored providerID to expected SDK key
+  const key = sdkKey(model.api.npm)
+  if (key && key !== model.providerID) {
+    const remap = (opts: Record<string, any> | undefined) => {
+      if (!opts) return opts
+      if (!(model.providerID in opts)) return opts
+      const result = { ...opts }
+      result[key] = result[model.providerID]
+      delete result[model.providerID]
+      return result
+    }
+
+    msgs = msgs.map((msg) => {
+      if (!Array.isArray(msg.content)) return { ...msg, providerOptions: remap(msg.providerOptions) }
+      return {
+        ...msg,
+        providerOptions: remap(msg.providerOptions),
+        content: msg.content.map((part) => {
+          if (part.type === "tool-approval-request" || part.type === "tool-approval-response") {
+            return { ...part }
           }
-          const arr = [...WIDELY_SUPPORTED_EFFORTS]
-          if (id.includes("gpt-5-") || id === "gpt-5") {
-            arr.unshift("minimal")
-          }
-          if (model.release_date >= "2025-11-13") {
-            arr.unshift("none")
-          }
-          if (model.release_date >= "2025-12-04") {
-            arr.push("xhigh")
-          }
-          return arr
-        })
-        return Object.fromEntries(
-          openaiEfforts.map((effort) => [
-            effort,
-            {
-              reasoningEffort: effort,
-              reasoningSummary: "auto",
-              include: ["reasoning.encrypted_content"],
-            },
-          ]),
-        )
+          return { ...part, providerOptions: remap(part.providerOptions) }
+        }),
+      } as typeof msg
+    })
+  }
 
-      case "@ai-sdk/anthropic":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
-      case "@ai-sdk/google-vertex/anthropic":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
+  return msgs
+}
 
-        if (isAnthropicAdaptive) {
+export function temperature(model: Provider.Model) {
+  const id = model.id.toLowerCase()
+  if (id.includes("qwen")) return 0.55
+  if (id.includes("claude")) return undefined
+  if (id.includes("gemini")) return 1.0
+  if (id.includes("glm-4.6")) return 1.0
+  if (id.includes("glm-4.7")) return 1.0
+  if (id.includes("minimax-m2")) return 1.0
+  if (id.includes("kimi-k2")) {
+    // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
+    if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
+      return 1.0
+    }
+    return 0.6
+  }
+  return undefined
+}
+
+export function topP(model: Provider.Model) {
+  const id = model.id.toLowerCase()
+  if (id.includes("qwen")) return 1
+  if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
+    return 0.95
+  }
+  return undefined
+}
+
+export function topK(model: Provider.Model) {
+  const id = model.id.toLowerCase()
+  if (id.includes("minimax-m2")) {
+    if (["m2.", "m25", "m21"].some((s) => id.includes(s))) return 40
+    return 20
+  }
+  if (id.includes("gemini")) return 64
+  return undefined
+}
+
+const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
+const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+
+function anthropicAdaptiveEfforts(apiId: string): string[] | null {
+  if (["opus-4-7", "opus-4.7"].some((v) => apiId.includes(v))) {
+    return ["low", "medium", "high", "xhigh", "max"]
+  }
+  if (["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) => apiId.includes(v))) {
+    return ["low", "medium", "high", "max"]
+  }
+  return null
+}
+
+export function variants(model: Provider.Model): Record<string, Record<string, any>> {
+  if (!model.capabilities.reasoning) return {}
+
+  const id = model.id.toLowerCase()
+  const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  if (
+    id.includes("deepseek") ||
+    id.includes("minimax") ||
+    id.includes("glm") ||
+    id.includes("mistral") ||
+    id.includes("kimi") ||
+    id.includes("k2p5") ||
+    id.includes("qwen") ||
+    id.includes("big-pickle")
+  )
+    return {}
+
+  // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
+  if (id.includes("grok") && id.includes("grok-3-mini")) {
+    if (model.api.npm === "@openrouter/ai-sdk-provider") {
+      return {
+        low: { reasoning: { effort: "low" } },
+        high: { reasoning: { effort: "high" } },
+      }
+    }
+    return {
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+    }
+  }
+  if (id.includes("grok")) return {}
+
+  switch (model.api.npm) {
+    case "@openrouter/ai-sdk-provider":
+      if (!model.id.includes("gpt") && !model.id.includes("gemini-3") && !model.id.includes("claude")) return {}
+      return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
+
+    case "@ai-sdk/gateway":
+      if (model.id.includes("anthropic")) {
+        if (adaptiveEfforts) {
           return Object.fromEntries(
             adaptiveEfforts.map((effort) => [
               effort,
               {
                 thinking: {
                   type: "adaptive",
-                  ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
-                    ? { display: "summarized" }
-                    : {}),
                 },
                 effort,
               },
             ]),
           )
         }
-
         return {
           high: {
             thinking: {
               type: "enabled",
-              budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+              budgetTokens: 16000,
             },
           },
           max: {
             thinking: {
               type: "enabled",
-              budgetTokens: Math.min(31_999, model.limit.output - 1),
+              budgetTokens: 31999,
             },
           },
         }
-
-      case "@ai-sdk/amazon-bedrock":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
-        if (isAnthropicAdaptive) {
-          return Object.fromEntries(
-            adaptiveEfforts.map((effort) => [
-              effort,
-              {
-                reasoningConfig: {
-                  type: "adaptive",
-                  maxReasoningEffort: effort,
-                },
-              },
-            ]),
-          )
-        }
-        // For Anthropic models on Bedrock, use reasoningConfig with budgetTokens
-        if (model.api.id.includes("anthropic")) {
-          return {
-            high: {
-              reasoningConfig: {
-                type: "enabled",
-                budgetTokens: 16000,
-              },
-            },
-            max: {
-              reasoningConfig: {
-                type: "enabled",
-                budgetTokens: 31999,
-              },
-            },
-          }
-        }
-
-        // For Amazon Nova models, use reasoningConfig with maxReasoningEffort
-        return Object.fromEntries(
-          WIDELY_SUPPORTED_EFFORTS.map((effort) => [
-            effort,
-            {
-              reasoningConfig: {
-                type: "enabled",
-                maxReasoningEffort: effort,
-              },
-            },
-          ]),
-        )
-
-      case "@ai-sdk/google-vertex":
-      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
-      case "@ai-sdk/google":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+      }
+      if (model.id.includes("google")) {
         if (id.includes("2.5")) {
           return {
             high: {
@@ -680,421 +483,655 @@ export namespace ProviderTransform {
             },
           }
         }
-        let levels = ["low", "high"]
-        if (id.includes("3.1")) {
-          levels = ["low", "medium", "high"]
-        }
-
         return Object.fromEntries(
-          levels.map((effort) => [
+          ["low", "high"].map((effort) => [
             effort,
             {
-              thinkingConfig: {
-                includeThoughts: true,
-                thinkingLevel: effort,
+              includeThoughts: true,
+              thinkingLevel: effort,
+            },
+          ]),
+        )
+      }
+      return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+
+    case "@ai-sdk/github-copilot":
+      if (model.id.includes("gemini")) {
+        // currently github copilot only returns thinking
+        return {}
+      }
+      if (model.id.includes("claude")) {
+        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      }
+      const copilotEfforts = iife(() => {
+        if (id.includes("5.1-codex-max") || id.includes("5.2") || id.includes("5.3"))
+          return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+        const arr = [...WIDELY_SUPPORTED_EFFORTS]
+        if (id.includes("gpt-5") && model.release_date >= "2025-12-04") arr.push("xhigh")
+        return arr
+      })
+      return Object.fromEntries(
+        copilotEfforts.map((effort) => [
+          effort,
+          {
+            reasoningEffort: effort,
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        ]),
+      )
+
+    case "@ai-sdk/cerebras":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cerebras
+    case "@ai-sdk/togetherai":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/togetherai
+    case "@ai-sdk/xai":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/xai
+    case "@ai-sdk/deepinfra":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/deepinfra
+    case "venice-ai-sdk-provider":
+    // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
+    case "@ai-sdk/openai-compatible":
+      return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+
+    case "@ai-sdk/azure":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
+      if (id === "o1-mini") return {}
+      const azureEfforts = ["low", "medium", "high"]
+      if (id.includes("gpt-5-") || id === "gpt-5") {
+        azureEfforts.unshift("minimal")
+      }
+      return Object.fromEntries(
+        azureEfforts.map((effort) => [
+          effort,
+          {
+            reasoningEffort: effort,
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        ]),
+      )
+    case "@ai-sdk/openai":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
+      if (id === "gpt-5-pro") return {}
+      const openaiEfforts = iife(() => {
+        if (id.includes("codex")) {
+          if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+          return WIDELY_SUPPORTED_EFFORTS
+        }
+        const arr = [...WIDELY_SUPPORTED_EFFORTS]
+        if (id.includes("gpt-5-") || id === "gpt-5") {
+          arr.unshift("minimal")
+        }
+        if (model.release_date >= "2025-11-13") {
+          arr.unshift("none")
+        }
+        if (model.release_date >= "2025-12-04") {
+          arr.push("xhigh")
+        }
+        return arr
+      })
+      return Object.fromEntries(
+        openaiEfforts.map((effort) => [
+          effort,
+          {
+            reasoningEffort: effort,
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        ]),
+      )
+
+    case "@ai-sdk/anthropic":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
+    case "@ai-sdk/google-vertex/anthropic":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
+
+      if (model.providerID === "github-copilot") {
+        if (model.api.id.includes("opus-4.7")) {
+          return Object.fromEntries(["medium"].map((effort) => [effort, { reasoningEffort: effort }]))
+        }
+      }
+
+      if (adaptiveEfforts) {
+        return Object.fromEntries(
+          adaptiveEfforts.map((effort) => [
+            effort,
+            {
+              thinking: {
+                type: "adaptive",
+                ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
+                  ? { display: "summarized" }
+                  : {}),
+              },
+              effort,
+            },
+          ]),
+        )
+      }
+
+      return {
+        high: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+          },
+        },
+        max: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: Math.min(31_999, model.limit.output - 1),
+          },
+        },
+      }
+
+    case "@ai-sdk/amazon-bedrock":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
+      if (adaptiveEfforts) {
+        return Object.fromEntries(
+          adaptiveEfforts.map((effort) => [
+            effort,
+            {
+              reasoningConfig: {
+                type: "adaptive",
+                maxReasoningEffort: effort,
               },
             },
           ]),
         )
-
-      case "@ai-sdk/mistral":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
-        return {}
-
-      case "@ai-sdk/cohere":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cohere
-        return {}
-
-      case "@ai-sdk/groq":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/groq
-        const groqEffort = ["none", ...WIDELY_SUPPORTED_EFFORTS]
-        return Object.fromEntries(
-          groqEffort.map((effort) => [
-            effort,
-            {
-              reasoningEffort: effort,
+      }
+      // For Anthropic models on Bedrock, use reasoningConfig with budgetTokens
+      if (model.api.id.includes("anthropic")) {
+        return {
+          high: {
+            reasoningConfig: {
+              type: "enabled",
+              budgetTokens: 16000,
             },
-          ]),
-        )
+          },
+          max: {
+            reasoningConfig: {
+              type: "enabled",
+              budgetTokens: 31999,
+            },
+          },
+        }
+      }
 
-      case "@ai-sdk/perplexity":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/perplexity
-        return {}
+      // For Amazon Nova models, use reasoningConfig with maxReasoningEffort
+      return Object.fromEntries(
+        WIDELY_SUPPORTED_EFFORTS.map((effort) => [
+          effort,
+          {
+            reasoningConfig: {
+              type: "enabled",
+              maxReasoningEffort: effort,
+            },
+          },
+        ]),
+      )
 
-      case "@jerome-benoit/sap-ai-provider-v2":
-        if (model.api.id.includes("anthropic")) {
-          if (isAnthropicAdaptive) {
-            return Object.fromEntries(
-              adaptiveEfforts.map((effort) => [
-                effort,
-                {
-                  thinking: {
-                    type: "adaptive",
-                  },
-                  effort,
+    case "@ai-sdk/google-vertex":
+    // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
+    case "@ai-sdk/google":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+      if (id.includes("2.5")) {
+        return {
+          high: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 16000,
+            },
+          },
+          max: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 24576,
+            },
+          },
+        }
+      }
+      let levels = ["low", "high"]
+      if (id.includes("3.1")) {
+        levels = ["low", "medium", "high"]
+      }
+
+      return Object.fromEntries(
+        levels.map((effort) => [
+          effort,
+          {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingLevel: effort,
+            },
+          },
+        ]),
+      )
+
+    case "@ai-sdk/mistral":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
+      return {}
+
+    case "@ai-sdk/cohere":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cohere
+      return {}
+
+    case "@ai-sdk/groq":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/groq
+      const groqEffort = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+      return Object.fromEntries(
+        groqEffort.map((effort) => [
+          effort,
+          {
+            reasoningEffort: effort,
+          },
+        ]),
+      )
+
+    case "@ai-sdk/perplexity":
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/perplexity
+      return {}
+
+    case "@jerome-benoit/sap-ai-provider-v2":
+      if (model.api.id.includes("anthropic")) {
+        if (adaptiveEfforts) {
+          return Object.fromEntries(
+            adaptiveEfforts.map((effort) => [
+              effort,
+              {
+                thinking: {
+                  type: "adaptive",
                 },
-              ]),
-            )
-          }
-          return {
-            high: {
-              thinking: {
-                type: "enabled",
-                budgetTokens: 16000,
+                effort,
               },
-            },
-            max: {
-              thinking: {
-                type: "enabled",
-                budgetTokens: 31999,
-              },
-            },
-          }
+            ]),
+          )
         }
-        if (model.api.id.includes("gemini") && id.includes("2.5")) {
-          return {
-            high: {
-              thinkingConfig: {
-                includeThoughts: true,
-                thinkingBudget: 16000,
-              },
+        return {
+          high: {
+            thinking: {
+              type: "enabled",
+              budgetTokens: 16000,
             },
-            max: {
-              thinkingConfig: {
-                includeThoughts: true,
-                thinkingBudget: 24576,
-              },
+          },
+          max: {
+            thinking: {
+              type: "enabled",
+              budgetTokens: 31999,
             },
-          }
+          },
         }
-        if (model.api.id.includes("gpt") || /\bo[1-9]/.test(model.api.id)) {
-          return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      }
+      if (model.api.id.includes("gemini") && id.includes("2.5")) {
+        return {
+          high: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 16000,
+            },
+          },
+          max: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 24576,
+            },
+          },
         }
-        return {}
-    }
-    return {}
+      }
+      if (model.api.id.includes("gpt") || /\bo[1-9]/.test(model.api.id)) {
+        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      }
+      return {}
+  }
+  return {}
+}
+
+export function options(input: {
+  model: Provider.Model
+  sessionID: string
+  providerOptions?: Record<string, any>
+}): Record<string, any> {
+  const result: Record<string, any> = {}
+
+  // openai and providers using openai package should set store to false by default.
+  if (
+    input.model.providerID === "openai" ||
+    input.model.api.npm === "@ai-sdk/openai" ||
+    input.model.api.npm === "@ai-sdk/github-copilot"
+  ) {
+    result["store"] = false
   }
 
-  export function options(input: {
-    model: Provider.Model
-    sessionID: string
-    providerOptions?: Record<string, any>
-  }): Record<string, any> {
-    const result: Record<string, any> = {}
+  if (input.model.api.npm === "@ai-sdk/azure") {
+    result["store"] = true
+    result["promptCacheKey"] = input.sessionID
+  }
 
-    // openai and providers using openai package should set store to false by default.
-    if (
-      input.model.providerID === "openai" ||
-      input.model.api.npm === "@ai-sdk/openai" ||
-      input.model.api.npm === "@ai-sdk/github-copilot"
-    ) {
-      result["store"] = false
+  if (input.model.api.npm === "@openrouter/ai-sdk-provider" || input.model.api.npm === "@llmgateway/ai-sdk-provider") {
+    result["usage"] = {
+      include: true,
     }
-
-    if (input.model.providerID === "azure" || input.model.api.npm === "@ai-sdk/azure") {
-      result["store"] = true
+    if (input.model.api.id.includes("gemini-3")) {
+      result["reasoning"] = { effort: "high" }
     }
+  }
 
-    if (input.model.api.npm === "@openrouter/ai-sdk-provider") {
-      result["usage"] = {
-        include: true,
+  if (
+    input.model.providerID === "baseten" ||
+    (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))
+  ) {
+    result["chat_template_args"] = { enable_thinking: true }
+  }
+
+  if (
+    ["zai", "zhipuai"].some((id) => input.model.providerID.includes(id)) &&
+    input.model.api.npm === "@ai-sdk/openai-compatible"
+  ) {
+    result["thinking"] = {
+      type: "enabled",
+      clear_thinking: false,
+    }
+  }
+
+  if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
+    result["promptCacheKey"] = input.sessionID
+  }
+
+  if (input.model.api.npm === "@ai-sdk/google" || input.model.api.npm === "@ai-sdk/google-vertex") {
+    if (input.model.capabilities.reasoning) {
+      result["thinkingConfig"] = {
+        includeThoughts: true,
       }
       if (input.model.api.id.includes("gemini-3")) {
-        result["reasoning"] = { effort: "high" }
+        result["thinkingConfig"]["thinkingLevel"] = "high"
       }
     }
+  }
 
-    if (
-      input.model.providerID === "baseten" ||
-      (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))
-    ) {
-      result["chat_template_args"] = { enable_thinking: true }
+  // Enable thinking by default for kimi-k2.5/k2p5 models using anthropic SDK
+  const modelId = input.model.api.id.toLowerCase()
+  if (
+    (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
+    (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))
+  ) {
+    result["thinking"] = {
+      type: "enabled",
+      budgetTokens: Math.min(16_000, Math.floor(input.model.limit.output / 2 - 1)),
     }
+  }
 
-    if (
-      ["zai", "zhipuai"].some((id) => input.model.providerID.includes(id)) &&
-      input.model.api.npm === "@ai-sdk/openai-compatible"
-    ) {
-      result["thinking"] = {
-        type: "enabled",
-        clear_thinking: false,
-      }
-    }
+  // Enable thinking for reasoning models on alibaba-cn (DashScope).
+  // DashScope's OpenAI-compatible API requires `enable_thinking: true` in the request body
+  // to return reasoning_content. Without it, models like kimi-k2.5, qwen-plus, qwen3, qwq,
+  // deepseek-r1, etc. never output thinking/reasoning tokens.
+  // Note: kimi-k2-thinking is excluded as it returns reasoning_content by default.
+  if (
+    input.model.providerID === "alibaba-cn" &&
+    input.model.capabilities.reasoning &&
+    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+    !modelId.includes("kimi-k2-thinking")
+  ) {
+    result["enable_thinking"] = true
+  }
 
-    if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
-      result["promptCacheKey"] = input.sessionID
-    }
-
-    if (input.model.api.npm === "@ai-sdk/google" || input.model.api.npm === "@ai-sdk/google-vertex") {
-      if (input.model.capabilities.reasoning) {
-        result["thinkingConfig"] = {
-          includeThoughts: true,
-        }
-        if (input.model.api.id.includes("gemini-3")) {
-          result["thinkingConfig"]["thinkingLevel"] = "high"
-        }
-      }
-    }
-
-    // Enable thinking by default for kimi-k2.5/k2p5 models using anthropic SDK
-    const modelId = input.model.api.id.toLowerCase()
-    if (
-      (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
-      (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))
-    ) {
-      result["thinking"] = {
-        type: "enabled",
-        budgetTokens: Math.min(16_000, Math.floor(input.model.limit.output / 2 - 1)),
-      }
-    }
-
-    // Enable thinking for reasoning models on alibaba-cn (DashScope).
-    // DashScope's OpenAI-compatible API requires `enable_thinking: true` in the request body
-    // to return reasoning_content. Without it, models like kimi-k2.5, qwen-plus, qwen3, qwq,
-    // deepseek-r1, etc. never output thinking/reasoning tokens.
-    // Note: kimi-k2-thinking is excluded as it returns reasoning_content by default.
-    if (
-      input.model.providerID === "alibaba-cn" &&
-      input.model.capabilities.reasoning &&
-      input.model.api.npm === "@ai-sdk/openai-compatible" &&
-      !modelId.includes("kimi-k2-thinking")
-    ) {
-      result["enable_thinking"] = true
-    }
-
-    if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-      if (!input.model.api.id.includes("gpt-5-pro")) {
-        result["reasoningEffort"] = "medium"
-        // Only inject reasoningSummary for providers that support it natively.
-        // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not understand this
-        // parameter and return "Unknown parameter: 'reasoningSummary'".
-        if (
-          input.model.api.npm === "@ai-sdk/openai" ||
-          input.model.api.npm === "@ai-sdk/azure" ||
-          input.model.api.npm === "@ai-sdk/github-copilot"
-        ) {
-          result["reasoningSummary"] = "auto"
-        }
-      }
-
-      // Only set textVerbosity for non-chat gpt-5.x models
-      // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
+  if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
+    if (!input.model.api.id.includes("gpt-5-pro")) {
+      result["reasoningEffort"] = "medium"
+      // Only inject reasoningSummary for providers that support it natively.
+      // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not understand this
+      // parameter and return "Unknown parameter: 'reasoningSummary'".
       if (
-        input.model.api.id.includes("gpt-5.") &&
-        !input.model.api.id.includes("codex") &&
-        !input.model.api.id.includes("-chat") &&
-        input.model.providerID !== "azure"
+        input.model.api.npm === "@ai-sdk/openai" ||
+        input.model.api.npm === "@ai-sdk/azure" ||
+        input.model.api.npm === "@ai-sdk/github-copilot"
       ) {
-        result["textVerbosity"] = "low"
-      }
-
-      if (input.model.providerID.startsWith("opencode")) {
-        result["promptCacheKey"] = input.sessionID
-        result["include"] = ["reasoning.encrypted_content"]
         result["reasoningSummary"] = "auto"
       }
     }
 
-    if (input.model.providerID === "venice") {
-      result["promptCacheKey"] = input.sessionID
+    // Only set textVerbosity for non-chat gpt-5.x models
+    // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
+    if (
+      input.model.api.id.includes("gpt-5.") &&
+      !input.model.api.id.includes("codex") &&
+      !input.model.api.id.includes("-chat") &&
+      input.model.providerID !== "azure"
+    ) {
+      result["textVerbosity"] = "low"
     }
 
-    if (input.model.providerID === "openrouter") {
-      result["prompt_cache_key"] = input.sessionID
+    if (input.model.providerID.startsWith("opencode")) {
+      result["promptCacheKey"] = input.sessionID
+      result["include"] = ["reasoning.encrypted_content"]
+      result["reasoningSummary"] = "auto"
     }
-    if (input.model.api.npm === "@ai-sdk/gateway") {
-      result["gateway"] = {
-        caching: "auto",
+  }
+
+  if (input.model.providerID === "venice") {
+    result["promptCacheKey"] = input.sessionID
+  }
+
+  if (input.model.providerID === "openrouter") {
+    result["prompt_cache_key"] = input.sessionID
+  }
+  if (input.model.api.npm === "@ai-sdk/gateway") {
+    result["gateway"] = {
+      caching: "auto",
+    }
+  }
+
+  return result
+}
+
+export function smallOptions(model: Provider.Model) {
+  if (
+    model.providerID === "openai" ||
+    model.api.npm === "@ai-sdk/openai" ||
+    model.api.npm === "@ai-sdk/github-copilot"
+  ) {
+    if (model.api.id.includes("gpt-5")) {
+      if (model.api.id.includes("5.") || model.api.id.includes("5-mini")) {
+        return { store: false, reasoningEffort: "low" }
+      }
+      return { store: false, reasoningEffort: "minimal" }
+    }
+    return { store: false }
+  }
+  if (model.providerID === "google") {
+    // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget
+    if (model.api.id.includes("gemini-3")) {
+      return { thinkingConfig: { thinkingLevel: "minimal" } }
+    }
+    return { thinkingConfig: { thinkingBudget: 0 } }
+  }
+  if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
+    if (model.api.id.includes("google")) {
+      return { reasoning: { enabled: false } }
+    }
+    return { reasoningEffort: "minimal" }
+  }
+
+  if (model.providerID === "venice") {
+    return { veniceParameters: { disableThinking: true } }
+  }
+
+  return {}
+}
+
+// Maps model ID prefix to provider slug used in providerOptions.
+// Example: "amazon/nova-2-lite" → "bedrock"
+const SLUG_OVERRIDES: Record<string, string> = {
+  amazon: "bedrock",
+}
+
+export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
+  if (model.api.npm === "@ai-sdk/gateway") {
+    // Gateway providerOptions are split across two namespaces:
+    // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
+    // - `<upstream slug>`: provider-specific model options (anthropic/openai/...)
+    // We keep `gateway` as-is and route every other top-level option under the
+    // model-derived upstream slug.
+    const i = model.api.id.indexOf("/")
+    const rawSlug = i > 0 ? model.api.id.slice(0, i) : undefined
+    const slug = rawSlug ? (SLUG_OVERRIDES[rawSlug] ?? rawSlug) : undefined
+    const gateway = options.gateway
+    const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "gateway"))
+    const has = Object.keys(rest).length > 0
+
+    const result: Record<string, any> = {}
+    if (gateway !== undefined) result.gateway = gateway
+
+    if (has) {
+      if (slug) {
+        // Route model-specific options under the provider slug
+        result[slug] = rest
+      } else if (gateway && typeof gateway === "object" && !Array.isArray(gateway)) {
+        result.gateway = { ...gateway, ...rest }
+      } else {
+        result.gateway = rest
       }
     }
 
     return result
   }
 
-  export function smallOptions(model: Provider.Model) {
-    if (
-      model.providerID === "openai" ||
-      model.api.npm === "@ai-sdk/openai" ||
-      model.api.npm === "@ai-sdk/github-copilot"
-    ) {
-      if (model.api.id.includes("gpt-5")) {
-        if (model.api.id.includes("5.")) {
-          return { store: false, reasoningEffort: "low" }
+  const key = sdkKey(model.api.npm) ?? model.providerID
+  // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
+  // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
+  // "azure" first. Pass both so model options work on either code path.
+  if (model.api.npm === "@ai-sdk/azure") {
+    return { openai: options, azure: options }
+  }
+  return { [key]: options }
+}
+
+export function maxOutputTokens(model: Provider.Model): number {
+  return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+}
+
+export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {
+  /*
+  if (["openai", "azure"].includes(providerID)) {
+    if (schema.type === "object" && schema.properties) {
+      for (const [key, value] of Object.entries(schema.properties)) {
+        if (schema.required?.includes(key)) continue
+        schema.properties[key] = {
+          anyOf: [
+            value as JSONSchema.JSONSchema,
+            {
+              type: "null",
+            },
+          ],
         }
-        return { store: false, reasoningEffort: "minimal" }
       }
-      return { store: false }
     }
-    if (model.providerID === "google") {
-      // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget
-      if (model.api.id.includes("gemini-3")) {
-        return { thinkingConfig: { thinkingLevel: "minimal" } }
-      }
-      return { thinkingConfig: { thinkingBudget: 0 } }
-    }
-    if (model.providerID === "openrouter") {
-      if (model.api.id.includes("google")) {
-        return { reasoning: { enabled: false } }
-      }
-      return { reasoningEffort: "minimal" }
-    }
-
-    if (model.providerID === "venice") {
-      return { veniceParameters: { disableThinking: true } }
-    }
-
-    return {}
   }
+  */
 
-  // Maps model ID prefix to provider slug used in providerOptions.
-  // Example: "amazon/nova-2-lite" → "bedrock"
-  const SLUG_OVERRIDES: Record<string, string> = {
-    amazon: "bedrock",
-  }
+  // Convert integer enums to string enums for Google/Gemini
+  if (model.providerID === "google" || model.api.id.includes("gemini")) {
+    const isPlainObject = (node: unknown): node is Record<string, any> =>
+      typeof node === "object" && node !== null && !Array.isArray(node)
+    const hasCombiner = (node: unknown) =>
+      isPlainObject(node) && (Array.isArray(node.anyOf) || Array.isArray(node.oneOf) || Array.isArray(node.allOf))
+    const hasSchemaIntent = (node: unknown) => {
+      if (!isPlainObject(node)) return false
+      if (hasCombiner(node)) return true
+      return [
+        "type",
+        "properties",
+        "items",
+        "prefixItems",
+        "enum",
+        "const",
+        "$ref",
+        "additionalProperties",
+        "patternProperties",
+        "required",
+        "not",
+        "if",
+        "then",
+        "else",
+      ].some((key) => key in node)
+    }
 
-  export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
-    if (model.api.npm === "@ai-sdk/gateway") {
-      // Gateway providerOptions are split across two namespaces:
-      // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
-      // - `<upstream slug>`: provider-specific model options (anthropic/openai/...)
-      // We keep `gateway` as-is and route every other top-level option under the
-      // model-derived upstream slug.
-      const i = model.api.id.indexOf("/")
-      const rawSlug = i > 0 ? model.api.id.slice(0, i) : undefined
-      const slug = rawSlug ? (SLUG_OVERRIDES[rawSlug] ?? rawSlug) : undefined
-      const gateway = options.gateway
-      const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "gateway"))
-      const has = Object.keys(rest).length > 0
+    const sanitizeGemini = (obj: any): any => {
+      if (obj === null || typeof obj !== "object") {
+        return obj
+      }
 
-      const result: Record<string, any> = {}
-      if (gateway !== undefined) result.gateway = gateway
+      if (Array.isArray(obj)) {
+        return obj.map(sanitizeGemini)
+      }
 
-      if (has) {
-        if (slug) {
-          // Route model-specific options under the provider slug
-          result[slug] = rest
-        } else if (gateway && typeof gateway === "object" && !Array.isArray(gateway)) {
-          result.gateway = { ...gateway, ...rest }
+      const result: any = {}
+      for (const [key, value] of Object.entries(obj)) {
+        if (key === "enum" && Array.isArray(value)) {
+          // Convert all enum values to strings
+          result[key] = value.map((v) => String(v))
+          // If we have integer type with enum, change type to string
+          if (result.type === "integer" || result.type === "number") {
+            result.type = "string"
+          }
+        } else if (typeof value === "object" && value !== null) {
+          result[key] = sanitizeGemini(value)
         } else {
-          result.gateway = rest
+          result[key] = value
         }
+      }
+
+      // Filter required array to only include fields that exist in properties
+      if (result.type === "object" && result.properties && Array.isArray(result.required)) {
+        result.required = result.required.filter((field: any) => field in result.properties)
+      }
+
+      if (result.type === "array" && !hasCombiner(result)) {
+        if (result.items == null) {
+          result.items = {}
+        }
+        // Ensure items has a type only when it's still schema-empty.
+        if (isPlainObject(result.items) && !hasSchemaIntent(result.items)) {
+          result.items.type = "string"
+        }
+      }
+
+      // Remove properties/required from non-object types (Gemini rejects these)
+      if (result.type && result.type !== "object" && !hasCombiner(result)) {
+        delete result.properties
+        delete result.required
       }
 
       return result
     }
 
-    const key = sdkKey(model.api.npm) ?? model.providerID
-    // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
-    // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
-    // "azure" first. Pass both so model options work on either code path.
-    if (model.api.npm === "@ai-sdk/azure") {
-      return { openai: options, azure: options }
-    }
-    return { [key]: options }
+    schema = sanitizeGemini(schema)
   }
 
-  export function maxOutputTokens(model: Provider.Model): number {
-    return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
-  }
+  return schema as JSONSchema7
+}
 
-  export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {
-    /*
-    if (["openai", "azure"].includes(providerID)) {
-      if (schema.type === "object" && schema.properties) {
-        for (const [key, value] of Object.entries(schema.properties)) {
-          if (schema.required?.includes(key)) continue
-          schema.properties[key] = {
-            anyOf: [
-              value as JSONSchema.JSONSchema,
-              {
-                type: "null",
-              },
-            ],
-          }
-        }
-      }
-    }
-    */
+const ProviderTransformOptionsValue = options
+const ProviderTransformMessageValue = message
+const ProviderTransformVariantsValue = variants
+const ProviderTransformProviderOptionsValue = providerOptions
+const ProviderTransformSchemaValue = schema
+const ProviderTransformOutputTokenMaxValue = OUTPUT_TOKEN_MAX
+const ProviderTransformMaxOutputTokensValue = maxOutputTokens
+const ProviderTransformTemperatureValue = temperature
+const ProviderTransformTopPValue = topP
+const ProviderTransformTopKValue = topK
+const ProviderTransformSmallOptionsValue = smallOptions
 
-    // Convert integer enums to string enums for Google/Gemini
-    if (model.providerID === "google" || model.api.id.includes("gemini")) {
-      const isPlainObject = (node: unknown): node is Record<string, any> =>
-        typeof node === "object" && node !== null && !Array.isArray(node)
-      const hasCombiner = (node: unknown) =>
-        isPlainObject(node) && (Array.isArray(node.anyOf) || Array.isArray(node.oneOf) || Array.isArray(node.allOf))
-      const hasSchemaIntent = (node: unknown) => {
-        if (!isPlainObject(node)) return false
-        if (hasCombiner(node)) return true
-        return [
-          "type",
-          "properties",
-          "items",
-          "prefixItems",
-          "enum",
-          "const",
-          "$ref",
-          "additionalProperties",
-          "patternProperties",
-          "required",
-          "not",
-          "if",
-          "then",
-          "else",
-        ].some((key) => key in node)
-      }
-
-      const sanitizeGemini = (obj: any): any => {
-        if (obj === null || typeof obj !== "object") {
-          return obj
-        }
-
-        if (Array.isArray(obj)) {
-          return obj.map(sanitizeGemini)
-        }
-
-        const result: any = {}
-        for (const [key, value] of Object.entries(obj)) {
-          if (key === "enum" && Array.isArray(value)) {
-            // Convert all enum values to strings
-            result[key] = value.map((v) => String(v))
-            // If we have integer type with enum, change type to string
-            if (result.type === "integer" || result.type === "number") {
-              result.type = "string"
-            }
-          } else if (typeof value === "object" && value !== null) {
-            result[key] = sanitizeGemini(value)
-          } else {
-            result[key] = value
-          }
-        }
-
-        // Filter required array to only include fields that exist in properties
-        if (result.type === "object" && result.properties && Array.isArray(result.required)) {
-          result.required = result.required.filter((field: any) => field in result.properties)
-        }
-
-        if (result.type === "array" && !hasCombiner(result)) {
-          if (result.items == null) {
-            result.items = {}
-          }
-          // Ensure items has a type only when it's still schema-empty.
-          if (isPlainObject(result.items) && !hasSchemaIntent(result.items)) {
-            result.items.type = "string"
-          }
-        }
-
-        // Remove properties/required from non-object types (Gemini rejects these)
-        if (result.type && result.type !== "object" && !hasCombiner(result)) {
-          delete result.properties
-          delete result.required
-        }
-
-        return result
-      }
-
-      schema = sanitizeGemini(schema)
-    }
-
-    return schema as JSONSchema7
-  }
+export namespace ProviderTransform {
+  export const OUTPUT_TOKEN_MAX = ProviderTransformOutputTokenMaxValue
+  export const options = ProviderTransformOptionsValue
+  export const message = ProviderTransformMessageValue
+  export const variants = ProviderTransformVariantsValue
+  export const providerOptions = ProviderTransformProviderOptionsValue
+  export const schema = ProviderTransformSchemaValue
+  export const maxOutputTokens = ProviderTransformMaxOutputTokensValue
+  export const temperature = ProviderTransformTemperatureValue
+  export const topP = ProviderTransformTopPValue
+  export const topK = ProviderTransformTopKValue
+  export const smallOptions = ProviderTransformSmallOptionsValue
 }

--- a/packages/opencode/src/server/instance/file.ts
+++ b/packages/opencode/src/server/instance/file.ts
@@ -20,7 +20,12 @@ export const FileRoutes = lazy(() =>
             description: "Matches",
             content: {
               "application/json": {
-                schema: resolver(Ripgrep.Match.shape.data.array()),
+                schema: resolver(
+                  z.object({
+                    items: Ripgrep.Match.shape.data.array(),
+                    partial: z.boolean(),
+                  }),
+                ),
               },
             },
           },

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -64,12 +64,13 @@ describe("file.ripgrep", () => {
       },
     })
 
-    const hits = await Ripgrep.search({
+    const result = await Ripgrep.search({
       cwd: tmp.path,
       pattern: "needle",
     })
 
-    expect(hits).toEqual([])
+    expect(result.partial).toBe(false)
+    expect(result.items).toEqual([])
   })
 
   test("files throws when ripgrep exits with an invalid glob error", async () => {
@@ -105,13 +106,18 @@ describe("file.ripgrep", () => {
     await fs.chmod(blocked, 0o000)
 
     try {
-      const hits = await Ripgrep.search({
+      const result = await Ripgrep.search({
         cwd: tmp.path,
         pattern: "needle",
       })
 
-      expect(hits.length).toBeGreaterThan(0)
-      expect(hits.some((hit) => hit.path.text === "match.ts")).toBe(true)
+      expect(result.partial).toBe(true)
+      expect(result.items.length).toBeGreaterThan(0)
+      expect(result.items.some((hit) => hit.path.text === "match.ts")).toBe(true)
+      expect(JSON.parse(JSON.stringify(result))).toEqual({
+        items: result.items,
+        partial: true,
+      })
     } finally {
       await fs.chmod(blocked, 0o755)
     }
@@ -138,12 +144,13 @@ describe("file.ripgrep", () => {
     })
 
     await withRipgrepConfig("--glob=!*.ts\n", async () => {
-      const hits = await Ripgrep.search({
+      const result = await Ripgrep.search({
         cwd: tmp.path,
         pattern: "needle",
       })
 
-      expect(hits.some((hit) => hit.path.text === "match.ts")).toBe(true)
+      expect(result.partial).toBe(false)
+      expect(result.items.some((hit) => hit.path.text === "match.ts")).toBe(true)
     })
   })
 })

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -5,10 +5,25 @@ import { unlink } from "fs/promises"
 import { ProviderID } from "../../src/provider/schema"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
-import { Provider } from "../../src/provider/provider"
+import { Provider } from "../../src/provider"
 import { Env } from "../../src/env"
 import { Global } from "../../src/global"
 import { Filesystem } from "../../src/util/filesystem"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { makeRuntime } from "../../src/effect/run-service"
+
+const env = makeRuntime(Env.Service, Env.defaultLayer)
+const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+
+async function list() {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* provider.list()
+    }),
+  )
+}
 
 test("Bedrock: config region takes precedence over AWS_REGION env var", async () => {
   await using tmp = await tmpdir({
@@ -31,11 +46,11 @@ test("Bedrock: config region takes precedence over AWS_REGION env var", async ()
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_REGION", "us-east-1")
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_REGION", "us-east-1")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].options?.region).toBe("eu-west-1")
     },
@@ -56,11 +71,11 @@ test("Bedrock: falls back to AWS_REGION env var when no config region", async ()
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_REGION", "eu-west-1")
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_REGION", "eu-west-1")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].options?.region).toBe("eu-west-1")
     },
@@ -111,12 +126,12 @@ test("Bedrock: loads when bearer token from auth.json is present", async () => {
     await Instance.provide({
       directory: tmp.path,
       init: async () => {
-        Env.set("AWS_PROFILE", "")
-        Env.set("AWS_ACCESS_KEY_ID", "")
-        Env.set("AWS_BEARER_TOKEN_BEDROCK", "")
+        set("AWS_PROFILE", "")
+        set("AWS_ACCESS_KEY_ID", "")
+        set("AWS_BEARER_TOKEN_BEDROCK", "")
       },
       fn: async () => {
-        const providers = await Provider.list()
+        const providers = await list()
         expect(providers[ProviderID.amazonBedrock]).toBeDefined()
         expect(providers[ProviderID.amazonBedrock].options?.region).toBe("eu-west-1")
       },
@@ -157,11 +172,11 @@ test("Bedrock: config profile takes precedence over AWS_PROFILE env var", async 
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
-      Env.set("AWS_ACCESS_KEY_ID", "test-key-id")
+      set("AWS_PROFILE", "default")
+      set("AWS_ACCESS_KEY_ID", "test-key-id")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].options?.region).toBe("us-east-1")
     },
@@ -189,10 +204,10 @@ test("Bedrock: includes custom endpoint in options when specified", async () => 
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].options?.endpoint).toBe(
         "https://bedrock-runtime.us-east-1.vpce-xxxxx.amazonaws.com",
@@ -222,13 +237,13 @@ test("Bedrock: autoloads when AWS_WEB_IDENTITY_TOKEN_FILE is present", async () 
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
-      Env.set("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/my-eks-role")
-      Env.set("AWS_PROFILE", "")
-      Env.set("AWS_ACCESS_KEY_ID", "")
+      set("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+      set("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/my-eks-role")
+      set("AWS_PROFILE", "")
+      set("AWS_ACCESS_KEY_ID", "")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].options?.region).toBe("us-east-1")
     },
@@ -265,10 +280,10 @@ test("Bedrock: model with us. prefix should not be double-prefixed", async () =>
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       // The model should exist with the us. prefix
       expect(providers[ProviderID.amazonBedrock].models["us.anthropic.claude-opus-4-5-20251101-v1:0"]).toBeDefined()
@@ -302,10 +317,10 @@ test("Bedrock: model with global. prefix should not be prefixed", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].models["global.anthropic.claude-opus-4-5-20251101-v1:0"]).toBeDefined()
     },
@@ -338,10 +353,10 @@ test("Bedrock: model with eu. prefix should not be double-prefixed", async () =>
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       expect(providers[ProviderID.amazonBedrock].models["eu.anthropic.claude-opus-4-5-20251101-v1:0"]).toBeDefined()
     },
@@ -374,10 +389,10 @@ test("Bedrock: model without prefix in US region should get us. prefix added", a
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("AWS_PROFILE", "default")
+      set("AWS_PROFILE", "default")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.amazonBedrock]).toBeDefined()
       // Non-prefixed model should still be registered
       expect(providers[ProviderID.amazonBedrock].models["anthropic.claude-opus-4-5-20251101-v1:0"]).toBeDefined()

--- a/packages/opencode/test/provider/gitlab-duo.test.ts
+++ b/packages/opencode/test/provider/gitlab-duo.test.ts
@@ -1,3 +1,4 @@
+export {}
 // TODO: UNCOMMENT WHEN GITLAB SUPPORT IS COMPLETED
 //
 //
@@ -8,7 +9,7 @@
 // import { ProviderID, ModelID } from "../../src/provider/schema"
 // import { tmpdir } from "../fixture/fixture"
 // import { Instance } from "../../src/project/instance"
-// import { Provider } from "../../src/provider/provider"
+// import { Provider } from "../../src/provider"
 // import { Env } from "../../src/env"
 // import { Global } from "../../src/global"
 // import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
@@ -30,7 +31,7 @@
 //       Env.set("GITLAB_TOKEN", "test-gitlab-token")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].key).toBe("test-gitlab-token")
 //     },
@@ -62,7 +63,7 @@
 //       Env.set("GITLAB_INSTANCE_URL", "https://gitlab.example.com")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].options?.instanceUrl).toBe("https://gitlab.example.com")
 //     },
@@ -100,7 +101,7 @@
 //       Env.set("GITLAB_TOKEN", "")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //     },
 //   })
@@ -135,7 +136,7 @@
 //       Env.set("GITLAB_TOKEN", "")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].key).toBe("glpat-test-pat-token")
 //     },
@@ -167,7 +168,7 @@
 //       Env.set("GITLAB_INSTANCE_URL", "https://gitlab.company.internal")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].options?.instanceUrl).toBe("https://gitlab.company.internal")
 //     },
@@ -198,7 +199,7 @@
 //       Env.set("GITLAB_TOKEN", "env-token")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //     },
 //   })
@@ -221,7 +222,7 @@
 //       Env.set("GITLAB_TOKEN", "test-token")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].options?.aiGatewayHeaders?.["anthropic-beta"]).toContain(
 //         "context-1m-2025-08-07",
@@ -257,7 +258,7 @@
 //       Env.set("GITLAB_TOKEN", "test-token")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       expect(providers[ProviderID.gitlab].options?.featureFlags).toBeDefined()
 //       expect(providers[ProviderID.gitlab].options?.featureFlags?.duo_agent_platform_agentic_chat).toBe(true)
@@ -282,7 +283,7 @@
 //       Env.set("GITLAB_TOKEN", "test-token")
 //     },
 //     fn: async () => {
-//       const providers = await Provider.list()
+//       const providers = await list()
 //       expect(providers[ProviderID.gitlab]).toBeDefined()
 //       const models = Object.keys(providers[ProviderID.gitlab].models)
 //       expect(models.length).toBeGreaterThan(0)
@@ -306,7 +307,7 @@
 //         Env.set("GITLAB_TOKEN", "test-token")
 //       },
 //       fn: async () => {
-//         const providers = await Provider.list()
+//         const providers = await list()
 //         const gitlab = providers[ProviderID.gitlab]
 //         expect(gitlab).toBeDefined()
 //         gitlab.models["duo-workflow-sonnet-4-6"] = {
@@ -332,10 +333,10 @@
 //           release_date: "",
 //           variants: {},
 //         }
-//         const model = await Provider.getModel(ProviderID.gitlab, ModelID.make("duo-workflow-sonnet-4-6"))
+//         const model = await getModel(ProviderID.gitlab, ModelID.make("duo-workflow-sonnet-4-6"))
 //         expect(model).toBeDefined()
 //         expect(model.options?.workflowRef).toBe("claude_sonnet_4_6")
-//         const language = await Provider.getLanguage(model)
+//         const language = await getLanguage(model)
 //         expect(language).toBeDefined()
 //         expect(language).toBeInstanceOf(GitLabWorkflowLanguageModel)
 //       },
@@ -354,11 +355,11 @@
 //         Env.set("GITLAB_TOKEN", "test-token")
 //       },
 //       fn: async () => {
-//         const providers = await Provider.list()
+//         const providers = await list()
 //         expect(providers[ProviderID.gitlab]).toBeDefined()
-//         const model = await Provider.getModel(ProviderID.gitlab, ModelID.make("duo-chat-sonnet-4-5"))
+//         const model = await getModel(ProviderID.gitlab, ModelID.make("duo-chat-sonnet-4-5"))
 //         expect(model).toBeDefined()
-//         const language = await Provider.getLanguage(model)
+//         const language = await getLanguage(model)
 //         expect(language).toBeDefined()
 //         expect(language).not.toBeInstanceOf(GitLabWorkflowLanguageModel)
 //       },
@@ -377,10 +378,10 @@
 //         Env.set("GITLAB_TOKEN", "test-token")
 //       },
 //       fn: async () => {
-//         const providers = await Provider.list()
+//         const providers = await list()
 //         const gitlab = providers[ProviderID.gitlab]
 //         expect(gitlab.options?.featureFlags).toBeDefined()
-//         const model = await Provider.getModel(ProviderID.gitlab, ModelID.make("duo-chat-sonnet-4-5"))
+//         const model = await getModel(ProviderID.gitlab, ModelID.make("duo-chat-sonnet-4-5"))
 //         expect(model).toBeDefined()
 //         expect(model.options).toBeDefined()
 //       },
@@ -401,7 +402,7 @@
 //         Env.set("GITLAB_TOKEN", "test-token")
 //       },
 //       fn: async () => {
-//         const providers = await Provider.list()
+//         const providers = await list()
 //         const models = Object.keys(providers[ProviderID.gitlab].models)
 //         expect(models).toContain("duo-chat-haiku-4-5")
 //         expect(models).toContain("duo-chat-sonnet-4-5")

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -6,13 +6,56 @@ import { tmpdir } from "../fixture/fixture"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
-import { ModelsDev } from "../../src/provider/models"
-import { Provider } from "../../src/provider/provider"
+import { ModelsDev } from "../../src/provider"
+import { Provider } from "../../src/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "../../src/util/filesystem"
 import { Env } from "../../src/env"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { makeRuntime } from "../../src/effect/run-service"
 
-function paid(providers: Awaited<ReturnType<typeof Provider.list>>) {
+const env = makeRuntime(Env.Service, Env.defaultLayer)
+const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+
+async function run<A, E>(fn: (provider: Provider.Interface) => Effect.Effect<A, E, never>) {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* fn(provider)
+    }),
+  )
+}
+
+async function list() {
+  return run((provider) => provider.list())
+}
+
+async function getProvider(providerID: ProviderID) {
+  return run((provider) => provider.getProvider(providerID))
+}
+
+async function getModel(providerID: ProviderID, modelID: ModelID) {
+  return run((provider) => provider.getModel(providerID, modelID))
+}
+
+async function getLanguage(model: Provider.Model) {
+  return run((provider) => provider.getLanguage(model))
+}
+
+async function closest(providerID: ProviderID, query: string[]) {
+  return run((provider) => provider.closest(providerID, query))
+}
+
+async function getSmallModel(providerID: ProviderID) {
+  return run((provider) => provider.getSmallModel(providerID))
+}
+
+async function defaultModel() {
+  return run((provider) => provider.defaultModel())
+}
+
+function paid(providers: Awaited<ReturnType<typeof list>>) {
   const item = providers[ProviderID.make("opencode")]
   expect(item).toBeDefined()
   return Object.values(item.models).filter((model) => model.cost.input > 0).length
@@ -32,10 +75,10 @@ test("provider loaded from env variable", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       // Provider should retain its connection source even if custom loaders
       // merge additional options.
@@ -66,7 +109,7 @@ test("provider loaded from config with apiKey option", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
     },
   })
@@ -87,10 +130,10 @@ test("disabled_providers excludes provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeUndefined()
     },
   })
@@ -111,11 +154,11 @@ test("enabled_providers restricts to only listed providers", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-      Env.set("OPENAI_API_KEY", "test-openai-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
+      set("OPENAI_API_KEY", "test-openai-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       expect(providers[ProviderID.openai]).toBeUndefined()
     },
@@ -141,10 +184,10 @@ test("model whitelist filters models for provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       const models = Object.keys(providers[ProviderID.anthropic].models)
       expect(models).toContain("claude-sonnet-4-20250514")
@@ -172,10 +215,10 @@ test("model blacklist excludes specific models", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       const models = Object.keys(providers[ProviderID.anthropic].models)
       expect(models).not.toContain("claude-sonnet-4-20250514")
@@ -207,10 +250,10 @@ test("custom model alias via config", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       expect(providers[ProviderID.anthropic].models["my-alias"]).toBeDefined()
       expect(providers[ProviderID.anthropic].models["my-alias"].name).toBe("My Custom Alias")
@@ -253,7 +296,7 @@ test("custom provider with npm package", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("custom-provider")]).toBeDefined()
       expect(providers[ProviderID.make("custom-provider")].name).toBe("Custom Provider")
       expect(providers[ProviderID.make("custom-provider")].models["custom-model"]).toBeDefined()
@@ -283,10 +326,10 @@ test("env variable takes precedence, config merges options", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "env-api-key")
+      set("ANTHROPIC_API_KEY", "env-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       // Config options should be merged
       expect(providers[ProviderID.anthropic].options.timeout).toBe(60000)
@@ -309,14 +352,14 @@ test("getModel returns model for valid provider/model", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model = await Provider.getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      const model = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
       expect(model).toBeDefined()
       expect(String(model.providerID)).toBe("anthropic")
       expect(String(model.id)).toBe("claude-sonnet-4-20250514")
-      const language = await Provider.getLanguage(model)
+      const language = await getLanguage(model)
       expect(language).toBeDefined()
     },
   })
@@ -336,10 +379,10 @@ test("getModel throws ModelNotFoundError for invalid model", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      expect(Provider.getModel(ProviderID.anthropic, ModelID.make("nonexistent-model"))).rejects.toThrow()
+      expect(getModel(ProviderID.anthropic, ModelID.make("nonexistent-model"))).rejects.toThrow()
     },
   })
 })
@@ -358,7 +401,7 @@ test("getModel throws ModelNotFoundError for invalid provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      expect(Provider.getModel(ProviderID.make("nonexistent-provider"), ModelID.make("some-model"))).rejects.toThrow()
+      expect(getModel(ProviderID.make("nonexistent-provider"), ModelID.make("some-model"))).rejects.toThrow()
     },
   })
 })
@@ -389,10 +432,10 @@ test("defaultModel returns first available model when no config set", async () =
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model = await Provider.defaultModel()
+      const model = await defaultModel()
       expect(model.providerID).toBeDefined()
       expect(model.modelID).toBeDefined()
     },
@@ -414,10 +457,10 @@ test("defaultModel respects config model setting", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model = await Provider.defaultModel()
+      const model = await defaultModel()
       expect(String(model.providerID)).toBe("anthropic")
       expect(String(model.modelID)).toBe("claude-sonnet-4-20250514")
     },
@@ -456,7 +499,7 @@ test("provider with baseURL from config", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("custom-openai")]).toBeDefined()
       expect(providers[ProviderID.make("custom-openai")].options.baseURL).toBe("https://custom.openai.com/v1")
     },
@@ -494,7 +537,7 @@ test("model cost defaults to zero when not specified", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("test-provider")].models["test-model"]
       expect(model.cost.input).toBe(0)
       expect(model.cost.output).toBe(0)
@@ -529,10 +572,10 @@ test("model options are merged from existing model", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.options.customOption).toBe("custom-value")
     },
@@ -558,10 +601,10 @@ test("provider removed when all models filtered out", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeUndefined()
     },
   })
@@ -581,10 +624,10 @@ test("closest finds model by partial match", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const result = await Provider.closest(ProviderID.anthropic, ["sonnet-4"])
+      const result = await closest(ProviderID.anthropic, ["sonnet-4"])
       expect(result).toBeDefined()
       expect(String(result?.providerID)).toBe("anthropic")
       expect(String(result?.modelID)).toContain("sonnet-4")
@@ -606,7 +649,7 @@ test("closest returns undefined for nonexistent provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const result = await Provider.closest(ProviderID.make("nonexistent"), ["model"])
+      const result = await closest(ProviderID.make("nonexistent"), ["model"])
       expect(result).toBeUndefined()
     },
   })
@@ -636,13 +679,13 @@ test("getModel uses realIdByKey for aliased models", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic].models["my-sonnet"]).toBeDefined()
 
-      const model = await Provider.getModel(ProviderID.anthropic, ModelID.make("my-sonnet"))
+      const model = await getModel(ProviderID.anthropic, ModelID.make("my-sonnet"))
       expect(model).toBeDefined()
       expect(String(model.id)).toBe("my-sonnet")
       expect(model.name).toBe("My Sonnet Alias")
@@ -682,7 +725,7 @@ test("provider api field sets model api.url", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       // api field is stored on model.api.url, used by getSDK to set baseURL
       expect(providers[ProviderID.make("custom-api")].models["model-1"].api.url).toBe("https://api.example.com/v1")
     },
@@ -722,7 +765,7 @@ test("explicit baseURL overrides api field", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("custom-api")].options.baseURL).toBe("https://custom.override.com/v1")
     },
   })
@@ -751,10 +794,10 @@ test("model inherits properties from existing database model", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.name).toBe("Custom Name for Sonnet")
       expect(model.capabilities.toolcall).toBe(true)
@@ -779,10 +822,10 @@ test("disabled_providers prevents loading even with env var", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("OPENAI_API_KEY", "test-openai-key")
+      set("OPENAI_API_KEY", "test-openai-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.openai]).toBeUndefined()
     },
   })
@@ -803,11 +846,11 @@ test("enabled_providers with empty array allows no providers", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-      Env.set("OPENAI_API_KEY", "test-openai-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
+      set("OPENAI_API_KEY", "test-openai-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(Object.keys(providers).length).toBe(0)
     },
   })
@@ -833,10 +876,10 @@ test("whitelist and blacklist can be combined", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       const models = Object.keys(providers[ProviderID.anthropic].models)
       expect(models).toContain("claude-sonnet-4-20250514")
@@ -875,7 +918,7 @@ test("model modalities default correctly", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("test-provider")].models["test-model"]
       expect(model.capabilities.input.text).toBe(true)
       expect(model.capabilities.output.text).toBe(true)
@@ -918,7 +961,7 @@ test("model with custom cost values", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("test-provider")].models["test-model"]
       expect(model.cost.input).toBe(5)
       expect(model.cost.output).toBe(15)
@@ -942,10 +985,10 @@ test("getSmallModel returns appropriate small model", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model = await Provider.getSmallModel(ProviderID.anthropic)
+      const model = await getSmallModel(ProviderID.anthropic)
       expect(model).toBeDefined()
       expect(model?.id).toContain("haiku")
     },
@@ -967,10 +1010,10 @@ test("getSmallModel respects config small_model override", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model = await Provider.getSmallModel(ProviderID.anthropic)
+      const model = await getSmallModel(ProviderID.anthropic)
       expect(model).toBeDefined()
       expect(String(model?.providerID)).toBe("anthropic")
       expect(String(model?.id)).toBe("claude-sonnet-4-20250514")
@@ -1015,11 +1058,11 @@ test("multiple providers can be configured simultaneously", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-anthropic-key")
-      Env.set("OPENAI_API_KEY", "test-openai-key")
+      set("ANTHROPIC_API_KEY", "test-anthropic-key")
+      set("OPENAI_API_KEY", "test-openai-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       expect(providers[ProviderID.openai]).toBeDefined()
       expect(providers[ProviderID.anthropic].options.timeout).toBe(30000)
@@ -1060,7 +1103,7 @@ test("provider with custom npm package", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("local-llm")]).toBeDefined()
       expect(providers[ProviderID.make("local-llm")].models["llama-3"].api.npm).toBe("@ai-sdk/openai-compatible")
       expect(providers[ProviderID.make("local-llm")].options.baseURL).toBe("http://localhost:11434/v1")
@@ -1094,10 +1137,10 @@ test("model alias name defaults to alias key when id differs", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic].models["sonnet"].name).toBe("sonnet")
     },
   })
@@ -1134,10 +1177,10 @@ test("provider with multiple env var options only includes apiKey when single en
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("MULTI_ENV_KEY_1", "test-key")
+      set("MULTI_ENV_KEY_1", "test-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("multi-env")]).toBeDefined()
       // When multiple env options exist, key should NOT be auto-set
       expect(providers[ProviderID.make("multi-env")].key).toBeUndefined()
@@ -1176,10 +1219,10 @@ test("provider with single env var includes apiKey automatically", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("SINGLE_ENV_KEY", "my-api-key")
+      set("SINGLE_ENV_KEY", "my-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("single-env")]).toBeDefined()
       // Single env option should auto-set key
       expect(providers[ProviderID.make("single-env")].key).toBe("my-api-key")
@@ -1213,10 +1256,10 @@ test("model cost overrides existing cost values", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.cost.input).toBe(999)
       expect(model.cost.output).toBe(888)
@@ -1263,7 +1306,7 @@ test("completely new provider not in database can be configured", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("brand-new-provider")]).toBeDefined()
       expect(providers[ProviderID.make("brand-new-provider")].name).toBe("Brand New")
       const model = providers[ProviderID.make("brand-new-provider")].models["new-model"]
@@ -1292,12 +1335,12 @@ test("disabled_providers and enabled_providers interaction", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-anthropic")
-      Env.set("OPENAI_API_KEY", "test-openai")
-      Env.set("GOOGLE_GENERATIVE_AI_API_KEY", "test-google")
+      set("ANTHROPIC_API_KEY", "test-anthropic")
+      set("OPENAI_API_KEY", "test-openai")
+      set("GOOGLE_GENERATIVE_AI_API_KEY", "test-google")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       // anthropic: in enabled, not in disabled = allowed
       expect(providers[ProviderID.anthropic]).toBeDefined()
       // openai: in enabled, but also in disabled = NOT allowed
@@ -1337,7 +1380,7 @@ test("model with tool_call false", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("no-tools")].models["basic-model"].capabilities.toolcall).toBe(false)
     },
   })
@@ -1372,7 +1415,7 @@ test("model defaults tool_call to true when not specified", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("default-tools")].models["model"].capabilities.toolcall).toBe(true)
     },
   })
@@ -1411,7 +1454,7 @@ test("model headers are preserved", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("headers-provider")].models["model"]
       expect(model.headers).toEqual({
         "X-Custom-Header": "custom-value",
@@ -1451,10 +1494,10 @@ test("provider env fallback - second env var used if first missing", async () =>
     directory: tmp.path,
     init: async () => {
       // Only set fallback, not primary
-      Env.set("FALLBACK_KEY", "fallback-api-key")
+      set("FALLBACK_KEY", "fallback-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       // Provider should load because fallback env var is set
       expect(providers[ProviderID.make("fallback-env")]).toBeDefined()
     },
@@ -1475,11 +1518,11 @@ test("getModel returns consistent results", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const model1 = await Provider.getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
-      const model2 = await Provider.getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      const model1 = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      const model2 = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
       expect(model1.providerID).toEqual(model2.providerID)
       expect(model1.id).toEqual(model2.id)
       expect(model1).toEqual(model2)
@@ -1516,7 +1559,7 @@ test("provider name defaults to id when not in database", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("my-custom-id")].name).toBe("my-custom-id")
     },
   })
@@ -1536,11 +1579,11 @@ test("ModelNotFoundError includes suggestions for typos", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
       try {
-        await Provider.getModel(ProviderID.anthropic, ModelID.make("claude-sonet-4")) // typo: sonet instead of sonnet
+        await getModel(ProviderID.anthropic, ModelID.make("claude-sonet-4")) // typo: sonet instead of sonnet
         expect(true).toBe(false) // Should not reach here
       } catch (e: any) {
         expect(e.data.suggestions).toBeDefined()
@@ -1564,11 +1607,11 @@ test("ModelNotFoundError for provider includes suggestions", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
       try {
-        await Provider.getModel(ProviderID.make("antropic"), ModelID.make("claude-sonnet-4")) // typo: antropic
+        await getModel(ProviderID.make("antropic"), ModelID.make("claude-sonnet-4")) // typo: antropic
         expect(true).toBe(false) // Should not reach here
       } catch (e: any) {
         expect(e.data.suggestions).toBeDefined()
@@ -1592,7 +1635,7 @@ test("getProvider returns undefined for nonexistent provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const provider = await Provider.getProvider(ProviderID.make("nonexistent"))
+      const provider = await getProvider(ProviderID.make("nonexistent"))
       expect(provider).toBeUndefined()
     },
   })
@@ -1612,10 +1655,10 @@ test("getProvider returns provider info", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const provider = await Provider.getProvider(ProviderID.anthropic)
+      const provider = await getProvider(ProviderID.anthropic)
       expect(provider).toBeDefined()
       expect(String(provider?.id)).toBe("anthropic")
     },
@@ -1636,10 +1679,10 @@ test("closest returns undefined when no partial match found", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const result = await Provider.closest(ProviderID.anthropic, ["nonexistent-xyz-model"])
+      const result = await closest(ProviderID.anthropic, ["nonexistent-xyz-model"])
       expect(result).toBeUndefined()
     },
   })
@@ -1659,11 +1702,11 @@ test("closest checks multiple query terms in order", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
       // First term won't match, second will
-      const result = await Provider.closest(ProviderID.anthropic, ["nonexistent", "haiku"])
+      const result = await closest(ProviderID.anthropic, ["nonexistent", "haiku"])
       expect(result).toBeDefined()
       expect(result?.modelID).toContain("haiku")
     },
@@ -1699,7 +1742,7 @@ test("model limit defaults to zero when not specified", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("no-limit")].models["model"]
       expect(model.limit.context).toBe(0)
       expect(model.limit.output).toBe(0)
@@ -1731,10 +1774,10 @@ test("provider options are deeply merged", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       // Custom options should be merged
       expect(providers[ProviderID.anthropic].options.timeout).toBe(30000)
       expect(providers[ProviderID.anthropic].options.headers["X-Custom"]).toBe("custom-value")
@@ -1769,10 +1812,10 @@ test("custom model inherits npm package from models.dev provider config", async 
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("OPENAI_API_KEY", "test-api-key")
+      set("OPENAI_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.openai].models["my-custom-model"]
       expect(model).toBeDefined()
       expect(model.api.npm).toBe("@ai-sdk/openai")
@@ -1804,10 +1847,10 @@ test("custom model inherits api.url from models.dev provider", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("OPENROUTER_API_KEY", "test-api-key")
+      set("OPENROUTER_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.openrouter]).toBeDefined()
 
       // New model not in database should inherit api.url from provider
@@ -1873,7 +1916,7 @@ test("mode cost preserves over-200k pricing from base model", () => {
         },
       },
     },
-  } as ModelsDev.Provider
+  } as unknown as ModelsDev.Provider
 
   const model = Provider.fromModelsDevProvider(provider).models["gpt-5.4-fast"]
   expect(model.cost.input).toEqual(5)
@@ -1937,10 +1980,10 @@ test("model variants are generated for reasoning models", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       // Claude sonnet 4 has reasoning capability
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.capabilities.reasoning).toBe(true)
@@ -1975,10 +2018,10 @@ test("model variants can be disabled via config", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.variants).toBeDefined()
       expect(model.variants!["high"]).toBeUndefined()
@@ -2018,10 +2061,10 @@ test("model variants can be customized via config", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.variants!["high"]).toBeDefined()
       expect(model.variants!["high"].thinking.budgetTokens).toBe(20000)
@@ -2057,10 +2100,10 @@ test("disabled key is stripped from variant config", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.variants!["max"]).toBeDefined()
       expect(model.variants!["max"].disabled).toBeUndefined()
@@ -2095,10 +2138,10 @@ test("all variants can be disabled via config", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.variants).toBeDefined()
       expect(Object.keys(model.variants!).length).toBe(0)
@@ -2133,10 +2176,10 @@ test("variant config merges with generated variants", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+      set("ANTHROPIC_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.variants!["high"]).toBeDefined()
       // Should have both the generated thinking config and the custom option
@@ -2171,10 +2214,10 @@ test("variants filtered in second pass for database models", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("OPENAI_API_KEY", "test-api-key")
+      set("OPENAI_API_KEY", "test-api-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.openai].models["gpt-5"]
       expect(model.variants).toBeDefined()
       expect(model.variants!["high"]).toBeUndefined()
@@ -2220,7 +2263,7 @@ test("custom model with variants enabled and disabled", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("custom-reasoning")].models["reasoning-model"]
       expect(model.variants).toBeDefined()
       // Enabled variants should exist
@@ -2275,10 +2318,10 @@ test("Google Vertex: retains baseURL for custom proxy", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("GOOGLE_APPLICATION_CREDENTIALS", "test-creds")
+      set("GOOGLE_APPLICATION_CREDENTIALS", "test-creds")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("vertex-proxy")]).toBeDefined()
       expect(providers[ProviderID.make("vertex-proxy")].options.baseURL).toBe("https://my-proxy.com/v1")
     },
@@ -2320,10 +2363,10 @@ test("Google Vertex: supports OpenAI compatible models", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("GOOGLE_APPLICATION_CREDENTIALS", "test-creds")
+      set("GOOGLE_APPLICATION_CREDENTIALS", "test-creds")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       const model = providers[ProviderID.make("vertex-openai")].models["gpt-4"]
 
       expect(model).toBeDefined()
@@ -2346,12 +2389,12 @@ test("cloudflare-ai-gateway loads with env variables", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("CLOUDFLARE_ACCOUNT_ID", "test-account")
-      Env.set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
-      Env.set("CLOUDFLARE_API_TOKEN", "test-token")
+      set("CLOUDFLARE_ACCOUNT_ID", "test-account")
+      set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
+      set("CLOUDFLARE_API_TOKEN", "test-token")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("cloudflare-ai-gateway")]).toBeDefined()
     },
   })
@@ -2378,12 +2421,12 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("CLOUDFLARE_ACCOUNT_ID", "test-account")
-      Env.set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
-      Env.set("CLOUDFLARE_API_TOKEN", "test-token")
+      set("CLOUDFLARE_ACCOUNT_ID", "test-account")
+      set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
+      set("CLOUDFLARE_API_TOKEN", "test-token")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.make("cloudflare-ai-gateway")]).toBeDefined()
       expect(providers[ProviderID.make("cloudflare-ai-gateway")].options.metadata).toEqual({
         invoked_by: "test",
@@ -2429,10 +2472,15 @@ test("plugin config providers persist after instance dispose", async () => {
 
   const first = await Instance.provide({
     directory: tmp.path,
-    fn: async () => {
-      await Plugin.init()
-      return Provider.list()
-    },
+    fn: async () =>
+      AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const plugin = yield* Plugin.Service
+          const provider = yield* Provider.Service
+          yield* plugin.init()
+          return yield* provider.list()
+        }),
+      ),
   })
   expect(first[ProviderID.make("demo")]).toBeDefined()
   expect(first[ProviderID.make("demo")].models[ModelID.make("chat")]).toBeDefined()
@@ -2441,7 +2489,7 @@ test("plugin config providers persist after instance dispose", async () => {
 
   const second = await Instance.provide({
     directory: tmp.path,
-    fn: async () => Provider.list(),
+    fn: async () => list(),
   })
   expect(second[ProviderID.make("demo")]).toBeDefined()
   expect(second[ProviderID.make("demo")].models[ModelID.make("chat")]).toBeDefined()
@@ -2473,11 +2521,11 @@ test("plugin config enabled and disabled providers are honored", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-anthropic-key")
-      Env.set("OPENAI_API_KEY", "test-openai-key")
+      set("ANTHROPIC_API_KEY", "test-anthropic-key")
+      set("OPENAI_API_KEY", "test-openai-key")
     },
     fn: async () => {
-      const providers = await Provider.list()
+      const providers = await list()
       expect(providers[ProviderID.anthropic]).toBeDefined()
       expect(providers[ProviderID.openai]).toBeUndefined()
     },
@@ -2498,7 +2546,7 @@ test("opencode loader keeps paid models when config apiKey is present", async ()
 
   const none = await Instance.provide({
     directory: base.path,
-    fn: async () => paid(await Provider.list()),
+    fn: async () => paid(await list()),
   })
 
   await using keyed = await tmpdir({
@@ -2521,7 +2569,7 @@ test("opencode loader keeps paid models when config apiKey is present", async ()
 
   const keyedCount = await Instance.provide({
     directory: keyed.path,
-    fn: async () => paid(await Provider.list()),
+    fn: async () => paid(await list()),
   })
 
   expect(none).toBe(0)
@@ -2542,7 +2590,7 @@ test("opencode loader keeps paid models when auth exists", async () => {
 
   const none = await Instance.provide({
     directory: base.path,
-    fn: async () => paid(await Provider.list()),
+    fn: async () => paid(await list()),
   })
 
   await using keyed = await tmpdir({
@@ -2576,7 +2624,7 @@ test("opencode loader keeps paid models when auth exists", async () => {
 
     const keyedCount = await Instance.provide({
       directory: keyed.path,
-      fn: async () => paid(await Provider.list()),
+      fn: async () => paid(await list()),
     })
 
     expect(none).toBe(0)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -365,6 +365,65 @@ test("getModel returns model for valid provider/model", async () => {
   })
 })
 
+test("opencode e2e env routes getLanguage through the test llm url", async () => {
+  const e2eURL = "http://127.0.0.1:4010/v1"
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("OPENCODE_E2E_LLM_URL", e2eURL)
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("opencode"), ModelID.make("gpt-5-nano"))
+      const language = await getLanguage(model)
+
+      expect(language.modelId).toBe("gpt-5-nano")
+      expect((language as any).config.url({ modelId: language.modelId, path: "/chat/completions" })).toBe(
+        `${e2eURL}/chat/completions`,
+      )
+    },
+  })
+})
+
+test("non-opencode models ignore the opencode e2e llm url override", async () => {
+  const e2eURL = "http://127.0.0.1:4010/v1"
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+      set("OPENCODE_E2E_LLM_URL", e2eURL)
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      const language = await getLanguage(model)
+
+      expect(language.modelId).toBe("claude-sonnet-4-20250514")
+      expect(language.provider).toBe("anthropic")
+    },
+  })
+})
+
 test("getModel throws ModelNotFoundError for invalid model", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { ProviderTransform } from "../../src/provider/transform"
+import { ProviderTransform } from "../../src/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-
-const OUTPUT_TOKEN_MAX = 32000
 
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
@@ -309,22 +307,6 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     const model = createGpt5Model("gpt-5.2-codex")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
     expect(result.textVerbosity).toBeUndefined()
-  })
-
-  test("gpt-5 compatible proxies should not inject reasoningSummary", () => {
-    const model = {
-      ...createGpt5Model("gpt-5"),
-      id: "custom-provider/gpt-5",
-      providerID: "custom-provider",
-      api: {
-        id: "gpt-5",
-        url: "https://api.custom.com",
-        npm: "@ai-sdk/openai-compatible",
-      },
-    }
-    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
-    expect(result.reasoningEffort).toBe("medium")
-    expect(result.reasoningSummary).toBeUndefined()
   })
 })
 
@@ -1397,13 +1379,17 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
     expect(result).toHaveLength(2)
-    expect(result[0].content).toMatchObject([
-      { type: "text", text: "I checked your home directory and looked for PDF files." },
-    ])
-    expect(result[1].content).toMatchObject([
-      { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
-      { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
-    ])
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
+    })
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+        { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+      ],
+    })
   })
 })
 
@@ -1976,6 +1962,11 @@ describe("ProviderTransform.message - cache control on gateway", () => {
           type: "ephemeral",
         },
       },
+      alibaba: {
+        cacheControl: {
+          type: "ephemeral",
+        },
+      },
     })
   })
 
@@ -2025,6 +2016,11 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
       copilot: {
         copilot_cache_control: {
+          type: "ephemeral",
+        },
+      },
+      alibaba: {
+        cacheControl: {
           type: "ephemeral",
         },
       },
@@ -2578,7 +2574,6 @@ describe("ProviderTransform.variants", () => {
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
     })
-
   })
 
   describe("@ai-sdk/azure", () => {
@@ -2717,7 +2712,7 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
-    test("opus 4.7 returns adaptive thinking options with summarized display", () => {
+    test("opus 4.7 returns adaptive thinking options with xhigh", () => {
       const model = createMockModel({
         id: "anthropic/claude-opus-4-7",
         providerID: "anthropic",


### PR DESCRIPTION
## Summary

Sync the upstream opencode foundation and provider tail needed for the v1.4.11 graft slice.
Restore compatibility surfaces around `Env`, `Provider`, `ProviderAuth`, `ProviderError`, `ProviderTransform`, and `ModelsDev`.
Preserve ripgrep `partial` results across JSON serialization and align the `/find` response to return `{ items, partial }`.

## Why

PR 9a is the foundation-provider tail of issue #27. The core lane stays inside opencode-internal foundation work under `provider` and `file`.

This PR includes two narrow compatibility exceptions that are required to keep that slice coherent:
- `packages/opencode/src/env/index.ts`: upstream provider wiring now depends on `Env.Service`, so this file bridges the new Effect service shape back into PawWork's existing sync surface.
- `packages/opencode/src/server/instance/file.ts`: `Ripgrep.search()` now serializes `{ items, partial }`, so the `/find` route schema needs to match the actual response contract.

Reviewed against the three-question philosophy: this is the smallest sound PR for the 9a lane, the remaining scope is sufficient for the upstream sync goal, and the verification plus scope notes are intended to make the slice reassuring to merge.

## Related Issue

Part of #27

## How To Verify

```bash
cd packages/opencode && bun run typecheck
cd packages/opencode && bun test ./test/provider/provider.test.ts
OPENCODE_E2E_KEEP_SANDBOX=1 bun --cwd packages/app test:e2e:local -- e2e/prompt/prompt.spec.ts --grep @smoke
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
