### PR TITLE
fix(app): stabilize session row left-side visuals (status slot + Pin/Filter icons)

### DIFF
--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -20,22 +20,23 @@ export type PawworkSidebarSession = {
 const FilterIcon = (props: { size?: number }) => {
   const size = props.size ?? 14
   return (
-    <svg width={size} height={size} viewBox="0 0 12 12" fill="none" aria-hidden="true">
-      <path d="M1.5 3h9M3 6h6M4.5 9h3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
+    <svg width={size} height={size} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+      <path d="M2.5 5h15M5 10h10M7.5 15h5" stroke="currentColor" stroke-linecap="square" />
     </svg>
   )
 }
 
 const PinIcon = (props: { filled?: boolean; size?: number }) => {
-  const size = props.size ?? 12
+  const size = props.size ?? 16
   return (
-    <svg width={size} height={size} viewBox="0 0 12 12" fill={props.filled ? "currentColor" : "none"} aria-hidden="true">
+    <svg width={size} height={size} viewBox="0 0 20 20" fill="none" aria-hidden="true">
       <path
-        d="M7.5 1.5l3 3-2 .5-1.5 3-1.5-1.5-2.5 2.5L3.5 9 6 6.5 4.5 5l3-1.5.5-2z"
+        d="M11 2L18 9L14 11L11 14L6 9L9 6Z"
         stroke="currentColor"
-        stroke-width="1.1"
-        stroke-linejoin="round"
+        stroke-linejoin="miter"
+        fill={props.filled ? "currentColor" : "none"}
       />
+      <path d="M8 11L2 18" stroke="currentColor" stroke-linecap="square" />
     </svg>
   )
 }

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -113,27 +113,25 @@ const SessionRow = (props: {
         props.clearHoverProjectSoon()
       }}
     >
-      <Show when={props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0}>
-        <div
-          class="shrink-0 size-6 flex items-center justify-center"
-          style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
-        >
-          <Switch>
-            <Match when={props.isWorking()}>
-              <Spinner class="size-[15px]" />
-            </Match>
-            <Match when={props.hasPermissions()}>
-              <div class="size-1.5 rounded-full bg-surface-warning-strong" />
-            </Match>
-            <Match when={props.hasError()}>
-              <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
-            </Match>
-            <Match when={props.unseenCount() > 0}>
-              <div class="size-1.5 rounded-full bg-text-interactive-base" />
-            </Match>
-          </Switch>
-        </div>
-      </Show>
+      <div
+        class="shrink-0 size-6 flex items-center justify-center"
+        style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
+      >
+        <Switch>
+          <Match when={props.isWorking()}>
+            <Spinner class="size-[15px]" />
+          </Match>
+          <Match when={props.hasPermissions()}>
+            <div class="size-1.5 rounded-full bg-surface-warning-strong" />
+          </Match>
+          <Match when={props.hasError()}>
+            <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
+          </Match>
+          <Match when={props.unseenCount() > 0}>
+            <div class="size-1.5 rounded-full bg-text-interactive-base" />
+          </Match>
+        </Switch>
+      </div>
       <div class="min-w-0 flex-1 flex items-center gap-2">
         <Show when={props.titleContent} fallback={<span class="text-14-regular text-text-strong min-w-0 flex-1 truncate">{title()}</span>}>
           {props.titleContent}


### PR DESCRIPTION
Closes #143.

## Summary

- **Commit 1** (`fix`) removes the outer `<Show>` wrapper around the sidebar session-row status slot in `sidebar-items.tsx`, so the `size-6` container always reserves 24px of width. The inner `<Switch>` (running / permission / error / unseen) is unchanged. Session title baseline no longer shifts when status indicators toggle.
- **Commit 2** (`refactor`) redraws `FilterIcon` and `PinIcon` in `pawwork-sidebar.tsx` on the 20x20 grid. `FilterIcon` uses `stroke-linecap="square"` to match upstream straight-line glyphs (`close`, `arrow-right`, `menu`). `PinIcon` uses a hexagonal head polygon + diagonal needle, default stroke width, default size 16. Needle origin `(8, 11)` sits on the head's bottom-left edge `y = x + 3` for clean attachment.

## Follow-up (out of scope)

During live review we noticed that the Pin button (rendered in `SessionItem` `leadingSlot`) and the status slot (inside `SessionRow`) are two separate reserved slots. The original intent implied by the issue reporter was for running state to appear *in the pin button position* — i.e. one unified slot with priority `running > permission > error > unseen > pin > empty`. This PR ships the #143 scope as written (two stable slots, matching the issue body's "Not in scope: Pin slot" note), and defers the merge refactor to #150. Merge is medium-risk: changes pin button a11y contract (pin must remain keyboard-reachable when pinned + running), requires passing leadingSlot into `SessionRow`, and shifts the top-level title baseline left by 28px.

## Test plan

- [x] `bun run typecheck` passes
- [x] Manual live verification on `bun dev:desktop`:
  - idle / pinned / running rows maintain stable title baseline
  - Pin icon at size 16 reads at roughly the visual weight of neighbouring sidebar icons
  - Filter icon three bars descending cleanly on 20x20 grid
  - Pinned (accent brand) / hover-to-reveal (weak) pin states render correctly
- [x] crosscheck reviewed (zero P0/P1; one P2 geometry fix autosquashed)