### PR TITLE
fix: preserve workspace state during session switches

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { cleanupSession, openSidebar, withSession } from "../actions"
+import { cleanupSession, cleanupTestProject, createTestProject, openSidebar, waitSession } from "../actions"
 import { promptSelector } from "../selectors"
 
 test("sidebar session links navigate to the selected session", async ({ page, slug, sdk, gotoSession }) => {
@@ -26,5 +26,44 @@ test("sidebar session links navigate to the selected session", async ({ page, sl
   } finally {
     await cleanupSession({ sdk, sessionID: one.id })
     await cleanupSession({ sdk, sessionID: two.id })
+  }
+})
+
+test("sidebar session links can switch workspaces without opening the error boundary", async ({ page, backend, project }) => {
+  const stamp = Date.now()
+  const other = await createTestProject({ serverUrl: backend.url })
+  const otherSdk = backend.sdk(other)
+  let targetID = ""
+  let sourceID = ""
+
+  try {
+    const target = await otherSdk.session.create({ title: `e2e cross workspace target ${stamp}` }).then((r) => r.data)
+    if (!target?.id) throw new Error("Target session create did not return an id")
+    targetID = target.id
+
+    await project.open({
+      extra: [other],
+      beforeGoto: async ({ sdk }) => {
+        const source = await sdk.session.create({ title: `e2e cross workspace source ${stamp}` }).then((r) => r.data)
+        if (!source?.id) throw new Error("Source session create did not return an id")
+        sourceID = source.id
+        project.trackSession(source.id)
+      },
+    })
+    project.trackDirectory(other)
+    project.trackSession(targetID, other)
+
+    await project.gotoSession(sourceID)
+    await openSidebar(page)
+
+    const targetLink = page.locator(`[data-session-id="${targetID}"] a`).first()
+    await expect(targetLink).toBeVisible()
+    await targetLink.click()
+
+    await waitSession(page, { directory: other, sessionID: targetID, serverUrl: backend.url })
+    await expect(page.locator(promptSelector)).toBeVisible()
+  } finally {
+    if (targetID) await cleanupSession({ sdk: otherSdk, sessionID: targetID })
+    await cleanupTestProject(other)
   }
 })

--- a/packages/app/src/context/sync-current-child.test.ts
+++ b/packages/app/src/context/sync-current-child.test.ts
@@ -34,4 +34,32 @@ describe("createCurrentSyncChild", () => {
     expect(childOwner).toBeDefined()
     expect(childOwner).not.toBe(providerOwner)
   })
+
+  test("seeds the last valid directory before a disposed provider accessor turns empty", () => {
+    let directory = "/tmp/project" as string | undefined
+    const calls: string[] = []
+
+    const current = createRoot((dispose) => {
+      const accessor = createCurrentSyncChild({
+        directory: () => directory,
+        child: (directory) => {
+          calls.push(directory)
+          return [{ directory }, () => {}] as const
+        },
+      })
+      dispose()
+      return accessor
+    })
+
+    directory = undefined
+
+    const value = createRoot((dispose) => {
+      const result = current()
+      dispose()
+      return result
+    })
+
+    expect(value[0].directory).toBe("/tmp/project")
+    expect(calls).toEqual(["/tmp/project"])
+  })
 })

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -62,8 +62,20 @@ type OptimisticItem = {
   parts: Part[]
 }
 
