### PR TITLE
fix(app): restore home model selector hit area for v0.2.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -144,7 +144,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -387,7 +387,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
+++ b/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
@@ -40,6 +40,21 @@ async function body(prompt: Locator) {
   return prompt.evaluate((el) => (el as HTMLElement).innerText)
 }
 
+async function hitTest(locator: Locator) {
+  return locator.evaluate((el) => {
+    const rect = el.getBoundingClientRect()
+    const x = rect.left + rect.width / 2
+    const y = rect.top + rect.height / 2
+    const hit = document.elementFromPoint(x, y)
+    const action = hit instanceof Element ? hit.closest("[data-action]")?.getAttribute("data-action") : null
+    return {
+      within: hit === el || !!hit && el.contains(hit),
+      action,
+      tag: hit?.tagName ?? null,
+    }
+  })
+}
+
 test("agent select returns focus to the prompt", async ({ page, gotoSession }) => {
   await gotoSession()
 
@@ -85,4 +100,19 @@ test("model select returns focus to the prompt", async ({ page, gotoSession }) =
   await expect(prompt).toBeFocused()
   await prompt.pressSequentially(" model")
   await expect.poll(() => body(prompt)).toContain("focus model")
+})
+
+test("home model selector opens without footer overlap", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const trigger = page.locator(`${promptModelSelector} [data-action="prompt-model"]`).first()
+  const hit = await hitTest(trigger)
+
+  expect(hit.within, `model trigger center was intercepted by ${hit.tag ?? "unknown"} (${hit.action ?? "no-action"})`).toBe(
+    true,
+  )
+
+  await trigger.click()
+
+  await expect(page.locator('[data-slot="list-item"]').first()).toBeVisible()
 })

