### PR TITLE
docs: add release checklist

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,0 +1,145 @@
+# PawWork Release Checklist
+
+Use this checklist for stable PawWork desktop releases.
+
+## 1. Prepare
+
+- Confirm the release PR targets `dev` and all required CI checks are green.
+- Confirm the version bump is merged into `dev`.
+- Confirm `dev` is up to date locally:
+
+```bash
+git switch dev
+git pull --ff-only
+```
+
+- Confirm the release tag does not already exist:
+
+```bash
+git fetch origin --tags
+git tag -l vX.Y.Z
+gh release view vX.Y.Z --repo Astro-Han/pawwork
+```
+
+## 2. Draft Release Notes Before Publishing
+
+Create or update the GitHub Release body before publishing the release. Use English first, direct user download links, then a short Chinese section.
+
+```md
+## Downloads
+
+- [macOS Apple Silicon](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64.dmg)
+- [macOS Intel](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64.dmg)
+- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64.exe)
+
+## Highlights
+
+- User-facing changes, bug fixes, or packaging fixes.
+
+## Runtime And Maintenance
+
+- Build, updater, notarization, dependency, or CI maintenance.
+
+## Verification
+
+- macOS Apple Silicon submit/finalize completed successfully, including notarization.
+- macOS Intel submit/finalize completed successfully, including notarization.
+- Windows x64 release build completed successfully.
+- vX.Y.Z is published as the latest stable release.
+
+## 中文版本
+
+### 下载
+
+- [macOS Apple 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64.dmg)
+- [macOS Intel 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64.dmg)
+- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64.exe)
+
+### 主要更新
+
+- 用一句话概括主要变化。
+```
+
+Do not rely on the GitHub Assets list as the primary download UI. It mixes user installers with updater metadata, so direct links make the intended downloads clear.
+
+## 3. Build Release Artifacts
+
+Submit macOS notarization for both architectures:
+
+```bash
+gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=submit -f channel=prod -f target=macos -f arch=arm64
+gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=submit -f channel=prod -f target=macos -f arch=x64
+```
+
+Record each submit run's source run ID, source run attempt, source ref, source sha, workflow ref, workflow sha, and Apple submission ID from the workflow summary.
+
+The submit workflow summary should include values like this:
+
+```text
+source_run_id: 123456789
+source_run_attempt: 1
+source_ref: dev
+source_sha: 0123456789abcdef0123456789abcdef01234567
+source_workflow_ref: dev
+source_workflow_sha: 0123456789abcdef0123456789abcdef01234567
+submission_id: 00000000-0000-0000-0000-000000000000
+```
+
+Finalize each macOS architecture with the exact command emitted by its submit workflow summary. If writing the commands manually, keep the arm64 and x64 values separate:
+
+For arm64, replace `ARM64_SOURCE_RUN_ID` with the `source_run_id` value from the arm64 submit summary, and apply the same mapping for the other `ARM64_` placeholders. Repeat with the x64 submit summary for the `X64_` placeholders.
+
+```bash
+gh workflow run build.yml --repo Astro-Han/pawwork --ref ARM64_SOURCE_WORKFLOW_REF -f phase=finalize -f channel=prod -f arch=arm64 -f source_run_id=ARM64_SOURCE_RUN_ID -f source_run_attempt=ARM64_SOURCE_RUN_ATTEMPT -f source_ref=ARM64_SOURCE_REF -f source_sha=ARM64_SOURCE_SHA -f source_workflow_ref=ARM64_SOURCE_WORKFLOW_REF -f source_workflow_sha=ARM64_SOURCE_WORKFLOW_SHA -f submission_id=ARM64_SUBMISSION_ID
+gh workflow run build.yml --repo Astro-Han/pawwork --ref X64_SOURCE_WORKFLOW_REF -f phase=finalize -f channel=prod -f arch=x64 -f source_run_id=X64_SOURCE_RUN_ID -f source_run_attempt=X64_SOURCE_RUN_ATTEMPT -f source_ref=X64_SOURCE_REF -f source_sha=X64_SOURCE_SHA -f source_workflow_ref=X64_SOURCE_WORKFLOW_REF -f source_workflow_sha=X64_SOURCE_WORKFLOW_SHA -f submission_id=X64_SUBMISSION_ID
+```
+
+Build and publish the Windows installer:
+
+```bash
+gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=full -f channel=prod -f target=windows -f arch=x64
+```
+
+## 4. Publish
+
+Verify the draft release has all expected user-facing installers before publishing:
+
+```bash
+gh release view vX.Y.Z --repo Astro-Han/pawwork --json isDraft,isPrerelease,assets,url
+```
+
+Publish the release as the latest stable release:
+
+```bash
+gh release edit vX.Y.Z --repo Astro-Han/pawwork --draft=false --latest --prerelease=false
+```
+
+## 5. Post-Release Verification
+
+Run the verification helper:
+
+```bash
+export GH_TOKEN="$(gh auth token)"
+bun packages/desktop-electron/scripts/verify-release.ts vX.Y.Z
+```
+
+`GH_TOKEN` is recommended so GitHub API requests use the authenticated rate limit.
+
+The helper verifies:
+
+- The GitHub Release is not a draft.
+- The GitHub Release is not a prerelease.
+- `pawwork-mac-arm64.dmg` exists.
+- `pawwork-mac-x64.dmg` exists.
+- `pawwork-win-x64.exe` exists.
+- updater `.zip` and `.blockmap` assets exist.
+- `latest.yml` points to `pawwork-win-x64.exe`.
+- `latest-mac.yml` includes both `pawwork-mac-arm64.zip` and `pawwork-mac-x64.zip`.
+
+Keep `.zip`, `.blockmap`, and `latest*.yml` assets unless updater requirements are proven safe without them.
+
+If verification fails, check the reported missing or malformed asset first, rerun only the affected build phase, and publish the release only after the verification helper passes.
+
+## 6. Close Release Issues
+
+Only close release-blocking issues after post-release verification passes. Leave a short comment with the release link and the verified artifact names.

