### PR TITLE
feat(instruction): finalize PawWork instruction fallback order and diagnostics

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -1,4 +1,3 @@
-import os from "os"
 import path from "path"
 import { Effect, Layer, Context } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
@@ -173,7 +172,10 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         if (config.instructions) {
           for (const raw of config.instructions) {
             if (raw.startsWith("https://") || raw.startsWith("http://")) continue
-            const instruction = raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(2)) : raw
+            // Route through Global.Path.home so systemPaths() and sources() agree on
+            // ~/ resolution; otherwise diagnostics could point at one path while the
+            // prompt reads from another.
+            const instruction = raw.startsWith("~/") ? path.join(Global.Path.home, raw.slice(2)) : raw
             const matches = yield* (
               path.isAbsolute(instruction)
                 ? fs.glob(path.basename(instruction), {
@@ -271,6 +273,56 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
           }
           const ok = yield* recordFileEntry(resolved)
           if (ok) globalLoaded = true
+        }
+
+        // Local file entries from config.instructions: glob-resolve them the same way
+        // systemPaths() does so the diagnostic includes file-based config contributions,
+        // not just URLs. Empty/unreadable matches are downgraded to considered so
+        // diagnostics agree with what system() actually loads.
+        const config = yield* cfg.get()
+        const localInstructions = (config.instructions ?? []).filter(
+          (item) => !item.startsWith("https://") && !item.startsWith("http://"),
+        )
+        for (const raw of localInstructions) {
+          const instruction = raw.startsWith("~/") ? path.join(Global.Path.home, raw.slice(2)) : raw
+          const matches = yield* (
+            path.isAbsolute(instruction)
+              ? fs.glob(path.basename(instruction), {
+                  cwd: path.dirname(instruction),
+                  absolute: true,
+                  include: "file",
+                })
+              : relative(instruction)
+          ).pipe(Effect.catch(() => Effect.succeed([] as string[])))
+          if (matches.length === 0) {
+            result.push({
+              status: "considered",
+              path: raw,
+              reason: "config.instructions entry resolved to no files",
+            })
+            continue
+          }
+          for (const match of matches) {
+            const resolved = path.resolve(match)
+            if (loadedPaths.has(resolved)) continue
+            yield* recordFileEntry(resolved)
+          }
+        }
+
+        // Remote instruction URLs from config.instructions: fetch concurrently to match
+        // system()'s 4-way concurrency, so a handful of dead URLs don't stack 5s timeouts
+        // and make sources() noticeably slower than the prompt build.
+        const urls = (config.instructions ?? []).filter(
+          (item) => item.startsWith("https://") || item.startsWith("http://"),
+        )
+        const bodies = yield* Effect.forEach(urls, fetch, { concurrency: 4 })
+        for (const [index, url] of urls.entries()) {
+          const body = bodies[index]
+          if (body) {
+            result.push({ status: "loaded", path: url })
+          } else {
+            result.push({ status: "considered", path: url, reason: "fetch failed or returned empty body" })
+          }
         }
 
         // Explicitly ignored ~/.claude/CLAUDE.md: show reason so users understand why

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -33,8 +33,12 @@ function globalInstructionFiles() {
     files.push(path.join(dir, "AGENTS.md"))
   }
   files.push(path.join(Global.Path.config, "AGENTS.md"))
-  if (!Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
-    files.push(path.join(os.homedir(), ".claude", "CLAUDE.md"))
+  // PawWork product baseline never falls back to global ~/.claude/CLAUDE.md (issue #230,
+  // acceptance #5). The flag still gates the fallback for plain opencode CLI users so
+  // their Claude Code interop is unchanged. Read Global.Path.home so OPENCODE_TEST_HOME
+  // can stub the home directory deterministically; os.homedir() is locked at process start.
+  if (!Runtime.isPawWork() && !Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+    files.push(path.join(Global.Path.home, ".claude", "CLAUDE.md"))
   }
   return files
 }

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -73,10 +73,16 @@ function extract(messages: MessageV2.WithParts[]) {
   return paths
 }
 
+export type InstructionSource =
+  | { status: "loaded"; path: string }
+  | { status: "considered"; path: string; reason: string }
+  | { status: "ignored"; path: string; reason: string }
+
 export interface Interface {
   readonly clear: (messageID: MessageID) => Effect.Effect<void>
   readonly systemPaths: () => Effect.Effect<Set<string>, AppFileSystem.Error>
   readonly system: () => Effect.Effect<string[], AppFileSystem.Error>
+  readonly sources: () => Effect.Effect<InstructionSource[], AppFileSystem.Error>
   readonly find: (dir: string) => Effect.Effect<string | undefined, AppFileSystem.Error>
   readonly resolve: (
     messages: MessageV2.WithParts[],
@@ -200,6 +206,91 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         ]
       })
 
+      const sources = Effect.fn("Instruction.sources")(function* () {
+        const result: InstructionSource[] = []
+        const loadedPaths = new Set<string>()
+
+        // Mark a file as loaded only after read() returns non-empty content; system()
+        // already drops empty/unreadable files so a "loaded" entry that the prompt
+        // doesn't see would mislead diagnostics.
+        const recordFileEntry = Effect.fnUntraced(function* (resolved: string) {
+          const content = yield* read(resolved)
+          if (content) {
+            result.push({ status: "loaded", path: resolved })
+            loadedPaths.add(resolved)
+            return true as const
+          }
+          result.push({ status: "considered", path: resolved, reason: "file is empty or unreadable" })
+          return false as const
+        })
+
+        // Project-level walk: emit the full priority chain, not just the winner. First
+        // file whose content reads back non-empty is loaded; later existing matches are
+        // considered with a priority-skipped reason. Absent files are not reported here
+        // because FILES holds basenames, not paths — the directory walk is the search.
+        if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+          let projectLoaded = false
+          for (const file of FILES()) {
+            const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
+            if (matches.length === 0) continue
+            for (const match of matches) {
+              const resolved = path.resolve(match)
+              if (loadedPaths.has(resolved)) continue
+              if (!projectLoaded) {
+                const ok = yield* recordFileEntry(resolved)
+                if (ok) projectLoaded = true
+              } else {
+                result.push({
+                  status: "considered",
+                  path: resolved,
+                  reason: "skipped because a higher-priority project instruction file was loaded",
+                })
+              }
+            }
+          }
+        }
+
+        // Global instruction file chain: report the full priority chain so debug output
+        // can show why a candidate was skipped (priority) or absent.
+        let globalLoaded = false
+        for (const file of globalInstructionFiles()) {
+          const resolved = path.resolve(file)
+          if (loadedPaths.has(resolved)) continue
+          const exists = yield* fs.existsSafe(file)
+          if (!exists) {
+            result.push({ status: "considered", path: resolved, reason: "absent" })
+            continue
+          }
+          if (globalLoaded) {
+            result.push({
+              status: "considered",
+              path: resolved,
+              reason: "skipped because a higher-priority global instruction file was loaded",
+            })
+            continue
+          }
+          const ok = yield* recordFileEntry(resolved)
+          if (ok) globalLoaded = true
+        }
+
+        // Explicitly ignored ~/.claude/CLAUDE.md: show reason so users understand why
+        // an existing file is not contributing. Covers both PawWork mode (issue #230,
+        // acceptance #5) and the legacy OPENCODE_DISABLE_CLAUDE_CODE_PROMPT opt-out.
+        const claudeFallback = path.resolve(path.join(Global.Path.home, ".claude", "CLAUDE.md"))
+        const ignoreReason = Runtime.isPawWork()
+          ? "PawWork product baseline disables global Claude Code fallback (issue #230)"
+          : Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+            ? "OPENCODE_DISABLE_CLAUDE_CODE_PROMPT environment variable is set"
+            : null
+        if (ignoreReason && !loadedPaths.has(claudeFallback)) {
+          if (yield* fs.existsSafe(claudeFallback)) {
+            result.push({ status: "ignored", path: claudeFallback, reason: ignoreReason })
+          }
+        }
+
+        return result
+      })
+
       const find = Effect.fn("Instruction.find")(function* (dir: string) {
         for (const file of FILES()) {
           const filepath = path.resolve(path.join(dir, file))
@@ -251,7 +342,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         return results
       })
 
-      return Service.of({ clear, systemPaths, system, find, resolve })
+      return Service.of({ clear, systemPaths, system, sources, find, resolve })
     }),
   )
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -16,11 +16,24 @@ import type { MessageID } from "./schema"
 
 const log = Log.create({ service: "instruction" })
 
