### PR TITLE
fix: normalize smoke inventory paths

### DIFF
--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -20,7 +20,17 @@ const expectedSmokeTests = [
   "packages/app/e2e/terminal/terminal-init.spec.ts:@smoke terminal mounts and can create a second tab",
 ]
 
+function normalizeSmokeInventoryPath(relative: string) {
+  return relative.replaceAll(path.win32.sep, path.posix.sep)
+}
+
 describe("e2e smoke tagging", () => {
+  test("normalizes Windows smoke inventory paths", () => {
+    expect(normalizeSmokeInventoryPath("packages\\app\\e2e\\settings\\settings.spec.ts")).toBe(
+      "packages/app/e2e/settings/settings.spec.ts",
+    )
+  })
+
   test("uses the expected @smoke inventory without legacy smoke titles", async () => {
     const legacy: string[] = []
     const tagged: string[] = []
@@ -30,7 +40,7 @@ describe("e2e smoke tagging", () => {
       absolute: true,
     })) {
       const text = await fs.readFile(file, "utf8")
-      const relative = path.relative(repoRoot, file)
+      const relative = normalizeSmokeInventoryPath(path.relative(repoRoot, file))
 
       for (const match of text.matchAll(/test(?:\.fixme)?\(\s*["']smoke\b/g)) {
         legacy.push(`${relative}:${match.index ?? 0}`)

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -20,13 +20,13 @@ const expectedSmokeTests = [
   "packages/app/e2e/terminal/terminal-init.spec.ts:@smoke terminal mounts and can create a second tab",
 ]
 
-function normalizeSmokeInventoryPath(relative: string) {
-  return relative.replaceAll(path.win32.sep, path.posix.sep)
+function normalizeSmokeInventoryPath(relative: string, separator = path.sep) {
+  return relative.replaceAll(separator, path.posix.sep)
 }
 
 describe("e2e smoke tagging", () => {
   test("normalizes Windows smoke inventory paths", () => {
-    expect(normalizeSmokeInventoryPath("packages\\app\\e2e\\settings\\settings.spec.ts")).toBe(
+    expect(normalizeSmokeInventoryPath("packages\\app\\e2e\\settings\\settings.spec.ts", path.win32.sep)).toBe(
       "packages/app/e2e/settings/settings.spec.ts",
     )
   })


### PR DESCRIPTION
## Summary

Normalize the generated smoke inventory file paths before comparing them with the expected POSIX-style snapshot, and add a regression test for Windows backslash paths.

## Why

The smoke inventory test builds entries from `path.relative(repoRoot, file)`. On Windows that returns backslash-separated paths, while the expected inventory uses slash-separated paths. This makes the Windows unit check fail even when the actual `@smoke` inventory is unchanged.

## Related Issue

No related issue. This is a small follow-up for a Windows-only test assertion exposed by CI.

## How To Verify

```bash
cd packages/opencode
bun test test/config/e2e-smoke-tagging.test.ts
bun run test:ci
cd ../..
bun turbo typecheck
bun turbo test:ci
```

## Screenshots or Recordings

Not applicable. Test-only change, no visible UI behavior.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cross-platform path normalization tests.

* **Chores**
  * Improved path consistency in smoke test inventory for better cross-platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->