### PR TITLE
refactor: sync session runtime lane

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -255,7 +255,7 @@ const InfoSchema = Schema.Struct({
         description: "Enable automatic compaction when context is full (default: true)",
       }),
       prune: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable pruning of old tool outputs (default: true)",
+        description: "Prune old tool outputs (default: `false`). Set `true` to enable.",
       }),
       tail_turns: Schema.optional(NonNegativeInt).annotate({
         description:

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -2,7 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import * as Session from "./session"
 import { SessionID, MessageID, PartID } from "./schema"
-import { Provider } from "../provider"
+import { Provider, ProviderTransform } from "../provider"
 import { MessageV2 } from "./message-v2"
 import z from "zod"
 import { Token } from "../util/token"
@@ -32,6 +32,12 @@ export const Event = {
 export const PRUNE_MINIMUM = 20_000
 export const PRUNE_PROTECT = 40_000
 const PRUNE_PROTECTED_TOOLS = ["skill"]
+// Keep the last exchange pair by default so a resumed session keeps the active request
+// and response intact. The token floor handles small contexts, while the ceiling keeps
+// retained text from crowding out the generated summary on larger models.
+const DEFAULT_TAIL_TURNS = 2
+const MIN_TAIL_TOKENS = 2_000
+const MAX_TAIL_TOKENS = 8_000
 export const CreateInput = z.object({
   sessionID: SessionID.zod,
   agent: z.string(),
@@ -67,6 +73,20 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionCompaction") {}
 
+function usable(input: { cfg: Config.Info; model: Provider.Model }) {
+  const reserved = input.cfg.compaction?.reserved ?? Math.min(20_000, ProviderTransform.maxOutputTokens(input.model))
+  return input.model.limit.input
+    ? Math.max(0, input.model.limit.input - reserved)
+    : Math.max(0, input.model.limit.context - ProviderTransform.maxOutputTokens(input.model))
+}
+
+function tailBudget(input: { cfg: Config.Info; model: Provider.Model }) {
+  return (
+    input.cfg.compaction?.preserve_recent_tokens ??
+    Math.min(MAX_TAIL_TOKENS, Math.max(MIN_TAIL_TOKENS, Math.floor(usable(input) * 0.25)))
+  )
+}
+
 export const layer: Layer.Layer<
   Service,
   never,
@@ -93,6 +113,61 @@ export const layer: Layer.Layer<
       model: Provider.Model
     }) {
       return overflow({ cfg: yield* config.get(), tokens: input.tokens, model: input.model })
+    })
+
+    const estimate = Effect.fn("SessionCompaction.estimate")(function* (input: {
+      messages: MessageV2.WithParts[]
+      model: Provider.Model
+    }) {
+      const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, input.model, { stripMedia: true })
+      // JSON adds structural overhead, so this intentionally overestimates instead of risking overflow.
+      return Token.estimate(JSON.stringify(msgs))
+    })
+
+    const select = Effect.fn("SessionCompaction.select")(function* (input: {
+      messages: MessageV2.WithParts[]
+      cfg: Config.Info
+      model: Provider.Model
+    }) {
+      const limit = input.cfg.compaction?.tail_turns ?? DEFAULT_TAIL_TURNS
+      if (limit <= 0) return { head: input.messages, tail_start_id: undefined }
+      const budget = tailBudget({ cfg: input.cfg, model: input.model })
+      const userStarts = input.messages.flatMap((msg, idx) => (msg.info.role === "user" ? [idx] : []))
+      const turns = input.messages.flatMap((msg, idx) =>
+        msg.info.role === "user" && !msg.parts.some((part) => part.type === "compaction") ? [idx] : [],
+      )
+      if (!turns.length) return { head: input.messages, tail_start_id: undefined }
+
+      let total = 0
+      let start = input.messages.length
+      let kept = 0
+
+      for (let i = turns.length - 1; i >= 0 && kept < limit; i--) {
+        const idx = turns[i]
+        const userIdx = userStarts.indexOf(idx)
+        const end = userIdx >= 0 && userIdx + 1 < userStarts.length ? userStarts[userIdx + 1] : input.messages.length
+        const size = yield* estimate({
+          messages: input.messages.slice(idx, end),
+          model: input.model,
+        })
+        if (kept === 0 && size > budget) {
+          // The latest turn must stay intact or be summarized with the rest.
+          // Keeping a partial turn would separate tool calls from their prompt.
+          log.info("tail fallback", { budget, size })
+          return { head: input.messages, tail_start_id: undefined }
+        }
+        if (total + size > budget) break
+        total += size
+        start = idx
+        kept++
+      }
+
+      // If the tail starts at the first message, there is no older head to summarize.
+      if (kept === 0 || start === 0) return { head: input.messages, tail_start_id: undefined }
+      return {
+        head: input.messages.slice(0, start),
+        tail_start_id: input.messages[start]?.info.id,
+      }
     })
 
     // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
@@ -157,6 +232,7 @@ export const layer: Layer.Layer<
         throw new Error(`Compaction parent must be a user message: ${input.parentID}`)
       }
       const userMessage = parent.info
