### PR TITLE
chore: bump version to v0.2.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "effect": "catalog:",
         "electron-context-menu": "4.1.2",
@@ -140,7 +140,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -396,7 +396,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Bump PawWork workspace package versions from `0.2.4` to `0.2.5` for the next desktop release.

## Why
This prepares the v0.2.5 release branch after `dev` CI returned green. The release is expected to use the current release workflow support for macOS Apple Silicon, macOS Intel, and Windows x64 artifacts. This PR only updates version metadata; #86 and #87 should be closed after the corresponding release artifacts are actually produced and verified.

## Related Issue
Related: #86, #87. This PR does not close them by itself because artifact verification happens after the release workflow runs.

## How To Verify
List the commands you ran and any manual checks you performed.

```bash
bun install --frozen-lockfile
rg -n '"version": "0\\.2\\.5"' packages/app/package.json packages/desktop-electron/package.json packages/opencode/package.json packages/util/package.json bun.lock
```

## Screenshots or Recordings
Not applicable. This is release metadata only and has no visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.5 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->