### PR TITLE
feat(desktop): updater progress indicator and reworked failure dialog

### DIFF
--- a/packages/desktop-electron/src/main/index-updater-source.test.ts
+++ b/packages/desktop-electron/src/main/index-updater-source.test.ts
@@ -46,4 +46,12 @@ describe("main updater source contracts", () => {
     expect(earlyReturnIndex).toBeGreaterThan(0)
     expect(listenerIndex).toBeGreaterThan(earlyReturnIndex)
   })
+
+  test("reapplies current progress to a new window on ready-to-show", () => {
+    expect(source).toContain('win.once("ready-to-show"')
+    const hookIndex = source.search(/win\.once\("ready-to-show"/)
+    const reapplySlice = source.slice(hookIndex, hookIndex + 400)
+    expect(reapplySlice).toMatch(/if\s*\(\s*currentProgress\s*!==\s*null\s*\)/)
+    expect(reapplySlice).toMatch(/win\.setProgressBar\(currentProgress\)/)
+  })
 })

--- a/packages/desktop-electron/src/main/index-updater-source.test.ts
+++ b/packages/desktop-electron/src/main/index-updater-source.test.ts
@@ -73,7 +73,8 @@ describe("main updater source contracts", () => {
   })
 
   test("failure dialog open-download-page opens the releases URL", () => {
-    expect(source).toContain('shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")')
+    expect(source).toMatch(/const LATEST_RELEASE_URL = "https:\/\/github\.com\/Astro-Han\/pawwork\/releases\/latest"/)
+    expect(source).toMatch(/shell\.openExternal\(LATEST_RELEASE_URL\)/)
   })
 
   test("install-failure dialog uses the unified structure without a retry button", () => {

--- a/packages/desktop-electron/src/main/index-updater-source.test.ts
+++ b/packages/desktop-electron/src/main/index-updater-source.test.ts
@@ -75,4 +75,17 @@ describe("main updater source contracts", () => {
   test("failure dialog open-download-page opens the releases URL", () => {
     expect(source).toContain('shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")')
   })
+
+  test("install-failure dialog uses the unified structure without a retry button", () => {
+    expect(source).toContain("labels.failed.installFailedMessage")
+    expect(source).toContain(
+      "[labels.failed.buttons.openDownloadPage, labels.failed.buttons.later]",
+    )
+    const installBlockStart = source.search(/catch\s*\(\s*error\s*\)\s*\{\s*logger\.error\("install update failed"/)
+    expect(installBlockStart).toBeGreaterThan(0)
+    const installSlice = source.slice(installBlockStart, installBlockStart + 800)
+    expect(installSlice).toContain("labels.failed.installFailedMessage")
+    expect(installSlice).toContain("labels.failed.currentVersionUnaffected")
+    expect(installSlice).not.toContain("labels.failed.buttons.retry")
+  })
 })

--- a/packages/desktop-electron/src/main/index-updater-source.test.ts
+++ b/packages/desktop-electron/src/main/index-updater-source.test.ts
@@ -54,4 +54,25 @@ describe("main updater source contracts", () => {
     expect(reapplySlice).toMatch(/if\s*\(\s*currentProgress\s*!==\s*null\s*\)/)
     expect(reapplySlice).toMatch(/win\.setProgressBar\(currentProgress\)/)
   })
+
+  test("failure dialog uses reason-specific copy and three recovery buttons", () => {
+    expect(source).toContain("labels.failed.reasonCopy[result.reason]")
+    expect(source).toContain("labels.failed.currentVersionUnaffected")
+    expect(source).toMatch(/\[result\.message,\s*labels\.failed\.currentVersionUnaffected\]/)
+    expect(source).toContain(
+      "[labels.failed.buttons.retry, labels.failed.buttons.openDownloadPage, labels.failed.buttons.later]",
+    )
+    expect(source).toContain("defaultId: 0")
+    expect(source).toContain("cancelId: 2")
+  })
+
+  test("failure dialog retry awaits recursion and logs rejection", () => {
+    expect(source).toMatch(
+      /try\s*\{\s*await\s+checkForUpdates\(alertOnFail\)\s*\}\s*catch\s*\(error\)\s*\{\s*logger\.error\("retry after update failure failed"/,
+    )
+  })
+
+  test("failure dialog open-download-page opens the releases URL", () => {
+    expect(source).toContain('shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")')
+  })
 })

--- a/packages/desktop-electron/src/main/index-updater-source.test.ts
+++ b/packages/desktop-electron/src/main/index-updater-source.test.ts
@@ -24,4 +24,26 @@ describe("main updater source contracts", () => {
       /rm\(pendingUpdateCacheDir\(\),\s*\{\s*recursive:\s*true,\s*force:\s*true\s*\}\)\s*\.catch\(\(\)\s*=>/,
     )
   })
+
+  test("broadcasts download progress to every open window", () => {
+    expect(source).toContain('autoUpdater.on("download-progress"')
+    expect(source).toMatch(/currentProgress\s*=\s*info\.percent\s*\/\s*100/)
+    expect(source).toMatch(/for\s*\(\s*const\s+win\s+of\s+BrowserWindow\.getAllWindows\(\)\s*\)/)
+    expect(source).toContain("win.setProgressBar(")
+  })
+
+  test("clears the progress bar on every updater terminal event", () => {
+    expect(source).toContain('autoUpdater.on("update-downloaded", clearProgressBar)')
+    expect(source).toContain('autoUpdater.on("update-not-available", clearProgressBar)')
+    expect(source).toContain('autoUpdater.on("update-cancelled", clearProgressBar)')
+    expect(source).toContain('autoUpdater.on("error"')
+    expect(source).toContain('logger.error("updater error"')
+  })
+
+  test("registers progress listeners only after the updater-disabled early return", () => {
+    const earlyReturnIndex = source.search(/if\s*\(\s*!UPDATER_ENABLED\s*\)\s*return/)
+    const listenerIndex = source.search(/autoUpdater\.on\("download-progress"/)
+    expect(earlyReturnIndex).toBeGreaterThan(0)
+    expect(listenerIndex).toBeGreaterThan(earlyReturnIndex)
+  })
 })

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -91,6 +91,14 @@ let currentProgress: number | null = null
 
 const LATEST_RELEASE_URL = "https://github.com/Astro-Han/pawwork/releases/latest"
 
+async function openLatestReleasePage() {
+  try {
+    await shell.openExternal(LATEST_RELEASE_URL)
+  } catch (error) {
+    logger.error("open latest release page failed", error)
+  }
+}
+
 function applyProgressBar(value: number) {
   for (const win of BrowserWindow.getAllWindows()) {
     win.setProgressBar(value)
@@ -682,7 +690,7 @@ async function checkForUpdates(alertOnFail: boolean) {
         logger.error("retry after update failure failed", error)
       }
     } else if (response.response === 1) {
-      await shell.openExternal(LATEST_RELEASE_URL)
+      await openLatestReleasePage()
     }
     return
   }
@@ -736,7 +744,7 @@ async function checkForUpdates(alertOnFail: boolean) {
         cancelId: 1,
       })
       if (response.response === 0) {
-        await shell.openExternal(LATEST_RELEASE_URL)
+        await openLatestReleasePage()
       }
     }
   } else {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -87,6 +87,19 @@ const initEmitter = new EventEmitter()
 let initStep: InitStep = { phase: "server_waiting" }
 
 let mainWindow: BrowserWindow | null = null
+let currentProgress: number | null = null
+
+function applyProgressBar(value: number) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.setProgressBar(value)
+  }
+}
+
+function clearProgressBar() {
+  currentProgress = null
+  applyProgressBar(-1)
+}
+
 let server: Server.Listener | null = null
 const loadingComplete = defer<void>()
 const deepLinkReadyWindows = new WeakSet<BrowserWindow>()
