### PR TITLE
fix(desktop): avoid main util ts import

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -141,7 +141,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -384,7 +384,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/desktop-electron/src/main/attachment-mime.test.ts
+++ b/packages/desktop-electron/src/main/attachment-mime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+
+import { IMAGE_EXTS } from "@opencode-ai/util/file-extensions"
+
+import { attachmentPathMime, MIME_BY_EXTENSION } from "./attachment-mime"
+
+describe("attachmentPathMime", () => {
+  test("returns MIME types for direct attachment files", () => {
+    expect(attachmentPathMime("/tmp/image.gif")).toBe("image/gif")
+    expect(attachmentPathMime("/tmp/image.jpeg")).toBe("image/jpeg")
+    expect(attachmentPathMime("/tmp/image.png")).toBe("image/png")
+    expect(attachmentPathMime("/tmp/image.JPG")).toBe("image/jpeg")
+    expect(attachmentPathMime("/tmp/image.webp")).toBe("image/webp")
+    expect(attachmentPathMime("/tmp/document.pdf")).toBe("application/pdf")
+  })
+
+  test("returns MIME types using an injected extension reader", () => {
+    const extname = (filepath: string) => filepath.slice(filepath.lastIndexOf("."))
+
+    expect(attachmentPathMime("C:\\tmp\\image.PNG", extname)).toBe("image/png")
+  })
+
+  test("keeps image MIME entries in sync with the renderer contract", () => {
+    const imageEntries = [...MIME_BY_EXTENSION.entries()]
+      .filter(([extension]) => extension !== "pdf")
+      .sort(([left], [right]) => left.localeCompare(right))
+
+    const rendererImageEntries = [...IMAGE_EXTS.entries()].sort(([left], [right]) => left.localeCompare(right))
+
+    expect(imageEntries).toEqual(rendererImageEntries)
+  })
+
+  test("returns undefined for unsupported extensions", () => {
+    expect(attachmentPathMime("/tmp/archive.zip")).toBeUndefined()
+  })
+
+  test("returns undefined for missing extensions", () => {
+    expect(attachmentPathMime("/tmp/no-extension")).toBeUndefined()
+  })
+})

--- a/packages/desktop-electron/src/main/attachment-mime.ts
+++ b/packages/desktop-electron/src/main/attachment-mime.ts
@@ -1,0 +1,16 @@
+import path from "node:path"
+
+// Keep image entries in sync with packages/util/src/file-extensions.ts::IMAGE_EXTS.
+export const MIME_BY_EXTENSION = new Map([
+  ["gif", "image/gif"],
+  ["jpeg", "image/jpeg"],
+  ["jpg", "image/jpeg"],
+  ["pdf", "application/pdf"],
+  ["png", "image/png"],
+  ["webp", "image/webp"],
+])
+
+export function attachmentPathMime(filepath: string, extname = path.extname) {
+  const suffix = extname(filepath).slice(1).toLowerCase()
+  return MIME_BY_EXTENSION.get(suffix)
+}

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -3,7 +3,6 @@ import path from "node:path"
 import { execFile } from "node:child_process"
 import { BrowserWindow, Notification, app, clipboard, dialog, ipcMain, shell } from "electron"
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron"
-import { IMAGE_EXTS } from "@opencode-ai/util/file-extensions"
 
 import type {
   DesktopContext,
@@ -14,6 +13,7 @@ import type {
   UpdateInfo,
   WslConfig,
 } from "../preload/types"
+import { attachmentPathMime } from "./attachment-mime"
 import { getStore } from "./store"
 import { setTitlebar } from "./windows"
 
@@ -32,12 +32,6 @@ function normalizeAttachmentPath(filepath: unknown) {
   if (typeof filepath !== "string" || filepath.length === 0) return
   if (/^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(filepath)) return filepath
   return path.resolve(filepath)
-}
-
-function attachmentPathMime(filepath: string) {
-  const suffix = path.extname(filepath).slice(1).toLowerCase()
-  if (suffix === "pdf") return "application/pdf"
-  return IMAGE_EXTS.get(suffix)
 }
 
 type Deps = {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Avoid importing `@opencode-ai/util/file-extensions` from the Electron main process by moving the attachment MIME lookup into desktop main code. Bump release packages to `0.2.7` for the startup-crash hotfix.

## Why

The published `v0.2.6` packaged app crashes on startup because the main process loads `node_modules/@opencode-ai/util/src/file-extensions.ts`, and Node refuses TypeScript stripping for files under `node_modules`. The broken `v0.2.6` GitHub Release has been deleted to prevent accidental downloads; `v0.2.7` should replace it as the latest stable release.

## Related Issue

Closes #159.

## How To Verify

```bash
bun --cwd packages/desktop-electron test src/main/attachment-mime.test.ts
bun --cwd packages/desktop-electron typecheck
bun --cwd packages/desktop-electron build
rg -n "@opencode-ai/util/file-extensions|node_modules/@opencode-ai/util/src/file-extensions" packages/desktop-electron/out || true
bun install --frozen-lockfile
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 0.2.7 across the monorepo.

* **New Features**
  * Added attachment file type → MIME detection to improve file handling and validation.

* **Tests**
  * Added tests covering attachment MIME detection, extension handling, and unsupported/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->