### PR TITLE
fix: keep sidebar row action width reserved

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-leading-slot.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-leading-slot.spec.ts
@@ -53,3 +53,38 @@ test("pawwork sidebar merges pin into the status slot with a stable title baseli
     expect(Math.round(pinRect.width)).toBe(24)
   })
 })
+
+test("pawwork sidebar keeps title width stable when the row action appears", async ({ page, sdk, gotoSession }) => {
+  const STAMP = Date.now()
+  const TITLE = `i192 regression long session title that should keep a stable truncation width ${STAMP}`
+
+  await withSession(sdk, TITLE, async (session) => {
+    await gotoSession(session.id)
+    await openSidebar(page)
+
+    const sidebar = page.locator(pawworkSidebarSelector).first()
+    const row = sidebar.locator(`[data-session-id="${session.id}"]`).first()
+    const titleNode = row.locator("span", { hasText: TITLE }).first()
+    const menu = row.locator('[data-action="session-row-menu"]').first()
+
+    const widthOf = async () => {
+      const rect = await titleNode.evaluate((el) => el.getBoundingClientRect())
+      return Math.round(rect.width)
+    }
+
+    await page.mouse.move(0, 0)
+    await expect(row).toBeVisible()
+    const baseline = await widthOf()
+
+    await row.hover()
+    expect(await widthOf()).toBe(baseline)
+
+    await page.mouse.move(0, 0)
+    await menu.focus()
+    expect(await widthOf()).toBe(baseline)
+
+    await page.keyboard.press("Enter")
+    await expect(page.getByRole("menuitem", { name: /pin session/i })).toBeVisible()
+    expect(await widthOf()).toBe(baseline)
+  })
+})

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -228,12 +228,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
 
           <Show when={!props.level}>
             <div
-              class="shrink-0 overflow-hidden transition-[width,opacity]"
+              class="w-6 shrink-0 overflow-hidden transition-opacity"
               classList={{
-                "w-6 opacity-100 pointer-events-auto": !!props.mobile,
-                "w-0 opacity-0 pointer-events-none": !props.mobile,
-                "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
-                "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
+                "opacity-100 pointer-events-auto": !!props.mobile,
+                "opacity-0 pointer-events-none": !props.mobile,
+                "group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
+                "group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
               }}
             >
               <Show


### PR DESCRIPTION
## Summary
- Keep the top-level sidebar session action slot at 24px on desktop while hidden, so the title flex area no longer shrinks on hover or focus.
- Add an E2E regression that measures the row title width across idle, hover, focused action, and open menu states.

## Test Plan
- bun --cwd packages/app test:e2e -- e2e/sidebar/sidebar-leading-slot.spec.ts
- bun --cwd packages/app typecheck

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented layout shift in the sidebar by keeping action controls from changing the session title's width, ensuring stable spacing when action buttons or menus appear.

* **Tests**
  * Added an end-to-end regression test that verifies the session title width remains unchanged across hover, focus, and menu-opening interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->