### PR TITLE
fix(app): ignore stale assistant messages for running state

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -16,6 +16,7 @@ import { getPawworkSkillMeta } from "@/components/session/pawwork-skill-meta"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionTitle } from "@/utils/session-title"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
+import { isSessionRunning } from "../session/session-running-state"
 import { childSessionOnPath, hasProjectPermissions } from "./helpers"
 
 export const ProjectIcon = (props: { project: LocalProject; class?: string; notify?: boolean }): JSX.Element => {
@@ -170,18 +171,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   })
   const isWorking = createMemo(() => {
     if (hasPermissions()) return false
-    const pending = (sessionStore.message[props.session.id] ?? []).findLast(
-      (message) =>
-        message.role === "assistant" &&
-        typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
-    )
-    const status = sessionStore.session_status[props.session.id]
-    return (
-      pending !== undefined ||
-      status?.type === "busy" ||
-      status?.type === "retry" ||
-      (status !== undefined && status.type !== "idle")
-    )
+    return isSessionRunning(sessionStore.session_status[props.session.id], sessionStore.message[props.session.id])
   })
 
   const tint = createMemo(() => messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent))

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -54,6 +54,7 @@ import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
+import { isSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { deriveArtifactFiles, nextFilesPanelAutoOpen } from "@/pages/session/files-tab-state"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
@@ -1606,12 +1607,7 @@ export default function Page() {
       return out
     })
 
