### PR TITLE
fix: expire stale session running state

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -15,7 +15,7 @@ import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionTitle } from "@/utils/session-title"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
-import { isSessionRunning } from "../session/session-running-state"
+import { createSessionRunning } from "../session/session-running-state"
 import { childSessionOnPath, hasProjectPermissions } from "./helpers"
 
 export const ProjectIcon = (props: { project: LocalProject; class?: string; notify?: boolean }): JSX.Element => {
@@ -148,9 +148,13 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       return !permission.autoResponds(item, props.session.directory)
     })
   })
+  const sessionRunning = createSessionRunning(
+    () => sessionStore.session_status[props.session.id],
+    () => sessionStore.message[props.session.id],
+  )
   const isWorking = createMemo(() => {
     if (hasPermissions()) return false
-    return isSessionRunning(sessionStore.session_status[props.session.id], sessionStore.message[props.session.id])
+    return sessionRunning()
   })
 
   const tint = createMemo(() => messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent))

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -56,7 +56,7 @@ import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
-import { isSessionRunning } from "@/pages/session/session-running-state"
+import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { deriveArtifactFiles, nextFilesPanelAutoOpen, type SessionArtifactFile } from "@/pages/session/files-tab-state"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
@@ -1672,7 +1672,11 @@ export default function Page() {
       return out
     })
 
