### PR TITLE
ci: lint PR conventions and polish CI workflows

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://json.schemastore.org/commitlintrc.json",
   "extends": ["@commitlint/config-conventional"]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,11 @@ jobs:
         with:
           bun-version: "1.3.11"
 
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "24"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
         with:
           node-version: "24"
@@ -137,6 +142,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
         with:
           node-version: "24"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,31 @@
+# Advisory check: lint commit messages on the PR against Conventional
+# Commits. Pairs with pr-title-lint.yml -- catches intermediate commits
+# that the PR title check cannot see. Not required in the `dev`
+# ruleset. (#69)
+name: commit-lint
+
+on:
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: commit-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: wagoid/commitlint-github-action@6cf16efdf4da5277c791d335142c03a0bdf1766e # wagoid/commitlint-github-action@v6.2.1
+        with:
+          configFile: .commitlintrc.json

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   review:
@@ -21,21 +21,13 @@ jobs:
         with:
           persist-credentials: false
 
-      # Non-blocking during the initial rollout: `warn-only` makes policy
-      # findings (CVEs, license violations) surface as a comment without
-      # failing the job, while still failing loudly on action-level
-      # misconfiguration (auth, parser, network). GitHub supports bun.lock
-      # directly, but the `catalog:` field and workspace resolution are the
-      # real unknowns on this repo. Once a PR run shows the dep graph is
-      # parsed correctly, drop warn-only, set fail-on-severity: high, and
-      # add this job to the dev ruleset. Tracked in #54.
-      #
-      # Skipped on fork PRs: GITHUB_TOKEN is read-only, so the
-      # comment-summary-in-pr write would fail or silently no-op under
-      # warn-only. Mirrors the fork guard on the junit publisher in ci.yml.
-      - if: >
-          github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # actions/dependency-review-action@v4.9.0
+      # Advisory check: `warn-only: true` surfaces CVE/license findings
+      # in the Actions log but never fails the PR. Paired with `never`
+      # for comment-summary-in-pr so the action needs no write access
+      # and runs on fork PRs too (exactly where advisory coverage is
+      # most useful). Upgrading to fail-on-severity: high is a separate
+      # decision.
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # actions/dependency-review-action@v4.9.0
         with:
-          comment-summary-in-pr: always
+          comment-summary-in-pr: never
           warn-only: true

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -96,6 +96,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
         with:
           node-version: "24"

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
         with:
           node-version: "24"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,48 @@
+# Advisory check: lint PR titles against Conventional Commits. Catches
+# drift early so PR titles read consistently in listings and serve as a
+# well-formed subject when a PR is squash-merged (this repo normally
+# uses merge commits, so the PR title is not the commit subject on
+# `dev`, but the convention still matters for review hygiene). Not
+# required in the `dev` ruleset -- failures flag the PR but do not
+# block merge. Draft PRs with `WIP:` prefix are skipped. (#68)
+name: pr-title-lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+    branches: [dev]
+
+concurrency:
+  group: pr-title-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            chore
+            ci
+            build
+            perf
+            test
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^\S.{2,}$
+          subjectPatternError: |
+            The subject after `type:` must be at least 3 characters and start with a non-space character.
+          wip: true


### PR DESCRIPTION
## Summary

- docs(ci): one-line comment at every `setup-node` usage documenting it is load-bearing (#70) — `bun install` triggers `trustedDependencies` postinstalls (electron, node-pty, esbuild, tree-sitter) that call `node` explicitly. Comment anchors to `trustedDependencies` in `package.json` so the list stays grep-able.
- ci: new advisory `pr-title-lint` workflow using `amannn/action-semantic-pull-request@v6.1.1` (SHA-pinned) to validate PR titles against Conventional Commits (#68).
- ci: new advisory `commit-lint` workflow using `wagoid/commitlint-github-action@v6.2.1` (SHA-pinned) with `.commitlintrc.json` extending `@commitlint/config-conventional` (#69).
- ci: flip `dependency-review`'s `comment-summary-in-pr` from `always` to `never`; drop the fork-skip guard and `pull-requests: write` permission (both only existed because of the always-on summary). Fork PRs now get advisory CVE/license coverage too.

## Why

Issue #54 (the CI merge-gate hardening epic) left four loose ends. This PR closes #67, #68, #69, and #70 in a single batch since all four are small workflow-level changes with no logical dependencies. Also folds in a small dependency-review cleanup: the always-on PR summary was useful during the initial rollout on #55 to verify `bun.lock` parses correctly, but it has served its purpose and is noise on every PR now.

AGENTS.md convention was updated in a prior local edit: PR titles switched from the old `[Feature]`/`[Bug]` scheme to Conventional Commits; issue titles still use `[Feature]`/`[Bug]` via `.github/ISSUE_TEMPLATE/*.yml`.

Decisions declined during two rounds of crosscheck review: re-adding `synchronize` to pr-title-lint (title does not change on push); dropping `fetch-depth: 0` on commit-lint (wagoid uses local git log, not the API); dropping `wip: true` (safe under merge-commit strategy); merging pr-title-lint and commit-lint into one file (mixed `pull_request_target` / `pull_request` security contexts); switching commit-lint to `bunx commitlint` inside ci.yml (real alternative but adds devDep; deferred).

## Related Issue

Closes #67
Closes #68
Closes #69
Closes #70

## How To Verify

```bash
# The PR itself is the smoke test:
# - pr-title-lint runs against this PR title (Conventional Commits -> pass)
# - commit-lint runs against the 4 commits on this branch (all Conventional -> pass)
# - dependency-review job runs green without posting a PR comment
# - ci / check, desktop-smoke / check, codeql / analyze-js-ts stay green
#   (no semantic change to their existing jobs)
```

`test:ci` exit-code audit for #67 is recorded as an issue comment on #67; `bun test --reporter=junit` was empirically verified to exit non-zero on a failing test.

## Screenshots or Recordings

No UI changes.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Commitlint to enforce conventional commit message rules
  * Implemented PR title linting requiring conventional commit format (e.g., `feat:`, `fix:`, `refactor:`)
  * Adjusted dependency review workflow to reduce required permissions and reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->