### PR TITLE
feat: add Volcano Engine Coding Plan provider

### DIFF
--- a/packages/app/e2e/settings/settings-providers.spec.ts
+++ b/packages/app/e2e/settings/settings-providers.spec.ts
@@ -37,6 +37,33 @@ test("custom provider form can be filled and validates input", async ({ page, go
   await closeSettingsPanel(page, settings)
 })
 
+test("shows volcano engine coding plan as a popular provider with api key connect flow", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const settings = await openSettings(page)
+  await settings.getByRole("tab", { name: "Providers" }).click()
+
+  const connectedRow = settings.locator('[data-provider-id="volcengine-plan"][data-provider-section="connected"]')
+  const row = settings.locator('[data-provider-id="volcengine-plan"][data-provider-section="popular"]')
+  if (await connectedRow.isVisible().catch(() => false)) {
+    await expect(connectedRow).toContainText("Volcano Engine Coding Plan")
+    await closeSettingsPanel(page, settings)
+    return
+  }
+
+  await expect(row).toBeVisible()
+  await expect(row).toContainText("Volcano Engine Coding Plan")
+
+  await row.getByRole("button", { name: "Connect" }).click()
+  await expect(page.getByRole("dialog")).toContainText("Volcano Engine Coding Plan")
+  await expect(page.getByLabel(/api key/i)).toBeVisible()
+
+  await page.keyboard.press("Escape")
+  await expect(page.getByRole("dialog")).toHaveCount(0)
+
+  await closeSettingsPanel(page, settings)
+})
+
 test("custom provider form shows validation errors", async ({ page, gotoSession }) => {
   await gotoSession()
 

--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -9,6 +9,7 @@ import { popularProviders } from "@/hooks/use-providers"
 import { useLanguage } from "@/context/language"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DialogSelectProvider } from "./dialog-select-provider"
+import { compareModelsForDisplay } from "@/utils/model-order"
 
 export const DialogManageModels: Component = () => {
   const local = useLocal()
@@ -44,7 +45,7 @@ export const DialogManageModels: Component = () => {
         key={(x) => `${x?.provider?.id}:${x?.id}`}
         items={local.model.list()}
         filterKeys={["provider.name", "name", "id"]}
-        sortBy={(a, b) => a.name.localeCompare(b.name)}
+        sortBy={compareModelsForDisplay}
         groupBy={(x) => x.provider.id}
         groupHeader={(group) => {
           const provider = group.items[0].provider

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -12,6 +12,7 @@ import { List } from "@opencode-ai/ui/list"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
+import { compareModelsForDisplay } from "@/utils/model-order"
 
 const isFree = (provider: string, cost: { input: number } | undefined) =>
   provider === "opencode" && (!cost || cost.input === 0)
@@ -44,7 +45,7 @@ const ModelList: Component<{
       items={models}
       current={model.current()}
       filterKeys={["provider.name", "name", "id"]}
-      sortBy={(a, b) => a.name.localeCompare(b.name)}
+      sortBy={compareModelsForDisplay}
       groupBy={(x) => x.provider.name}
       sortGroupsBy={(a, b) => {
         const aProvider = a.items[0].provider.id

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from "@/context/language"
 import { useModels } from "@/context/models"
 import { popularProviders } from "@/hooks/use-providers"
 import { SettingsList } from "./settings-list"
+import { compareModelsForDisplay } from "@/utils/model-order"
 
 type ModelItem = ReturnType<ReturnType<typeof useModels>["list"]>[number]
 
@@ -39,7 +40,7 @@ export const SettingsModels: Component = () => {
     items: (_filter) => models.list(),
     key: (x) => `${x.provider.id}:${x.id}`,
     filterKeys: ["provider.name", "name", "id"],
-    sortBy: (a, b) => a.name.localeCompare(b.name),
+    sortBy: compareModelsForDisplay,
     groupBy: (x) => x.provider.id,
     sortGroupsBy: (a, b) => {
       const aIndex = popularProviders.indexOf(a.category)

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -25,6 +25,7 @@ const PROVIDER_NOTES = [
   { match: (id: string) => id === "google", key: "dialog.provider.google.note" },
   { match: (id: string) => id === "openrouter", key: "dialog.provider.openrouter.note" },
   { match: (id: string) => id === "vercel", key: "dialog.provider.vercel.note" },
+  { match: (id: string) => id === "volcengine-plan", key: "dialog.provider.volcenginePlan.note" },
 ] as const
 
 export const SettingsProviders: Component = () => {
@@ -148,7 +149,11 @@ export const SettingsProviders: Component = () => {
             >
               <For each={connected()}>
                 {(item) => (
-                  <div class="group flex flex-wrap items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base last:border-none">
+                  <div
+                    class="group flex flex-wrap items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base last:border-none"
+                    data-provider-id={item.id}
+                    data-provider-section="connected"
+                  >
                     <div class="flex items-center gap-3 min-w-0">
                       <ProviderIcon id={item.id} class="size-5 shrink-0 icon-strong-base" />
                       <span class="text-14-medium text-text-strong truncate">{item.name}</span>
@@ -178,7 +183,11 @@ export const SettingsProviders: Component = () => {
           <SettingsList>
             <For each={popular()}>
               {(item) => (
-                <div class="flex flex-wrap items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base last:border-none">
+                <div
+                  class="flex flex-wrap items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base last:border-none"
+                  data-provider-id={item.id}
+                  data-provider-section="popular"
+                >
                   <div class="flex flex-col min-w-0">
                     <div class="flex items-center gap-x-3">
                       <ProviderIcon id={item.id} class="size-5 shrink-0 icon-strong-base" />

--- a/packages/app/src/context/models.test.ts
+++ b/packages/app/src/context/models.test.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
+import { compareModelsForDisplay } from "@/utils/model-order"
+
+let findProviderModel: typeof import("./models").findProviderModel
+let listAvailableProviderModels: typeof import("./models").listAvailableProviderModels
+let listProviderModels: typeof import("./models").listProviderModels
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useNavigate: () => () => undefined,
+    useParams: () => ({}),
+  }))
+
+  const mod = await import("./models")
+  findProviderModel = mod.findProviderModel
+  listAvailableProviderModels = mod.listAvailableProviderModels
+  listProviderModels = mod.listProviderModels
+})
+
+const provider = {
+  id: VOLCENGINE_PLAN_PROVIDER_ID,
+  models: {
+    "doubao-seed-2.0-code": { id: "doubao-seed-2.0-code", name: "Doubao Seed 2.0 Code" },
+    "glm-5.1": { id: "glm-5.1", name: "GLM 5.1" },
+    "kimi-k2.6": { id: "kimi-k2.6", name: "Kimi K2.6" },
+    "ark-code-latest": { id: "ark-code-latest", name: "Ark Code Latest" },
+  },
+}
+
+describe("provider model list helpers", () => {
+  test("hides the Volcano Engine latest alias from context model lists", () => {
+    expect(listAvailableProviderModels(provider).map((model) => model.id)).toEqual([
+      "doubao-seed-2.0-code",
+      "glm-5.1",
+      "kimi-k2.6",
+    ])
+  })
+
+  test("keeps the Volcano Engine latest alias resolvable for existing selections", () => {
+    expect(listProviderModels(provider).map((model) => model.id)).toEqual([
+      "doubao-seed-2.0-code",
+      "glm-5.1",
+      "kimi-k2.6",
+      "ark-code-latest",
+    ])
+    expect(
+      findProviderModel([provider], { providerID: VOLCENGINE_PLAN_PROVIDER_ID, modelID: "ark-code-latest" })?.id,
+    ).toBe("ark-code-latest")
+  })
+
+  test("passes only visible Volcano Engine models to UI display ordering", () => {
+    const visible = listAvailableProviderModels(provider)
+      .map((model) => ({ ...model, provider: { id: provider.id } }))
+      .sort(compareModelsForDisplay)
+
+    expect(visible.map((model) => model.id)).toEqual(["doubao-seed-2.0-code", "glm-5.1", "kimi-k2.6"])
+  })
+})

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -5,6 +5,7 @@ import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } fro
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
+import { filterSystemHiddenModels } from "@/utils/hidden-models"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -20,6 +21,29 @@ const RECENT_LIMIT = 5
 
 function modelKey(model: ModelKey) {
   return `${model.providerID}:${model.modelID}`
+}
+
+export function listAvailableProviderModels<T extends { id: string }>(provider: {
+  id: string
+  models: Record<string, T>
+}) {
+  return filterSystemHiddenModels(provider.id, Object.values(provider.models))
+}
+
+export function listProviderModels<T extends { id: string }>(provider: {
+  id: string
+  models: Record<string, T>
+}) {
+  return Object.values(provider.models)
+}
+
+export function findProviderModel<T extends { id: string }>(
+  providers: Array<{ id: string; models: Record<string, T> }>,
+  key: ModelKey,
+) {
+  const provider = providers.find((item) => item.id === key.providerID)
+  if (!provider) return
+  return listProviderModels(provider).find((model) => model.id === key.modelID)
 }
 
 export const { use: useModels, provider: ModelsProvider } = createSimpleContext({
@@ -38,7 +62,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const available = createMemo(() =>
       providers.connected().flatMap((p) =>
-        Object.values(p.models).map((m) => ({
+        listAvailableProviderModels(p).map((m) => ({
           ...m,
           provider: p,
         })),
@@ -92,15 +116,24 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       return map
     })
 
-    const list = createMemo(() =>
-      available().map((m) => ({
-        ...m,
-        name: m.name.replace("(latest)", "").trim(),
-        latest: m.name.includes("(latest)"),
-      })),
-    )
+    const decorateModel = (model: ReturnType<typeof available>[number]) => ({
+      ...model,
+      name: model.name.replace("(latest)", "").trim(),
+      latest: model.name.includes("(latest)"),
+    })
 
-    const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
+    const list = createMemo(() => available().map(decorateModel))
+
+    const find = (key: ModelKey) => {
+      const visible = list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
+      if (visible) return visible
+
+      const hit = findProviderModel(providers.connected(), key)
+      if (!hit) return
+      const provider = providers.connected().find((item) => item.id === key.providerID)
+      if (!provider) return
+      return decorateModel({ ...hit, provider })
+    }
 
     function update(model: ModelKey, state: Visibility) {
       const index = store.user.findIndex((x) => x.modelID === model.modelID && x.providerID === model.providerID)

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -9,6 +9,7 @@ export const popularProviders = [
   "anthropic",
   "github-copilot",
   "openai",
+  "volcengine-plan",
   "google",
   "openrouter",
   "vercel",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -115,6 +115,7 @@ export const dict = {
   "dialog.provider.google.note": "Gemini models for fast, structured responses",
   "dialog.provider.openrouter.note": "Access all supported models from one provider",
   "dialog.provider.vercel.note": "Unified access to AI models with smart routing",
+  "dialog.provider.volcenginePlan.note": "Connect with Volcano Ark Coding Plan model quota",
 
   "dialog.model.select.title": "Select model",
   "dialog.model.search.placeholder": "Search models",
@@ -579,7 +580,8 @@ export const dict = {
   "session.new.card.document.title": "Process documents",
   "session.new.card.document.description": "Edit, convert, and extract from Word, Excel, PowerPoint, and PDF files.",
   "session.new.card.analysis.title": "Analyze data",
-  "session.new.card.analysis.description": "Summarize spreadsheets, build charts, and answer questions from your files.",
+  "session.new.card.analysis.description":
+    "Summarize spreadsheets, build charts, and answer questions from your files.",
   "session.new.card.writing.title": "Write faster",
   "session.new.card.writing.description": "Draft emails, reports, plans, and polished work copy.",
   "session.new.worktree.main": "Main branch",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -140,6 +140,7 @@ export const dict = {
   "dialog.provider.google.note": "使用 Google 账号或 API 密钥连接",
   "dialog.provider.openrouter.note": "使用 OpenRouter 账号或 API 密钥连接",
   "dialog.provider.vercel.note": "使用 Vercel 账号或 API 密钥连接",
+  "dialog.provider.volcenginePlan.note": "使用火山方舟 Coding Plan 模型额度连接",
 
   "dialog.model.select.title": "选择模型",
   "dialog.model.search.placeholder": "搜索模型",

--- a/packages/app/src/utils/hidden-models.test.ts
+++ b/packages/app/src/utils/hidden-models.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { VOLCENGINE_PLAN_HIDDEN_MODEL_IDS, VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
+import { filterSystemHiddenModels, isSystemHiddenModel } from "./hidden-models"
+
+describe("isSystemHiddenModel", () => {
+  test("hides the Volcano Engine ark-code-latest compatibility alias", () => {
+    expect(
+      isSystemHiddenModel({ providerID: VOLCENGINE_PLAN_PROVIDER_ID, modelID: VOLCENGINE_PLAN_HIDDEN_MODEL_IDS[0] }),
+    ).toBe(true)
+  })
+
+  test("does not hide documented Volcano Engine model ids", () => {
+    expect(isSystemHiddenModel({ providerID: VOLCENGINE_PLAN_PROVIDER_ID, modelID: "doubao-seed-2.0-code" })).toBe(
+      false,
+    )
+    expect(isSystemHiddenModel({ providerID: VOLCENGINE_PLAN_PROVIDER_ID, modelID: "kimi-k2.6" })).toBe(false)
+  })
+
+  test("does not hide latest aliases for unrelated providers", () => {
+    expect(isSystemHiddenModel({ providerID: "openai", modelID: "gpt-5-latest" })).toBe(false)
+  })
+
+  test("filters hidden compatibility aliases from provider model lists", () => {
+    const models = [
+      { id: "doubao-seed-2.0-code", name: "Doubao Seed 2.0 Code" },
+      { id: "ark-code-latest", name: "Ark Code Latest" },
+    ]
+
+    expect(filterSystemHiddenModels(VOLCENGINE_PLAN_PROVIDER_ID, models).map((model) => model.id)).toEqual([
+      "doubao-seed-2.0-code",
+    ])
+  })
+})

--- a/packages/app/src/utils/hidden-models.ts
+++ b/packages/app/src/utils/hidden-models.ts
@@ -1,0 +1,21 @@
+import { VOLCENGINE_PLAN_HIDDEN_MODEL_IDS, VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
+
+export type HiddenModelKey = {
+  providerID: string
+  modelID: string
+}
+
+const SYSTEM_HIDDEN_MODELS: HiddenModelKey[] = VOLCENGINE_PLAN_HIDDEN_MODEL_IDS.map((modelID) => ({
+  providerID: VOLCENGINE_PLAN_PROVIDER_ID,
+  modelID,
+}))
+
+const systemHiddenModels = new Set(SYSTEM_HIDDEN_MODELS.map((model) => `${model.providerID}:${model.modelID}`))
+
+export function isSystemHiddenModel(model: HiddenModelKey) {
+  return systemHiddenModels.has(`${model.providerID}:${model.modelID}`)
+}
+
+export function filterSystemHiddenModels<T extends { id: string }>(providerID: string, models: T[]) {
+  return models.filter((model) => !isSystemHiddenModel({ providerID, modelID: model.id }))
+}

--- a/packages/app/src/utils/model-order.test.ts
+++ b/packages/app/src/utils/model-order.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { VOLCENGINE_PLAN_VISIBLE_MODEL_IDS } from "@opencode-ai/util/volcengine-plan"
+import { compareModelsForDisplay } from "./model-order"
+
+const model = (providerID: string, id: string, name: string) => ({
+  id,
+  name,
+  provider: { id: providerID, name: providerID },
+})
+
+describe("compareModelsForDisplay", () => {
+  test("keeps Volcano Engine models in documented order", () => {
+    const items = [
+      model("volcengine-plan", "kimi-k2.6", "Kimi K2.6"),
+      model("volcengine-plan", "doubao-seed-2.0-code", "Doubao Seed 2.0 Code"),
+      model("volcengine-plan", "glm-5.1", "GLM 5.1"),
+    ]
+
+    expect(
+      items
+        .slice()
+        .sort(compareModelsForDisplay)
+        .map((item) => item.id),
+    ).toEqual([
+      VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[0],
+      VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[6],
+      VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[9],
+    ])
+  })
+
+  test("keeps alphabetical order for providers without explicit order", () => {
+    const items = [model("openai", "b-model", "B Model"), model("openai", "a-model", "A Model")]
+
+    expect(
+      items
+        .slice()
+        .sort(compareModelsForDisplay)
+        .map((item) => item.name),
+    ).toEqual(["A Model", "B Model"])
+  })
+
+  test("uses stable ids when display names are equal", () => {
+    const items = [
+      model("openrouter", "z-model", "Same Model"),
+      model("openai", "b-model", "Same Model"),
+      model("openai", "a-model", "Same Model"),
+    ]
+
+    expect(
+      items
+        .slice()
+        .sort(compareModelsForDisplay)
+        .map((item) => `${item.provider.id}:${item.id}`),
+    ).toEqual(["openai:a-model", "openai:b-model", "openrouter:z-model"])
+  })
+})

--- a/packages/app/src/utils/model-order.ts
+++ b/packages/app/src/utils/model-order.ts
@@ -1,0 +1,29 @@
+import { VOLCENGINE_PLAN_PROVIDER_ID, VOLCENGINE_PLAN_VISIBLE_MODEL_IDS } from "@opencode-ai/util/volcengine-plan"
+
+type DisplayModel = {
+  id: string
+  name: string
+  provider: { id: string }
+}
+
+const providerModelOrder: Record<string, string[]> = {
+  [VOLCENGINE_PLAN_PROVIDER_ID]: [...VOLCENGINE_PLAN_VISIBLE_MODEL_IDS],
+}
+
+export function compareModelsForDisplay(a: DisplayModel, b: DisplayModel) {
+  if (a.provider.id === b.provider.id) {
+    const order = providerModelOrder[a.provider.id]
+    if (order) {
+      const aIndex = order.indexOf(a.id)
+      const bIndex = order.indexOf(b.id)
+      if (aIndex >= 0 && bIndex >= 0) return aIndex - bIndex
+      if (aIndex >= 0) return -1
+      if (bIndex >= 0) return 1
+    }
+  }
+  const byName = a.name.localeCompare(b.name)
+  if (byName !== 0) return byName
+  const byProvider = a.provider.id.localeCompare(b.provider.id)
+  if (byProvider !== 0) return byProvider
+  return a.id.localeCompare(b.id)
+}

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,6 +8,7 @@ import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
 import { Flock } from "../util/flock"
 import { Hash } from "../util/hash"
+import { withPawWorkProviders } from "./pawwork-providers"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -151,7 +152,7 @@ export const Data = lazy(async () => {
 
 export async function get() {
   const result = await Data()
-  return result as Record<string, Provider>
+  return withPawWorkProviders(result as Record<string, Provider>)
 }
 
 export async function refresh(force = false) {

--- a/packages/opencode/src/provider/pawwork-providers.ts
+++ b/packages/opencode/src/provider/pawwork-providers.ts
@@ -1,0 +1,92 @@
+import type { ModelsDev } from "./models"
+import {
+  VOLCENGINE_PLAN_HIDDEN_MODEL_IDS,
+  VOLCENGINE_PLAN_PROVIDER_ID,
+  VOLCENGINE_PLAN_VISIBLE_MODEL_IDS,
+  volcenginePlanModelFamily,
+} from "@opencode-ai/util/volcengine-plan"
+
+const CODING_PLAN_COST = {
+  input: 0,
+  output: 0,
+  cache_read: 0,
+  cache_write: 0,
+}
+
+type Model = ModelsDev.Provider["models"][string]
+
+const textModel = (id: string, name: string, context: number, output: number, extra: Partial<Model> = {}): Model => ({
+  id,
+  name,
+  family: volcenginePlanModelFamily(id),
+  attachment: false,
+  reasoning: false,
+  tool_call: true,
+  temperature: true,
+  release_date: "",
+  cost: CODING_PLAN_COST,
+  limit: { context, output },
+  modalities: { input: ["text"], output: ["text"] },
+  ...extra,
+})
+
+export const PAWWORK_PROVIDER_OVERLAYS: Record<string, ModelsDev.Provider> = {
+  [VOLCENGINE_PLAN_PROVIDER_ID]: {
+    id: VOLCENGINE_PLAN_PROVIDER_ID,
+    name: "Volcano Engine Coding Plan",
+    npm: "@ai-sdk/openai-compatible",
+    api: "https://ark.cn-beijing.volces.com/api/coding/v3",
+    env: ["ARK_API_KEY"],
+    models: {
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[0]]: textModel("doubao-seed-2.0-code", "Doubao Seed 2.0 Code", 256000, 4096, {
+        attachment: true,
+        modalities: { input: ["text", "image"], output: ["text"] },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[1]]: textModel("doubao-seed-2.0-pro", "Doubao Seed 2.0 Pro", 256000, 4096, {
+        attachment: true,
+        modalities: { input: ["text", "image"], output: ["text"] },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[2]]: textModel("doubao-seed-2.0-lite", "Doubao Seed 2.0 Lite", 256000, 4096),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[3]]: textModel("doubao-seed-code", "Doubao Seed Code", 256000, 4096, {
+        attachment: true,
+        modalities: { input: ["text", "image"], output: ["text"] },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[4]]: textModel("minimax-m2.7", "MiniMax M2.7", 204800, 131072, {
+        reasoning: true,
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[5]]: textModel("minimax-m2.5", "MiniMax M2.5", 204800, 131072, {
+        reasoning: true,
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[6]]: textModel("glm-5.1", "GLM 5.1", 200000, 131072, {
+        reasoning: true,
+        interleaved: { field: "reasoning_content" },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[7]]: textModel("glm-4.7", "GLM 4.7", 200000, 4096, {
+        reasoning: true,
+        interleaved: { field: "reasoning_content" },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[8]]: textModel("deepseek-v3.2", "DeepSeek V3.2", 128000, 4096),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[9]]: textModel("kimi-k2.6", "Kimi K2.6", 262144, 32768, {
+        attachment: true,
+        reasoning: true,
+        modalities: { input: ["text", "image", "video"], output: ["text"] },
+      }),
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[10]]: textModel("kimi-k2.5", "Kimi K2.5", 262144, 32768, {
+        attachment: true,
+        reasoning: true,
+        modalities: { input: ["text", "image"], output: ["text"] },
+      }),
+      [VOLCENGINE_PLAN_HIDDEN_MODEL_IDS[0]]: textModel("ark-code-latest", "Ark Code Latest", 256000, 4096, {
+        attachment: true,
+        modalities: { input: ["text", "image"], output: ["text"] },
+      }),
+    },
+  },
+}
+
+export function withPawWorkProviders(providers: Record<string, ModelsDev.Provider>) {
+  return {
+    ...providers,
+    ...PAWWORK_PROVIDER_OVERLAYS,
+  }
+}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -9,6 +9,7 @@ import { Npm } from "../npm"
 import { Hash } from "../util/hash"
 import { Plugin } from "../plugin"
 import { NamedError } from "@opencode-ai/util/error"
+import { VOLCENGINE_PLAN_DEFAULT_MODEL_ID, VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
 import { type LanguageModelV3 } from "@ai-sdk/provider"
 import * as ModelsDev from "./models"
 import { Auth } from "../auth"
@@ -905,6 +906,9 @@ export const Info = Schema.Struct({
 export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
 
 const DefaultModelIDs = Schema.Record(Schema.String, Schema.String)
+const defaultModelOverride: Record<string, string> = {
+  [VOLCENGINE_PLAN_PROVIDER_ID]: VOLCENGINE_PLAN_DEFAULT_MODEL_ID,
+}
 
 export const ListResult = Schema.Struct({
   all: Schema.Array(Info),
@@ -920,8 +924,22 @@ export const ConfigProvidersResult = Schema.Struct({
 export type ConfigProvidersResult = Types.DeepMutable<Schema.Schema.Type<typeof ConfigProvidersResult>>
 export type Language = LanguageModelV3
 
-export function defaultModelIDs<T extends { models: Record<string, { id: string }> }>(providers: Record<string, T>) {
-  return mapValues(providers, (item) => sort(Object.values(item.models))[0].id)
+export function defaultModelID<T extends { id?: string; models: Record<string, { id: string }> }>(
+  provider: T,
+  fallbackID?: string,
+) {
+  const preferred = defaultModelOverride[provider.id ?? fallbackID ?? ""]
+  if (preferred && provider.models[preferred]) return preferred
+  const models = sort(Object.values(provider.models))
+  const defaultModel = models[0]
+  if (!defaultModel) throw new Error(`Provider ${provider.id ?? fallbackID ?? "unknown"} has no models`)
+  return defaultModel.id
+}
+
+export function defaultModelIDs<T extends { id?: string; models: Record<string, { id: string }> }>(
+  providers: Record<string, T>,
+) {
+  return mapValues(providers, (item, id) => defaultModelID(item, id))
 }
 
 export interface Interface {
@@ -1684,7 +1702,8 @@ const layer: Layer.Layer<
 
       const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
       if (!provider) throw new Error("no providers found")
-      const [model] = sort(Object.values(provider.models))
+      const modelID = defaultModelID(provider)
+      const model = provider.models[modelID]
       if (!model) throw new Error("no models found")
       return {
         providerID: provider.id,
@@ -1776,6 +1795,7 @@ const ProviderModelValue = Model
 const ProviderInfoValue = Info
 const ProviderListResultValue = ListResult
 const ProviderConfigProvidersResultValue = ConfigProvidersResult
+const ProviderDefaultModelIDValue = defaultModelID
 const ProviderDefaultModelIDsValue = defaultModelIDs
 const ProviderFromModelsDevProviderValue = fromModelsDevProvider
 const ProviderListValue = list
@@ -1803,6 +1823,7 @@ export namespace Provider {
   export const Info = ProviderInfoValue.zod
   export const ListResult = ProviderListResultValue.zod
   export const ConfigProvidersResult = ProviderConfigProvidersResultValue.zod
+  export const defaultModelID = ProviderDefaultModelIDValue
   export const defaultModelIDs = ProviderDefaultModelIDsValue
   export const fromModelsDevProvider = ProviderFromModelsDevProviderValue
   export const list = ProviderListValue

--- a/packages/opencode/src/server/instance/config.ts
+++ b/packages/opencode/src/server/instance/config.ts
@@ -85,7 +85,7 @@ export const ConfigRoutes = lazy(() =>
         const providers = await Provider.list().then((x) => mapValues(x, (item) => item))
         return c.json({
           providers: Object.values(providers),
-          default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
+          default: mapValues(providers, (item) => Provider.defaultModelID(item)),
         })
       },
     ),

--- a/packages/opencode/src/server/instance/provider.ts
+++ b/packages/opencode/src/server/instance/provider.ts
@@ -59,7 +59,7 @@ export const ProviderRoutes = lazy(() =>
         )
         return c.json({
           all: Object.values(providers),
-          default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
+          default: mapValues(providers, (item) => Provider.defaultModelID(item)),
           connected: Object.keys(connected),
         })
       },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -14,6 +14,12 @@ import { Env } from "../../src/env"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { makeRuntime } from "../../src/effect/run-service"
+import {
+  VOLCENGINE_PLAN_DEFAULT_MODEL_ID,
+  VOLCENGINE_PLAN_HIDDEN_MODEL_IDS,
+  VOLCENGINE_PLAN_PROVIDER_ID,
+  VOLCENGINE_PLAN_VISIBLE_MODEL_IDS,
+} from "@opencode-ai/util/volcengine-plan"
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
@@ -1093,6 +1099,65 @@ test("provider.sort prioritizes preferred models", () => {
   expect(sorted[0].id).toContain("latest")
   expect(sorted[sorted.length - 1].id).not.toContain("gpt-5")
   expect(sorted[sorted.length - 1].id).not.toContain("sonnet-4")
+})
+
+test("includes Volcano Engine Coding Plan as a PawWork provider overlay", async () => {
+  const models = await ModelsDev.get()
+  const provider = models[VOLCENGINE_PLAN_PROVIDER_ID]
+
+  expect(provider).toBeDefined()
+  expect(provider.id).toBe(VOLCENGINE_PLAN_PROVIDER_ID)
+  expect(provider.name).toBe("Volcano Engine Coding Plan")
+  expect(provider.npm).toBe("@ai-sdk/openai-compatible")
+  expect(provider.api).toBe("https://ark.cn-beijing.volces.com/api/coding/v3")
+  expect(provider.env).toEqual(["ARK_API_KEY"])
+
+  expect(
+    Object.keys(provider.models).filter((id) => !VOLCENGINE_PLAN_HIDDEN_MODEL_IDS.some((hidden) => hidden === id)),
+  ).toEqual([...VOLCENGINE_PLAN_VISIBLE_MODEL_IDS])
+  expect(provider.models[VOLCENGINE_PLAN_HIDDEN_MODEL_IDS[0]]).toBeDefined()
+  expect(provider.models[VOLCENGINE_PLAN_DEFAULT_MODEL_ID].cost).toEqual({
+    input: 0,
+    output: 0,
+    cache_read: 0,
+    cache_write: 0,
+  })
+  expect(provider.models["glm-5.1"].family).toBe("glm")
+  expect(provider.models["glm-4.7"].family).toBe("glm")
+  expect(provider.models["deepseek-v3.2"].family).toBe("deepseek")
+})
+
+test("uses doubao-seed-2.0-code as the Volcano Coding Plan default model", async () => {
+  const models = await ModelsDev.get()
+  const provider = models[VOLCENGINE_PLAN_PROVIDER_ID]
+
+  expect(Provider.defaultModelIDs({ [provider.id]: provider })).toEqual({
+    [VOLCENGINE_PLAN_PROVIDER_ID]: VOLCENGINE_PLAN_DEFAULT_MODEL_ID,
+  })
+  expect(Provider.defaultModelID(Provider.fromModelsDevProvider(provider))).toBe(VOLCENGINE_PLAN_DEFAULT_MODEL_ID)
+})
+
+test("does not change defaults for non-Volcano providers with the same Doubao model id", () => {
+  const providers = {
+    "qiniu-ai": {
+      id: "qiniu-ai",
+      models: {
+        "doubao-seed-2.0-code": { id: "doubao-seed-2.0-code" },
+        "ark-code-latest": { id: "ark-code-latest" },
+      },
+    },
+  }
+
+  expect(Provider.defaultModelIDs(providers)).toEqual({
+    "qiniu-ai": "ark-code-latest",
+  })
+  expect(Provider.defaultModelID(providers["qiniu-ai"])).toBe("ark-code-latest")
+})
+
+test("reports a clear error when a provider has no defaultable models", () => {
+  expect(() => Provider.defaultModelID({ id: "empty-provider", models: {} })).toThrow(
+    "Provider empty-provider has no models",
+  )
 })
 
 test("multiple providers can be configured simultaneously", async () => {

--- a/packages/util/src/volcengine-plan.ts
+++ b/packages/util/src/volcengine-plan.ts
@@ -1,0 +1,31 @@
+export const VOLCENGINE_PLAN_PROVIDER_ID = "volcengine-plan"
+export const VOLCENGINE_PLAN_DEFAULT_MODEL_ID = "doubao-seed-2.0-code"
+
+export const VOLCENGINE_PLAN_VISIBLE_MODEL_IDS = [
+  "doubao-seed-2.0-code",
+  "doubao-seed-2.0-pro",
+  "doubao-seed-2.0-lite",
+  "doubao-seed-code",
+  "minimax-m2.7",
+  "minimax-m2.5",
+  "glm-5.1",
+  "glm-4.7",
+  "deepseek-v3.2",
+  "kimi-k2.6",
+  "kimi-k2.5",
+] as const
+
+export const VOLCENGINE_PLAN_HIDDEN_MODEL_IDS = ["ark-code-latest"] as const
+
+const VOLCENGINE_PLAN_MODEL_FAMILIES = [
+  ["doubao-seed", "doubao-seed"],
+  ["minimax", "minimax"],
+  ["glm", "glm"],
+  ["deepseek", "deepseek"],
+  ["kimi", "kimi"],
+  ["ark-code", "ark-code"],
+] as const
+
+export function volcenginePlanModelFamily(id: string) {
+  return VOLCENGINE_PLAN_MODEL_FAMILIES.find(([prefix]) => id === prefix || id.startsWith(`${prefix}-`))?.[1] ?? id
+}


### PR DESCRIPTION
## Summary

- Add a PawWork-maintained `volcengine-plan` provider overlay for Volcano Engine Coding Plan with the Ark Coding Plan endpoint and documented model ids.
- Default Volcano Engine Coding Plan to `doubao-seed-2.0-code` while keeping `ark-code-latest` runtime-resolvable but hidden from normal model lists.
- Show Volcano Engine Coding Plan as a Popular provider with API key connection flow, localized copy, and doc-order model sorting.

## Why

Volcano Engine Coding Plan should be a first-class provider in PawWork, matching the Alibaba Coding Plan style while using the correct Ark Coding Plan endpoint so users do not accidentally configure the regular Ark API endpoint.

## Related Issue

Closes #116

## How To Verify

```bash
bun test --timeout 30000 test/provider/provider.test.ts
bun run --cwd packages/opencode typecheck
bun test src/i18n/parity.test.ts src/utils/hidden-models.test.ts src/utils/model-order.test.ts src/context/models.test.ts
bun run --cwd packages/app typecheck
bun run --cwd packages/app test:e2e:local e2e/settings/settings-providers.spec.ts -g "Volcano Engine"
```

## Screenshots or Recordings

Not attached. The visible provider row and API key dialog are covered by the Playwright e2e check above.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Volcano Engine Coding Plan as a visible provider with connection dialog and provider note; appears in Popular or Connected sections.

* **Refactor**
  * Unified model display ordering and centralized default-model selection; system-level hiding/filtering of specific model aliases.

* **Tests**
  * Added E2E and unit tests for provider UI, model hiding, ordering, and default selection.

* **Chores**
  * Added English and Chinese translations for the provider note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->