### PR TITLE
fix: keep stale message parts renderable

### DIFF
--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+test("assistant part renderers capture item values before passing them to Part", () => {
+  const source = readFileSync(new URL("./message-part.tsx", import.meta.url), "utf8")
+
+  expect(source).toContain("function latestDefined")
+  expect(source).not.toContain("<Show when={item()} keyed>")
+  expect(source).not.toMatch(/part=\{item\(\)!?\}/)
+  expect(source).not.toMatch(/defaultOpen=\{partDefaultOpen\(item\(\)!?/)
+  expect(source).not.toMatch(/message=\{message\(\)!?\}/)
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -474,6 +474,15 @@ function list<T>(value: T[] | undefined | null, fallback: T[]) {
   return fallback
 }
 
+function latestDefined<T>(value: () => T | undefined) {
+  let latest: T | undefined
+  return () => {
+    const next = value()
+    if (next !== undefined) latest = next
+    return latest
+  }
+}
+
 function same<T>(a: readonly T[] | undefined, b: readonly T[] | undefined) {
   if (a === b) return true
   if (!a || !b) return false
@@ -670,16 +679,22 @@ export function AssistantParts(props: {
                   if (entry.type !== "part") return
                   return part().get(entry.ref.messageID)?.get(entry.ref.partID)
                 })
+                const stableMessage = latestDefined(() => message())
+                const stableItem = latestDefined(() => item())
 
                 return (
-                  <Show when={message()}>
-                    <Show when={item()}>
+                  <Show when={stableMessage()}>
+                    <Show when={stableItem()}>
                       <Part
-                        part={item()!}
-                        message={message()!}
+                        part={stableItem()!}
+                        message={stableMessage()!}
                         showAssistantCopyPartID={props.showAssistantCopyPartID}
                         turnDurationMs={props.turnDurationMs}
-                        defaultOpen={partDefaultOpen(item()!, props.shellToolDefaultOpen, props.editToolDefaultOpen)}
+                        defaultOpen={partDefaultOpen(
+                          stableItem()!,
+                          props.shellToolDefaultOpen,
+                          props.editToolDefaultOpen,
+                        )}
                       />
                     </Show>
                   </Show>
@@ -872,11 +887,12 @@ export function AssistantMessageDisplay(props: {
                   if (entry.type !== "part") return
                   return part().get(entry.ref.partID)
                 })
+                const stableItem = latestDefined(() => item())
 
                 return (
-                  <Show when={item()}>
+                  <Show when={stableItem()}>
                     <Part
-                      part={item()!}
+                      part={stableItem()!}
                       message={props.message}
                       showAssistantCopyPartID={props.showAssistantCopyPartID}
                     />


### PR DESCRIPTION
## Summary

- Keep assistant part and message props on their latest defined values so stale renderer rows do not pass `undefined` into `Part` or `ReasoningPartDisplay`.
- Add a focused regression guard for the direct live `item()` and `message()` prop pattern that caused the packaged renderer crash.

## Why

Fixes #112.

A session timeline row can stay mounted while its backing part accessor briefly resolves to `undefined`. The old render path passed live accessors directly into `Part`, so an already-mounted reasoning part could later read `part().text` from an undefined value and crash the renderer.

## Related Issue

Fixes #112

## How To Verify

Commands run:

```bash
cd packages/ui && bun test src/components/message-part-stale.test.ts
cd packages/ui && bun test src/components/message-file.test.ts src/components/message-part-stale.test.ts
bun --cwd packages/ui typecheck
bun --cwd packages/app typecheck
bun --cwd packages/desktop-electron typecheck
bun --cwd packages/app test:unit
bun turbo typecheck
bun turbo test:ci
```

Notes:

- `bun turbo test:ci` passed. Vite emitted existing chunk-size warnings during app build, not test failures.
- No generated files are included in this PR.

## Screenshots or Recordings

Not applicable. This is a renderer crash fix with no intended visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
