### PR TITLE
fix: include mac updater config in signed app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -686,6 +686,31 @@ jobs:
             *) echo "Unsupported channel: $OPENCODE_CHANNEL"; exit 1 ;;
           esac
 
+          case "$OPENCODE_CHANNEL" in
+            dev) expected_repo="" ;;
+            beta) expected_repo="pawwork-beta" ;;
+            prod) expected_repo="pawwork" ;;
+            *) echo "Unsupported channel: $OPENCODE_CHANNEL"; exit 1 ;;
+          esac
+
+          verify_app_update_config() {
+            local config_path="$1"
+
+            if [ -z "$expected_repo" ]; then
+              return 0
+            fi
+
+            if [ ! -f "$config_path" ]; then
+              echo "Expected app-update.yml at $config_path"
+              exit 1
+            fi
+
+            grep -qx "provider: github" "$config_path"
+            grep -qx "owner: Astro-Han" "$config_path"
+            grep -qx "repo: $expected_repo" "$config_path"
+            grep -qx "channel: latest" "$config_path"
+          }
+
           verify_dir="$RUNNER_TEMP/verify-notarized-artifacts"
           rm -rf "$verify_dir"
           mkdir -p "$verify_dir"
@@ -708,6 +733,8 @@ jobs:
 
           ditto -x -k "$zip_path" "$verify_dir"
           xcrun stapler validate -v "$verify_dir/$APP_NAME.app"
+          codesign --verify --deep --strict --verbose=2 "$verify_dir/$APP_NAME.app"
+          verify_app_update_config "$verify_dir/$APP_NAME.app/Contents/Resources/app-update.yml"
 
           mount_base="$RUNNER_TEMP/verify-dmg-mounts"
           rm -rf "$mount_base"
@@ -729,6 +756,7 @@ jobs:
 
             xcrun stapler validate -v "$mounted_app"
             codesign --verify --deep --strict --verbose=2 "$mounted_app"
+            verify_app_update_config "$mounted_app/Contents/Resources/app-update.yml"
 
             hdiutil detach "$mount_dir" -quiet
             rm -f "$attach_plist"

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import type { Configuration } from "electron-builder"
+import { createConfig, getPublishConfig } from "./electron-builder.config"
+import { serializeAppUpdateConfig } from "./scripts/write-app-update-config"
+
+const roots: string[] = []
+type AfterPackContext = Parameters<Extract<NonNullable<Configuration["afterPack"]>, (...args: any[]) => unknown>>[0]
+
+function macAfterPackContext(appOutDir: string, appBundleName: string, electronPlatformName = "darwin"): AfterPackContext {
+  return {
+    appOutDir,
+    electronPlatformName,
+    packager: {
+      getMacOsResourcesDir: (root: string) => join(root, `${appBundleName}.app`, "Contents", "Resources"),
+    },
+  } as AfterPackContext
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("electron builder app-update config", () => {
+  test("prod publish config feeds local updater config", () => {
+    expect(serializeAppUpdateConfig(getPublishConfig("prod")!)).toContain("repo: pawwork\n")
+  })
+
+  test("beta publish config feeds local updater config", () => {
+    expect(serializeAppUpdateConfig(getPublishConfig("beta")!)).toContain("repo: pawwork-beta\n")
+  })
+
+  test("dev does not publish updater config", () => {
+    expect(getPublishConfig("dev")).toBeUndefined()
+  })
+
+  test("mac packaging has an afterPack hook to write app-update.yml before signing", () => {
+    expect(typeof createConfig("prod").afterPack).toBe("function")
+  })
+
+  test("afterPack writes app-update.yml to the packager-reported macOS resources path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-builder-config-"))
+    roots.push(root)
+    const config = createConfig("prod")
+
+    await config.afterPack!(macAfterPackContext(root, "PawWork Product Filename"))
+
+    const configPath = join(root, "PawWork Product Filename.app", "Contents", "Resources", "app-update.yml")
+    expect(existsSync(configPath)).toBe(true)
+    expect(readFileSync(configPath, "utf8")).toContain("repo: pawwork\n")
+  })
+
+  test("afterPack writes beta app-update.yml to the beta app resources path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-builder-config-"))
+    roots.push(root)
+    const config = createConfig("beta")
+
+    await config.afterPack!(macAfterPackContext(root, "PawWork Beta"))
+
+    const configPath = join(root, "PawWork Beta.app", "Contents", "Resources", "app-update.yml")
+    expect(existsSync(configPath)).toBe(true)
+    expect(readFileSync(configPath, "utf8")).toContain("repo: pawwork-beta\n")
+  })
+
+  test("afterPack preserves an existing hook before writing updater config", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-builder-config-"))
+    roots.push(root)
+    const calls: string[] = []
+    const config = createConfig("prod", {
+      afterPack: async () => {
+        calls.push("existing")
+      },
+    })
+
+    await config.afterPack!(macAfterPackContext(root, "PawWork"))
+
+    const configPath = join(root, "PawWork.app", "Contents", "Resources", "app-update.yml")
+    expect(calls).toEqual(["existing"])
+    expect(existsSync(configPath)).toBe(true)
+  })
+
+  test("afterPack skips updater config when publish is not configured", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-builder-config-"))
+    roots.push(root)
+    const config = createConfig("dev")
+
+    await config.afterPack!(macAfterPackContext(root, "PawWork Dev"))
+
+    const configPath = join(root, "PawWork Dev.app", "Contents", "Resources", "app-update.yml")
+    expect(existsSync(configPath)).toBe(false)
+  })
+})

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -4,10 +4,12 @@ import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
 import type { Configuration } from "electron-builder"
