### PR TITLE
fix: preserve persisted cache crash diagnostics

### DIFF
--- a/packages/app/src/context/global-sync/child-store-error.test.ts
+++ b/packages/app/src/context/global-sync/child-store-error.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import { catchError, createRoot, getOwner } from "solid-js"
+import { createStore } from "solid-js/store"
+import {
+  ChildStoreError,
+  createPersistedChildCache,
+  validateChildStoreDirectory,
+} from "./child-store-error"
+
+const translate = (key: string) => {
+  if (key === "error.childStore.persistedCacheCreateFailed") return "Failed to create persisted cache"
+  return key
+}
+
+describe("child store diagnostics", () => {
+  test("rejects invalid workspace directories before persisted cache setup", () => {
+    for (const directory of [undefined, ""]) {
+      expect(() => validateChildStoreDirectory(directory)).toThrow("Invalid workspace directory for child store")
+
+      try {
+        validateChildStoreDirectory(directory)
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChildStoreError)
+        expect((error as ChildStoreError).context).toEqual({
+          kind: "workspace",
+          directory,
+        })
+        continue
+      }
+
+      throw new Error("expected invalid directory to throw")
+    }
+  })
+
+  test("describes unserializable invalid directories without masking validation errors", () => {
+    const circular: { self?: unknown } = {}
+    circular.self = circular
+
+    for (const directory of [1n, circular]) {
+      try {
+        validateChildStoreDirectory(directory)
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChildStoreError)
+        expect((error as ChildStoreError).message).toContain("<unserializable>")
+        expect((error as ChildStoreError).context.directory).toBe(directory)
+        continue
+      }
+
+      throw new Error("expected invalid directory to throw")
+    }
+  })
+
+  test("preserves the original persisted cache setup cause and context", () => {
+    const cause = new TypeError("storage init failed")
+    const target = {
+      storage: "pawwork.workspace.-tmp-project.abc123.dat",
+      key: "workspace:vcs",
+      legacy: ["vcs.v1"],
+    }
+
+    createRoot((dispose) => {
+      const owner = getOwner()
+      if (!owner) throw new Error("owner required")
+
+      try {
+        createPersistedChildCache({
+          owner,
+          directory: "/tmp/project",
+          kind: "vcs",
+          messageKey: "error.childStore.persistedCacheCreateFailed",
+          target,
+          store: createStore({ value: undefined as string | undefined }),
+          translate,
+          persist: () => {
+            throw cause
+          },
+        })
+      } catch (error) {
+        dispose()
+        expect(error).toBeInstanceOf(ChildStoreError)
+        expect(error).toHaveProperty("cause", cause)
+        expect((error as ChildStoreError).message).toContain("Failed to create persisted cache")
+        expect((error as ChildStoreError).message).toContain("cache=vcs")
+        expect((error as ChildStoreError).message).toContain("storage=pawwork.workspace.-tmp-project.abc123.dat")
+        expect((error as ChildStoreError).message).toContain("key=workspace:vcs")
+        expect((error as ChildStoreError).context).toEqual({
+          kind: "vcs",
+          directory: "/tmp/project",
+          storage: "pawwork.workspace.-tmp-project.abc123.dat",
+          key: "workspace:vcs",
+        })
+        return
+      }
+
+      dispose()
+      throw new Error("expected persisted cache setup to throw")
+    })
+  })
+
+  test("preserves cause when owner error boundary handles persisted setup failure", () => {
+    const cause = new TypeError("storage init failed")
+    const handled: unknown[] = []
+
+    catchError(
+      () => {
+        createRoot((dispose) => {
+          const owner = getOwner()
+          if (!owner) throw new Error("owner required")
+
+          try {
+            createPersistedChildCache({
+              owner,
+              directory: "/tmp/project",
+              kind: "vcs",
+              messageKey: "error.childStore.persistedCacheCreateFailed",
+              target: {
+                storage: "pawwork.workspace.-tmp-project.abc123.dat",
+                key: "workspace:vcs",
+              },
+              store: createStore({ value: undefined as string | undefined }),
+              translate,
+              persist: () => {
+                throw cause
+              },
+            })
+          } catch (error) {
+            dispose()
+            expect(error).toBeInstanceOf(ChildStoreError)
+            expect(error).toHaveProperty("cause", cause)
+            return
+          }
+
+          dispose()
+          throw new Error("expected persisted cache setup to throw")
+        })
+      },
+      (error) => {
+        handled.push(error)
+      },
+    )
+
+    expect(handled).toEqual([cause])
+  })
+})

