### PR TITLE
fix: prevent session flicker on prompt send

### DIFF
--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -3,6 +3,8 @@ const desktopTerminalSelector = '#right-panel[aria-hidden="false"] #terminal-pan
 const mobileTerminalSelector = '#terminal-panel[aria-hidden="false"] [data-component="terminal"]'
 export const terminalSelector = `${desktopTerminalSelector}, ${mobileTerminalSelector}`
 export const sessionComposerDockSelector = '[data-component="session-prompt-dock"]'
+export const sessionTurnListSelector = '[data-slot="session-turn-list"]'
+export const sessionMessageItemSelector = "[data-message-id]"
 export const questionDockSelector = '[data-component="dock-prompt"][data-kind="question"]'
 export const permissionDockSelector = '[data-component="dock-prompt"][data-kind="permission"]'
 export const sessionTodoToggleButtonSelector = '[data-action="session-todo-toggle-button"]'

--- a/packages/app/e2e/session/session-send-stability.spec.ts
+++ b/packages/app/e2e/session/session-send-stability.spec.ts
@@ -1,0 +1,161 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { assistantText } from "../actions"
+import {
+  promptSelector,
+  sessionComposerDockSelector,
+  sessionMessageItemSelector,
+  sessionTurnListSelector,
+} from "../selectors"
+
+const MAX_STABILITY_SAMPLES = 256
+
+type StabilitySample = {
+  at: number
+  url: string
+  composerDock: number
+  messageList: number
+  messages: number
+}
+type StabilityProbeResult = {
+  samples: StabilitySample[]
+  unmounts: StabilitySample[]
+  unmountCount: number
+}
+
+async function installSessionStabilityProbe(page: Page) {
+  await page.evaluate(
+    ({ composerDockSelector, maxSamples, messageItemSelector, turnListSelector }) => {
+      const read = () => ({
+        at: performance.now(),
+        url: window.location.href,
+        composerDock: document.querySelectorAll(composerDockSelector).length,
+        messageList: document.querySelectorAll(turnListSelector).length,
+        messages: document.querySelectorAll(messageItemSelector).length,
+      })
+      const changed = (a: ReturnType<typeof read>, b: ReturnType<typeof read>) =>
+        a.url !== b.url ||
+        a.composerDock !== b.composerDock ||
+        a.messageList !== b.messageList ||
+        a.messages !== b.messages
+      const samples = [read()]
+      const unmounts: ReturnType<typeof read>[] = []
+      let unmountCount = 0
+      const pushBounded = (list: ReturnType<typeof read>[], sample: ReturnType<typeof read>) => {
+        if (list.length < maxSamples) list.push(sample)
+      }
+      const record = () => {
+        const next = read()
+        const prev = samples[samples.length - 1]
+        if (!prev || changed(prev, next)) pushBounded(samples, next)
+      }
+      const removedMatches = (node: Node, selector: string) =>
+        node instanceof Element && (node.matches(selector) || !!node.querySelector(selector))
+      const recordRemovedMount = (input: { composerDock: boolean; messageList: boolean }) => {
+        unmountCount += 1
+        const current = read()
+        const sample = {
+          ...current,
+          composerDock: input.composerDock ? 0 : current.composerDock,
+          messageList: input.messageList ? 0 : current.messageList,
+        }
+        pushBounded(samples, sample)
+        pushBounded(unmounts, sample)
+      }
+      const recordMutations = (records: MutationRecord[]) => {
+        for (const record of records) {
+          for (const node of record.removedNodes) {
+            const composerDockRemoved = removedMatches(node, composerDockSelector)
+            const messageListRemoved = removedMatches(node, turnListSelector)
+            if (composerDockRemoved || messageListRemoved) {
+              recordRemovedMount({ composerDock: composerDockRemoved, messageList: messageListRemoved })
+            }
+          }
+        }
+        record()
+      }
+      let frame = requestAnimationFrame(function tick() {
+        record()
+        frame = requestAnimationFrame(tick)
+      })
+      const observer = new MutationObserver(recordMutations)
+      observer.observe(document.body, { childList: true, subtree: true })
+      const win = window as typeof window & {
+        __opencode_e2e?: Record<string, unknown> & {
+          sessionMountProbe?: { stop: () => unknown }
+        }
+      }
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        sessionMountProbe: {
+          stop() {
+            cancelAnimationFrame(frame)
+            observer.disconnect()
+            record()
+            delete win.__opencode_e2e?.sessionMountProbe
+            return { samples, unmounts, unmountCount }
+          },
+        },
+      }
+    },
+    {
+      composerDockSelector: sessionComposerDockSelector,
+      maxSamples: MAX_STABILITY_SAMPLES,
+      messageItemSelector: sessionMessageItemSelector,
+      turnListSelector: sessionTurnListSelector,
+    },
+  )
+}
+
+async function stopSessionStabilityProbe(page: Page) {
+  const result = await page.evaluate(() => {
+    const win = window as typeof window & {
+      __opencode_e2e?: {
+        sessionMountProbe?: { stop: () => unknown }
+      }
+    }
+    const probe = win.__opencode_e2e?.sessionMountProbe
+    if (!probe) throw new Error("session stability probe was not installed")
+    return probe.stop()
+  })
+  return result as StabilityProbeResult
+}
+
+test("keeps the session flow mounted while sending a prompt", async ({ page, project, assistant }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  await assistant.reply("seed reply")
+  const sessionID = await project.prompt("start a session")
+
+  await expect(page.locator(sessionTurnListSelector)).toHaveCount(1)
+  await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
+
+  const beforeCalls = await assistant.calls()
+  const token = `I248_OK_${Date.now()}`
+  await assistant.reply(token)
+
+  await installSessionStabilityProbe(page)
+  let result: StabilityProbeResult = { samples: [], unmounts: [], unmountCount: 0 }
+  try {
+    const prompt = page.locator(promptSelector).first()
+    await expect(prompt).toBeVisible()
+    await prompt.click()
+    await page.keyboard.type(`reply with ${token}`)
+    await expect
+      .poll(async () => (await prompt.textContent())?.replace(/\u200B/g, "").trim())
+      .toBe(`reply with ${token}`)
+    await page.keyboard.press("Enter")
+
+    await expect.poll(() => assistant.calls(), { timeout: 30_000 }).toBeGreaterThan(beforeCalls)
+    await expect.poll(() => assistantText(project.sdk, sessionID), { timeout: 30_000 }).toContain(token)
+  } finally {
+    result = await stopSessionStabilityProbe(page)
+  }
+
+  const unmounted = result.samples.filter((sample) => sample.composerDock === 0 || sample.messageList === 0)
+  expect(unmounted).toEqual([])
+  expect(result.unmounts).toEqual([])
+  expect(result.unmountCount).toBe(0)
+  expect(new Set(result.samples.map((sample) => sample.url)).size).toBe(1)
+})

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -58,7 +58,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { isSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
-import { deriveArtifactFiles, nextFilesPanelAutoOpen } from "@/pages/session/files-tab-state"
+import { deriveArtifactFiles, nextFilesPanelAutoOpen, type SessionArtifactFile } from "@/pages/session/files-tab-state"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
@@ -694,11 +694,17 @@ export default function Page() {
   const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
   const [artifactHistory, { refetch: refetchArtifactHistory }] = createResource(
     () => params.id,
-    (sessionID) => sdk.client.session.artifacts({ sessionID }).then((res) => res.data ?? []).catch(() => []),
+    async (sessionID) => ({
+      sessionID,
+      artifacts: await sdk.client.session.artifacts({ sessionID }).then((res) => res.data ?? []).catch(() => []),
+    }),
+    { initialValue: { sessionID: "", artifacts: [] as SessionArtifactFile[] } },
   )
   const artifactFiles = createMemo(() => {
-    const history = artifactHistory() ?? []
-    if (history.length > 0) return deriveArtifactFiles(sdk.directory, history)
+    const history = artifactHistory.latest
+    if (history?.sessionID === params.id && history.artifacts.length > 0) {
+      return deriveArtifactFiles(sdk.directory, history.artifacts)
+    }
 
     return deriveArtifactFiles(
       sdk.directory,


### PR DESCRIPTION
## Summary

- Keep session artifact history reads on the latest available value during refetch so prompt sends do not bubble to the root Suspense fallback.
- Add an E2E regression test that samples the session flow during prompt send and verifies the message list and composer dock stay mounted.

## Why

Sending a prompt could trigger artifact history refetch in the session page. While that resource was pending, the app-level Suspense fallback briefly replaced the route content with an empty main area, causing the whole session flow page to flicker.

## Related Issue

Fixes #248

## How To Verify

```bash
bun --cwd packages/app playwright test e2e/session/session-send-stability.spec.ts --reporter=line
bun --cwd packages/app playwright test e2e/session/session-send-stability.spec.ts --reporter=line --repeat-each=3
bun --cwd packages/app playwright test e2e/app/session.spec.ts e2e/session/session-send-stability.spec.ts --reporter=line
bun run --cwd packages/app typecheck
```

## Screenshots or Recordings

Manual Electron dev app check completed locally. The reported session-page flicker was no longer visible during prompt send.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end session stability test that monitors UI stability while sending a prompt, ensuring composer, turn list, and message elements remain mounted and that samples remain consistent.

* **Refactor**
  * Improved artifact history handling to avoid mixing artifacts across sessions and to ensure artifact-derived views reflect the current session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->