### PR TITLE
chore: bump desktop release to 0.2.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -145,7 +145,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -389,7 +389,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release version from 0.2.11 to 0.2.12 across the desktop package, app package, opencode package, util package, and lockfile workspace metadata.

## Why

Prepare the next stable desktop release after the seven PRs merged since v0.2.11:

- #226 OpenAI OAuth model filter for GPT-5.5
- #231 Windows native Win11 frame and cross-platform About modal
- #233 desktop proxy env applied to OpenAI auth flow
- #234 cloud session sharing replaced with local export
- #235 tool description cleanup and multiedit dead-code removal
- #236 LSP default off and TS-ecosystem scoped to nearest package
- #237 sidebar active state and density polish

## Related Issue

No linked issue. This is release preparation for v0.2.12.

## How To Verify

```bash
bun install --frozen-lockfile
node -p "require('./packages/desktop-electron/package.json').version"
bun test scripts/verify-release.test.ts # from packages/desktop-electron
bun test scripts/release-metadata-contract.test.ts scripts/release-workflow-contract.test.ts electron-builder-app-update.test.ts # from packages/desktop-electron
git diff --check
```

## Screenshots or Recordings

N/A. Version bump only, no visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 0.2.12 across all project packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->