### PR TITLE
chore: bump version to v0.2.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "effect": "catalog:",
         "electron-context-menu": "4.1.2",
@@ -140,7 +140,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -396,7 +396,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Bump the PawWork-managed 0.2.x workspace package versions from 0.2.3 to 0.2.4 and refresh bun.lock for the release build.

## Why
This prepares the v0.2.4 release after the desktop icon pipeline fix from #81, which addresses the v0.2.3 dock/Finder icon regression reported in #80.

## Related Issue
Follows #80 and #81.

## How To Verify
```bash
bun install --lockfile-only
cd packages/desktop-electron
bun test scripts/generate-icons.test.ts
OPENCODE_CHANNEL=prod bun ./scripts/generate-icons.ts prod
file resources/icons/icon.icns
file resources/icons/icon.ico
find resources/icons -type f | wc -l
bun run typecheck
OPENCODE_CHANNEL=prod bun run build
```

Observed locally: icon generation tests passed with 7 pass and 0 fail; prod icon generation wrote 53 files; icon.icns was reported as a Mac OS X icon; icon.ico was reported as an MS Windows icon resource; desktop typecheck passed; prod desktop build passed and reran the prebuild icon generation step.

## Screenshots or Recordings
Not applicable. This PR only bumps release versions and lockfile metadata.

## Checklist
- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.4 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->