### PR TITLE
fix: prevent shell failure render crash

### DIFF
--- a/packages/app/e2e/prompt/prompt-shell.spec.ts
+++ b/packages/app/e2e/prompt/prompt-shell.spec.ts
@@ -1,4 +1,5 @@
 import type { ToolPart } from "@opencode-ai/sdk/v2/client"
+import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { closeSettingsPanel, openSettings, withSession } from "../actions"
 import { promptModelSelector, promptSelector, promptVariantSelector } from "../selectors"
@@ -8,6 +9,19 @@ const isBash = (part: unknown): part is ToolPart => {
   if (!("type" in part) || part.type !== "tool") return false
   if (!("tool" in part) || part.tool !== "bash") return false
   return "state" in part
+}
+
+function capturePageErrors(page: Page) {
+  const pageErrors: string[] = []
+  const onPageError = (err: Error & { name?: string }) => {
+    const detail = [err.name, err.message, err.stack, String(err)].filter(Boolean).join("\n")
+    pageErrors.push(detail)
+  }
+  page.on("pageerror", onPageError)
+  return {
+    pageErrors,
+    dispose: () => page.off("pageerror", onPageError),
+  }
 }
 
 test("shell mode runs a command in the project directory", async ({ page, project }) => {
@@ -56,6 +70,58 @@ test("shell mode runs a command in the project directory", async ({ page, projec
       )
       .toEqual(expect.objectContaining({ cwd: project.directory, output: expect.stringContaining("README.md") }))
   })
+})
+
+test("shell mode renders command failures without crashing the renderer", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  const errors = capturePageErrors(page)
+  const COMMAND = "definitely-not-a-command-171 --help"
+  const COMMAND_FAILURE_PATTERN = /command not found|is not recognized/i
+
+  try {
+    await project.open()
+
+    await withSession(project.sdk, `e2e shell failure ${Date.now()}`, async (session) => {
+      project.trackSession(session.id)
+      await project.gotoSession(session.id)
+      await project.shell(COMMAND)
+
+      await page.locator('[data-component="tool-trigger"]').last().click()
+      await expect(page.locator('[data-component="bash-output"]').last()).toContainText(COMMAND)
+      await expect(page.locator('[data-component="bash-output"]').last()).toContainText(COMMAND_FAILURE_PATTERN)
+
+      await expect
+        .poll(
+          async () => {
+            const list = await project.sdk.session
+              .messages({ sessionID: session.id, limit: 50 })
+              .then((x) => x.data ?? [])
+            const msg = list.findLast(
+              (item) => item.info.role === "assistant" && "path" in item.info && item.info.path.cwd === project.directory,
+            )
+            if (!msg) return
+
+            const part = msg.parts
+              .filter(isBash)
+              .find((item) => item.state.input?.command === COMMAND && item.state.status === "completed")
+            if (!part || part.state.status !== "completed") return
+
+            const output =
+              typeof part.state.metadata?.output === "string" ? part.state.metadata.output : part.state.output
+            if (!COMMAND_FAILURE_PATTERN.test(output)) return
+
+            return { command: part.state.input.command, output }
+          },
+          { timeout: 90_000 },
+        )
+        .toEqual(expect.objectContaining({ command: COMMAND, output: expect.stringMatching(COMMAND_FAILURE_PATTERN) }))
+    })
+
+    expect(errors.pageErrors.join("\n")).not.toContain("switchFunc(...) is not a function")
+  } finally {
+    errors.dispose()
+  }
 })
 
 test("shell mode unmounts model and variant controls", async ({ page, project }) => {

--- a/packages/ui/src/components/basic-tool-trigger.test.ts
+++ b/packages/ui/src/components/basic-tool-trigger.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+test("BasicTool trigger rendering avoids Solid Switch for dynamic JSX triggers", () => {
+  const source = readFileSync(new URL("./basic-tool.tsx", import.meta.url), "utf8")
+  const triggerInfoStart = source.indexOf("const triggerInfo = () =>")
+  const triggerStart = source.indexOf("const trigger = () =>", triggerInfoStart)
+  expect(triggerInfoStart).toBeGreaterThanOrEqual(0)
+  expect(triggerStart).toBeGreaterThan(triggerInfoStart)
+  const triggerSource = source.slice(triggerInfoStart, triggerStart)
+
+  expect(triggerSource).not.toMatch(/<\s*Switch\b/)
+  expect(triggerSource).not.toMatch(/<\s*Match\b[^>]*\bwhen=\{\s*isTriggerTitle\(props\.trigger\)/)
+})

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -1,4 +1,4 @@
-import { createEffect, For, Match, on, onCleanup, Show, Switch, type JSX } from "solid-js"
+import { createEffect, For, on, onCleanup, Show, type JSX } from "solid-js"
 import { animate, type AnimationPlaybackControls } from "motion"
 import { useI18n } from "../context/i18n"
 import { createStore } from "solid-js/store"
@@ -124,6 +124,62 @@ export function BasicTool(props: BasicToolProps) {
     setState("open", value)
   }
 
+  const triggerInfo = () => {
+    const title = isTriggerTitle(props.trigger) ? props.trigger : undefined
+    if (!title) return props.trigger as JSX.Element
+
+    return (
+      <div data-slot="basic-tool-tool-info-structured">
+        <div data-slot="basic-tool-tool-info-main">
+          <span
+            data-slot="basic-tool-tool-title"
+            classList={{
+              [title.titleClass ?? ""]: !!title.titleClass,
+            }}
+          >
+            <TextShimmer text={title.title} active={pending()} />
+          </span>
+          <Show when={!pending()}>
+            <Show when={title.subtitle}>
+              <span
+                data-slot="basic-tool-tool-subtitle"
+                classList={{
+                  [title.subtitleClass ?? ""]: !!title.subtitleClass,
+                  clickable: !!props.onSubtitleClick,
+                }}
+                onClick={(e) => {
+                  if (props.onSubtitleClick) {
+                    e.stopPropagation()
+                    props.onSubtitleClick()
+                  }
+                }}
+              >
+                {title.subtitle}
+              </span>
+            </Show>
+            <Show when={title.args?.length}>
+              <For each={title.args}>
+                {(arg) => (
+                  <span
+                    data-slot="basic-tool-tool-arg"
+                    classList={{
+                      [title.argsClass ?? ""]: !!title.argsClass,
+                    }}
+                  >
+                    {arg}
+                  </span>
+                )}
+              </For>
+            </Show>
+          </Show>
+        </div>
+        <Show when={!pending() && title.action}>
+          <span data-slot="basic-tool-tool-action">{title.action}</span>
+        </Show>
+      </div>
+    )
+  }
+
   const trigger = () => (
     <div
       data-component="tool-trigger"
@@ -131,63 +187,7 @@ export function BasicTool(props: BasicToolProps) {
       data-hide-details={props.hideDetails ? "true" : undefined}
     >
       <div data-slot="basic-tool-tool-trigger-content">
-        <div data-slot="basic-tool-tool-info">
-          <Switch>
-            <Match when={isTriggerTitle(props.trigger) && props.trigger}>
-              {(title) => (
-                <div data-slot="basic-tool-tool-info-structured">
-                  <div data-slot="basic-tool-tool-info-main">
-                    <span
-                      data-slot="basic-tool-tool-title"
-                      classList={{
-                        [title().titleClass ?? ""]: !!title().titleClass,
-                      }}
-                    >
-                      <TextShimmer text={title().title} active={pending()} />
-                    </span>
-                    <Show when={!pending()}>
-                      <Show when={title().subtitle}>
-                        <span
-                          data-slot="basic-tool-tool-subtitle"
-                          classList={{
-                            [title().subtitleClass ?? ""]: !!title().subtitleClass,
-                            clickable: !!props.onSubtitleClick,
-                          }}
-                          onClick={(e) => {
-                            if (props.onSubtitleClick) {
-                              e.stopPropagation()
-                              props.onSubtitleClick()
-                            }
-                          }}
-                        >
-                          {title().subtitle}
-                        </span>
-                      </Show>
-                      <Show when={title().args?.length}>
-                        <For each={title().args}>
-                          {(arg) => (
-                            <span
-                              data-slot="basic-tool-tool-arg"
-                              classList={{
-                                [title().argsClass ?? ""]: !!title().argsClass,
-                              }}
-                            >
-                              {arg}
-                            </span>
-                          )}
-                        </For>
-                      </Show>
-                    </Show>
-                  </div>
-                  <Show when={!pending() && title().action}>
-                    <span data-slot="basic-tool-tool-action">{title().action}</span>
-                  </Show>
-                </div>
-              )}
-            </Match>
-            <Match when={true}>{props.trigger as JSX.Element}</Match>
-          </Switch>
-        </div>
+        <div data-slot="basic-tool-tool-info">{triggerInfo()}</div>
       </div>
       <Show when={props.children && !props.hideDetails && !props.locked && !pending()}>
         <Collapsible.Arrow />


### PR DESCRIPTION
## Summary

Fixes the renderer crash risk when a user-entered shell command fails through composer shell mode.

## Why

Issue #171 showed that shell failures such as `definitely-not-a-command-171 --help` produce valid command-not-found output, but the renderer could crash while displaying the completed bash tool part. This is separate from #170, which covers PATH and GitHub CLI environment assembly.

## Related Issue

Fixes #171.

## How To Verify

```bash
cd packages/ui
bun test src/components/basic-tool-trigger.test.ts src/components/message-part-stale.test.ts
bun run typecheck
cd ../app
bun run test:e2e e2e/prompt/prompt-shell.spec.ts
bun run typecheck
bun run test:unit
```

## Screenshots or Recordings

Not included. This is a renderer crash fix for an existing shell output view, not a visual design or copy change. The e2e regression verifies failed shell output renders without the Solid Switch page error.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test to verify shell command failure is shown and backend output is validated
  * Added a unit test to ensure trigger rendering no longer uses legacy branching patterns

* **Refactor**
  * Updated trigger rendering logic in the basic tool to a consolidated implementation (no behavior changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->