### PR TITLE
ci: split package unit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.ref == 'refs/heads/dev' && format('ci-{0}', github.run_id) || format('ci-{0}', github.event.pull_request.number || github.ref) }}
   cancel-in-progress: true
 
 permissions:
@@ -129,7 +129,7 @@ jobs:
       - name: typecheck
         run: bun turbo typecheck
 
-  unit:
+  unit-app:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
@@ -165,10 +165,227 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: .turbo/cache
-          key: turbo-${{ runner.os }}-unit-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          key: turbo-${{ runner.os }}-unit-app-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-unit-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
-            turbo-${{ runner.os }}-unit-
+            turbo-${{ runner.os }}-unit-app-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-app-
+
+      - run: bun install --frozen-lockfile
+
+      - name: unit
+        run: bun turbo test:ci --filter=@opencode-ai/app
+
+      - name: Publish unit reports
+        if: >
+          always() &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
+        with:
+          report_paths: packages/app/.artifacts/unit/junit.xml
+          check_name: unit results (app)
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload unit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        with:
+          name: unit-app-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/app/.artifacts/unit/junit.xml
+
+  unit-opencode:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-unit-opencode-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-unit-opencode-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-opencode-
+
+      - run: bun install --frozen-lockfile
+
+      - name: unit
+        run: bun turbo test:ci --filter=opencode
+
+      - name: Publish unit reports
+        if: >
+          always() &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
+        with:
+          report_paths: packages/opencode/.artifacts/unit/junit.xml
+          check_name: unit results (opencode)
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload unit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        with:
+          name: unit-opencode-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/opencode/.artifacts/unit/junit.xml
+
+  unit-desktop:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-unit-desktop-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-unit-desktop-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-desktop-
+
+      - run: bun install --frozen-lockfile
+
+      - name: unit
+        run: bun turbo test:ci --filter=@opencode-ai/desktop-electron
+
+      - name: Publish unit reports
+        if: >
+          always() &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
+        with:
+          report_paths: packages/desktop-electron/.artifacts/unit/junit.xml
+          check_name: unit results (desktop)
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload unit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        with:
+          name: unit-desktop-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/desktop-electron/.artifacts/unit/junit.xml
+
+  unit-windows:
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    permissions:
+      contents: read
+      checks: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-unit-windows-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-unit-windows-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-windows-
 
       - run: bun install --frozen-lockfile
 
@@ -184,8 +401,8 @@ jobs:
           )
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
         with:
-          report_paths: packages/*/.artifacts/unit/junit.xml
-          check_name: unit results
+          report_paths: packages/**/.artifacts/unit/junit.xml
+          check_name: unit results (windows)
           detailed_summary: true
           include_time_in_summary: true
           fail_on_failure: false
@@ -194,30 +411,35 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
-          name: unit-${{ github.run_attempt }}
+          name: unit-windows-${{ github.run_attempt }}
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
-          path: packages/*/.artifacts/unit/junit.xml
+          path: packages/**/.artifacts/unit/junit.xml
 
   # Aggregator for the `dev` branch ruleset. The required check on GitHub
-  # is `ci / check`; every new job added above MUST be listed in `needs:`
-  # below, otherwise its failure will not block merge. If this list grows
-  # past ~5 entries, consider switching to `re-actors/alls-green` for
-  # dynamic aggregation (tracked in issue #54).
+  # is `ci / check`; every new blocking job added above MUST be listed in
+  # `needs:` below, otherwise its failure will not block merge. Non-blocking
+  # signal jobs, such as `unit-windows`, intentionally stay outside this list.
+  # If the blocking list grows past ~5 entries, consider switching to
+  # `re-actors/alls-green` for dynamic aggregation (tracked in issue #54).
   check:
     if: always()
     needs:
       - changes
       - typecheck
-      - unit
+      - unit-app
+      - unit-opencode
+      - unit-desktop
     runs-on: ubuntu-latest
     steps:
       - name: Validate CI result
         env:
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
-          UNIT_RESULT: ${{ needs.unit.result }}
+          UNIT_APP_RESULT: ${{ needs['unit-app'].result }}
+          UNIT_OPENCODE_RESULT: ${{ needs['unit-opencode'].result }}
+          UNIT_DESKTOP_RESULT: ${{ needs['unit-desktop'].result }}
         run: |
           set -euo pipefail
 
@@ -226,8 +448,13 @@ jobs:
             exit 0
           fi
 
-          if [ "$TYPECHECK_RESULT" != "success" ] || [ "$UNIT_RESULT" != "success" ]; then
+          if [ "$TYPECHECK_RESULT" != "success" ] ||
+             [ "$UNIT_APP_RESULT" != "success" ] ||
+             [ "$UNIT_OPENCODE_RESULT" != "success" ] ||
+             [ "$UNIT_DESKTOP_RESULT" != "success" ]; then
             echo "typecheck=$TYPECHECK_RESULT"
-            echo "unit=$UNIT_RESULT"
+            echo "unit-app=$UNIT_APP_RESULT"
+            echo "unit-opencode=$UNIT_OPENCODE_RESULT"
+            echo "unit-desktop=$UNIT_DESKTOP_RESULT"
             exit 1
           fi