+      const compactionPart = parent.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
 
       let messages = input.messages
       let replay:
@@ -187,6 +263,15 @@ export const layer: Layer.Layer<
       const model = agent.model
         ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)
         : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
+      const cfg = yield* config.get()
+      // Drop the new compaction marker itself; otherwise it appears in the final turn's
+      // slice and inflates the retained-tail token estimate.
+      const history = compactionPart ? messages.filter((message) => message.info.id !== input.parentID) : messages
+      const selected = yield* select({
+        messages: history,
+        cfg,
+        model,
+      })
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
@@ -224,7 +309,7 @@ When constructing the summary, try to stick to this template:
 ---`
 
       const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
-      const msgs = structuredClone(messages)
+      const msgs = structuredClone(selected.head)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
       const ctx = yield* InstanceState.context
@@ -285,6 +370,14 @@ When constructing the summary, try to stick to this template:
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
         return "stop"
+      }
+
+      if (compactionPart && compactionPart.tail_start_id !== selected.tail_start_id) {
+        // Repeated compactions can move the retained-tail boundary forward as older turns accumulate.
+        yield* session.updatePart({
+          ...compactionPart,
+          tail_start_id: selected.tail_start_id,
+        })
       }
 
       if (result === "continue" && input.auto) {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -173,7 +173,7 @@ export const layer: Layer.Layer<
     // calls, then erases output of older tool calls to free context space
     const prune = Effect.fn("SessionCompaction.prune")(function* (input: { sessionID: SessionID }) {
       const cfg = yield* config.get()
-      if (cfg.compaction?.prune === false) return
+      if (cfg.compaction?.prune !== true) return
       log.info("pruning")
 
       const msgs = yield* session

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -75,9 +75,8 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 
 function usable(input: { cfg: Config.Info; model: Provider.Model }) {
   const reserved = input.cfg.compaction?.reserved ?? Math.min(20_000, ProviderTransform.maxOutputTokens(input.model))
-  return input.model.limit.input
-    ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, input.model.limit.context - ProviderTransform.maxOutputTokens(input.model))
+  const base = input.model.limit.input ?? input.model.limit.context
+  return Math.max(0, base - reserved)
 }
 
 function tailBudget(input: { cfg: Config.Info; model: Provider.Model }) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -210,6 +210,9 @@ export const CompactionPart = PartBase.extend({
   type: z.literal("compaction"),
   auto: z.boolean(),
   overflow: z.boolean().optional(),
+  tail_start_id: MessageID.zod
+    .describe("Message ID of the first retained message kept verbatim after compaction.")
+    .optional(),
 }).meta({
   ref: "CompactionPart",
 })
@@ -926,14 +929,26 @@ export function get(input: { sessionID: SessionID; messageID: MessageID }): With
 export function filterCompacted(msgs: Iterable<WithParts>) {
   const result = [] as WithParts[]
   const completed = new Set<string>()
+  let tailStartID: MessageID | undefined
+  // Read newest to oldest. The first tail marker wins, even before its summary finishes.
   for (const msg of msgs) {
     result.push(msg)
-    if (msg.info.role === "user" && completed.has(msg.info.id) && msg.parts.some((part) => part.type === "compaction"))
+    const compactionPart = msg.parts.find((part): part is CompactionPart => part.type === "compaction")
+    tailStartID ??= compactionPart?.tail_start_id
+    if (tailStartID && msg.info.id === tailStartID) break
+    if (msg.info.role === "user" && completed.has(msg.info.id) && compactionPart) {
+      if (tailStartID) continue
       break
+    }
     if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
       completed.add(msg.info.parentID)
   }
   result.reverse()
+  if (tailStartID) {
+    // After reversing to chronological order, drop everything before the retained tail.
+    const idx = result.findIndex((msg) => msg.info.id === tailStartID)
+    if (idx >= 0) return result.slice(idx)
+  }
   return result
 }
 

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -15,8 +15,6 @@ export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistan
 
   const reserved =
     input.cfg.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))
-  const usable = input.model.limit.input
-    ? input.model.limit.input - reserved
-    : context - ProviderTransform.maxOutputTokens(input.model)
+  const usable = Math.max(0, (input.model.limit.input ?? context) - reserved)
   return count >= usable
 }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -258,7 +258,8 @@ export const Event = {
     "session.error",
     z.object({
       sessionID: SessionID.zod.optional(),
-      error: MessageV2.Assistant.shape.error,
+      // z.lazy avoids eager access to MessageV2.Assistant while session.ts is still initializing.
+      error: z.lazy(() => MessageV2.Assistant.shape.error),
     }),
   ),
 }

--- a/packages/opencode/src/v2/session-entry.ts
+++ b/packages/opencode/src/v2/session-entry.ts
@@ -96,6 +96,29 @@ export namespace SessionEntry {
     text: Schema.String,
   }) {}
 
+  export class AssistantRetry extends Schema.Class<AssistantRetry>("Session.Entry.Assistant.Retry")({
+    attempt: Schema.Number,
+    error: SessionEvent.RetryError,
+    time: Schema.Struct({
+      created: Schema.DateTimeUtc,
+    }),
+  }) {
+    static fromEvent(event: SessionEvent.Retried) {
+      const error =
+        typeof event.error === "string"
+          // Legacy retry events stored only the message, so retryability cannot be recovered.
+          ? new SessionEvent.RetryError({ message: event.error, isRetryable: true })
+          : event.error
+      return new AssistantRetry({
+        attempt: event.attempt ?? 0,
+        error,
+        time: {
+          created: event.timestamp,
+        },
+      })
+    }
+  }
+
   export const AssistantContent = Schema.Union([AssistantText, AssistantReasoning, AssistantTool])
   export type AssistantContent = Schema.Schema.Type<typeof AssistantContent>
 
@@ -103,6 +126,7 @@ export namespace SessionEntry {
     ...Base,
     type: Schema.Literal("assistant"),
     content: AssistantContent.pipe(Schema.Array),
+    retries: AssistantRetry.pipe(Schema.Array, Schema.optional),
     cost: Schema.Number.pipe(Schema.optional),
     tokens: Schema.Struct({
       input: Schema.Number,
@@ -280,6 +304,11 @@ export namespace SessionEntry {
         if (!pendingAssistant) break
         const match = lastReasoning(pendingAssistant)
         if (match) match.text = event.text
+        break
+      }
+      case "retried": {
+        if (!pendingAssistant) break
+        pendingAssistant.retries = [...(pendingAssistant.retries ?? []), AssistantRetry.fromEvent(event)]
         break
       }
       case "step.ended": {

--- a/packages/opencode/src/v2/session-entry.ts
+++ b/packages/opencode/src/v2/session-entry.ts
@@ -146,8 +146,12 @@ export namespace SessionEntry {
     )
     const lastText = (assistant: Mutable<Assistant>) =>
       assistant.content.findLast((x: Mutable<AssistantContent>): x is Mutable<AssistantText> => x.type === "text")
-    const lastTool = (assistant: Mutable<Assistant>) =>
-      assistant.content.findLast((x: Mutable<AssistantContent>): x is Mutable<AssistantTool> => x.type === "tool")
+    // Tool events can interleave, so state updates must target the matching call.
+    const lastTool = (assistant: Mutable<Assistant>, callID: string) =>
+      assistant.content.findLast(
+        (x: Mutable<AssistantContent>): x is Mutable<AssistantTool> =>
+          x.type === "tool" && x.callID === callID,
+      )
     const lastReasoning = (assistant: Mutable<Assistant>) =>
       assistant.content.findLast(
         (x: Mutable<AssistantContent>): x is Mutable<AssistantReasoning> => x.type === "reasoning",
@@ -211,7 +215,7 @@ export namespace SessionEntry {
       }
       case "tool.input.delta": {
         if (!pendingAssistant) break
-        const match = lastTool(pendingAssistant)
+        const match = lastTool(pendingAssistant, event.callID)
         if (match && match.state.status === "pending") match.state.input += event.delta
         break
       }
@@ -220,7 +224,7 @@ export namespace SessionEntry {
       }
       case "tool.called": {
         if (!pendingAssistant) break
-        const match = lastTool(pendingAssistant)
+        const match = lastTool(pendingAssistant, event.callID)
         if (match) {
           match.time.ran = event.timestamp
           match.state = {
@@ -232,7 +236,7 @@ export namespace SessionEntry {
       }
       case "tool.success": {
         if (!pendingAssistant) break
-        const match = lastTool(pendingAssistant)
+        const match = lastTool(pendingAssistant, event.callID)
         if (match && match.state.status === "running") {
           match.state = {
             status: "completed",
@@ -247,7 +251,7 @@ export namespace SessionEntry {
       }
       case "tool.error": {
         if (!pendingAssistant) break
-        const match = lastTool(pendingAssistant)
+        const match = lastTool(pendingAssistant, event.callID)
         if (match && match.state.status === "running") {
           match.state = {
             status: "error",

--- a/packages/opencode/src/v2/session-event.ts
+++ b/packages/opencode/src/v2/session-event.ts
@@ -49,6 +49,17 @@ export namespace SessionEvent {
     source: Source.pipe(Schema.optional),
   }) {}
 
+  export class RetryError extends Schema.Class<RetryError>("Session.Event.Retry.Error")({
+    message: Schema.String,
+    statusCode: Schema.Number.pipe(Schema.optional),
+    isRetryable: Schema.Boolean,
+    responseHeaders: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
+    responseBody: Schema.String.pipe(Schema.optional),
+    metadata: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
+  }) {}
+  // Accept legacy string errors while new retry events carry structured context.
+  const RetryEventError = Schema.Union([RetryError, Schema.String])
+
   export class Prompt extends Schema.Class<Prompt>("Session.Event.Prompt")({
     ...Base,
     type: Schema.Literal("prompt"),
@@ -382,14 +393,16 @@ export namespace SessionEvent {
   export class Retried extends Schema.Class<Retried>("Session.Event.Retried")({
     ...Base,
     type: Schema.Literal("retried"),
-    error: Schema.String,
+    attempt: Schema.Number.pipe(Schema.optional),
+    error: RetryEventError,
   }) {
-    static create(input: BaseInput & { error: string }) {
+    static create(input: BaseInput & { attempt?: number; error: RetryError | string }) {
       return new Retried({
         id: input.id ?? ID.create(),
         type: "retried",
         timestamp: input.timestamp ?? DateTime.makeUnsafe(Date.now()),
         metadata: input.metadata,
+        ...(input.attempt !== undefined ? { attempt: input.attempt } : {}),
         error: input.error,
       })
     }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -540,6 +540,23 @@ describe("session.compaction.isOverflow", () => {
     ),
   )
 
+  it.live(
+    "respects reserved override without input caps",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const compact = yield* SessionCompaction.Service
+          const model = createModel({ context: 100_000, output: 10_000 })
+          const tokens = { input: 45_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
+          expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
+        }),
+      {
+        config: {
+          compaction: { reserved: 50_000 },
+        },
+      },
+    ),
+  )
 })
 
 describe("session.compaction.create", () => {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -593,7 +593,7 @@ describe("session.compaction.create", () => {
 
 describe("session.compaction.prune", () => {
   it.live(
-    "compacts old completed tool output",
+    "keeps old completed tool output by default",
     provideTmpdirInstance((dir) =>
       Effect.gen(function* () {
         const compact = yield* SessionCompaction.Service
@@ -676,9 +676,97 @@ describe("session.compaction.prune", () => {
         expect(part?.type).toBe("tool")
         expect(part?.state.status).toBe("completed")
         if (part?.type === "tool" && part.state.status === "completed") {
-          expect(part.state.time.compacted).toBeNumber()
+          expect(part.state.time.compacted).toBeUndefined()
         }
       }),
+    ),
+  )
+
+  it.live(
+    "compacts old completed tool output when prune is explicitly enabled",
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const first = yield* ssn.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          time: { created: Date.now() },
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: first.id,
+          sessionID: session.id,
+          type: "text",
+          text: "run a large tool",
+        })
+        const response = yield* ssn.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: dir, root: dir },
+          cost: 0,
+          tokens: {
+            output: 0,
+            input: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          parentID: first.id,
+          time: { created: Date.now() },
+          finish: "end_turn",
+        })
+        const part = yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: response.id,
+          sessionID: session.id,
+          type: "tool",
+          callID: crypto.randomUUID(),
+          tool: "bash",
+          state: {
+            status: "completed",
+            input: {},
+            output: "x".repeat(200_000),
+            title: "done",
+            metadata: {},
+            time: { start: Date.now(), end: Date.now() },
+          },
+        })
+        for (const text of ["second", "third"]) {
+          const msg = yield* ssn.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: session.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          yield* ssn.updatePart({
+            id: PartID.ascending(),
+            messageID: msg.id,
+            sessionID: session.id,
+            type: "text",
+            text,
+          })
+        }
+
+        yield* compact.prune({ sessionID: session.id })
+
+        const messages = yield* ssn.messages({ sessionID: session.id })
+        const updated = messages.flatMap((message) => message.parts).find((candidate) => candidate.id === part.id)
+        expect(updated?.type).toBe("tool")
+        if (updated?.type !== "tool" || updated.state.status !== "completed") return
+        expect(updated.state.time.compacted).toBeNumber()
+      }),
+      { config: { compaction: { prune: true } } },
     ),
   )
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -168,7 +168,19 @@ function layer(result: "continue" | "compact") {
   )
 }
 
-function runtime(result: "continue" | "compact", plugin = Plugin.defaultLayer, provider = ProviderTest.fake()) {
+function cfg(compaction?: Config.Info["compaction"]) {
+  const base = Config.Info.parse({})
+  return Layer.mock(Config.Service)({
+    get: () => Effect.succeed({ ...base, compaction }),
+  })
+}
+
+function runtime(
+  result: "continue" | "compact",
+  plugin = Plugin.defaultLayer,
+  provider = ProviderTest.fake(),
+  config = Config.defaultLayer,
+) {
   const bus = Bus.layer
   return ManagedRuntime.make(
     Layer.mergeAll(SessionCompaction.layer, bus).pipe(
@@ -178,7 +190,7 @@ function runtime(result: "continue" | "compact", plugin = Plugin.defaultLayer, p
       Layer.provide(Agent.defaultLayer),
       Layer.provide(plugin),
       Layer.provide(bus),
-      Layer.provide(Config.defaultLayer),
+      Layer.provide(config),
     ),
   )
 }
@@ -222,7 +234,73 @@ function llm() {
   }
 }
 
-function liveRuntime(layer: Layer.Layer<LLM.Service>, provider = ProviderTest.fake()) {
+function reply(
+  text: string,
+  capture?: (input: LLM.StreamInput) => void,
+): (input: LLM.StreamInput) => Stream.Stream<LLM.Event, unknown> {
+  return (input) => {
+    capture?.(input)
+    return Stream.make(
+      { type: "start" } satisfies LLM.Event,
+      { type: "text-start", id: "txt-0" } satisfies LLM.Event,
+      { type: "text-delta", id: "txt-0", delta: text, text } as LLM.Event,
+      { type: "text-end", id: "txt-0" } satisfies LLM.Event,
+      {
+        type: "finish-step",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        response: { id: "res", modelId: "test-model", timestamp: new Date() },
+        providerMetadata: undefined,
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+          },
+          outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: undefined,
+          },
+        },
+      } satisfies LLM.Event,
+      {
+        type: "finish",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        totalUsage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+          },
+          outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: undefined,
+          },
+        },
+      } satisfies LLM.Event,
+    )
+  }
+}
+
+function inputText(messages: LLM.StreamInput["messages"] | undefined) {
+  return (messages ?? []).flatMap((message) => {
+    const content = message.content
+    if (typeof content === "string") return [content]
+    if (!Array.isArray(content)) return []
+    return content.flatMap((part) =>
+      typeof part === "object" && part !== null && "text" in part && typeof part.text === "string" ? [part.text] : [],
+    )
+  })
+}
+
+function liveRuntime(layer: Layer.Layer<LLM.Service>, provider = ProviderTest.fake(), config = Config.defaultLayer) {
   const bus = Bus.layer
   const status = SessionStatus.layer.pipe(Layer.provide(bus))
   const processor = SessionProcessorModule.SessionProcessor.layer.pipe(Layer.provide(summary))
@@ -237,7 +315,7 @@ function liveRuntime(layer: Layer.Layer<LLM.Service>, provider = ProviderTest.fa
       Layer.provide(Plugin.defaultLayer),
       Layer.provide(status),
       Layer.provide(bus),
-      Layer.provide(Config.defaultLayer),
+      Layer.provide(config),
     ),
   )
 }
@@ -461,6 +539,7 @@ describe("session.compaction.isOverflow", () => {
       },
     ),
   )
+
 })
 
 describe("session.compaction.create", () => {
@@ -677,6 +756,128 @@ describe("session.compaction.prune", () => {
 })
 
 describe("session.compaction.process", () => {
+  test("summarizes older history and records the first retained recent turn", async () => {
+    let captured: LLM.StreamInput | undefined
+    await using tmp = await tmpdir()
+    const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create()
+        const first = await user(session.id, "first request")
+        await assistant(session.id, first.id, tmp.path)
+        const second = await user(session.id, "second request")
+        await assistant(session.id, second.id, tmp.path)
+        const compact = await user(session.id, "compact now")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: compact.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+        })
+
+        const fakeLLM = llm()
+        fakeLLM.push(
+          reply("older summary", (input) => {
+            captured = input
+          }),
+        )
+        const live = liveRuntime(
+          fakeLLM.layer,
+          ProviderTest.fake({ model }),
+          cfg({ tail_turns: 1, preserve_recent_tokens: 6_000 }),
+        )
+        try {
+          const beforeCompaction = await svc.messages({ sessionID: session.id })
+          await live.runPromise(
+            SessionCompaction.Service.use((compaction) =>
+              compaction.process({
+                parentID: compact.id,
+                messages: beforeCompaction,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+        } finally {
+          await live.dispose()
+        }
+
+        const messages = await svc.messages({ sessionID: session.id })
+        const compactPart = messages
+          .flatMap((message) => message.parts)
+          .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+
+        expect(compactPart?.tail_start_id).toBe(second.id)
+        expect(inputText(captured?.messages)).toContain("first request")
+        expect(inputText(captured?.messages)).not.toContain("second request")
+      },
+    })
+  })
+
+  test("summarizes all history when the latest turn exceeds the retained-tail budget", async () => {
+    let captured: LLM.StreamInput | undefined
+    await using tmp = await tmpdir()
+    const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create()
+        const first = await user(session.id, "first request")
+        await assistant(session.id, first.id, tmp.path)
+        const oversizedText = "recent oversized turn " + "x".repeat(20_000)
+        const oversized = await user(session.id, oversizedText)
+        await assistant(session.id, oversized.id, tmp.path)
+        const compact = await user(session.id, "compact now")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: compact.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+          tail_start_id: first.id,
+        })
+
+        const fakeLLM = llm()
+        fakeLLM.push(
+          reply("summary", (input) => {
+            captured = input
+          }),
+        )
+        const live = liveRuntime(
+          fakeLLM.layer,
+          ProviderTest.fake({ model }),
+          cfg({ tail_turns: 1, preserve_recent_tokens: 50 }),
+        )
+        try {
+          const beforeCompaction = await svc.messages({ sessionID: session.id })
+          await live.runPromise(
+            SessionCompaction.Service.use((compaction) =>
+              compaction.process({
+                parentID: compact.id,
+                messages: beforeCompaction,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+        } finally {
+          await live.dispose()
+        }
+
+        const messages = await svc.messages({ sessionID: session.id })
+        const compactPart = messages
+          .flatMap((message) => message.parts)
+          .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+
+        expect(compactPart?.tail_start_id).toBeUndefined()
+        expect(inputText(captured?.messages)).toContain("first request")
+        expect(inputText(captured?.messages)).toContain(oversizedText)
+      },
+    })
+  })
+
   test("throws when parent is not a user message", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
@@ -7,9 +7,13 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Log } from "../../src/util"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 
 const root = path.join(__dirname, "../..")
 void Log.init({ print: false })
+const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, SessionNs.defaultLayer))
 
 function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
   return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
@@ -114,6 +118,75 @@ async function addCompactionPart(sessionID: SessionID, messageID: MessageID) {
     messageID,
     type: "compaction",
     auto: true,
+  } as any)
+}
+
+function addUserEffect(ssn: SessionNs.Interface, sessionID: SessionID, text?: string) {
+  return Effect.gen(function* () {
+    const id = MessageID.ascending()
+    yield* ssn.updateMessage({
+      id,
+      sessionID,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "test",
+      model: { providerID: "test", modelID: "test" },
+      tools: {},
+      mode: "",
+    } as unknown as MessageV2.Info)
+    if (text) {
+      yield* ssn.updatePart({
+        id: PartID.ascending(),
+        sessionID,
+        messageID: id,
+        type: "text",
+        text,
+      })
+    }
+    return id
+  })
+}
+
+function addAssistantEffect(
+  ssn: SessionNs.Interface,
+  sessionID: SessionID,
+  parentID: MessageID,
+  opts?: { summary?: boolean; finish?: string; error?: MessageV2.Assistant["error"] },
+) {
+  return Effect.gen(function* () {
+    const id = MessageID.ascending()
+    yield* ssn.updateMessage({
+      id,
+      sessionID,
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID,
+      modelID: ModelID.make("test"),
+      providerID: ProviderID.make("test"),
+      mode: "",
+      agent: "default",
+      path: { cwd: "/", root: "/" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      summary: opts?.summary,
+      finish: opts?.finish,
+      error: opts?.error,
+    } as unknown as MessageV2.Info)
+    return id
+  })
+}
+
+function addCompactionPartEffect(
+  ssn: SessionNs.Interface,
+  input: { sessionID: SessionID; messageID: MessageID; tail_start_id?: MessageID },
+) {
+  return ssn.updatePart({
+    id: PartID.ascending(),
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    type: "compaction",
+    auto: true,
+    tail_start_id: input.tail_start_id,
   } as any)
 }
 
@@ -710,6 +783,118 @@ describe("MessageV2.filterCompacted", () => {
       },
     })
   })
+
+  it.live(
+    "keeps retained tail messages after a compaction part with tail_start_id",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+
+        const old = yield* addUserEffect(ssn, session.id, "old")
+        const oldAssistant = yield* addAssistantEffect(ssn, session.id, old)
+        const retained = yield* addUserEffect(ssn, session.id, "retained")
+        const retainedAssistant = yield* addAssistantEffect(ssn, session.id, retained)
+        const boundary = yield* addUserEffect(ssn, session.id, "compact")
+        yield* addCompactionPartEffect(ssn, { sessionID: session.id, messageID: boundary, tail_start_id: retained })
+
+        const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
+        const ids = result.map((message) => message.info.id)
+        expect(ids).toContain(retained)
+        expect(ids).toContain(retainedAssistant)
+        expect(ids).not.toContain(old)
+        expect(ids).not.toContain(oldAssistant)
+
+        yield* ssn.remove(session.id)
+      }),
+    ),
+  )
+
+  it.live(
+    "keeps retained tail messages after successful compaction summary",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+
+        const old = yield* addUserEffect(ssn, session.id, "old")
+        const oldAssistant = yield* addAssistantEffect(ssn, session.id, old)
+        const retained = yield* addUserEffect(ssn, session.id, "retained")
+        const retainedAssistant = yield* addAssistantEffect(ssn, session.id, retained)
+        const boundary = yield* addUserEffect(ssn, session.id, "compact")
+        yield* addCompactionPartEffect(ssn, { sessionID: session.id, messageID: boundary, tail_start_id: retained })
+        const summary = yield* addAssistantEffect(ssn, session.id, boundary, { summary: true, finish: "end_turn" })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: summary,
+          type: "text",
+          text: "summary",
+        })
+
+        const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
+        const ids = result.map((message) => message.info.id)
+        expect(ids).toContain(retained)
+        expect(ids).toContain(retainedAssistant)
+        expect(ids).not.toContain(old)
+        expect(ids).not.toContain(oldAssistant)
+
+        yield* ssn.remove(session.id)
+      }),
+    ),
+  )
+
+  it.live(
+    "uses the newest pending compaction tail marker",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+
+        const old = yield* addUserEffect(ssn, session.id, "old")
+        const oldAssistant = yield* addAssistantEffect(ssn, session.id, old)
+        const previousTail = yield* addUserEffect(ssn, session.id, "previous tail")
+        const previousTailAssistant = yield* addAssistantEffect(ssn, session.id, previousTail)
+        const previousBoundary = yield* addUserEffect(ssn, session.id, "previous compact")
+        yield* addCompactionPartEffect(ssn, {
+          sessionID: session.id,
+          messageID: previousBoundary,
+          tail_start_id: previousTail,
+        })
+        const previousSummary = yield* addAssistantEffect(ssn, session.id, previousBoundary, {
+          summary: true,
+          finish: "end_turn",
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: previousSummary,
+          type: "text",
+          text: "summary",
+        })
+
+        const newestTail = yield* addUserEffect(ssn, session.id, "newest tail")
+        const newestTailAssistant = yield* addAssistantEffect(ssn, session.id, newestTail)
+        const pendingBoundary = yield* addUserEffect(ssn, session.id, "pending compact")
+        yield* addCompactionPartEffect(ssn, {
+          sessionID: session.id,
+          messageID: pendingBoundary,
+          tail_start_id: newestTail,
+        })
+
+        const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
+        const ids = result.map((message) => message.info.id)
+        expect(ids).toContain(newestTail)
+        expect(ids).toContain(newestTailAssistant)
+        expect(ids).not.toContain(previousTail)
+        expect(ids).not.toContain(previousTailAssistant)
+        expect(ids).not.toContain(old)
+        expect(ids).not.toContain(oldAssistant)
+
+        yield* ssn.remove(session.id)
+      }),
+    ),
+  )
 
   test("handles empty iterable", () => {
     const result = MessageV2.filterCompacted([])

--- a/packages/opencode/test/session/session-entry.test.ts
+++ b/packages/opencode/test/session/session-entry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
 import * as DateTime from "effect/DateTime"
 import * as FastCheck from "effect/testing/FastCheck"
 import { SessionEntry } from "../../src/v2/session-entry"
@@ -75,6 +76,18 @@ function tools(state: SessionEntry.History) {
 
 function tool(state: SessionEntry.History, callID: string) {
   return tools(state).find((x) => x.callID === callID)
+}
+
+function retryError(message: string) {
+  return new SessionEvent.RetryError({
+    message,
+    isRetryable: true,
+  })
+}
+
+function retries(state: SessionEntry.History) {
+  const entry = last(state)
+  return entry?.retries ?? []
 }
 
 describe("session-entry step", () => {
@@ -345,6 +358,54 @@ describe("session-entry step", () => {
       expect(second?.state.status).toBe("pending")
     })
 
+    test("records retry attempts on the pending assistant", () => {
+      const next = run(
+        [
+          SessionEvent.Retried.create({
+            attempt: 1,
+            error: retryError("rate limited"),
+            timestamp: time(1),
+          }),
+          SessionEvent.Retried.create({
+            attempt: 2,
+            error: retryError("provider overloaded"),
+            timestamp: time(2),
+          }),
+        ],
+        active(),
+      )
+
+      expect(retries(next).map((retry) => retry.attempt)).toEqual([1, 2])
+      expect(retries(next).map((retry) => retry.error.message)).toEqual(["rate limited", "provider overloaded"])
+    })
+
+    test("normalizes legacy retry string errors", () => {
+      const decode = Schema.decodeUnknownSync(SessionEvent.Retried)
+      const event = decode({
+        id: SessionEvent.ID.create(),
+        type: "retried",
+        attempt: 1,
+        error: "rate limited",
+        timestamp: time(1),
+      })
+
+      const next = SessionEntry.step(active(), event)
+
+      expect(retries(next).map((retry) => retry.error.message)).toEqual(["rate limited"])
+      expect(retries(next).map((retry) => retry.error.isRetryable)).toEqual([true])
+    })
+
+    test("normalizes legacy retry events without attempt", () => {
+      const event = SessionEvent.Retried.create({
+        error: "rate limited",
+        timestamp: time(1),
+      })
+
+      const next = SessionEntry.step(active(), event)
+
+      expect(retries(next).map((retry) => retry.attempt)).toEqual([0])
+      expect(retries(next).map((retry) => retry.error.isRetryable)).toEqual([true])
+    })
   })
 
   describe("known reducer gaps", () => {

--- a/packages/opencode/test/session/session-entry.test.ts
+++ b/packages/opencode/test/session/session-entry.test.ts
@@ -314,6 +314,37 @@ describe("session-entry step", () => {
         { numRuns: 50 },
       )
     })
+
+    test("routes interleaved tool updates by callID", () => {
+      const next = run(
+        [
+          SessionEvent.Tool.Input.Started.create({ callID: "a", name: "bash", timestamp: time(1) }),
+          SessionEvent.Tool.Input.Started.create({ callID: "b", name: "read", timestamp: time(2) }),
+          SessionEvent.Tool.Input.Delta.create({ callID: "a", delta: "{\"cmd\":\"pwd\"}", timestamp: time(3) }),
+          SessionEvent.Tool.Called.create({
+            callID: "a",
+            tool: "bash",
+            input: { cmd: "pwd" },
+            provider: { executed: true },
+            timestamp: time(4),
+          }),
+          SessionEvent.Tool.Success.create({
+            callID: "a",
+            title: "pwd",
+            output: "/tmp/project",
+            provider: { executed: true },
+            timestamp: time(5),
+          }),
+        ],
+        active(),
+      )
+
+      const first = tool(next, "a")
+      const second = tool(next, "b")
+      expect(first?.state.status).toBe("completed")
+      expect(second?.state.status).toBe("pending")
+    })
+
   })
 
   describe("known reducer gaps", () => {

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -12,6 +12,14 @@ const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
 
 describe("PawWork runtime namespace", () => {
+  test("session error event schema can be imported without eager assistant shape access", () => {
+    expect(SessionNs.Event.Error.properties.shape.error).toBeDefined()
+    const result = SessionNs.Event.Error.properties.safeParse({
+      error: new MessageV2.ContextOverflowError({ message: "context exceeded" }).toObject(),
+    })
+    expect(result.success).toBe(true)
+  })
+
   test("plan files use .pawwork in git projects", async () => {
     await using tmp = await tmpdir({ git: true })
     const previous = process.env.PAWWORK_RUNTIME_NAMESPACE

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -633,6 +633,10 @@ export type CompactionPart = {
   type: "compaction"
   auto: boolean
   overflow?: boolean
+  /**
+   * Message ID of the first retained message kept verbatim after compaction.
+   */
+  tail_start_id?: string
 }
 
 export type Part =
@@ -1549,7 +1553,7 @@ export type Config = {
      */
     auto?: boolean
     /**
-     * Enable pruning of old tool outputs (default: true)
+     * Prune old tool outputs (default: `false`). Set `true` to enable.
      */
     prune?: boolean
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8914,6 +8914,11 @@
           },
           "overflow": {
             "type": "boolean"
+          },
+          "tail_start_id": {
+            "description": "Message ID of the first retained message kept verbatim after compaction.",
+            "type": "string",
+            "pattern": "^msg.*"
           }
         },
         "required": [
@@ -11538,7 +11543,7 @@
                 "type": "boolean"
               },
               "prune": {
-                "description": "Enable pruning of old tool outputs (default: true)",
+                "description": "Prune old tool outputs (default: `false`). Set `true` to enable.",
                 "type": "boolean"
               },
               "tail_turns": {


### PR DESCRIPTION
## Summary
- Sync the #92 Session lane for retained recent turns during compaction, including `tail_start_id` on compaction parts and compacted message filtering for successful summaries and pending compactions.
- Make tool-output pruning explicit opt-in via `compaction.prune`, and update config, SDK, and OpenAPI metadata.
- Fix v2 session entry reduction so interleaved tool events route by `callID`, retry attempts are recorded with structured error context, and session error schema access is deferred with `z.lazy`.

## Why
Part of #92. This lands the session runtime slice after the Base PR #102, while keeping Runtime Resource and Desktop work out of scope.

## Compatibility Notes
- Existing configs that still want automatic old tool-output pruning should set `compaction.prune: true`.
- v2 `retried` events now store structured retry errors, and legacy string retry errors are still accepted and normalized while reducing session entries.

## Related Issue
Part of #92.

## How To Verify

```bash
bun test test/session/compaction.test.ts test/session/messages-pagination.test.ts test/session/session-entry.test.ts test/session/session.test.ts
cd packages/opencode && bun run typecheck
cd packages/sdk/js && bun run typecheck
```

Latest local results after autosquash:

- Focused session tests: 115 pass, 0 fail
- `packages/opencode` typecheck: pass
- `packages/sdk/js` typecheck: pass
- `git diff --check origin/dev...HEAD`: pass

Note: full `bun turbo typecheck` currently fails in `@opencode-ai/desktop-electron` on `@opencode-ai/util/file-extensions` module resolution. This is outside this PR diff, which does not touch `packages/desktop-electron` or `packages/util`.

## Screenshots or Recordings
Not applicable. No visible UI changes.

## Checklist
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent tail-budgeting during compaction to preserve recent conversation turns.
  * Added structured assistant retry records with attempt counts and rich error details.
  * Compaction parts can mark a tail boundary (tail_start_id) to retain recent messages verbatim.

* **Bug Fixes**
  * Fixed tool state routing for interleaved concurrent tool calls.
  * Corrected overflow/headroom calculation for content management.

* **Configuration**
  * compaction.prune now defaults to false; set true to enable pruning.

* **Tests**
  * Added comprehensive compaction, pagination, retry, and schema validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->