+import { writeAppUpdateConfig, type GitHubPublishConfig } from "./scripts/write-app-update-config"
 
 const execFileAsync = promisify(execFile)
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 const signScript = path.join(rootDir, "script", "sign-windows.ps1")
+type Channel = "dev" | "beta" | "prod"
 
 async function signWindows(configuration: { path: string }) {
   if (process.platform !== "win32") return
@@ -20,11 +22,17 @@ async function signWindows(configuration: { path: string }) {
   )
 }
 
-const channel = (() => {
+function currentChannel(): Channel {
   const raw = process.env.OPENCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
   return "dev"
-})()
+}
+
+export function getPublishConfig(channel: Channel): GitHubPublishConfig | undefined {
+  if (channel === "beta") return { provider: "github", owner: "Astro-Han", repo: "pawwork-beta", channel: "latest" }
+  if (channel === "prod") return { provider: "github", owner: "Astro-Han", repo: "pawwork", channel: "latest" }
+  return undefined
+}
 
 const getBase = (): Configuration => ({
   artifactName: "pawwork-${os}-${arch}.${ext}",
@@ -87,39 +95,50 @@ const getBase = (): Configuration => ({
   },
 })
 
-function getConfig() {
-  const base = getBase()
+export function createConfig(channel: Channel = currentChannel(), baseOverrides: Partial<Configuration> = {}) {
+  const base = { ...getBase(), ...baseOverrides }
+  const publish = getPublishConfig(channel)
+
+  const withAppUpdateConfig = (configuration: Configuration): Configuration => ({
+    ...configuration,
+    publish,
+    afterPack: async (context) => {
+      if (typeof configuration.afterPack === "function") {
+        await configuration.afterPack(context)
+      }
+      if (context.electronPlatformName !== "darwin" || publish === undefined) return
+      await writeAppUpdateConfig(context.packager.getMacOsResourcesDir(context.appOutDir), publish)
+    },
+  })
 
   switch (channel) {
     case "dev": {
-      return {
+      return withAppUpdateConfig({
         ...base,
         appId: "ai.pawwork.desktop.dev",
         productName: "PawWork Dev",
         rpm: { packageName: "pawwork-dev" },
-      }
+      })
     }
     case "beta": {
-      return {
+      return withAppUpdateConfig({
         ...base,
         appId: "ai.pawwork.desktop.beta",
         productName: "PawWork Beta",
         protocols: { name: "PawWork Beta", schemes: ["pawwork"] },
-        publish: { provider: "github", owner: "Astro-Han", repo: "pawwork-beta", channel: "latest" },
         rpm: { packageName: "pawwork-beta" },
-      }
+      })
     }
     case "prod": {
-      return {
+      return withAppUpdateConfig({
         ...base,
         appId: "ai.pawwork.desktop",
         productName: "PawWork",
         protocols: { name: "PawWork", schemes: ["pawwork"] },
-        publish: { provider: "github", owner: "Astro-Han", repo: "pawwork", channel: "latest" },
         rpm: { packageName: "pawwork" },
-      }
+      })
     }
   }
 }
 
-export default getConfig()
+export default createConfig()

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "typecheck": "tsgo -b",
+    "typecheck:release": "tsgo -p tsconfig.release.json",
     "test": "bun test",
     "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "smoke:ci": "bun ./scripts/ci-smoke.ts",

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const workflow = readFileSync(join(import.meta.dir, "..", "..", "..", ".github", "workflows", "build.yml"), "utf8")
+
+describe("release workflow app-update verification", () => {
+  test("does not mutate app-update.yml after signing", () => {
+    expect(workflow).not.toContain("write-app-update-config")
+  })
+
+  test("verifies app-update.yml in extracted zip artifact", () => {
+    expect(workflow).toContain('verify_app_update_config "$verify_dir/$APP_NAME.app/Contents/Resources/app-update.yml"')
+  })
+
+  test("verifies codesign for extracted zip app", () => {
+    expect(workflow).toContain('codesign --verify --deep --strict --verbose=2 "$verify_dir/$APP_NAME.app"')
+  })
+
+  test("verifies app-update.yml in mounted dmg artifact", () => {
+    expect(workflow).toContain('verify_app_update_config "$mounted_app/Contents/Resources/app-update.yml"')
+  })
+
+  test("matches updater repo by exact line", () => {
+    expect(workflow).toContain('grep -qx "repo: $expected_repo" "$config_path"')
+  })
+
+  test("keeps submit phase packaging as a signed app directory", () => {
+    expect(workflow).toContain("npx electron-builder --mac dir --${{ matrix.arch_label }} --publish never")
+  })
+
+  test("keeps finalize phase packaging from the prepackaged signed app", () => {
+    expect(workflow).toContain('npx electron-builder --mac dmg zip --${{ matrix.arch_label }} --prepackaged "$APP_PATH"')
+  })
+})

--- a/packages/desktop-electron/scripts/write-app-update-config.test.ts
+++ b/packages/desktop-electron/scripts/write-app-update-config.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { serializeAppUpdateConfig, writeAppUpdateConfig } from "./write-app-update-config"
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("write-app-update-config", () => {
+  test("serializes prod GitHub updater config", () => {
+    expect(
+      serializeAppUpdateConfig({
+        provider: "github",
+        owner: "Astro-Han",
+        repo: "pawwork",
+        channel: "latest",
+      }),
+    ).toBe(
+      [
+        "provider: github",
+        "owner: Astro-Han",
+        "repo: pawwork",
+        "channel: latest",
+        "updaterCacheDirName: pawwork-updater",
+        "",
+      ].join("\n"),
+    )
+  })
+
+  test("serializes beta GitHub updater config", () => {
+    expect(
+      serializeAppUpdateConfig({
+        provider: "github",
+        owner: "Astro-Han",
+        repo: "pawwork-beta",
+        channel: "latest",
+      }),
+    ).toContain("repo: pawwork-beta")
+  })
+
+  test("does not write updater config without publish config", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-app-update-"))
+    roots.push(root)
+
+    expect(await writeAppUpdateConfig(join(root, "Resources"), undefined)).toBe(false)
+    expect(existsSync(join(root, "Resources", "app-update.yml"))).toBe(false)
+  })
+
+  test("writes updater config inside macOS app resources", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-app-update-"))
+    roots.push(root)
+
+    expect(
+      await writeAppUpdateConfig(join(root, "PawWork.app", "Contents", "Resources"), {
+        provider: "github",
+        owner: "Astro-Han",
+        repo: "pawwork",
+        channel: "latest",
+      }),
+    ).toBe(true)
+
+    const configPath = join(root, "PawWork.app", "Contents", "Resources", "app-update.yml")
+    expect(readFileSync(configPath, "utf8")).toContain("repo: pawwork")
+    expect(readFileSync(configPath, "utf8")).toContain("updaterCacheDirName: pawwork-updater")
+  })
+})

