### PR TITLE
feat(question): tighten dock cap, schema bounds, and tool description

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -84,7 +84,8 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const input = createMemo(() => store.custom[store.tab] ?? "")
   const on = createMemo(() => store.customOn[store.tab] === true)
   const multi = createMemo(() => question()?.multiple === true)
-  const count = createMemo(() => options().length + 1)
+  const customAllowed = createMemo(() => question()?.custom !== false)
+  const count = createMemo(() => options().length + (customAllowed() ? 1 : 0))
 
   const summary = createMemo(() => {
     const n = Math.min(store.tab + 1, total())
@@ -120,7 +121,8 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const pickFocus = (tab: number = store.tab) => {
     const list = questions()[tab]?.options ?? []
-    if (store.customOn[tab] === true) return list.length
+    const customOnTab = questions()[tab]?.custom !== false
+    if (customOnTab && store.customOn[tab] === true) return list.length
     return Math.max(
       0,
       list.findIndex((item) => store.answers[tab]?.includes(item.label) ?? false),
@@ -146,11 +148,13 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   onCleanup(() => {
     if (focusFrame !== undefined) cancelAnimationFrame(focusFrame)
     if (replied) return
+    const customByTab = (i: number) => questions()[i]?.custom !== false
     cache.set(props.request.id, {
       tab: store.tab,
       answers: store.answers.map((a) => (a ? [...a] : [])),
-      custom: store.custom.map((s) => s ?? ""),
-      customOn: store.customOn.map((b) => b ?? false),
+      // Iterate by total() to avoid leaving stale entries when a tab was never visited.
+      custom: Array.from({ length: total() }, (_, i) => (customByTab(i) ? store.custom[i] ?? "" : "")),
+      customOn: Array.from({ length: total() }, (_, i) => (customByTab(i) ? store.customOn[i] ?? false : false)),
     })
   })
 
@@ -306,6 +310,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     if (sending()) return
 
     if (optIndex === options().length) {
+      if (!customAllowed()) return
       customOpen()
       return
     }
@@ -444,78 +449,80 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
           )}
         </For>
 
-        <Show
-          when={store.editing}
-          fallback={
-            <button
-              type="button"
-              ref={customRef}
+        <Show when={customAllowed()}>
+          <Show
+            when={store.editing}
+            fallback={
+              <button
+                type="button"
+                ref={customRef}
+                data-slot="question-option"
+                data-custom="true"
+                data-picked={on()}
+                role={multi() ? "checkbox" : "radio"}
+                aria-checked={on()}
+                disabled={sending()}
+                onFocus={() => setStore("focus", options().length)}
+                onClick={customOpen}
+              >
+                <Mark multi={multi()} picked={on()} onClick={toggleCustomMark} />
+                <span data-slot="question-option-main">
+                  <span data-slot="option-label">{customLabel()}</span>
+                  <span data-slot="option-description">{input() || customPlaceholder()}</span>
+                </span>
+              </button>
+            }
+          >
+            <form
               data-slot="question-option"
               data-custom="true"
               data-picked={on()}
               role={multi() ? "checkbox" : "radio"}
               aria-checked={on()}
-              disabled={sending()}
-              onFocus={() => setStore("focus", options().length)}
-              onClick={customOpen}
+              onMouseDown={(e) => {
+                if (sending()) {
+                  e.preventDefault()
+                  return
+                }
+                if (e.target instanceof HTMLTextAreaElement) return
+                const input = e.currentTarget.querySelector('[data-slot="question-custom-input"]')
+                if (input instanceof HTMLTextAreaElement) input.focus()
+              }}
+              onSubmit={(e) => {
+                e.preventDefault()
+                commitCustom()
+              }}
             >
               <Mark multi={multi()} picked={on()} onClick={toggleCustomMark} />
               <span data-slot="question-option-main">
                 <span data-slot="option-label">{customLabel()}</span>
-                <span data-slot="option-description">{input() || customPlaceholder()}</span>
-              </span>
-            </button>
-          }
-        >
-          <form
-            data-slot="question-option"
-            data-custom="true"
-            data-picked={on()}
-            role={multi() ? "checkbox" : "radio"}
-            aria-checked={on()}
-            onMouseDown={(e) => {
-              if (sending()) {
-                e.preventDefault()
-                return
-              }
-              if (e.target instanceof HTMLTextAreaElement) return
-              const input = e.currentTarget.querySelector('[data-slot="question-custom-input"]')
-              if (input instanceof HTMLTextAreaElement) input.focus()
-            }}
-            onSubmit={(e) => {
-              e.preventDefault()
-              commitCustom()
-            }}
-          >
-            <Mark multi={multi()} picked={on()} onClick={toggleCustomMark} />
-            <span data-slot="question-option-main">
-              <span data-slot="option-label">{customLabel()}</span>
-              <textarea
-                ref={focusCustom}
-                data-slot="question-custom-input"
-                placeholder={customPlaceholder()}
-                value={input()}
-                rows={1}
-                disabled={sending()}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
+                <textarea
+                  ref={focusCustom}
+                  data-slot="question-custom-input"
+                  placeholder={customPlaceholder()}
+                  value={input()}
+                  rows={1}
+                  disabled={sending()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      e.preventDefault()
+                      setStore("editing", false)
+                      focus(options().length)
+                      return
+                    }
+                    if ((e.metaKey || e.ctrlKey) && !e.altKey) return
+                    if (e.key !== "Enter" || e.shiftKey) return
                     e.preventDefault()
-                    setStore("editing", false)
-                    focus(options().length)
-                    return
-                  }
-                  if ((e.metaKey || e.ctrlKey) && !e.altKey) return
-                  if (e.key !== "Enter" || e.shiftKey) return
-                  e.preventDefault()
-                  commitCustom()
-                }}
-                onInput={(e) => {
-                  customUpdate(e.currentTarget.value)
-                  resizeInput(e.currentTarget)
-                }}
-              />
-            </span>
-          </form>
+                    commitCustom()
+                  }}
+                  onInput={(e) => {
+                    customUpdate(e.currentTarget.value)
+                    resizeInput(e.currentTarget)
+                  }}
+                />
+              </span>
+            </form>
+          </Show>
         </Show>
       </div>
     </DockPrompt>

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -8,8 +8,6 @@ import { showToast } from "@opencode-ai/ui/toast"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
-import { makeEventListener } from "@solid-primitives/event-listener"
-import { createResizeObserver } from "@solid-primitives/resize-observer"
 
 const cache = new Map<string, { tab: number; answers: QuestionAnswer[]; custom: string[]; customOn: boolean[] }>()
 
@@ -118,28 +116,6 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     setStore("answers", store.tab, next ? [next] : [])
   }
 
