### PR TITLE
fix: remove Review plus button

### DIFF
--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -144,3 +144,19 @@ describe("makeRightPanelResizeHandler", () => {
     expect(received).toBe(280)
   })
 })
+
+describe("shouldShowReviewFileOpenButton", () => {
+  test("hides the file-open button while the Review tab is active", async () => {
+    const { shouldShowReviewFileOpenButton } = await import("./session-side-panel")
+
+    expect(shouldShowReviewFileOpenButton("review")).toBe(false)
+  })
+
+  test("keeps the file-open button for non-review tabs in the same panel", async () => {
+    const { shouldShowReviewFileOpenButton } = await import("./session-side-panel")
+
+    expect(shouldShowReviewFileOpenButton("empty")).toBe(true)
+    expect(shouldShowReviewFileOpenButton("context")).toBe(true)
+    expect(shouldShowReviewFileOpenButton("file:///tmp/example.ts")).toBe(true)
+  })
+})

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -43,6 +43,10 @@ export function makeRightPanelResizeHandler(
   }
 }
 
+export function shouldShowReviewFileOpenButton(activeTab: string | undefined): boolean {
+  return activeTab !== "review"
+}
+
 type RightPanelShellIconName = "status" | "folder" | "review" | "terminal"
 
 function RightPanelShellIcon(props: { icon: RightPanelShellIconName }) {
@@ -188,6 +192,27 @@ export function SessionSidePanel(props: {
     })
   }
 
+  const fileOpenButton = (className: string) => (
+    <Show when={shouldShowReviewFileOpenButton(activeTab())}>
+      <div class={className}>
+        <TooltipKeybind
+          title={language.t("command.file.open")}
+          keybind={command.keybind("file.open")}
+          class="flex items-center"
+        >
+          <IconButton
+            icon="plus-small"
+            variant="ghost"
+            iconSize="large"
+            class="!rounded-md"
+            onClick={() => openFilePicker(showAllFiles)}
+            aria-label={language.t("command.file.open")}
+          />
+        </TooltipKeybind>
+      </div>
+    </Show>
+  )
+
   createEffect(() => {
     if (!file.ready()) return
 
@@ -292,22 +317,7 @@ export function SessionSidePanel(props: {
                           <Show
                             when={showSecondaryReviewTabs()}
                             fallback={
-                              <div class="w-full bg-background-stronger flex items-center justify-end px-3 py-1.5">
-                                <TooltipKeybind
-                                  title={language.t("command.file.open")}
-                                  keybind={command.keybind("file.open")}
-                                  class="flex items-center"
-                                >
-                                  <IconButton
-                                    icon="plus-small"
-                                    variant="ghost"
-                                    iconSize="large"
-                                    class="!rounded-md"
-                                    onClick={() => openFilePicker(showAllFiles)}
-                                    aria-label={language.t("command.file.open")}
-                                  />
-                                </TooltipKeybind>
-                              </div>
+                              fileOpenButton("w-full bg-background-stronger flex items-center justify-end px-3 py-1.5")
                             }
                           >
                             <Tabs.List
@@ -357,22 +367,9 @@ export function SessionSidePanel(props: {
                               <SortableProvider ids={openedTabs()}>
                                 <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
                               </SortableProvider>
-                              <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
-                                <TooltipKeybind
-                                  title={language.t("command.file.open")}
-                                  keybind={command.keybind("file.open")}
-                                  class="flex items-center"
-                                >
-                                  <IconButton
-                                    icon="plus-small"
-                                    variant="ghost"
-                                    iconSize="large"
-                                    class="!rounded-md"
-                                    onClick={() => openFilePicker(showAllFiles)}
-                                    aria-label={language.t("command.file.open")}
-                                  />
-                                </TooltipKeybind>
-                              </div>
+                              {fileOpenButton(
+                                "bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3",
+                              )}
                             </Tabs.List>
                           </Show>
                         </div>


### PR DESCRIPTION
## Summary

Remove the standalone file-open plus button while the Review tab is active.

## Why

The Review Git changes surface should only show actions that are meaningful for the review workflow. The extra plus button could be clicked by mistake and had no clear purpose in that state.

## Related Issue

Fixes #85

## How To Verify

```bash
cd packages/app
bun test src/pages/session/session-side-panel.test.tsx
bun run typecheck
```

Fresh-eyes review was run twice. The final review reported no Critical, Important, or Minor issues.

## Screenshots or Recordings

Not attached. This environment did not run a manual desktop UI capture.

## Checklist

- [x] I ran the relevant verification steps
- [ ] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the file open button visibility behavior to prevent display when the review tab is active.

* **Refactor**
  * Centralized the file open button rendering logic for improved maintainability and consistency.

* **Tests**
  * Added test coverage for file open button visibility conditions across different tab states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->