### PR TITLE
fix: preserve shell path for gh cli

### DIFF
--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -116,6 +116,35 @@ describe("desktop server runtime namespace", () => {
     expect(env.PAWWORK_TEST_ENV).toBe("process")
   })
 
+  nonWindowsTest("keeps login shell PATH so Homebrew commands remain discoverable", async () => {
+    process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+    mockShellEnv = {
+      PATH: "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin",
+    }
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.PATH).toBe("/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin")
+  })
+
+  nonWindowsTest("keeps process GitHub CLI config priority without letting process PATH override shell PATH", async () => {
+    process.env.PATH = "/usr/bin:/bin"
+    process.env.GH_CONFIG_DIR = "/process/gh"
+    mockShellEnv = {
+      PATH: "/opt/homebrew/bin:/usr/bin:/bin",
+      GH_CONFIG_DIR: "/shell/gh",
+      XDG_CONFIG_HOME: "/shell/config",
+    }
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+    expect(env.GH_CONFIG_DIR).toBe("/process/gh")
+    expect(env.XDG_CONFIG_HOME).toBe(serverRoots.config)
+  })
+
   nonWindowsTest("derives GitHub CLI config directory from shell XDG config home", async () => {
     delete process.env.GH_CONFIG_DIR
     delete process.env.XDG_CONFIG_HOME

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -76,8 +76,12 @@ function buildServerEnv(password: string) {
   const shell = process.platform === "win32" ? null : getUserShell()
   const shellEnv = shell ? (loadShellEnv(shell) ?? {}) : {}
   const roots = runtimeRoots(app.getPath("userData"))
-  const mergedEnv = { ...shellEnv, ...process.env }
-  const ghConfigDir = githubConfigDir(mergedEnv, process.platform)
+  const originalEnv = { ...shellEnv, ...process.env }
+  const ghConfigDir = githubConfigDir(originalEnv, process.platform)
+  const mergedEnv = {
+    ...originalEnv,
+    ...(shellEnv.PATH ? { PATH: shellEnv.PATH } : {}),
+  }
   return {
     ...mergedEnv,
     OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",


### PR DESCRIPTION
## Summary

Preserve the login shell PATH when PawWork prepares the embedded server environment, so Homebrew-installed commands such as `gh` remain discoverable from PawWork shell flows.

## Why

PR #167 correctly preserved GitHub CLI auth by deriving `GH_CONFIG_DIR` before PawWork overrides `XDG_CONFIG_HOME`, but it also changed the general env merge so a narrow macOS GUI `process.env.PATH` could override the login shell PATH. This made `gh` look missing inside PawWork even though the normal terminal could resolve it.

## Related Issue

Fixes #170.

## How To Verify

```bash
cd packages/desktop-electron
bun test src/main/server.test.ts
bun test src/main/shell-env.test.ts
bun run typecheck
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable precedence handling to correctly prioritize shell-level settings over process-level configurations.

* **Tests**
  * Added test cases to verify correct precedence ordering for environment variables across different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->