--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  fetchJson,
+  fetchText,
+  normalizeTag,
+  parseUpdaterFileUrls,
+  verifyReleasePayload,
+  type GithubRelease,
+} from "./verify-release"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const baseRelease: GithubRelease = {
+  tag_name: "v0.2.6",
+  draft: false,
+  prerelease: false,
+  assets: [
+    {
+      name: "pawwork-mac-arm64.dmg",
+      browser_download_url: "https://example.com/pawwork-mac-arm64.dmg",
+    },
+    {
+      name: "pawwork-mac-arm64.zip",
+      browser_download_url: "https://example.com/pawwork-mac-arm64.zip",
+    },
+    {
+      name: "pawwork-mac-arm64.zip.blockmap",
+      browser_download_url: "https://example.com/pawwork-mac-arm64.zip.blockmap",
+    },
+    {
+      name: "pawwork-mac-x64.dmg",
+      browser_download_url: "https://example.com/pawwork-mac-x64.dmg",
+    },
+    {
+      name: "pawwork-mac-x64.zip",
+      browser_download_url: "https://example.com/pawwork-mac-x64.zip",
+    },
+    {
+      name: "pawwork-mac-x64.zip.blockmap",
+      browser_download_url: "https://example.com/pawwork-mac-x64.zip.blockmap",
+    },
+    {
+      name: "pawwork-win-x64.exe",
+      browser_download_url: "https://example.com/pawwork-win-x64.exe",
+    },
+    {
+      name: "pawwork-win-x64.exe.blockmap",
+      browser_download_url: "https://example.com/pawwork-win-x64.exe.blockmap",
+    },
+    {
+      name: "latest.yml",
+      browser_download_url: "https://example.com/latest.yml",
+    },
+    {
+      name: "latest-mac.yml",
+      browser_download_url: "https://example.com/latest-mac.yml",
+    },
+  ],
+}
+
+describe("verify-release", () => {
+  test("normalizes release tags", () => {
+    expect(normalizeTag("0.2.6")).toBe("v0.2.6")
+    expect(normalizeTag("v0.2.6")).toBe("v0.2.6")
+    expect(() => normalizeTag("vv0.2.6")).toThrow("Invalid release tag")
+    expect(() => normalizeTag("abc")).toThrow("Invalid release tag")
+  })
+
+  test("parses updater file urls and path entries", () => {
+    expect(
+      parseUpdaterFileUrls(`version: 0.2.6
+files:
+  - url: pawwork-mac-arm64.zip
+    size: 1
+  - url: pawwork-mac-x64.zip
+    size: 2
+path: pawwork-mac-arm64.zip
+`),
+    ).toEqual(["pawwork-mac-arm64.zip", "pawwork-mac-x64.zip", "pawwork-mac-arm64.zip"])
+  })
+
+  test("parses quoted updater file urls and path entries", () => {
+    expect(
+      parseUpdaterFileUrls(`files:
+  - url: "pawwork-mac-arm64.zip"
+  - url: 'pawwork-mac-x64.zip' # Intel macOS updater asset
+  - url: "pawwork-mac#arm64.zip"
+    path: "pawwork-win-x64.exe" # Windows updater asset
+`),
+    ).toEqual(["pawwork-mac-arm64.zip", "pawwork-mac-x64.zip", "pawwork-mac#arm64.zip", "pawwork-win-x64.exe"])
+  })
+
+  test("keeps inline comments outside escaped quoted values", () => {
+    expect(
+      parseUpdaterFileUrls(String.raw`files:
+  - url: "pawwork-mac\"arm64.zip" # comment
+  - url: "pawwork-mac\\"
+path: pawwork-win-x64.exe
+`),
+    ).toEqual([String.raw`pawwork-mac\"arm64.zip`, String.raw`pawwork-mac\\`, "pawwork-win-x64.exe"])
+  })
+
+  test("accepts a stable release with expected assets and updater metadata", () => {
+    expect(
+      verifyReleasePayload({
+        release: baseRelease,
+        latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+        latestMacYml: "files:\n  - url: pawwork-mac-arm64.zip\n  - url: pawwork-mac-x64.zip\n",
+      }),
+    ).toEqual([])
+  })
+
+  test("accepts updater metadata entries with full download URLs", () => {
+    expect(
+      verifyReleasePayload({
+        release: baseRelease,
+        latestYml: "files:\n  - url: https://github.com/Astro-Han/pawwork/releases/download/v0.2.6/pawwork-win-x64.exe\n",
+        latestMacYml:
+          "files:\n  - url: https://github.com/Astro-Han/pawwork/releases/download/v0.2.6/pawwork-mac-arm64.zip\n  - url: https://github.com/Astro-Han/pawwork/releases/download/v0.2.6/pawwork-mac-x64.zip\n",
+      }),
+    ).toEqual([])
+  })
+
+  test("reports missing macOS updater architecture metadata", () => {
+    expect(
+      verifyReleasePayload({
+        release: baseRelease,
+        latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+        latestMacYml: "files:\n  - url: pawwork-mac-x64.zip\n",
+      }),
+    ).toContain("latest-mac.yml does not include pawwork-mac-arm64.zip")
+  })
+
+  test("reports updater metadata that points to a missing asset", () => {
+    expect(
+      verifyReleasePayload({
+        release: {
+          ...baseRelease,
+          assets: baseRelease.assets.filter((asset) => asset.name !== "pawwork-mac-arm64.zip"),
+        },
+        latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+        latestMacYml: "files:\n  - url: pawwork-mac-arm64.zip\n  - url: pawwork-mac-x64.zip\n",
+      }),
+    ).toContain("latest-mac.yml references missing release asset: pawwork-mac-arm64.zip")
+  })
+
+  test("reports missing installer and updater sidecar assets", () => {
+    const failures = verifyReleasePayload({
+      release: {
+        ...baseRelease,
+        assets: baseRelease.assets.filter(
+          (asset) => asset.name !== "pawwork-mac-arm64.dmg" && asset.name !== "pawwork-win-x64.exe.blockmap",
+        ),
+      },
+      latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+      latestMacYml: "files:\n  - url: pawwork-mac-arm64.zip\n  - url: pawwork-mac-x64.zip\n",
+    })
+
+    expect(failures).toContain("Missing release asset: pawwork-mac-arm64.dmg")
+    expect(failures).toContain("Missing release asset: pawwork-win-x64.exe.blockmap")
+  })
+
+  test("reports missing updater metadata assets without requiring metadata downloads", () => {
+    const failures = verifyReleasePayload({
+      release: {
+        ...baseRelease,
+        assets: baseRelease.assets.filter((asset) => asset.name !== "latest.yml" && asset.name !== "latest-mac.yml"),
+      },
+      latestYml: "",
+      latestMacYml: "",
+    })
+
+    expect(failures).toContain("Missing release asset: latest.yml")
+    expect(failures).toContain("Missing release asset: latest-mac.yml")
+    expect(failures).toContain("latest.yml does not include pawwork-win-x64.exe")
+    expect(failures).toContain("latest-mac.yml does not include pawwork-mac-arm64.zip")
+    expect(failures).toContain("latest-mac.yml does not include pawwork-mac-x64.zip")
+  })
+
+  test("reports draft releases", () => {
+    expect(
+      verifyReleasePayload({
+        release: { ...baseRelease, draft: true },
+        latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+        latestMacYml: "files:\n  - url: pawwork-mac-arm64.zip\n  - url: pawwork-mac-x64.zip\n",
+      }),
+    ).toContain("Release v0.2.6 is still a draft")
+  })
+
+  test("reports prerelease releases", () => {
+    expect(
+      verifyReleasePayload({
+        release: { ...baseRelease, prerelease: true },
+        latestYml: "files:\n  - url: pawwork-win-x64.exe\n",
+        latestMacYml: "files:\n  - url: pawwork-mac-arm64.zip\n  - url: pawwork-mac-x64.zip\n",
+      }),
+    ).toContain("Release v0.2.6 is marked as a prerelease")
+  })
+
+  test("reports malformed updater metadata as missing required updater entries", () => {
+    const failures = verifyReleasePayload({
+      release: baseRelease,
+      latestYml: "files:\n  - broken: pawwork-win-x64.exe\n",
+      latestMacYml: "files:\n  - broken: pawwork-mac-arm64.zip\n",
+    })
+
+    expect(failures).toContain("latest.yml does not include pawwork-win-x64.exe")
+    expect(failures).toContain("latest-mac.yml does not include pawwork-mac-arm64.zip")
+    expect(failures).toContain("latest-mac.yml does not include pawwork-mac-x64.zip")
+  })
+
+  test("fetchText reports GitHub rate limit headers on HTTP errors", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("rate limited", {
+          status: 403,
+          statusText: "Forbidden",
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1234567890",
+          },
+        }),
+      )) as typeof fetch
+
+    await expect(fetchText("https://api.github.com/example")).rejects.toThrow("rate limit remaining: 0")
+  })
+
+  test("fetchText reports network failures with the request URL", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("socket hang up"))) as typeof fetch
+
+    await expect(fetchText("https://api.github.com/example")).rejects.toThrow(
+      "Failed to fetch https://api.github.com/example: socket hang up",
+    )
+  })
+
+  test("fetchJson reports invalid JSON with the request URL", async () => {
+    globalThis.fetch = (() => Promise.resolve(new Response("not json", { status: 200 }))) as typeof fetch
+
+    await expect(fetchJson("https://api.github.com/example")).rejects.toThrow(
+      "Failed to parse JSON from https://api.github.com/example",
+    )
+  })
+})

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -1,0 +1,233 @@
+export type GithubAsset = {
+  name: string
+  browser_download_url: string
+}
+
+// Minimal GitHub Release API subset used by the release verifier.
+export type GithubRelease = {
+  tag_name: string
+  draft: boolean
+  prerelease: boolean
+  assets: GithubAsset[]
+}
+
+type VerificationInput = {
+  release: GithubRelease
+  latestYml?: string
+  latestMacYml?: string
+}
+
+const DEFAULT_REPO = "Astro-Han/pawwork"
+const FETCH_TIMEOUT_MS = 15_000
+
+const REQUIRED_ASSETS = [
+  "pawwork-mac-arm64.dmg",
+  "pawwork-mac-arm64.zip",
+  "pawwork-mac-arm64.zip.blockmap",
+  "pawwork-mac-x64.dmg",
+  "pawwork-mac-x64.zip",
+  "pawwork-mac-x64.zip.blockmap",
+  "pawwork-win-x64.exe",
+  "pawwork-win-x64.exe.blockmap",
+  "latest.yml",
+  "latest-mac.yml",
+]
+
+export function parseUpdaterFileUrls(source: string) {
+  const urls: string[] = []
+
+  // This intentionally parses only the electron-builder metadata fields we verify.
+  // It is not a general YAML parser and ignores block scalars, multiline values,
+  // and other YAML forms that electron-builder does not emit for these fields.
+  for (const line of source.split(/\r?\n/)) {
+    const fileMatch = line.match(/^\s*-\s+url:\s*(.+?)\s*$/)
+    if (fileMatch) {
+      urls.push(parseYamlScalar(fileMatch[1]))
+      continue
+    }
+
+    const pathMatch = line.match(/^\s*path:\s*(.+?)\s*$/)
+    if (pathMatch) urls.push(parseYamlScalar(pathMatch[1]))
+  }
+
+  return urls
+}
+
+function parseYamlScalar(value: string) {
+  const trimmed = stripInlineComment(value).trim()
+  const quote = trimmed[0]
+  if ((quote === `"` || quote === `'`) && trimmed.at(-1) === quote) return trimmed.slice(1, -1)
+  return trimmed
+}
+
+function stripInlineComment(value: string) {
+  let quote: string | undefined
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if ((char === `"` || char === `'`) && !isEscaped(value, index)) {
+      quote = quote === char ? undefined : quote ?? char
+      continue
+    }
+
+    // The fallback space makes a leading # behave as a comment marker.
+    if (!quote && char === "#" && /\s/.test(value[index - 1] ?? " ")) {
+      return value.slice(0, index)
+    }
+  }
+
+  return value
+}
+
+function isEscaped(value: string, index: number) {
+  let slashCount = 0
+  for (let slashIndex = index - 1; slashIndex >= 0 && value[slashIndex] === "\\"; slashIndex -= 1) {
+    slashCount += 1
+  }
+  return slashCount % 2 === 1
+}
+
+function hasUpdaterEntry(urls: string[], expected: string) {
+  // electron-builder may emit either a bare filename or a full download URL.
+  return urls.some((url) => url === expected || url.endsWith(`/${expected}`))
+}
+
+function assetNameFromUrl(url: string) {
+  return url.split("/").at(-1) ?? url
+}
+
+function verifyReferencedAssets(sourceName: string, urls: string[], assetNames: Set<string>, failures: string[]) {
+  for (const url of urls) {
+    const asset = assetNameFromUrl(url)
+    if (!assetNames.has(asset)) failures.push(`${sourceName} references missing release asset: ${asset}`)
+  }
+}
+
+export function verifyReleasePayload(input: VerificationInput) {
+  const failures: string[] = []
+  const assetNames = new Set(input.release.assets.map((asset) => asset.name))
+
+  if (input.release.draft) failures.push(`Release ${input.release.tag_name} is still a draft`)
+  if (input.release.prerelease) failures.push(`Release ${input.release.tag_name} is marked as a prerelease`)
+
+  for (const asset of REQUIRED_ASSETS) {
+    if (!assetNames.has(asset)) failures.push(`Missing release asset: ${asset}`)
+  }
+
+  const latestUrls = input.latestYml === undefined ? [] : parseUpdaterFileUrls(input.latestYml)
+  verifyReferencedAssets("latest.yml", latestUrls, assetNames, failures)
+  if (!hasUpdaterEntry(latestUrls, "pawwork-win-x64.exe")) {
+    failures.push("latest.yml does not include pawwork-win-x64.exe")
+  }
+
+  const latestMacUrls = input.latestMacYml === undefined ? [] : parseUpdaterFileUrls(input.latestMacYml)
+  verifyReferencedAssets("latest-mac.yml", latestMacUrls, assetNames, failures)
+  for (const asset of ["pawwork-mac-arm64.zip", "pawwork-mac-x64.zip"]) {
+    if (!hasUpdaterEntry(latestMacUrls, asset)) failures.push(`latest-mac.yml does not include ${asset}`)
+  }
+
+  return failures
+}
+
+export function normalizeTag(raw: string) {
+  const normalized = raw.startsWith("v") ? raw : `v${raw}`
+  if (!/^v\d+\.\d+\.\d+$/.test(normalized)) {
+    throw new Error(`Invalid release tag: ${raw}. Expected vX.Y.Z or X.Y.Z.`)
+  }
+  return normalized
+}
+
+function githubHeaders() {
+  const headers = new Headers({
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  })
+  if (process.env.GH_TOKEN) headers.set("Authorization", `Bearer ${process.env.GH_TOKEN}`)
+  return headers
+}
+
+export async function fetchText(url: string) {
+  const response = await fetchWithTimeout(url)
+  if (!response.ok) throw new Error(formatFetchError("fetch", url, response))
+  return response.text()
+}
+
+export async function fetchJson<T>(url: string) {
+  const response = await fetchWithTimeout(url)
+  if (!response.ok) throw new Error(formatFetchError("fetch", url, response))
+
+  try {
+    return (await response.json()) as T
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse JSON from ${url}: ${message}`)
+  }
+}
+
+async function fetchWithTimeout(url: string) {
+  try {
+    return await fetch(url, {
+      headers: githubHeaders(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to fetch ${url}: ${message}`)
+  }
+}
+
+function formatFetchError(operation: string, url: string, response: Response) {
+  const rateRemaining = response.headers.get("x-ratelimit-remaining")
+  const rateReset = response.headers.get("x-ratelimit-reset")
+  const rateInfo =
+    rateRemaining === null ? "" : `, rate limit remaining: ${rateRemaining}${rateReset ? `, reset: ${rateReset}` : ""}`
+  return `Failed to ${operation} ${url}: ${response.status} ${response.statusText}${rateInfo}`
+}
+
+function findAsset(release: GithubRelease, name: string) {
+  return release.assets.find((entry) => entry.name === name)
+}
+
+async function fetchAssetText(release: GithubRelease, name: string) {
+  const asset = findAsset(release, name)
+  if (!asset) return undefined
+  return fetchText(asset.browser_download_url)
+}
+
+async function main() {
+  try {
+    const tag = process.argv[2]
+    if (!tag) {
+      console.error("Usage: bun packages/desktop-electron/scripts/verify-release.ts <tag> [owner/repo]")
+      process.exit(2)
+    }
+
+    const repo = process.argv[3] ?? DEFAULT_REPO
+    const normalizedTag = normalizeTag(tag)
+    if (!process.env.GH_TOKEN) {
+      console.warn("GH_TOKEN is not set; GitHub API requests will use the lower unauthenticated rate limit.")
+    }
+    const release = await fetchJson<GithubRelease>(
+      `https://api.github.com/repos/${repo}/releases/tags/${encodeURIComponent(normalizedTag)}`,
+    )
+    const latestYml = await fetchAssetText(release, "latest.yml")
+    const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
+    const failures = verifyReleasePayload({ release, latestYml, latestMacYml })
+
+    if (failures.length) {
+      console.error(`Release verification failed for ${repo} ${normalizedTag}:`)
+      for (const failure of failures) console.error(`- ${failure}`)
+      process.exit(1)
+    }
+
+    console.log(`Release verification passed for ${repo} ${normalizedTag}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Release verification could not run: ${message}`)
+    process.exit(1)
+  }
+}
+
+if (import.meta.main) {
+  await main()
+}