--- a/packages/app/src/shell-frame-contract.test.ts
+++ b/packages/app/src/shell-frame-contract.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 
 function read(relativePath: string) {
-  return fs.readFileSync(path.join(import.meta.dir, relativePath), "utf8")
+  return fs.readFileSync(path.join(import.meta.dir, relativePath), "utf8").replaceAll("\r\n", "\n")
 }
 
 test("desktop shell shares titlebar height across titlebar and narrow sidebar geometry", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test"
+import path from "node:path"
 import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
 import { buildSmokeEnv, requiredSelectors, resolveCiSmokeReadyFile, resolveMainEntry } from "./ci-smoke"
 
 describe("ci smoke helpers", () => {
   test("resolveMainEntry points at the built Electron main process bundle", () => {
-    expect(resolveMainEntry()).toMatch(/packages\/desktop-electron\/out\/main\/index\.js$/)
+    expect(resolveMainEntry().endsWith(path.join("packages", "desktop-electron", "out", "main", "index.js"))).toBe(
+      true,
+    )
   })
 
   test("buildSmokeEnv isolates the app state in a temporary home", () => {
@@ -24,7 +27,7 @@ describe("ci smoke helpers", () => {
 
   test("resolveCiSmokeReadyFile points at the CI-ready marker inside the isolated user data dir", () => {
     expect(resolveCiSmokeReadyFile("/tmp/pawwork-ci-smoke")).toBe(
-      "/tmp/pawwork-ci-smoke/ai.pawwork.desktop.dev/ci-smoke-ready.json",
+      path.join("/tmp/pawwork-ci-smoke", "ai.pawwork.desktop.dev", "ci-smoke-ready.json"),
     )
   })
 })

--- a/packages/desktop-electron/scripts/prepare-embedded-server.test.ts
+++ b/packages/desktop-electron/scripts/prepare-embedded-server.test.ts
@@ -4,5 +4,5 @@ import { resolveOpencodeRoot } from "./embedded-server-path"
 
 test("prepare-embedded-server resolves the opencode workspace from the script directory", () => {
   const scriptDir = path.join("/repo", "packages", "desktop-electron", "scripts")
-  expect(resolveOpencodeRoot(scriptDir)).toBe(path.join("/repo", "packages", "opencode"))
+  expect(resolveOpencodeRoot(scriptDir)).toBe(path.resolve(scriptDir, "../../opencode"))
 })

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -19,6 +19,7 @@ import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
+import { Lock } from "../util/lock"
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -69,76 +70,81 @@ export const EditTool = Tool.define(
           let diff = ""
           let contentOld = ""
           let contentNew = ""
-          yield* Effect.gen(function* () {
-            if (params.oldString === "") {
-              const existed = yield* afs.existsSafe(filePath)
-              contentNew = params.newString
-              diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
-              yield* ctx.ask({
-                permission: "edit",
-                patterns: [path.relative(Instance.worktree, filePath)],
-                always: ["*"],
-                metadata: {
-                  filepath: filePath,
-                  diff,
-                },
-              })
-              yield* afs.writeWithDirs(filePath, params.newString)
-              yield* format.file(filePath)
-              yield* bus.publish(File.Event.Edited, { file: filePath })
-              yield* bus.publish(FileWatcher.Event.Updated, {
-                file: filePath,
-                event: existed ? "change" : "add",
-              })
-              return
-            }
+          yield* Effect.acquireUseRelease(
+            Effect.promise(() => Lock.write(filePath)),
+            () =>
+              Effect.gen(function* () {
+                if (params.oldString === "") {
+                  const existed = yield* afs.existsSafe(filePath)
+                  contentNew = params.newString
+                  diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+                  yield* ctx.ask({
+                    permission: "edit",
+                    patterns: [path.relative(Instance.worktree, filePath)],
+                    always: ["*"],
+                    metadata: {
+                      filepath: filePath,
+                      diff,
+                    },
+                  })
+                  yield* afs.writeWithDirs(filePath, params.newString)
+                  yield* format.file(filePath)
+                  yield* bus.publish(File.Event.Edited, { file: filePath })
+                  yield* bus.publish(FileWatcher.Event.Updated, {
+                    file: filePath,
+                    event: existed ? "change" : "add",
+                  })
+                  return
+                }
 
-            const info = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
-            if (!info) throw new Error(`File ${filePath} not found`)
-            if (info.type === "Directory") throw new Error(`Path is a directory, not a file: ${filePath}`)
-            contentOld = yield* afs.readFileString(filePath)
+                const info = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+                if (!info) throw new Error(`File ${filePath} not found`)
+                if (info.type === "Directory") throw new Error(`Path is a directory, not a file: ${filePath}`)
+                contentOld = yield* afs.readFileString(filePath)
 
-            const ending = detectLineEnding(contentOld)
-            const old = convertToLineEnding(normalizeLineEndings(params.oldString), ending)
-            const next = convertToLineEnding(normalizeLineEndings(params.newString), ending)
+                const ending = detectLineEnding(contentOld)
+                const old = convertToLineEnding(normalizeLineEndings(params.oldString), ending)
+                const next = convertToLineEnding(normalizeLineEndings(params.newString), ending)
 
-            contentNew = replace(contentOld, old, next, params.replaceAll)
+                contentNew = replace(contentOld, old, next, params.replaceAll)
 
-            diff = trimDiff(
-              createTwoFilesPatch(
-                filePath,
-                filePath,
-                normalizeLineEndings(contentOld),
-                normalizeLineEndings(contentNew),
-              ),
-            )
-            yield* ctx.ask({
-              permission: "edit",
-              patterns: [path.relative(Instance.worktree, filePath)],
-              always: ["*"],
-              metadata: {
-                filepath: filePath,
-                diff,
-              },
-            })
+                diff = trimDiff(
+                  createTwoFilesPatch(
+                    filePath,
+                    filePath,
+                    normalizeLineEndings(contentOld),
+                    normalizeLineEndings(contentNew),
+                  ),
+                )
+                yield* ctx.ask({
+                  permission: "edit",
+                  patterns: [path.relative(Instance.worktree, filePath)],
+                  always: ["*"],
+                  metadata: {
+                    filepath: filePath,
+                    diff,
+                  },
+                })
 
-            yield* afs.writeWithDirs(filePath, contentNew)
-            yield* format.file(filePath)
-            yield* bus.publish(File.Event.Edited, { file: filePath })
-            yield* bus.publish(FileWatcher.Event.Updated, {
-              file: filePath,
-              event: "change",
-            })
-            contentNew = yield* afs.readFileString(filePath)
-            diff = trimDiff(
-              createTwoFilesPatch(
-                filePath,
-                filePath,
-                normalizeLineEndings(contentOld),
-                normalizeLineEndings(contentNew),
-              ),
-            )
-          }).pipe(Effect.orDie)
+                yield* afs.writeWithDirs(filePath, contentNew)
+                yield* format.file(filePath)
+                yield* bus.publish(File.Event.Edited, { file: filePath })
+                yield* bus.publish(FileWatcher.Event.Updated, {
+                  file: filePath,
+                  event: "change",
+                })
+                contentNew = yield* afs.readFileString(filePath)
+                diff = trimDiff(
+                  createTwoFilesPatch(
+                    filePath,
+                    filePath,
+                    normalizeLineEndings(contentOld),
+                    normalizeLineEndings(contentNew),
+                  ),
+                )
+              }),
+            (lock) => Effect.sync(() => lock[Symbol.dispose]()),
+          ).pipe(Effect.orDie)
 
           const filediff: Snapshot.FileDiff = {
             file: filePath,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1318,6 +1318,7 @@ it.live(
 
     const prev = process.env.OPENCODE_CONFIG_DIR
     const gitignorePath = path.join(tmp.extra, ".gitignore")
+    const install = spyOn(Npm, "install").mockResolvedValue(undefined)
 
     const testLayer = Config.layer.pipe(
       Layer.provide(AppFileSystem.defaultLayer),
@@ -1326,25 +1327,29 @@ it.live(
       Layer.provideMerge(infra),
     )
 
-    await withConfigDepsLock(async () => {
-      process.env.OPENCODE_CONFIG_DIR = tmp.extra
-      try {
-        await Instance.provide({
-          directory: tmp.path,
-          fn: async () => {
-            await Effect.runPromise(
-              Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(testLayer)),
-            )
-            await Effect.runPromise(
-              Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(testLayer)),
-            )
-          },
-        })
-      } finally {
-        if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
-        else process.env.OPENCODE_CONFIG_DIR = prev
-      }
-    })
+    try {
+      await withConfigDepsLock(async () => {
+        process.env.OPENCODE_CONFIG_DIR = tmp.extra
+        try {
+          await Instance.provide({
+            directory: tmp.path,
+            fn: async () => {
+              await Effect.runPromise(
+                Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(testLayer)),
+              )
+              await Effect.runPromise(
+                Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(testLayer)),
+              )
+            },
+          })
+        } finally {
+          if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
+          else process.env.OPENCODE_CONFIG_DIR = prev
+        }
+      })
+    } finally {
+      install.mockRestore()
+    }
 
     await waitFor(async () => {
       if (!(await Filesystem.exists(gitignorePath))) return false

--- a/packages/opencode/test/config/seed-e2e.test.ts
+++ b/packages/opencode/test/config/seed-e2e.test.ts
@@ -24,7 +24,7 @@ describe("seed e2e script", () => {
       ])
 
       const abort = new AbortController()
-      const timer = setTimeout(() => abort.abort(), 5_000)
+      const timer = setTimeout(() => abort.abort(), 20_000)
 
       try {
         const out = await Process.run(["bun", "script/seed-e2e.ts"], {
@@ -48,7 +48,12 @@ describe("seed e2e script", () => {
           },
         })
 
-        expect(out.code).toBe(0)
+        if (out.code !== 0) {
+          throw new Error(
+            `seed e2e exited with code ${out.code}\nstdout:\n${out.stdout.toString()}\nstderr:\n${out.stderr.toString()}`,
+          )
+        }
+
       } finally {
         clearTimeout(timer)
         await Promise.allSettled(
@@ -56,5 +61,5 @@ describe("seed e2e script", () => {
         )
       }
     })
-  }, 15_000)
+  }, 30_000)
 })

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -5,42 +5,166 @@ import { parseWorkflow, readWorkflow } from "./workflow-parser"
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const workflowPath = path.join(repoRoot, ".github", "workflows", "ci.yml")
 
+const pinned = {
+  checkout: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+  setupNode: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f",
+  setupBun: "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+  cache: "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
+  junit: "mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386",
+  artifact: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+}
+
+function steps(job: string) {
+  const parsed = parseWorkflow(workflowPath)
+  return parsed.jobs?.[job]?.steps ?? []
+}
+
+function checkoutStep(job: string) {
+  return steps(job).find((step) => step.uses?.startsWith("actions/checkout@"))
+}
+
+function stepByName(job: string, name: string) {
+  return steps(job).find((step) => step.name === name)
+}
+
 describe("ci workflow", () => {
   test("pins third-party actions and disables checkout credential persistence", () => {
     const workflow = readWorkflow(workflowPath)
     const parsed = parseWorkflow(workflowPath)
-    const jobs = parsed.jobs ?? {}
-    const changesSteps = jobs.changes?.steps ?? []
-    const typecheckSteps = jobs.typecheck?.steps ?? []
-    const unitSteps = jobs.unit?.steps ?? []
-    const changesCheckoutStep = changesSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
-    const typecheckCheckoutStep = typecheckSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
-    const unitCheckoutStep = unitSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
-    const typecheckBunStep = typecheckSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
-    const unitBunStep = unitSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
-    const junitStep = unitSteps.find((step) => step.name === "Publish unit reports")
-    const uploadArtifactsStep = unitSteps.find((step) => step.name === "Upload unit artifacts")
 
     expect(parsed.name).toBe("ci")
     expect(parsed.permissions).toEqual({ contents: "read" })
-    expect(changesCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
-    expect(typecheckCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
-    expect(unitCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
 
-    expect(changesCheckoutStep?.with).toEqual({
-      "fetch-depth": 0,
-      "persist-credentials": false,
-    })
+    for (const job of ["changes", "typecheck", "unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+      expect(checkoutStep(job)?.uses).toBe(pinned.checkout)
+      expect(checkoutStep(job)?.with?.["persist-credentials"]).toBe(false)
+    }
 
-    expect(typecheckCheckoutStep?.with).toEqual({ "persist-credentials": false })
-    expect(typecheckBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+    expect(checkoutStep("changes")?.with?.["fetch-depth"]).toBe(0)
 
-    expect(unitCheckoutStep?.with).toEqual({ "persist-credentials": false })
-    expect(unitBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
-    expect(junitStep?.uses).toBe("mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386")
-    expect(uploadArtifactsStep?.uses).toBe("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
+    for (const job of ["typecheck", "unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+      expect(steps(job).find((step) => step.uses?.startsWith("actions/setup-node@"))?.uses).toBe(pinned.setupNode)
+      expect(steps(job).find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))?.uses).toBe(pinned.setupBun)
+      expect(steps(job).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual([
+        pinned.cache,
+        pinned.cache,
+      ])
+    }
+
+    for (const job of ["unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+      expect(stepByName(job, "Publish unit reports")?.uses).toBe(pinned.junit)
+      expect(stepByName(job, "Upload unit artifacts")?.uses).toBe(pinned.artifact)
+    }
 
     expect(workflow).not.toContain("pull_request_target")
     expect(workflow).not.toContain("persist-credentials: true")
+  })
+
+  test("keeps dev runs and cancels stale pull request runs", () => {
+    const parsed = parseWorkflow(workflowPath)
+
+    expect(parsed.concurrency?.group).toContain("github.ref == 'refs/heads/dev'")
+    expect(parsed.concurrency?.group).toContain("github.run_id")
+    expect(parsed.concurrency?.["cancel-in-progress"]).toBe(true)
+  })
+
+  test("preserves the docs-only change detection contract", () => {
+    const parsed = parseWorkflow(workflowPath)
+    const changes = parsed.jobs?.changes
+    const filter = steps("changes").find((step) => step.id === "filter")
+
+    expect(changes?.outputs?.docs_only).toBe("${{ steps.filter.outputs.docs_only }}")
+    expect(filter?.env?.EVENT_NAME).toBe("${{ github.event_name }}")
+    expect(filter?.env?.BASE_SHA).toBe("${{ github.event.pull_request.base.sha || github.event.before }}")
+    expect(filter?.env?.HEAD_SHA).toBe("${{ github.sha }}")
+    expect(filter?.run).toContain("workflow_dispatch")
+    expect(filter?.run).toContain("docs_only=false")
+    expect(filter?.run).toContain("git diff --name-status --find-renames --find-copies")
+    expect(filter?.run).toContain("R*|C*)")
+    expect(filter?.run).toContain("if ! is_docs_path \"$path1\" || ! is_docs_path \"$path2\"; then")
+    expect(filter?.run).toContain("echo \"docs_only=$docs_only\" >> \"$GITHUB_OUTPUT\"")
+  })
+
+  test("splits required Linux unit jobs by package while preserving Turbo dependency semantics", () => {
+    const parsed = parseWorkflow(workflowPath)
+    const linuxUnitJobs = [
+      [
+        "unit-app",
+        "bun turbo test:ci --filter=@opencode-ai/app",
+        "packages/app/.artifacts/unit/junit.xml",
+        "unit results (app)",
+        "unit-app-${{ github.run_attempt }}",
+      ],
+      [
+        "unit-opencode",
+        "bun turbo test:ci --filter=opencode",
+        "packages/opencode/.artifacts/unit/junit.xml",
+        "unit results (opencode)",
+        "unit-opencode-${{ github.run_attempt }}",
+      ],
+      [
+        "unit-desktop",
+        "bun turbo test:ci --filter=@opencode-ai/desktop-electron",
+        "packages/desktop-electron/.artifacts/unit/junit.xml",
+        "unit results (desktop)",
+        "unit-desktop-${{ github.run_attempt }}",
+      ],
+    ] as const
+
+    for (const [jobName, command, reportPath, checkName, artifactName] of linuxUnitJobs) {
+      const job = parsed.jobs?.[jobName]
+      expect(job?.needs).toBe("changes")
+      expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
+      expect(job?.["runs-on"]).toBe("ubuntu-latest")
+      expect(job?.["timeout-minutes"]).toBe(30)
+      expect(job?.permissions).toEqual({ contents: "read", checks: "write" })
+      expect(stepByName(jobName, "unit")?.run).toBe(command)
+      expect(stepByName(jobName, "Publish unit reports")?.with?.report_paths).toBe(reportPath)
+      expect(stepByName(jobName, "Publish unit reports")?.with?.check_name).toBe(checkName)
+      expect(stepByName(jobName, "Upload unit artifacts")?.with?.name).toBe(artifactName)
+      expect(stepByName(jobName, "Upload unit artifacts")?.with?.path).toBe(reportPath)
+    }
+  })
+
+  test("keeps Windows unit as a non-blocking full-suite signal", () => {
+    const parsed = parseWorkflow(workflowPath)
+    const job = parsed.jobs?.["unit-windows"]
+
+    expect(job?.["runs-on"]).toBe("windows-latest")
+    expect(job?.["timeout-minutes"]).toBe(15)
+    expect(job?.["continue-on-error"]).toBe(true)
+    expect(job?.needs).toBe("changes")
+    expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
+    expect(stepByName("unit-windows", "unit")?.run).toBe("bun turbo test:ci")
+    expect(stepByName("unit-windows", "Publish unit reports")?.with?.report_paths).toBe(
+      "packages/**/.artifacts/unit/junit.xml",
+    )
+    expect(stepByName("unit-windows", "Publish unit reports")?.with?.check_name).toBe("unit results (windows)")
+    expect(stepByName("unit-windows", "Upload unit artifacts")?.with?.name).toBe(
+      "unit-windows-${{ github.run_attempt }}",
+    )
+    expect(stepByName("unit-windows", "Upload unit artifacts")?.with?.path).toBe(
+      "packages/**/.artifacts/unit/junit.xml",
+    )
+  })
+
+  test("keeps docs-only behavior and excludes Windows from the blocking aggregate", () => {
+    const parsed = parseWorkflow(workflowPath)
+    const check = parsed.jobs?.check
+    const needs = Array.isArray(check?.needs) ? check.needs : []
+    const validate = stepByName("check", "Validate CI result")
+
+    expect(check?.if).toBe("always()")
+    expect(needs).toEqual(["changes", "typecheck", "unit-app", "unit-opencode", "unit-desktop"])
+    expect(needs).not.toContain("unit-windows")
+    expect(validate?.env?.DOCS_ONLY).toBe("${{ needs.changes.outputs.docs_only }}")
+    expect(validate?.env?.TYPECHECK_RESULT).toBe("${{ needs.typecheck.result }}")
+    expect(validate?.env?.UNIT_APP_RESULT).toBe("${{ needs['unit-app'].result }}")
+    expect(validate?.env?.UNIT_OPENCODE_RESULT).toBe("${{ needs['unit-opencode'].result }}")
+    expect(validate?.env?.UNIT_DESKTOP_RESULT).toBe("${{ needs['unit-desktop'].result }}")
+    expect(validate?.run).toContain("Docs-only change, daily CI skipped.")
+    expect(validate?.run).toContain("UNIT_APP_RESULT")
+    expect(validate?.run).toContain("UNIT_OPENCODE_RESULT")
+    expect(validate?.run).toContain("UNIT_DESKTOP_RESULT")
   })
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -36,6 +36,15 @@ function wait(ms = 50) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+async function waitFor(fn: () => boolean, timeout = 5_000) {
+  const end = Date.now() + timeout
+  while (Date.now() < end) {
+    if (fn()) return
+    await wait(25)
+  }
+  throw new Error("timed out waiting for workspace status")
+}
+
 async function pluginProject() {
   return tmpdir({
     git: true,
@@ -117,8 +126,13 @@ describe("plugin.workspace", () => {
       directory: tmp.extra.space,
       extra: { key: "value" },
     })
-    await wait(100)
-    expect(Workspace.status().find((item) => item.workspaceID === info.id)?.status).not.toBe("connecting")
+    await waitFor(() => {
+      const status = Workspace.status().find((item) => item.workspaceID === info.id)
+      return status !== undefined && status.status !== "connecting"
+    })
+    const status = Workspace.status().find((item) => item.workspaceID === info.id)
+    expect(status).toBeDefined()
+    expect(status?.status).not.toBe("connecting")
   })
 
   test("plugin workspace adaptor registration does not survive instance disposal", async () => {

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,18 +1,21 @@
-import { afterAll, afterEach, describe, test, expect } from "bun:test"
+import { afterEach, describe, expect } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
-import { Effect, Layer, ManagedRuntime } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer } from "effect"
 import { EditTool } from "../../src/tool/edit"
 import { Instance } from "../../src/project/instance"
-import { tmpdir } from "../fixture/fixture"
+import { provideTmpdirInstance } from "../fixture/fixture"
 import { LSP } from "../../src/lsp"
 import { AppFileSystem } from "../../src/filesystem"
 import { Format } from "../../src/format"
 import { Agent } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
-import { BusEvent } from "../../src/bus/bus-event"
 import { Truncate } from "../../src/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { FileWatcher } from "../../src/file/watcher"
+import { Tool } from "../../src/tool/tool"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { testEffect } from "../lib/effect"
 
 const ctx = {
   sessionID: SessionID.make("ses_test-edit-session"),
@@ -29,7 +32,7 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
-const runtime = ManagedRuntime.make(
+const it = testEffect(
   Layer.mergeAll(
     LSP.defaultLayer,
     AppFileSystem.defaultLayer,
@@ -37,428 +40,341 @@ const runtime = ManagedRuntime.make(
     Bus.layer,
     Truncate.defaultLayer,
     Agent.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
   ),
 )
 
-afterAll(async () => {
-  await runtime.dispose()
+const init = Effect.fn("EditToolTest.init")(function* () {
+  const info = yield* EditTool
+  return yield* info.init()
 })
 
-const resolve = () =>
-  runtime.runPromise(
-    Effect.gen(function* () {
-      const info = yield* EditTool
-      return yield* info.init()
-    }),
-  )
+const run = Effect.fn("EditToolTest.run")(function* (
+  args: Tool.InferParameters<typeof EditTool>,
+  next: Tool.Context = ctx,
+) {
+  const tool = yield* init()
+  return yield* tool.execute(args, next)
+})
 
-const subscribeBus = <D extends BusEvent.Definition>(def: D, callback: () => unknown) =>
-  runtime.runPromise(Bus.Service.use((bus) => bus.subscribeCallback(def, callback)))
+const expectRunFailure = Effect.fn("EditToolTest.expectRunFailure")(function* (
+  args: Tool.InferParameters<typeof EditTool>,
+  message: string,
+) {
+  const exit = yield* run(args).pipe(Effect.exit)
+  expect(Exit.isFailure(exit)).toBe(true)
+  if (Exit.isFailure(exit)) {
+    expect(Cause.pretty(exit.cause)).toContain(message)
+  }
+})
+
+type FileUpdate = {
+  file: string
+  event: "change" | "add" | "unlink"
+}
+
+const nextFileUpdate = <A, E, R>(check: (event: FileUpdate) => boolean, trigger: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.gen(function* () {
+      const deferred = yield* Deferred.make<FileUpdate>()
+      const bus = yield* Bus.Service
+      const unsubscribe = yield* bus.subscribeCallback(FileWatcher.Event.Updated, (payload) => {
+        if (!check(payload.properties)) return
+        Deferred.doneUnsafe(deferred, Effect.succeed(payload.properties))
+      })
+      return { deferred, unsubscribe }
+    }),
+    ({ deferred }) =>
+      Effect.gen(function* () {
+        yield* trigger
+        return yield* Deferred.await(deferred).pipe(Effect.timeout("5 seconds"))
+      }),
+    ({ unsubscribe }) => Effect.sync(unsubscribe),
+  )
 
 describe("tool.edit", () => {
   describe("creating new files", () => {
-    test("creates new file when oldString is empty", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "newfile.txt")
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          const result = await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "",
-                newString: "new content",
-              },
-              ctx,
-            ),
-          )
+    it.live("creates new file when oldString is empty", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "newfile.txt")
+          const result = yield* run({
+            filePath: filepath,
+            oldString: "",
+            newString: "new content",
+          })
 
           expect(result.metadata.diff).toContain("new content")
 
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("creates new file with nested directories", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "nested", "dir", "file.txt")
+    it.live("creates new file with nested directories", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "nested", "dir", "file.txt")
+          yield* run({
+            filePath: filepath,
+            oldString: "",
+            newString: "nested file",
+          })
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "",
-                newString: "nested file",
-              },
-              ctx,
-            ),
-          )
-
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("nested file")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("emits add event for new files", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "new.txt")
+    it.live("emits add event for new files", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "new.txt")
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const { FileWatcher } = await import("../../src/file/watcher")
-
-          const events: string[] = []
-          const unsubUpdated = await subscribeBus(FileWatcher.Event.Updated, () => events.push("updated"))
-
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "",
-                newString: "content",
-              },
-              ctx,
-            ),
+          const event = yield* nextFileUpdate(
+            (payload) => payload.file === filepath && payload.event === "add",
+            run({
+              filePath: filepath,
+              oldString: "",
+              newString: "content",
+            }),
           )
 
-          expect(events).toContain("updated")
-          unsubUpdated()
-        },
-      })
-    })
+          expect(event).toEqual({
+            file: filepath,
+            event: "add",
+          })
+        }),
+      ),
+    )
   })
 
   describe("editing existing files", () => {
-    test("replaces text without requiring a prior read", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "existing-no-read.txt")
-      await fs.writeFile(filepath, "old content here", "utf-8")
+    it.live("replaces text without requiring a prior read", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "existing-no-read.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "old content here", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          const result = await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "old content",
-                newString: "new content",
-              },
-              ctx,
-            ),
-          )
+          const result = yield* run({
+            filePath: filepath,
+            oldString: "old content",
+            newString: "new content",
+          })
 
           expect(result.output).toContain("Edit applied successfully")
 
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("replaces text in existing file", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "existing.txt")
-      await fs.writeFile(filepath, "old content here", "utf-8")
+    it.live("replaces text in existing file", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "existing.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "old content here", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          const result = await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "old content",
-                newString: "new content",
-              },
-              ctx,
-            ),
-          )
+          const result = yield* run({
+            filePath: filepath,
+            oldString: "old content",
+            newString: "new content",
+          })
 
           expect(result.output).toContain("Edit applied successfully")
 
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("throws error when file does not exist", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "nonexistent.txt")
+    it.live("throws error when file does not exist", () =>
+      provideTmpdirInstance((dir) =>
+        expectRunFailure(
+          {
+            filePath: path.join(dir, "nonexistent.txt"),
+            oldString: "old",
+            newString: "new",
+          },
+          "not found",
+        ),
+      ),
+    )
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await expect(
-            Effect.runPromise(
-              edit.execute(
-                {
-                  filePath: filepath,
-                  oldString: "old",
-                  newString: "new",
-                },
-                ctx,
-              ),
-            ),
-          ).rejects.toThrow("not found")
-        },
-      })
-    })
+    it.live("throws error when oldString equals newString", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "content", "utf-8"))
 
