### PR TITLE
[Feature] Polish right panel tabs (Terminal, Review, Status)

### DIFF
--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -30,7 +30,10 @@ test("@smoke review tab no longer renders the legacy file-tree sub-panel", async
     await expect(page.locator("#file-tree-panel")).toHaveCount(0)
 
     // The Review tab content area still renders (empty state is fine when no diffs).
-    const reviewContent = rightPanel.getByRole("tabpanel").first()
-    await expect(reviewContent).toBeVisible()
+    // The right panel has nested Tabs, so locate the panel via the tab's aria-controls
+    // rather than .first() ordering.
+    const reviewPanelId = await reviewTab.getAttribute("aria-controls")
+    expect(reviewPanelId).toBeTruthy()
+    await expect(page.locator(`#${reviewPanelId}`)).toBeVisible()
   })
 })

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -2,58 +2,35 @@ import { test, expect } from "../fixtures"
 import { withSession } from "../actions"
 import { titlebarRightSelector } from "../selectors"
 
-test("@smoke review keeps the persistent file-tree pane for review navigation", async ({ page, project }) => {
+// Historical context: before the right-panel-polish PR (#52), the Review tab
+// carried a sibling vertical file-tree pane (#file-tree-panel) that surfaced
+// a full workspace tree next to the diff viewer. That pane was removed by
+// design so the diff viewer can claim the full Review pane width. This spec
+// now guards the inverse invariant: the pane must NOT render, and the Review
+// tab content area must still mount.
+test("@smoke review tab no longer renders the legacy file-tree sub-panel", async ({ page, project }) => {
   await project.open()
 
-  await withSession(project.sdk, `e2e file tree smoke ${Date.now()}`, async (session) => {
+  await withSession(project.sdk, `e2e review layout smoke ${Date.now()}`, async (session) => {
     await project.gotoSession(session.id)
 
     const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
     const rightPanel = page.locator("#right-panel")
-    const panel = page.locator("#file-tree-panel")
     const shellTabList = rightPanel.getByRole("tablist").first()
 
     await expect(rightToggle).toBeVisible()
     await rightToggle.click()
     await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
-    await expect(rightPanel).toBeVisible()
+
     const reviewTab = shellTabList.getByRole("tab", { name: "Review", exact: true })
     await reviewTab.click()
     await expect(reviewTab).toHaveAttribute("aria-selected", "true")
-    await expect(panel).toBeVisible()
-    await expect(panel.getByRole("tab", { name: /all/i })).toBeVisible()
 
-    const openFile = rightPanel.getByRole("button", { name: /^Open file$/i }).first()
-    await expect(openFile).toBeVisible()
-    await openFile.click()
+    // The old vertical file-tree pane is gone by design.
+    await expect(page.locator("#file-tree-panel")).toHaveCount(0)
 
-    const dialog = page
-      .getByRole("dialog")
-      .filter({ has: page.getByPlaceholder(/search files/i) })
-      .first()
-    await expect(dialog).toBeVisible()
-
-    const input = dialog.getByRole("textbox").first()
-    await input.fill("README.md")
-
-    const file = dialog.locator('[data-slot="list-item"][data-key^="file:"]').first()
-    await expect(file).toBeVisible({ timeout: 30_000 })
-    await file.click()
-
-    const tab = page.getByRole("tab", { name: "README.md" })
-    await expect(tab).toBeVisible()
-    await tab.click()
-    await expect(tab).toHaveAttribute("aria-selected", "true")
-    await expect(panel).toBeVisible()
-
-    await rightToggle.click()
-    await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
-
-    await rightToggle.click()
-    await expect(reviewTab).toHaveAttribute("aria-selected", "true")
-
-    const viewer = page.locator('[data-component="file"][data-mode="text"]').first()
-    await expect(viewer).toBeVisible()
-    await expect(viewer).toContainText("# e2e")
+    // The Review tab content area still renders (empty state is fine when no diffs).
+    const reviewContent = rightPanel.getByRole("tabpanel").first()
+    await expect(reviewContent).toBeVisible()
   })
 })

--- a/packages/app/src/components/session/session-sortable-terminal-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-terminal-tab.tsx
@@ -11,7 +11,11 @@ import { useTerminal, type LocalPTY } from "@/context/terminal"
 import { useLanguage } from "@/context/language"
 import { focusTerminalById } from "@/pages/session/helpers"
 
-export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () => void }): JSX.Element {
+export function SortableTerminalTab(props: {
+  terminal: LocalPTY
+  onClose?: () => void
+  totalCount: number
+}): JSX.Element {
   const terminal = useTerminal()
   const language = useLanguage()
   const sortable = createSortable(props.terminal.id)
@@ -132,15 +136,17 @@ export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () =>
             button: "border-0 outline-none focus:outline-none focus-visible:outline-none !shadow-none !ring-0",
           }}
           closeButton={
-            <IconButton
-              icon="close"
-              variant="ghost"
-              onClick={(e) => {
-                e.stopPropagation()
-                close()
-              }}
-              aria-label={language.t("terminal.close")}
-            />
+            props.totalCount > 1 ? (
+              <IconButton
+                icon="close"
+                variant="ghost"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  close()
+                }}
+                aria-label={language.t("terminal.close")}
+              />
+            ) : undefined
           }
         >
           <span onDblClick={edit} classList={{ invisible: store.editing }}>
@@ -180,10 +186,12 @@ export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () =>
                 <Icon name="edit" class="w-4 h-4 mr-2" />
                 {language.t("common.rename")}
               </DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={close}>
-                <Icon name="close" class="w-4 h-4 mr-2" />
-                {language.t("common.close")}
-              </DropdownMenu.Item>
+              <Show when={props.totalCount > 1}>
+                <DropdownMenu.Item onSelect={close}>
+                  <Icon name="close" class="w-4 h-4 mr-2" />
+                  {language.t("common.close")}
+                </DropdownMenu.Item>
+              </Show>
             </DropdownMenu.Content>
           </DropdownMenu.Portal>
         </DropdownMenu>

--- a/packages/app/src/components/session/session-status-connections.tsx
+++ b/packages/app/src/components/session/session-status-connections.tsx
@@ -1,6 +1,8 @@
 import { For, Show, createEffect, createMemo, on, onCleanup, type Accessor, type JSX } from "solid-js"
 import { createStore, reconcile } from "solid-js/store"