-  const measure = () => {
-    if (!root) return
-
-    const scroller = document.querySelector(".scroll-view__viewport")
-    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
-    const top =
-      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
-    if (!top) {
-      root.style.removeProperty("--question-prompt-max-height")
-      return
-    }
-
-    const dock = root.closest('[data-component="session-prompt-dock"]')
-    if (!(dock instanceof HTMLElement)) return
-
-    const dockBottom = dock.getBoundingClientRect().bottom
-    const below = Math.max(0, dockBottom - root.getBoundingClientRect().bottom)
-    const gap = 8
-    const max = Math.max(240, Math.floor(dockBottom - top - gap - below))
-    root.style.setProperty("--question-prompt-max-height", `${max}px`)
-  }
-
   const clamp = (i: number) => Math.max(0, Math.min(count() - 1, i))
 
   const pickFocus = (tab: number = store.tab) => {
@@ -164,27 +140,6 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   }
 
   onMount(() => {
-    let raf: number | undefined
-    const update = () => {
-      if (raf !== undefined) cancelAnimationFrame(raf)
-      raf = requestAnimationFrame(() => {
-        raf = undefined
-        measure()
-      })
-    }
-
-    update()
-
-    makeEventListener(window, "resize", update)
-
-    const dock = root?.closest('[data-component="session-prompt-dock"]')
-    const scroller = document.querySelector(".scroll-view__viewport")
-    createResizeObserver([dock, scroller], update)
-
-    onCleanup(() => {
-      if (raf !== undefined) cancelAnimationFrame(raf)
-    })
-
     focus(pickFocus())
   })
 

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -387,7 +387,13 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
       onKeyDown={nav}
       header={
         <>
-          <div data-slot="question-header-title">{summary()}</div>
+          <div data-slot="question-header-title">
+            <span data-slot="question-header-seq">{summary()}</span>
+            <span data-slot="question-header-separator" aria-hidden="true">·</span>
+            <span data-slot="question-header-mode">
+              {multi() ? language.t("ui.question.multiHint") : language.t("ui.question.singleHint")}
+            </span>
+          </div>
           <div data-slot="question-progress">
             <For each={questions()}>
               {(_, i) => (
@@ -430,9 +436,6 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
       }
     >
       <div data-slot="question-text">{question()?.question}</div>
-      <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
-        <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
-      </Show>
       <div data-slot="question-options">
         <For each={options()}>
           {(opt, i) => (

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -71,6 +71,8 @@ export function createMainWindow() {
     y: state.y,
     width: state.width,
     height: state.height,
+    minWidth: 480,
+    minHeight: 480,
     show: false,
     title: "PawWork",
     icon: iconPath(),

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -14,31 +14,62 @@ export namespace Question {
 
   export const Option = z
     .object({
-      label: z.string().describe("Display text (1-5 words, concise)"),
-      description: z.string().describe("Explanation of choice"),
+      label: z
+        .string()
+        .trim()
+        .min(1, "Option label cannot be empty.")
+        .max(50, "Option label is too long (max 50 chars). Keep labels to 1–5 words; put detail in description.")
+        .describe("Display text (1–5 words, max 50 chars)"),
+      description: z
+        .string()
+        .trim()
+        .min(1, "Option description cannot be empty.")
+        .max(50, "Option description is too long (max 50 chars). Keep it to one line; longer trade-off context belongs in the question or in normal streamed output before the tool call.")
+        .describe("One-line explanation of choice (max 50 chars)"),
     })
     .meta({ ref: "QuestionOption" })
   export type Option = z.infer<typeof Option>
 
   export const Info = z
     .object({
-      question: z.string().describe("Complete question"),
-      header: z.string().describe("Very short label (max 30 chars)"),
-      options: z.array(Option).describe("Available choices"),
+      question: z
+        .string()
+        .trim()
+        .min(1, "Question cannot be empty.")
+        .max(200, "Question is too long (max 200 chars). Stream longer framing or trade-off context as normal assistant output before invoking this tool, then keep the question short.")
+        .describe("Short question (max 200 chars). Stream longer framing as normal output first."),
+      header: z
+        .string()
+        .trim()
+        .min(1, "Header cannot be empty.")
+        .max(30, "Header is too long (max 30 chars). Use a chip-sized label like 'Auth method' or 'Approach'.")
+        .describe("Very short label (max 30 chars)"),
+      options: z
+        .array(Option)
+        .min(2, "Each question needs at least 2 options.")
+        .max(4, "Each question allows at most 4 options. Keep choices distinct and mutually exclusive.")
+        .describe("Available choices (2–4)"),
       multiple: z.boolean().optional().describe("Allow selecting multiple choices"),
       custom: z.boolean().optional().describe("Allow typing a custom answer (default: true)"),
     })
     .meta({ ref: "QuestionInfo" })
   export type Info = z.infer<typeof Info>
 
-  export const Prompt = Info.omit({ custom: true }).meta({ ref: "QuestionPrompt" })
+  // Prompt is the LLM-facing schema. Identical to Info — we expose `custom` so the
+  // tool description's "Set false only when the options are exhaustive" instruction
+  // is reachable from a real tool call. The omit({}) round-trip preserves the
+  // separate ref so docs render two distinct schemas (one internal, one tool input).
+  export const Prompt = Info.omit({}).meta({ ref: "QuestionPrompt" })
   export type Prompt = z.infer<typeof Prompt>
 
   export const Request = z
     .object({
       id: QuestionID.zod,
       sessionID: SessionID.zod,
-      questions: z.array(Info).describe("Questions to ask"),
+      questions: z
+        .array(Info)
+        .min(1, "Provide at least one question.")
+        .max(4, "Ask at most 4 questions per invocation. If you have more, split into multiple tool calls or stream context first."),
       tool: z
         .object({
           messageID: MessageID.zod,

--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -376,6 +376,7 @@ export const ExperimentalRoutes = lazy(() =>
               (value) => (value === "" ? undefined : value),
               z.union([z.coerce.number(), z.string()]).optional(),
             )
+            .optional()
             .meta({ description: "Cursor for loading the next page" }),
           search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
           limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -39,7 +39,7 @@ export const PlanExitTool = Tool.define(
                 header: "Build Agent",
                 custom: false,
                 options: [
-                  { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+                  { label: "Yes", description: "Switch to build agent and implement the plan" },
                   { label: "No", description: "Stay with plan agent to continue refining the plan" },
                 ],
               },

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -5,7 +5,11 @@ import { Question } from "../question"
 import DESCRIPTION from "./question.txt"
 
 const parameters = z.object({
-  questions: z.array(Question.Prompt).describe("Questions to ask"),
+  questions: z
+    .array(Question.Prompt)
+    .min(1, "Provide at least one question.")
+    .max(4, "Ask at most 4 questions per invocation. If you have more, split into multiple tool calls or stream context first.")
+    .describe("Questions to ask (1–4)"),
 })
 
 type Metadata = {

--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -1,10 +1,53 @@
-Use this tool when you need to ask the user questions during execution. This allows you to:
-1. Gather user preferences or requirements
-2. Clarify ambiguous instructions
-3. Get decisions on implementation choices as you work
-4. Offer choices to the user about what direction to take.
+Use this tool proactively when you need a user decision that meaningfully shapes the next step. The user clicks an option (or types a custom answer) and you continue with their answer in mind.
 
-Usage notes:
-- When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
-- Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
-- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+## When to Use
+
+1. **Hard-to-reverse choices**: pushing to dev, force-pushing, deleting branches/files, replacing branding assets, signing/notarizing.
+   - Example: "We're about to push this branch with 3 commits. Squash on merge or merge as-is?"
+2. **Multiple valid technical approaches**: when several solutions are reasonable and user preference matters.
+   - Example: "For the cap, do you want CSS-only with a constant or a dynamic measurement?"
+3. **Ambiguous scope**: when the request could mean different concrete deliverables.
+   - Example: "When you say 'clean up tests', do you mean delete obsolete ones, refactor for readability, or both?"
+4. **Content-style preferences**: tone, length, register, structure for user-facing copy.
+   - Example: "Should the X post lead with the metric or the story?"
+5. **Trade-off where defaults aren't obvious**: when picking the default would silently commit the user to one branch of a real choice.
+   - Example: "Add this gate to all 3 environments now, or only staging this week?"
+
+## When NOT to Use
+
+- Factual lookups you can answer by reading code, docs, or running a command.
+- The user already gave a specific instruction; just execute it.
+- Pure exploration tasks (use the explore agent or codesearch instead).
+- Trivial style choices a sensible default covers.
+- Confirmation theater: don't ask "should I proceed?" after the user already said proceed.
+
+## Examples
+
+GOOD:
+- `question: "Squash on merge or merge as-is?"` with options "Squash" / "Merge as-is".
+- `question: "Use SF Pro or system stack?"` with options "SF Pro" / "system stack".
+
+BAD (stuffs context into the question field; should stream context first then ask short):
+- `question: "We're shipping a feature flag for the new dock. The flag controls whether the new measurement runs only in dev mode initially or also in prod. The trade-off is that dev-only avoids any prod regressions but means we need a follow-up to flip it for the actual rollout. So should we enable it in prod from day 1?"` — 200+ chars; rejected by schema.
+- `question: "Yes or no?"` with no options array — schema requires 2–4 options.
+
+## Format
+
+- `header`: very short label (max 30 chars), shown as a chip.
+- `question`: short prompt (max 200 chars). If you need more context, stream it as normal assistant output BEFORE invoking this tool, then keep the question short.
+- `options`: 2–4 distinct choices; keep them mutually exclusive unless `multiple: true`.
+- `options[].label`: 1–5 words (max 50 chars).
+- `options[].description`: one-line explanation (max 50 chars). Longer per-option detail belongs in the streamed context above.
+- `multiple: true` only when choices aren't mutually exclusive (e.g. feature toggles).
+- `custom`: defaults to true; the dock adds a "Type your own answer" slot. Set false only when the options are exhaustive.
+- `questions`: 1–4 per invocation. If you have more, split.
+
+## Content routing
+
+The tool is for short clickable decisions, not long explanations.
+
+When framing a decision needs paragraphs of context, trade-offs, or background:
+1. Stream the context as normal assistant output FIRST (no tool call yet). The user reads it like any chat message.
+2. THEN invoke `question` with a short prompt that references the context you just streamed.
+
+This keeps the dock compact, every option visible without scroll, and the user's eye landing on the actual choice instead of a wall of text.

--- a/packages/opencode/test/question/schema.test.ts
+++ b/packages/opencode/test/question/schema.test.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "bun:test"
+import { Question } from "../../src/question"
+
+test("Option.label rejects > 50 chars", () => {
+  expect(() => Question.Option.parse({ label: "x".repeat(51), description: "ok" })).toThrow()
+})
+
+test("Option.label accepts exactly 50 chars", () => {
+  expect(() => Question.Option.parse({ label: "x".repeat(50), description: "ok" })).not.toThrow()
+})
+
+test("Option.description rejects > 50 chars", () => {
+  expect(() => Question.Option.parse({ label: "ok", description: "x".repeat(51) })).toThrow()
+})
+
+test("Option.description accepts exactly 50 chars", () => {
+  expect(() => Question.Option.parse({ label: "ok", description: "x".repeat(50) })).not.toThrow()
+})
+
+const validOption = { label: "ok", description: "ok" }
+const validInfo = {
+  question: "ok",
+  header: "ok",
+  options: [validOption, validOption],
+  multiple: false,
+  custom: true,
+}
+
+test("Info.question rejects > 200 chars", () => {
+  expect(() => Question.Info.parse({ ...validInfo, question: "x".repeat(201) })).toThrow()
+})
+
+test("Info.question accepts exactly 200 chars", () => {
+  expect(() => Question.Info.parse({ ...validInfo, question: "x".repeat(200) })).not.toThrow()
+})
+
+test("Info.header rejects > 30 chars", () => {
+  expect(() => Question.Info.parse({ ...validInfo, header: "x".repeat(31) })).toThrow()
+})
+
+test("Info.header accepts exactly 30 chars", () => {
+  expect(() => Question.Info.parse({ ...validInfo, header: "x".repeat(30) })).not.toThrow()
+})
+
+test("Option.label rejects empty / whitespace-only", () => {
+  expect(() => Question.Option.parse({ label: "", description: "ok" })).toThrow()
+  expect(() => Question.Option.parse({ label: "   ", description: "ok" })).toThrow()
+})
+
+test("Info.question rejects empty / whitespace-only", () => {
+  expect(() => Question.Info.parse({ ...validInfo, question: "" })).toThrow()
+  expect(() => Question.Info.parse({ ...validInfo, question: "   " })).toThrow()
+})
+
+test("Info.options rejects fewer than 2", () => {
+  expect(() => Question.Info.parse({ ...validInfo, options: [validOption] })).toThrow()
+})
+
+test("Info.options rejects more than 4", () => {
+  expect(() => Question.Info.parse({ ...validInfo, options: Array(5).fill(validOption) })).toThrow()
+})
+
+test("Info.options accepts exactly 2", () => {
+  expect(() => Question.Info.parse({ ...validInfo, options: [validOption, validOption] })).not.toThrow()
+})
+
+test("Info.options accepts exactly 4", () => {
+  expect(() => Question.Info.parse({ ...validInfo, options: Array(4).fill(validOption) })).not.toThrow()
+})
+
+test("Info rejects custom: false with empty options (caught by options.min(2))", () => {
+  // options.min(2) catches empty arrays before any custom-vs-options refinement could fire,
+  // so the dock is guaranteed to receive at least 2 selectable options regardless of custom.
+  expect(() => Question.Info.parse({ ...validInfo, custom: false, options: [] })).toThrow()
+})
+
+test("Prompt accepts custom flag (LLM can set it for exhaustive options)", () => {
+  // Prompt = Info.omit({}) — `custom` is exposed so the tool description's
+  // "Set false only when the options are exhaustive" instruction is reachable.
+  const withCustom = {
+    question: "ok",
+    header: "ok",
+    options: [validOption, validOption],
+    multiple: false,
+    custom: false,
+  }
+  expect(() => Question.Prompt.parse(withCustom)).not.toThrow()
+  // And without custom (defaults to true at the dock layer).
+  const withoutCustom = {
+    question: "ok",
+    header: "ok",
+    options: [validOption, validOption],
+    multiple: false,
+  }
+  expect(() => Question.Prompt.parse(withoutCustom)).not.toThrow()
+})
+
+test("Info.question rejection message includes the actionable hint", () => {
+  // Each .max() carries a hint so the LLM can repair on rejection. Guard a representative
+  // length-error and count-error so a future refactor can't silently drop the hint contract.
+  try {
+    Question.Info.parse({ ...validInfo, question: "x".repeat(201) })
+    throw new Error("should have thrown")
+  } catch (e: any) {
+    const msg = String(e?.message ?? e)
+    expect(msg).toContain("Question is too long")
+    expect(msg).toContain("max 200 chars")
+  }
+})
+
+test("Info.options rejection message includes the actionable hint", () => {
+  try {
+    Question.Info.parse({ ...validInfo, options: Array(5).fill(validOption) })
+    throw new Error("should have thrown")
+  } catch (e: any) {
+    const msg = String(e?.message ?? e)
+    expect(msg).toContain("at most 4 options")
+  }
+})
+
+test("Request.questions rejects more than 4", () => {
+  expect(() =>
+    Question.Request.parse({
+      id: "que_test",
+      sessionID: "ses_test",
+      questions: Array(5).fill(validInfo),
+    }),
+  ).toThrow()
+})
+
+test("Request.questions rejects empty array", () => {
+  expect(() =>
+    Question.Request.parse({
+      id: "que_test",
+      sessionID: "ses_test",
+      questions: [],
+    }),
+  ).toThrow()
+})
+
+test("Request.questions accepts 1 to 4", () => {
+  for (const n of [1, 2, 3, 4]) {
+    expect(() =>
+      Question.Request.parse({
+        id: "que_test",
+        sessionID: "ses_test",
+        questions: Array(n).fill(validInfo),
+      }),
+    ).not.toThrow()
+  }
+})

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -73,7 +73,10 @@ describe("tool.question", () => {
           {
             question: "What is your favorite animal?",
             header: "This Header is Over 12",
-            options: [{ label: "Dog", description: "Man's best friend" }],
+            options: [
+              { label: "Dog", description: "Man's best friend" },
+              { label: "Cat", description: "Independent companion" },
+            ],
           },
         ]
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -121,6 +121,8 @@ import type {
   SessionDeleteMessageResponses,
   SessionDeleteResponses,
   SessionDiffResponses,
+  SessionExportErrors,
+  SessionExportResponses,
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
@@ -756,12 +758,12 @@ export class Session extends HeyApiClient {
    * Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.
    */
   public list<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
       roots?: boolean
       start?: number
-      cursor?: number | string
+      cursor: number | string
       search?: string
       limit?: number
       archived?: boolean
@@ -1988,6 +1990,38 @@ export class Session2 extends HeyApiClient {
   }
 
   /**
+   * Export session log
+   *
+   * Export the full root session tree as a single JSON document for local debugging. If a child session id is provided, climbs to the topmost ancestor and exports the whole tree.
+   */
+  public export<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionExportResponses, SessionExportErrors, ThrowOnError>({
+      url: "/session/{sessionID}/export",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Get message diff
    *
    * Get the file changes (diff) that resulted from a specific user message in the session.
@@ -2352,6 +2386,9 @@ export class Session2 extends HeyApiClient {
         filename?: string
         url: string
         source?: FilePartSource
+        metadata?: {
+          [key: string]: unknown
+        }
       }>
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -758,12 +758,12 @@ export class Session extends HeyApiClient {
    * Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.
    */
   public list<ThrowOnError extends boolean = false>(
-    parameters: {
+    parameters?: {
       directory?: string
       workspace?: string
       roots?: boolean
       start?: number
-      cursor: number | string
+      cursor?: number | string
       search?: string
       limit?: number
       archived?: boolean

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -83,6 +83,14 @@ export type EventLspUpdated = {
   }
 }
 
+export type EventLspServerInstallFailed = {
+  type: "lsp.server.install.failed"
+  properties: {
+    pkg: string
+    error: string
+  }
+}
+
 export type EventMessagePartDelta = {
   type: "message.part.delta"
   properties: {
@@ -259,6 +267,187 @@ export type EventCommandExecuted = {
     sessionID: string
     arguments: string
     messageID: string
+  }
+}
+
+export type QuestionOption = {
+  /**
+   * Display text (1–5 words, max 50 chars)
+   */
+  label: string
+  /**
+   * One-line explanation of choice (max 50 chars)
+   */
+  description: string
+}
+
+export type QuestionInfo = {
+  /**
+   * Short question (max 200 chars). Stream longer framing as normal output first.
+   */
+  question: string
+  /**
+   * Very short label (max 30 chars)
+   */
+  header: string
+  /**
+   * Available choices (2–4)
+   */
+  options: Array<QuestionOption>
+  /**
+   * Allow selecting multiple choices
+   */
+  multiple?: boolean
+  /**
+   * Allow typing a custom answer (default: true)
+   */
+  custom?: boolean
+}
+
+export type QuestionRequest = {
+  id: string
+  sessionID: string
+  questions: Array<QuestionInfo>
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
+export type EventQuestionAsked = {
+  type: "question.asked"
+  properties: QuestionRequest
+}
+
+export type QuestionAnswer = Array<string>
+
+export type EventQuestionReplied = {
+  type: "question.replied"
+  properties: {
+    sessionID: string
+    requestID: string
+    answers: Array<QuestionAnswer>
+  }
+}
+
+export type EventQuestionRejected = {
+  type: "question.rejected"
+  properties: {
+    sessionID: string
+    requestID: string
+  }
+}
+
+export type Todo = {
+  /**
+   * Brief description of the task
+   */
+  content: string
+  /**
+   * Current status of the task: pending, in_progress, completed, cancelled
+   */
+  status: string
+  /**
+   * Priority level of the task: high, medium, low
+   */
+  priority: string
+}
+
+export type EventTodoUpdated = {
+  type: "todo.updated"
+  properties: {
+    sessionID: string
+    todos: Array<Todo>
+  }
+}
+
+export type SessionStatus =
+  | {
+      type: "idle"
+    }
+  | {
+      type: "retry"
+      attempt: number
+      message: string
+      next: number
+    }
+  | {
+      type: "busy"
+    }
+
+export type EventSessionStatus = {
+  type: "session.status"
+  properties: {
+    sessionID: string
+    status: SessionStatus
+  }
+}
+
+export type EventSessionIdle = {
+  type: "session.idle"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type EventSessionCompacted = {
+  type: "session.compacted"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type EventWorktreeReady = {
+  type: "worktree.ready"
+  properties: {
+    name: string
+    branch: string
+  }
+}
+
+export type EventWorktreeFailed = {
+  type: "worktree.failed"
+  properties: {
+    message: string
+  }
+}
+
+export type Pty = {
+  id: string
+  title: string
+  command: string
+  args: Array<string>
+  cwd: string
+  status: "running" | "exited"
+  pid: number
+}
+
+export type EventPtyCreated = {
+  type: "pty.created"
+  properties: {
+    info: Pty
+  }
+}
+
+export type EventPtyUpdated = {
+  type: "pty.updated"
+  properties: {
+    info: Pty
+  }
+}
+
+export type EventPtyExited = {
+  type: "pty.exited"
+  properties: {
+    id: string
+    exitCode: number
+  }
+}
+
+export type EventPtyDeleted = {
+  type: "pty.deleted"
+  properties: {
+    id: string
   }
 }
 
@@ -484,6 +673,9 @@ export type FilePart = {
   filename?: string
   url: string
   source?: FilePartSource
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type ToolStatePending = {
@@ -739,190 +931,6 @@ export type EventSessionDeleted = {
   }
 }
 
-export type QuestionOption = {
-  /**
-   * Display text (1-5 words, concise)
-   */
-  label: string
-  /**
-   * Explanation of choice
-   */
-  description: string
-}
-
-export type QuestionInfo = {
-  /**
-   * Complete question
-   */
-  question: string
-  /**
-   * Very short label (max 30 chars)
-   */
-  header: string
-  /**
-   * Available choices
-   */
-  options: Array<QuestionOption>
-  /**
-   * Allow selecting multiple choices
-   */
-  multiple?: boolean
-  /**
-   * Allow typing a custom answer (default: true)
-   */
-  custom?: boolean
-}
-
-export type QuestionRequest = {
-  id: string
-  sessionID: string
-  /**
-   * Questions to ask
-   */
-  questions: Array<QuestionInfo>
-  tool?: {
-    messageID: string
-    callID: string
-  }
-}
-
-export type EventQuestionAsked = {
-  type: "question.asked"
-  properties: QuestionRequest
-}
-
-export type QuestionAnswer = Array<string>
-
-export type EventQuestionReplied = {
-  type: "question.replied"
-  properties: {
-    sessionID: string
-    requestID: string
-    answers: Array<QuestionAnswer>
-  }
-}
-
-export type EventQuestionRejected = {
-  type: "question.rejected"
-  properties: {
-    sessionID: string
-    requestID: string
-  }
-}
-
-export type Todo = {
-  /**
-   * Brief description of the task
-   */
-  content: string
-  /**
-   * Current status of the task: pending, in_progress, completed, cancelled
-   */
-  status: string
-  /**
-   * Priority level of the task: high, medium, low
-   */
-  priority: string
-}
-
-export type EventTodoUpdated = {
-  type: "todo.updated"
-  properties: {
-    sessionID: string
-    todos: Array<Todo>
-  }
-}
-
-export type SessionStatus =
-  | {
-      type: "idle"
-    }
-  | {
-      type: "retry"
-      attempt: number
-      message: string
-      next: number
-    }
-  | {
-      type: "busy"
-    }
-
-export type EventSessionStatus = {
-  type: "session.status"
-  properties: {
-    sessionID: string
-    status: SessionStatus
-  }
-}
-
-export type EventSessionIdle = {
-  type: "session.idle"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type EventSessionCompacted = {
-  type: "session.compacted"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type EventWorktreeReady = {
-  type: "worktree.ready"
-  properties: {
-    name: string
-    branch: string
-  }
-}
-
-export type EventWorktreeFailed = {
-  type: "worktree.failed"
-  properties: {
-    message: string
-  }
-}
-
-export type Pty = {
-  id: string
-  title: string
-  command: string
-  args: Array<string>
-  cwd: string
-  status: "running" | "exited"
-  pid: number
-}
-
-export type EventPtyCreated = {
-  type: "pty.created"
-  properties: {
-    info: Pty
-  }
-}
-
-export type EventPtyUpdated = {
-  type: "pty.updated"
-  properties: {
-    info: Pty
-  }
-}
-
-export type EventPtyExited = {
-  type: "pty.exited"
-  properties: {
-    id: string
-    exitCode: number
-  }
-}
-
-export type EventPtyDeleted = {
-  type: "pty.deleted"
-  properties: {
-    id: string
-  }
-}
-
 export type Event =
   | EventProjectUpdated
   | EventServerConnected
@@ -932,6 +940,7 @@ export type Event =
   | EventInstallationUpdateAvailable
   | EventLspClientDiagnostics
   | EventLspUpdated
+  | EventLspServerInstallFailed
   | EventMessagePartDelta
   | EventPermissionAsked
   | EventPermissionReplied
@@ -943,16 +952,6 @@ export type Event =
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
-  | EventWorkspaceReady
-  | EventWorkspaceFailed
-  | EventWorkspaceStatus
-  | EventMessageUpdated
-  | EventMessageRemoved
-  | EventMessagePartUpdated
-  | EventMessagePartRemoved
-  | EventSessionCreated
-  | EventSessionUpdated
-  | EventSessionDeleted
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
@@ -966,6 +965,16 @@ export type Event =
   | EventPtyUpdated
   | EventPtyExited
   | EventPtyDeleted
+  | EventWorkspaceReady
+  | EventWorkspaceFailed
+  | EventWorkspaceStatus
+  | EventMessageUpdated
+  | EventMessageRemoved
+  | EventMessagePartUpdated
+  | EventMessagePartRemoved
+  | EventSessionCreated
+  | EventSessionUpdated
+  | EventSessionDeleted
 
 export type GlobalEvent = {
   directory: string
@@ -1468,14 +1477,12 @@ export type Config = {
    */
   mode?: {
     build?: AgentConfig
-    plan?: AgentConfig
     [key: string]: AgentConfig | undefined
   }
   /**
    * Agent configuration, see https://opencode.ai/docs/agents
    */
   agent?: {
-    plan?: AgentConfig
     build?: AgentConfig
     general?: AgentConfig
     explore?: AgentConfig
@@ -1843,6 +1850,9 @@ export type FilePartInput = {
   filename?: string
   url: string
   source?: FilePartSource
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type AgentPartInput = {
@@ -2997,7 +3007,7 @@ export type WorktreeResetResponse = WorktreeResetResponses[keyof WorktreeResetRe
 export type ExperimentalSessionListData = {
   body?: never
   path?: never
-  query?: {
+  query: {
     /**
      * Filter sessions by project directory
      */
@@ -3014,7 +3024,7 @@ export type ExperimentalSessionListData = {
     /**
      * Cursor for loading the next page
      */
-    cursor?: number | string
+    cursor: number | string
     /**
      * Filter sessions by title (case-insensitive)
      */
@@ -3511,6 +3521,38 @@ export type SessionShareResponses = {
 
 export type SessionShareResponse = SessionShareResponses[keyof SessionShareResponses]
 
+export type SessionExportData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/export"
+}
+
+export type SessionExportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionExportError = SessionExportErrors[keyof SessionExportErrors]
+
+export type SessionExportResponses = {
+  /**
+   * Successfully exported session
+   */
+  200: unknown
+}
+
 export type SessionDiffData = {
   body?: never
   path: {
@@ -3904,6 +3946,9 @@ export type SessionCommandData = {
       filename?: string
       url: string
       source?: FilePartSource
+      metadata?: {
+        [key: string]: unknown
+      }
     }>
   }
   path: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3007,7 +3007,7 @@ export type WorktreeResetResponse = WorktreeResetResponses[keyof WorktreeResetRe
 export type ExperimentalSessionListData = {
   body?: never
   path?: never
-  query: {
+  query?: {
     /**
      * Filter sessions by project directory
      */
@@ -3024,7 +3024,7 @@ export type ExperimentalSessionListData = {
     /**
      * Cursor for loading the next page
      */
-    cursor: number | string
+    cursor?: number | string
     /**
      * Filter sessions by title (case-insensitive)
      */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2064,9 +2064,16 @@
             "in": "query",
             "name": "cursor",
             "schema": {
-              "type": "number"
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
-            "description": "Return sessions updated before this timestamp (milliseconds since epoch)"
+            "description": "Cursor for loading the next page"
           },
           {
             "in": "query",
@@ -2091,10 +2098,22 @@
               "type": "boolean"
             },
             "description": "Include archived sessions (default false)"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "updated",
+                "created"
+              ]
+            },
+            "description": "Sort sessions by last update or creation time"
           }
         ],
         "summary": "List sessions",
-        "description": "Get a list of all OpenCode sessions across projects, sorted by most recently updated. Archived sessions are excluded by default.",
+        "description": "Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.",
         "responses": {
           "200": {
             "description": "List of sessions",
@@ -2215,10 +2234,22 @@
               "type": "number"
             },
             "description": "Maximum number of sessions to return"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "updated",
+                "created"
+              ]
+            },
+            "description": "Sort sessions by last update or creation time"
           }
         ],
         "summary": "List sessions",
-        "description": "Get a list of all OpenCode sessions, sorted by most recently updated.",
+        "description": "Get a list of all OpenCode sessions. Defaults to most recently updated; use sort=created for creation-time order.",
         "responses": {
           "200": {
             "description": "List of sessions",
@@ -3124,6 +3155,69 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.unshare({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/export": {
+      "get": {
+        "operationId": "session.export",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Export session log",
+        "description": "Export the full root session tree as a single JSON document for local debugging. If a child session id is provided, climbs to the topmost ancestor and exports the whole tree.",
+        "responses": {
+          "200": {
+            "description": "Successfully exported session"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.export({\n  ...\n})"
           }
         ]
       }
@@ -4231,6 +4325,13 @@
                             },
                             "source": {
                               "$ref": "#/components/schemas/FilePartSource"
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              },
+                              "additionalProperties": {}
                             }
                           },
                           "required": [
@@ -6919,6 +7020,34 @@
           "properties"
         ]
       },
+      "Event.lsp.server.install.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "lsp.server.install.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "pkg": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "pkg",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
       "Event.message.part.delta": {
         "type": "object",
         "properties": {
@@ -7554,6 +7683,575 @@
               "sessionID",
               "arguments",
               "messageID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "QuestionOption": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "description": "Display text (1–5 words, max 50 chars)",
+            "type": "string",
+            "maxLength": 50
+          },
+          "description": {
+            "description": "One-line explanation of choice (max 50 chars)",
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": [
+          "label",
+          "description"
+        ]
+      },
+      "QuestionInfo": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "description": "Short question (max 200 chars). Stream longer framing as normal output first.",
+            "type": "string",
+            "maxLength": 200
+          },
+          "header": {
+            "description": "Very short label (max 30 chars)",
+            "type": "string",
+            "maxLength": 30
+          },
+          "options": {
+            "description": "Available choices (2–4)",
+            "minItems": 2,
+            "maxItems": 4,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuestionOption"
+            }
+          },
+          "multiple": {
+            "description": "Allow selecting multiple choices",
+            "type": "boolean"
+          },
+          "custom": {
+            "description": "Allow typing a custom answer (default: true)",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "question",
+          "header",
+          "options"
+        ]
+      },
+      "QuestionRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^que.*"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "questions": {
+            "minItems": 1,
+            "maxItems": 4,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuestionInfo"
+            }
+          },
+          "tool": {
+            "type": "object",
+            "properties": {
+              "messageID": {
+                "type": "string",
+                "pattern": "^msg.*"
+              },
+              "callID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "messageID",
+              "callID"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "questions"
+        ]
+      },
+      "Event.question.asked": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "question.asked"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/QuestionRequest"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "QuestionAnswer": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "Event.question.replied": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "question.replied"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "requestID": {
+                "type": "string",
+                "pattern": "^que.*"
+              },
+              "answers": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QuestionAnswer"
+                }
+              }
+            },
+            "required": [
+              "sessionID",
+              "requestID",
+              "answers"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.question.rejected": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "question.rejected"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "requestID": {
+                "type": "string",
+                "pattern": "^que.*"
+              }
+            },
+            "required": [
+              "sessionID",
+              "requestID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Todo": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "description": "Brief description of the task",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status of the task: pending, in_progress, completed, cancelled",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Priority level of the task: high, medium, low",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "status",
+          "priority"
+        ]
+      },
+      "Event.todo.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "todo.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "todos": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Todo"
+                }
+              }
+            },
+            "required": [
+              "sessionID",
+              "todos"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "SessionStatus": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "idle"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "retry"
+              },
+              "attempt": {
+                "type": "number"
+              },
+              "message": {
+                "type": "string"
+              },
+              "next": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "type",
+              "attempt",
+              "message",
+              "next"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "busy"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "Event.session.status": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.status"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "status": {
+                "$ref": "#/components/schemas/SessionStatus"
+              }
+            },
+            "required": [
+              "sessionID",
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.idle": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.idle"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.compacted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.compacted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.ready": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.ready"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "branch"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Pty": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^pty.*"
+          },
+          "title": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "exited"
+            ]
+          },
+          "pid": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "command",
+          "args",
+          "cwd",
+          "status",
+          "pid"
+        ]
+      },
+      "Event.pty.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "info": {
+                "$ref": "#/components/schemas/Pty"
+              }
+            },
+            "required": [
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "info": {
+                "$ref": "#/components/schemas/Pty"
+              }
+            },
+            "required": [
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.exited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.exited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^pty.*"
+              },
+              "exitCode": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "exitCode"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.deleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.deleted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^pty.*"
+              }
+            },
+            "required": [
+              "id"
             ]
           }
         },
@@ -8366,6 +9064,13 @@
           },
           "source": {
             "$ref": "#/components/schemas/FilePartSource"
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
           }
         },
         "required": [
@@ -9283,568 +9988,6 @@
           "properties"
         ]
       },
-      "QuestionOption": {
-        "type": "object",
-        "properties": {
-          "label": {
-            "description": "Display text (1-5 words, concise)",
-            "type": "string"
-          },
-          "description": {
-            "description": "Explanation of choice",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "description"
-        ]
-      },
-      "QuestionInfo": {
-        "type": "object",
-        "properties": {
-          "question": {
-            "description": "Complete question",
-            "type": "string"
-          },
-          "header": {
-            "description": "Very short label (max 30 chars)",
-            "type": "string"
-          },
-          "options": {
-            "description": "Available choices",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/QuestionOption"
-            }
-          },
-          "multiple": {
-            "description": "Allow selecting multiple choices",
-            "type": "boolean"
-          },
-          "custom": {
-            "description": "Allow typing a custom answer (default: true)",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "question",
-          "header",
-          "options"
-        ]
-      },
-      "QuestionRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^que.*"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
-          },
-          "questions": {
-            "description": "Questions to ask",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/QuestionInfo"
-            }
-          },
-          "tool": {
-            "type": "object",
-            "properties": {
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              },
-              "callID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "messageID",
-              "callID"
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "sessionID",
-          "questions"
-        ]
-      },
-      "Event.question.asked": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "question.asked"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/QuestionRequest"
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "QuestionAnswer": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "Event.question.replied": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "question.replied"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "requestID": {
-                "type": "string",
-                "pattern": "^que.*"
-              },
-              "answers": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/QuestionAnswer"
-                }
-              }
-            },
-            "required": [
-              "sessionID",
-              "requestID",
-              "answers"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.question.rejected": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "question.rejected"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "requestID": {
-                "type": "string",
-                "pattern": "^que.*"
-              }
-            },
-            "required": [
-              "sessionID",
-              "requestID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Todo": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "description": "Brief description of the task",
-            "type": "string"
-          },
-          "status": {
-            "description": "Current status of the task: pending, in_progress, completed, cancelled",
-            "type": "string"
-          },
-          "priority": {
-            "description": "Priority level of the task: high, medium, low",
-            "type": "string"
-          }
-        },
-        "required": [
-          "content",
-          "status",
-          "priority"
-        ]
-      },
-      "Event.todo.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "todo.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "todos": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Todo"
-                }
-              }
-            },
-            "required": [
-              "sessionID",
-              "todos"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "SessionStatus": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "idle"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "retry"
-              },
-              "attempt": {
-                "type": "number"
-              },
-              "message": {
-                "type": "string"
-              },
-              "next": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "type",
-              "attempt",
-              "message",
-              "next"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "busy"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
-        ]
-      },
-      "Event.session.status": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.status"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "status": {
-                "$ref": "#/components/schemas/SessionStatus"
-              }
-            },
-            "required": [
-              "sessionID",
-              "status"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.idle": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.idle"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              }
-            },
-            "required": [
-              "sessionID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.compacted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.compacted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              }
-            },
-            "required": [
-              "sessionID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.worktree.ready": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.ready"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "branch": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "branch"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.worktree.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Pty": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^pty.*"
-          },
-          "title": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          },
-          "args": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "cwd": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "running",
-              "exited"
-            ]
-          },
-          "pid": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "command",
-          "args",
-          "cwd",
-          "status",
-          "pid"
-        ]
-      },
-      "Event.pty.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "info": {
-                "$ref": "#/components/schemas/Pty"
-              }
-            },
-            "required": [
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "info": {
-                "$ref": "#/components/schemas/Pty"
-              }
-            },
-            "required": [
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.exited": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.exited"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^pty.*"
-              },
-              "exitCode": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "id",
-              "exitCode"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.deleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.deleted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^pty.*"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
       "Event": {
         "anyOf": [
           {
@@ -9870,6 +10013,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.lsp.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.lsp.server.install.failed"
           },
           {
             "$ref": "#/components/schemas/Event.message.part.delta"
@@ -9903,36 +10049,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.command.executed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.ready"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.failed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.status"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.removed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.part.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.part.removed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.deleted"
           },
           {
             "$ref": "#/components/schemas/Event.question.asked"
@@ -9972,6 +10088,36 @@
           },
           {
             "$ref": "#/components/schemas/Event.pty.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.ready"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.status"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.removed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.part.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.part.removed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.deleted"
           }
         ]
       },