-    test("throws error when oldString equals newString", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "content", "utf-8")
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await expect(
-            Effect.runPromise(
-              edit.execute(
-                {
-                  filePath: filepath,
-                  oldString: "same",
-                  newString: "same",
-                },
-                ctx,
-              ),
-            ),
-          ).rejects.toThrow("identical")
-        },
-      })
-    })
-
-    test("throws error when oldString not found in file", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "actual content", "utf-8")
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await expect(
-            Effect.runPromise(
-              edit.execute(
-                {
-                  filePath: filepath,
-                  oldString: "not in file",
-                  newString: "replacement",
-                },
-                ctx,
-              ),
-            ),
-          ).rejects.toThrow()
-        },
-      })
-    })
-
-    test("replaces all occurrences with replaceAll option", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "foo bar foo baz foo", "utf-8")
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "foo",
-                newString: "qux",
-                replaceAll: true,
-              },
-              ctx,
-            ),
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: "same",
+              newString: "same",
+            },
+            "identical",
           )
+        }),
+      ),
+    )
 
-          const content = await fs.readFile(filepath, "utf-8")
+    it.live("throws error when oldString not found in file", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "actual content", "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: "not in file",
+              newString: "replacement",
+            },
+            "Could not find oldString",
+          )
+        }),
+      ),
+    )
+
+    it.live("replaces all occurrences with replaceAll option", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "foo bar foo baz foo", "utf-8"))
+
+          yield* run({
+            filePath: filepath,
+            oldString: "foo",
+            newString: "qux",
+            replaceAll: true,
+          })
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("qux bar qux baz qux")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("emits change event for existing files", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "original", "utf-8")
+    it.live("emits change event for existing files", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "original", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const { FileWatcher } = await import("../../src/file/watcher")
-
-          const events: string[] = []
-          const unsubUpdated = await subscribeBus(FileWatcher.Event.Updated, () => events.push("updated"))
-
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "original",
-                newString: "modified",
-              },
-              ctx,
-            ),
+          const event = yield* nextFileUpdate(
+            (payload) => payload.file === filepath && payload.event === "change",
+            run({
+              filePath: filepath,
+              oldString: "original",
+              newString: "modified",
+            }),
           )
 
