### PR TITLE
fix: prevent submit summary shell expansion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -803,7 +803,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
           ## Notarization Submitted
 
           - Submission ID: `${{ steps.submit_notarization.outputs.submission_id }}`
@@ -818,7 +818,7 @@ jobs:
 
           To finalize later, run:
 
-          \`gh workflow run build.yml --repo ${{ github.repository }} --ref ${{ needs.create-snapshot-tag.outputs.workflow_ref }} -f phase=finalize -f channel=${{ inputs.channel || 'dev' }} -f arch=${{ matrix.arch_label }} -f source_run_id=${{ github.run_id }} -f source_run_attempt=${{ github.run_attempt }} -f source_ref=${{ github.ref_name }} -f source_sha=${{ github.sha }} -f source_workflow_ref=${{ needs.create-snapshot-tag.outputs.workflow_ref }} -f source_workflow_sha=${{ needs.create-snapshot-tag.outputs.workflow_sha }} -f submission_id=${{ steps.submit_notarization.outputs.submission_id }}\`
+          `gh workflow run build.yml --repo ${{ github.repository }} --ref ${{ needs.create-snapshot-tag.outputs.workflow_ref }} -f phase=finalize -f channel=${{ inputs.channel || 'dev' }} -f arch=${{ matrix.arch_label }} -f source_run_id=${{ github.run_id }} -f source_run_attempt=${{ github.run_attempt }} -f source_ref=${{ github.ref_name }} -f source_sha=${{ github.sha }} -f source_workflow_ref=${{ needs.create-snapshot-tag.outputs.workflow_ref }} -f source_workflow_sha=${{ needs.create-snapshot-tag.outputs.workflow_sha }} -f submission_id=${{ steps.submit_notarization.outputs.submission_id }}`
           EOF
 
       - name: Package app

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -66,6 +66,22 @@ describe("release workflow", () => {
     }),
   )
 
+  it.live("writes the submit phase summary without executing Markdown backticks", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.promise(() => runSummarizeSubmitPhase())
+
+      expect(result.status).toBe(0)
+      expect(result.output).not.toContain("command not found")
+      expect(result.summary).toContain("- Submission ID: `sample-submission-id`")
+      expect(result.summary).toContain("- Source run ID: `123456`")
+      expect(result.summary).toContain("- Source sha: `0123456789abcdef0123456789abcdef01234567`")
+      expect(result.summary).toContain(
+        "`gh workflow run build.yml --repo Astro-Han/pawwork --ref workflow-snapshot-123",
+      )
+      expect(result.summary).not.toContain("\\`gh workflow run")
+    }),
+  )
+
   it.live("validates the release workflow configuration", () =>
     Effect.gen(function* () {
       const workflow = readWorkflow(workflowPath)
@@ -237,6 +253,57 @@ async function runSelectBuildTarget(input: { target: string; arch: string; phase
     output: `${result.stdout}${result.stderr}`,
     outputs,
   }
+}
+
+/** Runs the submit summary step with sample GitHub expression values. */
+async function runSummarizeSubmitPhase() {
+  const parsed = parseWorkflow(workflowPath)
+  const step = parsed.jobs?.["build-electron"]?.steps?.find((entry) => entry.name === "Summarize submit phase")
+  if (!step?.run) {
+    throw new Error("Missing Summarize submit phase step")
+  }
+
+  const script = replaceGithubExpressions(step.run)
+  await using tmp = await tmpdir()
+  const summaryPath = path.join(tmp.path, "step-summary")
+  const result = spawnSync("bash", ["-ec", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+  })
+
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout}${result.stderr}`,
+    summary: fs.existsSync(summaryPath) ? fs.readFileSync(summaryPath, "utf8") : "",
+  }
+}
+
+function replaceGithubExpressions(script: string) {
+  const replacements: Record<string, string> = {
+    "steps.submit_notarization.outputs.submission_id": "sample-submission-id",
+    "github.run_id": "123456",
+    "github.run_attempt": "2",
+    "github.ref_name": "dev",
+    "github.sha": "0123456789abcdef0123456789abcdef01234567",
+    "matrix.arch_label": "arm64",
+    "needs.create-snapshot-tag.outputs.workflow_ref": "workflow-snapshot-123",
+    "needs.create-snapshot-tag.outputs.workflow_sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "inputs.channel || 'dev'": "prod",
+    "github.repository": "Astro-Han/pawwork",
+  }
+
+  const result = script.replace(/\$\{\{\s*(.*?)\s*\}\}/g, (match, expression) => {
+    const key = expression.trim()
+    return replacements[key] ?? match
+  })
+
+  if (result.includes("${{")) {
+    throw new Error(`Unreplaced GitHub expression in submit summary script:\n${result}`)
+  }
+  return result
 }
 
 /** Parses the simple key=value records emitted to GITHUB_OUTPUT by this workflow step. */


### PR DESCRIPTION
## Summary

- Quote the macOS submit summary heredoc so Markdown backticks are written literally.
- Remove the now-unneeded backslash escapes around the emitted finalize command.
- Add a workflow contract test that executes the summary step with sample GitHub expression values.

## Why

The release submit summary step used an unquoted heredoc, so bash treated Markdown backtick content as command substitution and logged command not found lines during macOS submit runs. Closes #166.

## Related Issue

Closes #166.

## How To Verify

- bun install --frozen-lockfile
- cd packages/opencode && bun test test/github/build-workflow.test.ts
- cd packages/opencode && bun test test/github

## Screenshots or Recordings

Not applicable, CI workflow only.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release-summary formatting so Markdown backticks and special characters render correctly by preserving literal content in the workflow step output.

* **Tests**
  * Added an integration-style test that runs the summary step and verifies successful execution, absence of shell errors, and properly formatted summary output (including literal backticks and no escaped-backtick sequences).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->