### PR TITLE
refactor(app): merge sidebar pin and status slots (#150)

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-leading-slot.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-leading-slot.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../fixtures"
+import { openSidebar, withSession } from "../actions"
+import { pawworkSidebarSelector } from "../selectors"
+
+test("pawwork sidebar merges pin into the status slot with a stable title baseline", async ({
+  page,
+  sdk,
+  gotoSession,
+}) => {
+  const stamp = Date.now()
+  await withSession(sdk, `i150 regression ${stamp}`, async (session) => {
+    await gotoSession(session.id)
+    await openSidebar(page)
+
+    const sidebar = page.locator(pawworkSidebarSelector).first()
+    const row = sidebar.locator(`[data-session-id="${session.id}"]`).first()
+    const title = row.locator("span", { hasText: `i150 regression ${stamp}` }).first()
+
+    const leftOf = async (locator: typeof title) => {
+      const rect = await locator.evaluate((el) => el.getBoundingClientRect())
+      return Math.round(rect.left)
+    }
+
+    // Baseline: unpinned, no hover.
+    await page.mouse.move(0, 0)
+    await expect(row).toBeVisible()
+    const baseline = await leftOf(title)
+
+    // Hover must not shift the title horizontally (action slot grows on the right).
+    await row.hover()
+    expect(await leftOf(title)).toBe(baseline)
+
+    // Pin via row menu; the row rerenders in the pinned section.
+    await row.locator('[data-action="session-row-menu"]').click()
+    await page.getByRole("menuitem", { name: /pin session/i }).click()
+    const pinnedRow = sidebar
+      .locator(`[data-component="pawwork-sidebar-pinned"] [data-session-id="${session.id}"]`)
+      .first()
+    await expect(pinnedRow).toBeVisible()
+
+    const pinnedTitle = pinnedRow.locator("span", { hasText: `i150 regression ${stamp}` }).first()
+    await page.mouse.move(0, 0)
+    expect(await leftOf(pinnedTitle)).toBe(baseline)
+    await pinnedRow.hover()
+    expect(await leftOf(pinnedTitle)).toBe(baseline)
+
+    // Pin button should occupy the row's leading slot, not a separate column.
+    const pinButton = pinnedRow.locator('[data-action="pawwork-session-pin"][data-pinned="true"]').first()
+    await expect(pinButton).toBeVisible()
+    const pinRect = await pinButton.evaluate((el) => el.getBoundingClientRect())
+    const rowRect = await pinnedRow.evaluate((el) => el.getBoundingClientRect())
+    expect(Math.round(pinRect.left - rowRect.left)).toBe(8)
+    expect(Math.round(pinRect.width)).toBe(24)
+  })
+})

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -96,6 +96,7 @@ const SessionRow = (props: {
   warmPress: () => void
   warmFocus: () => void
   titleContent?: JSX.Element
+  leadingSlot?: JSX.Element
 }): JSX.Element => {
   const title = () => sessionTitle(props.session.title)
   const indicator = () => {
@@ -103,7 +104,7 @@ const SessionRow = (props: {
     if (props.hasPermissions()) return <div class="size-1.5 rounded-full bg-surface-warning-strong" />
     if (props.hasError()) return <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
     if (props.unseenCount() > 0) return <div class="size-1.5 rounded-full bg-text-interactive-base" />
-    return null
+    return props.leadingSlot ?? null
   }
 
   return (
@@ -195,6 +196,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       warmPress={() => warm(2, "high")}
       warmFocus={() => warm(2, "high")}
       titleContent={props.titleContent?.({ session: props.session, title: () => sessionTitle(props.session.title) ?? "" })}
+      leadingSlot={!props.level && props.leadingSlot ? props.leadingSlot(props.session) : undefined}
     />
   )
 
@@ -206,9 +208,6 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
         style={{ "padding-left": `${8 + (props.level ?? 0) * 16}px` }}
       >
         <div class="flex min-w-0 items-center gap-1">
-          <Show when={props.leadingSlot && !props.level}>
-            <div class="shrink-0">{props.leadingSlot?.(props.session)}</div>
-          </Show>
           <div class="min-w-0 flex-1">
             <Show
               when={!tooltip()}


### PR DESCRIPTION
## Summary

Top-level session rows now share a single 24px leading slot instead of a pin-button column plus a separate status column. The slot priority is `running > permission > error > unseen > pin > empty`. When a status is active, the pin button is not rendered in the DOM; users unpin via the row context menu or the `...` dots menu (both existing paths). Child sessions are unchanged.

Closes #150. The right-side action slot still transitions `w-0 → w-6` on hover, which shrinks the title's truncation area — tracked separately in #192.

## Measurement (Playwright, 4 states)

| State | Before | After | Δ |
| --- | --- | --- | --- |
| unpinned-idle | left=81 width=236 | left=53 width=264 | -28 / +28 |
| unpinned-hover | left=81 width=212 | left=53 width=240 | -28 / +28 |
| pinned-idle | left=81 width=236 | left=53 width=264 | -28 / +28 |
| pinned-hover | left=81 width=212 | left=53 width=240 | -28 / +28 |

Title baseline shifts left by exactly 28px (24px freed slot + 4px gap) and stays stable across all four states, matching the spec in #150.

## Design notes

The pin button is rendered as the indicator's fallback inside `SessionRow`, not as a sibling column. This technically nests a `<button>` inside `<A>`, which the existing `InlineEditor` already does when editing a title. The button's `stopPropagation()` on click blocks anchor navigation.

For the pinned + running (or permission / error / unseen) case, the pin button is hidden rather than stacked on top of the spinner. The issue body called out an "overlay" variant as a candidate but not a requirement; the context menu and dots menu both already offer unpin, so the simpler priority switch was chosen over absolute positioning.

## Test plan

- [x] Typecheck across the workspace (`bun turbo typecheck`)
- [x] App unit tests on `packages/app/src/pages/layout` (34 pass)
- [x] Full sidebar e2e suite (`bun run test:e2e:local -- sidebar/`, 7 pass, 3 pre-existing skips)
- [x] New regression spec `sidebar-leading-slot.spec.ts` — asserts title baseline is stable across idle / hover / pinned states and the pin button sits inside the row's first 24px slot
- [ ] Manual smoke on `bun dev:desktop`: idle unpinned row is visually clean, hover reveals outline pin, pinned row shows filled pin, child sessions have no pin button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test validating sidebar pinning behavior and title position stability when hovering and pinning items.

* **Bug Fixes**
  * Improved sidebar layout consistency for pinned items by refactoring indicator slot handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->