### PR TITLE
fix: keep sync store available during route changes

### DIFF
--- a/packages/app/src/context/sync-current-child.test.ts
+++ b/packages/app/src/context/sync-current-child.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot, getOwner } from "solid-js"
+import { createCurrentSyncChild } from "./sync"
+
+describe("createCurrentSyncChild", () => {
+  test("keeps sync child lookup usable after the provider owner is disposed", () => {
+    let providerOwner = undefined as ReturnType<typeof getOwner> | undefined
+    let childOwner = undefined as ReturnType<typeof getOwner> | undefined
+    let calls = 0
+
+    const current = createRoot((dispose) => {
+      providerOwner = getOwner()
+      const accessor = createCurrentSyncChild({
+        directory: () => "/tmp/project",
+        child: (directory) => {
+          calls++
+          expect(directory).toBe("/tmp/project")
+          childOwner = getOwner()
+          return [{ directory }, () => {}] as const
+        },
+      })
+      dispose()
+      return accessor
+    })
+
+    const value = createRoot((dispose) => {
+      const result = current()
+      dispose()
+      return result
+    })
+
+    expect(value[0].directory).toBe("/tmp/project")
+    expect(calls).toBe(1)
+    expect(childOwner).toBeDefined()
+    expect(childOwner).not.toBe(providerOwner)
+  })
+})

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -62,6 +62,10 @@ type OptimisticItem = {
   parts: Part[]
 }
 
+export function createCurrentSyncChild<Child>(input: { directory: () => string; child: (directory: string) => Child }) {
+  return () => input.child(input.directory())
+}
+
 type MessagePage = {
   session: Message[]
   part: { id: string; part: Part[] }[]
@@ -175,7 +179,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     type Child = ReturnType<(typeof globalSync)["child"]>
     type Setter = Child[1]
 
-    const current = createMemo(() => globalSync.child(sdk.directory))
+    const current = createCurrentSyncChild({
+      directory: () => sdk.directory,
+      child: globalSync.child,
+    })
     const target = (directory?: string) => {
       if (!directory || directory === sdk.directory) return current()
       return globalSync.child(directory)


### PR DESCRIPTION
## Summary

Fix a renderer crash when switching session routes across workspaces by resolving the current sync child store from the consuming owner instead of caching it in the Sync provider owner. Add a regression test for the owner lifecycle invariant.

## Why

Fixes #94. The crash stack pointed to `sync.data -> current()[0]` after a route change. The previous `createMemo(() => globalSync.child(sdk.directory))` resolved and pinned the child store under the provider owner, so stale consumer computations could still read through a disposed provider during cross-directory session navigation.

## Related Issue

Fixes #94

## How To Verify

Ran before dependency cleanup in this worktree:

```bash
bun test src/context/sync-current-child.test.ts
bun test src/context/sync-current-child.test.ts src/context/sync-optimistic.test.ts src/context/global-sync/child-store.test.ts
bun --cwd packages/app typecheck
bun --cwd packages/app test:unit
bun --cwd packages/app build
```

Also ran a real Electron client-route E2E against the patched renderer: started from the `/Users/yuhan/PawWork` session, routed to `/Users/yuhan/workspace/dev/pawwork` sessions `ses_25248bc9cffePSNl6PXk12tw86` and `ses_2544c191effeu1Nw5UECHonKbl`, and confirmed no `Something went wrong` page or `Cannot read properties of undefined` crash.

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for sync-child lookup persistence across provider lifecycle changes.

* **Refactor**
  * Improved internal sync-child initialization mechanism for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->