### PR TITLE
docs: remove stale Tauri platform comments

### DIFF
--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -13,7 +13,7 @@ export type Platform = {
   /** Platform discriminator */
   platform: "web" | "desktop"
 
-  /** Desktop OS (Tauri only) */
+  /** Desktop OS (desktop only) */
   os?: "macos" | "windows" | "linux"
 
   /** App version */
@@ -43,22 +43,22 @@ export type Platform = {
   /** Send a system notification (optional deep link) */
   notify(title: string, description?: string, href?: string): Promise<void>
 
-  /** Open directory picker dialog (native on Tauri, server-backed on web) */
+  /** Open directory picker dialog (native on desktop, server-backed on web) */
   openDirectoryPickerDialog?(opts?: OpenDirectoryPickerOptions): Promise<PickerPaths>
 
-  /** Open native file picker dialog (Tauri only) */
+  /** Open native file picker dialog (desktop only) */
   openFilePickerDialog?(opts?: OpenFilePickerOptions): Promise<PickerPaths>
 
-  /** Save file picker dialog (Tauri only) */
+  /** Save file picker dialog (desktop only) */
   saveFilePickerDialog?(opts?: SaveFilePickerOptions): Promise<string | null>
 
   /** Storage mechanism, defaults to localStorage */
   storage?: (name?: string) => SyncStorage | AsyncStorage
 
-  /** Check for updates (Tauri only) */
+  /** Check for updates (desktop only) */
   checkUpdate?(): Promise<UpdateInfo>
 
-  /** Install updates (Tauri only) */
+  /** Install updates (desktop only) */
   update?(): Promise<void>
 
   /** Fetch override */


### PR DESCRIPTION
## Summary

Update stale platform interface comments that still described desktop-only APIs as Tauri-only.

## Why

PR #93 removed the functional Tauri compatibility paths. These comments were non-functional keyword residue and could confuse future audits for Tauri cleanup.

## Related Issue

Part of #91.

## How To Verify

```bash
rg -n "Tauri only|native on Tauri|tauri|Tauri" packages/app/src/context/platform.tsx
git diff --check
```

`bun run --cwd packages/app typecheck` was attempted from the main checkout, but this checkout does not currently have dependencies installed, so `tsgo` was unavailable. This change is comments only.

## Screenshots or Recordings

Not applicable. Comments only.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform compatibility descriptions for desktop-related features to improve clarity on feature availability across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->