### PR TITLE
fix: guard session message cache reads

### DIFF
--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -10,10 +10,11 @@ import { StickyAccordionHeader } from "@opencode-ai/ui/sticky-accordion-header"
 import { File } from "@opencode-ai/ui/file"
 import { Markdown } from "@opencode-ai/ui/markdown"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
-import type { Message, Part, UserMessage } from "@opencode-ai/sdk/v2/client"
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
 import { getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
@@ -87,9 +88,6 @@ function RawMessage(props: {
   )
 }
 
-const emptyMessages: Message[] = []
-const emptyUserMessages: UserMessage[] = []
-
 export function SessionContextTab() {
   const sync = useSync()
   const language = useLanguage()
@@ -101,15 +99,14 @@ export function SessionContextTab() {
   const messages = createMemo(
     () => {
       const id = params.id
-      if (!id) return emptyMessages
-      return (sync.data.message[id] ?? []) as Message[]
+      return readSessionMessages(id ? sync.data.message[id] : undefined)
     },
     emptyMessages,
     { equals: same },
   )
 
   const userMessages = createMemo(
-    () => messages().filter((m) => m.role === "user") as UserMessage[],
+    () => readUserMessages(messages()),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -55,6 +55,7 @@ import {
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
@@ -69,7 +70,6 @@ import { extractPromptFromParts } from "@/utils/prompt"
 import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
 
-const emptyUserMessages: UserMessage[] = []
 type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 const emptyFollowups: FollowupItem[] = []
@@ -503,7 +503,11 @@ export default function Page() {
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
   const revertMessageID = createMemo(() => info()?.revert?.messageID)
-  const messages = createMemo(() => (params.id ? (sync.data.message[params.id] ?? []) : []))
+  const messages = createMemo(
+    () => readSessionMessages(params.id ? sync.data.message[params.id] : undefined),
+    emptyMessages,
+    { equals: same },
+  )
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
@@ -520,7 +524,7 @@ export default function Page() {
     return sync.session.history.loading(id)
   })
   const userMessages = createMemo(
-    () => messages().filter((m) => m.role === "user") as UserMessage[],
+    () => readUserMessages(messages()),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/pages/session/session-messages.test.ts
+++ b/packages/app/src/pages/session/session-messages.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import { readSessionMessages, readUserMessages } from "./session-messages"
+
+const message = (id: string, role: Message["role"]): Message =>
+  ({
+    id,
+    sessionID: "ses_1",
+    role,
+    time: { created: 1 },
+  }) as Message
+
+describe("session message readers", () => {
+  test("returns a stable empty list for missing or invalid session cache values", () => {
+    const empty = readSessionMessages(undefined)
+
+    expect(empty).toHaveLength(0)
+    expect(Object.isFrozen(empty)).toBe(true)
+    expect(readSessionMessages(null)).toBe(empty)
+    expect(readSessionMessages({})).toBe(empty)
+  })
+
+  test("preserves loaded message arrays", () => {
+    const loaded = [message("msg_1", "user"), message("msg_2", "assistant")]
+
+    expect(readSessionMessages(loaded)).toBe(loaded)
+  })
+
+  test("filters user messages from a safe message list", () => {
+    const loaded = [message("msg_1", "assistant"), message("msg_2", "user")]
+
+    expect(readUserMessages(readSessionMessages(loaded)).map((item) => item.id)).toEqual(["msg_2"])
+  })
+
+  test("returns a stable empty user list for missing or invalid inputs", () => {
+    const empty = readUserMessages(undefined)
+
+    expect(empty).toHaveLength(0)
+    expect(Object.isFrozen(empty)).toBe(true)
+    expect(readUserMessages("not an array")).toBe(empty)
+  })
+
+  test("skips malformed entries while filtering user messages", () => {
+    const loaded = [null, {}, message("msg_1", "assistant"), message("msg_2", "user")]
+
+    expect(readUserMessages(loaded).map((item) => item.id)).toEqual(["msg_2"])
+  })
+})

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -1,0 +1,18 @@
+import type { Message, UserMessage } from "@opencode-ai/sdk/v2/client"
+
+export const emptyMessages = Object.freeze([]) as unknown as Message[]
+export const emptyUserMessages = Object.freeze([]) as unknown as UserMessage[]
+
+export function readSessionMessages(value: unknown): Message[] {
+  return Array.isArray(value) ? (value as Message[]) : emptyMessages
+}
+
+function isUserMessage(value: unknown): value is UserMessage {
+  return !!value && typeof value === "object" && "role" in value && value.role === "user"
+}
+
+export function readUserMessages(messages: unknown): UserMessage[] {
+  if (!Array.isArray(messages)) return emptyUserMessages
+  const users = messages.filter(isUserMessage)
+  return users.length > 0 ? users : emptyUserMessages
+}

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -16,6 +16,7 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/util/array"
 import { canCloseSessionTab, closeSessionTab } from "@/pages/session/close-session-tab"
 import { createSessionTabs } from "@/pages/session/helpers"
+import { readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
 import { toggleDesktopTerminal } from "@/pages/session/terminal-shell-tab"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
@@ -75,10 +76,9 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const status = () => sync.data.session_status[params.id ?? ""] ?? idle
   const messages = () => {
     const id = params.id
-    if (!id) return []
-    return sync.data.message[id] ?? []
+    return readSessionMessages(id ? sync.data.message[id] : undefined)
   }
-  const userMessages = () => messages().filter((m) => m.role === "user") as UserMessage[]
+  const userMessages = () => readUserMessages(messages())
   const visibleUserMessages = () => {
     const revert = info()?.revert?.messageID
     if (!revert) return userMessages()


### PR DESCRIPTION
## Summary

Guard session message cache reads behind a shared safe reader, and reuse it in the session page, session context tab, and session command navigation.

## Why

PawWork 0.2.14 produced a renderer crash on a session route with `Cannot read properties of undefined (reading 'filter')`. The packaged stack maps to `messages().filter(...)` in the session page. If background prefetch or cache eviction leaves a session message cache value temporarily missing or malformed, the renderer should treat it as an empty message list instead of crashing.

## Related Issue

No GitHub issue yet. This PR is based on local problem report `pwr_moibnr62_2cfkgq`.

## How To Verify

List the commands run for this PR:

```bash
bun install --frozen-lockfile
bun test --preload ./happydom.ts src/pages/session/session-messages.test.ts src/pages/session/use-session-commands.test.ts src/pages/session/session-running-state.test.ts src/components/session/session-context-metrics.test.ts
bun run test:unit
bun run typecheck
```

## Screenshots or Recordings

Not applicable. This is a renderer crash guard with no intended visible UI change.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
