### PR TITLE
ci: split Windows unit signal by package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,14 +343,30 @@ jobs:
           path: packages/desktop-electron/.artifacts/unit/junit.xml
 
   unit-windows:
+    name: unit-windows-${{ matrix.package }}
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
-    timeout-minutes: 15
+    # Windows unit jobs are advisory and package-scoped. The 20-minute budget
+    # gives each matrix child room for Windows runner setup and install overhead
+    # while still surfacing the package that timed out.
+    timeout-minutes: 20
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: app
+            command: bun turbo test:ci --filter=@opencode-ai/app
+            report_path: packages/app/.artifacts/unit/junit.xml
+          - package: opencode
+            command: bun turbo test:ci --filter=opencode
+            report_path: packages/opencode/.artifacts/unit/junit.xml
+          - package: desktop
+            command: bun turbo test:ci --filter=@opencode-ai/desktop-electron
+            report_path: packages/desktop-electron/.artifacts/unit/junit.xml
     permissions:
       contents: read
-      checks: write
     defaults:
       run:
         shell: bash
@@ -382,45 +398,50 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: .turbo/cache
-          key: turbo-${{ runner.os }}-unit-windows-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
+          # Keep Turbo caches package-scoped because each matrix child runs a
+          # different test filter; restore keys reuse only that package's cache.
+          key: turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-unit-windows-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
-            turbo-${{ runner.os }}-unit-windows-
+            turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
+            turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-
 
       - run: bun install --frozen-lockfile
 
       - name: unit
-        run: bun turbo test:ci
+        id: unit
+        continue-on-error: true
+        run: |
+          set +e
+          ${{ matrix.command }}
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
 
-      - name: Publish unit reports
-        if: >
-          always() &&
-          (
-            github.event_name != 'pull_request' ||
-            github.event.pull_request.head.repo.full_name == github.repository
-          )
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # mikepenz/action-junit-report@v6
-        with:
-          report_paths: packages/**/.artifacts/unit/junit.xml
-          check_name: unit results (windows)
-          detailed_summary: true
-          include_time_in_summary: true
-          fail_on_failure: false
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "### Windows unit diagnostic"
+              echo ""
+              echo "- package: ${{ matrix.package }}"
+              echo "- exit code: $status"
+              echo "- status: failed advisory signal"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$status"
 
       - name: Upload unit artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
-          name: unit-windows-${{ github.run_attempt }}
+          name: unit-windows-${{ matrix.package }}-${{ github.run_attempt }}
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
-          path: packages/**/.artifacts/unit/junit.xml
+          path: ${{ matrix.report_path }}
 
   # Aggregator for the `dev` branch ruleset. The required check on GitHub
   # is `ci / check`; every new blocking job added above MUST be listed in
   # `needs:` below, otherwise its failure will not block merge. Non-blocking
-  # signal jobs, such as `unit-windows`, intentionally stay outside this list.
+  # signal jobs, such as `unit-windows-*`, intentionally stay outside this list.
   # If the blocking list grows past ~5 entries, consider switching to
   # `re-actors/alls-green` for dynamic aggregation (tracked in issue #54).
   check:

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -14,6 +14,42 @@ const pinned = {
   artifact: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
 }
 
