### PR TITLE
chore: bump version to v0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "effect": "catalog:",
         "electron-context-menu": "4.1.2",
@@ -139,7 +139,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -395,7 +395,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump `desktop-electron`, `app`, `opencode`, `util` from 0.2.2 → 0.2.3 (the four PawWork-managed packages from `chore: renumber to 0.2.x` 6ed14746)
- Refresh `bun.lock` with the new workspace versions; no other dependency changes

## Why

Re-release v0.2.3 after the prior dock-icon regression rollback. Signing, notarization, and the `build.yml` pipeline have cleared the local smoke checklist, and the local upstream tag pool has been cleared so that `origin` only carries the PawWork-owned `v0.2.2` — reusing `v0.2.3` no longer collides with anything on the remote.

## Related Issue

No direct issue link. Internal-feedback P0 (memory bloat) cannot be reproduced without a packaged dmg, so it stays open and gets investigated against the v0.2.3 build. #21 (skill AskUserQuestion misfire) is deferred to a follow-up.

## How To Verify

\`\`\`bash
bun turbo typecheck
bun turbo test:ci
\`\`\`

Local verification was skipped because this PR is a pure \`version\` string bump plus the matching \`bun.lock\` refresh — no executable code paths changed. The required CI checks (\`ci\`, \`desktop-smoke\`, \`codeql\`) will gate the merge.

## Screenshots or Recordings

N/A — no UI changes.

## Checklist

- [ ] I ran the relevant verification steps (deferred to CI; rationale above)
- [x] I tested visible changes manually when needed (no visible changes)
- [x] I am targeting the \`dev\` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions to 0.2.3 across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->