-          expect(events).toContain("updated")
-          unsubUpdated()
-        },
-      })
-    })
+          expect(event).toEqual({
+            file: filepath,
+            event: "change",
+          })
+        }),
+      ),
+    )
   })
 
   describe("edge cases", () => {
-    test("handles multiline replacements", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "line1\nline2\nline3", "utf-8")
+    it.live("handles multiline replacements", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "line1\nline2\nline3", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "line2",
-                newString: "new line 2\nextra line",
-              },
-              ctx,
-            ),
-          )
+          yield* run({
+            filePath: filepath,
+            oldString: "line2",
+            newString: "new line 2\nextra line",
+          })
 
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("line1\nnew line 2\nextra line\nline3")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("handles CRLF line endings", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "line1\r\nold\r\nline3", "utf-8")
+    it.live("handles CRLF line endings", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "line1\r\nold\r\nline3", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "old",
-                newString: "new",
-              },
-              ctx,
-            ),
-          )
+          yield* run({
+            filePath: filepath,
+            oldString: "old",
+            newString: "new",
+          })
 
-          const content = await fs.readFile(filepath, "utf-8")
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("line1\r\nnew\r\nline3")
-        },
-      })
-    })
+        }),
+      ),
+    )
 
-    test("throws error when oldString equals newString", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "content", "utf-8")
+    it.live("throws error when oldString equals newString", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "content", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await expect(
-            Effect.runPromise(
-              edit.execute(
-                {
-                  filePath: filepath,
-                  oldString: "",
-                  newString: "",
-                },
-                ctx,
-              ),
-            ),
-          ).rejects.toThrow("identical")
-        },
-      })
-    })
-
-    test("throws error when path is directory", async () => {
-      await using tmp = await tmpdir()
-      const dirpath = path.join(tmp.path, "adir")
-      await fs.mkdir(dirpath)
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          await expect(
-            Effect.runPromise(
-              edit.execute(
-                {
-                  filePath: dirpath,
-                  oldString: "old",
-                  newString: "new",
-                },
-                ctx,
-              ),
-            ),
-          ).rejects.toThrow("directory")
-        },
-      })
-    })
-
-    test("tracks file diff statistics", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "line1\nline2\nline3", "utf-8")
-
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          const result = await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "line2",
-                newString: "new line a\nnew line b",
-              },
-              ctx,
-            ),
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: "",
+              newString: "",
+            },
+            "identical",
           )
