### PR TITLE
docs: update README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,64 @@
 # PawWork
 
-**Process documents, analyze data, draft content. No API key, no command line, no setup.**
+**AI Agent for everyday work, made easy.**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![macOS](https://img.shields.io/badge/macOS-Apple_Silicon-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-supported-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
+[![Windows](https://img.shields.io/badge/Windows-supported-blue.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
 
 [中文说明](README_CN.md)
 
 ---
 
-PawWork is a desktop app for knowledge workers who want AI to handle real tasks, not just chat. Download the app, open it, and start working with your files.
+PawWork is an open-source desktop AI agent for everyday work. It goes beyond chat by turning messy files, notes, spreadsheets, PDFs, and web research into reviewable files, reports, drafts, and decision memos you can use.
 
-<!-- TODO: add screenshot here -->
+Open source, privacy-conscious, and ready to use on your desktop with the included free models.
 
-## What You Can Do
+## Ask PawWork to
 
-- **Office documents** — create and edit Word (.docx), Excel (.xlsx), PowerPoint (.pptx) without installing Office
-- **Data analysis** — drop a spreadsheet or CSV, get summaries, charts, and reports
-- **Writing help** — draft emails, reports, plans, and announcements from rough notes
-- **PDF processing** — merge, split, extract, and convert PDF files
+- extract key fields from invoices into a reviewable spreadsheet draft
+- summarize a CSV and create a report
+- merge several PDFs and organize the output
+- draft a weekly update from meeting notes and files
+- compare product pages and prepare a decision memo
+- inspect a code project and explain what to change
 
-All tools are built in. Nothing to install, no terminal, no package managers.
+## Why PawWork Is Different
+
+| What matters | PawWork | Typical closed agent apps |
+|---|---|---|
+| Getting started | Included free models. No API key, terminal, or setup required. | Easy to try, but often tied to one vendor account, credit system, or model. |
+| Transparency | Open source. You can inspect how the app works and how it changes. | Product behavior depends on the vendor. |
+| Privacy and control | You choose the workspace folder, use PawWork's free models or your own model account, and review important steps before continuing. | Data handling and automation rules depend on the vendor's platform. |
+| Model choice | Start free, then connect your own model account when you want more control. | Usually optimized around the vendor's default model or credit system. |
+| Real desktop work | Built for files, folders, spreadsheets, PDFs, notes, and local tasks. | Often starts as a broad chat or cloud task interface. |
+| User guidance | Starts from concrete tasks so you do not have to invent prompts from scratch. | Often asks users to figure out what the agent should do. |
+| Extensibility | Built around open skills and local tools that can grow with real work. | Extensions depend on the vendor roadmap. |
+
+## How It Works
+
+1. Choose a workspace folder.
+2. Describe the task in everyday language.
+3. Review the steps and use the result.
+
+PawWork works through the task, shows progress, and helps produce files, reports, drafts, or decisions you can review.
+
+## Current Focus
+
+PawWork is focused on real desktop tasks: local files, documents, spreadsheets, writing, research, and small technical projects. New task skills and built-in tools are added around real user workflows.
 
 ## Download
 
-macOS (Apple Silicon): **[Download .dmg](https://github.com/Astro-Han/pawwork/releases/latest)**
+Download the latest macOS and Windows builds from [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest). On macOS, download the `.dmg`. On Windows, download the `.exe`.
 
 ### macOS first launch
 
 GitHub Releases builds go through Apple code signing and notarization in the release workflow.
-If macOS still shows a warning on first launch, re-download the latest release artifact and try again.
+If macOS shows a warning on first launch, right-click the app and select Open, or go to System Settings > Privacy & Security and click Open Anyway.
 
-## Who This Is For
+### Windows first launch
 
-PawWork is built for people who work with documents, spreadsheets, and writing every day but don't want to learn programming or manage API keys. If you've tried ChatGPT or Claude but wished it could just work with your files directly on your computer, this is for you.
+If Windows SmartScreen appears on first launch, click **More info** and then **Run anyway** for the downloaded release build.
 
 ## Build from Source
 
@@ -48,7 +73,7 @@ cd packages/desktop-electron && bun run dev
 
 ## Credits
 
-PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode), with modifications.
+PawWork is a fork of [OpenCode](https://github.com/anomalyco/opencode). Thanks to the OpenCode project and community.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,39 +1,64 @@
 # 爪印 PawWork
 
-**处理文档、分析数据、起草内容。不需要 API Key，不需要命令行，不需要任何配置。**
+**让每个人都能用的日常工作 AI Agent。**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![macOS](https://img.shields.io/badge/macOS-Apple_Silicon-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-supported-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
+[![Windows](https://img.shields.io/badge/Windows-supported-blue.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
 
 [English](README.md)
 
 ---
 
-PawWork 是一个桌面应用，让知识工作者用 AI 直接处理手头的工作，而不只是聊天。下载，打开，开始干活。
+PawWork 是一个面向日常工作的开源桌面 AI Agent。它不只是聊天，而是帮你把零散文件、笔记、表格、PDF 和网页资料整理成可以检查和使用的文件、报告、草稿和决策建议。
 
-<!-- TODO: 添加截图 -->
+开源、更重视隐私和控制，内置免费模型，下载到电脑上即可开始。
 
-## 能做什么
+## 你可以让 PawWork
 
-- **Office 文档** — 创建和编辑 Word (.docx)、Excel (.xlsx)、PowerPoint (.pptx)，不需要安装 Office
-- **数据分析** — 拖入表格或 CSV，获得汇总、图表和报告
-- **写作辅助** — 从零散笔记起草邮件、周报、方案、通知
-- **PDF 处理** — 合并、拆分、提取、转换 PDF 文件
+- 把发票里的关键信息整理成一份可检查的表格草稿
+- 汇总一份 CSV，并生成报告
+- 合并几份 PDF，并整理输出文件
+- 根据会议记录和附件起草周报
+- 对比几个产品页面，并整理成决策建议
+- 检查一个代码项目，并说明该改哪里
 
-所有工具都内置在应用里。不需要安装任何东西，不需要终端，不需要包管理器。
+## PawWork 有什么不同
+
+| 你关心的事 | PawWork | 常见闭源 Agent 应用 |
+|---|---|---|
+| 开始使用 | 内置免费模型，不需要 API Key、不需要终端、不需要配置。 | 通常也容易试用，但往往绑定某个厂商账号、积分体系或默认模型。 |
+| 透明度 | 开源。你可以查看应用如何工作、如何变化。 | 产品行为取决于厂商。 |
+| 隐私和控制 | 你选择工作文件夹，使用 PawWork 免费模型或自己的模型账号，并在继续前查看关键步骤。 | 数据处理和自动化规则取决于厂商平台。 |
+| 模型选择 | 先免费使用；需要更多控制权时，可以接入自己的模型账号。 | 通常围绕厂商默认模型或积分系统优化。 |
+| 真实桌面工作 | 围绕文件夹、表格、PDF、笔记和本地任务设计。 | 很多产品从宽泛聊天或云端任务入口开始。 |
+| 上手引导 | 从具体任务开始，不需要用户自己琢磨怎么写提示词。 | 经常需要用户自己想清楚要让 Agent 做什么。 |
+| 可扩展性 | 基于开放 Skill 和本地工具，可以随着真实工作继续扩展。 | 扩展能力取决于厂商路线图。 |
+
+## 它怎么工作
+
+1. 选择工作文件夹。
+2. 用日常语言描述任务。
+3. 查看步骤并使用结果。
+
+PawWork 会一步步执行任务，展示进展，并帮你生成可以检查和使用的文件、报告、草稿或决策建议。
+
+## 当前重点
+
+PawWork 聚焦真实桌面任务：本地文件、文档、表格、写作、资料整理和小型技术项目。新的任务 Skill 和内置工具会围绕真实用户工作流持续增加。
 
 ## 下载
 
-macOS (Apple Silicon): **[下载 .dmg](https://github.com/Astro-Han/pawwork/releases/latest)**
+从 [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest) 下载最新的 macOS 和 Windows 版本。macOS 下载 `.dmg`，Windows 下载 `.exe`。
 
 ### macOS 首次打开
 
 GitHub Releases 提供的构建会经过 Apple 签名和公证。
-如果首次打开时 macOS 仍然弹出警告，请重新下载最新 release 产物后再试。
+如果首次打开时 macOS 弹出警告，请右键点击应用并选择“打开”，或者前往“系统设置 > 隐私与安全性”点击“仍要打开”。
 
-## 适合谁用
+### Windows 首次打开
 
-PawWork 是为每天跟文档、表格、写作打交道，但不想学编程或管理 API Key 的人设计的。如果你用过 ChatGPT 或 Claude，但希望 AI 能直接在你电脑上处理文件，PawWork 就是为你做的。
+如果 Windows SmartScreen 在首次打开时出现，请点击“更多信息”，然后对下载的 release 构建选择“仍要运行”。
 
 ## 从源码构建
 
@@ -48,7 +73,7 @@ cd packages/desktop-electron && bun run dev
 
 ## 致谢
 
-PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)，有修改。
+PawWork fork 自 [OpenCode](https://github.com/anomalyco/opencode)。感谢 OpenCode 项目和社区。
 
 ## License
 


### PR DESCRIPTION
## Summary

- rewrite `README.md` and `README_CN.md` around PawWork as an open-source desktop AI agent for everyday work
- replace the old office-tool framing with agent-style task examples, a comparison table, and a simpler how-it-works section
- update download copy for macOS + Windows, remove the visible screenshot TODO, and clarify first-launch instructions for both macOS and Windows

## Why

The current README was outdated and undersold PawWork's direction. It still read like a lightweight office tool, did not explain why PawWork goes beyond chat, and still listed macOS Apple Silicon only. This PR aligns the README copy with issue #134 and the current product direction.

## Related Issue

Closes #134

## How To Verify

```bash
git diff --check -- README.md README_CN.md
rg -n "AI workflow|workbench|super app|fully autonomous|artifact|BYOK|Your data never leaves|Apple_Silicon|TODO: add screenshot|添加截图|普通话" README.md README_CN.md
```

Manual checks:
- cold-read both README files for SEO, clarity, and over-claim risks
- confirm English and Chinese structures stay aligned
- confirm the download section now mentions both macOS and Windows
- confirm macOS first-launch guidance points users to Open / Open Anyway
- confirm Windows first-launch guidance covers SmartScreen prompts

## Screenshots or Recordings

N/A. README copy only, no visible app UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
