### PR TITLE
fix(opencode): improve Windows unit compatibility

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -118,6 +118,7 @@ export namespace Ripgrep {
     "x64-darwin": { platform: "x86_64-apple-darwin", extension: "tar.gz" },
     "x64-linux": { platform: "x86_64-unknown-linux-musl", extension: "tar.gz" },
     "arm64-win32": { platform: "aarch64-pc-windows-msvc", extension: "zip" },
+    "ia32-win32": { platform: "i686-pc-windows-msvc", extension: "zip" },
     "x64-win32": { platform: "x86_64-pc-windows-msvc", extension: "zip" },
   } as const
 
@@ -158,7 +159,7 @@ export namespace Ripgrep {
       const config = PLATFORM[platformKey]
       if (!config) throw new UnsupportedPlatformError({ platform: platformKey })
 
-      const version = "14.1.1"
+      const version = "15.1.0"
       const filename = `ripgrep-${version}-${config.platform}.${config.extension}`
       const url = `https://github.com/BurntSushi/ripgrep/releases/download/${version}/${filename}`
 

--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -7,7 +7,6 @@ import path from "path"
 import { readdir, rm } from "fs/promises"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@/util/flock"
-import { Arborist } from "@npmcli/arborist"
 
 export namespace Npm {
   const log = Log.create({ service: "npm" })
@@ -27,6 +26,16 @@ export namespace Npm {
 
   function directory(pkg: string) {
     return path.join(Global.Path.cache, "packages", sanitize(pkg))
+  }
+
+  async function loadArborist() {
+    if (process.platform === "win32") {
+      // Bun on Windows does not support the UV_FS_O_FILEMAP flag used by tar
+      // for small files. tar snapshots this env var during module init, so set
+      // it immediately before Arborist can import tar.
+      process.env.__FAKE_PLATFORM__ = "linux"
+    }
+    return import("@npmcli/arborist")
   }
 
   function resolveEntryPoint(name: string, dir: string) {
@@ -68,6 +77,7 @@ export namespace Npm {
       pkg,
     })
 
+    const { Arborist } = await loadArborist()
     const arborist = new Arborist({
       path: dir,
       binLinks: true,
@@ -108,6 +118,7 @@ export namespace Npm {
     log.info("checking dependencies", { dir })
 
     const reify = async () => {
+      const { Arborist } = await loadArborist()
       const arb = new Arborist({
         path: dir,
         binLinks: true,

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -358,14 +358,22 @@ export namespace Worktree {
       }
 
       function cleanDirectory(target: string) {
-        return Effect.promise(() =>
-          import("fs/promises")
-            .then((fsp) => fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }))
-            .catch((error) => {
+        // Match test preload cleanup: Windows can keep git and sqlite handles
+        // alive briefly after process teardown, so EBUSY needs a longer budget.
+        const maxRetries = process.platform === "win32" ? 30 : 5
+        const remove = (remaining: number): Effect.Effect<void> =>
+          fs.remove(target, { recursive: true, force: true }).pipe(
+            Effect.catch((error) => {
+              if (remaining > 0) {
+                return Effect.sleep(100).pipe(Effect.flatMap(() => remove(remaining - 1)))
+              }
               const message = errorMessage(error)
-              throw new RemoveFailedError({ message: message || "Failed to remove git worktree directory" })
+              return Effect.sync(() => {
+                throw new RemoveFailedError({ message: message || "Failed to remove git worktree directory" })
+              })
             }),
-        )
+          )
+        return remove(maxRetries)
       }
 
       const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {

--- a/packages/opencode/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/opencode/test/effect/cross-spawn-spawner.test.ts
@@ -169,7 +169,12 @@ describe("cross-spawn spawner", () => {
             'process.stderr.write("stderr\\n", done)',
           ].join("\n"),
         )
-        const [stdout, stderr] = yield* Effect.all([decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)])
+        // Drain both pipes in parallel so Windows CI does not stall when stderr
+        // waits behind stdout decoding.
+        const [stdout, stderr] = yield* Effect.all(
+          [decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)],
+          { concurrency: 2 },
+        )
         expect(stdout).toBe("stdout")
         expect(stderr).toBe("stderr")
       }),

--- a/packages/opencode/test/global/runtime-namespace.test.ts
+++ b/packages/opencode/test/global/runtime-namespace.test.ts
@@ -1,14 +1,33 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import { tmpdir } from "../fixture/fixture"
 
-function readGlobalPath(namespace?: string) {
+type Roots = {
+  data: string
+  cache: string
+  config: string
+  state: string
+}
+
+function rootsFor(dir: string): Roots {
+  return {
+    data: path.join(dir, "share"),
+    cache: path.join(dir, "cache"),
+    config: path.join(dir, "config"),
+    state: path.join(dir, "state"),
+  }
+}
+
+function readGlobalPath(roots: Roots, namespace?: string) {
   const script = `
-    process.env.XDG_DATA_HOME = "/tmp/pawwork-runtime-test/share"
-    process.env.XDG_CACHE_HOME = "/tmp/pawwork-runtime-test/cache"
-    process.env.XDG_CONFIG_HOME = "/tmp/pawwork-runtime-test/config"
-    process.env.XDG_STATE_HOME = "/tmp/pawwork-runtime-test/state"
+    process.env.XDG_DATA_HOME = ${JSON.stringify(roots.data)}
+    process.env.XDG_CACHE_HOME = ${JSON.stringify(roots.cache)}
+    process.env.XDG_CONFIG_HOME = ${JSON.stringify(roots.config)}
+    process.env.XDG_STATE_HOME = ${JSON.stringify(roots.state)}
     if (${JSON.stringify(namespace)} !== undefined) {
       process.env.PAWWORK_RUNTIME_NAMESPACE = ${JSON.stringify(namespace)}
+    } else {
+      delete process.env.PAWWORK_RUNTIME_NAMESPACE
     }
     const { Global } = await import("./src/global/index.ts")
     console.log(JSON.stringify(Global.Path))
@@ -25,24 +44,29 @@ function readGlobalPath(namespace?: string) {
   return JSON.parse(Buffer.from(result.stdout).toString()) as Record<string, string>
 }
 
-describe("Global runtime namespace", () => {
-  test("defaults to OpenCode namespace outside PawWork desktop", () => {
-    const paths = readGlobalPath()
+function expectCoreRoots(paths: Record<string, string>, roots: Roots, namespace: string) {
+  expect(paths.data).toBe(path.join(roots.data, namespace))
+  expect(paths.cache).toBe(path.join(roots.cache, namespace))
+  expect(paths.config).toBe(path.join(roots.config, namespace))
+  expect(paths.state).toBe(path.join(roots.state, namespace))
+}
 
-    expect(paths.data).toBe("/tmp/pawwork-runtime-test/share/opencode")
-    expect(paths.cache).toBe("/tmp/pawwork-runtime-test/cache/opencode")
-    expect(paths.config).toBe("/tmp/pawwork-runtime-test/config/opencode")
-    expect(paths.state).toBe("/tmp/pawwork-runtime-test/state/opencode")
+describe("Global runtime namespace", () => {
+  test("defaults to OpenCode namespace outside PawWork desktop", async () => {
+    await using tmp = await tmpdir()
+    const roots = rootsFor(tmp.path)
+    const paths = readGlobalPath(roots)
+
+    expectCoreRoots(paths, roots, "opencode")
   })
 
-  test("uses PawWork namespace when enabled", () => {
-    const paths = readGlobalPath("pawwork")
+  test("uses PawWork namespace when enabled", async () => {
+    await using tmp = await tmpdir()
+    const roots = rootsFor(tmp.path)
+    const paths = readGlobalPath(roots, "pawwork")
 
-    expect(paths.data).toBe("/tmp/pawwork-runtime-test/share/pawwork")
-    expect(paths.cache).toBe("/tmp/pawwork-runtime-test/cache/pawwork")
-    expect(paths.config).toBe("/tmp/pawwork-runtime-test/config/pawwork")
-    expect(paths.state).toBe("/tmp/pawwork-runtime-test/state/pawwork")
-    expect(paths.bin).toBe("/tmp/pawwork-runtime-test/cache/pawwork/bin")
-    expect(paths.log).toBe("/tmp/pawwork-runtime-test/share/pawwork/log")
+    expectCoreRoots(paths, roots, "pawwork")
+    expect(paths.bin).toBe(path.join(roots.cache, "pawwork", "bin"))
+    expect(paths.log).toBe(path.join(roots.data, "pawwork", "log"))
   })
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -45,6 +45,28 @@ async function waitFor(fn: () => boolean, timeout = 5_000) {
   throw new Error("timed out waiting for workspace status")
 }
 
+async function waitForCounter(file: string, min: number) {
+  const read = async () => {
+    const text = await Bun.file(file)
+      .text()
+      .catch((error) => {
+        if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") return "0"
+        throw error
+      })
+    const value = Number(text)
+    if (!Number.isFinite(value)) throw new Error(`invalid retry counter value: ${text}`)
+    return value
+  }
+  const end = Date.now() + 5_000
+  let value = 0
+  while (Date.now() < end) {
+    value = await read()
+    if (value > min) return value
+    await wait(50)
+  }
+  throw new Error(`timed out waiting for counter ${file} to exceed ${min}; last value=${value}`)
+}
+
 async function pluginProject() {
   return tmpdir({
     git: true,
@@ -362,13 +384,11 @@ describe("plugin.workspace", () => {
     await Instance.disposeAll()
 
     await Workspace.get(workspace.id)
-    await wait(100)
-    const first = Number(await Bun.file(tmp.extra.counter).text())
+    const first = await waitForCounter(tmp.extra.counter, 0)
     expect(first).toBeGreaterThan(0)
 
     await Workspace.get(workspace.id)
-    await wait(100)
-    const second = Number(await Bun.file(tmp.extra.counter).text())
+    const second = await waitForCounter(tmp.extra.counter, first)
     expect(second).toBeGreaterThan(first)
 
     const status = Workspace.status().find((item) => item.workspaceID === workspace.id)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1236,6 +1236,8 @@ unix(
   30_000,
 )
 
+const shellQueueTimeout = process.platform === "win32" ? 10_000 : 3_000
+
 it.live(
   "loop waits while shell runs and starts after shell exits",
   () =>
@@ -1271,7 +1273,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  shellQueueTimeout,
 )
 
 it.live(
@@ -1311,7 +1313,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  shellQueueTimeout,
 )
 
 unix(


### PR DESCRIPTION
## Summary

- Normalize runtime namespace tests for Windows path separators.
- Port the narrow Bun Windows tar workaround for npm and Arborist installs.
- Update managed ripgrep lookup and version for Windows, including arm64 and ia32 mappings.
- Stabilize plugin workspace retry, worktree cleanup, shell queue timing, and cross-spawn stream tests on Windows.

## Why

Issue #141's PR direction 1 targets the current `unit-windows-opencode` failure families from run 24781051308: runtime namespace path assertions, config dependency installs, plugin workspace timing and cleanup, and shell queue timing. Electron desktop Windows hardening remains a separate PR direction.

## Related Issue

Part of #141.

## How To Verify

```bash
cd packages/opencode
bun test test/global/runtime-namespace.test.ts
bun test test/effect/cross-spawn-spawner.test.ts
bun test test/config/config.test.ts test/config/seed-e2e.test.ts test/tool/registry.test.ts
bun test test/plugin/workspace-adaptor.test.ts
bun test test/session/prompt-effect.test.ts -t "loop waits while shell runs and starts after shell exits"
bun test test/session/prompt-effect.test.ts -t "shell completion resumes queued loop callers"
bun test test/file/ripgrep.test.ts
bun run test:ci
```

Latest local `bun run test:ci` result: 2016 pass, 8 skip, 1 todo, 0 fail.

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ia32-Windows platform support and updated ripgrep to v15.1.0

* **Bug Fixes**
  * Windows runtime compatibility workaround to avoid tar-related issues
  * More reliable directory cleanup on Windows via increased retry handling

* **Tests**
  * Improved test stability: concurrency handling, dynamic temp directories, polling helper for flaky timing, and increased timeouts for shell-related tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->