### PR TITLE
fix(app): stabilize session timeline scroll

### DIFF
--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -1,0 +1,185 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
+import { promptSelector, sessionItemSelector, sessionMessageItemSelector, sessionTurnListSelector } from "../selectors"
+import { createSdk } from "../utils"
+
+type Sdk = ReturnType<typeof createSdk>
+
+function timelineMetrics(page: Page) {
+  return page.evaluate((turnListSelector) => {
+    const list = document.querySelector(turnListSelector)
+    const viewport = list?.closest(".scroll-view__viewport")
+    if (!(viewport instanceof HTMLElement)) throw new Error("session timeline viewport not found")
+    return {
+      top: viewport.scrollTop,
+      height: viewport.scrollHeight,
+      client: viewport.clientHeight,
+      distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+    }
+  }, sessionTurnListSelector)
+}
+
+async function scrollTimelineToBottom(page: Page) {
+  await page.evaluate((turnListSelector) => {
+    const list = document.querySelector(turnListSelector)
+    const viewport = list?.closest(".scroll-view__viewport")
+    if (!(viewport instanceof HTMLElement)) throw new Error("session timeline viewport not found")
+    viewport.scrollTop = viewport.scrollHeight
+  }, sessionTurnListSelector)
+}
+
+async function sendVisiblePrompt(input: { page: Page; text: string }) {
+  const prompt = input.page.locator(promptSelector)
+  await expect(prompt).toBeVisible()
+  await prompt.click()
+  await input.page.keyboard.insertText(input.text)
+  await expect.poll(async () => (await prompt.textContent())?.replace(/\u200B/g, "").trim()).toBe(input.text)
+  await input.page.keyboard.press("Enter")
+}
+
+async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: number }) {
+  for (let i = 0; i < input.count; i++) {
+    await input.sdk.session.promptAsync({
+      sessionID: input.sessionID,
+      noReply: true,
+      parts: [
+        {
+          type: "text",
+          text: `seed turn ${i}\n${Array.from({ length: 16 }, (_, line) => `line ${line} ${"content ".repeat(8)}`).join("\n")}`,
+        },
+      ],
+    })
+  }
+}
+
+async function installMessageCountProbe(page: Page) {
+  await page.evaluate(
+    ({ maxSamples, messageSelector }) => {
+      const read = () => ({
+        url: window.location.href,
+        messages: document.querySelectorAll(messageSelector).length,
+      })
+      const samples = [read()]
+      const push = () => {
+        const next = read()
+        const prev = samples[samples.length - 1]
+        if (prev && prev.url === next.url && prev.messages === next.messages) return
+        if (samples.length < maxSamples) samples.push(next)
+      }
+      let frame = requestAnimationFrame(function tick() {
+        push()
+        frame = requestAnimationFrame(tick)
+      })
+      const observer = new MutationObserver(push)
+      observer.observe(document.body, { childList: true, subtree: true })
+      const win = window as typeof window & {
+        __opencode_e2e?: Record<string, unknown> & {
+          messageCountProbe?: { stop: () => unknown }
+        }
+      }
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        messageCountProbe: {
+          stop() {
+            cancelAnimationFrame(frame)
+            observer.disconnect()
+            push()
+            delete win.__opencode_e2e?.messageCountProbe
+            return samples
+          },
+        },
+      }
+    },
+    { maxSamples: 256, messageSelector: sessionMessageItemSelector },
+  )
+}
+
+async function stopMessageCountProbe(page: Page) {
+  return page.evaluate(() => {
+    const win = window as typeof window & {
+      __opencode_e2e?: {
+        messageCountProbe?: { stop: () => unknown }
+      }
+    }
+    const probe = win.__opencode_e2e?.messageCountProbe
+    if (!probe) throw new Error("message count probe was not installed")
+    return probe.stop()
+  }) as Promise<Array<{ url: string; messages: number }>>
+}
+
+test("keeps the latest turn in view when sending from an old message hash", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e scroll position ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 14 })
+
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+    await scrollTimelineToBottom(page)
+    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
+
+    const ids = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
+      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+    )
+    const oldID = ids[2]
+    if (!oldID) throw new Error("expected an older rendered message id")
+
+    await page.goto(`${page.url()}#message-${oldID}`)
+    await expect(page.locator(`#message-${oldID}`)).toBeVisible()
+    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom).toBeGreaterThan(100)
+
+    const token = `scroll_latest_${Date.now()}`
+    const beforeCount = await page.locator(sessionMessageItemSelector).count()
+    await sendVisiblePrompt({ page, text: `reply with ${token}` })
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(beforeCount + 1, { timeout: 30_000 })
+
+    await expect.poll(() => page.url()).not.toContain("#message-")
+    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom, { timeout: 30_000 }).toBeLessThan(40)
+    const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
+      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+    )
+    expect(rendered.at(-1)).not.toBe(oldID)
+  })
+})
+
+test("renders the full initial session window when switching sessions", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e switch source ${Date.now()}`, async (first) => {
+    project.trackSession(first.id)
+    await withSession(sdk, `e2e switch target ${Date.now()}`, async (second) => {
+      project.trackSession(second.id)
+      await seedSessionTurns({ sdk, sessionID: first.id, count: 14 })
+      await seedSessionTurns({ sdk, sessionID: second.id, count: 14 })
+
+      await project.gotoSession(first.id)
+      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+      await expect(page.locator(sessionItemSelector(second.id))).toBeVisible({ timeout: 30_000 })
+
+      await installMessageCountProbe(page)
+      await page.locator(sessionItemSelector(second.id)).click()
+      await expect(page).toHaveURL(new RegExp(`/session/${second.id}(?:[?#]|$)`))
+      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+      const samples = await stopMessageCountProbe(page)
+      const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
+        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+      )
+      const secondMessages = await sdk.session.messages({ sessionID: second.id, limit: 100 }).then((r) => r.data ?? [])
+      const secondIDs = new Set(secondMessages.filter((item) => item.info.role === "user").map((item) => item.info.id))
+
+      const switched = samples.filter((sample) => sample.url.includes(`/session/${second.id}`))
+      expect(switched.length).toBeGreaterThan(0)
+      expect(rendered.every((id) => secondIDs.has(id))).toBe(true)
+      expect(switched.filter((sample) => sample.messages > 0 && sample.messages < 10)).toEqual([])
+    })
+  })
+})

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -6,18 +6,33 @@ import { createSdk } from "../utils"
 
 type Sdk = ReturnType<typeof createSdk>
 