+import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
 import { useServer, ServerConnection } from "@/context/server"
 import { useSync } from "@/context/sync"
@@ -57,6 +59,13 @@ export function SessionStatusConnections(props: { shown: Accessor<boolean> }) {
   const language = useLanguage()
   const server = useServer()
   const sync = useSync()
+  const dialog = useDialog()
+
+  const openServerPicker = () => {
+    void import("@/components/dialog-select-server").then((x) => {
+      dialog.show(() => <x.DialogSelectServer />)
+    })
+  }
 
   const checkServerHealth = useCheckServerHealth()
   const [health, setHealth] = createStore({} as Record<ServerConnection.Key, ServerHealth | undefined>)
@@ -288,6 +297,12 @@ export function SessionStatusConnections(props: { shown: Accessor<boolean> }) {
           </For>
         </Show>
       </SectionRow>
+
+      <div class="px-4 py-3">
+        <Button variant="secondary" class="h-8 px-3 py-1.5" onClick={openServerPicker}>
+          {language.t("status.popover.action.manageServers")}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/components/session/session-status-connections.tsx
+++ b/packages/app/src/components/session/session-status-connections.tsx
@@ -1,0 +1,293 @@
+import { For, Show, createEffect, createMemo, on, onCleanup, type Accessor, type JSX } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
+import { Icon } from "@opencode-ai/ui/icon"
+import { useLanguage } from "@/context/language"
+import { useServer, ServerConnection } from "@/context/server"
+import { useSync } from "@/context/sync"
+import { useCheckServerHealth, type ServerHealth } from "@/utils/server-health"
+
+const POLL_MS = 10_000
+
+type CategoryState = "ok" | "warn" | "empty"
+
+function EmptyHint(props: { text: string }) {
+  return <div class="text-12-regular text-text-weaker py-1">{props.text}</div>
+}
+
+function SectionRow(props: {
+  title: string
+  count: number
+  state: CategoryState
+  expanded: boolean
+  onToggle: () => void
+  children?: JSX.Element
+}) {
+  const dot = () => {
+    if (props.state === "warn") return "bg-icon-critical-base"
+    if (props.state === "ok") return "bg-icon-success-base"
+    return "bg-border-weak-base"
+  }
+  return (
+    <div class="border-b border-border-weaker-base last:border-b-0">
+      <button
+        type="button"
+        class="flex items-center gap-2 w-full px-4 py-2.5 hover:bg-surface-raised-base-hover text-left"
+        onClick={props.onToggle}
+        aria-expanded={props.expanded}
+      >
+        <div class={`size-1.5 rounded-full shrink-0 ${dot()}`} aria-hidden />
+        <div class="text-13-regular text-text-base">{props.title}</div>
+        <div class="text-12-regular text-text-weaker">{props.count}</div>
+        <div class="flex-1" />
+        <Icon
+          name="chevron-down"
+          size="small"
+          class="text-icon-weaker transition-transform"
+          classList={{ "rotate-180": props.expanded }}
+        />
+      </button>
+      <Show when={props.expanded}>
+        <div class="px-4 pb-3">{props.children}</div>
+      </Show>
+    </div>
+  )
+}
+
+export function SessionStatusConnections(props: { shown: Accessor<boolean> }) {
+  const language = useLanguage()
+  const server = useServer()
+  const sync = useSync()
+
+  const checkServerHealth = useCheckServerHealth()
+  const [health, setHealth] = createStore({} as Record<ServerConnection.Key, ServerHealth | undefined>)
+  createEffect(() => {
+    if (!props.shown()) {
+      setHealth(reconcile({}))
+      return
+    }
+    const list = server.list
+    let dead = false
+    let inFlight = false
+    const refresh = async () => {
+      // Skip overlapping probes so an old slow refresh can't overwrite a newer snapshot.
+      if (inFlight) return
+      inFlight = true
+      try {
+        const results: Record<string, ServerHealth | undefined> = {}
+        // Per-probe try/catch so a single failing server doesn't abort the whole batch.
+        // An unexpected throw from checkServerHealth (which normally catches network errors
+        // itself) is treated as an explicit health failure so it surfaces as red rather than
+        // silently staying grey/"unprobed".
+        await Promise.all(
+          list.map(async (conn) => {
+            const key = ServerConnection.key(conn)
+            try {
+              results[key] = await checkServerHealth(conn.http)
+            } catch {
+              results[key] = { healthy: false }
+            }
+          }),
+        )
+        if (dead) return
+        setHealth(reconcile(results))
+      } finally {
+        inFlight = false
+      }
+    }
+    void refresh()
+    const id = setInterval(() => void refresh(), POLL_MS)
+    onCleanup(() => {
+      dead = true
+      clearInterval(id)
+    })
+  })
+
+  const servers = createMemo(() => server.list)
+  const serverState = createMemo<CategoryState>(() => {
+    const list = servers()
+    if (list.length === 0) return "empty"
+    const anyBad = list.some((conn) => health[ServerConnection.key(conn)]?.healthy === false)
+    if (anyBad) return "warn"
+    const anyHealthy = list.some((conn) => health[ServerConnection.key(conn)]?.healthy === true)
+    return anyHealthy ? "ok" : "empty"
+  })
+
+  const mcpEntries = createMemo(() => Object.entries(sync.data.mcp ?? {}))
+  const mcpState = createMemo<CategoryState>(() => {
+    const entries = mcpEntries()
+    if (entries.length === 0) return "empty"
+    const anyBad = entries.some(
+      ([, m]) => m?.status === "failed" || m?.status === "needs_auth" || m?.status === "needs_client_registration",
+    )
+    if (anyBad) return "warn"
+    const anyConnected = entries.some(([, m]) => m?.status === "connected")
+    return anyConnected ? "ok" : "empty"
+  })
+
+  const lspItems = createMemo(() => sync.data.lsp ?? [])
+  const lspState = createMemo<CategoryState>(() => {
+    const items = lspItems()
+    if (items.length === 0) return "empty"
+    const anyBad = items.some((it) => it.status === "error")
+    if (anyBad) return "warn"
+    const anyConnected = items.some((it) => it.status === "connected")
+    return anyConnected ? "ok" : "empty"
+  })
+
+  const plugins = createMemo(() =>
+    (sync.data.config.plugin ?? []).map((item) => (typeof item === "string" ? item : item[0])),
+  )
+  const pluginState = createMemo<CategoryState>(() => (plugins().length === 0 ? "empty" : "ok"))
+
+  const autoExpand = (state: CategoryState) => state === "warn"
+  const [ui, setUi] = createStore({
+    servers: autoExpand(serverState()),
+    mcp: autoExpand(mcpState()),
+    lsp: autoExpand(lspState()),
+    plugins: false,
+  })
+  // Fire only on transition into warn, so a user's manual collapse is respected
+  // until a fresh failure arrives.
+  createEffect(
+    on(serverState, (next, prev) => {
+      if (next === "warn" && prev !== "warn") setUi("servers", true)
+    }),
+  )
+  createEffect(
+    on(mcpState, (next, prev) => {
+      if (next === "warn" && prev !== "warn") setUi("mcp", true)
+    }),
+  )
+  createEffect(
+    on(lspState, (next, prev) => {
+      if (next === "warn" && prev !== "warn") setUi("lsp", true)
+    }),
+  )
+
+  return (
+    <div class="flex flex-col">
+      <div class="text-11-medium uppercase tracking-wide text-text-weaker px-4 py-3 pb-1">
+        {language.t("status.connections.title")}
+      </div>
+
+      <SectionRow
+        title={language.t("status.popover.tab.servers")}
+        count={servers().length}
+        state={serverState()}
+        expanded={ui.servers}
+        onToggle={() => setUi("servers", (v) => !v)}
+      >
+        <Show when={servers().length > 0} fallback={<EmptyHint text={language.t("status.connections.empty")} />}>
+          <For each={servers()}>
+            {(conn) => {
+              const key = ServerConnection.key(conn)
+              const dotClass = () => {
+                const probe = health[key]?.healthy
+                if (probe === false) return "bg-icon-critical-base"
+                if (probe === true) return "bg-icon-success-base"
+                // Unprobed / in-flight: match the aggregate grey so parent and row agree.
+                return "bg-border-weak-base"
+              }
+              return (
+                <div class="flex items-center gap-2 py-1">
+                  <div class={`size-1.5 rounded-full shrink-0 ${dotClass()}`} aria-hidden />
+                  <span class="text-13-regular text-text-base truncate min-w-0">{conn.http.url}</span>
+                </div>
+              )
+            }}
+          </For>
+        </Show>
+      </SectionRow>
+
+      <SectionRow
+        title={language.t("status.popover.tab.mcp")}
+        count={mcpEntries().length}
+        state={mcpState()}
+        expanded={ui.mcp}
+        onToggle={() => setUi("mcp", (v) => !v)}
+      >
+        <Show when={mcpEntries().length > 0} fallback={<EmptyHint text={language.t("status.connections.empty")} />}>
+          <For each={mcpEntries()}>
+            {([name, m]) => {
+              const s = () => m?.status
+              const bad = () => s() === "failed" || s() === "needs_auth" || s() === "needs_client_registration"
+              const label = () => {
+                if (s() === "connected") return undefined
+                if (s() === "disabled") return language.t("status.connections.state.disabled")
+                if (s() === "failed") return language.t("status.connections.state.failed")
+                if (s() === "needs_auth") return language.t("status.connections.state.needs_auth")
+                if (s() === "needs_client_registration")
+                  return language.t("status.connections.state.needs_client_registration")
+                return undefined
+              }
+              return (
+                <div class="flex items-center gap-2 py-1">
+                  <div
+                    classList={{
+                      "size-1.5 rounded-full shrink-0": true,
+                      "bg-icon-critical-base": bad(),
+                      "bg-icon-success-base": s() === "connected",
+                      "bg-border-weak-base": s() === "disabled" || !s(),
+                    }}
+                    aria-hidden
+                  />
+                  <span class="text-13-regular text-text-base truncate min-w-0">{name}</span>
+                  <Show when={label()}>
+                    <span class="text-11-regular text-text-weaker ml-auto">{label()}</span>
+                  </Show>
+                </div>
+              )
+            }}
+          </For>
+        </Show>
+      </SectionRow>
+
+      <SectionRow
+        title={language.t("status.popover.tab.lsp")}
+        count={lspItems().length}
+        state={lspState()}
+        expanded={ui.lsp}
+        onToggle={() => setUi("lsp", (v) => !v)}
+      >
+        <Show when={lspItems().length > 0} fallback={<EmptyHint text={language.t("status.connections.empty")} />}>
+          <For each={lspItems()}>
+            {(item) => (
+              <div class="flex items-center gap-2 py-1">
+                <div
+                  classList={{
+                    "size-1.5 rounded-full shrink-0": true,
+                    "bg-icon-critical-base": item.status === "error",
+                    "bg-icon-success-base": item.status === "connected",
+                    // Fallback for transient states (starting, stopped, unknown) so the dot stays visible.
+                    "bg-border-weak-base": item.status !== "error" && item.status !== "connected",
+                  }}
+                  aria-hidden
+                />
+                <span class="text-13-regular text-text-base truncate min-w-0">{item.name || item.id}</span>
+              </div>
+            )}
+          </For>
+        </Show>
+      </SectionRow>
+
+      <SectionRow
+        title={language.t("status.popover.tab.plugins")}
+        count={plugins().length}
+        state={pluginState()}
+        expanded={ui.plugins}
+        onToggle={() => setUi("plugins", (v) => !v)}
+      >
+        <Show when={plugins().length > 0} fallback={<EmptyHint text={language.t("status.connections.empty")} />}>
+          <For each={plugins()}>
+            {(plugin) => (
+              <div class="flex items-center gap-2 py-1">
+                <div class="size-1.5 rounded-full shrink-0 bg-icon-success-base" aria-hidden />
+                <span class="text-13-regular text-text-base truncate min-w-0">{plugin}</span>
+              </div>
+            )}
+          </For>
+        </Show>
+      </SectionRow>
+    </div>
+  )
+}

--- a/packages/app/src/components/session/session-status-panel.tsx
+++ b/packages/app/src/components/session/session-status-panel.tsx
@@ -1,0 +1,24 @@
+import { createMemo, type Accessor } from "solid-js"
+import { useParams } from "@solidjs/router"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { useSync } from "@/context/sync"
+import { SessionStatusSummary } from "./session-status-summary"
+import { SessionStatusConnections } from "./session-status-connections"
+
+export function SessionStatusPanel(props: { shown: Accessor<boolean> }) {
+  const params = useParams()
+  const sync = useSync()
+
+  const parts = createMemo<Part[]>(() => {
+    if (!params.id) return []
+    const messages = sync.data.message[params.id] ?? []
+    return messages.flatMap((message) => sync.data.part[message.id] ?? [])
+  })
+
+  return (
+    <div class="h-full min-h-0 overflow-y-auto">
+      <SessionStatusSummary parts={parts} />
+      <SessionStatusConnections shown={props.shown} />
+    </div>
+  )
+}

--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -1,0 +1,68 @@
+import { For, Show, createMemo, type Accessor, type JSX } from "solid-js"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { useLanguage } from "@/context/language"
+import { extractTodos, extractSources, type TodoItem } from "@/pages/session/session-status-extractors"
+
+const TODO_STATUS_STYLES: Record<string, { dot: string; text: string }> = {
+  completed: { dot: "bg-icon-success-base", text: "" },
+  in_progress: { dot: "bg-icon-info-base", text: "" },
+  pending: { dot: "bg-border-weak-base", text: "" },
+  cancelled: { dot: "bg-border-weak-base", text: "line-through text-text-weaker" },
+}
+
+function Section(props: { title: string; children: JSX.Element }) {
+  return (
+    <div class="flex flex-col gap-2 px-4 py-3">
+      <div class="text-11-medium uppercase tracking-wide text-text-weaker">{props.title}</div>
+      {props.children}
+    </div>
+  )
+}
+
+function Empty(props: { text: string }) {
+  return <div class="text-13-regular text-text-weaker">{props.text}</div>
+}
+
+function TodoRow(props: { todo: TodoItem }) {
+  const style = () => TODO_STATUS_STYLES[props.todo.status] ?? TODO_STATUS_STYLES.pending
+  return (
+    <div class="flex items-start gap-2.5 py-1">
+      <div class={`size-2 rounded-full shrink-0 mt-1.5 ${style().dot}`} aria-hidden />
+      <div class={`text-13-regular text-text-base min-w-0 ${style().text}`}>{props.todo.content}</div>
+    </div>
+  )
+}
+
+function SourceRow(props: { url: string }) {
+  return (
+    <div class="flex items-center gap-2 py-1" title={props.url}>
+      <span class="text-13-regular text-text-base truncate min-w-0">{props.url}</span>
+    </div>
+  )
+}
+
+export function SessionStatusSummary(props: { parts: Accessor<Part[]> }) {
+  const language = useLanguage()
+  const todos = createMemo(() => extractTodos(props.parts()))
+  const sources = createMemo(() => extractSources(props.parts()))
+
+  return (
+    <div class="flex flex-col">
+      <Section title={language.t("status.summary.progress")}>
+        <Show when={todos().length > 0} fallback={<Empty text={language.t("status.summary.progress.empty")} />}>
+          <div class="flex flex-col">
+            <For each={todos()}>{(todo) => <TodoRow todo={todo} />}</For>
+          </div>
+        </Show>
+      </Section>
+
+      <Section title={language.t("status.summary.sources")}>
+        <Show when={sources().length > 0} fallback={<Empty text={language.t("status.summary.sources.empty")} />}>
+          <div class="flex flex-col">
+            <For each={sources()}>{(url) => <SourceRow url={url} />}</For>
+          </div>
+        </Show>
+      </Section>
+    </div>
+  )
+}

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -257,7 +257,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           opened: false,
         },
         review: {
-          diffStyle: "split" as ReviewDiffStyle,
+          diffStyle: "unified" as ReviewDiffStyle,
           panelOpened: false,
         },
         fileTree: {
@@ -650,7 +650,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
       },
       review: {
-        diffStyle: createMemo(() => store.review?.diffStyle ?? "split"),
+        diffStyle: createMemo(() => store.review?.diffStyle ?? "unified"),
         setDiffStyle(diffStyle: ReviewDiffStyle) {
           if (!store.review) {
             setStore("review", { diffStyle, panelOpened: true })
@@ -791,7 +791,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         function setReviewPanelOpened(next: boolean) {
           const current = store.review
           if (!current) {
-            setStore("review", { diffStyle: "split" as ReviewDiffStyle, panelOpened: next })
+            setStore("review", { diffStyle: "unified" as ReviewDiffStyle, panelOpened: next })
             return
           }
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -620,6 +620,17 @@ export const dict = {
   "status.popover.tab.plugins": "Plugins",
   "status.popover.action.manageServers": "Manage servers",
 
+  "status.summary.progress": "Progress",
+  "status.summary.progress.empty": "No todos yet.",
+  "status.summary.sources": "Sources",
+  "status.summary.sources.empty": "No sources used yet.",
+  "status.connections.title": "Connections",
+  "status.connections.empty": "None configured.",
+  "status.connections.state.disabled": "disabled",
+  "status.connections.state.failed": "failed",
+  "status.connections.state.needs_auth": "needs auth",
+  "status.connections.state.needs_client_registration": "needs registration",
+
   "session.share.popover.title": "Publish on web",
   "session.share.popover.description.shared":
     "This session is public on the web. It is accessible to anyone with the link.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -568,6 +568,17 @@ export const dict = {
   "status.popover.tab.plugins": "插件",
   "status.popover.action.manageServers": "管理服务器",
 
+  "status.summary.progress": "进度",
+  "status.summary.progress.empty": "还没有待办事项。",
+  "status.summary.sources": "来源",
+  "status.summary.sources.empty": "还没有使用任何来源。",
+  "status.connections.title": "连接",
+  "status.connections.empty": "尚未配置。",
+  "status.connections.state.disabled": "已停用",
+  "status.connections.state.failed": "已失败",
+  "status.connections.state.needs_auth": "需要授权",
+  "status.connections.state.needs_client_registration": "需要注册",
+
   "session.share.popover.title": "发布到网页",
   "session.share.popover.description.shared": "此会话已在网页上公开。任何拥有链接的人都可以访问。",
   "session.share.popover.description.unshared": "在网页上公开分享此会话。任何拥有链接的人都可以访问。",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -563,6 +563,17 @@ export const dict = {
   "status.popover.tab.plugins": "外掛程式",
   "status.popover.action.manageServers": "管理伺服器",
 
+  "status.summary.progress": "進度",
+  "status.summary.progress.empty": "尚無待辦事項。",
+  "status.summary.sources": "來源",
+  "status.summary.sources.empty": "尚未使用任何來源。",
+  "status.connections.title": "連線",
+  "status.connections.empty": "尚未設定。",
+  "status.connections.state.disabled": "已停用",
+  "status.connections.state.failed": "已失敗",
+  "status.connections.state.needs_auth": "需要授權",
+  "status.connections.state.needs_client_registration": "需要註冊",
+
   "session.share.popover.title": "發佈到網頁",
   "session.share.popover.description.shared": "此工作階段已在網頁上公開。任何擁有連結的人都可以存取。",
   "session.share.popover.description.unshared": "在網頁上公開分享此工作階段。任何擁有連結的人都可以存取。",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1330,12 +1330,6 @@ export default function Page() {
     return true
   }
 
-  const focusReviewDiff = (path: string) => {
-    openReviewPanel()
-    view().review.openPath(path)
-    setTree({ activeDiff: path, pendingDiff: path })
-  }
-
   createEffect(() => {
     const pending = tree.pendingDiff
     if (!pending) return
@@ -2055,15 +2049,11 @@ export default function Page() {
         <SessionSidePanel
           canReview={canReview}
           diffs={reviewDiffs}
-          diffsReady={reviewReady}
-          empty={reviewEmptyText}
           hasReview={hasReview}
           reviewCount={reviewCount}
           reviewPanel={reviewPanel}
           files={artifactFiles}
           terminalPanel={() => <TerminalPanel embedded />}
-          activeDiff={tree.activeDiff}
-          focusReviewDiff={focusReviewDiff}
           size={size}
         />
       </div>

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -37,7 +37,7 @@ beforeAll(async () => {
     SortableTab: () => null,
     FileVisual: () => null,
   }))
-  mock.module("@/components/status-panel", () => ({ StatusPanel: () => null }))
+  mock.module("@/components/session/session-status-panel", () => ({ SessionStatusPanel: () => null }))
   mock.module("@/context/command", () => ({ useCommand: () => ({ keybind: () => "" }) }))
   mock.module("@/context/file", () => ({
     useFile: () => ({

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -31,7 +31,6 @@ beforeAll(async () => {
     getDraggableId: () => undefined,
   }))
   mock.module("@opencode-ai/ui/context/dialog", () => ({ useDialog: () => ({ show: () => undefined }) }))
-  mock.module("@/components/file-tree", () => ({ default: () => null }))
   mock.module("@/components/session-context-usage", () => ({ SessionContextUsage: () => null }))
   mock.module("@/components/session", () => ({
     SessionContextTab: () => null,

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -269,7 +269,7 @@ export function SessionSidePanel(props: {
             </Tabs.List>
 
             <Tabs.Content value="status" class="min-h-0 flex-1 overflow-hidden">
-              <SessionStatusPanel shown={open} />
+              <SessionStatusPanel shown={() => open() && sidePanelTab() === "status"} />
             </Tabs.Content>
 
             <Tabs.Content value="files" class="min-h-0 flex-1 overflow-hidden">

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -15,7 +15,7 @@ import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
-import { StatusPanel } from "@/components/status-panel"
+import { SessionStatusPanel } from "@/components/session/session-status-panel"
 import { useCommand } from "@/context/command"
 import { useFile, type SelectedLineRange } from "@/context/file"
 import { useLanguage } from "@/context/language"
@@ -269,7 +269,7 @@ export function SessionSidePanel(props: {
             </Tabs.List>
 
             <Tabs.Content value="status" class="min-h-0 flex-1 overflow-hidden">
-              <StatusPanel shown={open} />
+              <SessionStatusPanel shown={open} />
             </Tabs.Content>
 
             <Tabs.Content value="files" class="min-h-0 flex-1 overflow-hidden">

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -13,7 +13,6 @@ import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 
-import FileTree from "@/components/file-tree"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
 import { StatusPanel } from "@/components/status-panel"
@@ -68,15 +67,11 @@ function RightPanelShellIcon(props: { icon: RightPanelShellIconName }) {
 export function SessionSidePanel(props: {
   canReview: () => boolean
   diffs: () => (SnapshotFileDiff | VcsFileDiff)[]
-  diffsReady: () => boolean
-  empty: () => string
   hasReview: () => boolean
   reviewCount: () => number
   reviewPanel: () => JSX.Element
   files: () => FilesTabEntry[]
   terminalPanel?: () => JSX.Element
-  activeDiff?: string
-  focusReviewDiff: (path: string) => void
   size: Sizing
 }) {
   const layout = useLayout()
@@ -92,49 +87,6 @@ export function SessionSidePanel(props: {
   const reviewTab = createMemo(() => isDesktop())
   const sidePanelTab = createMemo(() => view().sidePanel.tab())
   const panelWidth = createMemo(() => formatRightPanelWidth(open(), layout.rightPanel.width()))
-  const treeWidth = createMemo(() => `${view().sidePanel.explorer.width()}px`)
-
-  const diffFiles = createMemo(() => props.diffs().map((d) => d.file))
-  const kinds = createMemo(() => {
-    const merge = (a: "add" | "del" | "mix" | undefined, b: "add" | "del" | "mix") => {
-      if (!a) return b
-      if (a === b) return a
-      return "mix" as const
-    }
-
-    const normalize = (p: string) => p.replaceAll("\\\\", "/").replace(/\/+$/, "")
-
-    const out = new Map<string, "add" | "del" | "mix">()
-    for (const diff of props.diffs()) {
-      const file = normalize(diff.file)
-      const kind = diff.status === "added" ? "add" : diff.status === "deleted" ? "del" : "mix"
-
-      out.set(file, kind)
-
-      const parts = file.split("/")
-      for (const [idx] of parts.slice(0, -1).entries()) {
-        const dir = parts.slice(0, idx + 1).join("/")
-        if (!dir) continue
-        out.set(dir, merge(out.get(dir), kind))
-      }
-    }
-    return out
-  })
-
-  const empty = (msg: string) => (
-    <div class="h-full flex flex-col">
-      <div class="h-6 shrink-0" aria-hidden />
-      <div class="flex-1 pb-64 flex items-center justify-center text-center">
-        <div class="text-12-regular text-text-weak">{msg}</div>
-      </div>
-    </div>
-  )
-
-  const nofiles = createMemo(() => {
-    const state = file.tree.state("")
-    if (!state?.loaded) return false
-    return file.tree.children("").length === 0
-  })
 
   const normalizeTab = (tab: string) => {
     if (!tab.startsWith("file://")) return tab
@@ -185,13 +137,8 @@ export function SessionSidePanel(props: {
     view().sidePanel.setTab(value as RightPanelTab)
     view().sidePanel.open()
   }
-  const fileTreeTab = () => view().sidePanel.explorer.tab()
-  const setFileTreeTabValue = (value: string) => {
-    if (value !== "changes" && value !== "all") return
-    view().sidePanel.explorer.setTab(value)
-  }
   const showAllFiles = () => {
-    if (fileTreeTab() !== "changes") return
+    if (view().sidePanel.explorer.tab() !== "changes") return
     view().sidePanel.explorer.setTab("all")
   }
 
@@ -330,9 +277,8 @@ export function SessionSidePanel(props: {
             </Tabs.Content>
 
             <Tabs.Content value="review" class="min-h-0 flex-1 overflow-hidden">
-              <div class="size-full flex">
-                <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-background-base">
-                  <div class="size-full min-w-0 h-full bg-background-base">
+              <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-background-base">
+                <div class="size-full min-w-0 h-full bg-background-base">
                     <DragDropProvider
                       onDragStart={handleDragStart}
                       onDragEnd={handleDragEnd}
@@ -479,87 +425,6 @@ export function SessionSidePanel(props: {
                     </DragDropProvider>
                   </div>
                 </div>
-                <div
-                  id="file-tree-panel"
-                  class="relative min-w-0 h-full shrink-0 overflow-hidden border-l border-border-weaker-base"
-                  style={{ width: treeWidth() }}
-                >
-                  <div class="h-full flex flex-col overflow-hidden group/filetree">
-                    <Tabs
-                      variant="pill"
-                      value={fileTreeTab()}
-                      onChange={setFileTreeTabValue}
-                      class="h-full"
-                      data-scope="filetree"
-                    >
-                      <Tabs.List>
-                        <Tabs.Trigger value="changes" class="flex-1" classes={{ button: "w-full" }}>
-                          {props.reviewCount()}{" "}
-                          {language.t(
-                            props.reviewCount() === 1 ? "session.review.change.one" : "session.review.change.other",
-                          )}
-                        </Tabs.Trigger>
-                        <Tabs.Trigger value="all" class="flex-1" classes={{ button: "w-full" }}>
-                          {language.t("session.files.all")}
-                        </Tabs.Trigger>
-                      </Tabs.List>
-                      <Tabs.Content value="changes" class="bg-background-stronger px-3 py-0">
-                        <Switch>
-                          <Match when={props.hasReview() || !props.diffsReady()}>
-                            <Show
-                              when={props.diffsReady()}
-                              fallback={
-                                <div class="px-2 py-2 text-12-regular text-text-weak">
-                                  {language.t("common.loading")}
-                                  {language.t("common.loading.ellipsis")}
-                                </div>
-                              }
-                            >
-                              <FileTree
-                                path=""
-                                class="pt-3"
-                                allowed={diffFiles()}
-                                kinds={kinds()}
-                                draggable={false}
-                                active={props.activeDiff}
-                                onFileClick={(node) => props.focusReviewDiff(node.path)}
-                              />
-                            </Show>
-                          </Match>
-                          <Match when={true}>{empty(props.empty())}</Match>
-                        </Switch>
-                      </Tabs.Content>
-                      <Tabs.Content value="all" class="bg-background-stronger px-3 py-0">
-                        <Switch>
-                          <Match when={nofiles()}>{empty(language.t("session.files.empty"))}</Match>
-                          <Match when={true}>
-                            <FileTree
-                              path=""
-                              class="pt-3"
-                              modified={diffFiles()}
-                              kinds={kinds()}
-                              onFileClick={(node) => openTab(file.tab(node.path))}
-                            />
-                          </Match>
-                        </Switch>
-                      </Tabs.Content>
-                    </Tabs>
-                  </div>
-                  <div onPointerDown={() => props.size.start()}>
-                    <ResizeHandle
-                      direction="horizontal"
-                      edge="start"
-                      size={view().sidePanel.explorer.width()}
-                      min={200}
-                      max={480}
-                      onResize={(width) => {
-                        props.size.touch()
-                        view().sidePanel.explorer.resize(width)
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
             </Tabs.Content>
 
             <Tabs.Content value="terminal" class="min-h-0 flex-1 overflow-hidden">

--- a/packages/app/src/pages/session/session-status-extractors.test.ts
+++ b/packages/app/src/pages/session/session-status-extractors.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "bun:test"
+import type { Part, ToolState } from "@opencode-ai/sdk/v2"
+import {
+  TOOL_TODOWRITE,
+  TOOL_WEBFETCH,
+  TOOL_WEBSEARCH,
+  extractTodos,
+  extractSources,
+} from "./session-status-extractors"
+
+const completedState = (
+  overrides: Partial<Extract<ToolState, { status: "completed" }>> = {},
+): Extract<ToolState, { status: "completed" }> => ({
+  status: "completed",
+  input: {},
+  output: "",
+  title: "",
+  metadata: {},
+  time: { start: 0, end: 0 },
+  ...overrides,
+})
+
+const toolPart = (tool: string, state: ToolState = completedState()): Part =>
+  ({
+    id: "p",
+    sessionID: "s",
+    messageID: "m",
+    type: "tool",
+    callID: "c",
+    tool,
+    state,
+  }) as Part
+
+describe("extractTodos", () => {
+  it("returns [] for empty parts", () => {
+    expect(extractTodos([])).toEqual([])
+  })
+
+  it("ignores non-todowrite tool parts", () => {
+    expect(extractTodos([toolPart("bash")])).toEqual([])
+  })
+
+  it("returns todos from the later todowrite call when two exist", () => {
+    const older = toolPart(
+      "todowrite",
+      completedState({ input: { todos: [{ content: "old", status: "pending", priority: "low" }] } }),
+    )
+    const newer = toolPart(
+      "todowrite",
+      completedState({ input: { todos: [{ content: "new", status: "in_progress", priority: "high" }] } }),
+    )
+    expect(extractTodos([older, newer])).toEqual([{ content: "new", status: "in_progress", priority: "high" }])
+  })
+
+  it("skips todowrite parts that are not completed", () => {
+    const running = toolPart("todowrite", {
+      status: "running",
+      input: { todos: [{ content: "x", status: "pending", priority: "low" }] },
+      metadata: {},
+      time: { start: 0 },
+    } as ToolState)
+    expect(extractTodos([running])).toEqual([])
+  })
+
+  it("filters malformed todo items", () => {
+    const part = toolPart(
+      "todowrite",
+      completedState({ input: { todos: [{ content: "ok", status: "pending", priority: "low" }, { nope: true }] } }),
+    )
+    expect(extractTodos([part])).toEqual([{ content: "ok", status: "pending", priority: "low" }])
+  })
+})
+
+const webfetchPart = (url: string): Part => toolPart("webfetch", completedState({ input: { url } }))
+
+const websearchPart = (output: string): Part =>
+  toolPart("websearch", completedState({ input: { query: "anything" }, output }))
+
+describe("extractSources", () => {
+  it("returns [] for empty parts", () => {
+    expect(extractSources([])).toEqual([])
+  })
+
+  it("extracts webfetch URLs from input.url", () => {
+    expect(extractSources([webfetchPart("https://example.com/a")])).toEqual(["https://example.com/a"])
+  })
+
+  it("extracts websearch URLs from output via http(s) regex", () => {
+    const out = "Result 1: https://example.com/x\nResult 2: http://foo.bar/y"
+    expect(extractSources([websearchPart(out)])).toEqual(["https://example.com/x", "http://foo.bar/y"])
+  })
+
+  it("dedupes URLs in first-seen order across all parts", () => {
+    expect(
+      extractSources([webfetchPart("https://a.com"), webfetchPart("https://a.com"), webfetchPart("https://b.com")]),
+    ).toEqual(["https://a.com", "https://b.com"])
+  })
+
+  it("caps at 20 after dedupe", () => {
+    const parts = Array.from({ length: 30 }, (_, i) => webfetchPart(`https://site-${i}.com`))
+    expect(extractSources(parts)).toHaveLength(20)
+  })
+
+  it("captures URLs with balanced parens (e.g. wikipedia disambiguation)", () => {
+    const out = "See https://en.wikipedia.org/wiki/Foo_(bar) and trailing) should not eat."
+    const sources = extractSources([websearchPart(out)])
+    expect(sources).toHaveLength(1)
+    expect(sources[0]).toBe("https://en.wikipedia.org/wiki/Foo_(bar)")
+  })
+
+  it("dedupes URLs that differ only in scheme/host casing", () => {
+    const sources = extractSources([webfetchPart("https://Example.com/p"), webfetchPart("https://example.com/p")])
+    expect(sources).toHaveLength(1)
+  })
+})
+
+describe("tool name sanity", () => {
+  const OPENCODE_TOOL_DIR = join(import.meta.dirname, "../../../../opencode/src/tool")
+  const cases: Array<[string, string]> = [
+    [TOOL_TODOWRITE, "todo.ts"],
+    [TOOL_WEBFETCH, "webfetch.ts"],
+    [TOOL_WEBSEARCH, "websearch.ts"],
+  ]
+  for (const [tool, filename] of cases) {
+    it(`"${tool}" literal appears in packages/opencode/src/tool/${filename}`, () => {
+      const source = readFileSync(join(OPENCODE_TOOL_DIR, filename), "utf8")
+      expect(source.includes(`"${tool}"`)).toBe(true)
+    })
+  }
+})

--- a/packages/app/src/pages/session/session-status-extractors.ts
+++ b/packages/app/src/pages/session/session-status-extractors.ts
@@ -1,0 +1,105 @@
+// Tool names are hardcoded here. Canonical definitions live in
+// packages/opencode/src/tool/ — if upstream renames a tool, the sanity test
+// in session-status-extractors.test.ts catches it by grepping the source file.
+//   todowrite → packages/opencode/src/tool/todo.ts
+//   webfetch  → packages/opencode/src/tool/webfetch.ts
+//   websearch → packages/opencode/src/tool/websearch.ts
+//
+// Input shape: parts live in sync.data.part[message.id], keyed by messageID.
+// Callers pass a pre-flattened Part[] — produced by
+//   messages.flatMap((m) => sync.data.part[m.id] ?? [])
+// so these extractors stay as pure functions testable against SDK fixtures.
+
+import type { Part } from "@opencode-ai/sdk/v2"
+
+export const TOOL_TODOWRITE = "todowrite"
+export const TOOL_WEBFETCH = "webfetch"
+export const TOOL_WEBSEARCH = "websearch"
+
+export interface TodoItem {
+  content: string
+  status: string
+  priority: string
+}
+
+function isToolPart(part: Part): part is Extract<Part, { type: "tool" }> {
+  return part.type === "tool"
+}
+
+function isValidTodo(value: unknown): value is TodoItem {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Partial<TodoItem>
+  return typeof v.content === "string" && typeof v.status === "string" && typeof v.priority === "string"
+}
+
+export function extractTodos(parts: Part[]): TodoItem[] {
+  let latest: TodoItem[] = []
+  for (const part of parts) {
+    if (!isToolPart(part)) continue
+    if (part.tool !== TOOL_TODOWRITE) continue
+    if (part.state.status !== "completed") continue
+    const rawInput = part.state.input
+    if (typeof rawInput !== "object" || rawInput === null) continue
+    const todos = (rawInput as { todos?: unknown }).todos
+    if (!Array.isArray(todos)) continue
+    latest = todos.filter(isValidTodo)
+  }
+  return latest
+}
+
+// Allow single-level balanced paren groups (any number of them, but no nesting) so
+// links like https://en.wikipedia.org/wiki/Foo_(bar) are captured whole. Unbalanced
+// trailing ')' is left out by the branch alternation.
+const URL_REGEX = /https?:\/\/(?:\([^()\s]*\)|[^\s<>"'()])+/g
+const TRAILING_PUNCT = /[.,;:!?]+$/
+const SOURCES_CAP = 20
+
+function normalizeUrl(raw: string): string {
+  return raw.replace(TRAILING_PUNCT, "")
+}
+
+// Lowercase only scheme + host for the dedupe key; path/query/fragment remain case-sensitive.
+// This prevents `HTTPS://Example.COM/p` and `https://example.com/p` from appearing twice.
+function dedupeKey(url: string): string {
+  return url.replace(/^(https?:\/\/[^/?#]+)/i, (m) => m.toLowerCase())
+}
+
+export function extractSources(parts: Part[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  const addUrl = (raw: string) => {
+    const url = normalizeUrl(raw)
+    if (!url) return
+    const key = dedupeKey(url)
+    if (seen.has(key)) return
+    seen.add(key)
+    out.push(url)
+  }
+
+  for (const part of parts) {
+    if (out.length >= SOURCES_CAP) break
+    if (!isToolPart(part)) continue
+    if (part.state.status !== "completed") continue
+
+    if (part.tool === TOOL_WEBFETCH) {
+      const rawInput = part.state.input
+      if (typeof rawInput !== "object" || rawInput === null) continue
+      const url = (rawInput as { url?: unknown }).url
+      if (typeof url === "string") addUrl(url)
+      continue
+    }
+
+    if (part.tool === TOOL_WEBSEARCH) {
+      const output = (part.state as { output?: unknown }).output
+      if (typeof output !== "string") continue
+      const matches = output.match(URL_REGEX) ?? []
+      for (const url of matches) {
+        if (out.length >= SOURCES_CAP) break
+        addUrl(url)
+      }
+    }
+  }
+
+  return out
+}

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -276,7 +276,9 @@ export function TerminalPanel(props: { embedded?: boolean }) {
               >
                 <Tabs.List class="h-10 border-b border-border-weaker-base">
                   <SortableProvider ids={ids()}>
-                    <For each={all()}>{(pty) => <SortableTerminalTab terminal={pty} onClose={close} />}</For>
+                    <For each={all()}>
+                      {(pty) => <SortableTerminalTab terminal={pty} totalCount={all().length} onClose={close} />}
+                    </For>
                   </SortableProvider>
                   <div class="h-full flex items-center justify-center">
                     <TooltipKeybind

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -10,7 +10,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke root route renders seeded home entrypoints",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
-  "packages/app/e2e/files/file-tree.spec.ts:@smoke review keeps the persistent file-tree pane for review navigation",
+  "packages/app/e2e/files/file-tree.spec.ts:@smoke review tab no longer renders the legacy file-tree sub-panel",
   "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",
   "packages/app/e2e/prompt/prompt.spec.ts:@smoke can send a prompt and receive a reply",
   "packages/app/e2e/settings/settings.spec.ts:@smoke PawWork settings opens as a full-pane surface, not a dialog",


### PR DESCRIPTION
## Summary

Closes #52. Five commits on `dev` that polish the three tabs inside the session right panel:

1. `7d25a6e82` — **Terminal**: hide the `×` button (and context-menu Close) on the lone terminal tab so the panel enforces its min-one invariant. Threaded `totalCount` from `terminal-panel.tsx` through `SortableTerminalTab`.
2. `30e369e2e` — **Review**: delete the vertical file-tree sub-panel that squeezed the diff viewer; the diff now fills the full Review pane. Flip the default diff style from `split` to `unified` (the right panel's 360px minimum cannot render split legibly; toggle still available). Trims now-dead props, memos, and helpers.
3. `5d2cd891b` — **Status (prereqs)**: pure `extractTodos` / `extractSources` module (reads a pre-flattened `Part[]`, dedupes URLs by scheme+host case-fold, caps at 20) plus i18n keys under `status.summary.*` / `status.connections.*` in `en` / `zh` / `zht`.
4. `6e9421069` — **Status (components)**: `SessionStatusSummary` (Progress + Sources with empty-state fallbacks, strikethrough for cancelled todos), `SessionStatusConnections` (Servers / MCP / LSP / Plugins as collapsible sections; green reserved for confirmed-live; auto-expand transition-only into warn; polling with in-flight guard + per-probe try/catch; thrown probes surface as unhealthy, not unprobed), `SessionStatusPanel` composer.
5. `093264bfd` — **Status (mount)**: swap the Status tab body from `StatusPanel` to `SessionStatusPanel`. The titlebar Status popover is unchanged; both surfaces independently subscribe to the same sync signals.

No `packages/ui/**` files touched (upstream carveout respected).

## Why

Closes the three items in #52. The Review tab was eating horizontal width for a workspace-tree navigator that duplicated the already-horizontal Files tab; the Status tab only showed infrastructure, missing session-level narrative (progress + sources) that Codex surfaces well; the Terminal tab let users close the last remaining pane, leaving the tab strip empty.

Two follow-up issues filed from the smoke round:
- #65 — Terminal tab-strip alignment + ghostty-web glyph rendering at narrow widths (upstream-bound)
- #66 — TODO dock possible non-surface during active runs (needs deliberate repro)

Went through four rounds of `/crosscheck` (Claude + Codex). Agreed findings fixed in-place during the polish cycle; disagreed items documented in commit messages with verified reasoning.

## Related Issue

Closes #52. Follow-ups: #65, #66.

## How To Verify

```bash
bun run typecheck                              # 8/8 tasks, EXIT=0
cd packages/app && bun test                    # 386 pass / 0 fail / 970 expect() calls
cd packages/app && bun test src/i18n/parity.test.ts
```

Manual smoke in `bun run dev:desktop`:

- **Terminal tab**: fresh session → `×` hidden on lone tab; click `+` → both tabs show `×`; close one → remaining tab's `×` disappears; `exit` in shell → panel auto-dismisses.
- **Review tab**: open a session with changed files → diff fills the full pane; no vertical divider; sticky per-file headers navigate between changes; default view is Unified (toggle to Split still works).
- **Status tab**: Progress lists todos (status-colored dots, cancelled reads muted + strikethrough); Sources lists webfetch/websearch URLs (deduped, parens-safe); Connections collapsed by default, auto-expands only on real failures; empty categories show "None configured."; long labels ellipsize.
- Titlebar Status popover is visually unchanged.

## Screenshots or Recordings

Manual smoke walkthrough done during the polish cycle. No screenshots attached here — all visual changes are structural (file-tree panel removed, Status panel shape changed) and covered by the How To Verify steps above.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Session Status area showing progress/todos, referenced sources, and a Connections view with live health checks for servers, MCP, LSP, and plugins.

* **Changes**
  * Terminal close controls are hidden when only one terminal is open.
  * Default code review diff view now uses unified style.
  * Removed the legacy file-tree explorer panel from the review UI.

* **Localization**
  * Added English, Simplified Chinese, and Traditional Chinese strings for status summary and connection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->