+        }),
+      ),
+    )
+
+    it.live("throws error when path is directory", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const dirpath = path.join(dir, "adir")
+          yield* Effect.promise(() => fs.mkdir(dirpath))
+
+          yield* expectRunFailure(
+            {
+              filePath: dirpath,
+              oldString: "old",
+              newString: "new",
+            },
+            "directory",
+          )
+        }),
+      ),
+    )
+
+    it.live("tracks file diff statistics", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "line1\nline2\nline3", "utf-8"))
+
+          const result = yield* run({
+            filePath: filepath,
+            oldString: "line2",
+            newString: "new line a\nnew line b",
+          })
 
           expect(result.metadata.filediff).toBeDefined()
           expect(result.metadata.filediff.file).toBe(filepath)
           expect(result.metadata.filediff.additions).toBeGreaterThan(0)
-        },
-      })
-    })
+        }),
+      ),
+    )
   })
 
   describe("line endings", () => {
@@ -500,190 +416,184 @@ describe("tool.edit", () => {
       replaceAll?: boolean
     }
 
-    const apply = async (input: Input) => {
-      await using tmp = await tmpdir({
-        init: async (dir) => {
-          await Bun.write(path.join(dir, "test.txt"), input.content)
-        },
-      })
+    const apply = (input: Input) =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filePath = path.join(dir, "test.txt")
+          yield* Effect.promise(() => Bun.write(filePath, input.content))
+          yield* run({
+            filePath,
+            oldString: input.oldString,
+            newString: input.newString,
+            replaceAll: input.replaceAll,
+          })
+          return yield* Effect.promise(() => Bun.file(filePath).text())
+        }),
+      )
 
-      return await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-          const filePath = path.join(tmp.path, "test.txt")
-          await Effect.runPromise(
-            edit.execute(
-              {
-                filePath,
-                oldString: input.oldString,
-                newString: input.newString,
-                replaceAll: input.replaceAll,
-              },
-              ctx,
-            ),
-          )
-          return await Bun.file(filePath).text()
-        },
-      })
-    }
+    it.live("preserves LF with LF multi-line strings", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\n"),
+          newString: normalize(next, "\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\n"))
+        expectLf(output)
+      }),
+    )
 