+const INITIAL_SESSION_WINDOW_MESSAGES = 10
+
+type TimelineMetrics = {
+  top: number
+  height: number
+  client: number
+  distanceFromBottom: number
+}
+
 function timelineMetrics(page: Page) {
   return page.evaluate((turnListSelector) => {
     const list = document.querySelector(turnListSelector)
     const viewport = list?.closest(".scroll-view__viewport")
-    if (!(viewport instanceof HTMLElement)) throw new Error("session timeline viewport not found")
+    if (!(viewport instanceof HTMLElement)) return null
     return {
       top: viewport.scrollTop,
       height: viewport.scrollHeight,
       client: viewport.clientHeight,
       distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
     }
-  }, sessionTurnListSelector)
+  }, sessionTurnListSelector) as Promise<TimelineMetrics | null>
+}
+
+async function expectTimelineMetrics(page: Page) {
+  const metrics = await timelineMetrics(page)
+  expect(metrics, "session timeline viewport should exist").not.toBeNull()
+  return metrics!
 }
 
 async function scrollTimelineToBottom(page: Page) {
@@ -120,9 +135,11 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
     await seedSessionTurns({ sdk, sessionID: session.id, count: 14 })
 
     await project.gotoSession(session.id)
-    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+      timeout: 30_000,
+    })
     await scrollTimelineToBottom(page)
-    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
 
     const ids = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
       items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
@@ -132,7 +149,7 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
 
     await page.goto(`${page.url()}#message-${oldID}`)
     await expect(page.locator(`#message-${oldID}`)).toBeVisible()