--- a/packages/app/src/context/global-sync/child-store-error.ts
+++ b/packages/app/src/context/global-sync/child-store-error.ts
@@ -1,0 +1,121 @@
+import { runWithOwner, type Owner } from "solid-js"
+import type { SetStoreFunction, Store } from "solid-js/store"
+import { persisted } from "@/utils/persist"
+
+export type ChildStoreCacheKind = "workspace" | "vcs" | "project" | "icon"
+
+export type ChildStoreErrorContext = {
+  kind: ChildStoreCacheKind
+  directory: unknown
+  storage?: string
+  key?: string
+}
+
+export type ChildStorePersistTarget = {
+  storage?: string
+  key: string
+  legacy?: string[]
+  migrate?: (value: unknown) => unknown
+}
+
+type PersistedResult<T> = ReturnType<typeof persisted<T>>
+
+export type ChildStorePersistedFactory = <T>(
+  target: ChildStorePersistTarget,
+  store: [Store<T>, SetStoreFunction<T>],
+) => PersistedResult<T>
+
+export class ChildStoreError extends Error {
+  readonly context: ChildStoreErrorContext
+
+  constructor(message: string, context: ChildStoreErrorContext, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = "ChildStoreError"
+    this.context = context
+  }
+}
+
+function describeDirectory(directory: unknown) {
+  if (typeof directory === "string") return directory.length > 0 ? JSON.stringify(directory) : "empty string"
+  if (directory === undefined) return "undefined"
+  if (directory === null) return "null"
+  try {
+    const json = JSON.stringify(directory)
+    return `${typeof directory}: ${json ?? String(directory)}`
+  } catch {
+    return `${typeof directory}: <unserializable>`
+  }
+}
+
+function contextDetails(context: ChildStoreErrorContext) {
+  return [
+    `cache=${context.kind}`,
+    context.storage ? `storage=${context.storage}` : undefined,
+    context.key ? `key=${context.key}` : undefined,
+    `directory=${describeDirectory(context.directory)}`,
+  ]
+    .filter((part): part is string => !!part)
+    .join(", ")
+}
+
+export function validateChildStoreDirectory(directory: unknown): asserts directory is string {
+  if (typeof directory === "string" && directory.length > 0) return
+  throw new ChildStoreError(`Invalid workspace directory for child store: ${describeDirectory(directory)}`, {
+    kind: "workspace",
+    directory,
+  })
+}
+
+export function createChildStorePersistedCacheError(input: {
+  translate: (key: string) => string
+  messageKey: string
+  context: ChildStoreErrorContext
+  cause?: unknown
+}) {
+  return new ChildStoreError(`${input.translate(input.messageKey)} (${contextDetails(input.context)})`, input.context, {
+    cause: input.cause,
+  })
+}
+
+export function createPersistedChildCache<T>(input: {
+  owner: Owner
+  directory: string
+  kind: Exclude<ChildStoreCacheKind, "workspace">
+  messageKey: string
+  target: ChildStorePersistTarget
+  store: [Store<T>, SetStoreFunction<T>]
+  translate: (key: string) => string
+  persist?: ChildStorePersistedFactory
+}) {
+  const persist: ChildStorePersistedFactory = input.persist ?? persisted
+  const context: ChildStoreErrorContext = {
+    kind: input.kind,
+    directory: input.directory,
+    storage: input.target.storage,
+    key: input.target.key,
+  }
+  let cause: unknown
+
+  try {
+    const cache = runWithOwner(input.owner, () => {
+      try {
+        return persist(input.target, input.store)
+      } catch (error) {
+        // runWithOwner can hand this to Solid's error boundary and return undefined.
+        cause = error
+        throw error
+      }
+    })
+
+    if (cache) return cache
+  } catch (error) {
+    cause ??= error
+  }
+
+  throw createChildStorePersistedCacheError({
+    translate: input.translate,
+    messageKey: input.messageKey,
+    context,
+    cause,
+  })
+}

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -3,26 +3,35 @@ import { createRoot, getOwner } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { State } from "./types"
 import { createChildStoreManager } from "./child-store"
+import { ChildStoreError, type ChildStorePersistedFactory } from "./child-store-error"
 
 const child = () => createStore({} as State)
 
