### PR TITLE
chore(deps): bump actions/setup-node from 6.3.0 to 6.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 
@@ -147,7 +147,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 
@@ -218,7 +218,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 
@@ -289,7 +289,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 
@@ -457,7 +457,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -101,7 +101,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -42,7 +42,7 @@ jobs:
       # esbuild, tree-sitter at time of writing), which call `node`
       # explicitly. Do not drop without first patching those scripts.
       # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # actions/setup-node@v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: "24"
 

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -95,7 +95,7 @@ describe("release workflow", () => {
         (step) => step.uses === "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
       )
       const setupNodeStep = steps.find(
-        (step) => step.uses === "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f",
+        (step) => step.uses === "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
       )
       const signedArtifactStep = steps.find((step) => step.name === "Upload signed app artifact")
       const nonMacArtifactStep = steps.find((step) => step.name === "Upload packaged app artifact")

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -9,7 +9,7 @@ const opencodeTestRoot = path.join(repoRoot, "packages", "opencode", "test")
 
 const pinned = {
   checkout: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
-  setupNode: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f",
+  setupNode: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
   setupBun: "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
   cache: "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
   junit: "mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386",


### PR DESCRIPTION
## Summary
Bump pinned `actions/setup-node` SHA from `53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0) to `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0) across all four workflows that use it, and update the workflow contract tests so the CI / release snapshot assertions match the new pin.

## Why
Supersedes #253. Dependabot only touched `build.yml` and `ci.yml`, leaving `desktop-smoke.yml` and `e2e-artifacts.yml` on v6.3.0, and it did not update the workflow contract tests (`packages/opencode/test/github/{ci,build}-workflow.test.ts`) which assert the pinned SHA verbatim — so its PR went red on `unit-opencode`. This PR bundles all four workflow files plus both contract tests in one commit so the action stays pinned consistently and tests stay green.

## Related Issue
No linked issue. Replaces dependabot PR #253.

## How To Verify

```bash
bun --cwd packages/opencode test test/github/ci-workflow.test.ts test/github/build-workflow.test.ts
```

All 14 tests pass locally with the new SHA.

## Screenshots or Recordings
Not applicable. CI infrastructure change with no runtime behavior impact.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions setup to use the latest Node.js configuration action version across build and CI pipelines.
  * Updated tests to validate the updated workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->