-export function createCurrentSyncChild<Child>(input: { directory: () => string; child: (directory: string) => Child }) {
-  return () => input.child(input.directory())
+export function createCurrentSyncChild<Child>(input: { directory: () => string | undefined; child: (directory: string) => Child }) {
+  const initialDirectory = input.directory()
+  let lastDirectory =
+    typeof initialDirectory === "string" && initialDirectory.length > 0 ? initialDirectory : undefined
+
+  return () => {
+    const directory = input.directory()
+    if (typeof directory === "string" && directory.length > 0) {
+      lastDirectory = directory
+      return input.child(directory)
+    }
+
+    return input.child(lastDirectory ?? (directory as string))
+  }
 }
 
 type MessagePage = {

--- a/packages/app/src/pages/session/session-layout.test.ts
+++ b/packages/app/src/pages/session/session-layout.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createStableLayoutMemo } from "./session-layout"
+
+describe("createStableLayoutMemo", () => {
+  test("reuses the last value when a disposed memo turns empty", () => {
+    let view = { sidePanel: { opened: true } } as { sidePanel: { opened: boolean } } | undefined
+
+    const current = createRoot((dispose) => {
+      const accessor = createStableLayoutMemo(() => view as { sidePanel: { opened: boolean } })
+      accessor()
+      dispose()
+      return accessor
+    })
+
+    view = undefined
+
+    expect(current()).toEqual({ sidePanel: { opened: true } })
+  })
+
+  test("throws when read before any value has been cached", () => {
+    const current = createRoot((dispose) => {
+      const accessor = createStableLayoutMemo(() => undefined as unknown as { sidePanel: { opened: boolean } })
+      dispose()
+      return accessor
+    })
+
+    expect(() => current()).toThrow("Stable layout memo read before initialization")
+  })
+})

--- a/packages/app/src/pages/session/session-layout.ts
+++ b/packages/app/src/pages/session/session-layout.ts
@@ -14,7 +14,24 @@ export const useSessionLayout = () => {
   return {
     params,
     sessionKey,
-    tabs: createMemo(() => layout.tabs(sessionKey)),
-    view: createMemo(() => layout.view(sessionKey)),
+    tabs: createStableLayoutMemo(() => layout.tabs(sessionKey)),
+    view: createStableLayoutMemo(() => layout.view(sessionKey)),
+  }
+}
+
+export function createStableLayoutMemo<T>(read: () => T) {
+  let last: { value: T } | undefined
+  const memo = createMemo(read)
+
+  return () => {
+    const value = memo()
+    if (value !== undefined) {
+      last = { value }
+      return value
+    }
+
+    if (last) return last.value
+
+    throw new Error("Stable layout memo read before initialization")
   }
 }


### PR DESCRIPTION
## Summary

- Preserve the last valid workspace directory for the current sync child accessor so disposed route providers cannot request a child store with `undefined`.
- Preserve the last valid session layout accessors during cross-workspace route switches.
- Add a sidebar E2E regression that switches from one workspace session to another without opening the error boundary.

## Why

Packaged v0.2.9 can crash with `ChildStoreError: Invalid workspace directory for child store: undefined` when navigating from one workspace session to another through the sidebar. The route switch can leave disposed Solid accessors readable for one more computation pass, so downstream code must not turn that transient empty value into an invalid child store lookup or layout read.

## Related Issue

No linked issue. This was reported from a v0.2.9 packaged build crash.

## How To Verify

```bash
bun install --frozen-lockfile
bun --cwd packages/app test:unit src/context/sync-current-child.test.ts src/pages/session/session-layout.test.ts
bun --cwd packages/app test:e2e -- sidebar/sidebar-session-links.spec.ts
bun --cwd packages/app typecheck
bun turbo typecheck
```

## Screenshots or Recordings

Not included. This is a crash fix with no visible UI or copy change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Labels: `bug`, `app`, `P1`.

Platform impact: renderer-only route/accessor fix. It should apply to both macOS and Windows because it does not touch OS-specific desktop, packaging, updater, signing, shell, or permission code.

Release notes: bug fix for cross-workspace sidebar session navigation crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access and open sessions from other workspaces directly via the sidebar.

* **Improvements**
  * Directory/session state is preserved when switching or linking across workspaces.
  * Layout state now persists and avoids becoming unset during transitions.
  * Improved stability and reliability when loading remote sessions.

* **Tests**
  * Added end-to-end and unit tests to validate cross-workspace session flows and layout preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->