@@ -11312,9 +11458,6 @@
             "properties": {
               "build": {
                 "$ref": "#/components/schemas/AgentConfig"
-              },
-              "plan": {
-                "$ref": "#/components/schemas/AgentConfig"
               }
             },
             "additionalProperties": {
@@ -11325,9 +11468,6 @@
             "description": "Agent configuration, see https://opencode.ai/docs/agents",
             "type": "object",
             "properties": {
-              "plan": {
-                "$ref": "#/components/schemas/AgentConfig"
-              },
               "build": {
                 "$ref": "#/components/schemas/AgentConfig"
               },
@@ -12499,6 +12639,13 @@
           },
           "source": {
             "$ref": "#/components/schemas/FilePartSource"
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
           }
         },
         "required": [

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -860,6 +860,32 @@
     line-height: var(--line-height-large);
     color: var(--text-strong);
     min-width: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-slot="question-header-seq"] {
+    color: var(--text-weak);
+    font-weight: var(--font-weight-medium);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  [data-slot="question-header-separator"] {
+    color: var(--icon-weak-base);
+    font-weight: var(--font-weight-regular);
+    flex-shrink: 0;
+  }
+
+  [data-slot="question-header-mode"] {
+    color: var(--text-strong);
+    font-weight: 600;
+    flex-shrink: 0;
   }
 
   [data-slot="question-progress"] {
@@ -921,15 +947,6 @@
     color: var(--text-strong);
     padding: 0 10px;
     white-space: pre-wrap;
-  }
-
-  [data-slot="question-hint"] {
-    font-family: var(--font-family-sans);
-    font-size: 13px;
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-large);
-    color: var(--text-weak);
-    padding: 0 10px;
   }
 
   [data-slot="question-options"] {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -832,7 +832,9 @@
   flex-direction: column;
   gap: 0;
   min-height: 0;
-  max-height: var(--question-prompt-max-height, 100dvh);
+  /* 180px = 44 (titlebar) + 48 (tabs) + 48 (sticky session title) + 40 (safety margin).
+     If session top chrome changes, retune this constant. */
+  max-height: min(70dvh, calc(100dvh - 180px));
 
   [data-slot="question-body"] {
     display: flex;

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -162,7 +162,7 @@ export const dict: Record<string, string> = {
   "ui.question.subtitle.answered": "{{count}} answered",
   "ui.question.answer.none": "(no answer)",
   "ui.question.review.notAnswered": "(not answered)",
-  "ui.question.multiHint": "Select all answers that apply",
-  "ui.question.singleHint": "Select one answer",
+  "ui.question.multiHint": "Pick multiple",
+  "ui.question.singleHint": "Pick 1",
   "ui.question.custom.placeholder": "Type your answer...",
 }

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -148,8 +148,8 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} 已回答",
   "ui.question.answer.none": "(无答案)",
   "ui.question.review.notAnswered": "(未回答)",
-  "ui.question.multiHint": "可多选",
-  "ui.question.singleHint": "选择一个答案",
+  "ui.question.multiHint": "多选",
+  "ui.question.singleHint": "单选",
   "ui.question.custom.placeholder": "输入你的答案...",
 
   "ui.fileSearch.placeholder": "查找",


### PR DESCRIPTION
## Summary

Closes #216 and #188 with four reversible commits:

- **C1 `feat(question)`** — schema bounds (`question.max(200)`, `header.max(30)`, `option.label.max(50)`, `option.description.max(50)`, `options.min(2).max(4)`, `questions.min(1).max(4)`), `Info.refine(custom !== false || options.length > 0)`, every bound carries an actionable hint message so the LLM gets a structured repair path on rejection. Tool description rewritten with `When / NOT / Examples / Format / Content routing` sections (inspired by Claude Code's `EnterPlanMode`); `Content routing` teaches the model to stream long framing as normal output before invoking the tool.
- **C2 `fix(ui)`** — replace the dynamic `measure()` (which fell back to `100dvh` when sticky-class detection failed, the v0.2.12 footer-off-screen repro) with a static `max-height: min(70dvh, calc(100dvh - 180px))`. The 180px buffer is the PawWork session top chrome stack: 44 titlebar + 48 tabs + 48 sticky session title + 40 safety margin. No JS measurement, no `ResizeObserver`, no CSS variables.
- **C3a `feat(ui)`** — honor `Question.Info.custom` flag: wrap the type-your-own-answer slot in `<Show when={q.custom !== false}>`, update `count() / pickFocus() / selectOption()`, and clear cache for tabs whose schema disallows custom (avoids stale focus on remount).
- **C3b `feat(ui)`** — inline mode chip in header: `{n} of {total} questions · {Pick 1 | Pick multiple}`. Mode renders weight 600 with `flex-shrink:0` so it survives ellipsis on narrow widths. Drop the dedicated `[data-slot="question-hint"]` row. Tighten `en` + `zh` hint copy: `Pick 1` / `Pick multiple` / `选 1 个` / `可选多个`. Other 16 locales follow upstream sync.

## Why

#216 reported the question dock blocking the footer at small viewport heights (the `measure()` fallback made it render at full viewport when sticky-class detection failed). #188 asked for clearer triggers and tighter formatting so the model invokes the tool more confidently and writes shorter, more clickable questions. Both ship together because they share the dock TSX surface and the schema-versus-prompt discipline; splitting into separate PRs would have meant rebasing the dock changes twice.

## Related Issue

Closes #216
Closes #188

## How To Verify

```bash
bun --cwd packages/opencode test test/question/schema.test.ts   # 16 pass / 0 fail
bun --cwd packages/opencode typecheck                            # 0 errors
bun --cwd packages/app typecheck                                 # 0 errors
bun --cwd packages/app test                                      # 577 pass / 0 fail
```

Manual UI smoke (passed locally on macOS arm64 dev:desktop):

- **Dock cap (C2)** — default window: dock fits ~70dvh, footer visible without scroll. ~480px-tall window: footer still visible (`100dvh - 180 = 300px` budget). 1080px tall: dock caps at ~70dvh ≈ 756px, internal scroll for overflow options.
- **Header inline mode (C3b)** — single-choice question: `2 of 4 questions · Pick 1` (zh: `第 2 题 / 共 4 题 · 选 1 个`). Multi-choice: `... · Pick multiple` / `可选多个`. ~480px-wide window: title ellipsizes, mode chip remains fully visible (`flex-shrink:0`), progress dots stay aligned right. No dedicated hint row below the question text.
- **Custom flag (C3a)** — default request keeps the type-your-own-answer slot. Request with `custom: false` renders no textarea; keyboard navigation does not focus an empty trailing slot.
- **Schema enforcement (C1)** — model with the new schema naturally writes 33–178 char questions on first try (verified via session DB inspection); a deliberately-long 250x payload was rejected with `Question is too long (max 200 chars)...` and the model self-corrected. 5-option request rejected with `Each question allows at most 4 options...`.

Performance check from session export: average reasoning per turn 96 tok across 12 follow-up turns; first-call schema orientation 615 tok one-time, paid into the prompt cache. No simplification warranted.

## Screenshots or Recordings

Verified on macOS dev:desktop. Header structure changes captured in spec at the linked issue comment; dock cap behavior is non-visual (footer-visible regression check).

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moved progress indicator and mode hint into the question header.

* **Bug Fixes**
  * Custom-answer control is only shown, focusable, and editable when supported; opening is blocked when not allowed.
  * Validation tightened for question text, headers, option labels/descriptions, and question counts (1–4 / 2–4 limits).

* **Documentation**
  * Updated question tool guidance with clearer decision criteria and input rules.

* **UI/Style**
  * Removed dynamic prompt resizing, refined header layout, and updated selection hint text.

* **Tests**
  * Added schema and tool tests covering the new validation rules.

* **Chores**
  * Enforced minimum main window dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->