### PR TITLE
fix: apply desktop proxy env to openai auth flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
         "electron-window-state": "^5.0.3",
         "marked": "^15",
         "semver": "^7.6.0",
+        "undici": "7.24.7",
       },
       "devDependencies": {
         "@actions/artifact": "4.0.0",
@@ -128,7 +129,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.4.11",
+      "version": "1.14.19",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -189,6 +190,7 @@
         "@opencode-ai/plugin": "workspace:*",
         "@opencode-ai/script": "workspace:*",
         "@opencode-ai/sdk": "workspace:*",
+        "@opencode-ai/shared": "workspace:*",
         "@opencode-ai/util": "workspace:*",
         "@openrouter/ai-sdk-provider": "2.5.1",
         "@parcel/watcher": "2.5.1",
@@ -281,7 +283,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.4.11",
+      "version": "1.14.19",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -306,7 +308,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.4.11",
+      "version": "1.14.19",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -321,7 +323,7 @@
     },
     "packages/shared": {
       "name": "@opencode-ai/shared",
-      "version": "1.4.11",
+      "version": "1.14.19",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "effect": "catalog:",
@@ -338,7 +340,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.4.11",
+      "version": "1.14.19",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -36,7 +36,8 @@
     "electron-updater": "^6",
     "electron-window-state": "^5.0.3",
     "marked": "^15",
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "undici": "7.24.7"
   },
   "devDependencies": {
     "@actions/artifact": "4.0.0",

--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -345,12 +345,12 @@ describe("desktop server runtime namespace", () => {
 
     expect(
       proxyConfigFromEnvForTest({
-        ALL_PROXY: "socks5h://127.0.0.1:7897",
+        ALL_PROXY: "http://127.0.0.1:7897",
         NO_PROXY: "localhost,127.0.0.1",
       }),
     ).toEqual({
-      httpProxy: "socks5h://127.0.0.1:7897",
-      httpsProxy: "socks5h://127.0.0.1:7897",
+      httpProxy: "http://127.0.0.1:7897",
+      httpsProxy: "http://127.0.0.1:7897",
       noProxy: "localhost,127.0.0.1",
     })
   })
@@ -400,5 +400,39 @@ describe("desktop server runtime namespace", () => {
       noProxy: "localhost,127.0.0.1",
     })
     expect(capturedDispatcher).toBeTruthy()
+  })
+
+  test("configureProxyDispatcher skips unsupported proxy protocols without crashing startup", async () => {
+    const warnings: unknown[] = []
+    const previousWarn = console.warn
+    console.warn = (...args) => {
+      warnings.push(args)
+    }
+
+    try {
+      const { configureProxyDispatcherForTest } = await import("./server")
+      const configured = await configureProxyDispatcherForTest(
+        {
+          ALL_PROXY: "socks5h://127.0.0.1:7897",
+          NO_PROXY: "localhost,127.0.0.1",
+        },
+        () => import("undici"),
+      )
+
+      expect(configured).toBe(false)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toEqual([
+        "[server] Skipped Node fetch proxy env with unsupported protocol",
+        {
+          keys: ["ALL_PROXY", "NO_PROXY"],
+          skipped: {
+            httpProxy: true,
+            httpsProxy: true,
+          },
+        },
+      ])
+    } finally {
+      console.warn = previousWarn
+    }
   })
 })

--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -339,4 +339,66 @@ describe("desktop server runtime namespace", () => {
       globalThis.fetch = previousFetch
     }
   })
+
+  test("maps ALL_PROXY to HTTP and HTTPS proxy config", async () => {
+    const { proxyConfigFromEnvForTest } = await import("./server")
+
+    expect(
+      proxyConfigFromEnvForTest({
+        ALL_PROXY: "socks5h://127.0.0.1:7897",
+        NO_PROXY: "localhost,127.0.0.1",
+      }),
+    ).toEqual({
+      httpProxy: "socks5h://127.0.0.1:7897",
+      httpsProxy: "socks5h://127.0.0.1:7897",
+      noProxy: "localhost,127.0.0.1",
+    })
+  })
+
+  test("configureProxyDispatcher skips when no HTTP or HTTPS proxy env is present", async () => {
+    const { configureProxyDispatcherForTest } = await import("./server")
+
+    const configured = await configureProxyDispatcherForTest(
+      {
+        NO_PROXY: "localhost",
+      },
+      async () => {
+        throw new Error("undici should not load without proxy env")
+      },
+    )
+
+    expect(configured).toBe(false)
+  })
+
+  test("configureProxyDispatcher registers EnvHttpProxyAgent using env-derived proxy config", async () => {
+    let capturedOptions: Record<string, string | undefined> | undefined
+    let capturedDispatcher: unknown
+    const { configureProxyDispatcherForTest } = await import("./server")
+
+    const configured = await configureProxyDispatcherForTest(
+      {
+        HTTPS_PROXY: "http://127.0.0.1:7897",
+        HTTP_PROXY: "http://127.0.0.1:7897",
+        NO_PROXY: "localhost,127.0.0.1",
+      },
+      async () => ({
+        EnvHttpProxyAgent: class {
+          constructor(options: Record<string, string | undefined>) {
+            capturedOptions = options
+          }
+        } as any,
+        setGlobalDispatcher: (dispatcher: unknown) => {
+          capturedDispatcher = dispatcher
+        },
+      }),
+    )
+
+    expect(configured).toBe(true)
+    expect(capturedOptions).toEqual({
+      httpProxy: "http://127.0.0.1:7897",
+      httpsProxy: "http://127.0.0.1:7897",
+      noProxy: "localhost,127.0.0.1",
+    })
+    expect(capturedDispatcher).toBeTruthy()
+  })
 })

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -26,6 +26,12 @@ type ProxyDispatcherModule = {
   setGlobalDispatcher(dispatcher: unknown): void
 }
 
