### PR TITLE
ci: support Intel and Windows release targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,21 @@ on:
           - beta
           - prod
         default: dev
+      target:
+        description: "Release target"
+        required: false
+        type: choice
+        options:
+          - macos
+          - windows
+        default: macos
       arch:
         description: "Target architecture"
         required: false
         type: choice
         options:
           - arm64
+          - x64
         default: arm64
       source_run_id:
         description: "Run ID from the submit phase"
@@ -58,7 +67,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.phase || 'submit' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.phase || 'submit' }}-${{ inputs.channel || 'dev' }}-${{ inputs.target || 'macos' }}-${{ inputs.arch || 'arm64' }}
   cancel-in-progress: true
 
 permissions:
@@ -66,8 +75,83 @@ permissions:
   contents: write
 
 jobs:
+  select-build-target:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      target: ${{ steps.select.outputs.target }}
+      arch: ${{ steps.select.outputs.arch }}
+    steps:
+      - id: select
+        run: |
+          set -euo pipefail
+
+          target="${INPUT_TARGET:-macos}"
+          arch="${INPUT_ARCH:-arm64}"
+          phase="${INPUT_PHASE:-submit}"
+
+          case "$target" in
+            macos)
+              case "$arch" in
+                arm64)
+                  host="macos-latest"
+                  platform_flag="--mac --arm64"
+                  ;;
+                x64)
+                  host="macos-15-intel"
+                  platform_flag="--mac --x64"
+                  ;;
+                *)
+                  echo "Unsupported macOS arch: $arch"
+                  exit 1
+                  ;;
+              esac
+              ;;
+            windows)
+              if [ "$phase" = "finalize" ]; then
+                echo "Windows releases do not use the macOS notarization finalize phase"
+                exit 1
+              fi
+              if [ "$arch" != "x64" ]; then
+                echo "Unsupported Windows arch: $arch"
+                exit 1
+              fi
+              host="windows-latest"
+              platform_flag="--win"
+              ;;
+            *)
+              echo "Unsupported release target: $target"
+              exit 1
+              ;;
+          esac
+
+          matrix=$(python3 - <<PY
+          import json
+          print(json.dumps({
+              "include": [{
+                  "host": "$host",
+                  "target": "$target",
+                  "platform_flag": "$platform_flag",
+                  "arch_label": "$arch",
+              }]
+          }))
+          PY
+          )
+
+          {
+            echo "target=$target"
+            echo "arch=$arch"
+            echo "matrix=$matrix"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_TARGET: ${{ inputs.target || 'macos' }}
+          INPUT_ARCH: ${{ inputs.arch || 'arm64' }}
+          INPUT_PHASE: ${{ inputs.phase || 'submit' }}
+
   create-snapshot-tag:
-    if: ${{ inputs.phase == 'submit' }}
+    needs:
+      - select-build-target
+    if: ${{ inputs.phase == 'submit' && needs.select-build-target.outputs.target == 'macos' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -79,7 +163,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          workflow_ref="workflow-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ inputs.arch || 'arm64' }}"
+          workflow_ref="workflow-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ needs.select-build-target.outputs.target }}-${{ needs.select-build-target.outputs.arch }}"
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -93,39 +177,33 @@ jobs:
 
   build-electron:
     needs:
+      - select-build-target
       - create-snapshot-tag
-    if: ${{ always() && (needs.create-snapshot-tag.result == 'success' || needs.create-snapshot-tag.result == 'skipped') }}
+    if: ${{ always() && needs.select-build-target.result == 'success' && (needs.create-snapshot-tag.result == 'success' || needs.create-snapshot-tag.result == 'skipped') }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - host: macos-latest
-            platform_flag: --mac --arm64
-            arch_label: arm64
-          # Uncomment after signing is verified:
-          # - host: macos-latest
-          #   platform_flag: --mac --x64
-          #   arch_label: x64
-          # - host: ubuntu-latest
-          #   platform_flag: --linux
-          #   arch_label: x64
-          # - host: windows-latest
-          #   platform_flag: --win
-          #   arch_label: x64
+      matrix: ${{ fromJSON(needs.select-build-target.outputs.matrix) }}
 
     runs-on: ${{ matrix.host }}
 
     steps:
-      - name: Validate Selected Arch
+      - name: Validate selected target
+        shell: bash
         run: |
           set -euo pipefail
 
-          if [ "$SELECTED_ARCH" != "arm64" ]; then
-            echo "Unsupported arch: $SELECTED_ARCH"
+          if [ "$SELECTED_TARGET" != "${{ matrix.target }}" ]; then
+            echo "Target mismatch: expected $SELECTED_TARGET, got ${{ matrix.target }}"
+            exit 1
+          fi
+
+          if [ "$SELECTED_ARCH" != "${{ matrix.arch_label }}" ]; then
+            echo "Arch mismatch: expected $SELECTED_ARCH, got ${{ matrix.arch_label }}"
             exit 1
           fi
         env:
-          SELECTED_ARCH: ${{ inputs.arch || 'arm64' }}
+          SELECTED_TARGET: ${{ needs.select-build-target.outputs.target }}
+          SELECTED_ARCH: ${{ needs.select-build-target.outputs.arch }}
 
       - name: Validate finalize inputs
         if: ${{ inputs.phase == 'finalize' }}
@@ -639,11 +717,32 @@ jobs:
 
       - name: Package app
         if: ${{ runner.os != 'macOS' && inputs.phase != 'finalize' }}
-        run: npx electron-builder ${{ matrix.platform_flag }} --publish never --config electron-builder.config.ts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          publish_flag="never"
+          if [ "${{ inputs.phase || 'submit' }}" = "full" ]; then
+            publish_flag="always"
+          fi
+
+          npx electron-builder ${{ matrix.platform_flag }} --publish "$publish_flag" --config electron-builder.config.ts
         working-directory: packages/desktop-electron
         timeout-minutes: 60
         env:
           OPENCODE_CHANNEL: ${{ inputs.channel || 'dev' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload packaged app artifact
+        if: ${{ runner.os == 'Windows' && inputs.phase != 'finalize' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pawwork-${{ runner.os }}-${{ matrix.arch_label }}
+          if-no-files-found: error
+          path: |
+            packages/desktop-electron/dist/*.exe
+            packages/desktop-electron/dist/*.exe.blockmap
+            packages/desktop-electron/dist/latest*.yml
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label }}

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -1,50 +1,194 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
+import { execFileSync, spawnSync } from "node:child_process"
+import fs from "node:fs"
 import path from "node:path"
+import { Effect } from "effect"
+import { tmpdir } from "../fixture/fixture"
+import { it } from "../lib/effect"
 import { parseWorkflow, readWorkflow } from "./workflow-parser"
 
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const workflowPath = path.join(repoRoot, ".github", "workflows", "build.yml")
 
 describe("release workflow", () => {
-  test("validates the release workflow configuration", () => {
-    const workflow = readWorkflow(workflowPath)
-    const parsed = parseWorkflow(workflowPath)
-    const buildElectron = parsed.jobs?.["build-electron"]
-    const cleanupSnapshotTag = parsed.jobs?.["cleanup-snapshot-tag"]
-    const steps = buildElectron?.steps ?? []
-    const checkoutSteps = steps.filter(
-      (step) => step.uses === "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
-    )
-    const setupNodeStep = steps.find(
-      (step) => step.uses === "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f",
-    )
-    const uploadArtifactSteps = steps.filter(
-      (step) => step.uses === "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-    )
-    const signedArtifactStep = steps.find((step) => step.name === "Upload signed app artifact")
+  it.live("selects the macOS x64 release matrix", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runSelectBuildTarget({ target: "macos", arch: "x64", phase: "submit" }),
+      )
 
-    expect(parsed.name).toBe("release")
-    expect(parsed.permissions).toEqual({
-      actions: "read",
-      contents: "write",
-    })
-    expect(parsed.on?.workflow_dispatch).toBeDefined()
-    expect(buildElectron?.["runs-on"]).toBe("${{ matrix.host }}")
-    expect(cleanupSnapshotTag?.needs).toContain("build-electron")
-    expect(cleanupSnapshotTag?.if).toBe(
-      "${{ always() && inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}",
-    )
-    expect(checkoutSteps).toHaveLength(2)
-    expect(checkoutSteps[0]?.with).toEqual({ "persist-credentials": false })
-    expect(checkoutSteps[1]?.with).toEqual({
-      "persist-credentials": false,
-      ref: "${{ inputs.source_sha }}",
-    })
-    expect(setupNodeStep?.with).toEqual({ "node-version": "24" })
-    expect(uploadArtifactSteps).toHaveLength(2)
-    expect(signedArtifactStep?.uses).toBe("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+      expect(result.status).toBe(0)
+      expect(result.outputs.target).toBe("macos")
+      expect(result.outputs.arch).toBe("x64")
+      expect(JSON.parse(result.outputs.matrix ?? "")).toEqual({
+        include: [{ host: "macos-15-intel", target: "macos", platform_flag: "--mac --x64", arch_label: "x64" }],
+      })
+    }),
+  )
 
-    expect(workflow).not.toContain("persist-credentials: true")
-    expect(workflow).not.toContain("pull_request_target")
-  })
+  it.live("selects the Windows x64 release matrix", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() =>
+        runSelectBuildTarget({ target: "windows", arch: "x64", phase: "submit" }),
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.outputs.target).toBe("windows")
+      expect(result.outputs.arch).toBe("x64")
+      expect(JSON.parse(result.outputs.matrix ?? "")).toEqual({
+        include: [{ host: "windows-latest", target: "windows", platform_flag: "--win", arch_label: "x64" }],
+      })
+    }),
+  )
+
+  it.live("rejects unsupported Windows release combinations", () =>
+    Effect.gen(function* () {
+      const arm64 = yield* Effect.promise(() =>
+        runSelectBuildTarget({ target: "windows", arch: "arm64", phase: "submit" }),
+      )
+      const finalize = yield* Effect.promise(() =>
+        runSelectBuildTarget({ target: "windows", arch: "x64", phase: "finalize" }),
+      )
+
+      expect(arm64.status).toBe(1)
+      expect(arm64.output).toContain("Unsupported Windows arch: arm64")
+      expect(finalize.status).toBe(1)
+      expect(finalize.output).toContain("Windows releases do not use the macOS notarization finalize phase")
+    }),
+  )
+
+  it.live("ignores malformed GitHub output lines", () =>
+    Effect.gen(function* () {
+      expect(parseGithubOutput("target=windows\nnot-an-output-line\narch=x64\n")).toEqual({
+        target: "windows",
+        arch: "x64",
+      })
+    }),
+  )
+
+  it.live("validates the release workflow configuration", () =>
+    Effect.gen(function* () {
+      const workflow = readWorkflow(workflowPath)
+      const parsed = parseWorkflow(workflowPath)
+      const selectBuildTarget = parsed.jobs?.["select-build-target"]
+      const createSnapshotTag = parsed.jobs?.["create-snapshot-tag"]
+      const buildElectron = parsed.jobs?.["build-electron"]
+      const cleanupSnapshotTag = parsed.jobs?.["cleanup-snapshot-tag"]
+      const steps = buildElectron?.steps ?? []
+      const checkoutSteps = steps.filter(
+        (step) => step.uses === "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+      )
+      const setupNodeStep = steps.find(
+        (step) => step.uses === "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f",
+      )
+      const signedArtifactStep = steps.find((step) => step.name === "Upload signed app artifact")
+      const nonMacArtifactStep = steps.find((step) => step.name === "Upload packaged app artifact")
+      const packageAppStep = steps.find((step) => step.name === "Package app")
+      const validateSelectedTargetStep = steps.find((step) => step.name === "Validate selected target")
+
+      expect(parsed.name).toBe("release")
+      expect(parsed.permissions).toEqual({
+        actions: "read",
+        contents: "write",
+      })
+      expect(parsed.concurrency?.group).toBe(
+        "${{ github.workflow }}-${{ github.ref }}-${{ inputs.phase || 'submit' }}-${{ inputs.channel || 'dev' }}-${{ inputs.target || 'macos' }}-${{ inputs.arch || 'arm64' }}",
+      )
+      expect(parsed.on?.workflow_dispatch).toBeDefined()
+      expect(workflow).toContain("target:")
+      expect(workflow).toContain("- macos")
+      expect(workflow).toContain("- windows")
+      expect(workflow).toContain("- x64")
+      expect(selectBuildTarget?.["runs-on"]).toBe("ubuntu-latest")
+      expect(selectBuildTarget?.outputs).toEqual({
+        arch: "${{ steps.select.outputs.arch }}",
+        matrix: "${{ steps.select.outputs.matrix }}",
+        target: "${{ steps.select.outputs.target }}",
+      })
+      expect(createSnapshotTag?.needs).toContain("select-build-target")
+      expect(buildElectron?.["runs-on"]).toBe("${{ matrix.host }}")
+      expect(buildElectron?.needs).toEqual(["select-build-target", "create-snapshot-tag"])
+      expect(buildElectron?.if).toContain("needs.select-build-target.result == 'success'")
+      expect(cleanupSnapshotTag?.needs).toContain("build-electron")
+      expect(cleanupSnapshotTag?.if).toBe(
+        "${{ always() && inputs.phase == 'finalize' && needs.build-electron.result == 'success' }}",
+      )
+      expect(checkoutSteps).toHaveLength(2)
+      expect(checkoutSteps[0]?.with).toEqual({ "persist-credentials": false })
+      expect(checkoutSteps[1]?.with).toEqual({
+        "persist-credentials": false,
+        ref: "${{ inputs.source_sha }}",
+      })
+      expect(setupNodeStep?.with).toEqual({ "node-version": "24" })
+      expect(signedArtifactStep?.uses).toBe("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+      expect(nonMacArtifactStep?.uses).toBe("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+      expect(nonMacArtifactStep?.if).toBe("${{ runner.os == 'Windows' && inputs.phase != 'finalize' }}")
+      expect(nonMacArtifactStep?.with?.["if-no-files-found"]).toBe("error")
+      expect(nonMacArtifactStep?.with?.path).toContain("packages/desktop-electron/dist/*.exe")
+      expect(nonMacArtifactStep?.with?.path).toContain("packages/desktop-electron/dist/latest*.yml")
+      expect(validateSelectedTargetStep?.shell).toBe("bash")
+      expect(validateSelectedTargetStep?.env).toEqual({
+        SELECTED_TARGET: "${{ needs.select-build-target.outputs.target }}",
+        SELECTED_ARCH: "${{ needs.select-build-target.outputs.arch }}",
+      })
+      expect(packageAppStep?.shell).toBe("bash")
+      expect(packageAppStep?.env).toEqual({
+        OPENCODE_CHANNEL: "${{ inputs.channel || 'dev' }}",
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+      })
+      expect(packageAppStep?.run).toContain('publish_flag="never"')
+      expect(packageAppStep?.run).toContain('if [ "${{ inputs.phase || \'submit\' }}" = "full" ]; then')
+      expect(packageAppStep?.run).toContain('publish_flag="always"')
+
+      expect(workflow).not.toContain("persist-credentials: true")
+      expect(workflow).not.toContain("pull_request_target")
+    }),
+  )
 })
+
+/** Runs the workflow selector step and returns the status plus GITHUB_OUTPUT entries. */
+async function runSelectBuildTarget(input: { target: string; arch: string; phase: string }) {
+  const ruby = String.raw`
+    require "yaml"
+
+    data = YAML.load_file(ARGV[0])
+    step = data["jobs"]["select-build-target"]["steps"].find { |entry| entry["id"] == "select" }
+    raise "Missing select-build-target step with id=select" unless step
+    puts step["run"]
+  `
+  const script = execFileSync("ruby", ["-e", ruby, workflowPath], { encoding: "utf8" })
+  await using tmp = await tmpdir()
+  const outputPath = path.join(tmp.path, "github-output")
+  const result = spawnSync("bash", ["-ec", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      INPUT_TARGET: input.target,
+      INPUT_ARCH: input.arch,
+      INPUT_PHASE: input.phase,
+      GITHUB_OUTPUT: outputPath,
+    },
+  })
+
+  const outputs = fs.existsSync(outputPath) ? parseGithubOutput(fs.readFileSync(outputPath, "utf8")) : {}
+
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout}${result.stderr}`,
+    outputs,
+  }
+}
+
+/** Parses the simple key=value records emitted to GITHUB_OUTPUT by this workflow step. */
+function parseGithubOutput(output: string) {
+  return Object.fromEntries(
+    output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((line) => {
+        const index = line.indexOf("=")
+        return index === -1 ? [] : ([[line.slice(0, index), line.slice(index + 1)]] as const)
+      }),
+  )
+}

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -1,16 +1,19 @@
 import { execFileSync } from "node:child_process"
 import fs from "node:fs"
 
+/** Parsed subset of a workflow step used by workflow contract tests. */
 export type WorkflowStep = {
   id?: string
   if?: string
   name?: string
   run?: string
+  shell?: string
   uses?: string
   with?: Record<string, unknown>
   env?: Record<string, string>
 }
 
+/** Parsed subset of a workflow job used by workflow contract tests. */
 export type WorkflowJob = {
   "continue-on-error"?: boolean
   if?: string
@@ -22,13 +25,19 @@ export type WorkflowJob = {
   "timeout-minutes"?: number
 }
 
+/** Parsed subset of a GitHub Actions workflow used by workflow contract tests. */
 export type Workflow = {
   name?: string
+  concurrency?: {
+    group?: string
+    "cancel-in-progress"?: boolean
+  }
   on?: Record<string, unknown>
   permissions?: Record<string, string>
   jobs?: Record<string, WorkflowJob>
 }
 
+/** Reads a workflow file as UTF-8 and fails clearly when it is missing. */
 export function readWorkflow(workflowPath: string) {
   if (!fs.existsSync(workflowPath)) {
     throw new Error(`Missing workflow: ${workflowPath}`)
@@ -36,6 +45,7 @@ export function readWorkflow(workflowPath: string) {
   return fs.readFileSync(workflowPath, "utf8")
 }
 
+/** Parses workflow YAML with Ruby, preserving GitHub's `on` key for assertions. */
 export function parseWorkflow(workflowPath: string) {
   const parsed = execFileSync(
     "ruby",


### PR DESCRIPTION
## Summary

Add explicit release target selection to `build.yml` so the release workflow can build one platform/architecture per dispatch: macOS arm64, macOS x64, or Windows x64.

The workflow now rejects unsupported Windows combinations before matrix expansion, keeps macOS arm64 as the default, includes target and arch in the concurrency group, and uploads Windows packaged artifacts for inspection. Windows `phase=full` can publish through electron-builder, while Windows `finalize` is rejected because finalize is only for macOS notarization.

Review feedback is addressed by failing the Windows upload step when expected artifacts are missing, keeping Windows signing variables out until Azure authentication is wired, making the selector tests more robust, and adding focused docstrings for the changed workflow test helpers.

Windows artifacts from this PR remain unsigned unless signing is added in a later PR.

## Why

The team needs a macOS Intel artifact for the current release work, and Windows distribution is now back on the release schedule. The old workflow only exposed arm64 and left x64/Windows matrix entries commented out, so it could not safely produce those release artifacts from the workflow UI.

## Related Issue

Part of #86

Part of #87

## How To Verify

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "ok"'
cd packages/opencode
bun test test/github/build-workflow.test.ts
bun test test/github
bun run typecheck
```

Additional checks:

```bash
git diff --check
actionlint .github/workflows/build.yml
```

`actionlint` still reports existing shellcheck warnings in unchanged macOS signing / summary blocks. The new target selection, matrix, concurrency, Windows packaging, and review-feedback fixes do not add new actionlint findings.

Fresh-eyes review loop completed with no remaining blocking findings.

## Screenshots or Recordings

Not applicable. This is a release workflow change with no visible UI.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose build target (macOS or Windows) and architecture (arm64 or x64); selection drives the build matrix and targeted builds.

* **Chores**
  * Safer concurrency keys and dynamic build gating; snapshot/tag creation restricted to macOS submit runs.
  * Packaging publish behavior now depends on release phase; Windows artifacts uploaded with OS/arch-aware names.

* **Tests**
  * Added integration and unit tests covering target selection, invalid combinations, output parsing, workflow validation, packaging, and artifact uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->