### PR TITLE
perf(app): remove session progress whip bar

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -8,46 +8,6 @@
 }
 
 @layer components {
-  @keyframes session-progress-whip {
-    0% {
-      clip-path: inset(0 100% 0 0 round 999px);
-      animation-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
-    }
-
-    48% {
-      clip-path: inset(0 0 0 0 round 999px);
-      animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
-    }
-
-    100% {
-      clip-path: inset(0 0 0 100% round 999px);
-    }
-  }
-
-  [data-component="session-progress"] {
-    position: absolute;
-    inset: 0 0 auto;
-    height: 2px;
-    overflow: hidden;
-    pointer-events: none;
-    opacity: 1;
-    transition: opacity 220ms ease-out;
-  }
-
-  [data-component="session-progress"][data-state="hiding"] {
-    opacity: 0;
-  }
-
-  [data-component="session-progress-bar"] {
-    width: 100%;
-    height: 100%;
-    border-radius: 999px;
-    background: var(--session-progress-color);
-    clip-path: inset(0 100% 0 0 round 999px);
-    animation: session-progress-whip var(--session-progress-ms, 1800ms) infinite;
-    will-change: clip-path;
-  }
-
   [data-component="getting-started"] {
     container-type: inline-size;
     container-name: getting-started;

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -21,7 +21,6 @@ import { taskDescription } from "@/pages/session/task-description"
 import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
 import { usePlatform } from "@/context/platform"
@@ -80,8 +79,6 @@ const messageComments = (parts: Part[]): MessageComment[] =>
   })
 
 export { taskDescription }
-
-const pace = (width: number) => Math.round(Math.max(1200, Math.min(3200, (Math.max(width, 360) * 2000) / 900)))
 
 const boundaryTarget = (root: HTMLElement, target: EventTarget | null) => {
   const current = target instanceof Element ? target : undefined
@@ -397,20 +394,7 @@ export function MessageTimeline(props: {
   })
   let titleRef: HTMLInputElement | undefined
 
-  const [bar, setBar] = createStore({
-    ms: pace(640),
-  })
-
   let more: HTMLButtonElement | undefined
-  let head: HTMLDivElement | undefined
-
-  createResizeObserver(
-    () => head,
-    () => {
-      if (!head || head.clientWidth <= 0) return
-      setBar("ms", pace(head.clientWidth))
-    },
-  )
 
   const errorMessage = (err: unknown) => {
     if (err && typeof err === "object" && "data" in err) {
@@ -754,10 +738,6 @@ export function MessageTimeline(props: {
           <div ref={props.setContentRef} class="min-w-0 w-full">
             <Show when={showHeader()}>
               <div
-                ref={(el) => {
-                  head = el
-                  setBar("ms", pace(el.clientWidth))
-                }}
                 data-session-title
                 classList={{
                   "sticky top-0 z-30 bg-[linear-gradient(to_bottom,var(--background-stronger)_48px,transparent)]": true,
@@ -768,19 +748,6 @@ export function MessageTimeline(props: {
                   "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
                 }}
               >
-                <Show when={workingStatus() !== "hidden"}>
-                  <div
-                    data-component="session-progress"
-                    data-state={workingStatus()}
-                    aria-hidden="true"
-                    style={{
-                      "--session-progress-color": tint() ?? "var(--icon-interactive-base)",
-                      "--session-progress-ms": `${bar.ms}ms`,
-                    }}
-                  >
-                    <div data-component="session-progress-bar" />
-                  </div>
-                </Show>
                 <div class="h-12 w-full flex items-center justify-between gap-2">
                   <div class="flex items-center gap-1 min-w-0 flex-1 pr-3">
                     <div class="flex items-center min-w-0 grow-1">


### PR DESCRIPTION
## Summary

Remove the whip progress bar at the top of the session header. Sidebar session indicator and header spinner remain as the working indicators.

## Why

The whip bar used a `clip-path` infinite CSS animation with `will-change: clip-path`, which forces a permanent compositor layer per active session and keeps GPU work alive whenever a session is in the running state. It is also redundant with the sidebar dot/spinner and the spinner next to the title, so removing it reduces visual noise without losing any signal. Same class of cause as #262 (sustained idle GPU/CPU from infinite session animations).

## Related Issue

No tracked issue. Follow-up to #262.

## How To Verify

```bash
cd packages/app
bunx tsgo -b
bun test --preload ./happydom.ts ./src
```

Manual check performed:

- Started `bun run dev:desktop`, opened a session, sent a message that triggered an LLM turn.
- Confirmed the top whip bar no longer renders in the session header.
- Confirmed the sidebar session item spinner and the header title spinner still animate while running and stop when the turn completes.
- Confirmed `document.querySelector('[data-component="session-progress"]')` returns `null` while a session is running.

## Screenshots or Recordings

Not included. Pure removal of an animated element; verified via DOM check and manual observation.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the animated session progress bar component from the message timeline interface.
  * Simplified the session title header by removing associated progress-tracking logic and measurement overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->