### PR TITLE
fix(app): require app update notice section

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -32,6 +32,10 @@ Create or update the GitHub Release body before publishing the release. Use Engl
 - [macOS Intel](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64.dmg)
 - [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64.exe)
 
+## App Update Notice
+
+- Short product-facing sentence for the in-app post-update modal. Do not include download links, PR numbers, verification details, or maintenance-only notes.
+
 ## Highlights
 
 - User-facing changes, bug fixes, or packaging fixes.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -141,7 +141,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -384,7 +384,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/context/highlights.test.ts
+++ b/packages/app/src/context/highlights.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { loadReleaseHighlights } from "./highlights"
 
 describe("loadReleaseHighlights (GitHub Releases API)", () => {
-  test("synthesizes a single PawWork highlight from the release body", () => {
+  test("reads the app-facing update notice section from the release body", () => {
     const payload = [
       {
         tag_name: "v0.2.3",
         name: "v0.2.3",
-        body: "Fixed first-message crash\n- bumped Minimax-M2.5\n",
+        body: "## Downloads\n\n- [macOS](https://example.com/app.dmg)\n\n## App Update Notice\n\nFixed first-message crash\n",
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.3", "0.2.2")
@@ -18,11 +18,11 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     })
   })
 
-  test("skips markdown headings and strips bullet markers on the first summary line", () => {
+  test("skips markdown headings and strips bullet markers inside the app update notice section", () => {
     const payload = [
       {
         tag_name: "v0.3.0",
-        body: "## Desktop\n\n- Added dark theme\n- Fixed dock icon\n",
+        body: "## Downloads\n\n- [macOS](https://example.com/app.dmg)\n\n## App Update Notice\n\n### Desktop\n\n- Added dark theme\n- Fixed dock icon\n\n## Verification\n\n- CI passed\n",
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.3.0", "0.2.3")
@@ -31,10 +31,32 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
 
   test("truncates long summaries with an ellipsis", () => {
     const long = "a".repeat(300)
-    const payload = [{ tag_name: "v1.0.0", body: long }]
+    const payload = [{ tag_name: "v1.0.0", body: `## App Update Notice\n\n${long}` }]
     const highlights = loadReleaseHighlights(payload, "1.0.0", "0.9.0")
     expect(highlights[0].description.endsWith("…")).toBe(true)
     expect(highlights[0].description.length).toBe(201)
+  })
+
+  test("does not guess from downloads when the app update notice section is missing", () => {
+    const payload = [
+      {
+        tag_name: "v0.2.6",
+        body: "## Downloads\n\n- [macOS Apple Silicon](https://github.com/Astro-Han/pawwork/releases/download/v0.2.6/pawwork-mac-arm64.dmg)\n\n## Highlights\n\n- Maintenance fixes\n",
+      },
+    ]
+    expect(loadReleaseHighlights(payload, "0.2.6", "0.2.5")).toHaveLength(0)
+  })
+
+  test("stops app update notice parsing at empty same-level headings", () => {
+    const payload = [
+      {
+        tag_name: "v0.2.6",
+        body: "## App Update Notice\n\n- Fixed update notices\n\n##\n\n- [macOS](https://example.com/app.dmg)\n",
+      },
+    ]
+    const highlights = loadReleaseHighlights(payload, "0.2.6", "0.2.5")
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe("Fixed update notices")
   })
 
   test("returns no highlights when the body is empty or only headings", () => {

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -61,8 +61,25 @@ function parseHighlight(value: unknown): Highlight | undefined {
   return { title, description, media }
 }
 
-function summarizeBody(body: string): string | undefined {
-  const lines = body
+function findAppUpdateNotice(body: string): string | undefined {
+  const lines = body.split(/\r?\n/)
+  const start = lines.findIndex((line) => /^#{2,6}\s+App Update Notice\s*$/i.test(line.trim()))
+  if (start === -1) return
+
+  const headingLevel = lines[start].trim().match(/^#+/)?.[0].length ?? 2
+  const section = lines.slice(start + 1)
+  const end = section.findIndex((line) => {
+    const heading = line.trim().match(/^(#{1,6})(?:\s|$)/)
+    return heading !== null && heading[1].length <= headingLevel
+  })
+  return (end === -1 ? section : section.slice(0, end)).join("\n")
+}
+
+function summarizeAppUpdateNotice(body: string): string | undefined {
+  const notice = findAppUpdateNotice(body)
+  if (!notice) return
+
+  const lines = notice
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"))
@@ -97,7 +114,7 @@ function parseRelease(value: unknown): ParsedRelease | undefined {
 
   const body = getText(value.body)
   if (tag && body) {
-    const summary = summarizeBody(body)
+    const summary = summarizeAppUpdateNotice(body)
     if (summary) {
       return {
         tag,

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Require GitHub Release bodies to provide a dedicated `## App Update Notice` section before the in-app post-update modal shows release text. Bump release package versions to `0.2.6`.

## Why

Fixes #124. The previous parser picked the first non-heading line from the general GitHub Release body, so a Downloads link could appear as the user-facing update notice. The app now avoids guessing from Downloads, Highlights, Verification, or maintenance sections.

## Related Issue

Fixes #124

## How To Verify

```bash
bun --cwd packages/app test src/context/highlights.test.ts
bun --cwd packages/app typecheck
bun install --frozen-lockfile
```

Also ran fresh-eyes code review with no Critical, Important, or worth-fixing Minor findings.

## Screenshots or Recordings

Not included. This changes release-note parsing behavior and release metadata, with no visible UI layout change in this branch.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.2.6 across all packages.
  * Improved in-app update notice generation from release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->