--- a/packages/desktop-electron/scripts/write-app-update-config.ts
+++ b/packages/desktop-electron/scripts/write-app-update-config.ts
@@ -1,0 +1,30 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+export type GitHubPublishConfig = {
+  provider: "github"
+  owner: string
+  repo: string
+  channel: string
+}
+
+const UPDATER_CACHE_DIR_NAME = "pawwork-updater"
+
+export function serializeAppUpdateConfig(publish: GitHubPublishConfig) {
+  return [
+    "provider: github",
+    `owner: ${publish.owner}`,
+    `repo: ${publish.repo}`,
+    `channel: ${publish.channel}`,
+    `updaterCacheDirName: ${UPDATER_CACHE_DIR_NAME}`,
+    "",
+  ].join("\n")
+}
+
+export async function writeAppUpdateConfig(resourcesDir: string, publish: GitHubPublishConfig | undefined) {
+  if (publish === undefined) return false
+
+  await mkdir(resourcesDir, { recursive: true })
+  await writeFile(join(resourcesDir, "app-update.yml"), serializeAppUpdateConfig(publish))
+  return true
+}

--- a/packages/desktop-electron/tsconfig.release.json
+++ b/packages/desktop-electron/tsconfig.release.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["electron-builder.config.ts", "scripts/write-app-update-config.ts"]
+}


### PR DESCRIPTION
## Summary

- Write Electron updater local config into macOS app resources from `afterPack`, before signing.
- Reuse the same beta/prod GitHub publish config for `app-update.yml` to avoid repo drift.
- Verify final notarized zip and dmg artifacts include the updater config and keep strict codesign checks.

## Why

Clicking Check for Updates in packaged PawWork can fail with `ENOENT` when `Contents/Resources/app-update.yml` is missing. The release flow signs the `.app` before the finalize packaging step, so the updater config must be present before signing rather than added later.

## Related Issue

Fixes #165

## How To Verify

```bash
cd packages/desktop-electron
bun test electron-builder-app-update.test.ts scripts/write-app-update-config.test.ts scripts/release-workflow-contract.test.ts
bun run typecheck:release
bun run typecheck
cd ../..
bun turbo typecheck
bun turbo test:ci
```

## Screenshots or Recordings

N/A, packaging and release workflow change only.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced app update configuration validation with channel-to-repository mapping for dev, beta, and production releases.
  * Stricter code signing verification for macOS builds.

* **Chores**
  * Added release-specific TypeScript configuration and validation checks.
  * Improved build configuration and release workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->