+const runAttempt = "${{ github.run_attempt }}"
+const windowsUnitJobName = "unit-windows"
+
+// Suffixes drive readable job and artifact names; commands use package.json names verbatim.
+// `opencode` is intentionally unscoped because that is its actual package name.
+const unitPackages = [
+  {
+    suffix: "app",
+    command: "bun turbo test:ci --filter=@opencode-ai/app",
+    reportPath: "packages/app/.artifacts/unit/junit.xml",
+  },
+  {
+    suffix: "opencode",
+    command: "bun turbo test:ci --filter=opencode",
+    reportPath: "packages/opencode/.artifacts/unit/junit.xml",
+  },
+  {
+    suffix: "desktop",
+    command: "bun turbo test:ci --filter=@opencode-ai/desktop-electron",
+    reportPath: "packages/desktop-electron/.artifacts/unit/junit.xml",
+  },
+] as const
+
+const linuxUnitJobs = unitPackages.map((pkg) => ({
+  ...pkg,
+  jobName: `unit-${pkg.suffix}`,
+  checkName: `unit results (${pkg.suffix})`,
+  artifactName: `unit-${pkg.suffix}-${runAttempt}`,
+}))
+
+const windowsUnitJobs = unitPackages.map((pkg) => ({
+  ...pkg,
+  jobName: `unit-windows-${pkg.suffix}`,
+  artifactName: `unit-windows-${pkg.suffix}-${runAttempt}`,
+}))
+
 function steps(job: string) {
   const parsed = parseWorkflow(workflowPath)
   return parsed.jobs?.[job]?.steps ?? []
@@ -35,14 +71,17 @@ describe("ci workflow", () => {
     expect(parsed.name).toBe("ci")
     expect(parsed.permissions).toEqual({ contents: "read" })
 
-    for (const job of ["changes", "typecheck", "unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+    const linuxUnitJobNames = linuxUnitJobs.map((job) => job.jobName)
+    const setupUnitJobNames = [...linuxUnitJobNames, windowsUnitJobName]
+
+    for (const job of ["changes", "typecheck", ...setupUnitJobNames]) {
       expect(checkoutStep(job)?.uses).toBe(pinned.checkout)
       expect(checkoutStep(job)?.with?.["persist-credentials"]).toBe(false)
     }
 
     expect(checkoutStep("changes")?.with?.["fetch-depth"]).toBe(0)
 
-    for (const job of ["typecheck", "unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+    for (const job of ["typecheck", ...setupUnitJobNames]) {
       expect(steps(job).find((step) => step.uses?.startsWith("actions/setup-node@"))?.uses).toBe(pinned.setupNode)
       expect(steps(job).find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))?.uses).toBe(pinned.setupBun)
       expect(steps(job).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual([
@@ -51,8 +90,13 @@ describe("ci workflow", () => {
       ])
     }
 
-    for (const job of ["unit-app", "unit-opencode", "unit-desktop", "unit-windows"]) {
+    for (const job of linuxUnitJobNames) {
       expect(stepByName(job, "Publish unit reports")?.uses).toBe(pinned.junit)
+    }
+
+    expect(stepByName(windowsUnitJobName, "Publish unit reports")).toBeUndefined()
+
+    for (const job of [...linuxUnitJobNames, windowsUnitJobName]) {
       expect(stepByName(job, "Upload unit artifacts")?.uses).toBe(pinned.artifact)
     }
 
@@ -87,37 +131,15 @@ describe("ci workflow", () => {
 
   test("splits required Linux unit jobs by package while preserving Turbo dependency semantics", () => {
     const parsed = parseWorkflow(workflowPath)
-    const linuxUnitJobs = [
-      [
-        "unit-app",
-        "bun turbo test:ci --filter=@opencode-ai/app",
-        "packages/app/.artifacts/unit/junit.xml",
-        "unit results (app)",
-        "unit-app-${{ github.run_attempt }}",
-      ],
-      [
-        "unit-opencode",
-        "bun turbo test:ci --filter=opencode",
-        "packages/opencode/.artifacts/unit/junit.xml",
-        "unit results (opencode)",
-        "unit-opencode-${{ github.run_attempt }}",
-      ],
-      [
-        "unit-desktop",
-        "bun turbo test:ci --filter=@opencode-ai/desktop-electron",
-        "packages/desktop-electron/.artifacts/unit/junit.xml",
-        "unit results (desktop)",
-        "unit-desktop-${{ github.run_attempt }}",
-      ],
-    ] as const
 
-    for (const [jobName, command, reportPath, checkName, artifactName] of linuxUnitJobs) {
+    for (const { jobName, command, reportPath, checkName, artifactName } of linuxUnitJobs) {
       const job = parsed.jobs?.[jobName]
       expect(job?.needs).toBe("changes")
       expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
       expect(job?.["runs-on"]).toBe("ubuntu-latest")
       expect(job?.["timeout-minutes"]).toBe(30)
       expect(job?.permissions).toEqual({ contents: "read", checks: "write" })
+      expect(job?.defaults?.run?.shell).toBeUndefined()
       expect(stepByName(jobName, "unit")?.run).toBe(command)
       expect(stepByName(jobName, "Publish unit reports")?.with?.report_paths).toBe(reportPath)
       expect(stepByName(jobName, "Publish unit reports")?.with?.check_name).toBe(checkName)
@@ -126,26 +148,54 @@ describe("ci workflow", () => {
     }
   })
 
-  test("keeps Windows unit as a non-blocking full-suite signal", () => {
+  test("splits Windows unit signals by package without publishing advisory check runs", () => {
     const parsed = parseWorkflow(workflowPath)
-    const job = parsed.jobs?.["unit-windows"]
+    const job = parsed.jobs?.[windowsUnitJobName]
+    const matrixIncludes = job?.strategy?.matrix?.include ?? []
 
-    expect(job?.["runs-on"]).toBe("windows-latest")
-    expect(job?.["timeout-minutes"]).toBe(15)
-    expect(job?.["continue-on-error"]).toBe(true)
+    expect(job?.name).toBe("unit-windows-${{ matrix.package }}")
     expect(job?.needs).toBe("changes")
     expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
-    expect(stepByName("unit-windows", "unit")?.run).toBe("bun turbo test:ci")
-    expect(stepByName("unit-windows", "Publish unit reports")?.with?.report_paths).toBe(
-      "packages/**/.artifacts/unit/junit.xml",
+    expect(job?.["runs-on"]).toBe("windows-latest")
+    expect(job?.["timeout-minutes"]).toBe(20)
+    expect(job?.["continue-on-error"]).toBe(true)
+    expect(job?.strategy?.["fail-fast"]).toBe(false)
+    expect(job?.permissions).toEqual({ contents: "read" })
+    expect(job?.defaults?.run?.shell).toBe("bash")
+    expect(stepByName(windowsUnitJobName, "unit")?.id).toBe("unit")
+    expect(stepByName(windowsUnitJobName, "unit")?.["continue-on-error"]).toBe(true)
+    expect(stepByName(windowsUnitJobName, "unit")?.run).toContain("${{ matrix.command }}")
+    expect(stepByName(windowsUnitJobName, "unit")?.run).toContain('echo "exit_code=$status" >> "$GITHUB_OUTPUT"')
+    expect(stepByName(windowsUnitJobName, "unit")?.run).toContain("### Windows unit diagnostic")
+    expect(stepByName(windowsUnitJobName, "unit")?.run).toContain("failed advisory signal")
+    expect(stepByName(windowsUnitJobName, "Publish unit reports")).toBeUndefined()
+    expect(stepByName(windowsUnitJobName, "Upload unit artifacts")?.uses).toBe(pinned.artifact)
+    expect(stepByName(windowsUnitJobName, "Upload unit artifacts")?.with?.name).toBe(
+      "unit-windows-${{ matrix.package }}-${{ github.run_attempt }}",
     )
-    expect(stepByName("unit-windows", "Publish unit reports")?.with?.check_name).toBe("unit results (windows)")
-    expect(stepByName("unit-windows", "Upload unit artifacts")?.with?.name).toBe(
-      "unit-windows-${{ github.run_attempt }}",
+    expect(stepByName(windowsUnitJobName, "Upload unit artifacts")?.with?.path).toBe("${{ matrix.report_path }}")
+
+    const turboCacheStep = steps(windowsUnitJobName).filter((step) => step.uses?.startsWith("actions/cache@"))[1]
+    expect(turboCacheStep?.with?.key).toBe(
+      "turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-${{ github.sha }}",
     )
-    expect(stepByName("unit-windows", "Upload unit artifacts")?.with?.path).toBe(
-      "packages/**/.artifacts/unit/junit.xml",
+    expect(turboCacheStep?.with?.["restore-keys"]).toBe(
+      "turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-\n" +
+        "turbo-${{ runner.os }}-unit-windows-${{ matrix.package }}-\n",
     )
+
+    expect(matrixIncludes).toEqual(
+      windowsUnitJobs.map(({ jobName, command, reportPath }) => ({
+        package: jobName.replace("unit-windows-", ""),
+        command,
+        report_path: reportPath,
+      })),
+    )
+
+    for (const { jobName, command, reportPath, artifactName } of windowsUnitJobs) {
+      expect(parsed.jobs?.[jobName]).toBeUndefined()
+      expect(artifactName).toBe(`unit-windows-${jobName.replace("unit-windows-", "")}-${runAttempt}`)
+    }
   })
 
   test("keeps docs-only behavior and excludes Windows from the blocking aggregate", () => {
@@ -157,6 +207,9 @@ describe("ci workflow", () => {
     expect(check?.if).toBe("always()")
     expect(needs).toEqual(["changes", "typecheck", "unit-app", "unit-opencode", "unit-desktop"])
     expect(needs).not.toContain("unit-windows")
+    expect(needs).not.toContain("unit-windows-app")
+    expect(needs).not.toContain("unit-windows-desktop")
+    expect(needs).not.toContain("unit-windows-opencode")
     expect(validate?.env?.DOCS_ONLY).toBe("${{ needs.changes.outputs.docs_only }}")
     expect(validate?.env?.TYPECHECK_RESULT).toBe("${{ needs.typecheck.result }}")
     expect(validate?.env?.UNIT_APP_RESULT).toBe("${{ needs['unit-app'].result }}")

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -3,6 +3,7 @@ import fs from "node:fs"
 
 /** Parsed subset of a workflow step used by workflow contract tests. */
 export type WorkflowStep = {
+  "continue-on-error"?: boolean
   id?: string
   if?: string
   name?: string
@@ -16,12 +17,25 @@ export type WorkflowStep = {
 /** Parsed subset of a workflow job used by workflow contract tests. */
 export type WorkflowJob = {
   "continue-on-error"?: boolean
+  /** Minimal `defaults.run` subset; add fields only when contract tests assert them. */
+  defaults?: {
+    run?: {
+      shell?: string
+    }
+  }
   if?: string
+  name?: string
   needs?: string | string[]
   "runs-on"?: string
   outputs?: Record<string, string>
   permissions?: Record<string, string>
   steps?: WorkflowStep[]
+  strategy?: {
+    "fail-fast"?: boolean
+    matrix?: {
+      include?: Record<string, unknown>[]
+    }
+  }
   "timeout-minutes"?: number
 }
 


### PR DESCRIPTION
## Summary

- split the advisory Windows unit signal into app, desktop, and opencode jobs
- keep Windows package jobs outside the required `ci / check` aggregate
- stop publishing separate failing Windows JUnit report checks while preserving package artifacts

## Why

The previous `unit-windows` job ran the full unit suite in one advisory Windows job. A timeout or flaky failure in one package made the whole Windows signal noisy and hard to diagnose. Issue #137 scopes this to package-level Windows signals while keeping the required Linux gate unchanged.

## Related Issue

Closes #137

## How To Verify

```bash
bun --cwd packages/opencode test test/github/ci-workflow.test.ts
actionlint .github/workflows/ci.yml
git diff --check
```

## Screenshots or Recordings

Not applicable, CI-only change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured Windows CI testing pipeline to separate and run package-specific test suites independently, improving test isolation, artifact organization, and execution efficiency.
  * Enhanced test infrastructure with improved configuration patterns and dynamic job generation for better maintainability, scalability, and test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->