@@ -587,6 +600,17 @@ function setupAutoUpdater() {
     allowDowngrade: autoUpdater.allowDowngrade,
     autoInstallOnAppQuit: autoUpdater.autoInstallOnAppQuit,
     currentVersion: app.getVersion(),
+  })
+  autoUpdater.on("download-progress", (info) => {
+    currentProgress = info.percent / 100
+    applyProgressBar(currentProgress)
+  })
+  autoUpdater.on("update-downloaded", clearProgressBar)
+  autoUpdater.on("update-not-available", clearProgressBar)
+  autoUpdater.on("update-cancelled", clearProgressBar)
+  autoUpdater.on("error", (error) => {
+    logger.error("updater error", error)
+    clearProgressBar()
   })
 }
 

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -660,11 +660,28 @@ async function checkForUpdates(alertOnFail: boolean) {
   if (result.status === "failed") {
     logger.log("no update decision", { reason: result.reason ?? "update check failed" })
     if (!alertOnFail) return
-    await dialog.showMessageBox({
+    const copy = labels.failed.reasonCopy[result.reason] ?? labels.failed.fallbackMessage
+    const detail = [result.message, labels.failed.currentVersionUnaffected]
+      .filter(Boolean)
+      .join("\n\n")
+    const response = await dialog.showMessageBox({
       type: "error",
-      message: result.message ?? labels.failed.fallbackMessage,
       title: labels.failed.title,
+      message: copy,
+      detail,
+      buttons: [labels.failed.buttons.retry, labels.failed.buttons.openDownloadPage, labels.failed.buttons.later],
+      defaultId: 0,
+      cancelId: 2,
     })
+    if (response.response === 0) {
+      try {
+        await checkForUpdates(alertOnFail)
+      } catch (error) {
+        logger.error("retry after update failure failed", error)
+      }
+    } else if (response.response === 1) {
+      await shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")
+    }
     return
   }
   if (!result.updateAvailable) {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -719,11 +719,23 @@ async function checkForUpdates(alertOnFail: boolean) {
       }
     } catch (error) {
       logger.error("install update failed", error)
-      await dialog.showMessageBox({
+      const response = await dialog.showMessageBox({
         type: "error",
         title: labels.failed.title,
-        message: error instanceof Error ? error.message : labels.failed.fallbackMessage,
+        message: labels.failed.installFailedMessage,
+        detail: [
+          error instanceof Error ? error.message : "",
+          labels.failed.currentVersionUnaffected,
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
+        buttons: [labels.failed.buttons.openDownloadPage, labels.failed.buttons.later],
+        defaultId: 0,
+        cancelId: 1,
       })
+      if (response.response === 0) {
+        await shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")
+      }
     }
   } else {
     updater.dismissReady()

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -89,6 +89,8 @@ let initStep: InitStep = { phase: "server_waiting" }
 let mainWindow: BrowserWindow | null = null
 let currentProgress: number | null = null
 
+const LATEST_RELEASE_URL = "https://github.com/Astro-Han/pawwork/releases/latest"
+
 function applyProgressBar(value: number) {
   for (const win of BrowserWindow.getAllWindows()) {
     win.setProgressBar(value)
@@ -680,7 +682,7 @@ async function checkForUpdates(alertOnFail: boolean) {
         logger.error("retry after update failure failed", error)
       }
     } else if (response.response === 1) {
-      await shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")
+      await shell.openExternal(LATEST_RELEASE_URL)
     }
     return
   }
@@ -734,7 +736,7 @@ async function checkForUpdates(alertOnFail: boolean) {
         cancelId: 1,
       })
       if (response.response === 0) {
-        await shell.openExternal("https://github.com/Astro-Han/pawwork/releases/latest")
+        await shell.openExternal(LATEST_RELEASE_URL)
       }
     }
   } else {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -356,6 +356,11 @@ function focusMainWindow(options: { openIfMissing?: boolean } = {}) {
 function openMainWindow() {
   const win = createMainWindow()
   mainWindow = win
+  win.once("ready-to-show", () => {
+    if (currentProgress !== null) {
+      win.setProgressBar(currentProgress)
+    }
+  })
   win.on("focus", () => syncMenuLocaleForWindow(win))
   win.on("closed", () => {
     if (mainWindow !== win) return

--- a/packages/desktop-electron/src/main/updater-dialog-labels.test.ts
+++ b/packages/desktop-electron/src/main/updater-dialog-labels.test.ts
@@ -7,7 +7,7 @@ describe("updater dialog labels", () => {
 
     expect(labels.busy.title).toBe("正在检查更新")
     expect(labels.disabled.message).toBe("此构建不支持更新。")
-    expect(labels.failed.title).toBe("检查更新失败")
+    expect(labels.failed.title).toBe("更新失败")
     expect(labels.none.message).toBe("PawWork 已是最新版本。")
     expect(labels.ready.message("0.2.5")).toBe("更新 0.2.5 已下载。现在重启？")
     expect(labels.ready.buttons).toEqual(["重启", "稍后"])
@@ -25,5 +25,31 @@ describe("updater dialog labels", () => {
 
     expect(labels.busy.title).toBe("Update Check in Progress")
     expect(labels.none.message).toBe("You're up to date.")
+  })
+
+  test("exposes reason-specific failed copy and recovery buttons in Simplified Chinese", () => {
+    const labels = updaterDialogLabels("zh")
+
+    expect(labels.failed.title).toBe("更新失败")
+    expect(labels.failed.installFailedMessage).toBe("安装失败。")
+    expect(labels.failed.reasonCopy.check).toBe("无法连接 GitHub。网络可能较慢或被阻断。")
+    expect(labels.failed.reasonCopy.download).toBe("下载未完成。")
+    expect(labels.failed.reasonCopy.metadata).toBe("更新信息不完整或无效。")
+    expect(labels.failed.reasonCopy.cache).toBe("缓存的更新处于异常状态。")
+    expect(labels.failed.currentVersionUnaffected).toBe("当前版本未受影响，可继续使用。")
+    expect(labels.failed.buttons).toEqual({ retry: "重试", openDownloadPage: "打开下载页", later: "稍后" })
+  })
+
+  test("exposes reason-specific failed copy in English", () => {
+    const labels = updaterDialogLabels("en")
+
+    expect(labels.failed.title).toBe("Update Failed")
+    expect(labels.failed.installFailedMessage).toBe("Installation failed.")
+    expect(labels.failed.reasonCopy.check).toBe("Could not reach GitHub. The network may be slow or blocked.")
+    expect(labels.failed.reasonCopy.download).toBe("The download did not complete.")
+    expect(labels.failed.reasonCopy.metadata).toBe("The update information was incomplete or invalid.")
+    expect(labels.failed.reasonCopy.cache).toBe("The cached update is in an unexpected state.")
+    expect(labels.failed.currentVersionUnaffected).toBe("Your current version is unaffected and continues to work.")
+    expect(labels.failed.buttons).toEqual({ retry: "Retry", openDownloadPage: "Open Download Page", later: "Later" })
   })
 })

--- a/packages/desktop-electron/src/main/updater-dialog-labels.ts
+++ b/packages/desktop-electron/src/main/updater-dialog-labels.ts
@@ -1,9 +1,18 @@
 import type { MenuLocale } from "./menu-labels"
 
+type FailedLabels = {
+  title: string
+  fallbackMessage: string
+  installFailedMessage: string
+  reasonCopy: Partial<Record<"check" | "download" | "metadata" | "cache", string>>
+  currentVersionUnaffected: string
+  buttons: { retry: string; openDownloadPage: string; later: string }
+}
+
 type Labels = {
   busy: { title: string; message: string }
   disabled: { title: string; message: string }
-  failed: { title: string; fallbackMessage: string }
+  failed: FailedLabels
   none: { title: string; message: string }
   ready: { title: string; message: (version?: string) => string; buttons: [string, string] }
 }
@@ -19,8 +28,17 @@ const labels: Record<MenuLocale, Labels> = {
       message: "Updates are not available in this build.",
     },
     failed: {
-      title: "Update Check Failed",
+      title: "Update Failed",
       fallbackMessage: "Failed to check for updates.",
+      installFailedMessage: "Installation failed.",
+      reasonCopy: {
+        check: "Could not reach GitHub. The network may be slow or blocked.",
+        download: "The download did not complete.",
+        metadata: "The update information was incomplete or invalid.",
+        cache: "The cached update is in an unexpected state.",
+      },
+      currentVersionUnaffected: "Your current version is unaffected and continues to work.",
+      buttons: { retry: "Retry", openDownloadPage: "Open Download Page", later: "Later" },
     },
     none: {
       title: "No Updates",
@@ -42,8 +60,17 @@ const labels: Record<MenuLocale, Labels> = {
       message: "此构建不支持更新。",
     },
     failed: {
-      title: "检查更新失败",
+      title: "更新失败",
       fallbackMessage: "检查更新失败。",
+      installFailedMessage: "安装失败。",
+      reasonCopy: {
+        check: "无法连接 GitHub。网络可能较慢或被阻断。",
+        download: "下载未完成。",
+        metadata: "更新信息不完整或无效。",
+        cache: "缓存的更新处于异常状态。",
+      },
+      currentVersionUnaffected: "当前版本未受影响，可继续使用。",
+      buttons: { retry: "重试", openDownloadPage: "打开下载页", later: "稍后" },
     },
     none: {
       title: "没有可用更新",


### PR DESCRIPTION
## Summary

Implements the v5.2 design in #213:

- During a download, broadcast `setProgressBar(info.percent / 100)` to every open `BrowserWindow` so macOS dock and Windows 10/11 taskbar icons show motion.
- New windows opened mid-download reapply the current progress on `ready-to-show`.
- Menu path's failure dialog now shows reason-specific copy for check / download / metadata / cache, includes the controller's own error message in the detail line, reassures that the current version is unaffected, and offers Retry / Open Download Page / Later.
- Install failure has its own dedicated dialog with `installFailedMessage` and only Open Download Page / Later (retry does not help after install failure).

No renderer changes. No new IPC. No new UI primitives.

Follow-up for network reliability (CDN / mirror) is tracked in #219.

## Test plan

- [x] `bun test packages/desktop-electron/src/main/updater-dialog-labels.test.ts`
- [x] `bun test packages/desktop-electron/src/main/index-updater-source.test.ts`
- [x] `bun --cwd packages/desktop-electron test` (282 pass)
- [x] `bun --cwd packages/desktop-electron typecheck`
- [x] Biome lint on touched files (1 pre-existing unrelated warning on `import { type MenuLocale }`, not in this PR's scope)
- [ ] Manual smoke on packaged dev build (requires real `UPDATER_ENABLED` + real feed; not runnable from `bun dev`) — gating before release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download progress shown via window progress bars and reapplied when windows become visible.
  * Failure dialogs now show localized, reason-specific messaging and structured action buttons; retry triggers another update check and opens releases when chosen.

* **Bug Fixes**
  * Progress cleared on completion, terminal updater states, and errors.
  * Progress listeners not registered when updater is disabled.

* **Localization**
  * Simplified Chinese and English failure labels updated and expanded.

* **Tests**
  * Added tests validating progress broadcast, clearing behavior, retry flow, and dialog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->