### PR TITLE
refactor(app): simplify sidebar active state and tighten density

### DIFF
--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -130,7 +130,7 @@ export const PawworkSidebar = (props: {
                   props.onTogglePinnedSession(session.id)
                 }}
                 classList={{
-                  "inline-flex size-6 items-center justify-center rounded transition-colors": true,
+                  "inline-flex size-5 items-center justify-center rounded transition-colors": true,
                   "text-text-strong opacity-100 pointer-events-auto": isPinned(),
                   "text-text-weak opacity-0 pointer-events-none group-hover/session:opacity-100 group-hover/session:pointer-events-auto group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto hover:text-text-base":
                     !isPinned(),

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -295,9 +295,9 @@ export const PawworkSidebar = (props: {
             when={props.sessions().length > 0}
             fallback={<div class="px-2 text-13-regular text-text-weak">{language.t("sidebar.pawwork.empty.sessions")}</div>}
           >
-            <nav class="flex flex-col gap-1">
+            <nav class="flex flex-col gap-0.5">
               <Show when={pinnedRows().length > 0}>
-                <section data-component="pawwork-sidebar-pinned" class="flex flex-col gap-1">
+                <section data-component="pawwork-sidebar-pinned" class="flex flex-col gap-0.5">
                   <div class="px-2 pb-1 text-11-medium text-text-weak">{language.t("sidebar.pawwork.pinned")}</div>
                   <For each={pinnedRows()}>{(entry) => renderSessionItem(entry)}</For>
                 </section>
@@ -327,7 +327,7 @@ export const PawworkSidebar = (props: {
               <Show when={props.sortMode() === "project"}>
                 <For each={groupedRows()}>
                   {(group) => (
-                    <section class="flex flex-col gap-1">
+                    <section class="flex flex-col gap-0.5">
                       <div data-component="pawwork-group-header" class="px-2 pt-3 pb-1 text-11-medium font-mono text-text-weak">
                         {group.label}
                       </div>

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -320,7 +320,7 @@ export const NewSessionItem = (props: {
 export const SessionSkeleton = (props: { count?: number }): JSX.Element => {
   const items = Array.from({ length: props.count ?? 4 }, (_, index) => index)
   return (
-    <div class="flex flex-col gap-1">
+    <div class="flex flex-col gap-0.5">
       <For each={items}>
         {() => <div class="h-8 w-full rounded-xl bg-surface-raised-base opacity-60 animate-pulse" />}
       </For>

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -119,7 +119,7 @@ const SessionRow = (props: {
       }}
     >
       <div
-        class="shrink-0 size-6 flex items-center justify-center"
+        class="shrink-0 size-5 flex items-center justify-center"
         style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
       >
         {indicator()}
@@ -204,7 +204,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     <>
       <div
         data-session-id={props.session.id}
-        class="group/session relative w-full min-w-0 rounded-md cursor-default pr-3 transition-colors hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active has-[.active]:shadow-[inset_2px_0_0_var(--color-accent-brand)]"
+        class="group/session relative w-full min-w-0 rounded-xl cursor-default pr-3 transition-colors hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-raised-base-hover"
         style={{ "padding-left": `${8 + (props.level ?? 0) * 16}px` }}
       >
         <div class="flex min-w-0 items-center gap-1">
@@ -294,7 +294,7 @@ export const NewSessionItem = (props: {
         props.clearHoverProjectSoon()
       }}
     >
-      <div class="shrink-0 size-6 flex items-center justify-center">
+      <div class="shrink-0 size-5 flex items-center justify-center">
         <Icon name="new-session" size="small" class="text-icon-weak" />
       </div>
       <span class="text-14-regular text-text-strong min-w-0 flex-1 truncate">{label}</span>
@@ -302,7 +302,7 @@ export const NewSessionItem = (props: {
   )
 
   return (
-    <div class="group/session relative w-full min-w-0 rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
+    <div class="group/session relative w-full min-w-0 rounded-xl cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-raised-base-hover">
       <Show
         when={!tooltip()}
         fallback={
@@ -322,7 +322,7 @@ export const SessionSkeleton = (props: { count?: number }): JSX.Element => {
   return (
     <div class="flex flex-col gap-1">
       <For each={items}>
-        {() => <div class="h-8 w-full rounded-md bg-surface-raised-base opacity-60 animate-pulse" />}
+        {() => <div class="h-8 w-full rounded-xl bg-surface-raised-base opacity-60 animate-pulse" />}
       </For>
     </div>
   )


### PR DESCRIPTION
## Summary

Simplify the session sidebar visuals: drop the orange left-bar marker on the active row, align active and hover backgrounds, and tighten gutter, radius, and row gap toward Codex / ChatGPT polish.

## Why

The active row used a 2px brand-coloured `inset` shadow as its primary marker. With the marker removed, the underlying `bg-surface-base-active` (alpha 0.059) is actually weaker than the hover background `bg-surface-raised-base-hover` (alpha 0.078), so an active row would have looked less prominent than a hovered row. Unifying the two backgrounds keeps a single visual signal — once the cursor leaves, only the active row stays highlighted, which is enough.

The gutter, radius, and gap changes are a small density pass aligned with the same goal — "less is more" — without touching design tokens or main conversation typography.

## Related Issue

No tracking issue; standalone polish.

## How To Verify

Local manual check in `bun run dev:desktop` (macOS, dark mode):
- Pick a session: active row uses subtle bg fill, no orange left bar
- Hover another row: same fill; cursor away leaves only the active row highlighted
- Trigger spinner / permission / error / unread states: leading dot still visible inside the narrower 20px gutter
- New chat row picks up the same active treatment
- Skeleton placeholder matches the loaded row radius (no jump on load)

## Screenshots or Recordings

Verified visually with the maintainer during dev:desktop iteration. Before/after screenshots can be attached if needed.

## Checklist

- [x] No related issue (visual polish, no tracked bug)
- [x] Labels: enhancement + ui + P3 set on creation
- [x] Manual UI check via `bun run dev:desktop` on macOS
- [x] No macOS / Windows behaviour delta — pure CSS class changes in `packages/app`
- [x] No docs / dependency / permission impact
- [x] Targets `dev`, Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced vertical spacing in the sidebar and pinned/group/session areas for tighter, more compact layout.
  * Slightly decreased icon/pin control sizing for better proportion and density.
  * Updated session and “new session” item corners to a softer radius and removed an extra active-state visual effect for a cleaner, more consistent appearance.
  * Tweaked skeleton placeholders to match the refined spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->