-    test("preserves LF with LF multi-line strings", async () => {
-      const content = normalize(old + "\n", "\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\n"),
-        newString: normalize(next, "\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\n"))
-      expectLf(output)
-    })
+    it.live("preserves CRLF with CRLF multi-line strings", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\r\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\r\n"),
+          newString: normalize(next, "\r\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\r\n"))
+        expectCrlf(output)
+      }),
+    )
 
-    test("preserves CRLF with CRLF multi-line strings", async () => {
-      const content = normalize(old + "\n", "\r\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\r\n"),
-        newString: normalize(next, "\r\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\r\n"))
-      expectCrlf(output)
-    })
+    it.live("preserves LF when old/new use CRLF", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\r\n"),
+          newString: normalize(next, "\r\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\n"))
+        expectLf(output)
+      }),
+    )
 
-    test("preserves LF when old/new use CRLF", async () => {
-      const content = normalize(old + "\n", "\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\r\n"),
-        newString: normalize(next, "\r\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\n"))
-      expectLf(output)
-    })
+    it.live("preserves CRLF when old/new use LF", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\r\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\n"),
+          newString: normalize(next, "\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\r\n"))
+        expectCrlf(output)
+      }),
+    )
 
-    test("preserves CRLF when old/new use LF", async () => {
-      const content = normalize(old + "\n", "\r\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\n"),
-        newString: normalize(next, "\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\r\n"))
-      expectCrlf(output)
-    })
+    it.live("preserves LF when newString uses CRLF", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\n"),
+          newString: normalize(next, "\r\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\n"))
+        expectLf(output)
+      }),
+    )
 
