### PR TITLE
fix: 修复 Windows 拖拽上传因浏览器 MIME 报告为 application/octet-stream 而被拒绝

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -10,6 +10,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { type LocalProject, getAvatarColors } from "@/context/layout"
 import { getFilename } from "@opencode-ai/util/path"
+import { IMAGE_EXTS, pathSuffix } from "@opencode-ai/util/file-extensions"
 import { Avatar } from "@opencode-ai/ui/avatar"
 import { useLanguage } from "@/context/language"
 
@@ -36,7 +37,9 @@ export function DialogEditProject(props: { project: LocalProject }) {
   let iconInput: HTMLInputElement | undefined
 
   function handleFileSelect(file: File) {
-    if (!file.type.startsWith("image/")) return
+    const suffix = pathSuffix(file.name)
+    const isImage = file.type.startsWith("image/") || IMAGE_EXTS.has(suffix)
+    if (!isImage) return
     const reader = new FileReader()
     reader.onload = (e) => {
       setStore("iconUrl", e.target?.result as string)

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -4,6 +4,7 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { useMutation } from "@tanstack/solid-query"
 import { Icon } from "@opencode-ai/ui/icon"
+import { showToast } from "@opencode-ai/ui/toast"
 import { createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -13,6 +14,8 @@ import { getFilename } from "@opencode-ai/util/path"
 import { IMAGE_EXTS, pathSuffix } from "@opencode-ai/util/file-extensions"
 import { Avatar } from "@opencode-ai/ui/avatar"
 import { useLanguage } from "@/context/language"
+
+const MAX_ICON_SIZE = 5 * 1024 * 1024
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 
@@ -40,9 +43,23 @@ export function DialogEditProject(props: { project: LocalProject }) {
     const suffix = pathSuffix(file.name)
     const isImage = file.type.startsWith("image/") || IMAGE_EXTS.has(suffix)
     if (!isImage) return
+    if (file.size > MAX_ICON_SIZE) {
+      showToast({
+        title: language.t("dialog.project.edit.icon.tooLarge.title"),
+        description: language.t("dialog.project.edit.icon.tooLarge.description"),
+      })
+      return
+    }
     const reader = new FileReader()
     reader.onload = (e) => {
       setStore("iconUrl", e.target?.result as string)
+      setStore("iconHover", false)
+    }
+    reader.onerror = () => {
+      showToast({
+        title: language.t("dialog.project.edit.icon.readFailed.title"),
+        description: language.t("dialog.project.edit.icon.readFailed.description"),
+      })
       setStore("iconHover", false)
     }
     reader.readAsDataURL(file)

--- a/packages/app/src/components/prompt-input/attachments.test.ts
+++ b/packages/app/src/components/prompt-input/attachments.test.ts
@@ -252,7 +252,7 @@ describe("createPromptAttachments", () => {
     expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.pasteUnsupported.title"])
   })
 
-  test("rejects malformed FileReader data URLs", async () => {
+  test("accepts empty FileReader MIME when the routed MIME is known", async () => {
     fileReaderDataUrl = "data:;base64,aGVsbG8="
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
@@ -272,13 +272,21 @@ describe("createPromptAttachments", () => {
 
     const result = await attachments.addAttachment(new File(["image"], "image.png", { type: "image/png" }))
 
-    expect(result).toBe(false)
-    expect(promptParts).toHaveLength(0)
-    expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.pasteUnsupported.title"])
+    expect(result).toBe(true)
+    expect(promptParts).toEqual([
+      {
+        type: "image",
+        id: expect.any(String),
+        filename: "image.png",
+        mime: "image/png",
+        dataUrl: "data:image/png;base64,aGVsbG8=",
+      },
+    ])
+    expect(toasts).toHaveLength(0)
   })
 
   test("reports direct attachment read failures in dropped file batches", async () => {
-    fileReaderDataUrl = "data:;base64,aGVsbG8="
+    fileReaderDataUrl = "data:;base64,not-base64"
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
       isDialogActive: () => false,

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -41,7 +41,7 @@ function dataUrl(file: File, mime: string) {
       }
       const actual = header.slice("data:".length, -base64Marker.length).toLowerCase()
       const payload = value.slice(comma + 1)
-      if (!actual || !dataUrlMimeCompatible(actual, mime.toLowerCase()) || !isBase64Payload(payload)) {
+      if (!dataUrlMimeCompatible(actual, mime.toLowerCase()) || !isBase64Payload(payload)) {
         resolve("")
         return
       }

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -12,6 +12,7 @@ import { routeBrowserFile, routePickedPath, type AttachRoute, type ModelInputSup
 
 function dataUrlMimeCompatible(actual: string, expected: string) {
   if (actual === expected) return true
+  if (!actual || actual === "application/octet-stream") return true
   if (expected !== "text/plain") return false
   return textMime(actual)
 }

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -325,7 +325,13 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     }
 
     const dropped = event.dataTransfer?.files
-    if (!dropped) return
+    if (!dropped || dropped.length === 0) {
+      showToast({
+        title: language.t("prompt.toast.pasteUnsupported.title"),
+        description: language.t("prompt.toast.pasteUnsupported.description"),
+      })
+      return
+    }
 
     await addAttachments(Array.from(dropped))
   }

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -326,10 +326,7 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
 
     const dropped = event.dataTransfer?.files
     if (!dropped || dropped.length === 0) {
-      showToast({
-        title: language.t("prompt.toast.pasteUnsupported.title"),
-        description: language.t("prompt.toast.pasteUnsupported.description"),
-      })
+      warn()
       return
     }
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -382,6 +382,10 @@ export const dict = {
   "dialog.project.edit.worktree.startup": "Workspace startup script",
   "dialog.project.edit.worktree.startup.description": "Runs after creating a new workspace (worktree).",
   "dialog.project.edit.worktree.startup.placeholder": "e.g. bun install",
+  "dialog.project.edit.icon.tooLarge.title": "Image too large",
+  "dialog.project.edit.icon.tooLarge.description": "Please choose an image under 5MB.",
+  "dialog.project.edit.icon.readFailed.title": "Failed to read image",
+  "dialog.project.edit.icon.readFailed.description": "The selected file could not be loaded. Please try another image.",
 
   "dialog.releaseNotes.action.getStarted": "Get started",
   "dialog.releaseNotes.action.next": "Next",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -388,6 +388,10 @@ export const dict = {
   "dialog.project.edit.worktree.startup": "工作区启动脚本",
   "dialog.project.edit.worktree.startup.description": "在创建新的工作区 (worktree) 后运行。",
   "dialog.project.edit.worktree.startup.placeholder": "例如 bun install",
+  "dialog.project.edit.icon.tooLarge.title": "图片过大",
+  "dialog.project.edit.icon.tooLarge.description": "请选择 5MB 以下的图片。",
+  "dialog.project.edit.icon.readFailed.title": "读取图片失败",
+  "dialog.project.edit.icon.readFailed.description": "无法加载所选文件，请尝试其他图片。",
 
   "context.breakdown.title": "上下文拆分",
   "context.breakdown.note": "输入 token 的大致拆分。“其他”包含工具定义和开销。",

--- a/packages/desktop-electron/src/main/attachment-mime.test.ts
+++ b/packages/desktop-electron/src/main/attachment-mime.test.ts
@@ -20,7 +20,7 @@ describe("attachmentPathMime", () => {
     expect(attachmentPathMime("C:\\tmp\\image.PNG", extname)).toBe("image/png")
   })
 
-  test("keeps image MIME entries in sync with the renderer contract", () => {
+  test("derives MIME_BY_EXTENSION from IMAGE_EXTS so they stay in sync", () => {
     const imageEntries = [...MIME_BY_EXTENSION.entries()]
       .filter(([extension]) => extension !== "pdf")
       .sort(([left], [right]) => left.localeCompare(right))

--- a/packages/desktop-electron/src/main/attachment-mime.ts
+++ b/packages/desktop-electron/src/main/attachment-mime.ts
@@ -1,13 +1,9 @@
 import path from "node:path"
+import { IMAGE_EXTS } from "@opencode-ai/util/file-extensions"
 
-// Keep image entries in sync with packages/util/src/file-extensions.ts::IMAGE_EXTS.
 export const MIME_BY_EXTENSION = new Map([
-  ["gif", "image/gif"],
-  ["jpeg", "image/jpeg"],
-  ["jpg", "image/jpeg"],
+  ...IMAGE_EXTS,
   ["pdf", "application/pdf"],
-  ["png", "image/png"],
-  ["webp", "image/webp"],
 ])
 
 export function attachmentPathMime(filepath: string, extname = path.extname) {

--- a/packages/desktop-electron/src/main/attachment-mime.ts
+++ b/packages/desktop-electron/src/main/attachment-mime.ts
@@ -1,9 +1,13 @@
 import path from "node:path"
-import { IMAGE_EXTS } from "@opencode-ai/util/file-extensions"
 
+// Keep image entries in sync with packages/util/src/file-extensions.ts::IMAGE_EXTS.
 export const MIME_BY_EXTENSION = new Map([
-  ...IMAGE_EXTS,
+  ["gif", "image/gif"],
+  ["jpeg", "image/jpeg"],
+  ["jpg", "image/jpeg"],
   ["pdf", "application/pdf"],
+  ["png", "image/png"],
+  ["webp", "image/webp"],
 ])
 
 export function attachmentPathMime(filepath: string, extname = path.extname) {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -172,13 +172,19 @@ describe("tool.registry", () => {
       },
     })
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const ids = await ToolRegistry.ids()
-        expect(ids).toContain("cowsay")
-      },
-    })
+    const install = spyOn(Npm, "install").mockResolvedValue(undefined)
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).toContain("cowsay")
+        },
+      })
+    } finally {
+      install.mockRestore()
+    }
   })
 
   test("waits for config-scoped dependencies before importing local tools with bare imports", async () => {


### PR DESCRIPTION
## 修复内容

本 PR 修复了两个位置中同一类问题：当浏览器/操作系统将文件 MIME 类型报告为 `application/octet-stream` 或空字符串时，拖拽上传的文件会被静默拒绝。

### 1. `prompt-input/attachments.ts`

`dataUrlMimeCompatible()` 之前对 `application/octet-stream` 和空字符串返回 `false`，导致 Windows 下拖拽的图片/PDF 被错误拒绝。现在将其视为"无具体类型信息"，信任前置步骤通过文件后缀推断出的类型。

### 2. `dialog-edit-project.tsx`

`handleFileSelect()` 之前仅依赖 `file.type.startsWith("image/")`，同样导致 Windows 下拖拽的项目图标图片被静默拒绝。现在通过文件后缀（`IMAGE_EXTS`）做回退校验。

## 关联 Issue

- Fixes #291
- Fixes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon upload: validate by MIME and extension, enforce 5MB limit, and show clear error when too large or read fails.
  * Fixed drag-and-drop/clipboard flow to surface a “paste unsupported” message when no files are provided.
  * Improved handling of ambiguous/missing MIME on pasted files so valid images are accepted.

* **Localization**
  * Added EN/ZH messages for icon-too-large and image-read-failed.

* **Tests**
  * Updated tests to cover ambiguous-MIME acceptance and read-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->