### PR TITLE
chore: bump version to 0.2.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -141,7 +141,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -384,7 +384,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Bump PawWork workspace release metadata from 0.2.7 to 0.2.8.

## Why
Prepare the next stable desktop release after the macOS updater config fix in #168 landed on dev.

## Related Issue
No issue. This is a release preparation PR.

## How To Verify
```bash
bun install --frozen-lockfile
bun turbo typecheck
bun test scripts/verify-release.test.ts scripts/release-metadata-contract.test.ts scripts/release-workflow-contract.test.ts electron-builder-app-update.test.ts scripts/write-app-update-config.test.ts
```

Earlier in this release-prep pass, `bun turbo test:ci` also completed with Turbo success. The opencode JUnit report emitted a warning after reporting 2030 pass, 0 fail; I did not use that command as the final local gate because it triggered checkout/reset side effects in this checkout.

## Screenshots or Recordings
Not applicable. No visible UI changes.

## Checklist
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English