-    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom).toBeGreaterThan(100)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeGreaterThan(100)
 
     const token = `scroll_latest_${Date.now()}`
     const beforeCount = await page.locator(sessionMessageItemSelector).count()
@@ -140,7 +157,9 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
     await expect(page.locator(sessionMessageItemSelector)).toHaveCount(beforeCount + 1, { timeout: 30_000 })
 
     await expect.poll(() => page.url()).not.toContain("#message-")
-    await expect.poll(async () => (await timelineMetrics(page)).distanceFromBottom, { timeout: 30_000 }).toBeLessThan(40)
+    await expect
+      .poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom, { timeout: 30_000 })
+      .toBeLessThan(40)
     const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
       items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
     )
@@ -162,24 +181,32 @@ test("renders the full initial session window when switching sessions", async ({
       await seedSessionTurns({ sdk, sessionID: second.id, count: 14 })
 
       await project.gotoSession(first.id)
-      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+        timeout: 30_000,
+      })
       await expect(page.locator(sessionItemSelector(second.id))).toBeVisible({ timeout: 30_000 })
 
       await installMessageCountProbe(page)
       await page.locator(sessionItemSelector(second.id)).click()
       await expect(page).toHaveURL(new RegExp(`/session/${second.id}(?:[?#]|$)`))
-      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+        timeout: 30_000,
+      })
       const samples = await stopMessageCountProbe(page)
       const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
         items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
       )
       const secondMessages = await sdk.session.messages({ sessionID: second.id, limit: 100 }).then((r) => r.data ?? [])
-      const secondIDs = new Set(secondMessages.filter((item) => item.info.role === "user").map((item) => item.info.id))
+      const secondIDs = new Set(secondMessages.map((item) => item.info.id))
 
       const switched = samples.filter((sample) => sample.url.includes(`/session/${second.id}`))
       expect(switched.length).toBeGreaterThan(0)
       expect(rendered.every((id) => secondIDs.has(id))).toBe(true)
