### PR TITLE
fix: isolate release metadata downloads

### DIFF
--- a/packages/desktop-electron/scripts/finalize-latest-yml.ts
+++ b/packages/desktop-electron/scripts/finalize-latest-yml.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun"
-import { mkdir } from "node:fs/promises"
+import { mkdtemp } from "node:fs/promises"
 import path from "path"
 
 const dir = process.env.LATEST_YML_DIR!
@@ -133,16 +133,15 @@ async function downloadExisting(tag: string, filename: string) {
     configured ? await readFile(path.join(configured, filename)) : undefined,
   )
 
-  const existingDir = path.join(tmp, "existing-latest-yml")
-  await mkdir(existingDir, { recursive: true })
+  const liveDir = await mkdtemp(path.join(tmp, "live-latest-yml-"))
   try {
-    await $`gh release download ${tag} --pattern ${filename} --dir ${existingDir} --repo ${repo}`.quiet()
+    await $`gh release download ${tag} --pattern ${filename} --dir ${liveDir} --repo ${repo} --clobber`.quiet()
   } catch (error) {
     const message = shellErrorText(error)
     if (isMissingAssetError(message)) return cached
     throw new Error(`Failed to download existing ${filename}: ${message}`)
   }
-  const live = assertSameVersion("GitHub release", filename, await readFile(path.join(existingDir, filename)))
+  const live = assertSameVersion("GitHub release", filename, await readFile(path.join(liveDir, filename)))
   return mergeLatest(cached, live)
 }
 

--- a/packages/desktop-electron/scripts/release-metadata-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-metadata-contract.test.ts
@@ -114,6 +114,32 @@ describe("release metadata finalizer", () => {
     expect(latestMac).toContain("PawWork-stale-x64.zip")
   })
 
+  test("does not collide when EXISTING_LATEST_YML_DIR is RUNNER_TEMP/existing-latest-yml", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
+    roots.push(root)
+    const latestDir = join(root, "latest-yml")
+    const runnerTemp = join(root, "runner")
+    const binDir = join(root, "bin")
+    const snapshotDir = join(runnerTemp, "existing-latest-yml")
+    mkdirSync(runnerTemp, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFakeGh(binDir, {
+      "latest-mac.yml": "PawWork-live-x64.zip",
+    })
+    writeLatest(snapshotDir, "latest-mac.yml", "PawWork-snapshot-x64.zip")
+
+    writeLatest(join(latestDir, "latest-yml-aarch64-apple-darwin"), "latest-mac.yml", "PawWork-new-arm64.zip")
+
+    const proc = spawnFinalizer(binDir, latestDir, runnerTemp, { EXISTING_LATEST_YML_DIR: snapshotDir })
+
+    expect(await proc.exited).toBe(0)
+    const latestMac = readFileSync(join(runnerTemp, "latest-mac.yml"), "utf8")
+    expect(latestMac).toContain("PawWork-new-arm64.zip")
+    expect(latestMac).toContain("PawWork-live-x64.zip")
+    expect(latestMac).toContain("PawWork-snapshot-x64.zip")
+  })
+
   test("uses live integrity metadata when live and snapshot urls collide", async () => {
     const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
     roots.push(root)
@@ -269,7 +295,7 @@ function writeFakeGh(binDir: string, downloads: Record<string, string | FixtureF
   writeFileSync(
     helper,
     [
-      "const { appendFileSync, mkdirSync, writeFileSync } = require('node:fs')",
+      "const { appendFileSync, existsSync, mkdirSync, writeFileSync } = require('node:fs')",
       "const { join } = require('node:path')",
       `const downloads = ${JSON.stringify(downloads)}`,
       `const downloadFailure = ${JSON.stringify(downloadFailure ?? null)}`,
@@ -291,7 +317,12 @@ function writeFakeGh(binDir: string, downloads: Record<string, string | FixtureF
       "    console.error(`no matches found for ${pattern}`)",
       "    process.exit(1)",
       "  }",
-      "  writeFileSync(join(dir, pattern), latestYml(downloads[pattern]), 'utf8')",
+      "  const target = join(dir, pattern)",
+      "  if (existsSync(target) && !args.includes('--clobber') && !args.includes('-c')) {",
+      "    console.error(`${target} already exists (use clobber to overwrite file or skip-existing to skip file)`)",
+      "    process.exit(1)",
+      "  }",
+      "  writeFileSync(target, latestYml(downloads[pattern]), 'utf8')",
       "  process.exit(0)",
       "}",
       "appendFileSync(uploadLog, `${args.join(' ')}\\n`, 'utf8')",


### PR DESCRIPTION
## Summary

Keep live updater metadata downloads in a separate temp directory from the predownloaded release metadata cache.

## Why

The v0.2.6 macOS x64 finalize run completed notarization and artifact verification, then failed while finalizing updater metadata because `gh release download` refused to write `latest-mac.yml` over a preexisting cached file. The release draft was repaired manually, but the workflow needs this fix so future finalize runs do not fail at the same step.

## Related Issue

No issue. Found during the v0.2.6 release workflow.

## How To Verify

```bash
bun --cwd packages/desktop-electron test scripts/release-metadata-contract.test.ts
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for merging live and predownloaded release metadata.
  * Enhanced download validation to prevent unintended file overwrites.

* **Chores**
  * Refined internal release metadata handling scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->