### PR TITLE
fix: scope auth env for workspace adaptors

### DIFF
--- a/packages/opencode/src/control-plane/types.ts
+++ b/packages/opencode/src/control-plane/types.ts
@@ -25,6 +25,9 @@ export type Target =
     }
 
 export type Adaptor = {
+  auth?: {
+    providers: string[]
+  }
   configure(input: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
   // from is reserved for future workspace copy flows; core does not pass it today.
   create(config: WorkspaceInfo, env?: Record<string, string>, from?: WorkspaceInfo): Promise<void>

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -1,5 +1,6 @@
 import z from "zod"
 import { setTimeout as sleep } from "node:timers/promises"
+import { Effect } from "effect"
 import { fn } from "@/util/fn"
 import { Database, eq } from "@/storage/db"
 import { Project } from "@/project/project"
@@ -204,9 +205,27 @@ export namespace Workspace {
         .run()
     })
 
+    const requestedProviders = [...new Set(adaptor.auth?.providers ?? [])]
+    const scopedAuth =
+      requestedProviders.length === 0
+        ? undefined
+        : await AppRuntime.runPromise(
+            Auth.Service.use((auth) =>
+              Effect.gen(function* () {
+                const all = yield* auth.all()
+                return Object.fromEntries(
+                  requestedProviders
+                    .map((provider) => [provider, all[provider]] as const)
+                    .filter(([, value]) => value !== undefined),
+                )
+              }),
+            ),
+          )
+
     const env = Object.fromEntries(
       Object.entries({
-        OPENCODE_AUTH_CONTENT: JSON.stringify(await AppRuntime.runPromise(Auth.Service.use((auth) => auth.all()))),
+        OPENCODE_AUTH_CONTENT:
+          scopedAuth && Object.keys(scopedAuth).length > 0 ? JSON.stringify(scopedAuth) : undefined,
         OPENCODE_WORKSPACE_ID: info.id,
         OPENCODE_EXPERIMENTAL_WORKSPACES: "true",
         OTEL_EXPORTER_OTLP_HEADERS: process.env.OTEL_EXPORTER_OTLP_HEADERS,

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -1,9 +1,12 @@
 import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { unlink } from "node:fs/promises"
 import { Effect } from "effect"
 import { mkdir } from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Global } from "../../src/global"
+import { Filesystem } from "../../src/util/filesystem"
 import { eq } from "../../src/storage/db"
 import { tmpdir } from "../fixture/fixture"
 import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
@@ -116,6 +119,32 @@ async function pluginProject() {
   })
 }
 
+async function withAuthFile<T>(auth: Record<string, unknown>, fn: () => Promise<T>) {
+  const authPath = path.join(Global.Path.data, "auth.json")
+  let original: string | undefined
+
+  try {
+    original = await Filesystem.readText(authPath)
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      original = undefined
+    } else {
+      throw error
+    }
+  }
+
+  try {
+    await Filesystem.write(authPath, JSON.stringify(auth))
+    return await fn()
+  } finally {
+    if (original !== undefined) {
+      await Filesystem.write(authPath, original)
+    } else {
+      await unlink(authPath).catch(() => {})
+    }
+  }
+}
+
 describe("plugin.workspace", () => {
   test("plugin can install a workspace adaptor", async () => {
     await using tmp = await pluginProject()
@@ -157,9 +186,7 @@ describe("plugin.workspace", () => {
       if (expected === undefined) expect(created.env).not.toHaveProperty(key)
       else expect(created.env[key]).toBe(expected)
     }
-    const auth = JSON.parse(created.env.OPENCODE_AUTH_CONTENT)
-    expect(typeof auth).toBe("object")
-    expect(auth).not.toBeNull()
+    expect(created.env).not.toHaveProperty("OPENCODE_AUTH_CONTENT")
     await waitFor(() => {
       const status = Workspace.status().find((item) => item.workspaceID === info.id)
       return status !== undefined && status.status !== "connecting"
@@ -167,6 +194,97 @@ describe("plugin.workspace", () => {
     const status = Workspace.status().find((item) => item.workspaceID === info.id)
     expect(status).toBeDefined()
     expect(status?.status).not.toBe("connecting")
+  })
+
+  test("plugin workspace adaptor only receives the requested auth providers", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        const mark = path.join(dir, "created.json")
+        const space = path.join(dir, "space")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "scoped",',
+            '    description: "scoped auth adaptor",',
+            '    auth: { providers: ["openai"] },',
+            "    configure(input) {",
+            `      return { ...input, name: "scoped", branch: "scoped/main", directory: ${JSON.stringify(space)} }`,
+            "    },",
+            "    async create(input, env) {",
+            `      await Bun.write(${JSON.stringify(mark)}, JSON.stringify({ input, env }))`,
+            "    },",
+            "    async remove() {},",
+            "    target(input) {",
+            '      return { type: "local", directory: input.directory }',
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { mark, space, type }
+      },
+    })
+
+    await mkdir(tmp.extra.space, { recursive: true })
+
+    await withAuthFile(
+      {
+        openai: {
+          type: "api",
+          key: "sk-openai",
+        },
+        anthropic: {
+          type: "api",
+          key: "sk-anthropic",
+        },
+      },
+      async () => {
+        const info = await Instance.provide({
+          directory: tmp.path,
+          fn: async () =>
+            Effect.gen(function* () {
+              const plugin = yield* Plugin.Service
+              yield* plugin.init()
+              return Workspace.create({
+                type: tmp.extra.type,
+                branch: null,
+                extra: null,
+                projectID: Instance.project.id,
+              })
+            }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
+        })
+
+        expect(info.directory).toBe(tmp.extra.space)
+
+        const created = JSON.parse(await Bun.file(tmp.extra.mark).text())
+        expect(JSON.parse(created.env.OPENCODE_AUTH_CONTENT)).toEqual({
+          openai: {
+            type: "api",
+            key: "sk-openai",
+          },
+        })
+      },
+    )
   })
 
   test("plugin workspace adaptor registration does not survive instance disposal", async () => {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -48,11 +48,15 @@ export type WorkspaceTarget =
 export type WorkspaceAdaptor = {
   name: string
   description: string
+  auth?: {
+    providers: string[]
+  }
   configure(config: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
   /**
    * Environment variables to pass to spawned workspace processes.
    *
-   * This can include OPENCODE_AUTH_CONTENT, a serialized provider auth blob.
+   * Set auth.providers to opt in to OPENCODE_AUTH_CONTENT for specific providers.
+   * Core only forwards the requested provider entries, never the full auth store by default.
    * Treat values as secrets and avoid persisting or logging them.
    * The from parameter is reserved for future workspace copy flows; core does not pass it today.
    */


### PR DESCRIPTION
## Summary
- add an explicit `auth.providers` opt-in on workspace adaptors before forwarding `OPENCODE_AUTH_CONTENT`
- scope forwarded auth entries to the requested providers instead of serializing the whole auth store
- cover the new contract with workspace adaptor tests for the default no-auth path and the scoped-auth path

## Why
Issue #173 tracks the follow-up from #155: third-party or remote workspace adaptors should not receive unrelated credentials by default. This change keeps the existing env bridge for adaptors that truly need auth, but narrows the boundary to an explicit provider allowlist.

## Related Issue
Closes #173

## How To Verify
- `bun test test/plugin/workspace-adaptor.test.ts`
- `bun run typecheck` in `packages/opencode`
- `bun run typecheck` in `packages/plugin`
- `bun turbo typecheck`
- `git diff --check`

## Screenshots or Recordings
Not applicable. No visible UI changes.

## Checklist
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptors can optionally declare required auth providers; during workspace creation only the selected provider credentials are forwarded, reducing credential exposure.

* **Documentation**
  * Docs updated to explain how adaptor auth provider selection controls selective credential forwarding.

* **Tests**
  * Tests added/updated to verify selective forwarding and that the auth-forwarding environment variable is omitted when no requested providers are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->