### PR TITLE
fix(app): apply home model selector choices

### DIFF
--- a/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
+++ b/packages/app/e2e/prompt/prompt-footer-focus.spec.ts
@@ -28,6 +28,20 @@ async function state(page: Page) {
   return value
 }
 
+const modelKey = (model?: { providerID: string; modelID: string } | null) =>
+  model ? `${model.providerID}:${model.modelID}` : null
+
+async function selectModel(page: Page, model: { providerID: string; modelID: string }) {
+  const key = modelKey(model)
+  await page.locator(`${promptModelSelector} [data-action="prompt-model"]`).first().click()
+
+  const item = page.locator(`[data-slot="list-item"][data-key="${model.providerID}:${model.modelID}"]`).first()
+  await expect(item).toBeVisible()
+  await item.click({ force: true })
+
+  await expect.poll(() => probe(page).then((value) => modelKey(value?.model)), { timeout: 10_000 }).toBe(key)
+}
+
 async function ready(page: Page) {
   const prompt = page.locator(promptSelector)
   await prompt.click()
@@ -55,8 +69,12 @@ async function hitTest(locator: Locator) {
   })
 }
 
-test("agent select returns focus to the prompt", async ({ page, gotoSession }) => {
-  await gotoSession()
+test("agent select returns focus to the prompt", async ({ page, project }) => {
+  await project.open()
+  const session = await project.sdk.session.create({ title: `e2e agent focus ${Date.now()}` }).then((r) => r.data)
+  if (!session?.id) throw new Error("Session create did not return an id")
+  project.trackSession(session.id)
+  await project.gotoSession(session.id)
 
   const prompt = await ready(page)
 
@@ -85,21 +103,42 @@ test("model select returns focus to the prompt", async ({ page, gotoSession }) =
   const prompt = await ready(page)
 
   const info = await state(page)
-  const key = info.model ? `${info.model.providerID}:${info.model.modelID}` : null
-  const next = info.models?.find((item) => `${item.providerID}:${item.modelID}` !== key)
+  const key = modelKey(info.model)
+  const next = info.models?.find((item) => modelKey(item) !== key)
   test.skip(!next, "only one model available")
   if (!next) return
 
-  await page.locator(`${promptModelSelector} [data-action="prompt-model"]`).first().click()
-
-  const item = page.locator(`[data-slot="list-item"][data-key="${next.providerID}:${next.modelID}"]`).first()
-  await expect(item).toBeVisible()
-  await item.click({ force: true })
-
+  await selectModel(page, next)
   await expect(page.locator(`${promptModelSelector} [data-action="prompt-model"] span`).first()).toHaveText(next.name)
   await expect(prompt).toBeFocused()
   await prompt.pressSequentially(" model")
   await expect.poll(() => body(prompt)).toContain("focus model")
+})
+
+test("home selected model is used for the first prompt", async ({ page, project }) => {
+  await project.open()
+
+  const info = await state(page)
+  const key = modelKey(info.model)
+  const next = info.models?.find((item) => modelKey(item) !== key)
+  test.skip(!next, "only one model available")
+  if (!next) return
+  const nextKey = modelKey(next)
+
+  await selectModel(page, next)
+
+  const sessionID = await project.prompt(`home selected model ${Date.now()}`)
+  await expect
+    .poll(
+      async () => {
+        const messages = await project.sdk.session.messages({ sessionID, limit: 50 }).then((r) => r.data ?? [])
+        return messages
+          .filter((message) => message.info.role === "user")
+          .some((message) => modelKey(message.info.model ?? null) === nextKey)
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true)
 })
 
 test("home model selector opens without footer overlap", async ({ page, gotoSession }) => {
@@ -116,4 +155,18 @@ test("home model selector opens without footer overlap", async ({ page, gotoSess
   await trigger.click()
 
   await expect(page.locator('[data-slot="list-item"]').first()).toBeVisible()
+})
+
+test("home model selector closes when keyboard focus leaves", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const trigger = page.locator(`${promptModelSelector} [data-action="prompt-model"]`).first()
+  await trigger.click()
+
+  const item = page.locator('[data-slot="list-item"]').first()
+  await expect(item).toBeVisible()
+
+  await page.keyboard.press("Shift+Tab")
+
+  await expect(item).toBeHidden()
 })

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -110,6 +110,25 @@ export function ModelSelectorPopover(props: {
     setStore("dismiss", dismiss)
     setStore("open", false)
   }
+  let ignoreFocusOutsideForPointerInside = false
+
+  const handlePointerDownInside = () => {
+    ignoreFocusOutsideForPointerInside = true
+    window.setTimeout(() => {
+      ignoreFocusOutsideForPointerInside = false
+    }, 0)
+  }
+
+  const handleFocusOutside = (
+    event: Parameters<NonNullable<ComponentProps<typeof Kobalte.Content>["onFocusOutside"]>>[0],
+  ) => {
+    if (ignoreFocusOutsideForPointerInside) {
+      ignoreFocusOutsideForPointerInside = false
+      event.preventDefault()
+      return
+    }
+    close("outside")
+  }
 
   const handleManage = () => {
     close("manage")
@@ -148,8 +167,9 @@ export function ModelSelectorPopover(props: {
             event.preventDefault()
             event.stopPropagation()
           }}
+          onPointerDown={handlePointerDownInside}
           onPointerDownOutside={() => close("outside")}
-          onFocusOutside={() => close("outside")}
+          onFocusOutside={handleFocusOutside}
           onCloseAutoFocus={(event) => {
             const dismiss = store.dismiss
             if (dismiss === "outside") event.preventDefault()

--- a/packages/desktop-electron/scripts/report-problem-smoke.mjs
+++ b/packages/desktop-electron/scripts/report-problem-smoke.mjs
@@ -102,5 +102,5 @@ try {
   assert(summary.markdownHasReportPayload, "expected full report to include the fenced JSON payload")
 } finally {
   await app.close().catch(() => undefined)
-  rmSync(homeDir, { force: true, recursive: true })
+  rmSync(homeDir, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })
 }


### PR DESCRIPTION
## Summary

- Added E2E coverage that proves the home model selector updates model state and the first prompt uses the selected model.
- Fixed the model popover so focus movement inside the popover does not close it before list item click selection runs.
- Kept the existing agent focus E2E on the session composer path where the agent control actually exists.
- Hardened the report-problem desktop smoke cleanup path so macOS `ENOTEMPTY` cleanup races do not fail an otherwise successful smoke run.

## Why

The home model selector was closing on `focus outside` during the pointer sequence. The list item received pointer down, then the popover unmounted before pointer up and click, so `List.onSelect` never called `model.set`. This meant the UI still submitted prompts with the old model.

The fix keeps pointer outside and Escape dismissal behavior, but prevents Kobalte's cancelable focus outside event from closing the popover during internal item clicks.

The failed `desktop-smoke` run completed the report-problem smoke assertions successfully, then failed while deleting the temporary home directory with `ENOTEMPTY`. The cleanup now uses Node's built-in recursive remove retry options, which targets the failing cleanup layer without changing the smoke behavior under test.

## Related Issue

Closes #205

## How To Verify

```bash
bun --cwd packages/app test:e2e e2e/prompt/prompt-footer-focus.spec.ts --project=chromium --grep "model select returns focus|home selected model"
bun --cwd packages/app test:e2e e2e/prompt/prompt-footer-focus.spec.ts --project=chromium
bun --cwd packages/app typecheck
bun --cwd packages/app test:unit src/components/prompt-input/submit.test.ts src/context/models.test.ts
node --check packages/desktop-electron/scripts/report-problem-smoke.mjs
bun --cwd packages/desktop-electron build
PAWWORK_FEEDBACK_FORM_URL=https://example.com/pawwork-feedback bun --cwd packages/desktop-electron smoke:report
```

Note: I also checked `e2e/session/session-model-persistence.spec.ts` because it is adjacent, but did not include it as a passing verifier. It currently has an older helper mismatch around reading the home footer and agent controls, separate from this click-path fix.

## Screenshots or Recordings

No screenshot attached. There is no visual appearance change. The behavior is covered by the E2E checks above.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selector popover focus behavior to prevent unintended closes when interacting inside the selector, reducing accidental dismissals.

* **Testing & Validation**
  * Expanded end-to-end tests for model selection: ensures selected model is applied to the first prompt, verifies focus returns to the prompt after selection, confirms Shift+Tab hides the selector list, and stabilizes session handling and model-selection assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