### PR DESCRIPTION
## Summary

Add a tracked release checklist and a post-release verification helper for PawWork desktop releases.

## Why

The v0.2.5 release exposed process gaps around release notes timing, manual release command handling, and updater metadata verification. This PR documents the intended release flow and adds a script that verifies user-facing installers plus updater metadata before release issues are closed.

## Related Issue

Closes #120

## How To Verify

```bash
cd packages/desktop-electron && bun test scripts/verify-release.test.ts
cd packages/desktop-electron && bun run typecheck
cd packages/desktop-electron && bun test
git diff --check
bun packages/desktop-electron/scripts/verify-release.ts v0.2.5
```

Expected result for the final command: it fails on v0.2.5 because that release's current `latest-mac.yml` does not include `pawwork-mac-arm64.zip`. That is the historical release gap this checklist/helper is meant to catch for future releases.

## Screenshots or Recordings

Not included. This is a release process and verification script change with no visible UI.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a stable release checklist documenting end-to-end desktop release steps (preflight, build, notarization, publish, and post-release verification), with English and Chinese release-note guidance.

* **Tests**
  * Added comprehensive tests covering release verification logic and many failure scenarios to ensure artifact and metadata integrity.

* **Chores**
  * Added a release verification utility to validate release state, required installers/sidecars, updater pointers, and tag formatting before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->