-const FILES = [
-  "AGENTS.md",
-  ...(Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT ? [] : ["CLAUDE.md"]),
-  "CONTEXT.md", // deprecated
-]
+// PawWork keeps project-level CLAUDE.md as compatibility (issue #230, acceptance #6),
+// even if a parent process inherits OPENCODE_DISABLE_CLAUDE_CODE_PROMPT. The flag only
+// suppresses Claude Code interop in plain opencode CLI mode. Exported so the gate can
+// be unit tested without mutating module-scope flags.
+export function projectFiles(deps: { isPawWork: boolean; disableClaudeCodePrompt: boolean }): string[] {
+  return [
+    "AGENTS.md",
+    ...(deps.isPawWork || !deps.disableClaudeCodePrompt ? ["CLAUDE.md"] : []),
+    "CONTEXT.md", // deprecated
+  ]
+}
+
+function FILES() {
+  return projectFiles({
+    isPawWork: Runtime.isPawWork(),
+    disableClaudeCodePrompt: Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT,
+  })
+}
 
 function configDir() {
   return Runtime.isPawWork() ? Flag.PAWWORK_CONFIG_DIR : Flag.OPENCODE_CONFIG_DIR
@@ -135,7 +148,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
 
         // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-          for (const file of FILES) {
+          for (const file of FILES()) {
             const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
             if (matches.length > 0) {
               matches.forEach((item) => paths.add(path.resolve(item)))
@@ -188,7 +201,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
       })
 
       const find = Effect.fn("Instruction.find")(function* (dir: string) {
-        for (const file of FILES) {
+        for (const file of FILES()) {
           const filepath = path.resolve(path.join(dir, file))
           if (yield* fs.existsSafe(filepath)) return filepath
         }

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -749,6 +749,102 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
+  test("sources() reports config.instructions URL in diagnostics regardless of fetch outcome", async () => {
+    // Acceptance criterion #7: URL contributions to system() must also appear in the
+    // diagnostic so prompt and diagnostic stay in lockstep. Uses an unreachable URL
+    // so the assertion accepts either fetch outcome deterministically.
+    const originalConfig = process.env.OPENCODE_CONFIG_CONTENT
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+
+    process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      instructions: ["http://127.0.0.1:1/never-listening.md"],
+    })
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const url = "http://127.0.0.1:1/never-listening.md"
+                const urlEntry = sources.find((s) => s.path === url)
+                expect(urlEntry).toBeDefined()
+                if (urlEntry?.status === "considered") {
+                  expect(urlEntry.reason).toMatch(/fetch failed|empty body/)
+                }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+      if (originalConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = originalConfig
+    }
+  })
+
+  test("sources() reports local file paths from config.instructions", async () => {
+    // Acceptance criterion #7 / parity with system(): non-URL config.instructions
+    // entries are glob-resolved into the system prompt; the diagnostic must mirror
+    // that so debugging reflects what the model actually sees.
+    const originalConfig = process.env.OPENCODE_CONFIG_CONTENT
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "rules", "extra.md"), "# PawWork Relative Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "1"
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+
+    process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      instructions: ["rules/extra.md"],
+    })
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const expected = path.resolve(path.join(pawworkConfig.path, "rules", "extra.md"))
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === expected)
+                expect(loaded).toBeDefined()
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+      if (originalConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = originalConfig
+    }
+  })
+
   test("ignores ~/.claude/CLAUDE.md global fallback in PawWork runtime mode", async () => {
     // Verifies acceptance criterion #5 of issue #230: PawWork no longer falls back
     // to global ~/.claude/CLAUDE.md as an instruction source. Project-level CLAUDE.md

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -392,6 +392,8 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     pawworkConfigDir: process.env.PAWWORK_CONFIG_DIR,
     runtimeNamespace: process.env.PAWWORK_RUNTIME_NAMESPACE,
     disableProjectConfig: process.env.OPENCODE_DISABLE_PROJECT_CONFIG,
+    testHome: process.env.OPENCODE_TEST_HOME,
+    disableClaudePrompt: process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT,
   }
 
   afterEach(() => {
@@ -403,6 +405,10 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     else process.env.PAWWORK_RUNTIME_NAMESPACE = original.runtimeNamespace
     if (original.disableProjectConfig === undefined) delete process.env.OPENCODE_DISABLE_PROJECT_CONFIG
     else process.env.OPENCODE_DISABLE_PROJECT_CONFIG = original.disableProjectConfig
+    if (original.testHome === undefined) delete process.env.OPENCODE_TEST_HOME
+    else process.env.OPENCODE_TEST_HOME = original.testHome
+    if (original.disableClaudePrompt === undefined) delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    else process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = original.disableClaudePrompt
   })
 
   test("ignores OPENCODE_CONFIG_DIR AGENTS.md in PawWork runtime mode", async () => {
@@ -472,6 +478,232 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
                 const paths = yield* svc.systemPaths()
                 expect(paths.has(path.join(profileTmp.path, "AGENTS.md"))).toBe(true)
                 expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(false)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("ignores ~/.claude/CLAUDE.md global fallback in PawWork runtime mode", async () => {
+    // Verifies acceptance criterion #5 of issue #230: PawWork no longer falls back
+    // to global ~/.claude/CLAUDE.md as an instruction source. Project-level CLAUDE.md
+    // (compatibility, criterion #6) is covered separately below.
+    await using fakeHome = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Global Claude Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                const claudeFallback = path.resolve(path.join(fakeHome.path, ".claude", "CLAUDE.md"))
+                expect(paths.has(claudeFallback)).toBe(false)
+                expect(Array.from(paths).some((p) => p.endsWith(path.join(".claude", "CLAUDE.md")))).toBe(false)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("fresh PawWork install loads no instruction sources when nothing is configured", async () => {
+    // Acceptance criterion: with no project AGENTS.md/CLAUDE.md, no PawWork global,
+    // and no ~/.claude/CLAUDE.md, the system surface is the bundled prompt only.
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                expect(paths.size).toBe(0)
+                const rules = yield* svc.system()
+                expect(rules).toEqual([])
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("loads project AGENTS.md when present in PawWork runtime mode", async () => {
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Project Instructions")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                expect(paths.has(path.join(projectTmp.path, "AGENTS.md"))).toBe(true)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("falls back to project CLAUDE.md when AGENTS.md is absent (compatibility)", async () => {
+    // Acceptance criterion #6: project-level CLAUDE.md remains a compatibility
+    // fallback when project AGENTS.md is absent. Distinct from the global ~/.claude
+    // fallback which is removed.
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "CLAUDE.md"), "# Project Claude Instructions")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                expect(paths.has(path.join(projectTmp.path, "CLAUDE.md"))).toBe(true)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("loads PawWork global AGENTS.md from PAWWORK_CONFIG_DIR", async () => {
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# PawWork Global Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                expect(paths.has(path.join(pawworkConfig.path, "AGENTS.md"))).toBe(true)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("non-PawWork runtime keeps ~/.claude/CLAUDE.md fallback when flag unset", async () => {
+    // Regression guard for the Runtime.isPawWork() gate: opencode CLI users on default
+    // behavior should still get the Claude Code interop fallback. Catches accidental
+    // condition inversion or future Runtime.isPawWork() changes.
+    await using fakeHome = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Global Claude Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                const claudeFallback = path.resolve(path.join(fakeHome.path, ".claude", "CLAUDE.md"))
+                expect(paths.has(claudeFallback)).toBe(true)
               }),
             ),
           ),

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
 import { Effect } from "effect"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-import { Instruction } from "../../src/session/instruction"
+import { Instruction, projectFiles } from "../../src/session/instruction"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { Instance } from "../../src/project/instance"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -217,6 +217,41 @@ describe("Instruction.resolve", () => {
   })
 
   test.todo("fetches remote instructions from config URLs via HttpClient", () => {})
+})
+
+describe("projectFiles gate", () => {
+  test("PawWork mode keeps CLAUDE.md even when OPENCODE_DISABLE_CLAUDE_CODE_PROMPT is set", () => {
+    // Regression for issue #230 acceptance #6: a PawWork process inheriting the
+    // disable flag must still discover project-level CLAUDE.md as compatibility.
+    expect(projectFiles({ isPawWork: true, disableClaudeCodePrompt: true })).toEqual([
+      "AGENTS.md",
+      "CLAUDE.md",
+      "CONTEXT.md",
+    ])
+  })
+
+  test("PawWork mode keeps CLAUDE.md when flag is unset", () => {
+    expect(projectFiles({ isPawWork: true, disableClaudeCodePrompt: false })).toEqual([
+      "AGENTS.md",
+      "CLAUDE.md",
+      "CONTEXT.md",
+    ])
+  })
+
+  test("opencode CLI mode drops CLAUDE.md when OPENCODE_DISABLE_CLAUDE_CODE_PROMPT is set", () => {
+    expect(projectFiles({ isPawWork: false, disableClaudeCodePrompt: true })).toEqual([
+      "AGENTS.md",
+      "CONTEXT.md",
+    ])
+  })
+
+  test("opencode CLI mode keeps CLAUDE.md when flag is unset", () => {
+    expect(projectFiles({ isPawWork: false, disableClaudeCodePrompt: false })).toEqual([
+      "AGENTS.md",
+      "CLAUDE.md",
+      "CONTEXT.md",
+    ])
+  })
 })
 
 describe("Instruction.system", () => {

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -522,6 +522,233 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
+  test("sources() reports ~/.claude/CLAUDE.md as ignored with reason when present in PawWork mode", async () => {
+    // Acceptance criterion #7: diagnostics explain why the global Claude Code fallback
+    // was ignored. Uses OPENCODE_TEST_HOME so Global.Path.home resolves to a tmpdir,
+    // making the test deterministic across CI environments.
+    await using fakeHome = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Global Claude Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const expected = path.resolve(path.join(fakeHome.path, ".claude", "CLAUDE.md"))
+                const ignored = sources.find((s) => s.status === "ignored" && s.path === expected)
+                expect(ignored).toBeDefined()
+                if (ignored?.status === "ignored") {
+                  expect(ignored.reason).toContain("PawWork")
+                  expect(ignored.reason).toContain("Claude")
+                }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("sources() reports priority-skipped global instruction file as considered", async () => {
+    // Acceptance criterion #7 covers "considered" sources. When both PAWWORK_CONFIG_DIR
+    // and Global.Path.config have AGENTS.md, only the higher-priority one is loaded; the
+    // other should appear as considered with a priority-skipped reason.
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# PawWork Profile Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Global Instructions")
+      },
+    })
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const pawworkAgents = path.resolve(path.join(pawworkConfig.path, "AGENTS.md"))
+                const globalAgents = path.resolve(path.join(globalTmp.path, "AGENTS.md"))
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === pawworkAgents)
+                const skipped = sources.find((s) => s.status === "considered" && s.path === globalAgents)
+                expect(loaded).toBeDefined()
+                expect(skipped).toBeDefined()
+                if (skipped?.status === "considered") {
+                  expect(skipped.reason).toContain("higher-priority")
+                }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("sources() reports project priority chain as loaded plus considered siblings", async () => {
+    // When both AGENTS.md and CLAUDE.md exist in the project root, system() loads only
+    // AGENTS.md. sources() must surface CLAUDE.md as considered with the priority reason
+    // so debug output can explain the project fallback order from issue #230.
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Project AGENTS")
+        await Bun.write(path.join(dir, "CLAUDE.md"), "# Project CLAUDE")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const agents = path.resolve(path.join(projectTmp.path, "AGENTS.md"))
+                const claude = path.resolve(path.join(projectTmp.path, "CLAUDE.md"))
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === agents)
+                const skipped = sources.find((s) => s.status === "considered" && s.path === claude)
+                expect(loaded).toBeDefined()
+                expect(skipped).toBeDefined()
+                if (skipped?.status === "considered") {
+                  expect(skipped.reason).toContain("higher-priority project")
+                }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("sources() downgrades empty AGENTS.md from loaded to considered", async () => {
+    // system() drops empty/unreadable files from the prompt, so sources() must mirror
+    // that or diagnostics will claim a file is loaded that the model never sees.
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const projectAgents = path.resolve(path.join(projectTmp.path, "AGENTS.md"))
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === projectAgents)
+                const considered = sources.find((s) => s.status === "considered" && s.path === projectAgents)
+                expect(loaded).toBeUndefined()
+                expect(considered).toBeDefined()
+                if (considered?.status === "considered") {
+                  expect(considered.reason).toMatch(/empty|unreadable/)
+                }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("sources() lists loaded project AGENTS.md", async () => {
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Project Instructions")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const projectAgents = path.resolve(path.join(projectTmp.path, "AGENTS.md"))
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === projectAgents)
+                expect(loaded).toBeDefined()
+                expect(loaded?.status).toBe("loaded")
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
   test("ignores ~/.claude/CLAUDE.md global fallback in PawWork runtime mode", async () => {
     // Verifies acceptance criterion #5 of issue #230: PawWork no longer falls back
     // to global ~/.claude/CLAUDE.md as an instruction source. Project-level CLAUDE.md


### PR DESCRIPTION
## Summary

- Drop the `~/.claude/CLAUDE.md` global fallback in PawWork runtime mode so users on their own provider keys do not silently inherit global Claude Code instructions as their PawWork baseline.
- Keep project-level `CLAUDE.md` as a compatibility fallback (issue #230 acceptance #6) and keep the `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` flag working for plain opencode CLI users so their Claude Code interop is unchanged.
- Expose `Instruction.sources()` returning structured `InstructionSource` entries so debug surfaces can explain which instruction files were loaded and which were intentionally ignored, including the now-suppressed global Claude Code fallback with reason.
- Add five focused tests covering the PawWork instruction fallback order: fresh install, project `AGENTS.md`, project `CLAUDE.md` compatibility, PawWork global `AGENTS.md`, and ignored global `~/.claude/CLAUDE.md`. Plus two more tests for the new `sources()` diagnostic.

## Why

Issue #230 was partially landed already: the system prompt rewrite and tool collaboration guidance shipped in `pawwork.txt`, and #128 (subagent rename) merged. The remaining acceptance criteria #5, #7, #8 — drop the global Claude Code fallback, expose diagnostics, and add focused tests — were still open. This PR closes those.

The global Claude Code fallback currently lets a user with no PawWork or project instructions silently fall back to whatever they have in `~/.claude/CLAUDE.md`. That violates the product baseline goal stated in the issue: PawWork should own its default behavior, not inherit it from a different agent's config. PawWork users running their own provider keys are the dominant case and they need the PawWork product baseline to be the source of truth.

## Related Issue

Closes #230.

## How To Verify

```bash
bun --cwd packages/opencode test test/session/instruction.test.ts
bun run typecheck
```

The 5 fallback scenario tests turn green only after the runtime gate in commit 2 lands; the diagnostic tests in commit 3 cover acceptance #7. All `Instruction.system` and `Instruction.systemPaths` callers are unaffected because the change is additive (new `sources()` method) plus a runtime-conditional removal in `globalInstructionFiles()`.

## Screenshots or Recordings

Not applicable. Harness behavior change with no visible UI.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes ordered instruction-source provenance (loaded/considered/ignored) with explicit reasons and a new API to list them.

* **Changes**
  * PawWork mode now suppresses the user-level Claude fallback and excludes it from global search; project-first priority and outcomes for URL/local/global entries are surfaced. Home-path expansion behavior standardized.

* **Tests**
  * Expanded tests covering discovery, priority resolution, URL/local outcomes, and PawWork diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->