+function createManager(persist?: ChildStorePersistedFactory) {
+  const owner = createRoot((dispose) => {
+    const current = getOwner()
+    dispose()
+    return current
+  })
+  if (!owner) throw new Error("owner required")
+
+  return createChildStoreManager({
+    owner,
+    persist,
+    isBooting: () => false,
+    isLoadingSessions: () => false,
+    onBootstrap() {},
+    onDispose() {},
+    translate: (key) => {
+      if (key === "error.childStore.persistedCacheCreateFailed") return "Failed to create persisted cache"
+      return key
+    },
+  })
+}
+
 describe("createChildStoreManager", () => {
   test("does not evict the active directory during mark", () => {
-    const owner = createRoot((dispose) => {
-      const current = getOwner()
-      dispose()
-      return current
-    })
-    if (!owner) throw new Error("owner required")
-
-    const manager = createChildStoreManager({
-      owner,
-      isBooting: () => false,
-      isLoadingSessions: () => false,
-      onBootstrap() {},
-      onDispose() {},
-      translate: (key) => key,
-    })
+    const manager = createManager()
 
     Array.from({ length: 30 }, (_, index) => `/pinned-${index}`).forEach((directory) => {
       manager.children[directory] = child()
@@ -34,5 +43,62 @@ describe("createChildStoreManager", () => {
     manager.mark(directory)
 
     expect(manager.children[directory]).toBeDefined()
+  })
+
+  test("rejects invalid runtime directories before persisted cache setup", () => {
+    const manager = createManager()
+
+    expect(() => manager.child(undefined as unknown as string)).toThrow("Invalid workspace directory for child store")
+  })
+
+  test("preserves persisted setup cause and workspace target context", () => {
+    const cause = new TypeError("storage init failed")
+    const persist: ChildStorePersistedFactory = () => {
+      throw cause
+    }
+    const manager = createManager(persist)
+
+    try {
+      manager.child("/tmp/project")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChildStoreError)
+      expect(error).toHaveProperty("cause", cause)
+      expect((error as ChildStoreError).message).toContain("Failed to create persisted cache")
+      expect((error as ChildStoreError).message).toContain("cache=vcs")
+      expect((error as ChildStoreError).message).toContain("key=workspace:vcs")
+      expect((error as ChildStoreError).context.kind).toBe("vcs")
+      expect((error as ChildStoreError).context.directory).toBe("/tmp/project")
+      expect((error as ChildStoreError).context.key).toBe("workspace:vcs")
+      expect((error as ChildStoreError).context.storage).toStartWith("pawwork.workspace.-tmp-project.")
+      return
+    }
+
+    throw new Error("expected child store creation to throw")
+  })
+
+  test("does not publish partial cache state when a later persisted cache fails", () => {
+    const cause = new TypeError("project storage init failed")
+    const directory = "/tmp/project"
+    let calls = 0
+    const persist: ChildStorePersistedFactory = (_target, store) => {
+      calls += 1
+      if (calls === 2) throw cause
+      return [store[0], store[1], null, Object.assign(() => true, { promise: undefined })]
+    }
+    const manager = createManager(persist)
+
+    try {
+      manager.child(directory)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChildStoreError)
+      expect(error).toHaveProperty("cause", cause)
+      expect(manager.children[directory]).toBeUndefined()
+      expect(manager.vcsCache.has(directory)).toBe(false)
+      expect(manager.metaCache.has(directory)).toBe(false)
+      expect(manager.iconCache.has(directory)).toBe(false)
+      return
+    }
+
+    throw new Error("expected child store creation to throw")
   })
 })

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -1,7 +1,12 @@
 import { createRoot, getOwner, onCleanup, runWithOwner, type Owner } from "solid-js"
 import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
-import { Persist, persisted } from "@/utils/persist"
+import { Persist } from "@/utils/persist"
 import type { VcsInfo } from "@opencode-ai/sdk/v2/client"
+import {
+  createPersistedChildCache,
+  validateChildStoreDirectory,
+  type ChildStorePersistedFactory,
+} from "./child-store-error"
 import {
   DIR_IDLE_TTL_MS,
   MAX_DIR_STORES,
@@ -17,6 +22,7 @@ import { canDisposeDirectory, pickDirectoriesToEvict } from "./eviction"
 
 export function createChildStoreManager(input: {
   owner: Owner
+  persist?: ChildStorePersistedFactory
   isBooting: (directory: string) => boolean
   isLoadingSessions: (directory: string) => boolean
   onBootstrap: (directory: string) => void
@@ -122,34 +128,43 @@ export function createChildStoreManager(input: {
   }
 
   function ensureChild(directory: string) {
-    if (!directory) console.error("No directory provided")
+    validateChildStoreDirectory(directory)
     if (!children[directory]) {
-      const vcs = runWithOwner(input.owner, () =>
-        persisted(
-          Persist.workspace(directory, "vcs", ["vcs.v1"]),
-          createStore({ value: undefined as VcsInfo | undefined }),
-        ),
-      )
-      if (!vcs) throw new Error(input.translate("error.childStore.persistedCacheCreateFailed"))
+      const vcs = createPersistedChildCache({
+        owner: input.owner,
+        directory,
+        kind: "vcs",
+        messageKey: "error.childStore.persistedCacheCreateFailed",
+        target: Persist.workspace(directory, "vcs", ["vcs.v1"]),
+        store: createStore({ value: undefined as VcsInfo | undefined }),
+        translate: input.translate,
+        persist: input.persist,
+      })
+
+      const meta = createPersistedChildCache({
+        owner: input.owner,
+        directory,
+        kind: "project",
+        messageKey: "error.childStore.persistedProjectMetadataCreateFailed",
+        target: Persist.workspace(directory, "project", ["project.v1"]),
+        store: createStore({ value: undefined as ProjectMeta | undefined }),
+        translate: input.translate,
+        persist: input.persist,
+      })
+
+      const icon = createPersistedChildCache({
+        owner: input.owner,
+        directory,
+        kind: "icon",
+        messageKey: "error.childStore.persistedProjectIconCreateFailed",
+        target: Persist.workspace(directory, "icon", ["icon.v1"]),
+        store: createStore({ value: undefined as string | undefined }),
+        translate: input.translate,
+        persist: input.persist,
+      })
       const vcsStore = vcs[0]
       vcsCache.set(directory, { store: vcsStore, setStore: vcs[1], ready: vcs[3] })
-
-      const meta = runWithOwner(input.owner, () =>
-        persisted(
-          Persist.workspace(directory, "project", ["project.v1"]),
-          createStore({ value: undefined as ProjectMeta | undefined }),
-        ),
-      )
-      if (!meta) throw new Error(input.translate("error.childStore.persistedProjectMetadataCreateFailed"))
       metaCache.set(directory, { store: meta[0], setStore: meta[1], ready: meta[3] })
-
-      const icon = runWithOwner(input.owner, () =>
-        persisted(
-          Persist.workspace(directory, "icon", ["icon.v1"]),
-          createStore({ value: undefined as string | undefined }),
-        ),
-      )
-      if (!icon) throw new Error(input.translate("error.childStore.persistedProjectIconCreateFailed"))
       iconCache.set(directory, { store: icon[0], setStore: icon[1], ready: icon[3] })
 
       const init = () =>


### PR DESCRIPTION
## Summary

Preserve the original cause and child-store cache context when workspace persisted cache creation fails. Invalid runtime workspace directory input now fails before persistence setup instead of continuing into `Persist.workspace(...)`.

## Why

Closes #156. The packaged app could show only `Failed to create persisted cache`, which hid the synchronous exception, storage file, key, cache kind, and workspace directory. The fix keeps the failure at the child-store layer and does not change storage namespace behavior.

This intentionally turns empty workspace directories into explicit child-store errors too. Previously `ensureChild("")` only logged and continued into a fallback workspace cache path, which masked bad upstream input.

## Related Issue

Closes #156

## How To Verify

```bash
bun --cwd packages/app typecheck
(cd packages/app && bun test --preload ./happydom.ts ./src/context/sync-current-child.test.ts ./src/context/global-sync/child-store-error.test.ts ./src/context/global-sync/child-store.test.ts ./src/utils/persist.test.ts)
```

## Screenshots or Recordings

Not applicable. No visible UI layout change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better child-store persistence flow with optional custom persistence support and stricter directory validation.

* **Bug Fixes**
  * Improved error wrapping that preserves original causes and prevents partial/invalid cache publishing.

* **Tests**
  * Added tests covering error diagnostics, propagation, and persisted-cache failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->