+type ProxyConfig = {
+  httpProxy?: string
+  httpsProxy?: string
+  noProxy?: string
+}
+
 export function getDefaultServerUrl(): string | null {
   const value = getStore().get(DEFAULT_SERVER_URL_KEY)
   return typeof value === "string" ? value : null
@@ -120,13 +126,51 @@ function prepareServerEnv(password: string) {
   Object.assign(process.env, buildServerEnv(password))
 }
 
-function proxyConfigFromEnv(env: NodeJS.ProcessEnv) {
+function proxyConfigFromEnv(env: NodeJS.ProcessEnv): ProxyConfig | null {
   const allProxy = env.ALL_PROXY ?? env.all_proxy
   const httpProxy = env.HTTP_PROXY ?? env.http_proxy ?? allProxy
   const httpsProxy = env.HTTPS_PROXY ?? env.https_proxy ?? allProxy
   const noProxy = env.NO_PROXY ?? env.no_proxy
   if (!httpProxy && !httpsProxy) return null
   return { httpProxy, httpsProxy, noProxy }
+}
+
+function presentProxyEnvKeys(env: NodeJS.ProcessEnv) {
+  return PROXY_ENV_KEYS.filter((key) => Boolean(env[key]))
+}
+
+function supportedProxyUrl(url: string | undefined) {
+  if (!url) return undefined
+  try {
+    const protocol = new URL(url).protocol
+    if (protocol === "http:" || protocol === "https:") return url
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeProxyConfig(proxy: ProxyConfig) {
+  const httpProxy = supportedProxyUrl(proxy.httpProxy)
+  const httpsProxy = supportedProxyUrl(proxy.httpsProxy)
+  const skipped = {
+    httpProxy: Boolean(proxy.httpProxy && !httpProxy),
+    httpsProxy: Boolean(proxy.httpsProxy && !httpsProxy),
+  }
+  if (!httpProxy && !httpsProxy) {
+    return {
+      proxy: null,
+      skipped,
+    }
+  }
+  return {
+    proxy: {
+      httpProxy,
+      httpsProxy,
+      noProxy: proxy.noProxy,
+    },
+    skipped,
+  }
 }
 
 async function configureProxyDispatcher(
@@ -138,12 +182,30 @@ async function configureProxyDispatcher(
     console.log("[server] No Node fetch proxy env detected")
     return false
   }
-  const { EnvHttpProxyAgent, setGlobalDispatcher } = await load()
-  setGlobalDispatcher(new EnvHttpProxyAgent(proxy))
-  console.log("[server] Configured Node fetch proxy from env", {
-    keys: PROXY_ENV_KEYS.filter((key) => Boolean(env[key])),
-  })
-  return true
+  const configuredKeys = presentProxyEnvKeys(env)
+  const normalized = normalizeProxyConfig(proxy)
+  if (!normalized.proxy) {
+    console.warn("[server] Skipped Node fetch proxy env with unsupported protocol", {
+      keys: configuredKeys,
+      skipped: normalized.skipped,
+    })
+    return false
+  }
+  try {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await load()
+    setGlobalDispatcher(new EnvHttpProxyAgent(normalized.proxy))
+    console.log("[server] Configured Node fetch proxy from env", {
+      keys: configuredKeys,
+    })
+    return true
+  } catch (error) {
+    console.warn("[server] Failed to configure Node fetch proxy from env", {
+      keys: configuredKeys,
+      skipped: normalized.skipped,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
 }
 
 export const buildServerEnvForTest = buildServerEnv

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -6,9 +6,25 @@ import { PAWWORK_RUNTIME, runtimeRoots } from "./runtime-namespace"
 import { getUserShell, loadShellEnv } from "./shell-env"
 import { getStore } from "./store"
 
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const
+
 export type WslConfig = { enabled: boolean }
 
 export type HealthCheck = { wait: Promise<void> }
+
+type ProxyDispatcherModule = {
+  EnvHttpProxyAgent: new (options: { httpProxy?: string; httpsProxy?: string; noProxy?: string }) => unknown
+  setGlobalDispatcher(dispatcher: unknown): void
+}
 
 export function getDefaultServerUrl(): string | null {
   const value = getStore().get(DEFAULT_SERVER_URL_KEY)
@@ -35,6 +51,7 @@ export function setWslConfig(config: WslConfig) {
 
 export async function spawnLocalServer(hostname: string, port: number, password: string) {
   prepareServerEnv(password)
+  await configureProxyDispatcher(process.env)
   const { Log, Server } = await import("virtual:opencode-server")
   await Log.init({ print: false, level: "WARN" })
   const listener = await Server.listen({
@@ -103,8 +120,36 @@ function prepareServerEnv(password: string) {
   Object.assign(process.env, buildServerEnv(password))
 }
 
+function proxyConfigFromEnv(env: NodeJS.ProcessEnv) {
+  const allProxy = env.ALL_PROXY ?? env.all_proxy
+  const httpProxy = env.HTTP_PROXY ?? env.http_proxy ?? allProxy
+  const httpsProxy = env.HTTPS_PROXY ?? env.https_proxy ?? allProxy
+  const noProxy = env.NO_PROXY ?? env.no_proxy
+  if (!httpProxy && !httpsProxy) return null
+  return { httpProxy, httpsProxy, noProxy }
+}
+
+async function configureProxyDispatcher(
+  env: NodeJS.ProcessEnv,
+  load: () => Promise<ProxyDispatcherModule> = () => import("undici"),
+) {
+  const proxy = proxyConfigFromEnv(env)
+  if (!proxy) {
+    console.log("[server] No Node fetch proxy env detected")
+    return false
+  }
+  const { EnvHttpProxyAgent, setGlobalDispatcher } = await load()
+  setGlobalDispatcher(new EnvHttpProxyAgent(proxy))
+  console.log("[server] Configured Node fetch proxy from env", {
+    keys: PROXY_ENV_KEYS.filter((key) => Boolean(env[key])),
+  })
+  return true
+}
+
 export const buildServerEnvForTest = buildServerEnv
 export const githubConfigDirForTest = githubConfigDir
+export const proxyConfigFromEnvForTest = proxyConfigFromEnv
+export const configureProxyDispatcherForTest = configureProxyDispatcher
 
 export async function checkHealth(url: string, password?: string | null): Promise<boolean> {
   let healthUrl: URL

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -131,7 +131,49 @@ interface TokenResponse {
   expires_in?: number
 }
 
+function proxyEnvSummary() {
+  return {
+    HTTP_PROXY: Boolean(process.env.HTTP_PROXY || process.env.http_proxy),
+    HTTPS_PROXY: Boolean(process.env.HTTPS_PROXY || process.env.https_proxy),
+    ALL_PROXY: Boolean(process.env.ALL_PROXY || process.env.all_proxy),
+    NO_PROXY: Boolean(process.env.NO_PROXY || process.env.no_proxy),
+  }
+}
+
+export async function formatOAuthFailure(action: string, response: Response): Promise<string> {
+  const parts = [`status=${response.status}`]
+  const requestId = response.headers.get("x-request-id")
+  const cfRay = response.headers.get("cf-ray")
+  const cfMitigated = response.headers.get("cf-mitigated")
+  if (requestId) parts.push(`request_id=${requestId}`)
+  if (cfRay) parts.push(`cf_ray=${cfRay}`)
+  if (cfMitigated) parts.push(`cf_mitigated=${cfMitigated}`)
+
+  try {
+    const payload = await response.clone().json()
+    const error = typeof payload?.error === "object" && payload.error ? payload.error : payload
+    const code = typeof error?.code === "string" ? error.code : typeof error?.error === "string" ? error.error : undefined
+    const type = typeof error?.type === "string" ? error.type : undefined
+    const message =
+      typeof error?.message === "string"
+        ? error.message
+        : typeof error?.error_description === "string"
+          ? error.error_description
+          : undefined
+    if (code) parts.push(`code=${code}`)
+    if (type) parts.push(`type=${type}`)
+    if (message) parts.push(`message=${message}`)
+  } catch {}
+
+  return `${action} failed (${parts.join(", ")})`
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
+  log.info("codex token exchange start", {
+    issuer: ISSUER,
+    host: "auth.openai.com",
+    proxy: proxyEnvSummary(),
+  })
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -144,7 +186,12 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
     }).toString(),
   })
   if (!response.ok) {
-    throw new Error(`Token exchange failed: ${response.status}`)
+    const message = await formatOAuthFailure("Token exchange", response)
+    log.warn("codex token exchange failed", {
+      proxy: proxyEnvSummary(),
+      message,
+    })
+    throw new Error(message)
   }
   return response.json()
 }
@@ -160,7 +207,12 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> 
     }).toString(),
   })
   if (!response.ok) {
-    throw new Error(`Token refresh failed: ${response.status}`)
+    const message = await formatOAuthFailure("Token refresh", response)
+    log.warn("codex token refresh failed", {
+      proxy: proxyEnvSummary(),
+      message,
+    })
+    throw new Error(message)
   }
   return response.json()
 }
@@ -571,7 +623,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                     })
 
                     if (!tokenResponse.ok) {
-                      throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+                      throw new Error(await formatOAuthFailure("Token exchange", tokenResponse))
                     }
 
                     const tokens: TokenResponse = await tokenResponse.json()

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -623,7 +623,12 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                     })
 
                     if (!tokenResponse.ok) {
-                      throw new Error(await formatOAuthFailure("Token exchange", tokenResponse))
+                      const message = await formatOAuthFailure("Token exchange", tokenResponse)
+                      log.warn("codex token exchange failed", {
+                        proxy: proxyEnvSummary(),
+                        message,
+                      })
+                      throw new Error(message)
                     }
 
                     const tokens: TokenResponse = await tokenResponse.json()

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,7 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  formatOAuthFailure,
   shouldKeepCodexOAuthModel,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
