### PR TITLE
fix: grant pr title lint status permission

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -19,6 +19,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 jobs:
   lint-pr-title:


### PR DESCRIPTION
## Summary

Add `statuses: write` to the `pr-title-lint` workflow permissions.

## Why

`pr-title-lint / lint-pr-title` started failing on PR #73 even though the title itself is valid. The failing job log shows `Resource not accessible by integration` when `amannn/action-semantic-pull-request` tries to create a commit status from a `pull_request_target` run. The workflow currently grants `contents: read` and `pull-requests: read`, but not `statuses: write`.

## Related Issue

None.

## How To Verify

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-title-lint.yml")'
```

Manual checks:
- Inspected the failed `pr-title-lint / lint-pr-title` run on PR #73 and confirmed the error is a missing commit-status permission, not a title-format violation.
- Confirmed the workflow change is a single-line permission addition on the `pull_request_target` workflow.

## Screenshots or Recordings

Not applicable.

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch
