### PR TITLE
fix: sync runtime import handling

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -21,6 +21,7 @@ import { zod } from "@/util/effect-zod"
 import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
+import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema, Types } from "effect"
 import { EffectBridge } from "@/effect"
 import { InstanceState } from "@/effect"
@@ -124,6 +125,10 @@ const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>
   "gitlab-ai-provider": () => import("gitlab-ai-provider").then((m) => m.createGitLab),
   "@ai-sdk/github-copilot": () => import("./sdk/copilot").then((m) => m.createOpenaiCompatible),
   "venice-ai-sdk-provider": () => import("venice-ai-sdk-provider").then((m) => m.createVenice),
+}
+
+export function localProviderImportSpec(input: string) {
+  return input.startsWith("file://") ? input : pathToFileURL(input).href
 }
 
 type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
@@ -1526,7 +1531,7 @@ const layer: Layer.Layer<
           installedPath = model.api.npm
         }
 
-        const mod = await import(installedPath)
+        const mod = await import(localProviderImportSpec(installedPath))
 
         const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
         const loaded = fn({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -50,6 +50,10 @@ import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { needsConfigDependencies, usesConfigDependencies } from "../config/dependency"
 
+export function localToolImportSpec(input: string) {
+  return input.startsWith("file://") ? input : pathToFileURL(input).href
+}
+
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
 
@@ -177,7 +181,7 @@ export namespace ToolRegistry {
               ...Permission.disabled(ids, rules),
             ])
             if (ids.length && ids.every((id) => disabled.has(id))) continue
-            const spec = process.platform === "win32" ? match : pathToFileURL(match).href
+            const spec = localToolImportSpec(match)
             const configDir = path.dirname(path.dirname(match))
             const usesDeps = yield* Effect.promise(() => usesConfigDependencies(match))
             if (usesDeps && depsFailed.has(configDir)) continue

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -8,6 +8,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
+import { localProviderImportSpec } from "../../src/provider/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "../../src/util/filesystem"
 import { Env } from "../../src/env"
@@ -1256,6 +1257,17 @@ test("provider with custom npm package", async () => {
       expect(providers[ProviderID.make("local-llm")].options.baseURL).toBe("http://localhost:11434/v1")
     },
   })
+})
+
+test("local provider import spec normalizes filesystem paths to file URLs", () => {
+  const providerPath = path.resolve("pawwork-provider", "index.js")
+  expect(localProviderImportSpec(providerPath)).toStartWith("file://")
+  expect(localProviderImportSpec(providerPath)).not.toBe(providerPath)
+  expect(localProviderImportSpec("file:///tmp/pawwork-provider/index.js")).toBe(
+    "file:///tmp/pawwork-provider/index.js",
+  )
+  expect(localProviderImportSpec("C:\\Users\\test\\provider.js")).toStartWith("file://")
+  expect(localProviderImportSpec("C:\\Users\\test\\provider.js")).not.toBe("C:\\Users\\test\\provider.js")
 })
 
 // Edge cases for model configuration

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "../fixture/fixture"
 import { writeMockConfigInstall } from "../shared/mock-npm-install"
 import { withConfigDepsLock } from "../shared/config-deps-lock"
 import { Instance } from "../../src/project/instance"
-import { ToolRegistry } from "../../src/tool/registry"
+import { localToolImportSpec, ToolRegistry } from "../../src/tool/registry"
 import { Npm } from "../../src/npm"
 
 afterEach(async () => {
@@ -91,6 +91,15 @@ describe("tool.registry", () => {
         expect(ids).toContain("hello")
       },
     })
+  })
+
+  test("local tool import spec normalizes filesystem paths to file URLs", () => {
+    const toolPath = path.resolve("pawwork-tools", "marked.ts")
+    expect(localToolImportSpec(toolPath)).toStartWith("file://")
+    expect(localToolImportSpec(toolPath)).not.toBe(toolPath)
+    expect(localToolImportSpec("C:\\Users\\test\\tool.ts")).toStartWith("file://")
+    expect(localToolImportSpec("C:\\Users\\test\\tool.ts")).not.toBe("C:\\Users\\test\\tool.ts")
+    expect(localToolImportSpec("file:///tmp/tool.ts")).toBe("file:///tmp/tool.ts")
   })
 
   test("loads tools with external dependencies without crashing", async () => {


### PR DESCRIPTION
## Summary
Sync the #92 Runtime Resource lane slice for upstream `92c005866`, normalizing local provider and local tool dynamic imports through `file://` URLs.

## Why
Part of #92. Upstream `v1.14.20` fixes local dynamic imports on Windows and Node because Node rejects raw Windows filesystem paths in dynamic `import()`. PawWork needs this for Windows plugin and tool loading reliability.

## Related Issue
Part of #92.

## How To Verify

```bash
(cd packages/opencode && bun test test/provider/provider.test.ts -t "custom provider with npm package|local provider import spec normalizes filesystem paths to file URLs")
(cd packages/opencode && bun test test/tool/registry.test.ts -t "loads tools from .opencode/tool|loads tools from .opencode/tools|local tool import spec normalizes filesystem paths to file URLs")
(cd packages/opencode && bun test test/provider/provider.test.ts test/tool/registry.test.ts)
(cd packages/opencode && bun run typecheck)
git diff --check origin/dev...HEAD
rg -n 'import\(installedPath\)|process\.platform === "win32" \? match' packages/opencode/src/provider/provider.ts packages/opencode/src/tool/registry.ts
```

Expected for the final `rg` command: no output.

## Screenshots or Recordings
Not applicable. No UI changes.

## Checklist
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English