@@ -139,6 +140,47 @@ describe("plugin.codex", () => {
       expect(shouldKeepCodexOAuthModel("gpt-5.3", "gpt-5.3")).toBe(false)
       expect(shouldKeepCodexOAuthModel("gpt-4.1", "gpt-4.1")).toBe(false)
       expect(shouldKeepCodexOAuthModel("custom-model", "custom-model")).toBe(false)
+    })
+  })
+
+  describe("formatOAuthFailure", () => {
+    test("includes safe JSON error fields and request metadata", async () => {
+      const response = new Response(
+        JSON.stringify({
+          error: {
+            code: "unsupported_country_region_territory",
+            type: "request_forbidden",
+            message: "Country, region, or territory not supported",
+          },
+        }),
+        {
+          status: 403,
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": "req_123",
+            "cf-ray": "ray_123",
+            "cf-mitigated": "challenge",
+          },
+        },
+      )
+
+      expect(await formatOAuthFailure("Token exchange", response)).toBe(
+        "Token exchange failed (status=403, request_id=req_123, cf_ray=ray_123, cf_mitigated=challenge, code=unsupported_country_region_territory, type=request_forbidden, message=Country, region, or territory not supported)",
+      )
+    })
+
+    test("falls back to status and headers when response is not JSON", async () => {
+      const response = new Response("<html>blocked</html>", {
+        status: 403,
+        headers: {
+          "content-type": "text/html",
+          "x-request-id": "req_html",
+        },
+      })
+
+      expect(await formatOAuthFailure("Token exchange", response)).toBe(
+        "Token exchange failed (status=403, request_id=req_html)",
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- configure desktop-side Node fetch to honor inherited proxy environment variables before starting the embedded opencode server
- surface actionable OpenAI OAuth diagnostics instead of bare 403 errors, including request metadata and safe error fields
- verify the full desktop flow manually: OpenAI OAuth succeeds, GPT-5.5 appears in Models, and a minimal GPT-5.5 prompt returns successfully

## Why

Issue #227 showed that PawWork could load shell proxy variables but still fail OpenAI OAuth token exchange because the desktop main-process fetch path did not explicitly use them. That made desktop behavior diverge from terminal-launched flows and reduced failures to an unhelpful `Token exchange failed: 403`.

This PR fixes the network path at the desktop layer and improves failure visibility when OpenAI or Cloudflare rejects the request.

## Related Issue

Closes #227

## How To Verify

```bash
bun --cwd packages/desktop-electron test src/main/server.test.ts
bun --cwd packages/opencode test test/plugin/codex.test.ts test/provider/models-refresh.test.ts
```

Manual checks:

- start the desktop dev app with `cd packages/desktop-electron && bun run dev`
- connect OpenAI with ChatGPT Pro/Plus browser OAuth in the desktop app
- confirm browser callback succeeds and the provider appears under Connected providers
- open Settings > Models and confirm `GPT-5.5` is present
- start a session with `GPT-5.5` and send `Reply with exactly OK`
- confirm the app returns `OK`

## Screenshots or Recordings

No visible UI changes. Not included.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app now detects and configures HTTP(S) proxy settings from environment variables, handling missing/unsupported protocols gracefully.
  * OAuth token exchange/refresh now produces richer, structured failure messages for clearer diagnostics.

* **Tests**
  * Added tests covering proxy configuration behavior and enhanced OAuth failure formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->