### PR TITLE
feat: update OpenAI OAuth model filter for GPT-5.5

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -375,6 +375,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.3-codex",
           "gpt-5.4",
           "gpt-5.4-mini",
+          "gpt-5.5",
         ])
         for (const [modelId, model] of Object.entries(provider.models)) {
           if (modelId.includes("codex")) continue

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -375,11 +375,12 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.3-codex",
           "gpt-5.4",
           "gpt-5.4-mini",
-          "gpt-5.5",
         ])
         for (const [modelId, model] of Object.entries(provider.models)) {
           if (modelId.includes("codex")) continue
           if (allowedModels.has(model.api.id)) continue
+          const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
+          if (match && parseFloat(match[1]) > 5.4) continue
           delete provider.models[modelId]
         }
 

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -15,6 +15,16 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+const CODEX_OAUTH_ALLOWED_MODELS = new Set([
+  "gpt-5.1-codex",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex-mini",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+])
 
 interface PkceCodes {
   verifier: string
@@ -86,6 +96,16 @@ export function extractAccountId(tokens: TokenResponse): string | undefined {
     return claims ? extractAccountIdFromClaims(claims) : undefined
   }
   return undefined
+}
+
+export function shouldKeepCodexOAuthModel(modelId: string, apiId: string): boolean {
+  if (modelId.includes("codex")) return true
+  if (CODEX_OAUTH_ALLOWED_MODELS.has(apiId)) return true
+  const match = apiId.match(/^gpt-(\d+)\.(\d+)/)
+  if (!match) return false
+  const major = Number(match[1])
+  const minor = Number(match[2])
+  return major > 5 || (major === 5 && minor > 4)
 }
 
 function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string): string {
@@ -365,22 +385,8 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set([
-          "gpt-5.1-codex",
-          "gpt-5.1-codex-max",
-          "gpt-5.1-codex-mini",
-          "gpt-5.2",
-          "gpt-5.2-codex",
-          "gpt-5.3-codex",
-          "gpt-5.4",
-          "gpt-5.4-mini",
-        ])
         for (const [modelId, model] of Object.entries(provider.models)) {
-          if (modelId.includes("codex")) continue
-          if (allowedModels.has(model.api.id)) continue
-          const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
-          if (match && parseFloat(match[1]) > 5.4) continue
+          if (shouldKeepCodexOAuthModel(modelId, model.api.id)) continue
           delete provider.models[modelId]
         }
 

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,7 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  shouldKeepCodexOAuthModel,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
 
@@ -118,6 +119,26 @@ describe("plugin.codex", () => {
           refresh_token: "rt",
         }),
       ).toBe("acc-123")
+    })
+  })
+
+  describe("shouldKeepCodexOAuthModel", () => {
+    test("keeps explicit OAuth models and codex model ids", () => {
+      expect(shouldKeepCodexOAuthModel("gpt-5.4", "gpt-5.4")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("some-codex-model", "custom-model")).toBe(true)
+    })
+
+    test("keeps future GPT minor versions using semantic comparison", () => {
+      expect(shouldKeepCodexOAuthModel("gpt-5.5", "gpt-5.5")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("gpt-5.5-mini", "gpt-5.5-mini")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("gpt-5.10", "gpt-5.10")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("gpt-6.0", "gpt-6.0")).toBe(true)
+    })
+
+    test("drops older non-allowlisted GPT and unrelated models", () => {
+      expect(shouldKeepCodexOAuthModel("gpt-5.3", "gpt-5.3")).toBe(false)
+      expect(shouldKeepCodexOAuthModel("gpt-4.1", "gpt-4.1")).toBe(false)
+      expect(shouldKeepCodexOAuthModel("custom-model", "custom-model")).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

Backport upstream OpenCode commit `97f3c746f3f` to include `gpt-5.5` in the OpenAI OAuth/Codex model allowlist.

## Why

The refreshed `models.dev` catalog already contains `gpt-5.5`, but OpenAI OAuth applies a plugin-level allowlist before exposing models. Without this backport, PawWork can refresh the catalog successfully and still hide `gpt-5.5` from ChatGPT Pro/Plus OAuth users.

## Related Issue

Closes #228.

## How To Verify

```bash
bun --cwd packages/opencode test test/plugin/codex.test.ts test/provider/models-refresh.test.ts
```

## Screenshots or Recordings

Not applicable. No visible UI changes beyond model availability after auth.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Codex OAuth model filtering: Codex-labeled models and explicit whitelist entries are kept, newer gpt versions (semantic versions > 5.4) are now allowed, while older or unrelated models are excluded to prevent offering unsupported options during authentication.
* **Tests**
  * Added coverage validating model/pair scenarios and semantic-version ordering for allowed and disallowed gpt releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->