-    test("preserves LF when newString uses CRLF", async () => {
-      const content = normalize(old + "\n", "\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\n"),
-        newString: normalize(next, "\r\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\n"))
-      expectLf(output)
-    })
+    it.live("preserves CRLF when newString uses LF", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\r\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(old, "\r\n"),
+          newString: normalize(next, "\n"),
+        })
+        expect(output).toBe(normalize(next + "\n", "\r\n"))
+        expectCrlf(output)
+      }),
+    )
 
-    test("preserves CRLF when newString uses LF", async () => {
-      const content = normalize(old + "\n", "\r\n")
-      const output = await apply({
-        content,
-        oldString: normalize(old, "\r\n"),
-        newString: normalize(next, "\n"),
-      })
-      expect(output).toBe(normalize(next + "\n", "\r\n"))
-      expectCrlf(output)
-    })
+    it.live("preserves LF with mixed old/new line endings", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\n")
+        const output = yield* apply({
+          content,
+          oldString: "alpha\nbeta\r\ngamma",
+          newString: "alpha\r\nbeta\nomega",
+        })
+        expect(output).toBe(normalize(alt + "\n", "\n"))
+        expectLf(output)
+      }),
+    )
 
-    test("preserves LF with mixed old/new line endings", async () => {
-      const content = normalize(old + "\n", "\n")
-      const output = await apply({
-        content,
-        oldString: "alpha\nbeta\r\ngamma",
-        newString: "alpha\r\nbeta\nomega",
-      })
-      expect(output).toBe(normalize(alt + "\n", "\n"))
-      expectLf(output)
-    })
+    it.live("preserves CRLF with mixed old/new line endings", () =>
+      Effect.gen(function* () {
+        const content = normalize(old + "\n", "\r\n")
+        const output = yield* apply({
+          content,
+          oldString: "alpha\r\nbeta\ngamma",
+          newString: "alpha\nbeta\r\nomega",
+        })
+        expect(output).toBe(normalize(alt + "\n", "\r\n"))
+        expectCrlf(output)
+      }),
+    )
 
