### PR TITLE
feat(agent): subagent lifecycle v1 (foreground-only)

### DIFF
--- a/packages/opencode/migration/20260428080316_subagent_lifecycle/migration.sql
+++ b/packages/opencode/migration/20260428080316_subagent_lifecycle/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `session` ADD `created_by_agent_tool` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `session` ADD `subagent_type` text;

--- a/packages/opencode/migration/20260428080316_subagent_lifecycle/snapshot.json
+++ b/packages/opencode/migration/20260428080316_subagent_lifecycle/snapshot.json
@@ -1,0 +1,1511 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "35a62e67-48b8-456c-b5a0-2753848fae2d",
+  "prevIds": [
+    "57c01470-eb95-4288-a184-3cdb8c353c99"
+  ],
+  "ddl": [
+    {
+      "name": "account_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_entry",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "name": "event_sequence",
+      "entityType": "tables"
+    },
+    {
+      "name": "event",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_account_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_org_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "owner_directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "session_entry"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "created_by_agent_tool",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "subagent_type",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "skill",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "active_account_id"
+      ],
+      "tableTo": "account",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_account_state_active_account_id_account_id_fk",
+      "entityType": "fks",
+      "table": "account_state"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "workspace"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_entry_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_entry"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "tableTo": "event_sequence",
+      "columnsTo": [
+        "aggregate_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_event_aggregate_id_event_sequence_aggregate_id_fk",
+      "entityType": "fks",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_state_pk",
+      "table": "account_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_pk",
+      "table": "workspace",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_entry_pk",
+      "table": "session_entry",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "nameExplicit": false,
+      "name": "event_sequence_pk",
+      "table": "event_sequence",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_pk",
+      "table": "event",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "time_created",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_time_created_id_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_id_id_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_entry_session_idx",
+      "entityType": "indexes",
+      "table": "session_entry"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_entry_session_type_idx",
+      "entityType": "indexes",
+      "table": "session_entry"
+    },
+    {
+      "columns": [
+        {
+          "value": "time_created",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_entry_time_created_idx",
+      "entityType": "indexes",
+      "table": "session_entry"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_workspace_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -239,6 +239,19 @@ export const CompactionPart = PartBase.extend({
 })
 export type CompactionPart = z.infer<typeof CompactionPart>
 
+export const SubtaskEvent = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("started"), at: z.number() }),
+  z.object({ type: z.literal("tool_started"), tool: z.string(), label: z.string(), at: z.number() }),
+  z.object({ type: z.literal("tool_completed"), tool: z.string(), at: z.number() }),
+  z.object({ type: z.literal("model_wait_started"), at: z.number() }),
+  z.object({ type: z.literal("completed"), at: z.number() }),
+  z.object({ type: z.literal("completed_empty"), at: z.number() }),
+  z.object({ type: z.literal("canceled_by_user"), at: z.number() }),
+  z.object({ type: z.literal("failed"), kind: z.string(), at: z.number() }),
+  z.object({ type: z.literal("consumed"), at: z.number() }),
+])
+export type SubtaskEvent = z.infer<typeof SubtaskEvent>
+
 export const SubtaskPart = PartBase.extend({
   type: z.literal("subtask"),
   prompt: z.string(),
@@ -251,6 +264,34 @@ export const SubtaskPart = PartBase.extend({
     })
     .optional(),
   command: z.string().optional(),
+  // identity (NEW; .optional() so legacy decode succeeds without a primary key)
+  tool_call_id: z.string().optional(),
+  parent_session_id: z.string().optional(),
+  parent_message_id: z.string().optional(),
+  subagent_session_id: z.string().optional(),
+  // lifecycle (NEW)
+  status: z
+    .enum(["running", "completed", "completed_empty", "failed", "canceled_by_user"])
+    .default("completed"),
+  started_at: z.number().optional(),
+  updated_at: z.number().optional(),
+  ended_at: z.number().optional(),
+  consumed_at: z.number().optional(),
+  // progress (NEW)
+  last_activity: z
+    .object({
+      kind: z.enum(["model_waiting", "thinking", "tool"]),
+      label: z.string(),
+      tool: z.string().optional(),
+      at: z.number(),
+    })
+    .optional(),
+  recent_events: z.array(SubtaskEvent).max(20).default([]),
+  // result (NEW)
+  result_summary: z.string().optional(),
+  result_text: z.string().optional(),
+  partial_result: z.string().nullable().optional(),
+  error: z.object({ kind: z.string(), message: z.string() }).optional(),
 }).meta({
   ref: "SubtaskPart",
 })

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -277,15 +277,6 @@ export const SubtaskPart = PartBase.extend({
   updated_at: z.number().optional(),
   ended_at: z.number().optional(),
   consumed_at: z.number().optional(),
-  // progress (NEW)
-  last_activity: z
-    .object({
-      kind: z.enum(["model_waiting", "thinking", "tool"]),
-      label: z.string(),
-      tool: z.string().optional(),
-      at: z.number(),
-    })
-    .optional(),
   recent_events: z.array(SubtaskEvent).max(20).default([]),
   // result (NEW)
   result_summary: z.string().optional(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -234,12 +234,18 @@ export const layer = Layer.effect(
     const runner = Effect.fn("SessionPrompt.runner")(function* () {
       return yield* EffectBridge.make()
     })
+    // Tracks subagent sessions whose runner.onInterrupt fired during the most recent prompt run.
+    // Reset at the start of each prompt() call; written when loop()'s onInterrupt arg fires; read
+    // by AgentTool.execute via AgentPromptOps.wasInterrupted to deterministically distinguish
+    // "child runner aborted" from "model returned naturally" without racing ctx.abort.aborted.
+    const interruptedSessions = new Set<SessionID>()
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       const run = yield* runner()
       return {
         cancel: (sessionID: SessionID) => run.fork(cancel(sessionID)),
         resolvePromptParts: (template: string) => resolvePromptParts(template),
         prompt: (input: PromptInput) => prompt(input),
+        wasInterrupted: (sessionID: SessionID) => interruptedSessions.has(sessionID),
       } satisfies AgentPromptOps
     })
 
@@ -1467,6 +1473,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.prompt")(
       function* (input: PromptInput) {
+        interruptedSessions.delete(input.sessionID)
         const session = yield* sessions.get(input.sessionID)
         yield* revert.cleanup(session)
         const message = yield* createUserMessage(input)
@@ -1791,7 +1798,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>) {
-      return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID))
+      const onInterrupt = Effect.gen(function* () {
+        interruptedSessions.add(input.sessionID)
+        return yield* lastAssistant(input.sessionID)
+      })
+      return yield* state.ensureRunning(input.sessionID, onInterrupt, runLoop(input.sessionID))
     })
 
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -245,7 +245,14 @@ export const layer = Layer.effect(
         cancel: (sessionID: SessionID) => run.fork(cancel(sessionID)),
         resolvePromptParts: (template: string) => resolvePromptParts(template),
         prompt: (input: PromptInput) => prompt(input),
-        wasInterrupted: (sessionID: SessionID) => interruptedSessions.has(sessionID),
+        // Self-cleaning read: each subagent dispatch reads `wasInterrupted` exactly once after
+        // ops.prompt resolves, so deleting on read keeps the Set bounded by concurrent inflight
+        // subagents instead of growing across the whole runtime lifetime.
+        wasInterrupted: (sessionID: SessionID) => {
+          const interrupted = interruptedSessions.has(sessionID)
+          if (interrupted) interruptedSessions.delete(sessionID)
+          return interrupted
+        },
       } satisfies AgentPromptOps
     })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1888,6 +1888,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               command: input.command,
               model: { providerID: taskModel.providerID, modelID: taskModel.modelID },
               prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
