### PR TITLE
fix: run release snapshot cleanup after finalize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -659,7 +659,7 @@ jobs:
   cleanup-snapshot-tag:
     needs:
       - build-electron
-    if: ${{ inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}
+    if: ${{ always() && inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -6,7 +6,7 @@ const repoRoot = path.join(import.meta.dir, "../../../..")
 const workflowPath = path.join(repoRoot, ".github", "workflows", "build.yml")
 
 describe("release workflow", () => {
-  test("pins upgraded checkout and upload-artifact refs in the release workflow", () => {
+  test("validates the release workflow configuration", () => {
     const workflow = readWorkflow(workflowPath)
     const parsed = parseWorkflow(workflowPath)
     const buildElectron = parsed.jobs?.["build-electron"]
@@ -30,6 +30,7 @@ describe("release workflow", () => {
     })
     expect(parsed.on?.workflow_dispatch).toBeDefined()
     expect(buildElectron?.["runs-on"]).toBe("${{ matrix.host }}")
+    expect(cleanupSnapshotTag?.needs).toContain("build-electron")
     expect(cleanupSnapshotTag?.if).toBe(
       "${{ always() && inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}",
     )

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -10,6 +10,7 @@ describe("build workflow", () => {
     const workflow = readWorkflow(workflowPath)
     const parsed = parseWorkflow(workflowPath)
     const buildElectron = parsed.jobs?.["build-electron"]
+    const cleanupSnapshotTag = parsed.jobs?.["cleanup-snapshot-tag"]
     const steps = buildElectron?.steps ?? []
     const checkoutSteps = steps.filter(
       (step) => step.uses === "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
@@ -29,6 +30,9 @@ describe("build workflow", () => {
     })
     expect(parsed.on?.workflow_dispatch).toBeDefined()
     expect(buildElectron?.["runs-on"]).toBe("${{ matrix.host }}")
+    expect(cleanupSnapshotTag?.if).toBe(
+      "${{ always() && inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}",
+    )
     expect(checkoutSteps).toHaveLength(2)
     expect(checkoutSteps[0]?.with).toEqual({ "persist-credentials": false })
     expect(checkoutSteps[1]?.with).toEqual({

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -5,7 +5,7 @@ import { parseWorkflow, readWorkflow } from "./workflow-parser"
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const workflowPath = path.join(repoRoot, ".github", "workflows", "build.yml")
 
-describe("build workflow", () => {
+describe("release workflow", () => {
   test("pins upgraded checkout and upload-artifact refs in the release workflow", () => {
     const workflow = readWorkflow(workflowPath)
     const parsed = parseWorkflow(workflowPath)
@@ -23,7 +23,7 @@ describe("build workflow", () => {
     )
     const signedArtifactStep = steps.find((step) => step.name === "Upload signed app artifact")
 
-    expect(parsed.name).toBe("build")
+    expect(parsed.name).toBe("release")
     expect(parsed.permissions).toEqual({
       actions: "read",
       contents: "write",


### PR DESCRIPTION
## Summary

Fix the manual release workflow so `cleanup-snapshot-tag` can run after successful finalize builds, and rename the workflow display name from `build` to `release` while keeping the file path as `build.yml`.

## Why

Fixes #79. In finalize runs, `create-snapshot-tag` is intentionally skipped. GitHub Actions can propagate skipped dependencies to downstream jobs unless the downstream job explicitly evaluates its own condition, so `cleanup-snapshot-tag` was skipped even when `build-electron` succeeded. The cleanup job now uses `always()` while still requiring `phase == finalize` and a successful `build-electron` result.

## Related Issue

Fixes #79

## How To Verify

```bash
cd packages/opencode
bun test test/github
bun run typecheck
```

Fresh-eyes review also completed with no Critical, Important, or Minor issues.

## Screenshots or Recordings

Not applicable. This is a GitHub Actions workflow change.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CI workflow from "build" to "release" and clarified workflow intent.
  * Improved cleanup behavior so release cleanup runs reliably even when earlier steps fail or are canceled, while preserving finalization and prerequisite checks.

* **Tests**
  * Updated workflow tests to reflect the rename and new cleanup conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->