### PR TITLE
docs: tighten PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,9 @@ Required for visible UI changes.
 
 ## Checklist
 
-- [ ] I ran the relevant verification steps
-- [ ] I tested visible changes manually when needed
-- [ ] I am targeting the `dev` branch
+- [ ] I linked the related issue, or stated why there is no issue
+- [ ] This PR has type, scope, and priority labels
+- [ ] I listed the relevant verification steps, including tests when behavior changed
+- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
+- [ ] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
+- [ ] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,9 @@ Required for visible UI changes.
 ## Checklist
 
 - [ ] I linked the related issue, or stated why there is no issue
-- [ ] This PR has type, scope, and priority labels
+- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
 - [ ] I listed the relevant verification steps, including tests when behavior changed
 - [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
 - [ ] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
 - [ ] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
+- [ ] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


### PR DESCRIPTION
## Summary

Tighten the pull request checklist so authors confirm issue linkage, required labels, verification, UI evidence when relevant, desktop platform impact, and any docs, release, dependency, permission, credential, deletion, generated, or local-file implications.

## Why

The previous checklist only covered verification, manual UI testing, and the target branch. That missed several PawWork review gates that have repeatedly mattered for PR hygiene and release safety.

## Related Issue

No related issue. This is a small repository process update.

## How To Verify

Reviewed the template diff locally. No runtime tests were run because this only changes the GitHub pull request template. Also attempted a direct push to dev, and GitHub rejected it with the repository rule that changes must be made through a pull request.

## Screenshots or Recordings

Not applicable. No visible product UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant