### PR TITLE
fix: preserve empty reasoning_content for DeepSeek V4 thinking mode

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -185,24 +185,19 @@ function normalizeMessages(
         // Filter out reasoning parts from content
         const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-        // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-        if (reasoningText) {
-          return {
-            ...msg,
-            content: filteredContent,
-            providerOptions: {
-              ...msg.providerOptions,
-              openaiCompatible: {
-                ...msg.providerOptions?.openaiCompatible,
-                [field]: reasoningText,
-              },
-            },
-          }
-        }
-
+        // Include reasoning_content | reasoning_details directly on the message for all assistant messages.
+        // Always set the field even when empty — some providers (e.g. DeepSeek) may return empty
+        // reasoning_content which still needs to be sent back in subsequent requests.
         return {
           ...msg,
           content: filteredContent,
+          providerOptions: {
+            ...msg.providerOptions,
+            openaiCompatible: {
+              ...msg.providerOptions?.openaiCompatible,
+              [field]: reasoningText,
+            },
+          },
         }
       }
 


### PR DESCRIPTION
## Summary

Cherry-pick upstream opencode PR [#24146](https://github.com/anomalyco/opencode/pull/24146) to fix DeepSeek V4 multi-turn failures when switching models mid-conversation.

## Why

DeepSeek V4 thinking mode requires `reasoning_content` on every assistant message in subsequent requests. Previously `normalizeMessages` only injected the field when `reasoningText` was non-empty, so historical assistant messages produced by other models (e.g. GLM-5, GPT-4o) had no `reasoning_content` and DeepSeek rejected the request with `400 The reasoning_content in the thinking mode must be passed back to the API.` Fix always sets the field — empty string included — so cross-model history is accepted.

## Related Issue

Closes #250

## How To Verify

Manual repro on dev:desktop with this branch:

1. Start a session with GLM-5 (or any non-DeepSeek-V4 model), exchange one turn.
2. Switch model to `deepseek-v4-pro`, send another message.
3. Before the fix: `400 reasoning_content must be passed back`. After the fix: assistant replies normally with `finish=stop`, reasoning tokens recorded.

Verified locally via session export `pawwork-session-mighty-canyon-2026-04-27`: glm-5 → deepseek-v4-pro turn completes with `error=null`, `finish=stop`, 258 reasoning tokens preserved. CI handles broader checks.

## Screenshots or Recordings

N/A — backend transform fix, no UI surface.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English