### PR TITLE
fix: isolate status panel test

### DIFF
--- a/packages/app/src/components/status-panel.test.tsx
+++ b/packages/app/src/components/status-panel.test.tsx
@@ -4,6 +4,6 @@ describe("StatusPanel", () => {
   test("re-exports the reusable status panel component", async () => {
     const source = await Bun.file(new URL("./status-panel.tsx", import.meta.url)).text()
 
-    expect(source.trim()).toBe('export { StatusPanel } from "./status-popover-body"')
+    expect(source.trim()).toMatch(/^export\s+{\s*StatusPanel\s*}\s*from\s*['"]\.\/status-popover-body['"];?$/)
   })
 })

--- a/packages/app/src/components/status-panel.test.tsx
+++ b/packages/app/src/components/status-panel.test.tsx
@@ -1,78 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test"
-
-beforeEach(() => {
-  mock.restore()
-  mock.module("@/context/sync", () => ({
-    useSync: () => ({
-      data: {
-        mcp: {},
-        mcp_ready: true,
-        lsp: [],
-        lsp_ready: true,
-        config: { plugin: [] },
-      },
-      set: () => {},
-    }),
-  }))
-  mock.module("@/context/server", () => ({
-    useServer: () => ({
-      current: undefined,
-      list: [],
-      key: undefined,
-      setActive: () => {},
-    }),
-    normalizeServerUrl: (value: string) => value,
-    ServerConnection: {
-      key: (value: unknown) => JSON.stringify(value),
-    },
-  }))
-  mock.module("@/context/platform", () => ({
-    usePlatform: () => ({ getDefaultServer: () => undefined }),
-  }))
-  mock.module("@opencode-ai/ui/context/dialog", () => ({
-    useDialog: () => ({ show: () => {} }),
-  }))
-  mock.module("@/context/language", () => ({
-    useLanguage: () => ({ t: (key: string) => key }),
-  }))
-  mock.module("@solidjs/router", () => ({
-    useNavigate: () => () => {},
-  }))
-  mock.module("@/context/sdk", () => ({
-    useSDK: () => ({
-      client: {
-        mcp: {
-          status: async () => ({ data: {} }),
-          connect: async () => ({ data: {} }),
-          disconnect: async () => ({ data: {} }),
-        },
-        lsp: { status: async () => ({ data: [] }) },
-      },
-    }),
-  }))
-  mock.module("@tanstack/solid-query", () => ({
-    useMutation: () => ({
-      mutate: () => {},
-      mutateAsync: async () => undefined,
-      isPending: () => false,
-      variables: undefined,
-    }),
-  }))
-  mock.module("@/utils/server-health", () => ({
-    useCheckServerHealth: () => async () => undefined,
-  }))
-  mock.module("@/components/server/server-row", () => ({
-    ServerHealthIndicator: () => null,
-    ServerRow: (props: { children?: unknown }) => props.children,
-  }))
-  mock.module("@opencode-ai/ui/toast", () => ({
-    showToast: () => {},
-  }))
-})
+import { describe, expect, test } from "bun:test"
 
 describe("StatusPanel", () => {
-  test("exports a reusable status panel component", () => {
-    const { StatusPanel } = require("./status-panel")
-    expect(typeof StatusPanel).toBe("function")
+  test("re-exports the reusable status panel component", async () => {
+    const source = await Bun.file(new URL("./status-panel.tsx", import.meta.url)).text()
+
+    expect(source.trim()).toBe('export { StatusPanel } from "./status-popover-body"')
   })
 })

--- a/packages/app/src/components/status-panel.test.tsx
+++ b/packages/app/src/components/status-panel.test.tsx
@@ -4,6 +4,6 @@ describe("StatusPanel", () => {
   test("re-exports the reusable status panel component", async () => {
     const source = await Bun.file(new URL("./status-panel.tsx", import.meta.url)).text()
 
-    expect(source.trim()).toMatch(/^export\s+{\s*StatusPanel\s*}\s*from\s*['"]\.\/status-popover-body['"];?$/)
+    expect(source.trim()).toMatch(/^export\s+{\s*StatusPanel\s*}\s+from\s*["']\.\/status-popover-body["'];?$/)
   })
 })


### PR DESCRIPTION
## Summary
Fixes the dev CI unit failure by replacing a broad StatusPanel import smoke test with a source-level re-export contract test.

## Why
The previous test installed process-level Bun module mocks for sync, router, language, and solid-query. In CI order those mocks leaked into later app tests, causing false missing-export failures even though source and dependencies were valid. This keeps the test scoped to what `status-panel.tsx` actually owns.

## Related Issue
No dedicated issue. Follow-up from the dev CI unit failure on run 24756909830.

## How To Verify
List the commands you ran and any manual checks you performed.

```bash
cd packages/app && bun test --preload ./happydom.ts ./src/components/status-panel.test.tsx ./src/context/sync-optimistic.test.ts ./src/context/language.test.ts ./src/context/terminal.test.ts ./src/context/comments.test.ts ./src/context/layout.test.ts ./src/context/global-sync/bootstrap.test.ts ./src/pages/session/session-side-panel.test.tsx ./src/pages/session/review-tab.test.tsx ./src/pages/session/composer/session-composer-state.test.ts
cd packages/app && mkdir -p .artifacts/unit && bun test --preload ./happydom.ts ./src --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml
bun turbo test:ci
```

## Screenshots or Recordings
Not applicable. This is test-only and has no visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test structure to improve maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->