### PR TITLE
fix: order sessions by creation time

### DIFF
--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -25,7 +25,7 @@ describe("pickDirectoriesToEvict", () => {
 
 describe("loadRootSessionsWithFallback", () => {
   test("uses limited roots query when supported", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; roots: true; limit?: number; sort?: "created" }> = []
 
     const result = await loadRootSessionsWithFallback({
       directory: "dir",
@@ -38,11 +38,11 @@ describe("loadRootSessionsWithFallback", () => {
 
     expect(result.data).toEqual([])
     expect(result.limited).toBe(true)
-    expect(calls).toEqual([{ directory: "dir", roots: true, limit: 10 }])
+    expect(calls).toEqual([{ directory: "dir", roots: true, limit: 10, sort: "created" }])
   })
 
   test("falls back to full roots query on limited-query failure", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; roots: true; limit?: number; sort?: "created" }> = []
 
     const result = await loadRootSessionsWithFallback({
       directory: "dir",
@@ -57,8 +57,8 @@ describe("loadRootSessionsWithFallback", () => {
     expect(result.data).toEqual([])
     expect(result.limited).toBe(false)
     expect(calls).toEqual([
-      { directory: "dir", roots: true, limit: 25 },
-      { directory: "dir", roots: true },
+      { directory: "dir", roots: true, limit: 25, sort: "created" },
+      { directory: "dir", roots: true, sort: "created" },
     ])
   })
 })

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -4,13 +4,13 @@ import { createStore } from "solid-js/store"
 import type { State } from "./types"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./event-reducer"
 
-const rootSession = (input: { id: string; parentID?: string; archived?: number }) =>
+const rootSession = (input: { id: string; parentID?: string; archived?: number; created?: number; updated?: number }) =>
   ({
     id: input.id,
     parentID: input.parentID,
     time: {
-      created: 1,
-      updated: 1,
+      created: input.created ?? 1,
+      updated: input.updated ?? input.created ?? 1,
       archived: input.archived,
     },
   }) as Session
@@ -249,8 +249,8 @@ describe("applyDirectoryEvent", () => {
   })
 
   test("cleans caches for trimmed sessions on session.created", () => {
-    const dropped = rootSession({ id: "ses_b" })
-    const kept = rootSession({ id: "ses_a" })
+    const dropped = rootSession({ id: "ses_b", created: 1 })
+    const kept = rootSession({ id: "ses_a", created: 2 })
     const message = userMessage("msg_1", dropped.id)
     const todos: string[] = []
     const [store, setStore] = createStore(

--- a/packages/app/src/context/global-sync/session-load.ts
+++ b/packages/app/src/context/global-sync/session-load.ts
@@ -2,14 +2,14 @@ import type { RootLoadArgs } from "./types"
 
 export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
   try {
-    const result = await input.list({ directory: input.directory, roots: true, limit: input.limit })
+    const result = await input.list({ directory: input.directory, roots: true, limit: input.limit, sort: "created" })
     return {
       data: result.data,
       limit: input.limit,
       limited: true,
     } as const
   } catch {
-    const result = await input.list({ directory: input.directory, roots: true })
+    const result = await input.list({ directory: input.directory, roots: true, sort: "created" })
     return {
       data: result.data,
       limit: input.limit,

--- a/packages/app/src/context/global-sync/session-trim.test.ts
+++ b/packages/app/src/context/global-sync/session-trim.test.ts
@@ -14,6 +14,28 @@ const session = (input: { id: string; parentID?: string; created: number; update
   }) as Session
 
 describe("trimSessions", () => {
+  test("selects base roots by creation time before returning id-sorted store order", () => {
+    const now = 1_000_000
+    const list = [
+      session({ id: "a-old", created: now - 30_000_000 }),
+      session({ id: "m-new", created: now - 100_000 }),
+      session({ id: "z-middle", created: now - 200_000 }),
+    ]
+
+    const result = trimSessions(list, { limit: 2, permission: {}, now })
+
+    expect(result.map((x) => x.id)).toEqual(["m-new", "z-middle"])
+  })
+
+  test("uses id ascending when selecting roots with identical creation time", () => {
+    const now = 40_000_000
+    const list = [session({ id: "z-root", created: 1 }), session({ id: "a-root", created: 1 })]
+
+    const result = trimSessions(list, { limit: 1, permission: {}, now })
+
+    expect(result.map((x) => x.id)).toEqual(["a-root"])
+  })
+
   test("keeps base roots and recent roots beyond the limit", () => {
     const now = 1_000_000
     const list = [

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -1,5 +1,5 @@
 import type { PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
-import { cmp } from "./utils"
+import { cmp, compareSessionsByCreated } from "./utils"
 import { SESSION_RECENT_LIMIT, SESSION_RECENT_WINDOW } from "./types"
 
 export function sessionUpdatedAt(session: Session) {
@@ -40,7 +40,7 @@ export function trimSessions(
     .filter((s) => !!s?.id)
     .filter((s) => !s.time?.archived)
     .sort((a, b) => cmp(a.id, b.id))
-  const roots = all.filter((s) => !s.parentID)
+  const roots = all.filter((s) => !s.parentID).sort(compareSessionsByCreated)
   const children = all.filter((s) => !!s.parentID)
   const base = roots.slice(0, limit)
   const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -120,7 +120,7 @@ export type DisposeCheck = {
 export type RootLoadArgs = {
   directory: string
   limit: number
-  list: (query: { directory: string; roots: true; limit?: number }) => Promise<{ data?: Session[] }>
+  list: (query: { directory: string; roots: true; limit?: number; sort?: "created" }) => Promise<{ data?: Session[] }>
 }
 
 export type RootLoadResult = {

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -1,6 +1,12 @@
-import type { Agent, Project, ProviderListResponse } from "@opencode-ai/sdk/v2/client"
+import type { Agent, Project, ProviderListResponse, Session } from "@opencode-ai/sdk/v2/client"
 
 export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+
+export function compareSessionsByCreated(a: Session, b: Session) {
+  const created = b.time.created - a.time.created
+  if (created !== 0) return created
+  return a.id.localeCompare(b.id)
+}
 
 function isAgent(input: unknown): input is Agent {
   if (!input || typeof input !== "object") return false

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -169,7 +169,6 @@ export default function Layout(props: ParentProps) {
     hoverProject: undefined as string | undefined,
     scrollSessionKey: undefined as string | undefined,
     nav: undefined as HTMLElement | undefined,
-    sortNow: Date.now(),
     sizing: false,
     peek: undefined as string | undefined,
     peeked: false,
@@ -191,16 +190,7 @@ export default function Layout(props: ParentProps) {
   }
   const isBusy = (directory: string) => !!state.busyWorkspaces[workspaceKey(directory)]
   const navLeave = { current: undefined as number | undefined }
-  const sortNow = () => state.sortNow
   let sizet: number | undefined
-  let sortNowInterval: ReturnType<typeof setInterval> | undefined
-  const sortNowTimeout = setTimeout(
-    () => {
-      setState("sortNow", Date.now())
-      sortNowInterval = setInterval(() => setState("sortNow", Date.now()), 60_000)
-    },
-    60_000 - (Date.now() % 60_000),
-  )
 
   const aim = createAim({
     enabled: () => !layout.sidebar.opened(),
@@ -216,8 +206,6 @@ export default function Layout(props: ParentProps) {
     dialogDead = true
     dialogRun += 1
     if (navLeave.current !== undefined) clearTimeout(navLeave.current)
-    clearTimeout(sortNowTimeout)
-    if (sortNowInterval) clearInterval(sortNowInterval)
     if (sizet !== undefined) clearTimeout(sizet)
     if (peekt !== undefined) clearTimeout(peekt)
     aim.reset()
@@ -670,21 +658,19 @@ export default function Layout(props: ParentProps) {
   })
 
   const currentSessions = createMemo(() => {
-    const now = Date.now()
     const dirs = visibleSessionDirs()
     if (dirs.length === 0) return [] as Session[]
 
     const result: Session[] = []
     for (const dir of dirs) {
       const [dirStore] = globalSync.child(dir, { bootstrap: true })
-      const dirSessions = sortedRootSessions(dirStore, now)
+      const dirSessions = sortedRootSessions(dirStore)
       result.push(...dirSessions)
     }
     return result
   })
 
   const collectPawworkSessions = (projects: LocalProject[]) => {
-    const now = Date.now()
     const seen = new Set<string>()
     const result: PawworkSidebarSession[] = []
     const labels = resolvePawworkProjectLabels(projects, globalSync.data.path.home)
@@ -696,12 +682,12 @@ export default function Layout(props: ParentProps) {
         seen.add(key)
 
         const [dirStore] = globalSync.child(directory, { bootstrap: true })
-        for (const session of sortedRootSessions(dirStore, now)) {
+        for (const session of sortedRootSessions(dirStore)) {
           result.push({
             session,
             slug: base64Encode(session.directory),
             projectLabel: labels.get(project.worktree) ?? displayName(project),
-            updated: session.time?.updated ?? session.time?.created ?? 0,
+            created: session.time?.created ?? session.time?.updated ?? 0,
           })
         }
       }
@@ -1423,10 +1409,7 @@ export default function Layout(props: ParentProps) {
       clearLastProjectSession(root)
     }
 
-    const latest = latestRootSession(
-      dirs.map((item) => globalSync.child(item, { bootstrap: false })[0]),
-      Date.now(),
-    )
+    const latest = latestRootSession(dirs.map((item) => globalSync.child(item, { bootstrap: false })[0]))
     if (latest && (await openSession(latest))) {
       return
     }
@@ -1436,12 +1419,11 @@ export default function Layout(props: ParentProps) {
         dirs.map(async (item) => ({
           path: { directory: item },
           session: await globalSDK.client.session
-            .list({ directory: item })
+            .list({ directory: item, sort: "created" })
             .then((x) => x.data ?? [])
             .catch(() => []),
         })),
       ),
-      Date.now(),
     )
     if (fetched && (await openSession(fetched))) {
       return
@@ -2323,12 +2305,7 @@ export default function Layout(props: ParentProps) {
                   </Button>
                 </div>
                 <div class="flex-1 min-h-0">
-                  <LocalWorkspace
-                    ctx={workspaceSidebarCtx}
-                    project={project()!}
-                    sortNow={sortNow}
-                    mobile={panelProps.mobile}
-                  />
+                  <LocalWorkspace ctx={workspaceSidebarCtx} project={project()!} mobile={panelProps.mobile} />
                 </div>
               </Show>
               <Show when={!pawworkSidebar() && workspacesEnabled()}>
@@ -2369,7 +2346,6 @@ export default function Layout(props: ParentProps) {
                                 ctx={workspaceSidebarCtx}
                                 directory={directory}
                                 project={project()!}
-                                sortNow={sortNow}
                                 mobile={panelProps.mobile}
                               />
                             )}

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  sortedRootSessions,
   startupAutoselectDirectory,
   workspaceKey,
 } from "./helpers"
@@ -133,27 +134,86 @@ describe("layout workspace helpers", () => {
   })
 
   test("finds the latest root session across workspaces", () => {
-    const result = latestRootSession(
-      [
-        {
-          path: { directory: "/root" },
-          session: [session({ id: "root", directory: "/root", time: { created: 1, updated: 1, archived: undefined } })],
-        },
-        {
-          path: { directory: "/workspace" },
-          session: [
-            session({
-              id: "workspace",
-              directory: "/workspace",
-              time: { created: 2, updated: 2, archived: undefined },
-            }),
-          ],
-        },
-      ],
-      120_000,
-    )
+    const result = latestRootSession([
+      {
+        path: { directory: "/root" },
+        session: [session({ id: "root", directory: "/root", time: { created: 1, updated: 1, archived: undefined } })],
+      },
+      {
+        path: { directory: "/workspace" },
+        session: [
+          session({
+            id: "workspace",
+            directory: "/workspace",
+            time: { created: 2, updated: 2, archived: undefined },
+          }),
+        ],
+      },
+    ])
 
     expect(result?.id).toBe("workspace")
+  })
+
+  test("finds latest root session by creation time instead of last update", () => {
+    const result = latestRootSession([
+      {
+        path: { directory: "/workspace" },
+        session: [
+          session({
+            id: "older-active",
+            directory: "/workspace",
+            time: { created: 10, updated: 100, archived: undefined },
+          }),
+          session({
+            id: "newer-quiet",
+            directory: "/workspace",
+            time: { created: 20, updated: 20, archived: undefined },
+          }),
+        ],
+      },
+    ])
+
+    expect(result?.id).toBe("newer-quiet")
+  })
+
+  test("sorts visible root sessions by creation time", () => {
+    const result = sortedRootSessions({
+      path: { directory: "/workspace" },
+      session: [
+        session({
+          id: "older-active",
+          directory: "/workspace",
+          time: { created: 10, updated: 100, archived: undefined },
+        }),
+        session({
+          id: "newer-quiet",
+          directory: "/workspace",
+          time: { created: 20, updated: 20, archived: undefined },
+        }),
+      ],
+    })
+
+    expect(result.map((item) => item.id)).toEqual(["newer-quiet", "older-active"])
+  })
+
+  test("sorts root sessions with identical creation time by id ascending", () => {
+    const result = sortedRootSessions({
+      path: { directory: "/workspace" },
+      session: [
+        session({
+          id: "z-session",
+          directory: "/workspace",
+          time: { created: 20, updated: 50, archived: undefined },
+        }),
+        session({
+          id: "a-session",
+          directory: "/workspace",
+          time: { created: 20, updated: 10, archived: undefined },
+        }),
+      ],
+    })
+
+    expect(result.map((item) => item.id)).toEqual(["a-session", "z-session"])
   })
 
   test("detects project permissions with a filter", () => {
@@ -180,32 +240,29 @@ describe("layout workspace helpers", () => {
   })
 
   test("ignores archived and child sessions when finding latest root session", () => {
-    const result = latestRootSession(
-      [
-        {
-          path: { directory: "/workspace" },
-          session: [
-            session({
-              id: "archived",
-              directory: "/workspace",
-              time: { created: 10, updated: 10, archived: 10 },
-            }),
-            session({
-              id: "child",
-              directory: "/workspace",
-              parentID: "parent",
-              time: { created: 20, updated: 20, archived: undefined },
-            }),
-            session({
-              id: "root",
-              directory: "/workspace",
-              time: { created: 30, updated: 30, archived: undefined },
-            }),
-          ],
-        },
-      ],
-      120_000,
-    )
+    const result = latestRootSession([
+      {
+        path: { directory: "/workspace" },
+        session: [
+          session({
+            id: "archived",
+            directory: "/workspace",
+            time: { created: 10, updated: 10, archived: 10 },
+          }),
+          session({
+            id: "child",
+            directory: "/workspace",
+            parentID: "parent",
+            time: { created: 20, updated: 20, archived: undefined },
+          }),
+          session({
+            id: "root",
+            directory: "/workspace",
+            time: { created: 30, updated: 30, archived: undefined },
+          }),
+        ],
+      },
+    ])
 
     expect(result?.id).toBe("root")
   })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -1,5 +1,6 @@
 import { getFilename } from "@opencode-ai/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
+import { compareSessionsByCreated } from "@/context/global-sync/utils"
 
 type SessionStore = {
   session?: Session[]
@@ -14,30 +15,15 @@ export const workspaceKey = (directory: string) => {
   return value.replace(/\/+$/, "")
 }
 
-function sortSessions(now: number) {
-  const oneMinuteAgo = now - 60 * 1000
-  return (a: Session, b: Session) => {
-    const aUpdated = a.time.updated ?? a.time.created
-    const bUpdated = b.time.updated ?? b.time.created
-    const aRecent = aUpdated > oneMinuteAgo
-    const bRecent = bUpdated > oneMinuteAgo
-    if (aRecent && bRecent) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
-    if (aRecent && !bRecent) return -1
-    if (!aRecent && bRecent) return 1
-    return bUpdated - aUpdated
-  }
-}
-
 const isRootVisibleSession = (session: Session, directory: string) =>
   workspaceKey(session.directory) === workspaceKey(directory) && !session.parentID && !session.time?.archived
 
 const roots = (store: SessionStore) =>
   (store.session ?? []).filter((session) => isRootVisibleSession(session, store.path.directory))
 
-export const sortedRootSessions = (store: SessionStore, now: number) => roots(store).sort(sortSessions(now))
+export const sortedRootSessions = (store: SessionStore) => roots(store).sort(compareSessionsByCreated)
 
-export const latestRootSession = (stores: SessionStore[], now: number) =>
-  stores.flatMap(roots).sort(sortSessions(now))[0]
+export const latestRootSession = (stores: SessionStore[]) => stores.flatMap(roots).sort(compareSessionsByCreated)[0]
 
 export function hasProjectPermissions<T>(
   request: Record<string, T[] | undefined> | undefined,

--- a/packages/app/src/pages/layout/pawwork-session-nav.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-nav.test.ts
@@ -7,25 +7,25 @@ import {
 
 const sessions: PawworkSessionItem[] = [
   {
-    id: "alpha",
-    title: "Q2 narrative",
-    directory: "/repo",
-    projectLabel: "pawwork",
-    updated: 300,
-  },
-  {
     id: "beta",
     title: "Release notes",
     directory: "/repo",
     projectLabel: "pawwork",
-    updated: 200,
+    created: 200,
   },
   {
     id: "gamma",
     title: "OpenCLI comparison",
     directory: "/repo",
     projectLabel: "research",
-    updated: 100,
+    created: 100,
+  },
+  {
+    id: "alpha",
+    title: "Q2 narrative",
+    directory: "/repo",
+    projectLabel: "pawwork",
+    created: 300,
   },
 ]
 
@@ -52,6 +52,32 @@ describe("buildPawworkSessionSections", () => {
 
     expect(result.groups.map((group) => group.label)).toEqual(["pawwork", "research"])
     expect(result.groups[0].items.map((item) => item.id)).toEqual(["alpha", "beta"])
+  })
+
+  test("uses id ascending as the creation-time tiebreaker", () => {
+    const tied = [
+      { ...sessions[0], id: "zeta", created: 400 },
+      { ...sessions[1], id: "alpha", created: 400 },
+      { ...sessions[2], id: "middle", created: 300 },
+    ]
+
+    const byTime = buildPawworkSessionSections({
+      sessions: tied,
+      pinnedIDs: [],
+      sortMode: "time",
+    })
+    expect(byTime.recent.map((item) => item.id)).toEqual(["alpha", "zeta", "middle"])
+
+    const byProject = buildPawworkSessionSections({
+      sessions: tied,
+      pinnedIDs: [],
+      sortMode: "project",
+    })
+    expect(byProject.groups.flatMap((group) => group.items.map((item) => item.id))).toEqual([
+      "alpha",
+      "zeta",
+      "middle",
+    ])
   })
 })
 

--- a/packages/app/src/pages/layout/pawwork-session-nav.ts
+++ b/packages/app/src/pages/layout/pawwork-session-nav.ts
@@ -5,7 +5,13 @@ export type PawworkSessionItem = {
   title: string
   directory: string
   projectLabel: string
-  updated: number
+  created: number
+}
+
+function comparePawworkSessionsByCreated(a: PawworkSessionItem, b: PawworkSessionItem) {
+  const created = b.created - a.created
+  if (created !== 0) return created
+  return a.id.localeCompare(b.id)
 }
 
 export function buildPawworkSessionSections(input: {
@@ -24,13 +30,13 @@ export function buildPawworkSessionSections(input: {
   if (input.sortMode === "time") {
     return {
       pinned,
-      recent: unpinned.sort((a, b) => b.updated - a.updated),
+      recent: unpinned.sort(comparePawworkSessionsByCreated),
       groups: [] as { label: string; items: PawworkSessionItem[] }[],
     }
   }
 
   const groups = new Map<string, PawworkSessionItem[]>()
-  for (const item of unpinned.sort((a, b) => b.updated - a.updated)) {
+  for (const item of unpinned.sort(comparePawworkSessionsByCreated)) {
     const key = item.projectLabel || "other"
     if (!groups.has(key)) groups.set(key, [])
     groups.get(key)!.push(item)

--- a/packages/app/src/pages/layout/pawwork-session-source.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.test.ts
@@ -30,13 +30,23 @@ describe("resolvePawworkProjectLabels", () => {
 })
 
 describe("sortPawworkSidebarSessions", () => {
-  test("sorts sessions globally by most recent update before project label", () => {
+  test("sorts sessions globally by creation time before project label", () => {
     const result = sortPawworkSidebarSessions([
-      { id: "older-a", updated: 100, projectLabel: "alpha" },
-      { id: "newer-b", updated: 300, projectLabel: "beta" },
-      { id: "middle-a", updated: 200, projectLabel: "alpha" },
+      { id: "older-a", created: 100, projectLabel: "alpha" },
+      { id: "newer-b", created: 300, projectLabel: "beta" },
+      { id: "middle-a", created: 200, projectLabel: "alpha" },
     ])
 
     expect(result.map((item) => item.id)).toEqual(["newer-b", "middle-a", "older-a"])
+  })
+
+  test("uses project label then id ascending when creation times match", () => {
+    const result = sortPawworkSidebarSessions([
+      { id: "zeta", created: 100, projectLabel: "beta" },
+      { id: "zebra", created: 100, projectLabel: "alpha" },
+      { id: "alpha", created: 100, projectLabel: "alpha" },
+    ])
+
+    expect(result.map((item) => item.id)).toEqual(["alpha", "zebra", "zeta"])
   })
 })

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -10,7 +10,7 @@ type ProjectLike = {
 
 type SessionLike = {
   id: string
-  updated: number
+  created: number
   projectLabel: string
 }
 
@@ -37,9 +37,13 @@ export function resolvePawworkProjectLabels<T extends ProjectLike>(projects: T[]
 }
 
 export function sortPawworkSidebarSessions<T extends SessionLike>(sessions: T[]) {
-  return sessions
-    .slice()
-    .sort((a, b) => b.updated - a.updated || a.projectLabel.localeCompare(b.projectLabel) || a.id.localeCompare(b.id))
+  return sessions.slice().sort((a, b) => {
+    const created = b.created - a.created
+    if (created !== 0) return created
+    const project = a.projectLabel.localeCompare(b.projectLabel)
+    if (project !== 0) return project
+    return a.id.localeCompare(b.id)
+  })
 }
 
 export function pawworkSessionDirectories(input: {

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -14,7 +14,7 @@ export type PawworkSidebarSession = {
   session: Session
   slug: string
   projectLabel: string
-  updated: number
+  created: number
 }
 
 const FilterIcon = (props: { size?: number }) => {
@@ -80,7 +80,7 @@ export const PawworkSidebar = (props: {
         title: item.session.title ?? "",
         directory: item.session.directory,
         projectLabel: item.projectLabel,
-        updated: item.updated,
+        created: item.created,
       })),
       pinnedIDs: props.pinnedIDs(),
       sortMode: props.sortMode(),

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -271,7 +271,6 @@ export const SortableProject = (props: {
   project: LocalProject
   mobile?: boolean
   ctx: ProjectSidebarContext
-  sortNow: Accessor<number>
 }): JSX.Element => {
   const globalSync = useGlobalSync()
   const language = useLanguage()
@@ -301,10 +300,10 @@ export const SortableProject = (props: {
   }
 
   const projectStore = createMemo(() => globalSync.child(props.project.worktree, { bootstrap: false })[0])
-  const projectSessions = createMemo(() => sortedRootSessions(projectStore(), props.sortNow()))
+  const projectSessions = createMemo(() => sortedRootSessions(projectStore()))
   const workspaceSessions = (directory: string) => {
     const [data] = globalSync.child(directory, { bootstrap: false })
-    return sortedRootSessions(data, props.sortNow())
+    return sortedRootSessions(data)
   }
   const tile = () => (
     <ProjectTile

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -292,7 +292,6 @@ export const SortableWorkspace = (props: {
   ctx: WorkspaceSidebarContext
   directory: string
   project: LocalProject
-  sortNow: Accessor<number>
   mobile?: boolean
 }): JSX.Element => {
   const navigate = useNavigate()
@@ -306,7 +305,7 @@ export const SortableWorkspace = (props: {
     pendingRename: false,
   })
   const slug = createMemo(() => base64Encode(props.directory))
-  const sessions = createMemo(() => sortedRootSessions(workspaceStore, props.sortNow()))
+  const sessions = createMemo(() => sortedRootSessions(workspaceStore))
   const local = createMemo(() => props.directory === props.project.worktree)
   const active = createMemo(() => workspaceKey(props.ctx.currentDir()) === workspaceKey(props.directory))
   const workspaceValue = createMemo(() => {
@@ -441,7 +440,6 @@ export const SortableWorkspace = (props: {
 export const LocalWorkspace = (props: {
   ctx: WorkspaceSidebarContext
   project: LocalProject
-  sortNow: Accessor<number>
   mobile?: boolean
 }): JSX.Element => {
   const globalSync = useGlobalSync()
@@ -451,7 +449,7 @@ export const LocalWorkspace = (props: {
     return { store, setStore }
   })
   const slug = createMemo(() => base64Encode(props.project.worktree))
-  const sessions = createMemo(() => sortedRootSessions(workspace().store, props.sortNow()))
+  const sessions = createMemo(() => sortedRootSessions(workspace().store))
   const booted = createMemo((prev) => prev || workspace().store.status === "complete", false)
   const count = createMemo(() => sessions()?.length ?? 0)
   const loading = createMemo(() => !booted() && count() === 0)

--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -18,6 +18,7 @@ import { lazy } from "../../util/lazy"
 import { Effect, Option } from "effect"
 import { WorkspaceRoutes } from "./workspace"
 import { Agent } from "@/agent/agent"
+import { SessionID } from "@/session/schema"
 
 const ConsoleOrgOption = z.object({
   accountID: z.string(),
@@ -36,6 +37,30 @@ const ConsoleSwitchBody = z.object({
   accountID: z.string(),
   orgID: z.string(),
 })
+
+function encodeCreatedSessionCursor(session: Session.GlobalInfo) {
+  return Buffer.from(JSON.stringify({ created: session.time.created, id: session.id }), "utf8").toString("base64url")
+}
+
+const CreatedSessionCursor = z.object({ created: z.number(), id: SessionID.zod })
+
+function decodeCreatedSessionCursor(value: string | number | undefined) {
+  if (value === undefined) return undefined
+  if (typeof value === "number") return undefined
+  try {
+    const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8"))
+    const parsed = CreatedSessionCursor.safeParse(decoded)
+    return parsed.success ? parsed.data : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function decodeUpdatedSessionCursor(value: string | number | undefined) {
+  if (value === undefined) return undefined
+  const cursor = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(cursor) ? cursor : undefined
+}
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
@@ -324,7 +349,7 @@ export const ExperimentalRoutes = lazy(() =>
       describeRoute({
         summary: "List sessions",
         description:
-          "Get a list of all OpenCode sessions across projects, sorted by most recently updated. Archived sessions are excluded by default.",
+          "Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.",
         operationId: "experimental.session.list",
         responses: {
           200: {
@@ -346,13 +371,19 @@ export const ExperimentalRoutes = lazy(() =>
             .number()
             .optional()
             .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
-          cursor: z.coerce
-            .number()
-            .optional()
-            .meta({ description: "Return sessions updated before this timestamp (milliseconds since epoch)" }),
+          cursor: z
+            .preprocess(
+              (value) => (value === "" ? undefined : value),
+              z.union([z.coerce.number(), z.string()]).optional(),
+            )
+            .meta({ description: "Cursor for loading the next page" }),
           search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
           limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
           archived: z.coerce.boolean().optional().meta({ description: "Include archived sessions (default false)" }),
+          sort: z
+            .enum(["updated", "created"])
+            .optional()
+            .meta({ description: "Sort sessions by last update or creation time" }),
         }),
       ),
       async (c) => {
@@ -363,17 +394,26 @@ export const ExperimentalRoutes = lazy(() =>
           directory: query.directory,
           roots: query.roots,
           start: query.start,
-          cursor: query.cursor,
+          cursor:
+            query.sort === "created"
+              ? decodeCreatedSessionCursor(query.cursor)
+              : decodeUpdatedSessionCursor(query.cursor),
           search: query.search,
           limit: limit + 1,
           archived: query.archived,
+          sort: query.sort,
         })) {
           sessions.push(session)
         }
         const hasMore = sessions.length > limit
         const list = hasMore ? sessions.slice(0, limit) : sessions
         if (hasMore && list.length > 0) {
-          c.header("x-next-cursor", String(list[list.length - 1].time.updated))
+          c.header(
+            "x-next-cursor",
+            query.sort === "created"
+              ? encodeCreatedSessionCursor(list[list.length - 1])
+              : String(list[list.length - 1].time.updated),
+          )
         }
         return c.json(list)
       },

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -35,7 +35,7 @@ export const SessionRoutes = lazy(() =>
       "/",
       describeRoute({
         summary: "List sessions",
-        description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
+        description: "Get a list of all OpenCode sessions. Defaults to most recently updated; use sort=created for creation-time order.",
         operationId: "session.list",
         responses: {
           200: {
@@ -59,6 +59,7 @@ export const SessionRoutes = lazy(() =>
             .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
           search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
           limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
+          sort: z.enum(["updated", "created"]).optional().meta({ description: "Sort sessions by last update or creation time" }),
         }),
       ),
       async (c) => {
@@ -70,6 +71,7 @@ export const SessionRoutes = lazy(() =>
           start: query.start,
           search: query.search,
           limit: query.limit,
+          sort: query.sort,
         })) {
           sessions.push(session)
         }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -8,7 +8,7 @@ import { type ProviderMetadata, type LanguageModelUsage } from "ai"
 import { Flag } from "../flag/flag"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, gte, isNull, desc, like, inArray, lt } from "../storage/db"
+import { Database, NotFoundError, eq, and, or, gte, isNull, desc, asc, like, inArray, lt, gt } from "../storage/db"
 import { SyncEvent } from "../sync"
 import type { SQL } from "../storage/db"
 import { PartTable, SessionTable } from "./session.sql"
@@ -734,6 +734,20 @@ export const removePart = fn(RemovePartInput, (input) => runPromise((svc) => svc
 export const updateMessage = fn(MessageV2.Info, (input) => runPromise((svc) => svc.updateMessage(input)))
 export const updatePart = fn(MessageV2.Part, (input) => runPromise((svc) => svc.updatePart(input)))
 
+type ListSort = "updated" | "created"
+type GlobalListCursor =
+  | number
+  | {
+      created: number
+      id: SessionID
+    }
+
+function sessionOrder(sort: ListSort) {
+  return sort === "created"
+    ? [desc(SessionTable.time_created), asc(SessionTable.id)]
+    : [desc(SessionTable.time_updated), desc(SessionTable.id)]
+}
+
 export function* list(input?: {
   directory?: string
   workspaceID?: WorkspaceID
@@ -741,6 +755,7 @@ export function* list(input?: {
   start?: number
   search?: string
   limit?: number
+  sort?: ListSort
 }) {
   const project = Instance.project
   const conditions = [eq(SessionTable.project_id, project.id)]
@@ -764,13 +779,15 @@ export function* list(input?: {
   }
 
   const limit = input?.limit ?? 100
+  const sort = input?.sort ?? "updated"
+  const order = sessionOrder(sort)
 
   const rows = Database.use((db) =>
     db
       .select()
       .from(SessionTable)
       .where(and(...conditions))
-      .orderBy(desc(SessionTable.time_updated))
+      .orderBy(...order)
       .limit(limit)
       .all(),
   )
@@ -783,12 +800,14 @@ export function* listGlobal(input?: {
   directory?: string
   roots?: boolean
   start?: number
-  cursor?: number
+  cursor?: GlobalListCursor
   search?: string
   limit?: number
   archived?: boolean
+  sort?: ListSort
 }) {
   const conditions: SQL[] = []
+  const sort = input?.sort ?? "updated"
 
   if (input?.directory) {
     conditions.push(eq(SessionTable.directory, input.directory))
@@ -799,8 +818,22 @@ export function* listGlobal(input?: {
   if (input?.start) {
     conditions.push(gte(SessionTable.time_updated, input.start))
   }
-  if (input?.cursor) {
-    conditions.push(lt(SessionTable.time_updated, input.cursor))
+  if (input?.cursor !== undefined) {
+    if (sort === "created") {
+      if (typeof input.cursor !== "number") {
+        conditions.push(
+          or(
+            lt(SessionTable.time_created, input.cursor.created),
+            and(eq(SessionTable.time_created, input.cursor.created), gt(SessionTable.id, input.cursor.id)),
+          )!,
+        )
+      } else {
+        // Numeric cursors are invalid for created-order pagination and are ignored.
+      }
+    } else {
+      const cursor = typeof input.cursor === "number" ? input.cursor : input.cursor.created
+      conditions.push(lt(SessionTable.time_updated, cursor))
+    }
   }
   if (input?.search) {
     conditions.push(like(SessionTable.title, `%${input.search}%`))
@@ -819,7 +852,8 @@ export function* listGlobal(input?: {
             .from(SessionTable)
             .where(and(...conditions))
         : db.select().from(SessionTable)
-    return query.orderBy(desc(SessionTable.time_updated), desc(SessionTable.id)).limit(limit).all()
+    const order = sessionOrder(sort)
+    return query.orderBy(...order).limit(limit).all()
   })
 
   const ids = [...new Set(rows.map((row) => row.project_id))]

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Project } from "../../src/project/project"
+import { Server } from "../../src/server/server"
 import { Session as SessionNs } from "../../src/session"
+import type { SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
@@ -20,7 +23,12 @@ const svc = {
   setArchived(input: Parameters<typeof SessionNs.setArchived>[0]) {
     return run(SessionNs.Service.use((svc) => svc.setArchived(input)))
   },
+  touch(sessionID: SessionID) {
+    return run(SessionNs.Service.use((svc) => svc.touch(sessionID)))
+  },
 }
+
+const it = testEffect(SessionNs.defaultLayer)
 
 describe("session.listGlobal", () => {
   test("lists sessions across projects with project metadata", async () => {
@@ -78,27 +86,303 @@ describe("session.listGlobal", () => {
     expect(allIds).toContain(archived.id)
   })
 
-  test("supports cursor pagination", async () => {
+  it.live(
+    "supports cursor pagination",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      const first = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "page-one" }),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const second = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "page-two" }),
+      })
+
+      const page = [...svc.listGlobal({ directory: tmp.path, limit: 1 })]
+      expect(page.length).toBe(1)
+      expect(page[0].id).toBe(second.id)
+
+      const next = [...svc.listGlobal({ directory: tmp.path, limit: 10, cursor: page[0].time.updated })]
+      const ids = next.map((session) => session.id)
+
+      expect(ids).toContain(first.id)
+      expect(ids).not.toContain(second.id)
+    }),
+  )
+
+  it.live(
+    "keeps default global ordering by last update for existing clients",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      const older = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "older-session" }),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const newer = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "newer-session" }),
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.touch(older.id),
+      })
+
+      const sessions = [...svc.listGlobal({ directory: tmp.path, limit: 2 })]
+
+      expect(sessions.map((session) => session.id)).toEqual([older.id, newer.id])
+    }),
+  )
+
+  it.live(
+    "orders global sessions by creation time when requested",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      const older = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "older-session" }),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const newer = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "newer-session" }),
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.touch(older.id),
+      })
+
+      const sessions = [...svc.listGlobal({ directory: tmp.path, limit: 2, sort: "created" })]
+
+      expect(sessions.map((session) => session.id)).toEqual([newer.id, older.id])
+    }),
+  )
+
+  test("paginates created-order sessions that share the same creation time", async () => {
     await using tmp = await tmpdir({ git: true })
+    const originalNow = Date.now
+    Date.now = () => 1_000
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await svc.create({ title: "same-time-a" })
+          await svc.create({ title: "same-time-b" })
+        },
+      })
+    } finally {
+      Date.now = originalNow
+    }
 
-    const first = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => svc.create({ title: "page-one" }),
-    })
-    await new Promise((resolve) => setTimeout(resolve, 5))
-    const second = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => svc.create({ title: "page-two" }),
-    })
-
-    const page = [...svc.listGlobal({ directory: tmp.path, limit: 1 })]
+    const page = [...svc.listGlobal({ directory: tmp.path, limit: 1, sort: "created" })]
     expect(page.length).toBe(1)
-    expect(page[0].id).toBe(second.id)
 
-    const next = [...svc.listGlobal({ directory: tmp.path, limit: 10, cursor: page[0].time.updated })]
-    const ids = next.map((session) => session.id)
+    const next = [
+      ...svc.listGlobal({
+        directory: tmp.path,
+        limit: 10,
+        sort: "created",
+        cursor: { created: page[0].time.created, id: page[0].id },
+      }),
+    ]
 
-    expect(ids).toContain(first.id)
-    expect(ids).not.toContain(second.id)
+    expect(next.length).toBe(1)
+    expect(next[0].time.created).toBe(page[0].time.created)
+    expect(page[0].id.localeCompare(next[0].id)).toBeLessThan(0)
   })
+
+  it.live(
+    "session route orders by creation time when requested",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const older = await svc.create({ title: "route-older-session" })
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          const newer = await svc.create({ title: "route-newer-session" })
+          await svc.touch(older.id)
+
+          const app = Server.Default().app
+          const response = await app.request(
+            `/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=2&sort=created`,
+          )
+          expect(response.status).toBe(200)
+          const body = (await response.json()) as SessionNs.Info[]
+
+          expect(body.map((session) => session.id)).toEqual([newer.id, older.id])
+        },
+      })
+    }),
+  )
+
+  test("experimental route round-trips created-order cursor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalNow = Date.now
+    Date.now = () => 1_000
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await svc.create({ title: "route-same-time-a" })
+          await svc.create({ title: "route-same-time-b" })
+        },
+      })
+    } finally {
+      Date.now = originalNow
+    }
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.Default().app
+        const first = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=1&sort=created`,
+        )
+        expect(first.status).toBe(200)
+        const cursor = first.headers.get("x-next-cursor")
+        expect(cursor).toBeTruthy()
+        const firstBody = (await first.json()) as SessionNs.GlobalInfo[]
+        expect(firstBody).toHaveLength(1)
+
+        const second = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=10&sort=created&cursor=${encodeURIComponent(cursor!)}`,
+        )
+        expect(second.status).toBe(200)
+        const secondBody = (await second.json()) as SessionNs.GlobalInfo[]
+        expect(secondBody).toHaveLength(1)
+        expect(secondBody[0].id).not.toBe(firstBody[0].id)
+      },
+    })
+  })
+
+  test("experimental route ignores malformed created-order cursor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await svc.create({ title: "malformed-cursor" })
+
+        const app = Server.Default().app
+        const response = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=10&sort=created&cursor=abc`,
+        )
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as SessionNs.GlobalInfo[]
+
+        expect(body.map((session) => session.title)).toContain("malformed-cursor")
+      },
+    })
+  })
+
+  test("experimental route ignores empty updated cursor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await svc.create({ title: "empty-updated-cursor" })
+
+        const app = Server.Default().app
+        const response = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=10&cursor=`,
+        )
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as SessionNs.GlobalInfo[]
+
+        expect(body.map((session) => session.title)).toContain("empty-updated-cursor")
+      },
+    })
+  })
+
+  test("experimental route ignores undefined-string updated cursor", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await svc.create({ title: "undefined-updated-cursor" })
+
+        const app = Server.Default().app
+        const response = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=10&cursor=undefined`,
+        )
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as SessionNs.GlobalInfo[]
+
+        expect(body.map((session) => session.title)).toContain("undefined-updated-cursor")
+      },
+    })
+  })
+
+  test("experimental route ignores numeric cursor for created-order pagination", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalNow = Date.now
+    Date.now = () => 1_000
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await svc.create({ title: "numeric-created-cursor-a" })
+          await svc.create({ title: "numeric-created-cursor-b" })
+        },
+      })
+    } finally {
+      Date.now = originalNow
+    }
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.Default().app
+        const response = await app.request(
+          `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=10&sort=created&cursor=1000`,
+        )
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as SessionNs.GlobalInfo[]
+
+        expect(body.map((session) => session.title).sort()).toEqual([
+          "numeric-created-cursor-a",
+          "numeric-created-cursor-b",
+        ])
+      },
+    })
+  })
+
+  it.live(
+    "experimental route keeps default numeric updated cursor",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+      const older = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "route-older" }),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.create({ title: "route-newer" }),
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => svc.touch(older.id),
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const app = Server.Default().app
+          const first = await app.request(
+            `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=1`,
+          )
+          expect(first.status).toBe(200)
+          const cursor = first.headers.get("x-next-cursor")
+          expect(cursor).toBeTruthy()
+          expect(Number.isFinite(Number(cursor))).toBe(true)
+        },
+      })
+    }),
+  )
 })

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
+import type { SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
@@ -16,7 +18,12 @@ const svc = {
   create(input?: Parameters<typeof SessionNs.create>[0]) {
     return run(SessionNs.Service.use((svc) => svc.create(input)))
   },
+  touch(sessionID: SessionID) {
+    return run(SessionNs.Service.use((svc) => svc.touch(sessionID)))
+  },
 }
+
+const it = testEffect(SessionNs.defaultLayer)
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -107,4 +114,44 @@ describe("session.list", () => {
       },
     })
   })
+
+  it.live(
+    "keeps default ordering by last update for existing clients",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const older = await svc.create({ title: "older-session" })
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          const newer = await svc.create({ title: "newer-session" })
+          await svc.touch(older.id)
+
+          const sessions = [...svc.list({ roots: true, limit: 2 })]
+
+          expect(sessions.map((session) => session.id)).toEqual([older.id, newer.id])
+        },
+      })
+    }),
+  )
+
+  it.live(
+    "orders root sessions by creation time when requested",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const older = await svc.create({ title: "older-session" })
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          const newer = await svc.create({ title: "newer-session" })
+          await svc.touch(older.id)
+
+          const sessions = [...svc.list({ roots: true, limit: 2, sort: "created" })]
+
+          expect(sessions.map((session) => session.id)).toEqual([newer.id, older.id])
+        },
+      })
+    }),
+  )
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -753,7 +753,7 @@ export class Session extends HeyApiClient {
   /**
    * List sessions
    *
-   * Get a list of all OpenCode sessions across projects, sorted by most recently updated. Archived sessions are excluded by default.
+   * Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -761,10 +761,11 @@ export class Session extends HeyApiClient {
       workspace?: string
       roots?: boolean
       start?: number
-      cursor?: number
+      cursor?: number | string
       search?: string
       limit?: number
       archived?: boolean
+      sort?: "updated" | "created"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -781,6 +782,7 @@ export class Session extends HeyApiClient {
             { in: "query", key: "search" },
             { in: "query", key: "limit" },
             { in: "query", key: "archived" },
+            { in: "query", key: "sort" },
           ],
         },
       ],
@@ -1522,7 +1524,7 @@ export class Session2 extends HeyApiClient {
   /**
    * List sessions
    *
-   * Get a list of all OpenCode sessions, sorted by most recently updated.
+   * Get a list of all OpenCode sessions. Defaults to most recently updated; use sort=created for creation-time order.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -1532,6 +1534,7 @@ export class Session2 extends HeyApiClient {
       start?: number
       search?: string
       limit?: number
+      sort?: "updated" | "created"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1546,6 +1549,7 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "start" },
             { in: "query", key: "search" },
             { in: "query", key: "limit" },
+            { in: "query", key: "sort" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3008,9 +3008,9 @@ export type ExperimentalSessionListData = {
      */
     start?: number
     /**
-     * Return sessions updated before this timestamp (milliseconds since epoch)
+     * Cursor for loading the next page
      */
-    cursor?: number
+    cursor?: number | string
     /**
      * Filter sessions by title (case-insensitive)
      */
@@ -3023,6 +3023,10 @@ export type ExperimentalSessionListData = {
      * Include archived sessions (default false)
      */
     archived?: boolean
+    /**
+     * Sort sessions by last update or creation time
+     */
+    sort?: "updated" | "created"
   }
   url: "/experimental/session"
 }
@@ -3083,6 +3087,10 @@ export type SessionListData = {
      * Maximum number of sessions to return
      */
     limit?: number
+    /**
+     * Sort sessions by last update or creation time
+     */
+    sort?: "updated" | "created"
   }
   url: "/session"
 }


### PR DESCRIPTION
## Summary

Sessions in the PawWork desktop sidebar now keep creation-time order instead of jumping when an older session receives activity. Backend session APIs keep updated-time ordering by default and add an explicit `sort=created` option for the desktop root-session load path.

## Why

The previous UI behavior used last updated time in several places, so any action in an older session moved it above newer sessions. Creation-time order is more stable and matches the expected session list mental model.

## Related Issue

No linked issue. This PR fixes a bug reported directly in the coding session.

## How To Verify

```bash
cd packages/opencode
bun test --timeout 30000 test/server/session-list.test.ts test/server/global-session-list.test.ts
bun run typecheck
cd ../app
bun test --preload ./happydom.ts ./src/context/global-sync.test.ts ./src/context/global-sync/session-trim.test.ts ./src/pages/layout/helpers.test.ts ./src/pages/layout/pawwork-session-source.test.ts ./src/pages/layout/pawwork-session-nav.test.ts
bun run typecheck
```

## Screenshots or Recordings

Not included. This changes ordering behavior only; targeted tests cover the visible session-list ordering logic.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be sorted by creation time via the `sort` query parameter on session list endpoints
  * Added cursor-based pagination support for creation-time sorted sessions

* **Refactor**
  * Removed time-windowing session sort logic in favor of strict creation-time ordering
  * Implemented deterministic tie-breaking using session IDs for consistent, reproducible results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->