### PR TITLE
fix: preserve gh cli auth config

### DIFF
--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -10,6 +10,8 @@ const serverRoots = {
   state: path.join(userData, "state"),
 }
 
+let mockShellEnv: Record<string, string> = {}
+
 mock.module("electron", () => ({
   app: {
     getPath: (name: string) => (name === "userData" ? userData : `/tmp/${name}`),
@@ -26,13 +28,13 @@ mock.module("./store", () => ({
 }))
 
 mock.module("./shell-env", () => ({
-  getUserShell: () => null,
+  getUserShell: () => "/bin/zsh",
   isNushell: (shell: string) => {
     const name = path.basename(shell).toLowerCase()
     const raw = shell.toLowerCase()
     return name === "nu" || name === "nu.exe" || raw.endsWith("\\nu.exe")
   },
-  loadShellEnv: () => ({}),
+  loadShellEnv: () => mockShellEnv,
   mergeShellEnv: (shell: Record<string, string> | null, env: Record<string, string>) => ({
     ...(shell || {}),
     ...env,
@@ -52,6 +54,7 @@ mock.module("./shell-env", () => ({
 const originalEnv = { ...process.env }
 
 afterEach(() => {
+  mockShellEnv = {}
   for (const key of Object.keys(process.env)) {
     if (!(key in originalEnv)) delete process.env[key]
   }
@@ -63,6 +66,8 @@ afterAll(() => {
 })
 
 describe("desktop server runtime namespace", () => {
+  const nonWindowsTest = process.platform === "win32" ? test.skip : test
+
   test("prepares PawWork-owned server environment before embedded server import", async () => {
     const { buildServerEnvForTest } = await import("./server")
 
@@ -76,6 +81,155 @@ describe("desktop server runtime namespace", () => {
     expect(env.XDG_CACHE_HOME).toBe(serverRoots.cache)
     expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
     expect(env.XDG_STATE_HOME).toBe(serverRoots.state)
+  })
+
+  test("uses process GitHub CLI config directory before shell config directory", async () => {
+    process.env.GH_CONFIG_DIR = "/process/gh"
+    mockShellEnv = { GH_CONFIG_DIR: "/shell/gh", XDG_CONFIG_HOME: "/shell/config" }
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+    expect(env.GH_CONFIG_DIR).toBe("/process/gh")
+  })
+
+  test("keeps explicit GitHub CLI config directory while isolating PawWork config", async () => {
+    process.env.GH_CONFIG_DIR = "/custom/gh"
+    process.env.XDG_CONFIG_HOME = "/user/config"
+    process.env.HOME = "/Users/example"
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+    expect(env.GH_CONFIG_DIR).toBe("/custom/gh")
+  })
+
+  test("keeps process env values before shell env values", async () => {
+    process.env.PAWWORK_TEST_ENV = "process"
+    mockShellEnv = { PAWWORK_TEST_ENV: "shell" }
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.PAWWORK_TEST_ENV).toBe("process")
+  })
+
+  nonWindowsTest("derives GitHub CLI config directory from shell XDG config home", async () => {
+    delete process.env.GH_CONFIG_DIR
+    delete process.env.XDG_CONFIG_HOME
+    mockShellEnv = { XDG_CONFIG_HOME: "/shell/config" }
+    process.env.HOME = "/Users/example"
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+    expect(env.GH_CONFIG_DIR).toBe(path.join("/shell/config", "gh"))
+  })
+
+  test("uses process XDG config home before shell XDG config home", async () => {
+    delete process.env.GH_CONFIG_DIR
+    process.env.XDG_CONFIG_HOME = "/process/config"
+    mockShellEnv = { XDG_CONFIG_HOME: "/shell/config" }
+    process.env.HOME = "/Users/example"
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+    expect(env.GH_CONFIG_DIR).toBe(path.join("/process/config", "gh"))
+  })
+
+  nonWindowsTest("derives GitHub CLI config directory from home when original XDG config home is absent", async () => {
+    delete process.env.GH_CONFIG_DIR
+    delete process.env.XDG_CONFIG_HOME
+    mockShellEnv = {}
+    process.env.HOME = "/Users/example"
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+    expect(env.GH_CONFIG_DIR).toBe(path.join("/Users/example", ".config", "gh"))
+  })
+
+  test("derives Windows GitHub CLI config directory from AppData when XDG config home is absent", async () => {
+    delete process.env.GH_CONFIG_DIR
+    const { githubConfigDirForTest } = await import("./server")
+
+    expect(
+      githubConfigDirForTest(
+        {
+          AppData: "C:\\Users\\example\\AppData\\Roaming",
+          HOME: "C:\\Users\\example",
+        },
+        "win32",
+      ),
+    ).toBe(path.join("C:\\Users\\example\\AppData\\Roaming", "GitHub CLI"))
+  })
+
+  test("derives Windows GitHub CLI config directory from uppercase APPDATA", async () => {
+    delete process.env.GH_CONFIG_DIR
+    const { githubConfigDirForTest } = await import("./server")
+
+    expect(
+      githubConfigDirForTest(
+        {
+          APPDATA: "C:\\Users\\example\\AppData\\Roaming",
+          HOME: "C:\\Users\\example",
+        },
+        "win32",
+      ),
+    ).toBe(path.join("C:\\Users\\example\\AppData\\Roaming", "GitHub CLI"))
+  })
+
+  test("derives Windows GitHub CLI config directory from lowercase appdata", async () => {
+    delete process.env.GH_CONFIG_DIR
+    const { githubConfigDirForTest } = await import("./server")
+
+    expect(
+      githubConfigDirForTest(
+        {
+          appdata: "C:\\Users\\example\\AppData\\Roaming",
+          HOME: "C:\\Users\\example",
+        },
+        "win32",
+      ),
+    ).toBe(path.join("C:\\Users\\example\\AppData\\Roaming", "GitHub CLI"))
+  })
+
+  test("uses injectable path utility for platform-specific GitHub CLI config paths", async () => {
+    delete process.env.GH_CONFIG_DIR
+    const { githubConfigDirForTest } = await import("./server")
+    const pathUtils = {
+      join: (...parts: string[]) => parts.join("\\"),
+    }
+
+    expect(
+      githubConfigDirForTest(
+        {
+          APPDATA: "C:\\Users\\example\\AppData\\Roaming",
+        },
+        "win32",
+        pathUtils,
+      ),
+    ).toBe("C:\\Users\\example\\AppData\\Roaming\\GitHub CLI")
+  })
+
+  test("derives Windows GitHub CLI config directory from home when AppData is absent", async () => {
+    delete process.env.GH_CONFIG_DIR
+    const { githubConfigDirForTest } = await import("./server")
+
+    expect(
+      githubConfigDirForTest(
+        {
+          HOME: "C:\\Users\\example",
+        },
+        "win32",
+      ),
+    ).toBe(path.join("C:\\Users\\example", ".config", "gh"))
   })
 
   test("runtime roots keep Windows-shaped user data under PawWork", async () => {

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -1,4 +1,5 @@
 import { app } from "electron"
+import path from "node:path"
 import { DEFAULT_SERVER_URL_KEY, WSL_ENABLED_KEY } from "./constants"
 import { rendererOrigin } from "./renderer-protocol"
 import { PAWWORK_RUNTIME, runtimeRoots } from "./runtime-namespace"
@@ -58,19 +59,34 @@ export async function spawnLocalServer(hostname: string, port: number, password:
   return { listener, health: { wait } }
 }
 
+function githubConfigDir(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  pathUtils: Pick<typeof path, "join"> = path,
+) {
+  if (env.GH_CONFIG_DIR) return env.GH_CONFIG_DIR
+  if (env.XDG_CONFIG_HOME) return pathUtils.join(env.XDG_CONFIG_HOME, "gh")
+  const appData = env.AppData ?? env.APPDATA ?? (platform === "win32" ? env.appdata : undefined)
+  if (platform === "win32" && appData) return pathUtils.join(appData, "GitHub CLI")
+  if (env.HOME) return pathUtils.join(env.HOME, ".config", "gh")
+  return undefined
+}
+
 function buildServerEnv(password: string) {
   const shell = process.platform === "win32" ? null : getUserShell()
   const shellEnv = shell ? (loadShellEnv(shell) ?? {}) : {}
   const roots = runtimeRoots(app.getPath("userData"))
+  const mergedEnv = { ...shellEnv, ...process.env }
+  const ghConfigDir = githubConfigDir(mergedEnv, process.platform)
   return {
-    ...process.env,
-    ...shellEnv,
+    ...mergedEnv,
     OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
     OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
     OPENCODE_CLIENT: PAWWORK_RUNTIME.client,
     OPENCODE_SERVER_USERNAME: PAWWORK_RUNTIME.serverUsername,
     OPENCODE_SERVER_PASSWORD: password,
     PAWWORK_RUNTIME_NAMESPACE: "pawwork",
+    ...(ghConfigDir ? { GH_CONFIG_DIR: ghConfigDir } : {}),
     XDG_DATA_HOME: roots.data,
     XDG_CACHE_HOME: roots.cache,
     XDG_CONFIG_HOME: roots.config,
@@ -84,6 +100,7 @@ function prepareServerEnv(password: string) {
 }
 
 export const buildServerEnvForTest = buildServerEnv
+export const githubConfigDirForTest = githubConfigDir
 
 export async function checkHealth(url: string, password?: string | null): Promise<boolean> {
   let healthUrl: URL


### PR DESCRIPTION
## Summary
Preserve GitHub CLI authentication for PawWork agent commands by deriving `GH_CONFIG_DIR` before the desktop server overwrites `XDG_CONFIG_HOME` with PawWork's isolated config directory.

## Why
PawWork's desktop server correctly isolates opencode state under the app user data directory, but `gh` also uses `XDG_CONFIG_HOME` to locate `hosts.yml`. After the isolation change, agent-run `gh auth status` looked in PawWork's config directory and reported that the user was not logged in even though the normal terminal login still worked.

## Related Issue
No issue. This is a narrow regression fix with a reproduced root cause.

## How To Verify
```bash
cd packages/desktop-electron
bun test src/main/server.test.ts
bun run typecheck
```

Manual env repro:
1. `env -u GH_CONFIG_DIR -u GH_TOKEN -u GITHUB_TOKEN XDG_CONFIG_HOME="$isolated_config" gh auth status` reports not logged in.
2. `env -u GH_TOKEN -u GITHUB_TOKEN XDG_CONFIG_HOME="$isolated_config" GH_CONFIG_DIR="$gh_auth_dir" gh auth status` sees the existing login.

## Screenshots or Recordings
Not applicable. No visible UI change.

## Checklist
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub CLI configuration directory resolution to properly handle environment variable precedence across different platforms.

* **Tests**
  * Enhanced test coverage for environment variable handling and platform-specific configuration path derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->