-      expect(switched.filter((sample) => sample.messages > 0 && sample.messages < 10)).toEqual([])
+      expect(
+        switched.filter(
+          (sample) => sample.messages > 0 && sample.messages < INITIAL_SESSION_WINDOW_MESSAGES,
+        ),
+      ).toEqual([])
     })
   })
 })

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -36,12 +36,14 @@ async function expectTimelineMetrics(page: Page) {
 }
 
 async function scrollTimelineToBottom(page: Page) {
-  await page.evaluate((turnListSelector) => {
+  const found = await page.evaluate((turnListSelector) => {
     const list = document.querySelector(turnListSelector)
     const viewport = list?.closest(".scroll-view__viewport")
-    if (!(viewport instanceof HTMLElement)) throw new Error("session timeline viewport not found")
+    if (!(viewport instanceof HTMLElement)) return false
     viewport.scrollTop = viewport.scrollHeight
+    return true
   }, sessionTurnListSelector)
+  expect(found, "session timeline viewport should exist").toBe(true)
 }
 
 async function sendVisiblePrompt(input: { page: Page; text: string }) {
@@ -188,7 +190,7 @@ test("renders the full initial session window when switching sessions", async ({
 
       await installMessageCountProbe(page)
       await page.locator(sessionItemSelector(second.id)).click()
-      await expect(page).toHaveURL(new RegExp(`/session/${second.id}(?:[?#]|$)`))
+      await expect.poll(() => new URL(page.url()).pathname.endsWith(`/session/${second.id}`)).toBe(true)
       await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
         timeout: 30_000,
       })

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -378,7 +378,7 @@ export function MessageTimeline(props: {
     return language.t("command.session.new")
   })
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
-  const stageCfg = { init: 1, batch: 3 }
+  const stageCfg = { init: 10, batch: 3 }
   const staging = createTimelineStaging({
     sessionKey,
     turnStart: () => props.turnStart,

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -378,6 +378,7 @@ export function MessageTimeline(props: {
     return language.t("command.session.new")
   })
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
+  // Match the initial window cap so session switches do not reveal the window in partial batches.
   const stageCfg = { init: 10, batch: 3 }
   const staging = createTimelineStaging({
     sessionKey,

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -144,7 +144,11 @@ export const useSessionHashScroll = (input: {
 
   createEffect(() => {
     const hash = location.hash
-    if (!hash) clearing = false
+    if (!hash) {
+      clearing = false
+    } else if (clearing) {
+      return
+    }
     if (!input.sessionID() || !input.messagesReady()) return
     cancel()
     queue(() => applyHash("auto"))

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -27,7 +27,7 @@ export const useSessionHashScroll = (input: {
   const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
   const messageIndex = createMemo(() => new Map(visibleUserMessages().map((m, i) => [m.id, i])))
   let pendingKey = ""
-  let clearing = false
+  let clearingHash: string | undefined
 
   const location = useLocation()
   const navigate = useNavigate()
@@ -50,14 +50,14 @@ export const useSessionHashScroll = (input: {
     input.consumePendingMessage(input.sessionKey())
     if (input.pendingMessage()) input.setPendingMessage(undefined)
     if (!location.hash) return
-    clearing = true
+    clearingHash = location.hash
     navigate(location.pathname + location.search, { replace: true })
   }
 
   const updateHash = (id: string) => {
     const hash = `#${input.anchor(id)}`
     if (location.hash === hash) return
-    clearing = false
+    clearingHash = undefined
     navigate(location.pathname + location.search + hash, {
       replace: true,
     })
@@ -145,9 +145,11 @@ export const useSessionHashScroll = (input: {
   createEffect(() => {
     const hash = location.hash
     if (!hash) {
-      clearing = false
-    } else if (clearing) {
+      clearingHash = undefined
+    } else if (hash === clearingHash) {
       return
+    } else {
+      clearingHash = undefined
     }
     if (!input.sessionID() || !input.messagesReady()) return
     cancel()
@@ -173,7 +175,7 @@ export const useSessionHashScroll = (input: {
       }
     }
 
-    if (!targetId && !clearing) targetId = messageIdFromHash(location.hash)
+    if (!targetId && !clearingHash) targetId = messageIdFromHash(location.hash)
     if (!targetId) return
 
     const pending = input.pendingMessage() === targetId
@@ -195,7 +197,7 @@ export const useSessionHashScroll = (input: {
     visibleUserMessages()
 
     let targetId = input.pendingMessage()
-    if (!targetId && !clearing) targetId = messageIdFromHash(location.hash)
+    if (!targetId && !clearingHash) targetId = messageIdFromHash(location.hash)
     if (!targetId) return
     if (messageById().has(targetId)) return
     if (!input.historyMore() || input.historyLoading()) return


### PR DESCRIPTION
## Summary

- Keep stale message hashes from being re-applied while the session composer clears the hash after sending.
- Render the complete initial 10-turn session window on session switches instead of staging from a single turn.
- Add E2E coverage for continuing from an old message hash and for switching between long sessions.

## Why

Two session timeline issues could make the UI feel unstable:

- Continuing a conversation from an old message hash could clear the hash and then immediately re-apply the stale hash, sending the timeline back toward the old message.
- Switching sessions rendered the capped 10-turn window in visible stages, which could look like a flicker.

## Related Issue

No linked issue. Reported directly during debugging.

## How To Verify

List commands:

(cd packages/app && bun playwright test e2e/session/session-scroll-position.spec.ts)
(cd packages/app && bun playwright test e2e/session/session-send-stability.spec.ts)
(cd packages/app && bun run typecheck)

## Screenshots or Recordings

Not attached. This is interaction stability behavior covered by E2E checks.

## Checklist

- [x] I linked related issue, or stated why no issue
- [x] This PR has type, scope, and priority labels
- [x] I listed verification steps
- [x] I considered screenshots or recordings for visible UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating session timeline scrolling and message rendering across navigation and session switching.

* **Bug Fixes**
  * Improved scroll position handling when navigating via URL hash and returning to recent messages.
  * Enhanced initial message visibility during session switches for smoother transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->