-  const busy = (sessionID: string) => {
-    if ((sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle") return true
-    return (sync.data.message[sessionID] ?? []).some(
-      (item) => item.role === "assistant" && typeof item.time.completed !== "number",
-    )
-  }
+  const busy = (sessionID: string) => isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
 
   const queuedFollowups = createMemo(() => {
     const id = params.id

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -19,6 +19,7 @@ import { Binary } from "@opencode-ai/util/binary"
 import { getFilename } from "@opencode-ai/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
+import { isSessionRunning } from "@/pages/session/session-running-state"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
@@ -261,8 +262,7 @@ export function MessageTimeline(props: {
     return sync.data.session_status[id] ?? idle
   })
   const working = createMemo(() => {
-    const status = sessionStatus() ?? idle
-    return !!pending() || status.type !== "idle"
+    return isSessionRunning(sessionStatus(), sessionMessages())
   })
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 

--- a/packages/app/src/pages/session/session-running-state.test.ts
+++ b/packages/app/src/pages/session/session-running-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, SessionStatus } from "@opencode-ai/sdk/v2/client"
+import { isSessionRunning } from "./session-running-state"
+
+const idle: SessionStatus = { type: "idle" }
+const busy: SessionStatus = { type: "busy" }
+const retry: SessionStatus = { type: "retry", attempt: 1, message: "rate limited", next: 1_776_773_000_000 }
+
+const user = (id: string, created: number): Message =>
+  ({
+    id,
+    sessionID: "ses_1",
+    role: "user",
+    time: { created },
+  }) as Message
+
+const assistant = (
+  id: string,
+  created: number,
+  completed?: number,
+  finish?: "stop" | "tool-calls",
+): Message =>
+  ({
+    id,
+    sessionID: "ses_1",
+    role: "assistant",
+    parentID: "msg_user",
+    time: completed === undefined ? { created } : { created, completed },
+    finish,
+  }) as Message
+
+describe("isSessionRunning", () => {
+  test("ignores a stale incomplete assistant message when a later assistant completed", () => {
+    const messages = [
+      user("msg_user_1", 1),
+      assistant("msg_stale", 2),
+      user("msg_user_2", 3),
+      assistant("msg_done", 4, 5, "stop"),
+    ]
+
+    expect(isSessionRunning(idle, messages)).toBe(false)
+  })
+
+  test("ignores a stale incomplete assistant message when a later user message exists", () => {
+    const messages = [user("msg_user_1", 1), assistant("msg_stale", 2), user("msg_user_2", 3)]
+
+    expect(isSessionRunning(idle, messages)).toBe(false)
+  })
+
+  test("returns true when live session status is busy", () => {
+    expect(isSessionRunning(busy, [assistant("msg_done", 1, 2, "stop")])).toBe(true)
+  })
+
+  test("returns true when live session status is retry", () => {
+    expect(isSessionRunning(retry, [assistant("msg_done", 1, 2, "stop")])).toBe(true)
+  })
+
+  test("returns true when the latest assistant message is incomplete", () => {
+    const messages = [user("msg_user", 1), assistant("msg_pending", 2)]
+
+    expect(isSessionRunning(idle, messages)).toBe(true)
+  })
+
+  test("returns false when there are no assistant messages and status is idle", () => {
+    expect(isSessionRunning(idle, [user("msg_user", 1)])).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/session-running-state.test.ts
+++ b/packages/app/src/pages/session/session-running-state.test.ts
@@ -30,6 +30,16 @@ const assistant = (
   }) as Message
 
 describe("isSessionRunning", () => {
+  test("treats undefined status as idle and handles missing messages", () => {
+    expect(isSessionRunning(undefined, undefined)).toBe(false)
+    expect(isSessionRunning(undefined, [])).toBe(false)
+  })
+
+  test("uses latest-message fallback when status is undefined", () => {
+    expect(isSessionRunning(undefined, [user("msg_user", 1)])).toBe(false)
+    expect(isSessionRunning(undefined, [user("msg_user", 1), assistant("msg_pending", 2)])).toBe(true)
+  })
+
   test("ignores a stale incomplete assistant message when a later assistant completed", () => {
     const messages = [
       user("msg_user_1", 1),
@@ -59,6 +69,10 @@ describe("isSessionRunning", () => {
     const messages = [user("msg_user", 1), assistant("msg_pending", 2)]
 
     expect(isSessionRunning(idle, messages)).toBe(true)
+  })
+
+  test("returns false when there are no messages and status is idle", () => {
+    expect(isSessionRunning(idle, [])).toBe(false)
   })
 
   test("returns false when there are no assistant messages and status is idle", () => {

--- a/packages/app/src/pages/session/session-running-state.ts
+++ b/packages/app/src/pages/session/session-running-state.ts
@@ -1,0 +1,10 @@
+import type { Message, SessionStatus } from "@opencode-ai/sdk/v2/client"
+
+const idle = { type: "idle" as const }
+
+export function isSessionRunning(status: SessionStatus | undefined, messages: readonly Message[] | undefined): boolean {
+  if ((status ?? idle).type !== "idle") return true
+
+  const latest = messages?.at(-1)
+  return latest?.role === "assistant" && typeof latest.time.completed !== "number"
+}

--- a/packages/app/src/pages/session/session-running-state.ts
+++ b/packages/app/src/pages/session/session-running-state.ts
@@ -6,5 +6,5 @@ export function isSessionRunning(status: SessionStatus | undefined, messages: re
   if ((status ?? idle).type !== "idle") return true
 
   const latest = messages?.at(-1)
-  return latest?.role === "assistant" && typeof latest.time.completed !== "number"
+  return latest?.role === "assistant" && typeof latest.time?.completed !== "number"
 }

--- a/packages/app/src/pages/session/session-running-state.ts
+++ b/packages/app/src/pages/session/session-running-state.ts
@@ -2,6 +2,7 @@ import type { Message, SessionStatus } from "@opencode-ai/sdk/v2/client"
 
 const idle = { type: "idle" as const }
 
+/** Status is authoritative; when idle, only the latest message can indicate in-flight work. */
 export function isSessionRunning(status: SessionStatus | undefined, messages: readonly Message[] | undefined): boolean {
   if ((status ?? idle).type !== "idle") return true
 


### PR DESCRIPTION
## Summary

- Add a shared `isSessionRunning` helper for app session running-state checks.
- Treat live non-idle `session_status` as authoritative, and only fall back to message history when the latest message is an incomplete assistant message.
- Replace the broad historical incomplete-assistant scans in the session timeline, sidebar item, and session busy helper.

## Why

A stale incomplete assistant message from an older turn can remain in session history even after later turns complete. The previous UI checks treated any historical incomplete assistant message as current work, which kept completed sessions showing progress/spinners.

## Related Issue

Fixes #95

## How To Verify

```bash
cd packages/app && bun run test:unit src/pages/session/session-running-state.test.ts
cd packages/app && bun run test:unit
cd packages/app && bun run typecheck
bun turbo typecheck
bun turbo test:ci
```

## Screenshots or Recordings

Not included. This is a state-derivation fix covered by unit tests, with no intentional visual design change.

## Checklist

- [x] I ran the relevant verification steps
- [x] I tested visible changes manually when needed
- [x] I am targeting the `dev` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated session state determination logic into a centralized shared helper function, reducing code duplication and improving maintainability across multiple application components.

* **Tests**
  * Added comprehensive test coverage for session running state evaluation, including edge cases and various status conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->