### PR TITLE
fix(opencode): treat ripgrep --files exit 1 as empty result

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -307,6 +307,9 @@ export namespace Ripgrep {
     if (buffer) yield buffer
     const exit = await proc.exited
     input.signal?.throwIfAborted()
+    // ripgrep exits 1 when --files matches nothing (glob filters out everything,
+    // or search root is fully gitignored). Treat as empty result; only ≥2 is fatal.
+    if (exit === 1) return
     if (exit !== 0) {
       const stderr = (await text(proc.stderr)).trim()
       throw new Error(stderr || `ripgrep failed with exit code ${exit}`)

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -73,6 +73,23 @@ describe("file.ripgrep", () => {
     expect(result.items).toEqual([])
   })
 
+  test("files returns empty when glob matches nothing (ripgrep exit 1)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "match.ts"), "const value = 1\n")
+      },
+    })
+
+    const files = await Array.fromAsync(
+      Ripgrep.files({
+        cwd: tmp.path,
+        glob: ["nothing-here-xyz/*"],
+      }),
+    )
+
+    expect(files).toEqual([])
+  })
+
   test("files throws when ripgrep exits with an invalid glob error", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -90,6 +90,29 @@ describe("file.ripgrep", () => {
     expect(files).toEqual([])
   })
 
+  test("files returns empty when search root is gitignored (mirrors #243)", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "docs", "content-strategy", "posts"), { recursive: true })
+        await Bun.write(
+          path.join(dir, "docs", "content-strategy", "posts", "sample.md"),
+          "# sample\n",
+        )
+        await Bun.write(path.join(dir, ".git", "info", "exclude"), "docs/\n")
+      },
+    })
+
+    const files = await Array.fromAsync(
+      Ripgrep.files({
+        cwd: tmp.path,
+        glob: ["docs/content-strategy/posts/*"],
+      }),
+    )
+
+    expect(files).toEqual([])
+  })
+
   test("files throws when ripgrep exits with an invalid glob error", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## Summary

Add `if (exit === 1) return` to `Ripgrep.files()` (packages/opencode/src/file/ripgrep.ts:308-313) so that "no matching files" produces an empty stream instead of throwing. Adds two regression tests: a wrapper-level "no-match" guard, and a #243-shaped gitignored-subtree guard.

## Why

ripgrep `--files` returns exit code 1 when zero files match (per ripgrep convention: 0 = match, 1 = no match, 2 = real error). The wrapper was treating any non-zero exit as fatal and surfacing `ripgrep failed with exit code 1` to the model, which broke `glob` against any gitignored subtree.

In this repo this is high-impact: AGENTS.md "Local files" keeps `docs/` out of the index via `.git/info/exclude`, so every model `glob` against `docs/**` errored out. Observed 6 times in one session across kimi-for-coding/k2p6 and alibaba-coding-plan-cn/glm-5 (#243).

Why a 1-line patch instead of cherry-picking from upstream: upstream introduced the same exit-1 handling as a side effect of two back-to-back architectural rewrites — #21703 (wasm worker backend, +645 lines) and #22773 (native restore on top of effect-based Stream, −645 lines). Neither is a clean small patch and both would drag in the new Effect Stream callback shape plus reapplying our local cross-spawn-spawner adaptation. Last sync (#48 "feat: sync opencode foundation tail") already grafted the parallel `search()` exit-1 fix because that function shape was unchanged upstream; it skipped `files()` because upstream had restructured it. This PR closes that gap with a 1-line patch and will harmlessly converge with upstream the next time `Ripgrep.files()` is synced wholesale.

The downstream `glob` tool already has `if (files.length === 0) output.push("No files found")` at packages/opencode/src/tool/glob.ts:75 — that branch was dead code before this fix because the wrapper threw before length could be checked. The patch wires up an existing intended path.

## Boundary

This patch preserves ripgrep's existing ignore semantics. A `glob` whose search root is fully covered by `.gitignore` or `.git/info/exclude` now returns an empty list with `No files found` instead of an error — but the gitignored content itself stays invisible to the tool. Making local-only docs (e.g. PawWork's `docs/`) discoverable to the model is an orthogonal product decision and is out of scope for this PR.

## Related Issue

Closes #243.

## How To Verify

```bash
bun --cwd packages/opencode typecheck
bun --cwd packages/opencode test test/file/ripgrep.test.ts
```

Local results: typecheck PASS; ripgrep suite 12 pass / 0 fail (was 10 pass; two new tests guard the fix from different angles — `files returns empty when glob matches nothing (ripgrep exit 1)` covers the wrapper-level exit-1 path; `files returns empty when search root is gitignored (mirrors #243)` covers the boundary in the original bug shape and would also catch a future `--no-ignore`-style regression that silently exposes gitignored content). Existing `files throws when ripgrep exits with an invalid glob error` test continues to pass, confirming exit ≥2 is still treated as fatal.

In-product smoke (deferred to real session, will record in PR comment):

- [ ] In a session at PawWork repo root, ask the model to `glob` for `docs/content-strategy/**/*` (or any path under a gitignored root). Expected: tool returns empty list with `No files found`, no `ripgrep failed` error.
- [ ] Sanity: `glob` for `packages/opencode/src/file/*` still returns matching paths.

## Screenshots or Recordings

N/A. No UI surface changed.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings (N/A — no UI)
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes (none; ripgrep exit code semantics are identical across platforms)
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant (none)
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File search now returns an empty result when no files match the criteria or when the search root is fully ignored, instead of treating these cases as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->