### PR TITLE
ci: restore turbo cache hits on PR unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: .turbo/cache
-          key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          key: turbo-${{ runner.os }}-typecheck-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
-            turbo-${{ runner.os }}-
+            turbo-${{ runner.os }}-typecheck-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-typecheck-
 
       - run: bun install --frozen-lockfile
 
@@ -155,10 +155,10 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: .turbo/cache
-          key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          key: turbo-${{ runner.os }}-unit-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
-            turbo-${{ runner.os }}-
+            turbo-${{ runner.os }}-unit-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-


### PR DESCRIPTION
## Summary

Change `actions/cache` path from `node_modules/.cache/turbo` (turbo v1 default) to `.turbo/cache` (turbo v2 default) so the cache dir actually has contents to save, and add a per-job discriminator (`-typecheck` / `-unit`) to the cache key so the two concurrent jobs stop racing on the same reservation.

## Why

`ci / unit` spends ~232s on every PR, even YAML-only ones. Root cause is a two-layer cache failure that compounds: the cache path pointed at an empty directory (turbo v1 default, but we run turbo v2), so every post-step logged `[warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.` — no `turbo-Linux-*` entry ever landed in the pool (verified: 37 caches, 10.3 GB, zero turbo entries). Even with the path fixed, both jobs shared the exact same cache key, so they would race on `reserveCache`; per `actions/toolkit` source, the loser catches `ReserveCacheError` and logs it at info level without uploading. `typecheck` (~60s) always finishes before `unit` (~232s), so unit's cache would never enter the pool and subsequent runs would restore typecheck-flavored tarballs into unit jobs, producing task-hash misses and another full 232s run. Splitting the keys makes each job own its own slice.

## Related Issue

Closes #74. The issue lists three levers: turbo cache fix (this PR), `--filter=...[origin/dev]` (obsoleted by turbo's own content-hash skipping once cache is working), and bun / desktop-electron concurrency (independent micro-optimisation, open a fresh issue if benchmark warrants it). Note: the issue body's `passThroughEnv: ["*"]` hypothesis is not the root cause — local `turbo --dry=json` with fake GitHub runner env produces identical task hashes, confirming `passThroughEnv` is a "pass through but don't hash" allowlist, not the opposite.

## How To Verify

Pre-merge (local, already run):

```bash
bun turbo run test:ci --filter=opencode --dry=json 2>/dev/null \
  | jq '.tasks[] | {hash, envMode, passThroughEnv}' > /tmp/h1.json
GITHUB_RUN_ID=9999 GITHUB_SHA=deadbeef bun turbo run test:ci --filter=opencode --dry=json 2>/dev/null \
  | jq '.tasks[] | {hash, envMode, passThroughEnv}' > /tmp/h2.json
diff /tmp/h1.json /tmp/h2.json   # empty diff confirms env does not affect hash
```

Post-merge (CI observation — cannot be reproduced locally because `actions/cache` save/restore only runs on GitHub runners):

- On this PR's own `ci / unit` and `ci / typecheck` runs: post-step should log `Cache saved with key: turbo-Linux-typecheck-...` and `turbo-Linux-unit-...` (no `Path Validation Error`, no `ReserveCacheError`).
- On the next non-docs-only PR after merge: both jobs log `Cache restored from key: turbo-Linux-typecheck-...` / `turbo-Linux-unit-...`; `bun turbo test:ci` output contains `>>> FULL TURBO` for unchanged tasks.
- Cache pool check: `gh api /repos/Astro-Han/pawwork/actions/caches | jq '.actions_caches[].key' | grep turbo` should return `turbo-Linux-typecheck-*` and `turbo-Linux-unit-*` entries.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed (N/A — CI-only change)
- [x] I am targeting the `dev` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-visible changes**

This release contains only internal infrastructure updates to the continuous integration build pipeline. No new features, bug fixes, or user-facing functionality have been modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- re-trigger pr-title-lint after #76 -->