--- a/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
+++ b/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
@@ -106,6 +106,7 @@ test("home model selector opens without footer overlap", async ({ page, gotoSess
   await gotoSession()
 
   const trigger = page.locator(`${promptModelSelector} [data-action="prompt-model"]`).first()
+  await expect(trigger).toBeVisible()
   const hit = await hitTest(trigger)
 
   expect(hit.within, `model trigger center was intercepted by ${hit.tag ?? "unknown"} (${hit.action ?? "no-action"})`).toBe(

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1514,75 +1514,128 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             }}
           />
 
-          <div class="pointer-events-none absolute bottom-2 right-2 flex items-center gap-2">
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept={ACCEPTED_FILE_TYPES.join(",")}
-              class="hidden"
-              onChange={(e) => {
-                const list = e.currentTarget.files
-                if (list) void addAttachments(Array.from(list))
-                e.currentTarget.value = ""
-              }}
-            />
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={ACCEPTED_FILE_TYPES.join(",")}
+            class="hidden"
+            onChange={(e) => {
+              const list = e.currentTarget.files
+              if (list) void addAttachments(Array.from(list))
+              e.currentTarget.value = ""
+            }}
+          />
 
-            <Show when={props.homeMode && store.mode === "normal"}>
-              <div class="flex items-center gap-1.5 pointer-events-auto">
-                {renderModelControl(buttons)}
-                {renderVariantControl(buttons)}
-              </div>
-            </Show>
-            <div class="flex items-center gap-1 pointer-events-auto">
-              <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
-                <IconButton
-                  data-action="prompt-submit"
-                  type="submit"
-                  disabled={store.mode !== "normal" || (!working() && blank() && !props.selectedSkill?.())}
-                  tabIndex={store.mode === "normal" ? undefined : -1}
-                  icon={stopping() ? "stop" : "arrow-up"}
-                  variant="primary"
-                  class="size-8"
-                  style={buttons()}
-                  aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
-                />
-              </Tooltip>
-            </div>
-          </div>
+          <Show
+            when={props.homeMode}
+            fallback={
+              <>
+                <div class="pointer-events-none absolute bottom-2 right-2 flex items-center gap-2">
+                  <div class="flex items-center gap-1 pointer-events-auto">
+                    <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
+                      <IconButton
+                        data-action="prompt-submit"
+                        type="submit"
+                        disabled={store.mode !== "normal" || (!working() && blank() && !props.selectedSkill?.())}
+                        tabIndex={store.mode === "normal" ? undefined : -1}
+                        icon={stopping() ? "stop" : "arrow-up"}
+                        variant="primary"
+                        class="size-8"
+                        style={buttons()}
+                        aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
+                      />
+                    </Tooltip>
+                  </div>
+                </div>
 
-          <div class="pointer-events-none absolute bottom-2 left-2">
-            <div
-              aria-hidden={store.mode !== "normal"}
-              class="pointer-events-auto flex items-center gap-2"
-              style={{
-                "pointer-events": buttonsSpring() > 0.5 ? "auto" : "none",
-              }}
-            >
-              <Show when={props.homeMode}>
-                <WorkspaceChip />
-              </Show>
-              <TooltipKeybind
-                placement="top"
-                title={language.t("prompt.action.attachFile")}
-                keybind={command.keybind("file.attach")}
+                <div class="pointer-events-none absolute bottom-2 left-2">
+                  <div
+                    aria-hidden={store.mode !== "normal"}
+                    class="pointer-events-auto flex items-center gap-2"
+                    style={{
+                      "pointer-events": buttonsSpring() > 0.5 ? "auto" : "none",
+                    }}
+                  >
+                    <TooltipKeybind
+                      placement="top"
+                      title={language.t("prompt.action.attachFile")}
+                      keybind={command.keybind("file.attach")}
+                    >
+                      <Button
+                        data-action="prompt-attach"
+                        type="button"
+                        variant="ghost"
+                        class="size-8 p-0"
+                        style={buttons()}
+                        onClick={pick}
+                        disabled={store.mode !== "normal"}
+                        tabIndex={store.mode === "normal" ? undefined : -1}
+                        aria-label={language.t("prompt.action.attachFile")}
+                      >
+                        <Icon name="plus" class="size-4.5" />
+                      </Button>
+                    </TooltipKeybind>
+                  </div>
+                </div>
+              </>
+            }
+          >
+            <div class="pointer-events-none absolute inset-x-2 bottom-2 flex items-center justify-between gap-2">
+              <div
+                aria-hidden={store.mode !== "normal"}
+                class="pointer-events-auto flex min-w-0 items-center gap-2"
+                style={{
+                  "pointer-events": buttonsSpring() > 0.5 ? "auto" : "none",
+                }}
               >
-                <Button
-                  data-action="prompt-attach"
-                  type="button"
-                  variant="ghost"
-                  class="size-8 p-0"
-                  style={buttons()}
-                  onClick={pick}
-                  disabled={store.mode !== "normal"}
-                  tabIndex={store.mode === "normal" ? undefined : -1}
-                  aria-label={language.t("prompt.action.attachFile")}
+                <WorkspaceChip />
+                <TooltipKeybind
+                  placement="top"
+                  title={language.t("prompt.action.attachFile")}
+                  keybind={command.keybind("file.attach")}
                 >
-                  <Icon name="plus" class="size-4.5" />
-                </Button>
-              </TooltipKeybind>
+                  <Button
+                    data-action="prompt-attach"
+                    type="button"
+                    variant="ghost"
+                    class="size-8 shrink-0 p-0"
+                    style={buttons()}
+                    onClick={pick}
+                    disabled={store.mode !== "normal"}
+                    tabIndex={store.mode === "normal" ? undefined : -1}
+                    aria-label={language.t("prompt.action.attachFile")}
+                  >
+                    <Icon name="plus" class="size-4.5" />
+                  </Button>
+                </TooltipKeybind>
+              </div>
+
+              <div class="flex min-w-0 items-center justify-end gap-2">
+                <Show when={store.mode === "normal"}>
+                  <div class="flex min-w-0 items-center gap-1.5 pointer-events-auto">
+                    {renderModelControl(buttons)}
+                    {renderVariantControl(buttons)}
+                  </div>
+                </Show>
+                <div class="flex items-center gap-1 pointer-events-auto">
+                  <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
+                    <IconButton
+                      data-action="prompt-submit"
+                      type="submit"
+                      disabled={store.mode !== "normal" || (!working() && blank() && !props.selectedSkill?.())}
+                      tabIndex={store.mode === "normal" ? undefined : -1}
+                      icon={stopping() ? "stop" : "arrow-up"}
+                      variant="primary"
+                      class="size-8"
+                      style={buttons()}
+                      aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
+                    />
+                  </Tooltip>
+                </div>
+              </div>
             </div>
-          </div>
+          </Show>
         </div>
       </DockShellForm>
       <Show when={!props.homeMode && (store.mode === "normal" || store.mode === "shell")}>

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- switch the home composer footer to a single bottom row in `homeMode`, so the workspace chip and attach button no longer overlap the model selector hit area
- add a home-page e2e regression that hit-tests the model trigger center point before opening the model menu
- bump the desktop package versions to `0.2.9`

## Why

Release testing found a homepage-only regression after `#191` and `#193`: the model selector looked clickable but did nothing because the left footer controls were intercepting the click target. In-session model switching still worked, so the fix stays scoped to the home composer layout.

## Related Issue

No standalone issue. This was found during release testing after `#191` and `#193` merged.

## How To Verify

```bash
cd packages/app
bun run typecheck
bun run test:e2e:local -- --grep "home model selector opens without footer overlap"
```

Manual check:

- open `New session`
- click the home model selector
- switch from one visible model to another, for example `Ling 2.6 Flash Free` to `Hy3 preview Free`
- confirm the menu opens and the selection changes

## Screenshots or Recordings

- Local E2E screenshot captured after the fix: `/Users/yuhan/Downloads/pawwork-home-e2e-2026-04-24.png`

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Maintainer labeling is fine for this release PR.

Notes:

- The worktree still has local-only drift in `bun.lock` and `packages/opencode/src/provider/models-snapshot.js` from dependency install and predev generation. Those changes are not part of the two pushed commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked prompt input footer to improve action grouping and layout in home vs. non-home modes.

* **Tests**
  * Added end-to-end test to verify prompt footer focus/click behavior for the model selector.

* **Chores**
  * Bumped package versions to 0.2.9 across the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->