-  const busy = (sessionID: string) => isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
+  const currentRunning = createSessionRunning(
+    () => (params.id ? sync.data.session_status[params.id] : undefined),
+    () => (params.id ? sync.data.message[params.id] : undefined),
+  )
+  const busy = () => currentRunning()
 
   const queuedFollowups = createMemo(() => {
     const id = params.id
@@ -1725,7 +1729,7 @@ export default function Page() {
   const queueEnabled = createMemo(() => {
     const id = params.id
     if (!id) return false
-    return settings.general.followup() === "queue" && busy(id) && !composer.blocked() && !isChildSession()
+    return settings.general.followup() === "queue" && busy() && !composer.blocked() && !isChildSession()
   })
 
   const followupText = (item: FollowupDraft) => {
@@ -1789,7 +1793,7 @@ export default function Page() {
   }
 
   const halt = (sessionID: string) =>
-    busy(sessionID) ? sdk.client.session.abort({ sessionID }).catch(() => {}) : Promise.resolve()
+    busy() ? sdk.client.session.abort({ sessionID }).catch(() => {}) : Promise.resolve()
 
   const revertMutation = useMutation(() => ({
     mutationFn: async (input: { sessionID: string; messageID: string }) => {
@@ -1890,7 +1894,7 @@ export default function Page() {
     if (followup.paused[sessionID]) return
     if (isChildSession()) return
     if (composer.blocked()) return
-    if (busy(sessionID)) return
+    if (busy()) return
 
     void sendFollowup(sessionID, item.id)
   })

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -18,7 +18,7 @@ import { Binary } from "@opencode-ai/util/binary"
 import { getFilename } from "@opencode-ai/util/path"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { taskDescription } from "@/pages/session/task-description"
-import { isSessionRunning } from "@/pages/session/session-running-state"
+import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
@@ -258,9 +258,7 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const working = createMemo(() => {
-    return isSessionRunning(sessionStatus(), sessionMessages())
-  })
+  const working = createSessionRunning(sessionStatus, sessionMessages)
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 
   const [timeoutDone, setTimeoutDone] = createSignal(true)
@@ -279,7 +277,7 @@ export function MessageTimeline(props: {
   })
 
   const activeMessageID = createMemo(() => {
-    const parentID = pending()?.parentID
+    const parentID = working() ? pending()?.parentID : undefined
     if (parentID) {
       const messages = sessionMessages()
       const result = Binary.search(messages, parentID, (message) => message.id)

--- a/packages/app/src/pages/session/session-running-state.test.ts
+++ b/packages/app/src/pages/session/session-running-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message, SessionStatus } from "@opencode-ai/sdk/v2/client"
-import { isSessionRunning } from "./session-running-state"
+import { isSessionRunning, PENDING_MESSAGE_FALLBACK_MS, runningFallbackExpiresAt } from "./session-running-state"
 
 const idle: SessionStatus = { type: "idle" }
 const busy: SessionStatus = { type: "busy" }
@@ -37,7 +37,7 @@ describe("isSessionRunning", () => {
 
   test("uses latest-message fallback when status is undefined", () => {
     expect(isSessionRunning(undefined, [user("msg_user", 1)])).toBe(false)
-    expect(isSessionRunning(undefined, [user("msg_user", 1), assistant("msg_pending", 2)])).toBe(true)
+    expect(isSessionRunning(undefined, [user("msg_user", 1), assistant("msg_pending", 2)], { now: 10_000 })).toBe(true)
   })
 
   test("ignores a stale incomplete assistant message when a later assistant completed", () => {
@@ -65,10 +65,29 @@ describe("isSessionRunning", () => {
     expect(isSessionRunning(retry, [assistant("msg_done", 1, 2, "stop")])).toBe(true)
   })
 
-  test("returns true when the latest assistant message is incomplete", () => {
+  test("returns true when the latest assistant message was just created", () => {
     const messages = [user("msg_user", 1), assistant("msg_pending", 2)]
 
-    expect(isSessionRunning(idle, messages)).toBe(true)
+    expect(isSessionRunning(idle, messages, { now: 10_000 })).toBe(true)
+  })
+
+  test("ignores a stale latest assistant message left incomplete by an interrupted turn", () => {
+    const messages = [user("msg_user", 1), assistant("msg_stale", 2)]
+
+    expect(isSessionRunning(idle, messages, { now: 40_000 })).toBe(false)
+  })
+
+  test("exposes the fallback expiry while the latest assistant message is fresh", () => {
+    const messages = [user("msg_user", 1), assistant("msg_pending", 2)]
+
+    expect(runningFallbackExpiresAt(idle, messages, { now: 10_000 })).toBe(2 + PENDING_MESSAGE_FALLBACK_MS)
+    expect(runningFallbackExpiresAt(idle, messages, { now: 40_000 })).toBeUndefined()
+  })
+
+  test("ignores malformed assistant messages without created time", () => {
+    const malformed = { id: "msg_bad", sessionID: "ses_1", role: "assistant" } as Message
+
+    expect(isSessionRunning(idle, [user("msg_user", 1), malformed], { now: 10_000 })).toBe(false)
   })
 
   test("returns false when there are no messages and status is idle", () => {

--- a/packages/app/src/pages/session/session-running-state.ts
+++ b/packages/app/src/pages/session/session-running-state.ts
@@ -1,11 +1,73 @@
 import type { Message, SessionStatus } from "@opencode-ai/sdk/v2/client"
+import { createEffect, createMemo, createSignal, onCleanup, type Accessor } from "solid-js"
 
 const idle = { type: "idle" as const }
+// Server status should arrive quickly after a message is created. A longer window keeps stale turns visually active longer.
+export const PENDING_MESSAGE_FALLBACK_MS = 30_000
 
 /** Status is authoritative; when idle, only the latest message can indicate in-flight work. */
-export function isSessionRunning(status: SessionStatus | undefined, messages: readonly Message[] | undefined): boolean {
+export function isSessionRunning(
+  status: SessionStatus | undefined,
+  messages: readonly Message[] | undefined,
+  options: { now?: number } = {},
+): boolean {
   if ((status ?? idle).type !== "idle") return true
 
+  return runningFallbackExpiresAt(status, messages, options) !== undefined
+}
+
+/** Returns undefined when the latest-message fallback is inactive, regardless of why. */
+export function runningFallbackExpiresAt(
+  status: SessionStatus | undefined,
+  messages: readonly Message[] | undefined,
+  options: { now?: number } = {},
+): number | undefined {
+  if ((status ?? idle).type !== "idle") return
+
   const latest = messages?.at(-1)
-  return latest?.role === "assistant" && typeof latest.time?.completed !== "number"
+  if (latest?.role !== "assistant") return
+  if (typeof latest.time?.completed === "number") return
+  const created = latest.time?.created
+  if (typeof created !== "number") return
+
+  const now = options.now ?? Date.now()
+  const expiresAt = created + PENDING_MESSAGE_FALLBACK_MS
+  return expiresAt > now ? expiresAt : undefined
+}
+
+export function createSessionRunning(
+  status: Accessor<SessionStatus | undefined>,
+  messages: Accessor<readonly Message[] | undefined>,
+): Accessor<boolean> {
+  const [tick, setTick] = createSignal(0)
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const clearTimer = () => {
+    if (!timer) return
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  createEffect(() => {
+    const currentStatus = status()
+    const currentMessages = messages()
+    const currentNow = Date.now()
+
+    clearTimer()
+
+    const expiresAt = runningFallbackExpiresAt(currentStatus, currentMessages, { now: currentNow })
+    if (expiresAt === undefined) return
+
+    timer = setTimeout(() => {
+      timer = undefined
+      setTick((value) => value + 1)
+    }, Math.max(0, expiresAt - currentNow) + 10)
+  })
+
+  onCleanup(clearTimer)
+
+  return createMemo(() => {
+    tick()
+    return isSessionRunning(status(), messages())
+  })
 }


### PR DESCRIPTION
## Summary

Fix stale session running state so interrupted or incomplete historical assistant messages cannot keep PawWork visually active forever.

This PR adds a bounded fallback for fresh incomplete assistant messages and a Solid reactive timeout so the UI recomputes when that fallback expires. It applies the shared running-state helper to the session timeline, sidebar session item, and current-session busy checks.

## Why

#252 reports sustained CPU usage in the installed desktop app after normal session usage. During diagnosis, a copied installed-app session showed the latest assistant message lacked `time.completed`, while `session.status` was idle. The UI treated that stale message as still running, which kept progress/spinner animations active and caused renderer/GPU work even though the session was effectively idle.

The previous helper only looked at the latest incomplete assistant message. That made stale data indistinguishable from a genuinely fresh in-flight turn.

This addresses the confirmed stale-running UI cause found during the #252 investigation. #252 can remain open as the broader tracking issue for any future high CPU or memory causes that are not covered by this path.

## Related Issue

Addresses #252

## How To Verify

```bash
cd packages/app
bun test --preload ./happydom.ts ./src/pages/session/session-running-state.test.ts
bun run typecheck

cd ../desktop-electron
bun run build
```

Manual check performed:

- Built the desktop production bundle.
- Started Electron preview with the copied dev data from the affected installed app.
- Opened the target session through `opencode://open-project?directory=/Users/yuhan/workspace/openclaw-setup`.
- Confirmed the target session rendered with no `.session-progress-whip` and `document.getAnimations({ subtree: true }).filter(a => a.playState === "running").length === 0`.
- Confirmed the Electron main, GPU, and renderer processes sampled at `0.0%` CPU after the session was idle.

## Screenshots or Recordings

Not included. This is a running-state/performance fix; the manual check used process sampling and DevTools runtime inspection rather than a visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now stay marked active for 30 seconds when awaiting assistant replies; session activity is tracked reactively with timed updates.

* **Bug Fixes**
  * Prevents selecting a parent message when a session is not active; session-busy checks are now used consistently.

* **Tests**
  * Enhanced tests for session running detection, fallback timeout behavior, and malformed message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->