+              status: "completed" as const,
+              recent_events: [],
             },
           ]
         : [...templateParts, ...(input.parts ?? [])]

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -22,6 +22,8 @@ export const SessionTable = sqliteTable(
       .references(() => ProjectTable.id, { onDelete: "cascade" }),
     workspace_id: text().$type<WorkspaceID>(),
     parent_id: text().$type<SessionID>(),
+    created_by_agent_tool: integer({ mode: "boolean" }).default(false),
+    subagent_type: text(),
     slug: text().notNull(),
     directory: text().notNull(),
     title: text().notNull(),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -31,6 +31,11 @@ import type { Provider } from "@/provider"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import { Effect, Layer, Option, Context } from "effect"
+import {
+  SubagentRunWriterContext,
+  SubagentRunGuardViolation,
+  lifecycleFieldsChanged,
+} from "./subagent-run-context"
 
 const log = Log.create({ service: "session" })
 
@@ -510,6 +515,26 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
 
     const updatePart = <T extends MessageV2.Part>(part: T): Effect.Effect<T> =>
       Effect.gen(function* () {
+        if (part.type === "subtask") {
+          const isWriter = yield* SubagentRunWriterContext
+          if (!isWriter) {
+            const existing = yield* getPart({
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              partID: part.id,
+            }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (
+              lifecycleFieldsChanged(
+                existing as unknown as Record<string, unknown> | undefined,
+                part as unknown as Record<string, unknown>,
+              )
+            ) {
+              return yield* Effect.die(
+                new SubagentRunGuardViolation((part as { tool_call_id?: string }).tool_call_id),
+              )
+            }
+          }
+        }
         yield* Effect.sync(() =>
           SyncEvent.run(MessageV2.Event.PartUpdated, {
             sessionID: part.sessionID,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -518,11 +518,13 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         if (part.type === "subtask") {
           const isWriter = yield* SubagentRunWriterContext
           if (!isWriter) {
+            // No catch: getPart's typed error channel is never; defects (e.g. database failure)
+            // should propagate so the guard can't be silently bypassed by a missing read.
             const existing = yield* getPart({
               sessionID: part.sessionID,
               messageID: part.messageID,
               partID: part.id,
-            }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            })
             if (
               lifecycleFieldsChanged(
                 existing as unknown as Record<string, unknown> | undefined,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -525,9 +525,14 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
               messageID: part.messageID,
               partID: part.id,
             })
+            // Only police mutations: first writes (existing === undefined) are allowed so
+            // Session.fork() / migration / import paths can clone historical SubtaskParts with
+            // their persisted lifecycle values. Once a part exists, lifecycle fields are frozen
+            // for non-writers.
             if (
+              existing &&
               lifecycleFieldsChanged(
-                existing as unknown as Record<string, unknown> | undefined,
+                existing as unknown as Record<string, unknown>,
                 part as unknown as Record<string, unknown>,
               )
             ) {

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -68,6 +68,8 @@ export function fromRow(row: SessionRow): Info {
     workspaceID: row.workspace_id ?? undefined,
     directory: row.directory,
     parentID: row.parent_id ?? undefined,
+    createdByAgentTool: row.created_by_agent_tool ?? false,
+    subagentType: row.subagent_type ?? null,
     title: row.title,
     skill: row.skill ?? undefined,
     version: row.version,
@@ -90,6 +92,8 @@ export function toRow(info: Info) {
     project_id: info.projectID,
     workspace_id: info.workspaceID,
     parent_id: info.parentID,
+    created_by_agent_tool: info.createdByAgentTool,
+    subagent_type: info.subagentType,
     slug: info.slug,
     directory: info.directory,
     title: info.title,
@@ -127,6 +131,8 @@ export const Info = z
     workspaceID: WorkspaceID.zod.optional(),
     directory: z.string(),
     parentID: SessionID.zod.optional(),
+    createdByAgentTool: z.boolean().default(false),
+    subagentType: z.string().nullable().default(null),
     skill: z.string().optional(),
     summary: z
       .object({
@@ -189,6 +195,8 @@ export const CreateInput = z
     skill: z.string().optional(),
     permission: Info.shape.permission,
     workspaceID: WorkspaceID.zod.optional(),
+    createdByAgentTool: z.boolean().optional(),
+    subagentType: z.string().nullable().optional(),
   })
   .optional()
 export type CreateInput = z.output<typeof CreateInput>
@@ -349,6 +357,8 @@ export interface Interface {
     skill?: string
     permission?: Permission.Ruleset
     workspaceID?: WorkspaceID
+    createdByAgentTool?: boolean
+    subagentType?: string | null
   }) => Effect.Effect<Info>
   readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info>
   readonly touch: (sessionID: SessionID) => Effect.Effect<void>
@@ -411,6 +421,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       workspaceID?: WorkspaceID
       directory: string
       permission?: Permission.Ruleset
+      createdByAgentTool?: boolean
+      subagentType?: string | null
     }) {
       const ctx = yield* InstanceState.context
       const result: Info = {
@@ -421,6 +433,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         directory: input.directory,
         workspaceID: input.workspaceID,
         parentID: input.parentID,
+        createdByAgentTool: input.createdByAgentTool ?? false,
+        subagentType: input.subagentType ?? null,
         title: input.title ?? createDefaultTitle(!!input.parentID),
         skill: input.skill,
         permission: input.permission,
@@ -535,6 +549,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       skill?: string
       permission?: Permission.Ruleset
       workspaceID?: WorkspaceID
+      createdByAgentTool?: boolean
+      subagentType?: string | null
     }) {
       const directory = yield* InstanceState.directory
       const workspace = yield* InstanceState.workspaceID
@@ -545,6 +561,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         skill: input?.skill,
         permission: input?.permission,
         workspaceID: input?.workspaceID ?? (workspace as WorkspaceID | undefined),
+        createdByAgentTool: input?.createdByAgentTool,
+        subagentType: input?.subagentType,
       })
     })
 

--- a/packages/opencode/src/session/subagent-run-context.ts
+++ b/packages/opencode/src/session/subagent-run-context.ts
@@ -38,26 +38,19 @@ export class SubagentRunGuardViolation extends Error {
  * last_activity / error arrays/objects with identical content is NOT rejected. Only genuine
  * lifecycle mutations trip the guard.
  *
+ * Caller contract: `existing` must be a real persisted part. First-write paths (no row yet)
+ * are allowed unconditionally upstream — Session.fork / migration / import need to seed
+ * historical lifecycle values without going through SubagentRun writers.
+ *
  * Limitation: JSON.stringify is order-sensitive (`{a:1,b:2}` vs `{b:2,a:1}` produce different
  * strings) and drops `undefined` values. This is acceptable here because lifecycle field shapes
  * are produced by SubagentRun writers with stable key order, and `undefined` lifecycle fields
- * are short-circuited above as "no change".
+ * compare equal to `undefined` on both sides.
  */
 export const lifecycleFieldsChanged = (
-  existing: Record<string, unknown> | undefined,
+  existing: Record<string, unknown>,
   next: Record<string, unknown>,
 ): boolean => {
-  if (!existing) {
-    // First write of this part. Reject only if the writer set a non-default lifecycle value.
-    for (const k of LIFECYCLE_KEYS) {
-      const v = next[k]
-      if (v === undefined) continue
-      if (k === "status" && v === "completed") continue
-      if (k === "recent_events" && Array.isArray(v) && v.length === 0) continue
-      return true
-    }
-    return false
-  }
   for (const k of LIFECYCLE_KEYS) {
     if (JSON.stringify(existing[k]) !== JSON.stringify(next[k])) return true
   }

--- a/packages/opencode/src/session/subagent-run-context.ts
+++ b/packages/opencode/src/session/subagent-run-context.ts
@@ -1,0 +1,57 @@
+import { Context } from "effect"
+
+/**
+ * True only inside SubagentRun service writer methods. Read by Session.updatePart
+ * to gate writes that mutate SubtaskPart lifecycle fields. Single shared module
+ * keeps both writers and the guard observing the same Reference without a Layer wrapper.
+ */
+export const SubagentRunWriterContext: Context.Reference<boolean> = Context.Reference<boolean>(
+  "@pawwork/SubagentRunWriterContext",
+  { defaultValue: () => false },
+)
+
+const LIFECYCLE_KEYS = [
+  "status",
+  "started_at",
+  "updated_at",
+  "ended_at",
+  "consumed_at",
+  "last_activity",
+  "recent_events",
+  "result_summary",
+  "result_text",
+  "partial_result",
+  "error",
+] as const
+
+export class SubagentRunGuardViolation {
+  readonly _tag = "SubagentRunGuardViolation"
+  constructor(readonly tool_call_id: string | undefined) {}
+}
+
+/**
+ * Returns true if `next` mutates any lifecycle field relative to `existing`. Compares by value
+ * (JSON.stringify) not by reference, so a static-field update that re-clones recent_events /
+ * last_activity / error arrays/objects with identical content is NOT rejected. Only genuine
+ * lifecycle mutations trip the guard.
+ */
+export const lifecycleFieldsChanged = (
+  existing: Record<string, unknown> | undefined,
+  next: Record<string, unknown>,
+): boolean => {
+  if (!existing) {
+    // First write of this part. Reject only if the writer set a non-default lifecycle value.
+    for (const k of LIFECYCLE_KEYS) {
+      const v = next[k]
+      if (v === undefined) continue
+      if (k === "status" && v === "completed") continue
+      if (k === "recent_events" && Array.isArray(v) && v.length === 0) continue
+      return true
+    }
+    return false
+  }
+  for (const k of LIFECYCLE_KEYS) {
+    if (JSON.stringify(existing[k]) !== JSON.stringify(next[k])) return true
+  }
+  return false
+}

--- a/packages/opencode/src/session/subagent-run-context.ts
+++ b/packages/opencode/src/session/subagent-run-context.ts
@@ -24,9 +24,12 @@ const LIFECYCLE_KEYS = [
   "error",
 ] as const
 
-export class SubagentRunGuardViolation {
+export class SubagentRunGuardViolation extends Error {
   readonly _tag = "SubagentRunGuardViolation"
-  constructor(readonly tool_call_id: string | undefined) {}
+  constructor(readonly tool_call_id: string | undefined) {
+    super(`SubagentRun lifecycle field write outside writer context (tool_call_id=${tool_call_id ?? "?"})`)
+    this.name = "SubagentRunGuardViolation"
+  }
 }
 
 /**
@@ -34,6 +37,11 @@ export class SubagentRunGuardViolation {
  * (JSON.stringify) not by reference, so a static-field update that re-clones recent_events /
  * last_activity / error arrays/objects with identical content is NOT rejected. Only genuine
  * lifecycle mutations trip the guard.
+ *
+ * Limitation: JSON.stringify is order-sensitive (`{a:1,b:2}` vs `{b:2,a:1}` produce different
+ * strings) and drops `undefined` values. This is acceptable here because lifecycle field shapes
+ * are produced by SubagentRun writers with stable key order, and `undefined` lifecycle fields
+ * are short-circuited above as "no change".
  */
 export const lifecycleFieldsChanged = (
   existing: Record<string, unknown> | undefined,

--- a/packages/opencode/src/session/subagent-run-context.ts
+++ b/packages/opencode/src/session/subagent-run-context.ts
@@ -24,7 +24,6 @@ const LIFECYCLE_KEYS = [
   "updated_at",
   "ended_at",
   "consumed_at",
-  "last_activity",
   "recent_events",
   "result_summary",
   "result_text",
@@ -43,7 +42,7 @@ export class SubagentRunGuardViolation extends Error {
 /**
  * Returns true if `next` mutates any lifecycle field relative to `existing`. Compares by value
  * (JSON.stringify) not by reference, so a static-field update that re-clones recent_events /
- * last_activity / error arrays/objects with identical content is NOT rejected. Only genuine
+ * recent_events / error arrays/objects with identical content is NOT rejected. Only genuine
  * lifecycle mutations trip the guard.
  *
  * Caller contract: `existing` must be a real persisted part. First-write paths (no row yet)

--- a/packages/opencode/src/session/subagent-run-context.ts
+++ b/packages/opencode/src/session/subagent-run-context.ts
@@ -10,7 +10,15 @@ export const SubagentRunWriterContext: Context.Reference<boolean> = Context.Refe
   { defaultValue: () => false },
 )
 
+// Includes both lifecycle state (status, timestamps, events, results) and immutable linkage
+// fields (tool_call_id, parent_*_id, subagent_session_id). Linkage fields are set once at
+// `start` / `patchSession` and must never be repointed: rewriting them would corrupt
+// findLatestBySessionID, ownership checks, and the in-memory tool_call_id index.
 const LIFECYCLE_KEYS = [
+  "tool_call_id",
+  "parent_session_id",
+  "parent_message_id",
+  "subagent_session_id",
   "status",
   "started_at",
   "updated_at",

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -57,10 +57,6 @@ export interface Interface {
   readonly start: (input: StartInput) => Effect.Effect<MessageV2.SubtaskPart>
   readonly patchSession: (toolCallID: string, sessionID: SessionID) => Effect.Effect<void>
   readonly recordEvent: (toolCallID: string, event: MessageV2.SubtaskEvent) => Effect.Effect<void>
-  readonly recordActivity: (
-    toolCallID: string,
-    activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
-  ) => Effect.Effect<void>
   readonly finalize: (
     toolCallID: string,
     status: TerminalStatus,
@@ -90,6 +86,9 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@pawwork/SubagentRun") {}
 
+// Default cap on parallel subagent dispatches per parent. Picked to stay within typical
+// per-conversation token / context budgets while still letting parents fan out useful
+// work. Not currently configurable; promoting to Config is a v1.1 follow-up.
 const MAX_ACTIVE = 5
 
 export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
@@ -137,9 +136,12 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
 
     const releaseSlot = (parentID: SessionID): Effect.Effect<void> =>
       getSlotLock(parentID).withPermits(1)(
-        Effect.sync(() => {
+        Effect.gen(function* () {
           const current = activeCounts.get(parentID) ?? 0
-          if (current > 0) activeCounts.set(parentID, current - 1)
+          // Underflow is always a bug (release without matching reserve). Die so the invariant
+          // violation surfaces instead of silently clipping at 0 and hiding double-release.
+          if (current <= 0) return yield* Effect.die(new Error(`releaseSlot underflow for ${parentID}`))
+          activeCounts.set(parentID, current - 1)
         }),
       )
 
@@ -200,12 +202,15 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
             updated_at: now,
             recent_events: [{ type: "started" as const, at: now }],
           } satisfies MessageV2.SubtaskPart
+          const persisted = yield* session.updatePart(part)
+          // Index after persistence — if updatePart fails, the cache stays clean instead of
+          // pointing at a row that does not exist in storage.
           partsByToolCall.set(input.tool_call_id, {
             sessionID: input.parent_session_id,
             messageID: input.parent_message_id,
             partID,
           })
-          return yield* session.updatePart(part)
+          return persisted
         }),
       )
 
@@ -214,18 +219,6 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
         session.updatePart({
           ...existing,
           subagent_session_id: sessionID,
-          updated_at: Date.now(),
-        }).pipe(Effect.asVoid),
-      )
-
-    const recordActivity = (
-      toolCallID: string,
-      activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
-    ): Effect.Effect<void> =>
-      withExistingPart(toolCallID, (existing) =>
-        session.updatePart({
-          ...existing,
-          last_activity: activity,
           updated_at: Date.now(),
         }).pipe(Effect.asVoid),
       )
@@ -252,11 +245,13 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
           // Hard cap: if all 20 entries are lifecycle and a 21st arrives, evict the oldest
           // lifecycle entry so SubtaskEvent.array().max(20) cannot be violated on next decode.
           while (merged.length > 20) merged.shift()
-          // Sort after eviction so chronological order is preserved across lifecycle/progress.
-          merged.sort((a, b) => a.at - b.at)
+          // Stable sort by timestamp, breaking ties on insertion order so events sharing
+          // `Date.now()` (e.g., recordRejected's `started`+`failed` pair) keep deterministic order.
+          const indexed = merged.map((e, i) => ({ e, i }))
+          indexed.sort((a, b) => a.e.at - b.e.at || a.i - b.i)
           yield* session.updatePart({
             ...existing,
-            recent_events: merged,
+            recent_events: indexed.map((x) => x.e),
             updated_at: Date.now(),
           })
         }),
@@ -312,12 +307,14 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
             ],
             error: { kind: "too_many_active", message: input.reason },
           } satisfies MessageV2.SubtaskPart
+          const persisted = yield* session.updatePart(part)
+          // Index after persistence — same rationale as `start`.
           partsByToolCall.set(input.tool_call_id, {
             sessionID: input.parent_session_id,
             messageID: input.parent_message_id,
             partID,
           })
-          return yield* session.updatePart(part)
+          return persisted
         }),
       )
 
@@ -408,7 +405,6 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
       start,
       patchSession,
       recordEvent,
-      recordActivity,
       finalize,
       recordRejected,
       setConsumed,

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -1,0 +1,294 @@
+import { Context, Effect, Layer, Semaphore } from "effect"
+import { Bus } from "../bus"
+import * as Session from "./session"
+import { PartID as PartIDNs, type MessageID, type PartID, type SessionID } from "./schema"
+import type { MessageV2 } from "./message-v2"
+import type { ProviderID, ModelID } from "../provider/schema"
+
+export class TooManyActive {
+  readonly _tag = "TooManyActive"
+  constructor(readonly parentID: SessionID) {}
+}
+
+export class NotFound {
+  readonly _tag = "NotFound"
+  constructor(readonly key: string) {}
+}
+
+export type TerminalStatus = "completed" | "completed_empty" | "failed" | "canceled_by_user"
+export type AgentListFilter = TerminalStatus | "running" | "all_active" | "all"
+
+export interface StartInput {
+  parent_session_id: SessionID
+  parent_message_id: MessageID
+  tool_call_id: string
+  description: string
+  prompt: string
+  agent: string
+  subagent_type: string
+  command?: string
+  model?: { providerID: ProviderID; modelID: ModelID }
+}
+
+export interface FinalizeFields {
+  result_text?: string
+  result_summary?: string
+  partial_result?: string | null
+  error?: { kind: string; message: string }
+  ended_at?: number
+}
+
+export interface RejectedInput {
+  parent_session_id: SessionID
+  parent_message_id: MessageID
+  tool_call_id: string
+  description: string
+  prompt: string
+  agent: string
+  subagent_type: string
+  command?: string
+  model?: { providerID: ProviderID; modelID: ModelID }
+  reason: string
+}
+
+export interface Interface {
+  readonly reserveSlot: (parentID: SessionID) => Effect.Effect<void, TooManyActive>
+  readonly releaseSlot: (parentID: SessionID) => Effect.Effect<void>
+  readonly start: (input: StartInput) => Effect.Effect<MessageV2.SubtaskPart>
+  readonly patchSession: (toolCallID: string, sessionID: SessionID) => Effect.Effect<void>
+  readonly recordEvent: (toolCallID: string, event: MessageV2.SubtaskEvent) => Effect.Effect<void>
+  readonly recordActivity: (
+    toolCallID: string,
+    activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
+  ) => Effect.Effect<void>
+  readonly finalize: (
+    toolCallID: string,
+    status: TerminalStatus,
+    fields: FinalizeFields,
+  ) => Effect.Effect<void>
+  readonly recordRejected: (input: RejectedInput) => Effect.Effect<MessageV2.SubtaskPart>
+  readonly setConsumed: (toolCallID: string) => Effect.Effect<void>
+  readonly read: (toolCallID: string) => Effect.Effect<MessageV2.SubtaskPart, NotFound>
+  readonly findLatestBySessionID: (
+    parentID: SessionID,
+    subagentSessionID: SessionID,
+  ) => Effect.Effect<MessageV2.SubtaskPart, NotFound>
+  readonly list: (
+    parentID: SessionID,
+    filter: { status: AgentListFilter; limit: number },
+  ) => Effect.Effect<MessageV2.SubtaskPart[]>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@pawwork/SubagentRun") {}
+
+const MAX_ACTIVE = 5
+
+export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const session = yield* Session.Service
+
+    const slotLocks = new Map<SessionID, Semaphore.Semaphore>()
+    const activeCounts = new Map<SessionID, number>()
+    const rowLocks = new Map<string, Semaphore.Semaphore>()
+    const partsByToolCall = new Map<
+      string,
+      { sessionID: SessionID; messageID: MessageID; partID: PartID }
+    >()
+
+    const getSlotLock = (parentID: SessionID) => {
+      const hit = slotLocks.get(parentID)
+      if (hit) return hit
+      const next = Semaphore.makeUnsafe(1)
+      slotLocks.set(parentID, next)
+      return next
+    }
+
+    const getRowLock = (toolCallID: string) => {
+      const hit = rowLocks.get(toolCallID)
+      if (hit) return hit
+      const next = Semaphore.makeUnsafe(1)
+      rowLocks.set(toolCallID, next)
+      return next
+    }
+
+    const reserveSlot = (parentID: SessionID): Effect.Effect<void, TooManyActive> =>
+      getSlotLock(parentID).withPermits(1)(
+        Effect.gen(function* () {
+          const current = activeCounts.get(parentID) ?? 0
+          if (current >= MAX_ACTIVE) {
+            return yield* Effect.fail(new TooManyActive(parentID))
+          }
+          activeCounts.set(parentID, current + 1)
+        }),
+      )
+
+    const releaseSlot = (parentID: SessionID): Effect.Effect<void> =>
+      getSlotLock(parentID).withPermits(1)(
+        Effect.sync(() => {
+          const current = activeCounts.get(parentID) ?? 0
+          if (current > 0) activeCounts.set(parentID, current - 1)
+        }),
+      )
+
+    const readPart = (toolCallID: string) =>
+      Effect.gen(function* () {
+        const ref = partsByToolCall.get(toolCallID)
+        if (!ref) return yield* Effect.fail(new NotFound(toolCallID))
+        const got = yield* session.getPart({
+          sessionID: ref.sessionID,
+          messageID: ref.messageID,
+          partID: ref.partID,
+        })
+        if (!got || got.type !== "subtask") return yield* Effect.fail(new NotFound(toolCallID))
+        return got as MessageV2.SubtaskPart
+      })
+
+    const start = Effect.fn("SubagentRun.start")(function* (input: StartInput) {
+      const partID = PartIDNs.ascending() as PartID
+      const now = Date.now()
+      const part = {
+        type: "subtask" as const,
+        id: partID,
+        sessionID: input.parent_session_id,
+        messageID: input.parent_message_id,
+        prompt: input.prompt,
+        description: input.description,
+        agent: input.agent,
+        model: input.model,
+        command: input.command,
+        tool_call_id: input.tool_call_id,
+        parent_session_id: input.parent_session_id,
+        parent_message_id: input.parent_message_id,
+        subagent_session_id: undefined,
+        status: "running" as const,
+        started_at: now,
+        updated_at: now,
+        recent_events: [{ type: "started" as const, at: now }],
+      } satisfies MessageV2.SubtaskPart
+      partsByToolCall.set(input.tool_call_id, {
+        sessionID: input.parent_session_id,
+        messageID: input.parent_message_id,
+        partID,
+      })
+      return yield* session.updatePart(part)
+    })
+
+    const patchSession = (toolCallID: string, sessionID: SessionID): Effect.Effect<void> =>
+      getRowLock(toolCallID).withPermits(1)(
+        Effect.gen(function* () {
+          const existing = yield* readPart(toolCallID).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (!existing) return
+          yield* session.updatePart({
+            ...existing,
+            subagent_session_id: sessionID,
+            updated_at: Date.now(),
+          })
+        }),
+      )
+
+    const recordActivity = (
+      toolCallID: string,
+      activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
+    ): Effect.Effect<void> =>
+      getRowLock(toolCallID).withPermits(1)(
+        Effect.gen(function* () {
+          const existing = yield* readPart(toolCallID).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (!existing) return
+          yield* session.updatePart({
+            ...existing,
+            last_activity: activity,
+            updated_at: Date.now(),
+          })
+        }),
+      )
+
+    const recordEvent = (toolCallID: string, _event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
+      Effect.die(new Error(`SubagentRun.recordEvent for ${toolCallID}: implemented in Task 5`))
+
+    const finalize = (
+      toolCallID: string,
+      status: TerminalStatus,
+      fields: FinalizeFields,
+    ): Effect.Effect<void> =>
+      getRowLock(toolCallID).withPermits(1)(
+        Effect.gen(function* () {
+          const existing = yield* readPart(toolCallID).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (!existing) return
+          if (existing.status !== "running") return
+          yield* session.updatePart({
+            ...existing,
+            status,
+            ended_at: fields.ended_at ?? Date.now(),
+            updated_at: Date.now(),
+            ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
+            ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
+            ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
+            ...(fields.error !== undefined ? { error: fields.error } : {}),
+          })
+        }),
+      )
+
+    const recordRejected = (_input: RejectedInput): Effect.Effect<MessageV2.SubtaskPart> =>
+      Effect.die(new Error("SubagentRun.recordRejected: implemented in Task 11"))
+
+    const setConsumed = (toolCallID: string): Effect.Effect<void> =>
+      getRowLock(toolCallID).withPermits(1)(
+        Effect.gen(function* () {
+          const existing = yield* readPart(toolCallID).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (!existing) return
+          if (existing.consumed_at) return
+          yield* session.updatePart({
+            ...existing,
+            consumed_at: Date.now(),
+            updated_at: Date.now(),
+          })
+        }),
+      )
+
+    const read = (toolCallID: string): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
+      readPart(toolCallID)
+
+    const findLatestBySessionID = (
+      _parentID: SessionID,
+      _subagentSessionID: SessionID,
+    ): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
+      Effect.die(new Error("SubagentRun.findLatestBySessionID: implemented in Task 13"))
+
+    const list = (
+      _parentID: SessionID,
+      _filter: { status: AgentListFilter; limit: number },
+    ): Effect.Effect<MessageV2.SubtaskPart[]> =>
+      Effect.die(new Error("SubagentRun.list: implemented in Task 12"))
+
+    return Service.of({
+      reserveSlot,
+      releaseSlot,
+      start,
+      patchSession,
+      recordEvent,
+      recordActivity,
+      finalize,
+      recordRejected,
+      setConsumed,
+      read,
+      findLatestBySessionID,
+      list,
+    })
+  }),
+)
+
+export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(
+  Layer.provide(Bus.layer),
+  Layer.provide(Session.defaultLayer),
+)
+
+export * as SubagentRun from "./subagent-run"

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -242,29 +242,34 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
       "consumed",
     ])
 
+    // Append `event` to `existing` and apply ring eviction + stable sort. Shared by recordEvent,
+    // finalize, and setConsumed so every state transition lands in recent_events with consistent
+    // capping behavior. Lifecycle events (started / <terminal> / consumed) are never evicted in
+    // favor of progress events; if the ring is all lifecycle and overflows, the oldest lifecycle
+    // entry yields. Sort breaks ties on insertion index for deterministic ordering.
+    const appendLifecycleEvent = (
+      existing: ReadonlyArray<MessageV2.SubtaskEvent>,
+      event: MessageV2.SubtaskEvent,
+    ): MessageV2.SubtaskEvent[] => {
+      const merged = [...existing, event]
+      while (merged.length > 20) {
+        const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
+        if (idx < 0) break
+        merged.splice(idx, 1)
+      }
+      while (merged.length > 20) merged.shift()
+      const indexed = merged.map((e, i) => ({ e, i }))
+      indexed.sort((a, b) => a.e.at - b.e.at || a.i - b.i)
+      return indexed.map((x) => x.e)
+    }
+
     const recordEvent = (toolCallID: string, event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
       withExistingPart(toolCallID, (existing) =>
-        Effect.gen(function* () {
-          const merged = [...existing.recent_events, event]
-          // First pass: prefer evicting non-lifecycle (progress) events from the front.
-          while (merged.length > 20) {
-            const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
-            if (idx < 0) break
-            merged.splice(idx, 1)
-          }
-          // Hard cap: if all 20 entries are lifecycle and a 21st arrives, evict the oldest
-          // lifecycle entry so SubtaskEvent.array().max(20) cannot be violated on next decode.
-          while (merged.length > 20) merged.shift()
-          // Stable sort by timestamp, breaking ties on insertion order so events sharing
-          // `Date.now()` (e.g., recordRejected's `started`+`failed` pair) keep deterministic order.
-          const indexed = merged.map((e, i) => ({ e, i }))
-          indexed.sort((a, b) => a.e.at - b.e.at || a.i - b.i)
-          yield* session.updatePart({
-            ...existing,
-            recent_events: indexed.map((x) => x.e),
-            updated_at: Date.now(),
-          })
-        }),
+        session.updatePart({
+          ...existing,
+          recent_events: appendLifecycleEvent(existing.recent_events, event),
+          updated_at: Date.now(),
+        }).pipe(Effect.asVoid),
       )
 
     const finalize = (
@@ -275,11 +280,20 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
       withExistingPart(toolCallID, (existing) =>
         Effect.gen(function* () {
           if (existing.status !== "running") return
+          const now = Date.now()
+          // Append the matching terminal event so recent_events records the actual transition
+          // (started → <terminal>) instead of leaving the ring stuck at "started".
+          const event: MessageV2.SubtaskEvent =
+            status === "failed"
+              ? { type: "failed", kind: fields.error?.kind ?? "unknown", at: now }
+              : { type: status, at: now }
+          const merged = appendLifecycleEvent(existing.recent_events, event)
           yield* session.updatePart({
             ...existing,
             status,
-            ended_at: fields.ended_at ?? Date.now(),
-            updated_at: Date.now(),
+            ended_at: fields.ended_at ?? now,
+            updated_at: now,
+            recent_events: merged,
             ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
             ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
             ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
@@ -332,10 +346,13 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
       withExistingPart(toolCallID, (existing) =>
         Effect.gen(function* () {
           if (existing.consumed_at) return
+          const now = Date.now()
+          const merged = appendLifecycleEvent(existing.recent_events, { type: "consumed", at: now })
           yield* session.updatePart({
             ...existing,
-            consumed_at: Date.now(),
-            updated_at: Date.now(),
+            consumed_at: now,
+            updated_at: now,
+            recent_events: merged,
           })
         }),
       )

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -216,11 +216,23 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
 
     const patchSession = (toolCallID: string, sessionID: SessionID): Effect.Effect<void> =>
       withExistingPart(toolCallID, (existing) =>
-        session.updatePart({
-          ...existing,
-          subagent_session_id: sessionID,
-          updated_at: Date.now(),
-        }).pipe(Effect.asVoid),
+        Effect.gen(function* () {
+          // Single-assignment: same id is a no-op, different id is a defect. Re-pointing
+          // a row to a new child would corrupt findLatestBySessionID and ownership checks.
+          if (existing.subagent_session_id === sessionID) return
+          if (existing.subagent_session_id && existing.subagent_session_id !== sessionID) {
+            return yield* Effect.die(
+              new Error(
+                `subagent_session_id already set for ${toolCallID} (have ${existing.subagent_session_id}, got ${sessionID})`,
+              ),
+            )
+          }
+          yield* session.updatePart({
+            ...existing,
+            subagent_session_id: sessionID,
+            updated_at: Date.now(),
+          })
+        }),
       )
 
     const LIFECYCLE_KINDS = new Set<MessageV2.SubtaskEvent["type"]>([

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -4,6 +4,7 @@ import * as Session from "./session"
 import { PartID as PartIDNs, type MessageID, type PartID, type SessionID } from "./schema"
 import type { MessageV2 } from "./message-v2"
 import type { ProviderID, ModelID } from "../provider/schema"
+import { SubagentRunWriterContext } from "./subagent-run-context"
 
 export class TooManyActive {
   readonly _tag = "TooManyActive"
@@ -88,6 +89,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
   Effect.gen(function* () {
     const session = yield* Session.Service
 
+    const withWriter = <A, E, R>(eff: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+      Effect.provideService(eff, SubagentRunWriterContext, true)
+
     const slotLocks = new Map<SessionID, Semaphore.Semaphore>()
     const activeCounts = new Map<SessionID, number>()
     const rowLocks = new Map<string, Semaphore.Semaphore>()
@@ -144,67 +148,74 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
         return got as MessageV2.SubtaskPart
       })
 
-    const start = Effect.fn("SubagentRun.start")(function* (input: StartInput) {
-      const partID = PartIDNs.ascending() as PartID
-      const now = Date.now()
-      const part = {
-        type: "subtask" as const,
-        id: partID,
-        sessionID: input.parent_session_id,
-        messageID: input.parent_message_id,
-        prompt: input.prompt,
-        description: input.description,
-        agent: input.agent,
-        model: input.model,
-        command: input.command,
-        tool_call_id: input.tool_call_id,
-        parent_session_id: input.parent_session_id,
-        parent_message_id: input.parent_message_id,
-        subagent_session_id: undefined,
-        status: "running" as const,
-        started_at: now,
-        updated_at: now,
-        recent_events: [{ type: "started" as const, at: now }],
-      } satisfies MessageV2.SubtaskPart
-      partsByToolCall.set(input.tool_call_id, {
-        sessionID: input.parent_session_id,
-        messageID: input.parent_message_id,
-        partID,
-      })
-      return yield* session.updatePart(part)
-    })
+    const start = (input: StartInput): Effect.Effect<MessageV2.SubtaskPart> =>
+      withWriter(
+        Effect.gen(function* () {
+          const partID = PartIDNs.ascending() as PartID
+          const now = Date.now()
+          const part = {
+            type: "subtask" as const,
+            id: partID,
+            sessionID: input.parent_session_id,
+            messageID: input.parent_message_id,
+            prompt: input.prompt,
+            description: input.description,
+            agent: input.agent,
+            model: input.model,
+            command: input.command,
+            tool_call_id: input.tool_call_id,
+            parent_session_id: input.parent_session_id,
+            parent_message_id: input.parent_message_id,
+            subagent_session_id: undefined,
+            status: "running" as const,
+            started_at: now,
+            updated_at: now,
+            recent_events: [{ type: "started" as const, at: now }],
+          } satisfies MessageV2.SubtaskPart
+          partsByToolCall.set(input.tool_call_id, {
+            sessionID: input.parent_session_id,
+            messageID: input.parent_message_id,
+            partID,
+          })
+          return yield* session.updatePart(part)
+        }),
+      )
 
     const patchSession = (toolCallID: string, sessionID: SessionID): Effect.Effect<void> =>
-      getRowLock(toolCallID).withPermits(1)(
-        Effect.gen(function* () {
-          const existing = yield* readPart(toolCallID).pipe(
-            Effect.catch(() => Effect.succeed(undefined)),
-          )
-          if (!existing) return
-          yield* session.updatePart({
-            ...existing,
-            subagent_session_id: sessionID,
-            updated_at: Date.now(),
-          })
-        }),
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            yield* session.updatePart({
+              ...existing,
+              subagent_session_id: sessionID,
+              updated_at: Date.now(),
+            })
+          }),
+        ),
       )
 
     const recordActivity = (
       toolCallID: string,
       activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
     ): Effect.Effect<void> =>
-      getRowLock(toolCallID).withPermits(1)(
-        Effect.gen(function* () {
-          const existing = yield* readPart(toolCallID).pipe(
-            Effect.catch(() => Effect.succeed(undefined)),
-          )
-          if (!existing) return
-          yield* session.updatePart({
-            ...existing,
-            last_activity: activity,
-            updated_at: Date.now(),
-          })
-        }),
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            yield* session.updatePart({
+              ...existing,
+              last_activity: activity,
+              updated_at: Date.now(),
+            })
+          }),
+        ),
       )
 
     const LIFECYCLE_KINDS = new Set<MessageV2.SubtaskEvent["type"]>([
@@ -217,25 +228,27 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
     ])
 
     const recordEvent = (toolCallID: string, event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
-      getRowLock(toolCallID).withPermits(1)(
-        Effect.gen(function* () {
-          const existing = yield* readPart(toolCallID).pipe(
-            Effect.catch(() => Effect.succeed(undefined)),
-          )
-          if (!existing) return
-          const merged = [...existing.recent_events, event]
-          while (merged.length > 20) {
-            const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
-            if (idx < 0) break
-            merged.splice(idx, 1)
-          }
-          merged.sort((a, b) => a.at - b.at)
-          yield* session.updatePart({
-            ...existing,
-            recent_events: merged,
-            updated_at: Date.now(),
-          })
-        }),
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            const merged = [...existing.recent_events, event]
+            while (merged.length > 20) {
+              const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
+              if (idx < 0) break
+              merged.splice(idx, 1)
+            }
+            merged.sort((a, b) => a.at - b.at)
+            yield* session.updatePart({
+              ...existing,
+              recent_events: merged,
+              updated_at: Date.now(),
+            })
+          }),
+        ),
       )
 
     const finalize = (
@@ -243,43 +256,47 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
       status: TerminalStatus,
       fields: FinalizeFields,
     ): Effect.Effect<void> =>
-      getRowLock(toolCallID).withPermits(1)(
-        Effect.gen(function* () {
-          const existing = yield* readPart(toolCallID).pipe(
-            Effect.catch(() => Effect.succeed(undefined)),
-          )
-          if (!existing) return
-          if (existing.status !== "running") return
-          yield* session.updatePart({
-            ...existing,
-            status,
-            ended_at: fields.ended_at ?? Date.now(),
-            updated_at: Date.now(),
-            ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
-            ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
-            ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
-            ...(fields.error !== undefined ? { error: fields.error } : {}),
-          })
-        }),
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            if (existing.status !== "running") return
+            yield* session.updatePart({
+              ...existing,
+              status,
+              ended_at: fields.ended_at ?? Date.now(),
+              updated_at: Date.now(),
+              ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
+              ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
+              ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
+              ...(fields.error !== undefined ? { error: fields.error } : {}),
+            })
+          }),
+        ),
       )
 
     const recordRejected = (_input: RejectedInput): Effect.Effect<MessageV2.SubtaskPart> =>
       Effect.die(new Error("SubagentRun.recordRejected: implemented in Task 11"))
 
     const setConsumed = (toolCallID: string): Effect.Effect<void> =>
-      getRowLock(toolCallID).withPermits(1)(
-        Effect.gen(function* () {
-          const existing = yield* readPart(toolCallID).pipe(
-            Effect.catch(() => Effect.succeed(undefined)),
-          )
-          if (!existing) return
-          if (existing.consumed_at) return
-          yield* session.updatePart({
-            ...existing,
-            consumed_at: Date.now(),
-            updated_at: Date.now(),
-          })
-        }),
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            if (existing.consumed_at) return
+            yield* session.updatePart({
+              ...existing,
+              consumed_at: Date.now(),
+              updated_at: Date.now(),
+            })
+          }),
+        ),
       )
 
     const read = (toolCallID: string): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -207,8 +207,36 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
         }),
       )
 
-    const recordEvent = (toolCallID: string, _event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
-      Effect.die(new Error(`SubagentRun.recordEvent for ${toolCallID}: implemented in Task 5`))
+    const LIFECYCLE_KINDS = new Set<MessageV2.SubtaskEvent["type"]>([
+      "started",
+      "completed",
+      "completed_empty",
+      "canceled_by_user",
+      "failed",
+      "consumed",
+    ])
+
+    const recordEvent = (toolCallID: string, event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
+      getRowLock(toolCallID).withPermits(1)(
+        Effect.gen(function* () {
+          const existing = yield* readPart(toolCallID).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (!existing) return
+          const merged = [...existing.recent_events, event]
+          while (merged.length > 20) {
+            const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
+            if (idx < 0) break
+            merged.splice(idx, 1)
+          }
+          merged.sort((a, b) => a.at - b.at)
+          yield* session.updatePart({
+            ...existing,
+            recent_events: merged,
+            updated_at: Date.now(),
+          })
+        }),
+      )
 
     const finalize = (
       toolCallID: string,

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -419,10 +419,18 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
     ): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
       Effect.gen(function* () {
         const all = yield* collectSubtaskParts(parentID)
-        const matches = all.filter((p) => p.subagent_session_id === subagentSessionID)
+        // Tie-break started_at on insertion index (newer scan order) so two rows started in the
+        // same millisecond — possible under burst dispatch — pick the most recently inserted
+        // row deterministically instead of the first one we happened to see.
+        const matches = all
+          .map((p, index) => ({ p, index }))
+          .filter(({ p }) => p.subagent_session_id === subagentSessionID)
         if (matches.length === 0) return yield* Effect.fail(new NotFound(subagentSessionID))
-        matches.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
-        const match = matches[0]
+        matches.sort(
+          (a, b) =>
+            (b.p.started_at ?? 0) - (a.p.started_at ?? 0) || b.index - a.index,
+        )
+        const match = matches[0].p
         // Refresh the in-memory index so subsequent `setConsumed` / `recordEvent` on this row
         // hit the fast path. Without this, `agent_output` finding a row by subagent_session_id
         // after a host restart would fail to mark it consumed (withExistingPart's NotFound
@@ -443,9 +451,16 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
     ): Effect.Effect<MessageV2.SubtaskPart[]> =>
       Effect.gen(function* () {
         const all = yield* collectSubtaskParts(parentID)
-        const filtered = all.filter((p) => matchesFilter(p, filter.status))
-        filtered.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
-        return filtered.slice(0, filter.limit)
+        // Same tie-break rationale as findLatestBySessionID — burst dispatch can collide on
+        // started_at, so secondary-sort on insertion index for deterministic newest-first order.
+        const filtered = all
+          .map((p, index) => ({ p, index }))
+          .filter(({ p }) => matchesFilter(p, filter.status))
+        filtered.sort(
+          (a, b) =>
+            (b.p.started_at ?? 0) - (a.p.started_at ?? 0) || b.index - a.index,
+        )
+        return filtered.slice(0, filter.limit).map(({ p }) => p)
       })
 
     return Service.of({

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -337,17 +337,49 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
     const read = (toolCallID: string): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
       readPart(toolCallID)
 
+    const collectSubtaskParts = (parentID: SessionID): Effect.Effect<MessageV2.SubtaskPart[]> =>
+      Effect.gen(function* () {
+        const messages = yield* session.messages({ sessionID: parentID })
+        const parts: MessageV2.SubtaskPart[] = []
+        for (const m of messages) {
+          for (const p of m.parts) {
+            if (p.type === "subtask") parts.push(p)
+          }
+        }
+        return parts
+      })
+
+    const matchesFilter = (
+      part: MessageV2.SubtaskPart,
+      filter: AgentListFilter,
+    ): boolean => {
+      if (filter === "all") return true
+      if (filter === "all_active") return part.status === "running" || !part.consumed_at
+      return part.status === filter
+    }
+
     const findLatestBySessionID = (
-      _parentID: SessionID,
-      _subagentSessionID: SessionID,
+      parentID: SessionID,
+      subagentSessionID: SessionID,
     ): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
-      Effect.die(new Error("SubagentRun.findLatestBySessionID: implemented in Task 13"))
+      Effect.gen(function* () {
+        const all = yield* collectSubtaskParts(parentID)
+        const matches = all.filter((p) => p.subagent_session_id === subagentSessionID)
+        if (matches.length === 0) return yield* Effect.fail(new NotFound(subagentSessionID))
+        matches.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
+        return matches[0]
+      })
 
     const list = (
-      _parentID: SessionID,
-      _filter: { status: AgentListFilter; limit: number },
+      parentID: SessionID,
+      filter: { status: AgentListFilter; limit: number },
     ): Effect.Effect<MessageV2.SubtaskPart[]> =>
-      Effect.die(new Error("SubagentRun.list: implemented in Task 12"))
+      Effect.gen(function* () {
+        const all = yield* collectSubtaskParts(parentID)
+        const filtered = all.filter((p) => matchesFilter(p, filter.status))
+        filtered.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
+        return filtered.slice(0, filter.limit)
+      })
 
     return Service.of({
       reserveSlot,

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -153,7 +153,7 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
           partID: ref.partID,
         })
         if (!got || got.type !== "subtask") return yield* Effect.fail(new NotFound(toolCallID))
-        return got as MessageV2.SubtaskPart
+        return hydrateSubtask(got as MessageV2.SubtaskPart)
       })
 
     // DRY shell for "read row, no-op if missing, then write under row mutex with writer context".
@@ -382,13 +382,23 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
         ),
       )
 
+    // Coerces lifecycle defaults that the SubtaskPart zod schema would have applied during a
+    // parse pass. Necessary because MessageV2.parts() returns `row.data as Part` without parsing,
+    // so legacy rows persisted before this PR can reach list/output as `status === undefined`.
+    // Without this, agent_list renders "undefined (unread)" for old subtask rows.
+    const hydrateSubtask = (p: MessageV2.SubtaskPart): MessageV2.SubtaskPart => ({
+      ...p,
+      status: p.status ?? "completed",
+      recent_events: p.recent_events ?? [],
+    })
+
     const collectSubtaskParts = (parentID: SessionID): Effect.Effect<MessageV2.SubtaskPart[]> =>
       Effect.gen(function* () {
         const messages = yield* session.messages({ sessionID: parentID })
         const parts: MessageV2.SubtaskPart[] = []
         for (const m of messages) {
           for (const p of m.parts) {
-            if (p.type === "subtask") parts.push(p)
+            if (p.type === "subtask") parts.push(hydrateSubtask(p))
           }
         }
         return parts

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -25,7 +25,6 @@ export interface StartInput {
   description: string
   prompt: string
   agent: string
-  subagent_type: string
   command?: string
   model?: { providerID: ProviderID; modelID: ModelID }
 }
@@ -45,7 +44,6 @@ export interface RejectedInput {
   description: string
   prompt: string
   agent: string
-  subagent_type: string
   command?: string
   model?: { providerID: ProviderID; modelID: ModelID }
   reason: string

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -1,5 +1,4 @@
 import { Context, Effect, Layer, Semaphore } from "effect"
-import { Bus } from "../bus"
 import * as Session from "./session"
 import { PartID as PartIDNs, type MessageID, type PartID, type SessionID } from "./schema"
 import type { MessageV2 } from "./message-v2"
@@ -70,6 +69,15 @@ export interface Interface {
   readonly recordRejected: (input: RejectedInput) => Effect.Effect<MessageV2.SubtaskPart>
   readonly setConsumed: (toolCallID: string) => Effect.Effect<void>
   readonly read: (toolCallID: string) => Effect.Effect<MessageV2.SubtaskPart, NotFound>
+  /**
+   * Same as `read` but falls back to scanning the parent session's persisted parts when the
+   * in-memory tool_call_id index misses (e.g., after a host restart). agent_output uses this
+   * path so `agent_output { tool_call_id }` keeps working across restarts.
+   */
+  readonly readByToolCallID: (
+    parentID: SessionID,
+    toolCallID: string,
+  ) => Effect.Effect<MessageV2.SubtaskPart, NotFound>
   readonly findLatestBySessionID: (
     parentID: SessionID,
     subagentSessionID: SessionID,
@@ -84,7 +92,7 @@ export class Service extends Context.Service<Service, Interface>()("@pawwork/Sub
 
 const MAX_ACTIVE = 5
 
-export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> = Layer.effect(
+export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const session = yield* Session.Service
@@ -148,6 +156,26 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
         return got as MessageV2.SubtaskPart
       })
 
+    // DRY shell for "read row, no-op if missing, then write under row mutex with writer context".
+    // All single-row mutators reuse this so the catch surface is uniform: NotFound (row missing
+    // from both cache and persistence) becomes a silent no-op; non-NotFound failures (storage
+    // errors, etc.) propagate as defects rather than getting swallowed as a missing row.
+    const withExistingPart = (
+      toolCallID: string,
+      mutate: (existing: MessageV2.SubtaskPart) => Effect.Effect<void>,
+    ): Effect.Effect<void> =>
+      withWriter(
+        getRowLock(toolCallID).withPermits(1)(
+          Effect.gen(function* () {
+            const existing = yield* readPart(toolCallID).pipe(
+              Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
+            )
+            if (!existing) return
+            yield* mutate(existing)
+          }),
+        ),
+      )
+
     const start = (input: StartInput): Effect.Effect<MessageV2.SubtaskPart> =>
       withWriter(
         Effect.gen(function* () {
@@ -182,40 +210,24 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
       )
 
     const patchSession = (toolCallID: string, sessionID: SessionID): Effect.Effect<void> =>
-      withWriter(
-        getRowLock(toolCallID).withPermits(1)(
-          Effect.gen(function* () {
-            const existing = yield* readPart(toolCallID).pipe(
-              Effect.catch(() => Effect.succeed(undefined)),
-            )
-            if (!existing) return
-            yield* session.updatePart({
-              ...existing,
-              subagent_session_id: sessionID,
-              updated_at: Date.now(),
-            })
-          }),
-        ),
+      withExistingPart(toolCallID, (existing) =>
+        session.updatePart({
+          ...existing,
+          subagent_session_id: sessionID,
+          updated_at: Date.now(),
+        }).pipe(Effect.asVoid),
       )
 
     const recordActivity = (
       toolCallID: string,
       activity: NonNullable<MessageV2.SubtaskPart["last_activity"]>,
     ): Effect.Effect<void> =>
-      withWriter(
-        getRowLock(toolCallID).withPermits(1)(
-          Effect.gen(function* () {
-            const existing = yield* readPart(toolCallID).pipe(
-              Effect.catch(() => Effect.succeed(undefined)),
-            )
-            if (!existing) return
-            yield* session.updatePart({
-              ...existing,
-              last_activity: activity,
-              updated_at: Date.now(),
-            })
-          }),
-        ),
+      withExistingPart(toolCallID, (existing) =>
+        session.updatePart({
+          ...existing,
+          last_activity: activity,
+          updated_at: Date.now(),
+        }).pipe(Effect.asVoid),
       )
 
     const LIFECYCLE_KINDS = new Set<MessageV2.SubtaskEvent["type"]>([
@@ -228,27 +240,26 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
     ])
 
     const recordEvent = (toolCallID: string, event: MessageV2.SubtaskEvent): Effect.Effect<void> =>
-      withWriter(
-        getRowLock(toolCallID).withPermits(1)(
-          Effect.gen(function* () {
-            const existing = yield* readPart(toolCallID).pipe(
-              Effect.catch(() => Effect.succeed(undefined)),
-            )
-            if (!existing) return
-            const merged = [...existing.recent_events, event]
-            while (merged.length > 20) {
-              const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
-              if (idx < 0) break
-              merged.splice(idx, 1)
-            }
-            merged.sort((a, b) => a.at - b.at)
-            yield* session.updatePart({
-              ...existing,
-              recent_events: merged,
-              updated_at: Date.now(),
-            })
-          }),
-        ),
+      withExistingPart(toolCallID, (existing) =>
+        Effect.gen(function* () {
+          const merged = [...existing.recent_events, event]
+          // First pass: prefer evicting non-lifecycle (progress) events from the front.
+          while (merged.length > 20) {
+            const idx = merged.findIndex((e) => !LIFECYCLE_KINDS.has(e.type))
+            if (idx < 0) break
+            merged.splice(idx, 1)
+          }
+          // Hard cap: if all 20 entries are lifecycle and a 21st arrives, evict the oldest
+          // lifecycle entry so SubtaskEvent.array().max(20) cannot be violated on next decode.
+          while (merged.length > 20) merged.shift()
+          // Sort after eviction so chronological order is preserved across lifecycle/progress.
+          merged.sort((a, b) => a.at - b.at)
+          yield* session.updatePart({
+            ...existing,
+            recent_events: merged,
+            updated_at: Date.now(),
+          })
+        }),
       )
 
     const finalize = (
@@ -256,26 +267,20 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
       status: TerminalStatus,
       fields: FinalizeFields,
     ): Effect.Effect<void> =>
-      withWriter(
-        getRowLock(toolCallID).withPermits(1)(
-          Effect.gen(function* () {
-            const existing = yield* readPart(toolCallID).pipe(
-              Effect.catch(() => Effect.succeed(undefined)),
-            )
-            if (!existing) return
-            if (existing.status !== "running") return
-            yield* session.updatePart({
-              ...existing,
-              status,
-              ended_at: fields.ended_at ?? Date.now(),
-              updated_at: Date.now(),
-              ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
-              ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
-              ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
-              ...(fields.error !== undefined ? { error: fields.error } : {}),
-            })
-          }),
-        ),
+      withExistingPart(toolCallID, (existing) =>
+        Effect.gen(function* () {
+          if (existing.status !== "running") return
+          yield* session.updatePart({
+            ...existing,
+            status,
+            ended_at: fields.ended_at ?? Date.now(),
+            updated_at: Date.now(),
+            ...(fields.result_text !== undefined ? { result_text: fields.result_text } : {}),
+            ...(fields.result_summary !== undefined ? { result_summary: fields.result_summary } : {}),
+            ...(fields.partial_result !== undefined ? { partial_result: fields.partial_result } : {}),
+            ...(fields.error !== undefined ? { error: fields.error } : {}),
+          })
+        }),
       )
 
     const recordRejected = (input: RejectedInput): Effect.Effect<MessageV2.SubtaskPart> =>
@@ -317,25 +322,41 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
       )
 
     const setConsumed = (toolCallID: string): Effect.Effect<void> =>
-      withWriter(
-        getRowLock(toolCallID).withPermits(1)(
-          Effect.gen(function* () {
-            const existing = yield* readPart(toolCallID).pipe(
-              Effect.catch(() => Effect.succeed(undefined)),
-            )
-            if (!existing) return
-            if (existing.consumed_at) return
-            yield* session.updatePart({
-              ...existing,
-              consumed_at: Date.now(),
-              updated_at: Date.now(),
-            })
-          }),
-        ),
+      withExistingPart(toolCallID, (existing) =>
+        Effect.gen(function* () {
+          if (existing.consumed_at) return
+          yield* session.updatePart({
+            ...existing,
+            consumed_at: Date.now(),
+            updated_at: Date.now(),
+          })
+        }),
       )
 
     const read = (toolCallID: string): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
       readPart(toolCallID)
+
+    const readByToolCallID = (
+      parentID: SessionID,
+      toolCallID: string,
+    ): Effect.Effect<MessageV2.SubtaskPart, NotFound> =>
+      readPart(toolCallID).pipe(
+        Effect.catchTag("NotFound", () =>
+          Effect.gen(function* () {
+            const all = yield* collectSubtaskParts(parentID)
+            const match = all.find((p) => p.tool_call_id === toolCallID)
+            if (!match) return yield* Effect.fail(new NotFound(toolCallID))
+            // Refresh the in-memory index so subsequent reads/writes from the same process hit
+            // the fast path. Best-effort: a row reachable via persistence has stable identity.
+            partsByToolCall.set(toolCallID, {
+              sessionID: match.sessionID,
+              messageID: match.messageID,
+              partID: match.id,
+            })
+            return match
+          }),
+        ),
+      )
 
     const collectSubtaskParts = (parentID: SessionID): Effect.Effect<MessageV2.SubtaskPart[]> =>
       Effect.gen(function* () {
@@ -392,6 +413,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
       recordRejected,
       setConsumed,
       read,
+      readByToolCallID,
       findLatestBySessionID,
       list,
     })
@@ -399,7 +421,6 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
 )
 
 export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(
-  Layer.provide(Bus.layer),
   Layer.provide(Session.defaultLayer),
 )
 

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -278,8 +278,43 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Session.Service> =
         ),
       )
 
-    const recordRejected = (_input: RejectedInput): Effect.Effect<MessageV2.SubtaskPart> =>
-      Effect.die(new Error("SubagentRun.recordRejected: implemented in Task 11"))
+    const recordRejected = (input: RejectedInput): Effect.Effect<MessageV2.SubtaskPart> =>
+      withWriter(
+        Effect.gen(function* () {
+          const partID = PartIDNs.ascending() as PartID
+          const now = Date.now()
+          const part = {
+            type: "subtask" as const,
+            id: partID,
+            sessionID: input.parent_session_id,
+            messageID: input.parent_message_id,
+            prompt: input.prompt,
+            description: input.description,
+            agent: input.agent,
+            model: input.model,
+            command: input.command,
+            tool_call_id: input.tool_call_id,
+            parent_session_id: input.parent_session_id,
+            parent_message_id: input.parent_message_id,
+            subagent_session_id: undefined,
+            status: "failed" as const,
+            started_at: now,
+            updated_at: now,
+            ended_at: now,
+            recent_events: [
+              { type: "started" as const, at: now },
+              { type: "failed" as const, kind: "too_many_active", at: now },
+            ],
+            error: { kind: "too_many_active", message: input.reason },
+          } satisfies MessageV2.SubtaskPart
+          partsByToolCall.set(input.tool_call_id, {
+            sessionID: input.parent_session_id,
+            messageID: input.parent_message_id,
+            partID,
+          })
+          return yield* session.updatePart(part)
+        }),
+      )
 
     const setConsumed = (toolCallID: string): Effect.Effect<void> =>
       withWriter(

--- a/packages/opencode/src/session/subagent-run.ts
+++ b/packages/opencode/src/session/subagent-run.ts
@@ -397,7 +397,19 @@ export const layer: Layer.Layer<Service, never, Session.Service> = Layer.effect(
         const matches = all.filter((p) => p.subagent_session_id === subagentSessionID)
         if (matches.length === 0) return yield* Effect.fail(new NotFound(subagentSessionID))
         matches.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
-        return matches[0]
+        const match = matches[0]
+        // Refresh the in-memory index so subsequent `setConsumed` / `recordEvent` on this row
+        // hit the fast path. Without this, `agent_output` finding a row by subagent_session_id
+        // after a host restart would fail to mark it consumed (withExistingPart's NotFound
+        // no-op path swallows the mutation).
+        if (match.tool_call_id) {
+          partsByToolCall.set(match.tool_call_id, {
+            sessionID: match.sessionID,
+            messageID: match.messageID,
+            partID: match.id,
+          })
+        }
+        return match
       })
 
     const list = (

--- a/packages/opencode/src/tool/agent-list.ts
+++ b/packages/opencode/src/tool/agent-list.ts
@@ -34,7 +34,7 @@ const formatRow = (p: MessageV2.SubtaskPart, now: number): string => {
   const elapsed = isLegacy ? "-" : formatElapsed(now - (p.started_at ?? now))
   const statusLabel =
     p.status === "running" ? "running" : p.consumed_at ? p.status : `${p.status} (unread)`
-  const activity = p.last_activity?.label ?? p.result_summary ?? (isLegacy ? "(legacy)" : "")
+  const activity = p.result_summary ?? (isLegacy ? "(legacy)" : "")
   return [
     p.subagent_session_id ?? "-",
     statusLabel,

--- a/packages/opencode/src/tool/agent-list.ts
+++ b/packages/opencode/src/tool/agent-list.ts
@@ -1,8 +1,20 @@
-import z from "zod"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { SubagentRun } from "../session/subagent-run"
 import type { MessageV2 } from "../session/message-v2"
+
+export const Parameters = Schema.Struct({
+  status: Schema.Literals([
+    "running",
+    "completed",
+    "completed_empty",
+    "failed",
+    "canceled_by_user",
+    "all_active",
+    "all",
+  ]).pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed("all_active" as const))),
+  limit: Schema.Number.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(5))),
+})
 
 const formatElapsed = (ms: number): string => {
   if (ms <= 0) return "0s"
@@ -38,20 +50,7 @@ export const AgentListTool = Tool.define(
     return {
       description:
         "List subagents launched by this parent session. Filter by lifecycle status; default `all_active` shows running plus unread terminal rows.",
-      parameters: z.object({
-        status: z
-          .enum([
-            "running",
-            "completed",
-            "completed_empty",
-            "failed",
-            "canceled_by_user",
-            "all_active",
-            "all",
-          ])
-          .default("all_active"),
-        limit: z.number().int().min(1).max(50).default(5),
-      }),
+      parameters: Parameters,
       execute: (
         params: { status: SubagentRun.AgentListFilter; limit: number },
         ctx: Tool.Context,

--- a/packages/opencode/src/tool/agent-list.ts
+++ b/packages/opencode/src/tool/agent-list.ts
@@ -17,7 +17,9 @@ export const Parameters = Schema.Struct({
 })
 
 const formatElapsed = (ms: number): string => {
-  if (ms <= 0) return "0s"
+  // Negative durations imply clock skew (started_at in the future). Surface "-" so the
+  // anomaly is visible instead of silently rendered as 0s.
+  if (ms < 0) return "-"
   const s = Math.floor(ms / 1000)
   if (s < 3600) return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}s`
   const h = Math.floor(s / 3600)

--- a/packages/opencode/src/tool/agent-list.ts
+++ b/packages/opencode/src/tool/agent-list.ts
@@ -1,0 +1,74 @@
+import z from "zod"
+import { Effect } from "effect"
+import * as Tool from "./tool"
+import { SubagentRun } from "../session/subagent-run"
+import type { MessageV2 } from "../session/message-v2"
+
+const formatElapsed = (ms: number): string => {
+  if (ms <= 0) return "0s"
+  const s = Math.floor(ms / 1000)
+  if (s < 3600) return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}s`
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  return `${h}h${String(m).padStart(2, "0")}`
+}
+
+const truncateActivity = (s: string): string => (s.length > 60 ? s.slice(0, 59) + "…" : s)
+
+const formatRow = (p: MessageV2.SubtaskPart, now: number): string => {
+  const isLegacy = !p.tool_call_id || !p.started_at
+  const elapsed = isLegacy ? "-" : formatElapsed(now - (p.started_at ?? now))
+  const statusLabel =
+    p.status === "running" ? "running" : p.consumed_at ? p.status : `${p.status} (unread)`
+  const activity = p.last_activity?.label ?? p.result_summary ?? (isLegacy ? "(legacy)" : "")
+  return [
+    p.subagent_session_id ?? "-",
+    statusLabel,
+    p.description,
+    `latest: ${truncateActivity(activity)}`,
+    elapsed,
+  ].join(" | ")
+}
+
+export const AgentListTool = Tool.define(
+  "agent_list",
+  Effect.gen(function* () {
+    const subagentRun = yield* SubagentRun.Service
+
+    return {
+      description:
+        "List subagents launched by this parent session. Filter by lifecycle status; default `all_active` shows running plus unread terminal rows.",
+      parameters: z.object({
+        status: z
+          .enum([
+            "running",
+            "completed",
+            "completed_empty",
+            "failed",
+            "canceled_by_user",
+            "all_active",
+            "all",
+          ])
+          .default("all_active"),
+        limit: z.number().int().min(1).max(50).default(5),
+      }),
+      execute: (
+        params: { status: SubagentRun.AgentListFilter; limit: number },
+        ctx: Tool.Context,
+      ) =>
+        Effect.gen(function* () {
+          const rows = yield* subagentRun.list(ctx.sessionID, {
+            status: params.status,
+            limit: params.limit,
+          })
+          const now = Date.now()
+          const lines = rows.map((p) => formatRow(p, now))
+          return {
+            title: "agent_list",
+            metadata: { count: rows.length, status: params.status },
+            output: lines.length > 0 ? lines.join("\n") : "(no subagents match this filter)",
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/agent-output.ts
+++ b/packages/opencode/src/tool/agent-output.ts
@@ -41,7 +41,10 @@ const formatTranscript = (p: MessageV2.SubtaskPart): string => {
   // canceled_by_user rows still surface their preserved partial under detail=transcript.
   const body = p.result_text ?? p.partial_result ?? null
   if (body) {
-    const trimmed = body.length > 1000 ? body.slice(0, 1000) + "…(truncated)" : body
+    const trimmed =
+      body.length > 1000
+        ? `${body.slice(0, 1000)}…(truncated, ${body.length} chars total)`
+        : body
     lines.push(`result: ${trimmed}`)
   }
   return lines.join("\n")
@@ -74,21 +77,28 @@ export const AgentOutputTool = Tool.define(
               new Error("exactly one of subagent_session_id or tool_call_id is required"),
             )
           }
-          const NOT_FOUND = new Error("subagent not found or not accessible from this parent")
+          // Narrow catch: only "row not found" maps to a clean not-found response. Storage errors,
+          // schema decode failures, and other defects propagate via Effect.orDie so the model sees
+          // a real defect instead of a misleading "not found".
           const row = params.tool_call_id
             ? yield* subagentRun
                 .readByToolCallID(ctx.sessionID, params.tool_call_id)
-                .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
+                .pipe(Effect.catchTag("NotFound", () => Effect.succeed(null as MessageV2.SubtaskPart | null)))
             : yield* subagentRun
                 .findLatestBySessionID(ctx.sessionID, params.subagent_session_id! as SessionID)
-                .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
-          if (!row || !row.tool_call_id) return yield* Effect.fail(NOT_FOUND)
-          if (row.parent_session_id !== ctx.sessionID) return yield* Effect.fail(NOT_FOUND)
+                .pipe(Effect.catchTag("NotFound", () => Effect.succeed(null as MessageV2.SubtaskPart | null)))
+          if (!row || !row.tool_call_id)
+            return yield* Effect.fail(new Error("subagent not found or not accessible from this parent"))
+          if (row.parent_session_id !== ctx.sessionID)
+            return yield* Effect.fail(new Error("subagent not found or not accessible from this parent"))
           if (row.subagent_session_id) {
+            // session.get throws NotFoundError, which Effect.gen wraps as a defect (Cause.Die),
+            // not a typed failure. catchCause is required to convert it back to a clean response.
             const child = yield* sessions
               .get(row.subagent_session_id as SessionID)
-              .pipe(Effect.catch(() => Effect.succeed(null)))
-            if (!child || !child.createdByAgentTool) return yield* Effect.fail(NOT_FOUND)
+              .pipe(Effect.catchCause(() => Effect.succeed(null)))
+            if (!child || !child.createdByAgentTool)
+              return yield* Effect.fail(new Error("subagent not found or not accessible from this parent"))
           }
           if (row.status !== "running" && !row.consumed_at) {
             yield* subagentRun.setConsumed(row.tool_call_id)

--- a/packages/opencode/src/tool/agent-output.ts
+++ b/packages/opencode/src/tool/agent-output.ts
@@ -1,4 +1,5 @@
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
+import { NotFoundError } from "../storage/db"
 import * as Tool from "./tool"
 import { Session } from "../session"
 import type { SessionID } from "../session/schema"
@@ -16,7 +17,7 @@ export const Parameters = Schema.Struct({
 
 const formatResult = (p: MessageV2.SubtaskPart): string => {
   if (p.status === "running") {
-    return [`status: running`, `latest: ${p.last_activity?.label ?? "-"}`].join("\n")
+    return [`status: running`, `summary: ${p.result_summary ?? "-"}`].join("\n")
   }
   if (p.status === "failed") {
     return [
@@ -43,7 +44,6 @@ const formatTranscript = (p: MessageV2.SubtaskPart): string => {
     `summary: ${p.result_summary ?? "-"}`,
     `events: ${p.recent_events.length}`,
     `child_session: ${p.subagent_session_id ?? "-"}`,
-    `latest: ${p.last_activity?.label ?? "-"}`,
   ]
   // Mirror formatResult's fallback chain: prefer result_text, then partial_result, so
   // canceled_by_user rows still surface their preserved partial under detail=transcript.
@@ -100,11 +100,19 @@ export const AgentOutputTool = Tool.define(
           if (row.parent_session_id !== ctx.sessionID)
             return yield* Effect.fail(new Error("subagent not found or not accessible from this parent"))
           if (row.subagent_session_id) {
-            // session.get throws NotFoundError, which Effect.gen wraps as a defect (Cause.Die),
-            // not a typed failure. catchCause is required to convert it back to a clean response.
+            // session.get throws NotFoundError as a defect (Cause.Die). Suppress only that case;
+            // re-raise any other defect (storage I/O, schema decode) so it isn't masked as a clean
+            // not-found response.
             const child = yield* sessions
               .get(row.subagent_session_id as SessionID)
-              .pipe(Effect.catchCause(() => Effect.succeed(null)))
+              .pipe(
+                Effect.catchCause((cause) => {
+                  const err = Cause.squash(cause)
+                  return err instanceof NotFoundError
+                    ? Effect.succeed(null)
+                    : Effect.failCause(cause)
+                }),
+              )
             if (!child || !child.createdByAgentTool)
               return yield* Effect.fail(new Error("subagent not found or not accessible from this parent"))
           }

--- a/packages/opencode/src/tool/agent-output.ts
+++ b/packages/opencode/src/tool/agent-output.ts
@@ -25,6 +25,14 @@ const formatResult = (p: MessageV2.SubtaskPart): string => {
       `error.message: ${p.error?.message ?? ""}`,
     ].join("\n")
   }
+  if (p.status === "canceled_by_user") {
+    // Prefix with the terminal state so the model never mistakes a cancellation for a normal
+    // completion. Body still surfaces partial output when the runner captured it.
+    return [
+      `status: canceled_by_user`,
+      p.partial_result ? `partial_result:\n${p.partial_result}` : `(no partial output)`,
+    ].join("\n")
+  }
   if (p.status === "completed_empty") return "status: completed_empty\n(no output)"
   return p.result_text ?? p.partial_result ?? ""
 }

--- a/packages/opencode/src/tool/agent-output.ts
+++ b/packages/opencode/src/tool/agent-output.ts
@@ -1,10 +1,18 @@
-import z from "zod"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { Session } from "../session"
 import type { SessionID } from "../session/schema"
 import { SubagentRun } from "../session/subagent-run"
 import type { MessageV2 } from "../session/message-v2"
+
+export const Parameters = Schema.Struct({
+  subagent_session_id: Schema.optional(Schema.String),
+  tool_call_id: Schema.optional(Schema.String),
+  detail: Schema.Literals(["result", "transcript"]).pipe(
+    Schema.optional,
+    Schema.withDecodingDefault(Effect.succeed("result" as const)),
+  ),
+})
 
 const formatResult = (p: MessageV2.SubtaskPart): string => {
   if (p.status === "running") {
@@ -29,10 +37,11 @@ const formatTranscript = (p: MessageV2.SubtaskPart): string => {
     `child_session: ${p.subagent_session_id ?? "-"}`,
     `latest: ${p.last_activity?.label ?? "-"}`,
   ]
-  if (p.result_text) {
-    const trimmed = p.result_text.length > 1000
-      ? p.result_text.slice(0, 1000) + "…(truncated)"
-      : p.result_text
+  // Mirror formatResult's fallback chain: prefer result_text, then partial_result, so
+  // canceled_by_user rows still surface their preserved partial under detail=transcript.
+  const body = p.result_text ?? p.partial_result ?? null
+  if (body) {
+    const trimmed = body.length > 1000 ? body.slice(0, 1000) + "…(truncated)" : body
     lines.push(`result: ${trimmed}`)
   }
   return lines.join("\n")
@@ -47,16 +56,7 @@ export const AgentOutputTool = Tool.define(
     return {
       description:
         "Read a subagent's result or transcript preview. Pass exactly one of subagent_session_id or tool_call_id; reading a terminal row marks it consumed.",
-      parameters: z
-        .object({
-          subagent_session_id: z.string().optional(),
-          tool_call_id: z.string().optional(),
-          detail: z.enum(["result", "transcript"]).default("result"),
-        })
-        .refine(
-          (v) => Boolean(v.subagent_session_id) !== Boolean(v.tool_call_id),
-          { message: "exactly one of subagent_session_id or tool_call_id is required" },
-        ),
+      parameters: Parameters,
       execute: (
         params: {
           subagent_session_id?: string
@@ -66,11 +66,19 @@ export const AgentOutputTool = Tool.define(
         ctx: Tool.Context,
       ) =>
         Effect.gen(function* () {
+          // XOR validation on subagent_session_id / tool_call_id. Schema-level filter is awkward
+          // in Effect Schema 4 beta; doing it imperatively at the entry of execute keeps the
+          // error message clear while still rejecting both-or-neither at runtime.
+          if (Boolean(params.subagent_session_id) === Boolean(params.tool_call_id)) {
+            return yield* Effect.fail(
+              new Error("exactly one of subagent_session_id or tool_call_id is required"),
+            )
+          }
           const NOT_FOUND = new Error("subagent not found or not accessible from this parent")
           const row = params.tool_call_id
-            ? yield* subagentRun.read(params.tool_call_id).pipe(
-                Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)),
-              )
+            ? yield* subagentRun
+                .readByToolCallID(ctx.sessionID, params.tool_call_id)
+                .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
             : yield* subagentRun
                 .findLatestBySessionID(ctx.sessionID, params.subagent_session_id! as SessionID)
                 .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))

--- a/packages/opencode/src/tool/agent-output.ts
+++ b/packages/opencode/src/tool/agent-output.ts
@@ -1,0 +1,93 @@
+import z from "zod"
+import { Effect } from "effect"
+import * as Tool from "./tool"
+import { Session } from "../session"
+import type { SessionID } from "../session/schema"
+import { SubagentRun } from "../session/subagent-run"
+import type { MessageV2 } from "../session/message-v2"
+
+const formatResult = (p: MessageV2.SubtaskPart): string => {
+  if (p.status === "running") {
+    return [`status: running`, `latest: ${p.last_activity?.label ?? "-"}`].join("\n")
+  }
+  if (p.status === "failed") {
+    return [
+      `status: failed`,
+      `error.kind: ${p.error?.kind ?? "unknown"}`,
+      `error.message: ${p.error?.message ?? ""}`,
+    ].join("\n")
+  }
+  if (p.status === "completed_empty") return "status: completed_empty\n(no output)"
+  return p.result_text ?? p.partial_result ?? ""
+}
+
+const formatTranscript = (p: MessageV2.SubtaskPart): string => {
+  const lines = [
+    `status: ${p.status}`,
+    `summary: ${p.result_summary ?? "-"}`,
+    `events: ${p.recent_events.length}`,
+    `child_session: ${p.subagent_session_id ?? "-"}`,
+    `latest: ${p.last_activity?.label ?? "-"}`,
+  ]
+  if (p.result_text) {
+    const trimmed = p.result_text.length > 1000
+      ? p.result_text.slice(0, 1000) + "…(truncated)"
+      : p.result_text
+    lines.push(`result: ${trimmed}`)
+  }
+  return lines.join("\n")
+}
+
+export const AgentOutputTool = Tool.define(
+  "agent_output",
+  Effect.gen(function* () {
+    const subagentRun = yield* SubagentRun.Service
+    const sessions = yield* Session.Service
+
+    return {
+      description:
+        "Read a subagent's result or transcript preview. Pass exactly one of subagent_session_id or tool_call_id; reading a terminal row marks it consumed.",
+      parameters: z
+        .object({
+          subagent_session_id: z.string().optional(),
+          tool_call_id: z.string().optional(),
+          detail: z.enum(["result", "transcript"]).default("result"),
+        })
+        .refine(
+          (v) => Boolean(v.subagent_session_id) !== Boolean(v.tool_call_id),
+          { message: "exactly one of subagent_session_id or tool_call_id is required" },
+        ),
+      execute: (
+        params: {
+          subagent_session_id?: string
+          tool_call_id?: string
+          detail: "result" | "transcript"
+        },
+        ctx: Tool.Context,
+      ) =>
+        Effect.gen(function* () {
+          const NOT_FOUND = new Error("subagent not found or not accessible from this parent")
+          const row = params.tool_call_id
+            ? yield* subagentRun.read(params.tool_call_id).pipe(
+                Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)),
+              )
+            : yield* subagentRun
+                .findLatestBySessionID(ctx.sessionID, params.subagent_session_id! as SessionID)
+                .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
+          if (!row || !row.tool_call_id) return yield* Effect.fail(NOT_FOUND)
+          if (row.parent_session_id !== ctx.sessionID) return yield* Effect.fail(NOT_FOUND)
+          if (row.subagent_session_id) {
+            const child = yield* sessions
+              .get(row.subagent_session_id as SessionID)
+              .pipe(Effect.catch(() => Effect.succeed(null)))
+            if (!child || !child.createdByAgentTool) return yield* Effect.fail(NOT_FOUND)
+          }
+          if (row.status !== "running" && !row.consumed_at) {
+            yield* subagentRun.setConsumed(row.tool_call_id)
+          }
+          const output = params.detail === "result" ? formatResult(row) : formatTranscript(row)
+          return { title: "agent_output", metadata: { status: row.status }, output }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -432,7 +432,7 @@ export const AgentTool = Tool.define(
                   .pipe(Effect.catchTag("NotFound", () => Effect.succeed(null as MessageV2.SubtaskPart | null)))
                 if (current?.status === "running") {
                   yield* subagentRun.finalize(ctx.callID!, "failed", {
-                    error: { kind: "execution_error", message: errorMessage(cause) },
+                    error: { kind: "execution_error", message: errorMessage(Cause.squash(cause)) },
                     ended_at: Date.now(),
                   })
                 }

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -79,6 +79,8 @@ export const AgentTool = Tool.define(
         (yield* sessions.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${next.name} subagent)`,
+          createdByAgentTool: true,
+          subagentType: params.subagent_type,
           permission: [
             ...(canTodo
               ? []

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -45,14 +45,46 @@ const errorMessage = (e: unknown): string => {
   }
 }
 
-const truncateHead = (s: string, n: number): string => (s.length <= n ? s : s.slice(0, n))
+const truncateHead = (s: string, n: number): string => (s.length <= n ? s : s.slice(0, n) + "…")
 
-// Stub replaced in Task 10. Reads the last completed assistant text from the child session
-// (used for partial_result on cancel). Returns null when no completed text exists.
-const readLastCompletedAssistantText = (_sessionID: SessionID): Effect.Effect<string | null> =>
-  Effect.succeed(null)
+const SANITIZE_LIMIT = 200
+const STACK_RE = /\n\s+at\s+.+/g
+const PATH_RE = /\/(?:Users|home)\/[^\s)]+/g
+// Non-greedy JSON match so legitimate prose containing braces (e.g., a sanitized status header
+// quoted in an error message) is not stripped wholesale. Matches one envelope at a time.
+const JSON_ENVELOPE_RE = /\{[\s\S]+?\}/g
 
-// Stub replaced in Task 10. Renders the SubtaskPart into the tool's text output.
+const sanitizeErrorMessage = (msg: string): string =>
+  msg
+    .replace(STACK_RE, "")
+    .replace(PATH_RE, "<path>")
+    .replace(JSON_ENVELOPE_RE, "<json>")
+    .slice(0, SANITIZE_LIMIT)
+    .trim()
+
+// TextPart in message-v2.ts has no explicit state field; completion is signaled by `time.end`.
+// Conservative default: returns false when `time` or `time.end` is missing → partial_result
+// stays null on mid-token streaming aborts, which is safer than leaking a half-token.
+const isTextPartCompleted = (p: MessageV2.TextPart): boolean => p.time?.end !== undefined
+
+// Reads the child session's most recent assistant text part with stable (completed) content.
+// Used by finalizeAfter for partial_result on cancellation; returns null when no completed text
+// exists (e.g., cancellation during the first tool call or mid-token streaming abort).
+const makeReadLastCompletedAssistantText =
+  (sessions: Session.Service["Service"]) =>
+  (childID: SessionID): Effect.Effect<string | null> =>
+    Effect.gen(function* () {
+      const messages = yield* sessions.messages({ sessionID: childID, limit: 5 })
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i]
+        if (m.info.role !== "assistant") continue
+        const textParts = m.parts.filter((p): p is MessageV2.TextPart => p.type === "text")
+        const completed = textParts.findLast((p) => isTextPartCompleted(p))
+        if (completed?.text && completed.text.trim().length > 0) return completed.text
+      }
+      return null
+    })
+
 const synthesizeOutput = (
   part: MessageV2.SubtaskPart,
   childID: SessionID | undefined,
@@ -61,26 +93,57 @@ const synthesizeOutput = (
   metadata: { sessionId: SessionID | undefined; status: MessageV2.SubtaskPart["status"] }
   output: string
 } => {
-  const lines: string[] = []
-  if (part.status !== "completed") {
-    lines.push(`status: ${part.status}`)
-    if (part.error) lines.push(`error: ${part.error.kind}`)
-    lines.push("")
+  const resumeHint = childID
+    ? `subagent_session_id: ${childID} (pass this to resume the same subagent dispatch)`
+    : null
+  const wrapper = (text: string) => `<subagent_result>\n${text}\n</subagent_result>`
+
+  if (part.status === "completed") {
+    // PRESERVE the EXACT 5-line success format from the original tool: resume hint, blank,
+    // open tag, text, close tag. Existing prompt teaching depends on this shape.
+    return {
+      title: part.description,
+      metadata: { sessionId: childID, status: part.status },
+      output: [
+        resumeHint,
+        "",
+        "<subagent_result>",
+        part.result_text ?? "",
+        "</subagent_result>",
+      ]
+        .filter((x): x is string => x !== null)
+        .join("\n"),
+    }
   }
-  if (childID) {
-    lines.push(`subagent_session_id: ${childID} (pass this to resume the same subagent dispatch)`)
-    lines.push("")
+
+  let header: string
+  let body: string
+  switch (part.status) {
+    case "completed_empty":
+      header = "status: completed_empty"
+      body = wrapper("")
+      break
+    case "canceled_by_user":
+      header = "status: canceled_by_user"
+      body = wrapper(part.partial_result ?? "")
+      break
+    case "failed":
+      header = `status: failed\nerror: ${sanitizeErrorMessage(part.error?.message ?? "")}`
+      body = wrapper("")
+      break
+    case "running":
+      // Defensive: should never be returned to the model since execute waits for terminal state.
+      header = "status: running"
+      body = wrapper("")
+      break
   }
-  lines.push("<subagent_result>")
-  lines.push(part.result_text ?? part.partial_result ?? "")
-  lines.push("</subagent_result>")
+
   return {
     title: part.description,
-    metadata: {
-      sessionId: childID,
-      status: part.status,
-    },
-    output: lines.join("\n"),
+    metadata: { sessionId: childID, status: part.status },
+    output: [resumeHint, "", header, body]
+      .filter((x): x is string => x !== null)
+      .join("\n"),
   }
 }
 
@@ -91,6 +154,7 @@ export const AgentTool = Tool.define(
     const config = yield* Config.Service
     const sessions = yield* Session.Service
     const subagentRun = yield* SubagentRun.Service
+    const readLastCompletedAssistantText = makeReadLastCompletedAssistantText(sessions)
 
     const run = Effect.fn("AgentTool.execute")(function* (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) {
       const cfg = yield* config.get()

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -12,6 +12,13 @@ export interface AgentPromptOps {
   cancel(sessionID: SessionID): void
   resolvePromptParts(template: string): Effect.Effect<SessionPrompt.PromptInput["parts"]>
   prompt(input: SessionPrompt.PromptInput): Effect.Effect<MessageV2.WithParts>
+  /**
+   * After ops.prompt resolves, returns true iff the child session's runner.onInterrupt
+   * fired during execution (parent abort propagated through `cancel()`, OR a user
+   * canceled the child session directly). Returns false on natural completion or model
+   * failure. Synchronous query.
+   */
+  wasInterrupted(sessionID: SessionID): boolean
 }
 
 const id = "agent"

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -7,7 +7,8 @@ import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
 import { SubagentRun } from "../session/subagent-run"
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
+import { NotFoundError } from "../storage/db"
 
 export interface AgentPromptOps {
   cancel(sessionID: SessionID): void
@@ -39,12 +40,15 @@ const truncateHead = (s: string, n: number): string => (s.length <= n ? s : s.sl
 
 const SANITIZE_LIMIT = 200
 const STACK_RE = /\n\s+at\s+.+/g
-const PATH_RE = /\/(?:Users|home)\/[^\s)]+/g
+// Covers POSIX home paths (/Users/..., /home/...), Windows drive paths (C:\Users\...,
+// D:\projects\...), and UNC paths (\\server\share\...). All collapse to "<path>" so usernames
+// and local layout never leak into persisted SubtaskPart.error.message.
+const PATH_RE = /(?:\/(?:Users|home)\/[^\s)]+|[A-Za-z]:\\[^\s)]+|\\\\[^\s)]+)/g
 // Non-greedy JSON match so legitimate prose containing braces (e.g., a sanitized status header
 // quoted in an error message) is not stripped wholesale. Matches one envelope at a time.
 const JSON_ENVELOPE_RE = /\{[\s\S]+?\}/g
 
-const sanitizeErrorMessage = (msg: string): string =>
+export const sanitizeErrorMessage = (msg: string): string =>
   msg
     .replace(STACK_RE, "")
     .replace(PATH_RE, "<path>")
@@ -207,9 +211,15 @@ export const AgentTool = Tool.define(
           )
         }
       }
+      // sessions.get throws NotFoundError as a defect (Cause.Die). Suppress only that case so the
+      // resume path can fall through to "subagent_session_id not found"; rethrow any other defect
+      // (storage I/O, schema decode) instead of masking it as missing.
       const session = params.subagent_session_id
         ? yield* sessions.get(SessionID.make(params.subagent_session_id)).pipe(
-            Effect.catchCause(() => Effect.succeed(undefined)),
+            Effect.catchCause((cause) => {
+              const err = Cause.squash(cause)
+              return err instanceof NotFoundError ? Effect.succeed(undefined) : Effect.failCause(cause)
+            }),
           )
         : undefined
       if (params.subagent_session_id && !session) {

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -35,16 +35,6 @@ export const Parameters = Schema.Struct({
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this dispatch" }),
 })
 
-const errorMessage = (e: unknown): string => {
-  if (e instanceof Error) return e.message
-  if (typeof e === "string") return e
-  try {
-    return JSON.stringify(e)
-  } catch {
-    return String(e)
-  }
-}
-
 const truncateHead = (s: string, n: number): string => (s.length <= n ? s : s.slice(0, n) + "…")
 
 const SANITIZE_LIMIT = 200
@@ -61,6 +51,24 @@ const sanitizeErrorMessage = (msg: string): string =>
     .replace(JSON_ENVELOPE_RE, "<json>")
     .slice(0, SANITIZE_LIMIT)
     .trim()
+
+// Sanitizes at the entry point so persisted SubtaskPart.error.message never contains raw stacks,
+// paths, or JSON envelopes — agent_output reads this field directly without re-sanitizing.
+const errorMessage = (e: unknown): string => {
+  const raw =
+    e instanceof Error
+      ? e.message
+      : typeof e === "string"
+        ? e
+        : (() => {
+            try {
+              return JSON.stringify(e)
+            } catch {
+              return String(e)
+            }
+          })()
+  return sanitizeErrorMessage(raw)
+}
 
 // TextPart in message-v2.ts has no explicit state field; completion is signaled by `time.end`.
 // Conservative default: returns false when `time` or `time.end` is missing → partial_result
@@ -327,13 +335,9 @@ export const AgentTool = Tool.define(
               return synthesizeOutput(part, nextSession.id)
             }
 
-            // Idempotent finalizer. **Source of truth for "child was interrupted" is
-            // `ops.wasInterrupted(child)`** — set by SessionRunState.onInterrupt firing on the
-            // child runner. Do NOT also OR with `ctx.abort.aborted`: a parent abort that lands
-            // AFTER ops.prompt's natural success but BEFORE this handler runs would otherwise
-            // relabel a completed run as canceled_by_user and lose the result_text. The pre-
-            // aborted short-circuit above already covers the case where parent aborted before
-            // ops.prompt was invoked at all.
+            // Idempotent finalizer. `wasInterrupted` is the source of truth for cancellation;
+            // do not OR with `ctx.abort.aborted` (it can flip after natural success and relabel
+            // completed runs as canceled).
             const finalizeAfter = (
               result: { kind: "ok"; r: MessageV2.WithParts } | { kind: "err"; error: unknown },
             ) =>
@@ -404,18 +408,20 @@ export const AgentTool = Tool.define(
             const finalPart = yield* subagentRun.read(ctx.callID!)
             return synthesizeOutput(finalPart, nextSession.id)
           }).pipe(
-            Effect.catch((error) =>
+            Effect.catchCause((cause) =>
               Effect.gen(function* () {
                 const current = yield* subagentRun
                   .read(ctx.callID!)
                   .pipe(Effect.catchTag("NotFound", () => Effect.succeed(null as MessageV2.SubtaskPart | null)))
                 if (current?.status === "running") {
                   yield* subagentRun.finalize(ctx.callID!, "failed", {
-                    error: { kind: "execution_error", message: errorMessage(error) },
+                    error: { kind: "execution_error", message: errorMessage(cause) },
                     ended_at: Date.now(),
                   })
                 }
-                return yield* Effect.fail(error)
+                // Re-fail with the original cause so stack, annotations, and parallel-error
+                // metadata are preserved instead of getting flattened into Effect.fail.
+                return yield* Effect.failCause(cause)
               }),
             ),
           )

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -255,7 +255,6 @@ export const AgentTool = Tool.define(
           description: params.description,
           prompt: params.prompt,
           agent: next.name,
-          subagent_type: params.subagent_type,
           command: params.command,
           model,
           reason:
@@ -281,7 +280,6 @@ export const AgentTool = Tool.define(
               description: params.description,
               prompt: params.prompt,
               agent: next.name,
-              subagent_type: params.subagent_type,
               command: params.command,
               model,
             })

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -327,13 +327,18 @@ export const AgentTool = Tool.define(
               return synthesizeOutput(part, nextSession.id)
             }
 
-            // Idempotent finalizer: latches `interrupted` synchronously at handler entry so a
-            // late parent abort during cleanup of a real model failure cannot misclassify it.
+            // Idempotent finalizer. **Source of truth for "child was interrupted" is
+            // `ops.wasInterrupted(child)`** — set by SessionRunState.onInterrupt firing on the
+            // child runner. Do NOT also OR with `ctx.abort.aborted`: a parent abort that lands
+            // AFTER ops.prompt's natural success but BEFORE this handler runs would otherwise
+            // relabel a completed run as canceled_by_user and lose the result_text. The pre-
+            // aborted short-circuit above already covers the case where parent aborted before
+            // ops.prompt was invoked at all.
             const finalizeAfter = (
               result: { kind: "ok"; r: MessageV2.WithParts } | { kind: "err"; error: unknown },
             ) =>
               Effect.gen(function* () {
-                const interrupted = ops.wasInterrupted(nextSession.id) || ctx.abort.aborted
+                const interrupted = ops.wasInterrupted(nextSession.id)
                 const current = yield* subagentRun.read(ctx.callID!)
                 if (current.status !== "running") return
                 if (interrupted) {
@@ -365,6 +370,16 @@ export const AgentTool = Tool.define(
                 }
               })
 
+            // Wraps the success-path finalize so a transient finalize failure does not
+            // propagate to the next pipe step (Effect.catch) and re-run finalizeAfter as
+            // `kind: "err"`, which would relabel a completed run as failed. Idempotency in
+            // SubagentRun.finalize already protects the row state; this just stops the success
+            // result from being rebranded.
+            const finalizeOk = (r: MessageV2.WithParts) =>
+              finalizeAfter({ kind: "ok", r }).pipe(
+                Effect.catchCause(() => Effect.void),
+              )
+
             const parts = yield* ops.resolvePromptParts(params.prompt)
             yield* ops
               .prompt({
@@ -382,7 +397,7 @@ export const AgentTool = Tool.define(
                 parts,
               })
               .pipe(
-                Effect.tap((r) => finalizeAfter({ kind: "ok", r })),
+                Effect.tap((r) => finalizeOk(r)),
                 Effect.catch((error) => finalizeAfter({ kind: "err", error })),
               )
 
@@ -393,7 +408,7 @@ export const AgentTool = Tool.define(
               Effect.gen(function* () {
                 const current = yield* subagentRun
                   .read(ctx.callID!)
-                  .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
+                  .pipe(Effect.catchTag("NotFound", () => Effect.succeed(null as MessageV2.SubtaskPart | null)))
                 if (current?.status === "running") {
                   yield* subagentRun.finalize(ctx.callID!, "failed", {
                     error: { kind: "execution_error", message: errorMessage(error) },

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -6,6 +6,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
+import { SubagentRun } from "../session/subagent-run"
 import { Effect, Schema } from "effect"
 
 export interface AgentPromptOps {
@@ -34,15 +35,67 @@ export const Parameters = Schema.Struct({
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this dispatch" }),
 })
 
+const errorMessage = (e: unknown): string => {
+  if (e instanceof Error) return e.message
+  if (typeof e === "string") return e
+  try {
+    return JSON.stringify(e)
+  } catch {
+    return String(e)
+  }
+}
+
+const truncateHead = (s: string, n: number): string => (s.length <= n ? s : s.slice(0, n))
+
+// Stub replaced in Task 10. Reads the last completed assistant text from the child session
+// (used for partial_result on cancel). Returns null when no completed text exists.
+const readLastCompletedAssistantText = (_sessionID: SessionID): Effect.Effect<string | null> =>
+  Effect.succeed(null)
+
+// Stub replaced in Task 10. Renders the SubtaskPart into the tool's text output.
+const synthesizeOutput = (
+  part: MessageV2.SubtaskPart,
+  childID: SessionID | undefined,
+): {
+  title: string
+  metadata: { sessionId: SessionID | undefined; status: MessageV2.SubtaskPart["status"] }
+  output: string
+} => {
+  const lines: string[] = []
+  if (part.status !== "completed") {
+    lines.push(`status: ${part.status}`)
+    if (part.error) lines.push(`error: ${part.error.kind}`)
+    lines.push("")
+  }
+  if (childID) {
+    lines.push(`subagent_session_id: ${childID} (pass this to resume the same subagent dispatch)`)
+    lines.push("")
+  }
+  lines.push("<subagent_result>")
+  lines.push(part.result_text ?? part.partial_result ?? "")
+  lines.push("</subagent_result>")
+  return {
+    title: part.description,
+    metadata: {
+      sessionId: childID,
+      status: part.status,
+    },
+    output: lines.join("\n"),
+  }
+}
+
 export const AgentTool = Tool.define(
   id,
   Effect.gen(function* () {
     const agent = yield* Agent.Service
     const config = yield* Config.Service
     const sessions = yield* Session.Service
+    const subagentRun = yield* SubagentRun.Service
 
     const run = Effect.fn("AgentTool.execute")(function* (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) {
       const cfg = yield* config.get()
+
+      if (!ctx.callID) return yield* Effect.fail(new Error("AgentTool.execute requires ctx.callID"))
 
       if (!ctx.extra?.bypassAgentCheck) {
         yield* ctx.ask({
@@ -64,124 +117,233 @@ export const AgentTool = Tool.define(
       const canAgent = next.permission.some((rule) => rule.permission === id)
       const canTodo = next.permission.some((rule) => rule.permission === "todowrite")
 
-      const agentSessionID = params.subagent_session_id
-      // Validate the SessionID shape up front so a typo in subagent_session_id
-      // surfaces a clear error instead of silently falling through to "create
-      // a new session", which would lose the user's intent to resume.
-      if (agentSessionID !== undefined) {
-        const exit = Schema.decodeUnknownExit(SessionID)(agentSessionID)
+      const ops = ctx.extra?.promptOps as AgentPromptOps
+      if (!ops) return yield* Effect.fail(new Error("AgentTool requires promptOps in ctx.extra"))
+
+      const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
+      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
+
+      // Validate the SessionID shape up front so a typo in subagent_session_id surfaces a clear
+      // error instead of silently falling through to "create a fresh session", which would lose
+      // the user's intent to resume. Pulled forward from upstream's pre-refactor agent.ts.
+      if (params.subagent_session_id !== undefined) {
+        const exit = Schema.decodeUnknownExit(SessionID)(params.subagent_session_id)
         if (exit._tag === "Failure") {
           return yield* Effect.fail(
             new Error(
-              `Invalid subagent_session_id: ${JSON.stringify(agentSessionID)}. Pass a previously emitted subagent_session_id to resume, or omit the field to start a fresh dispatch.`,
+              `Invalid subagent_session_id: ${JSON.stringify(params.subagent_session_id)}. Pass a previously emitted subagent_session_id to resume, or omit the field to start a fresh dispatch.`,
             ),
           )
         }
       }
-      const session = agentSessionID
-        ? yield* sessions.get(SessionID.make(agentSessionID)).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
+      const session = params.subagent_session_id
+        ? yield* sessions.get(SessionID.make(params.subagent_session_id)).pipe(
+            Effect.catchCause(() => Effect.succeed(undefined)),
+          )
         : undefined
-      const nextSession =
-        session ??
-        (yield* sessions.create({
-          parentID: ctx.sessionID,
-          title: params.description + ` (@${next.name} subagent)`,
-          createdByAgentTool: true,
-          subagentType: params.subagent_type,
-          permission: [
-            ...(canTodo
-              ? []
-              : [
-                  {
-                    permission: "todowrite" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(canAgent
-              ? []
-              : [
-                  {
-                    permission: id,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(cfg.experimental?.primary_tools?.map((item) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: item,
-            })) ?? []),
-          ],
-        }))
-
-      const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
-      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
+      if (params.subagent_session_id && !session) {
+        return yield* Effect.fail(new Error("subagent_session_id not found"))
+      }
+      if (session) {
+        if (session.parentID !== ctx.sessionID) {
+          return yield* Effect.fail(new Error("subagent does not belong to this parent"))
+        }
+        if (!session.createdByAgentTool) {
+          return yield* Effect.fail(new Error("subagent was not created by the agent tool"))
+        }
+        if (session.subagentType !== params.subagent_type) {
+          return yield* Effect.fail(new Error("subagent_type does not match"))
+        }
+      }
 
       const model = next.model ?? {
         modelID: msg.info.modelID,
         providerID: msg.info.providerID,
       }
 
-      yield* ctx.metadata({
-        title: params.description,
-        metadata: {
-          sessionId: nextSession.id,
+      // Cap-rejection check happens before any slot is reserved or expensive work begins.
+      // The TooManyActive failure is mapped to a synthesized status: failed output instead.
+      const reserveResult = yield* subagentRun.reserveSlot(ctx.sessionID).pipe(
+        Effect.catchTag("TooManyActive", () => Effect.succeed("rejected" as const)),
+      )
+      if (reserveResult === "rejected") {
+        const rejected = yield* subagentRun.recordRejected({
+          parent_session_id: ctx.sessionID,
+          parent_message_id: ctx.messageID,
+          tool_call_id: ctx.callID,
+          description: params.description,
+          prompt: params.prompt,
+          agent: next.name,
+          subagent_type: params.subagent_type,
+          command: params.command,
           model,
-        },
-      })
-
-      const ops = ctx.extra?.promptOps as AgentPromptOps
-      if (!ops) return yield* Effect.fail(new Error("AgentTool requires promptOps in ctx.extra"))
-
-      const messageID = MessageID.ascending()
-
-      function cancel() {
-        ops.cancel(nextSession.id)
+          reason:
+            "This is a limit, not a failure. Wait for an existing subagent to complete, or reduce the dispatch.",
+        })
+        return synthesizeOutput(rejected, undefined)
       }
 
-      return yield* Effect.acquireUseRelease(
-        Effect.sync(() => {
-          ctx.abort.addEventListener("abort", cancel)
-        }),
-        () =>
-          Effect.gen(function* () {
-            const parts = yield* ops.resolvePromptParts(params.prompt)
-            const result = yield* ops.prompt({
-              messageID,
-              sessionID: nextSession.id,
-              model: {
-                modelID: model.modelID,
-                providerID: model.providerID,
-              },
+      // Slot reserved. Effect.scoped wraps the rest so:
+      //   - releaseSlot fires on every exit path (success, error, defect, fiber interrupt)
+      //   - listener cleanup fires on every exit path
+      //   - SubtaskPart row never gets stranded in `running`: outer catchAll finalizes if any
+      //     pre-prompt step throws between `start` and `ops.prompt`.
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() => subagentRun.releaseSlot(ctx.sessionID))
+
+          return yield* Effect.gen(function* () {
+            yield* subagentRun.start({
+              parent_session_id: ctx.sessionID,
+              parent_message_id: ctx.messageID,
+              tool_call_id: ctx.callID!,
+              description: params.description,
+              prompt: params.prompt,
               agent: next.name,
-              tools: {
-                ...(canTodo ? {} : { todowrite: false }),
-                ...(canAgent ? {} : { agent: false }),
-                ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),
-              },
-              parts,
+              subagent_type: params.subagent_type,
+              command: params.command,
+              model,
             })
 
-            return {
+            const nextSession =
+              session ??
+              (yield* sessions.create({
+                parentID: ctx.sessionID,
+                title: params.description + ` (@${next.name} subagent)`,
+                createdByAgentTool: true,
+                subagentType: params.subagent_type,
+                permission: [
+                  ...(canTodo
+                    ? []
+                    : [
+                        {
+                          permission: "todowrite" as const,
+                          pattern: "*" as const,
+                          action: "deny" as const,
+                        },
+                      ]),
+                  ...(canAgent
+                    ? []
+                    : [
+                        {
+                          permission: id,
+                          pattern: "*" as const,
+                          action: "deny" as const,
+                        },
+                      ]),
+                  ...(cfg.experimental?.primary_tools?.map((item) => ({
+                    pattern: "*",
+                    action: "allow" as const,
+                    permission: item,
+                  })) ?? []),
+                ],
+              }))
+
+            yield* subagentRun.patchSession(ctx.callID!, nextSession.id)
+
+            yield* ctx.metadata({
               title: params.description,
               metadata: {
                 sessionId: nextSession.id,
                 model,
               },
-              output: [
-                `subagent_session_id: ${nextSession.id} (pass this to resume the same subagent dispatch)`,
-                "",
-                "<subagent_result>",
-                result.parts.findLast((item) => item.type === "text")?.text ?? "",
-                "</subagent_result>",
-              ].join("\n"),
+            })
+
+            const onParentAbort = () => ops.cancel(nextSession.id)
+            ctx.abort.addEventListener("abort", onParentAbort)
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => ctx.abort.removeEventListener("abort", onParentAbort)),
+            )
+
+            // Pre-aborted short-circuit. If parent already aborted before we got here, skip
+            // ops.prompt entirely and finalize as canceled_by_user with no partial_result.
+            if (ctx.abort.aborted) {
+              yield* subagentRun.finalize(ctx.callID!, "canceled_by_user", {
+                partial_result: null,
+                ended_at: Date.now(),
+              })
+              const part = yield* subagentRun.read(ctx.callID!)
+              return synthesizeOutput(part, nextSession.id)
             }
-          }),
-        () =>
-          Effect.sync(() => {
-            ctx.abort.removeEventListener("abort", cancel)
-          }),
+
+            // Idempotent finalizer: latches `interrupted` synchronously at handler entry so a
+            // late parent abort during cleanup of a real model failure cannot misclassify it.
+            const finalizeAfter = (
+              result: { kind: "ok"; r: MessageV2.WithParts } | { kind: "err"; error: unknown },
+            ) =>
+              Effect.gen(function* () {
+                const interrupted = ops.wasInterrupted(nextSession.id) || ctx.abort.aborted
+                const current = yield* subagentRun.read(ctx.callID!)
+                if (current.status !== "running") return
+                if (interrupted) {
+                  const partial = yield* readLastCompletedAssistantText(nextSession.id)
+                  yield* subagentRun.finalize(ctx.callID!, "canceled_by_user", {
+                    partial_result: partial,
+                    ended_at: Date.now(),
+                  })
+                  return
+                }
+                if (result.kind === "err") {
+                  yield* subagentRun.finalize(ctx.callID!, "failed", {
+                    error: { kind: "execution_error", message: errorMessage(result.error) },
+                    ended_at: Date.now(),
+                  })
+                  return
+                }
+                const lastText = result.r.parts.findLast((p) => p.type === "text")?.text ?? ""
+                if (lastText.trim().length === 0) {
+                  yield* subagentRun.finalize(ctx.callID!, "completed_empty", {
+                    ended_at: Date.now(),
+                  })
+                } else {
+                  yield* subagentRun.finalize(ctx.callID!, "completed", {
+                    result_text: lastText,
+                    result_summary: truncateHead(lastText, 300),
+                    ended_at: Date.now(),
+                  })
+                }
+              })
+
+            const parts = yield* ops.resolvePromptParts(params.prompt)
+            yield* ops
+              .prompt({
+                messageID: MessageID.ascending(),
+                sessionID: nextSession.id,
+                model: { modelID: model.modelID, providerID: model.providerID },
+                agent: next.name,
+                tools: {
+                  agent: false,
+                  ...(canTodo ? {} : { todowrite: false }),
+                  ...Object.fromEntries(
+                    (cfg.experimental?.primary_tools ?? []).map((item) => [item, false]),
+                  ),
+                },
+                parts,
+              })
+              .pipe(
+                Effect.tap((r) => finalizeAfter({ kind: "ok", r })),
+                Effect.catch((error) => finalizeAfter({ kind: "err", error })),
+              )
+
+            const finalPart = yield* subagentRun.read(ctx.callID!)
+            return synthesizeOutput(finalPart, nextSession.id)
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.gen(function* () {
+                const current = yield* subagentRun
+                  .read(ctx.callID!)
+                  .pipe(Effect.catch(() => Effect.succeed(null as MessageV2.SubtaskPart | null)))
+                if (current?.status === "running") {
+                  yield* subagentRun.finalize(ctx.callID!, "failed", {
+                    error: { kind: "execution_error", message: errorMessage(error) },
+                    ended_at: Date.now(),
+                  })
+                }
+                return yield* Effect.fail(error)
+              }),
+            ),
+          )
+        }),
       )
     })
 

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -438,6 +438,8 @@ export const AgentTool = Tool.define(
                 }
                 // Re-fail with the original cause so stack, annotations, and parallel-error
                 // metadata are preserved instead of getting flattened into Effect.fail.
+                // ctx.metadata (set in step 4) keeps subagent_session_id visible to the parent
+                // for resume even when the tool result lands as `error`.
                 return yield* Effect.failCause(cause)
               }),
             ),

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -82,11 +82,15 @@ const isTextPartCompleted = (p: MessageV2.TextPart): boolean => p.time?.end !== 
 // Reads the child session's most recent assistant text part with stable (completed) content.
 // Used by finalizeAfter for partial_result on cancellation; returns null when no completed text
 // exists (e.g., cancellation during the first tool call or mid-token streaming abort).
+//
+// Scans the full message history rather than a fixed window: tool-heavy children can push the
+// last completed assistant text past any short backscan, and cancellation is a rare path so the
+// extra read cost is acceptable.
 const makeReadLastCompletedAssistantText =
   (sessions: Session.Service["Service"]) =>
   (childID: SessionID): Effect.Effect<string | null> =>
     Effect.gen(function* () {
-      const messages = yield* sessions.messages({ sessionID: childID, limit: 5 })
+      const messages = yield* sessions.messages({ sessionID: childID })
       for (let i = messages.length - 1; i >= 0; i--) {
         const m = messages[i]
         if (m.info.role !== "assistant") continue
@@ -382,16 +386,13 @@ export const AgentTool = Tool.define(
                 }
               })
 
-            // Wraps the success-path finalize so a transient finalize failure does not
-            // propagate to the next pipe step (Effect.catch) and re-run finalizeAfter as
-            // `kind: "err"`, which would relabel a completed run as failed. Idempotency in
-            // SubagentRun.finalize already protects the row state; this just stops the success
-            // result from being rebranded.
-            const finalizeOk = (r: MessageV2.WithParts) =>
-              finalizeAfter({ kind: "ok", r }).pipe(
-                Effect.catchCause(() => Effect.void),
-              )
-
+            // Explicit success / failure dispatch so each path runs its matching finalize
+            // exactly once and bugs don't get reclassified across paths:
+            //  - success: ok-finalize runs; if it fails, the failure propagates so the outer
+            //    catchCause sees the storage error instead of read() returning a stale "running"
+            //    row that synthesizeOutput would render as a defective success.
+            //  - failure: err-finalize runs (best-effort row cleanup), then the original cause
+            //    re-raises via failCause so stack/annotations survive.
             const parts = yield* ops.resolvePromptParts(params.prompt)
             yield* ops
               .prompt({
@@ -409,8 +410,16 @@ export const AgentTool = Tool.define(
                 parts,
               })
               .pipe(
-                Effect.tap((r) => finalizeOk(r)),
-                Effect.catch((error) => finalizeAfter({ kind: "err", error })),
+                Effect.matchCauseEffect({
+                  onSuccess: (r) => finalizeAfter({ kind: "ok", r }),
+                  onFailure: (cause) =>
+                    Effect.gen(function* () {
+                      yield* finalizeAfter({ kind: "err", error: Cause.squash(cause) }).pipe(
+                        Effect.catchCause(() => Effect.void),
+                      )
+                      return yield* Effect.failCause(cause)
+                    }),
+                }),
               )
 
             const finalPart = yield* subagentRun.read(ctx.callID!)

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -114,7 +114,6 @@ export const AgentTool = Tool.define(
         return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
       }
 
-      const canAgent = next.permission.some((rule) => rule.permission === id)
       const canTodo = next.permission.some((rule) => rule.permission === "todowrite")
 
       const ops = ctx.extra?.promptOps as AgentPromptOps
@@ -213,20 +212,18 @@ export const AgentTool = Tool.define(
                 createdByAgentTool: true,
                 subagentType: params.subagent_type,
                 permission: [
+                  // v1 nested-deny: agent is denied unconditionally so a subagent cannot
+                  // recursively dispatch its own subagents (#283 non-goal: nested subagents).
+                  {
+                    permission: id,
+                    pattern: "*" as const,
+                    action: "deny" as const,
+                  },
                   ...(canTodo
                     ? []
                     : [
                         {
                           permission: "todowrite" as const,
-                          pattern: "*" as const,
-                          action: "deny" as const,
-                        },
-                      ]),
-                  ...(canAgent
-                    ? []
-                    : [
-                        {
-                          permission: id,
                           pattern: "*" as const,
                           action: "deny" as const,
                         },

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -51,6 +51,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
+import { SubagentRun } from "../session/subagent-run"
 import { needsConfigDependencies, usesConfigDependencies } from "../config/dependency"
 
 export function localToolImportSpec(input: string) {
@@ -94,6 +95,7 @@ export namespace ToolRegistry {
     | Agent.Service
     | Skill.Service
     | Session.Service
+    | SubagentRun.Service
     | Provider.Service
     | LSP.Service
     | Settings.Service
@@ -397,6 +399,7 @@ export namespace ToolRegistry {
       Layer.provide(Skill.defaultLayer),
       Layer.provide(Agent.defaultLayer),
       Layer.provide(Session.defaultLayer),
+      Layer.provide(SubagentRun.defaultLayer),
       Layer.provide(Provider.defaultLayer),
       Layer.provide(LSP.defaultLayer),
       Layer.provide(Settings.defaultLayer),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -7,6 +7,8 @@ import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
 import { ReadTool } from "./read"
 import { AgentTool } from "./agent"
+import { AgentListTool } from "./agent-list"
+import { AgentOutputTool } from "./agent-output"
 import { TodoWriteTool } from "./todo"
 import { TrashTool } from "./trash"
 import { WebFetchTool } from "./webfetch"
@@ -120,6 +122,8 @@ export namespace ToolRegistry {
 
       const invalid = yield* InvalidTool
       const agent = yield* AgentTool
+      const agentList = yield* AgentListTool
+      const agentOutput = yield* AgentOutputTool
       const read = yield* ReadTool
       const question = yield* QuestionTool
       const todo = yield* TodoWriteTool
@@ -251,6 +255,8 @@ export namespace ToolRegistry {
             write: Tool.init(writetool),
             trash: Tool.init(trashtool),
             agent: Tool.init(agent),
+            agentList: Tool.init(agentList),
+            agentOutput: Tool.init(agentOutput),
             fetch: Tool.init(webfetch),
             todo: Tool.init(todo),
             search: Tool.init(websearch),
@@ -275,6 +281,8 @@ export namespace ToolRegistry {
               tool.write,
               tool.trash,
               tool.agent,
+              tool.agentList,
+              tool.agentOutput,
               tool.fetch,
               tool.todo,
               ...(webSearchEnabled ? [tool.search] : []),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -28,6 +28,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
+import { SubagentRun } from "../../src/session/subagent-run"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { Skill } from "../../src/skill"
@@ -183,6 +184,7 @@ function makeHttp() {
     Layer.provide(CrossSpawnSpawner.defaultLayer),
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
+    Layer.provide(SubagentRun.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(question),
     Layer.provideMerge(deps),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -338,6 +338,8 @@ const addSubtask = (sessionID: SessionID, messageID: MessageID, model = ref) =>
       description: "inspect bug",
       agent: "general",
       model,
+      status: "completed",
+      recent_events: [],
     })
   })
 

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -17,6 +17,7 @@ import { FetchHttpClient } from "effect/unstable/http"
 import fs from "fs/promises"
 import path from "path"
 import { Session } from "../../src/session"
+import { SubagentRun } from "../../src/session/subagent-run"
 import { LLM } from "../../src/session/llm"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
@@ -136,6 +137,7 @@ function makeHttp() {
     Layer.provide(CrossSpawnSpawner.defaultLayer),
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
+    Layer.provide(SubagentRun.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(question),
     Layer.provideMerge(deps),

--- a/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
+++ b/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { Log } from "@opencode-ai/core/util/log"
+import { MessageID, type SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SubagentRun } from "../../src/session/subagent-run"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+const setup = (
+  body: (api: { svc: SubagentRun.Interface; sessions: Session.Interface; parent: Session.Info; messageID: MessageID }) => Effect.Effect<void>,
+) =>
+  Effect.gen(function* () {
+    const svc = yield* SubagentRun.Service
+    const sessions = yield* Session.Service
+    const parent = yield* sessions.create({})
+    const msg = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID: parent.id,
+      agent: "build",
+      model: ref,
+      time: { created: Date.now() },
+    })
+    yield* body({ svc, sessions, parent, messageID: msg.id })
+  })
+
+const run = (program: Effect.Effect<void, unknown, SubagentRun.Service | Session.Service>) =>
+  Effect.runPromise(
+    program.pipe(Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer))),
+  )
+
+describe("subagent lifecycle integration", () => {
+  test("completed terminal state with result_text", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_completed",
+                description: "review",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.finalize("call_completed", "completed", {
+                result_text: "all good",
+                result_summary: "all good",
+              })
+              const part = yield* svc.read("call_completed")
+              expect(part.status).toBe("completed")
+              expect(part.result_text).toBe("all good")
+              expect(part.ended_at).toBeDefined()
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("completed_empty terminal state when result_text is blank", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_empty",
+                description: "noop",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.finalize("call_empty", "completed_empty", {})
+              const part = yield* svc.read("call_empty")
+              expect(part.status).toBe("completed_empty")
+              expect(part.result_text).toBeUndefined()
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("failed terminal state with execution_error", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_failed",
+                description: "fail",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.finalize("call_failed", "failed", {
+                error: { kind: "execution_error", message: "model returned 500" },
+              })
+              const part = yield* svc.read("call_failed")
+              expect(part.status).toBe("failed")
+              expect(part.error?.kind).toBe("execution_error")
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("failed terminal state with too_many_active via recordRejected", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              const part = yield* svc.recordRejected({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_capped",
+                description: "review",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+                reason: "limit exceeded",
+              })
+              expect(part.status).toBe("failed")
+              expect(part.error?.kind).toBe("too_many_active")
+              // No transient running state recorded.
+              expect(part.recent_events.find((e) => e.type === "started")?.at).toBeDefined()
+              expect(part.recent_events.find((e) => e.type === "failed")?.at).toBeDefined()
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("canceled_by_user terminal state with partial_result", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_canceled",
+                description: "cancel",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.finalize("call_canceled", "canceled_by_user", {
+                partial_result: "partial work",
+              })
+              const part = yield* svc.read("call_canceled")
+              expect(part.status).toBe("canceled_by_user")
+              expect(part.partial_result).toBe("partial work")
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("findLatestBySessionID returns the most recent matching row", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              const childID = "ses_child_for_resume" as SessionID
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_a",
+                description: "first",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.patchSession("call_a", childID)
+              yield* svc.finalize("call_a", "completed", { result_text: "first" })
+              // 1ms delay to ensure distinct timestamps
+              yield* Effect.sleep("5 millis")
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_b",
+                description: "second",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.patchSession("call_b", childID)
+              const latest = yield* svc.findLatestBySessionID(parent.id, childID)
+              expect(latest.tool_call_id).toBe("call_b")
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("list filters running vs completed correctly", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          setup(({ svc, parent, messageID }) =>
+            Effect.gen(function* () {
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_run",
+                description: "running one",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.start({
+                parent_session_id: parent.id,
+                parent_message_id: messageID,
+                tool_call_id: "call_done",
+                description: "completed one",
+                prompt: "x",
+                agent: "build",
+                subagent_type: "reviewer",
+                model: ref,
+              })
+              yield* svc.finalize("call_done", "completed", { result_text: "ok" })
+              const running = yield* svc.list(parent.id, { status: "running", limit: 10 })
+              const completed = yield* svc.list(parent.id, { status: "completed", limit: 10 })
+              const all = yield* svc.list(parent.id, { status: "all", limit: 10 })
+              expect(running.map((p) => p.tool_call_id)).toEqual(["call_run"])
+              expect(completed.map((p) => p.tool_call_id)).toEqual(["call_done"])
+              expect(all.length).toBe(2)
+            }),
+          ),
+        ),
+    })
+  })
+})

--- a/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
+++ b/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
@@ -62,7 +62,6 @@ describe("subagent lifecycle integration", () => {
                 description: "review",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.finalize("call_completed", "completed", {
@@ -94,7 +93,6 @@ describe("subagent lifecycle integration", () => {
                 description: "noop",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.finalize("call_empty", "completed_empty", {})
@@ -122,7 +120,6 @@ describe("subagent lifecycle integration", () => {
                 description: "fail",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.finalize("call_failed", "failed", {
@@ -152,7 +149,6 @@ describe("subagent lifecycle integration", () => {
                 description: "review",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
                 reason: "limit exceeded",
               })
@@ -182,7 +178,6 @@ describe("subagent lifecycle integration", () => {
                 description: "cancel",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.finalize("call_canceled", "canceled_by_user", {
@@ -213,7 +208,6 @@ describe("subagent lifecycle integration", () => {
                 description: "first",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.patchSession("call_a", childID)
@@ -227,7 +221,6 @@ describe("subagent lifecycle integration", () => {
                 description: "second",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.patchSession("call_b", childID)
@@ -254,7 +247,6 @@ describe("subagent lifecycle integration", () => {
                 description: "running one",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.start({
@@ -264,7 +256,6 @@ describe("subagent lifecycle integration", () => {
                 description: "completed one",
                 prompt: "x",
                 agent: "build",
-                subagent_type: "reviewer",
                 model: ref,
               })
               yield* svc.finalize("call_done", "completed", { result_text: "ok" })

--- a/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
+++ b/packages/opencode/test/session/subagent-lifecycle-integration.test.ts
@@ -16,7 +16,12 @@ const ref = {
 }
 
 const setup = (
-  body: (api: { svc: SubagentRun.Interface; sessions: Session.Interface; parent: Session.Info; messageID: MessageID }) => Effect.Effect<void>,
+  body: (api: {
+    svc: SubagentRun.Interface
+    sessions: Session.Interface
+    parent: Session.Info
+    messageID: MessageID
+  }) => Effect.Effect<void, unknown>,
 ) =>
   Effect.gen(function* () {
     const svc = yield* SubagentRun.Service
@@ -35,7 +40,10 @@ const setup = (
 
 const run = (program: Effect.Effect<void, unknown, SubagentRun.Service | Session.Service>) =>
   Effect.runPromise(
-    program.pipe(Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer))),
+    program.pipe(
+      Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+      Effect.orDie,
+    ),
   )
 
 describe("subagent lifecycle integration", () => {

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -2,9 +2,53 @@ import { describe, expect, test } from "bun:test"
 import { Session } from "../../src/session"
 import { Instance } from "../../src/project/instance"
 import { Log } from "@opencode-ai/core/util/log"
+import { MessageV2 } from "../../src/session/message-v2"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
+
+describe("SubtaskPart backward compat", () => {
+  test("decodes a legacy row lacking lifecycle fields as terminal-completed", () => {
+    const legacy = {
+      type: "subtask" as const,
+      id: "prt_legacy",
+      sessionID: "ses_x",
+      messageID: "msg_x",
+      prompt: "old",
+      description: "old",
+      agent: "build",
+    }
+    const decoded = MessageV2.SubtaskPart.parse(legacy)
+    expect(decoded.status).toBe("completed")
+    expect(decoded.recent_events).toEqual([])
+    expect(decoded.started_at).toBeUndefined()
+    expect(decoded.tool_call_id).toBeUndefined()
+  })
+
+  test("accepts a row with all new lifecycle fields populated", () => {
+    const full = {
+      type: "subtask" as const,
+      id: "prt_new",
+      sessionID: "ses_x",
+      messageID: "msg_x",
+      prompt: "p",
+      description: "d",
+      agent: "build",
+      tool_call_id: "call_1",
+      parent_session_id: "ses_x",
+      parent_message_id: "msg_x",
+      subagent_session_id: "ses_child",
+      status: "running" as const,
+      started_at: 1000,
+      updated_at: 1500,
+      recent_events: [{ type: "started" as const, at: 1000 }],
+    }
+    const decoded = MessageV2.SubtaskPart.parse(full)
+    expect(decoded.status).toBe("running")
+    expect(decoded.tool_call_id).toBe("call_1")
+    expect(decoded.recent_events).toHaveLength(1)
+  })
+})
 
 describe("Session.create new fields", () => {
   test("persists createdByAgentTool and subagentType", async () => {

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Cause, Effect, Layer } from "effect"
 import { Session } from "../../src/session"
 import { Instance } from "../../src/project/instance"
 import { Log } from "@opencode-ai/core/util/log"
@@ -8,6 +8,7 @@ import { MessageID } from "../../src/session/schema"
 import type { PartID, SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { SubagentRun } from "../../src/session/subagent-run"
+import { SubagentRunGuardViolation } from "../../src/session/subagent-run-context"
 import { tmpdir } from "../fixture/fixture"
 
 const ref = {
@@ -346,11 +347,20 @@ describe("SubtaskPart backward compat", () => {
             agent: "build",
             model: ref,
           })
-          // Direct write that flips status — should be rejected as a defect.
+          // Direct write that flips status — should be rejected as a defect with the specific
+          // SubagentRunGuardViolation tag and the violating tool_call_id, so this test fails
+          // loudly if updatePart starts failing for an unrelated reason in the future.
           const exit = yield* session
             .updatePart({ ...part, status: "completed" as const })
             .pipe(Effect.exit)
           expect(exit._tag).toBe("Failure")
+          if (exit._tag !== "Failure") return
+          const violation = exit.cause.reasons
+            .filter(Cause.isDieReason)
+            .map((r) => r.defect)
+            .find((d): d is SubagentRunGuardViolation => d instanceof SubagentRunGuardViolation)
+          expect(violation).toBeDefined()
+          expect(violation?.tool_call_id).toBe("call_guard")
         })
         await Effect.runPromise(
           program.pipe(

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -106,6 +106,60 @@ describe("SubtaskPart backward compat", () => {
     })
   })
 
+  test("recent_events ring pins lifecycle events and evicts progress FIFO", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          yield* svc.start({
+            parent_session_id: parent.id,
+            parent_message_id: msg.id,
+            tool_call_id: "call_ring",
+            description: "review",
+            prompt: "hi",
+            agent: "build",
+            subagent_type: "reviewer",
+            model: ref,
+          })
+          for (let i = 0; i < 30; i++) {
+            yield* svc.recordEvent("call_ring", {
+              type: "tool_started",
+              tool: "read",
+              label: `f${i}.ts`,
+              at: Date.now() + i,
+            })
+            yield* svc.recordEvent("call_ring", {
+              type: "tool_completed",
+              tool: "read",
+              at: Date.now() + i + 0.5,
+            })
+          }
+          yield* svc.finalize("call_ring", "completed", { result_text: "done" })
+          const final = yield* svc.read("call_ring")
+          expect(final.recent_events.find((e) => e.type === "started")).toBeDefined()
+          expect(final.recent_events.length).toBeLessThanOrEqual(20)
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
   test("accepts a row with all new lifecycle fields populated", () => {
     const full = {
       type: "subtask" as const,

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -203,6 +203,70 @@ describe("SubtaskPart backward compat", () => {
     })
   })
 
+  test("slot mutex serializes reservations and releases under sequential dispatch", async () => {
+    // The slot semaphore is a Semaphore.makeUnsafe(1) per parent. Lock-ordering
+    // invariant: slot mutex is acquired BEFORE per-row mutex everywhere; row mutex
+    // operations never call back into reserveSlot. This test asserts that 5 sequential
+    // reservations + 1 cap rejection + interleaved releases never deadlock the service.
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+
+          // Reserve 5 slots and start a row for each. Row writes (start) acquire the
+          // per-row mutex; if start ever called back into reserveSlot, this loop would
+          // deadlock on iteration 6 (since slot is held while waiting for row, and
+          // row would wait for slot).
+          for (let i = 0; i < 5; i++) {
+            yield* svc.reserveSlot(parent.id)
+            yield* svc.start({
+              parent_session_id: parent.id,
+              parent_message_id: msg.id,
+              tool_call_id: `call_lock_${i}`,
+              description: `dispatch ${i}`,
+              prompt: "x",
+              agent: "build",
+              subagent_type: "reviewer",
+              model: ref,
+            })
+          }
+
+          // 6th reservation is rejected.
+          const sixth = yield* svc.reserveSlot(parent.id).pipe(Effect.flip)
+          expect(sixth._tag).toBe("TooManyActive")
+
+          // Release all 5 slots, then re-reserve to confirm the slot count is back to
+          // zero. Releases interleaved with reads of the row (read acquires no mutex
+          // but reads from the in-memory map populated by start) — proves no implicit
+          // dependency cycle.
+          for (let i = 0; i < 5; i++) {
+            yield* svc.read(`call_lock_${i}`)
+            yield* svc.releaseSlot(parent.id)
+          }
+          yield* svc.reserveSlot(parent.id)
+          yield* svc.releaseSlot(parent.id)
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
   test("rejects direct Session.updatePart writes that mutate lifecycle fields", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -5,7 +5,7 @@ import { Instance } from "../../src/project/instance"
 import { Log } from "@opencode-ai/core/util/log"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID } from "../../src/session/schema"
-import type { SessionID } from "../../src/session/schema"
+import type { PartID, SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { SubagentRun } from "../../src/session/subagent-run"
 import { tmpdir } from "../fixture/fixture"
@@ -257,6 +257,63 @@ describe("SubtaskPart backward compat", () => {
           }
           yield* svc.reserveSlot(parent.id)
           yield* svc.releaseSlot(parent.id)
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
+  test("allows first-write of a SubtaskPart with persisted lifecycle values (Session.fork compatibility)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ref = { providerID: "anthropic" as ProviderID, modelID: "claude-3-5-sonnet" as ModelID }
+        const program = Effect.gen(function* () {
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const partID = "prt_first_write" as PartID
+          const cloned: MessageV2.SubtaskPart = {
+            type: "subtask",
+            id: partID,
+            sessionID: parent.id,
+            messageID: msg.id,
+            prompt: "review me",
+            description: "review",
+            agent: "build",
+            model: ref,
+            tool_call_id: "call_fork_clone",
+            parent_session_id: parent.id,
+            parent_message_id: msg.id,
+            subagent_session_id: undefined,
+            status: "completed",
+            started_at: Date.now() - 1_000,
+            ended_at: Date.now(),
+            updated_at: Date.now(),
+            recent_events: [
+              { type: "started", at: Date.now() - 1_000 },
+              { type: "completed", at: Date.now() },
+            ],
+            result_text: "looks good",
+            result_summary: "looks good",
+          }
+          // Non-writer path (Session.fork replays parts via updatePart without
+          // SubagentRunWriterContext). Must succeed because this is a first write,
+          // not a lifecycle mutation of an existing row.
+          const exit = yield* session.updatePart(cloned).pipe(Effect.exit)
+          expect(exit._tag).toBe("Success")
         })
         await Effect.runPromise(
           program.pipe(

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -160,6 +160,49 @@ describe("SubtaskPart backward compat", () => {
     })
   })
 
+  test("recordRejected writes a failed SubtaskPart with too_many_active error", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const part = yield* svc.recordRejected({
+            parent_session_id: parent.id,
+            parent_message_id: msg.id,
+            tool_call_id: "call_rej",
+            description: "review",
+            prompt: "hi",
+            agent: "build",
+            subagent_type: "reviewer",
+            model: ref,
+            reason: "Wait or reduce dispatch.",
+          })
+          expect(part.status).toBe("failed")
+          expect(part.error?.kind).toBe("too_many_active")
+          expect(part.error?.message).toBe("Wait or reduce dispatch.")
+          expect(part.subagent_session_id).toBeUndefined()
+          expect(part.recent_events.map((e) => e.type)).toEqual(["started", "failed"])
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
   test("rejects direct Session.updatePart writes that mutate lifecycle fields", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -83,7 +83,6 @@ describe("SubtaskPart backward compat", () => {
             description: "review",
             prompt: "hi",
             agent: "build",
-            subagent_type: "reviewer",
             model: ref,
           })
           expect(part.status).toBe("running")
@@ -130,7 +129,6 @@ describe("SubtaskPart backward compat", () => {
             description: "review",
             prompt: "hi",
             agent: "build",
-            subagent_type: "reviewer",
             model: ref,
           })
           for (let i = 0; i < 30; i++) {
@@ -184,7 +182,6 @@ describe("SubtaskPart backward compat", () => {
             description: "review",
             prompt: "hi",
             agent: "build",
-            subagent_type: "reviewer",
             model: ref,
             reason: "Wait or reduce dispatch.",
           })
@@ -238,7 +235,6 @@ describe("SubtaskPart backward compat", () => {
               description: `dispatch ${i}`,
               prompt: "x",
               agent: "build",
-              subagent_type: "reviewer",
               model: ref,
             })
           }
@@ -348,7 +344,6 @@ describe("SubtaskPart backward compat", () => {
             description: "review",
             prompt: "hi",
             agent: "build",
-            subagent_type: "reviewer",
             model: ref,
           })
           // Direct write that flips status — should be rejected as a defect.

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
 import { Session } from "../../src/session"
 import { Instance } from "../../src/project/instance"
 import { Log } from "@opencode-ai/core/util/log"
 import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID } from "../../src/session/schema"
+import type { SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SubagentRun } from "../../src/session/subagent-run"
 import { tmpdir } from "../fixture/fixture"
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
 
 void Log.init({ print: false })
 
@@ -23,6 +33,77 @@ describe("SubtaskPart backward compat", () => {
     expect(decoded.recent_events).toEqual([])
     expect(decoded.started_at).toBeUndefined()
     expect(decoded.tool_call_id).toBeUndefined()
+  })
+
+  test("rejects more than 5 concurrent reservations per parent", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const parentID = "ses_parent_cap" as SessionID
+          for (let i = 0; i < 5; i++) yield* svc.reserveSlot(parentID)
+          const sixth = yield* svc.reserveSlot(parentID).pipe(Effect.flip)
+          expect(sixth._tag).toBe("TooManyActive")
+          // releasing one frees a slot
+          yield* svc.releaseSlot(parentID)
+          yield* svc.reserveSlot(parentID) // should succeed
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
+  test("start writes a running SubtaskPart on the parent message", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const part = yield* svc.start({
+            parent_session_id: parent.id,
+            parent_message_id: msg.id,
+            tool_call_id: "call_abc",
+            description: "review",
+            prompt: "hi",
+            agent: "build",
+            subagent_type: "reviewer",
+            model: ref,
+          })
+          expect(part.status).toBe("running")
+          expect(part.tool_call_id).toBe("call_abc")
+          expect(part.subagent_session_id).toBeUndefined()
+          expect(part.recent_events.map((e) => e.type)).toEqual(["started"])
+
+          yield* svc.finalize("call_abc", "completed", { result_text: "done" })
+          const final = yield* svc.read("call_abc")
+          expect(final.status).toBe("completed")
+          expect(final.result_text).toBe("done")
+          expect(final.ended_at).toBeDefined()
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
   })
 
   test("accepts a row with all new lifecycle fields populated", () => {

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -160,6 +160,48 @@ describe("SubtaskPart backward compat", () => {
     })
   })
 
+  test("rejects direct Session.updatePart writes that mutate lifecycle fields", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const program = Effect.gen(function* () {
+          const svc = yield* SubagentRun.Service
+          const session = yield* Session.Service
+          const parent = yield* session.create({})
+          const msg = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: parent.id,
+            agent: "build",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const part = yield* svc.start({
+            parent_session_id: parent.id,
+            parent_message_id: msg.id,
+            tool_call_id: "call_guard",
+            description: "review",
+            prompt: "hi",
+            agent: "build",
+            subagent_type: "reviewer",
+            model: ref,
+          })
+          // Direct write that flips status — should be rejected as a defect.
+          const exit = yield* session
+            .updatePart({ ...part, status: "completed" as const })
+            .pipe(Effect.exit)
+          expect(exit._tag).toBe("Failure")
+        })
+        await Effect.runPromise(
+          program.pipe(
+            Effect.provide(Layer.mergeAll(SubagentRun.defaultLayer, Session.defaultLayer)),
+          ),
+        )
+      },
+    })
+  })
+
   test("accepts a row with all new lifecycle fields populated", () => {
     const full = {
       type: "subtask" as const,

--- a/packages/opencode/test/session/subagent-run.test.ts
+++ b/packages/opencode/test/session/subagent-run.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { Log } from "@opencode-ai/core/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+describe("Session.create new fields", () => {
+  test("persists createdByAgentTool and subagentType", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const created = await Session.create({
+          title: "child",
+          createdByAgentTool: true,
+          subagentType: "reviewer",
+        })
+        const fetched = await Session.get(created.id)
+        expect(fetched.createdByAgentTool).toBe(true)
+        expect(fetched.subagentType).toBe("reviewer")
+      },
+    })
+  })
+
+  test("defaults are false / null when not provided", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const created = await Session.create({ title: "plain" })
+        const fetched = await Session.get(created.id)
+        expect(fetched.createdByAgentTool).toBe(false)
+        expect(fetched.subagentType).toBeNull()
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -193,15 +193,17 @@ describe("tool.agent", () => {
     ),
   )
 
-  // Updated in Task 9 — resume validation now requires createdByAgentTool=true on the
-  // existing child session. The seed in this test creates a plain child, which Task 9
-  // replaces with a SubagentRun-created child that satisfies the new invariants.
-  it.live.skip("execute resumes an existing task session from subagent_session_id", () =>
+  it.live("execute resumes an existing subagent session", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
         const { chat, assistant } = yield* seed()
-        const child = yield* sessions.create({ parentID: chat.id, title: "Existing child" })
+        const child = yield* sessions.create({
+          parentID: chat.id,
+          title: "Existing child",
+          createdByAgentTool: true,
+          subagentType: "general",
+        })
         const tool = yield* AgentTool
         const def = yield* tool.init()
         let seen: SessionPrompt.PromptInput | undefined
@@ -321,8 +323,118 @@ describe("tool.agent", () => {
     ),
   )
 
-  // Updated in Task 9 — agent.ts now fails fast when subagent_session_id refers to a
-  // missing session, so the "creates a child anyway" semantic no longer holds.
+  it.live("execute fails when subagent_session_id refers to a missing session", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* AgentTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const exit = yield* def
+          .execute(
+            {
+              description: "inspect bug",
+              prompt: "x",
+              subagent_type: "general",
+              subagent_session_id: "ses_missing",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              callID: "call_resume_missing",
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live("execute fails when subagent_session_id refers to a non-agent session", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        // Plain child (createdByAgentTool defaults to false) — resume must reject.
+        const plainChild = yield* sessions.create({ parentID: chat.id, title: "Plain" })
+        const tool = yield* AgentTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const exit = yield* def
+          .execute(
+            {
+              description: "inspect bug",
+              prompt: "x",
+              subagent_type: "general",
+              subagent_session_id: plainChild.id,
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              callID: "call_resume_plain",
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+      }),
+    ),
+  )
+
+  it.live("execute fails when subagent_type does not match the existing child", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const child = yield* sessions.create({
+          parentID: chat.id,
+          title: "Mismatched",
+          createdByAgentTool: true,
+          subagentType: "reviewer",
+        })
+        const tool = yield* AgentTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const exit = yield* def
+          .execute(
+            {
+              description: "inspect bug",
+              prompt: "x",
+              subagent_type: "general",
+              subagent_session_id: child.id,
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              callID: "call_resume_mismatch",
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+      }),
+    ),
+  )
+
   it.live.skip("execute creates a child when subagent_session_id does not exist", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { Config } from "../../src/config/config"
@@ -9,7 +9,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-import { AgentTool, type AgentPromptOps } from "../../src/tool/agent"
+import { AgentTool, sanitizeErrorMessage, type AgentPromptOps } from "../../src/tool/agent"
 import { SubagentRun } from "../../src/session/subagent-run"
 import { Truncate } from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
@@ -112,6 +112,25 @@ function reply(input: Parameters<typeof SessionPrompt.prompt>[0], text: string):
     ],
   }
 }
+
+describe("sanitizeErrorMessage", () => {
+  // Invariant-style assertions: output must not contain any sensitive substring from the
+  // input. This is what catches regressions when a future field shape (e.g. WSL paths,
+  // Cygwin mounts) leaks through; it does not depend on the literal replacement format.
+  const cases: ReadonlyArray<{ name: string; input: string; sensitive: ReadonlyArray<string> }> = [
+    { name: "POSIX home (Mac)", input: "ENOENT /Users/alice/secret/data.json", sensitive: ["alice", "secret/data.json"] },
+    { name: "POSIX home (Linux)", input: "open /home/alice/.ssh/id_rsa failed", sensitive: ["alice", ".ssh/id_rsa"] },
+    { name: "Windows drive path", input: "Cannot find C:\\Users\\alice\\AppData\\Roaming\\app.json", sensitive: ["alice", "AppData", "app.json"] },
+    { name: "Windows UNC path", input: "Mount failed at \\\\fileserver\\share\\confidential", sensitive: ["fileserver", "confidential"] },
+    { name: "JSON envelope leak", input: 'request failed: {"apiKey":"sk-real-token","trace":"oops"}', sensitive: ["sk-real-token", "apiKey"] },
+  ]
+  for (const { name, input, sensitive } of cases) {
+    test(name, () => {
+      const out = sanitizeErrorMessage(input)
+      for (const s of sensitive) expect(out).not.toContain(s)
+    })
+  }
+})
 
 describe("tool.agent", () => {
   it.live("description sorts subagents by name and is stable across calls", () =>

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -64,7 +64,11 @@ const seed = Effect.fn("AgentToolTest.seed")(function* (title = "Pinned") {
   return { chat, assistant }
 })
 
-function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void; text?: string }): AgentPromptOps {
+function stubOps(opts?: {
+  onPrompt?: (input: SessionPrompt.PromptInput) => void
+  text?: string
+  interruptedSessions?: ReadonlySet<string>
+}): AgentPromptOps {
   return {
     cancel() {},
     resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
@@ -73,6 +77,7 @@ function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void;
         opts?.onPrompt?.(input)
         return reply(input, opts?.text ?? "done")
       }),
+    wasInterrupted: (id) => opts?.interruptedSessions?.has(id) ?? false,
   }
 }
 

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -363,10 +363,7 @@ describe("tool.agent", () => {
     ),
   )
 
-  // Updated in Task 8 — `agent` is now denied unconditionally in every child session
-  // regardless of whether the caller has canAgent permission, both at the permission
-  // ruleset and the prompt-time tools map.
-  it.live.skip("execute shapes child permissions for task, todowrite, and primary tools", () =>
+  it.live("execute shapes child permissions for task, todowrite, and primary tools", () =>
     provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
@@ -400,6 +397,11 @@ describe("tool.agent", () => {
           expect(child.parentID).toBe(chat.id)
           expect(child.permission).toEqual([
             {
+              permission: "agent",
+              pattern: "*",
+              action: "deny",
+            },
+            {
               permission: "todowrite",
               pattern: "*",
               action: "deny",
@@ -416,6 +418,7 @@ describe("tool.agent", () => {
             },
           ])
           expect(seen?.tools).toEqual({
+            agent: false,
             todowrite: false,
             bash: false,
             read: false,

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -10,6 +10,7 @@ import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { AgentTool, type AgentPromptOps } from "../../src/tool/agent"
+import { SubagentRun } from "../../src/session/subagent-run"
 import { Truncate } from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
 import { provideTmpdirInstance } from "../fixture/fixture"
@@ -30,6 +31,7 @@ const it = testEffect(
     Config.defaultLayer,
     CrossSpawnSpawner.defaultLayer,
     Session.defaultLayer,
+    SubagentRun.defaultLayer,
     Truncate.defaultLayer,
     ToolRegistry.defaultLayer,
   ),
@@ -191,7 +193,10 @@ describe("tool.agent", () => {
     ),
   )
 
-  it.live("execute resumes an existing task session from subagent_session_id", () =>
+  // Updated in Task 9 — resume validation now requires createdByAgentTool=true on the
+  // existing child session. The seed in this test creates a plain child, which Task 9
+  // replaces with a SubagentRun-created child that satisfies the new invariants.
+  it.live.skip("execute resumes an existing task session from subagent_session_id", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -214,6 +219,7 @@ describe("tool.agent", () => {
             messageID: assistant.id,
             agent: "build",
             abort: new AbortController().signal,
+            callID: "call_test_" + Math.random().toString(36).slice(2),
             extra: { promptOps },
             messages: [],
             metadata: () => Effect.void,
@@ -252,6 +258,7 @@ describe("tool.agent", () => {
               messageID: assistant.id,
               agent: "build",
               abort: new AbortController().signal,
+              callID: "call_test_" + Math.random().toString(36).slice(2),
               extra: { promptOps, ...extra },
               messages: [],
               metadata: () => Effect.void,
@@ -299,6 +306,7 @@ describe("tool.agent", () => {
             messageID: assistant.id,
             agent: "build",
             abort: new AbortController().signal,
+            callID: "call_test_" + Math.random().toString(36).slice(2),
             extra: { promptOps, bypassAgentCheck: true },
             messages: [],
             metadata: () => Effect.void,
@@ -306,14 +314,16 @@ describe("tool.agent", () => {
           },
         )
 
-        const child = yield* sessions.get(result.metadata.sessionId)
+        const child = yield* sessions.get(result.metadata.sessionId!)
         expect(child.createdByAgentTool).toBe(true)
         expect(child.subagentType).toBe("general")
       }),
     ),
   )
 
-  it.live("execute creates a child when subagent_session_id does not exist", () =>
+  // Updated in Task 9 — agent.ts now fails fast when subagent_session_id refers to a
+  // missing session, so the "creates a child anyway" semantic no longer holds.
+  it.live.skip("execute creates a child when subagent_session_id does not exist", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
@@ -335,6 +345,7 @@ describe("tool.agent", () => {
             messageID: assistant.id,
             agent: "build",
             abort: new AbortController().signal,
+            callID: "call_test_" + Math.random().toString(36).slice(2),
             extra: { promptOps },
             messages: [],
             metadata: () => Effect.void,
@@ -344,15 +355,18 @@ describe("tool.agent", () => {
 
         const kids = yield* sessions.children(chat.id)
         expect(kids).toHaveLength(1)
-        expect(kids[0]?.id).toBe(result.metadata.sessionId)
+        expect(kids[0]?.id).toBe(result.metadata.sessionId!)
         expect(result.metadata.sessionId).not.toBe("ses_missing")
         expect(result.output).toContain(`subagent_session_id: ${result.metadata.sessionId}`)
-        expect(seen?.sessionID).toBe(result.metadata.sessionId)
+        expect(seen?.sessionID).toBe(result.metadata.sessionId!)
       }),
     ),
   )
 
-  it.live("execute shapes child permissions for task, todowrite, and primary tools", () =>
+  // Updated in Task 8 — `agent` is now denied unconditionally in every child session
+  // regardless of whether the caller has canAgent permission, both at the permission
+  // ruleset and the prompt-time tools map.
+  it.live.skip("execute shapes child permissions for task, todowrite, and primary tools", () =>
     provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
@@ -374,6 +388,7 @@ describe("tool.agent", () => {
               messageID: assistant.id,
               agent: "build",
               abort: new AbortController().signal,
+              callID: "call_test_" + Math.random().toString(36).slice(2),
               extra: { promptOps },
               messages: [],
               metadata: () => Effect.void,
@@ -381,7 +396,7 @@ describe("tool.agent", () => {
             },
           )
 
-          const child = yield* sessions.get(result.metadata.sessionId)
+          const child = yield* sessions.get(result.metadata.sessionId!)
           expect(child.parentID).toBe(chat.id)
           expect(child.permission).toEqual([
             {

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -274,6 +274,40 @@ describe("tool.agent", () => {
     ),
   )
 
+  it.live("execute marks new child sessions with createdByAgentTool and subagentType", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* AgentTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps, bypassAgentCheck: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const child = yield* sessions.get(result.metadata.sessionId)
+        expect(child.createdByAgentTool).toBe(true)
+        expect(child.subagentType).toBe("general")
+      }),
+    ),
+  )
+
   it.live("execute creates a child when subagent_session_id does not exist", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Implements subagent lifecycle v1 (foreground-only) per #283. The agent tool now exposes explicit terminal states (completed / completed_empty / failed / canceled_by_user), caps parallel dispatch at 5 per parent, and ships two new model-callable inspection tools (`agent_list`, `agent_output`) so a parent agent can ask "is my subagent still running, what is it doing, what did it return".

## Why

Today the agent tool returns an empty `<subagent_result>` on cancel and silently swallows model failures, with no way for the dispatching agent to introspect or recover. This change makes lifecycle explicit, queryable, and bounded so common subagent failure modes stop being invisible. Background execution (`run_in_background`, notification injection, abandoned sweep, nested subagents) is intentionally deferred to v1.1.

## Related Issue

#283 (v5 spec, comment id 4332342274).

## Architecture

- `SubtaskPart` (`packages/opencode/src/session/message-v2.ts`) extended with all lifecycle / progress / result fields. Every new field is `.optional()` or `.default(...)` so legacy rows decode as terminal-completed without rewrites.
- New `Session` columns `created_by_agent_tool` + `subagent_type` mark child sessions as agent-tool-created and tag the subagent type.
- New `SubagentRun` service (`packages/opencode/src/session/subagent-run.ts`) is the single writer for lifecycle fields. Parent slot reservation is gated by `Semaphore.makeUnsafe(1)` per parent at MAX_ACTIVE=5; per-row mutex serializes lifecycle writes.
- Single-writer guard via `Context.Reference<boolean>` in `subagent-run-context.ts`. `Session.updatePart` rejects non-writer SubtaskPart writes that mutate lifecycle fields with `SubagentRunGuardViolation`.
- `AgentTool.execute` restructured into a scoped 8-step flow with `Effect.addFinalizer` for `releaseSlot` + listener cleanup on every exit path, and an outer `Effect.catch` that finalizes a started SubtaskPart to `failed` so pre-prompt errors cannot strand the row in `running`.
- `AgentPromptOps.wasInterrupted(sessionID)` query (set by `SessionRunState.onInterrupt` firing on the child runner) deterministically distinguishes child-runner abort from natural completion or model failure.
- `agent_list` filters by lifecycle status (running / completed / completed_empty / failed / canceled_by_user / all_active / all). `agent_output` accepts XOR(`subagent_session_id`, `tool_call_id`), validates parent ownership and `createdByAgentTool`, and marks terminal rows consumed on first read.

## Spec deviations

Two implementable mechanisms in this branch differ slightly from the literal spec text; both preserve the spec's intent:

1. **Single-writer enforcement uses a shared `Context.Reference` + inline check, not a Layer wrapper.** The spec sketch was a circular layer dep; the Reference lives in its own module so both writers and the guard observe it without circularity.
2. **Direct child-abort detection uses an additive `AgentPromptOps.wasInterrupted(sessionID)` query, not a subscribe API.** The current `SessionRunState` exposes no such API; the per-Instance `Set` written from `loop()`'s `onInterrupt` arg gives equivalent semantics with smaller surface.

## Not in this PR (deferred / known limitations)

- **UI agent card rendering (Task 15 in plan).** `packages/app/` is mid-rewrite and does not yet render `SubtaskPart` at all. Lifecycle data is queryable via `agent_list` / `agent_output`; the visual card is a follow-up.
- **`reserveSlot` cap accuracy after host restart.** In-memory `activeCounts` resets on restart; persisted `running` rows are not re-counted. Stranded `running` rows belong to the v1.1 abandoned-sweep work.
- **Background dispatch (`run_in_background`, `agent_stop`, `block=true`, abandoned, notification injection, nested subagents).** All v1.1.

## How To Verify

\`\`\`bash
bun --cwd packages/opencode run typecheck
bun --cwd packages/opencode test test/session/subagent-run.test.ts \
  test/session/subagent-lifecycle-integration.test.ts \
  test/tool/agent.test.ts \
  test/session/prompt-effect.test.ts
\`\`\`

Targeted suites cover: cap rejection + FIFO contention, lock-ordering invariant, all five terminal states end-to-end, ring-eviction with lifecycle pinning + hard-20 cap, single-writer guard violation, resume validation (parent / createdByAgentTool / subagent_type), backward-compat decode of legacy SubtaskPart rows.

Repo-wide \`turbo test:ci\` left to PR CI.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting \`dev\`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subagent lifecycle: subtask status, capped event history, activity tracking, consumption semantics, interruption-aware prompts, resume safeguards, and per-parent concurrency limits
  * Two built-in tools: list subagents and fetch subagent results/transcripts

* **Tests**
  * New integration and unit suites covering lifecycle, persistence, concurrency, resume, error sanitization, and formatting

* **Chores**
  * Session schema extended with agent-created marker (default false) and subagent type (nullable)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->