### PR TITLE
chore: release v0.2.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -145,7 +145,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -389,7 +389,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Bump PawWork release package versions from `0.2.13` to `0.2.14`.

## Why
Prepare the next stable desktop release. Carries the session flow flicker fix from #251 (#248) so users sending prompts no longer see the route content briefly replaced by the Suspense fallback.

## Related Issue
No linked issue. This is the release bump PR. Behavior changes shipping in this release: #248 (via #251).

## How To Verify

```bash
bun install --frozen-lockfile
```

## Screenshots or Recordings
Not applicable. No visible UI changes in this PR.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.2.14 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->