### PR TITLE
fix(scripts): point dev:desktop at packages/desktop-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
-    "dev:desktop": "bun --cwd packages/desktop tauri dev",
+    "dev:desktop": "bun --cwd packages/desktop-electron dev",
     "dev:web": "bun --cwd packages/app dev",
     "dev:console": "ulimit -n 10240 2>/dev/null; bun run --cwd packages/console/app dev",
     "dev:storybook": "bun --cwd packages/storybook storybook",


### PR DESCRIPTION
## Summary

Update root `dev:desktop` script to invoke `packages/desktop-electron` instead of the removed `packages/desktop` (Tauri) path.

## Why

The desktop app migrated from Tauri (`packages/desktop`) to Electron (`packages/desktop-electron`), but `package.json` still had `"dev:desktop": "bun --cwd packages/desktop tauri dev"`. Running `bun run dev:desktop` from the repo root failed with `ENOENT: Could not change directory to "packages/desktop"`.

## Related Issue

None.

## How To Verify

```bash
bun install
bun run dev:desktop
```

Confirmed locally: predev copies dev icons, `build:embedded-server` builds the node bundle, electron-vite builds main + preload, renderer dev server comes up on `http://localhost:5174/`, and the Electron app prints `app starting { version: '0.2.2', packaged: false }`.

Also grepped the repo for other stale `packages/desktop` (non-electron) references. Only hits outside `packages/desktop-electron` were in this root `package.json`. Stale Tauri references inside `packages/desktop-electron/README.md` and `icons/README.md` are out of scope for this PR.

## Screenshots or Recordings

N/A (no visible UI change).

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the \`dev\` branch