-    test("preserves CRLF with mixed old/new line endings", async () => {
-      const content = normalize(old + "\n", "\r\n")
-      const output = await apply({
-        content,
-        oldString: "alpha\r\nbeta\ngamma",
-        newString: "alpha\nbeta\r\nomega",
-      })
-      expect(output).toBe(normalize(alt + "\n", "\r\n"))
-      expectCrlf(output)
-    })
+    it.live("replaceAll preserves LF for multi-line blocks", () =>
+      Effect.gen(function* () {
+        const blockOld = "alpha\nbeta"
+        const blockNew = "alpha\nbeta-updated"
+        const content = normalize(blockOld + "\n" + blockOld + "\n", "\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(blockOld, "\n"),
+          newString: normalize(blockNew, "\n"),
+          replaceAll: true,
+        })
+        expect(output).toBe(normalize(blockNew + "\n" + blockNew + "\n", "\n"))
+        expectLf(output)
+      }),
+    )
 
-    test("replaceAll preserves LF for multi-line blocks", async () => {
-      const blockOld = "alpha\nbeta"
-      const blockNew = "alpha\nbeta-updated"
-      const content = normalize(blockOld + "\n" + blockOld + "\n", "\n")
-      const output = await apply({
-        content,
-        oldString: normalize(blockOld, "\n"),
-        newString: normalize(blockNew, "\n"),
-        replaceAll: true,
-      })
-      expect(output).toBe(normalize(blockNew + "\n" + blockNew + "\n", "\n"))
-      expectLf(output)
-    })
-
-    test("replaceAll preserves CRLF for multi-line blocks", async () => {
-      const blockOld = "alpha\nbeta"
-      const blockNew = "alpha\nbeta-updated"
-      const content = normalize(blockOld + "\n" + blockOld + "\n", "\r\n")
-      const output = await apply({
-        content,
-        oldString: normalize(blockOld, "\r\n"),
-        newString: normalize(blockNew, "\r\n"),
-        replaceAll: true,
-      })
-      expect(output).toBe(normalize(blockNew + "\n" + blockNew + "\n", "\r\n"))
-      expectCrlf(output)
-    })
+    it.live("replaceAll preserves CRLF for multi-line blocks", () =>
+      Effect.gen(function* () {
+        const blockOld = "alpha\nbeta"
+        const blockNew = "alpha\nbeta-updated"
+        const content = normalize(blockOld + "\n" + blockOld + "\n", "\r\n")
+        const output = yield* apply({
+          content,
+          oldString: normalize(blockOld, "\r\n"),
+          newString: normalize(blockNew, "\r\n"),
+          replaceAll: true,
+        })
+        expect(output).toBe(normalize(blockNew + "\n" + blockNew + "\n", "\r\n"))
+        expectCrlf(output)
+      }),
+    )
   })
 
   describe("concurrent editing", () => {
-    test("serializes concurrent edits to same file", async () => {
-      await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "file.txt")
-      await fs.writeFile(filepath, "0", "utf-8")
+    it.live("serializes concurrent edits to same file", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "0", "utf-8"))
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const edit = await resolve()
-
-          // Two concurrent edits
-          const promise1 = Effect.runPromise(
-            edit.execute(
-              {
+          const results = yield* Effect.all(
+            [
+              run({
                 filePath: filepath,
                 oldString: "0",
                 newString: "1",
-              },
-              ctx,
-            ),
-          )
-
-          const promise2 = Effect.runPromise(
-            edit.execute(
-              {
+              }).pipe(Effect.exit),
+              run({
                 filePath: filepath,
                 oldString: "0",
                 newString: "2",
-              },
-              ctx,
-            ),
+              }).pipe(Effect.exit),
+            ],
+            { concurrency: 2 },
           )
 
-          // Both should complete without error (though one might fail due to content mismatch)
-          const results = await Promise.allSettled([promise1, promise2])
-          expect(results.some((r) => r.status === "fulfilled")).toBe(true)
-        },
-      })
-    })
+          expect(results.some((result) => Exit.isSuccess(result))).toBe(true)
+        }),
+      ),
+    )
   })
 })

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -591,7 +591,11 @@ describe("tool.edit", () => {
             { concurrency: 2 },
           )
 
-          expect(results.some((result) => Exit.isSuccess(result))).toBe(true)
+          expect(results.filter((result) => Exit.isSuccess(result))).toHaveLength(1)
+          expect(results.filter((result) => Exit.isFailure(result))).toHaveLength(1)
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(["1", "2"]).toContain(content)
         }),
       ),
     )


### PR DESCRIPTION
## Summary

- split required Linux unit CI into app, opencode, and desktop package jobs
- add a non-blocking Windows full unit-suite signal
- add workflow contract coverage for docs-only behavior, aggregate gating, pinned actions, per-package artifacts, and Windows non-blocking status
- stabilize the opencode unit tests from #121 and the workspace adaptor flaky surfaced by this PR CI
- make app contract tests line-ending agnostic for the Windows signal
- make desktop path assertions platform-native and remove real package-manager work from a config unit test
- cap the non-blocking Windows unit signal at 15 minutes

## Why

CI has been failing too often from a mix of broad unit jobs and known flaky tests. This keeps the required `ci / check` gate intact while making Linux unit failures easier to localize and adding Windows signal without blocking merges yet.

## Related Issue

Closes #121

## How To Verify

```bash
cd packages/opencode
bun test test/github/ci-workflow.test.ts
bun test --timeout 30000 test/config/seed-e2e.test.ts test/tool/edit.test.ts test/plugin/workspace-adaptor.test.ts

cd ../..
bun turbo test:ci --filter=@opencode-ai/app
bun turbo test:ci --filter=opencode
bun turbo test:ci --filter=@opencode-ai/desktop-electron
bun turbo typecheck
```

## Screenshots or Recordings

Not applicable, CI-only change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased test timeouts and stability; added helpers (deferred, timeout, polling), improved teardown via try/finally, normalized path/line-ending assertions, restored mocked spies, converted tests to effect-based style, and expanded CI workflow validations (action pinning, concurrency, docs-only detection, and per-platform unit job checks).

* **Chores**
  * Reorganized CI: split Linux unit jobs by target with install steps, refined Windows unit reporting/artifacts, and updated aggregate check to require all Linux unit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



