### PR TITLE
fix(openai): sync OAuth context and retry fixes

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -449,6 +449,16 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             output: 0,
             cache: { read: 0, write: 0 },
           }
+
+          // GPT-5.5 has a smaller effective window when routed through Codex OAuth.
+          if (model.id.includes("gpt-5.5")) {
+            model.limit = {
+              context: 400_000,
+              // @ts-expect-error Provider SDK v1 model limits do not type input, but opencode uses it for compaction.
+              input: 272_000,
+              output: 128_000,
+            }
+          }
         }
 
         return {

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -108,6 +108,10 @@ export function shouldKeepCodexOAuthModel(modelId: string, apiId: string): boole
   return major > 5 || (major === 5 && minor > 4)
 }
 
+export function hasCodexOAuthGpt55Limit(apiId: string): boolean {
+  return /^gpt-5\.5(?:$|-)/.test(apiId)
+}
+
 function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string): string {
   const params = new URLSearchParams({
     response_type: "code",
@@ -450,14 +454,13 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             cache: { read: 0, write: 0 },
           }
 
-          // GPT-5.5 has a smaller effective window when routed through Codex OAuth.
-          if (model.id.includes("gpt-5.5")) {
-            model.limit = {
+          if (hasCodexOAuthGpt55Limit(model.api.id)) {
+            const limit: typeof model.limit & { input: number } = {
               context: 400_000,
-              // @ts-expect-error Provider SDK v1 model limits do not type input, but opencode uses it for compaction.
               input: 272_000,
               output: 128_000,
             }
+            model.limit = limit
           }
         }
 

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -111,12 +111,13 @@ export type ParsedStreamError =
   | {
       type: "api_error"
       message: string
-      isRetryable: false
+      isRetryable: boolean
       responseBody: string
     }
 
 export function parseStreamError(input: unknown): ParsedStreamError | undefined {
-  const body = json(input)
+  const raw = json(input)
+  const body = typeof raw?.message === "string" ? (json(raw.message) ?? raw) : raw
   if (!body) return
 
   const responseBody = JSON.stringify(body)
@@ -148,6 +149,13 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
         type: "api_error",
         message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
         isRetryable: false,
+        responseBody,
+      }
+    case "server_error":
+      return {
+        type: "api_error",
+        message: typeof body?.error?.message === "string" ? body?.error?.message : "Server error.",
+        isRetryable: true,
         responseBody,
       }
   }

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -102,6 +102,10 @@ function json(input: unknown) {
   return undefined
 }
 
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
 export type ParsedStreamError =
   | {
       type: "context_overflow"
@@ -117,13 +121,18 @@ export type ParsedStreamError =
 
 export function parseStreamError(input: unknown): ParsedStreamError | undefined {
   const raw = json(input)
-  const body = typeof raw?.message === "string" ? (json(raw.message) ?? raw) : raw
-  if (!body) return
+  if (!isRecord(raw)) return
+
+  const inner = typeof raw.message === "string" ? json(raw.message) : undefined
+  // OpenAI stream errors can arrive wrapped in an Error-like object. Use the
+  // inner provider payload so responseBody matches the payload users need.
+  const body = isRecord(inner) && inner.type === "error" ? inner : raw
 
   const responseBody = JSON.stringify(body)
   if (body.type !== "error") return
 
-  switch (body?.error?.code) {
+  const error = isRecord(body.error) ? body.error : undefined
+  switch (error?.code) {
     case "context_length_exceeded":
       return {
         type: "context_overflow",
@@ -147,14 +156,14 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
     case "invalid_prompt":
       return {
         type: "api_error",
-        message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
+        message: typeof error.message === "string" ? error.message : "Invalid prompt.",
         isRetryable: false,
         responseBody,
       }
     case "server_error":
       return {
         type: "api_error",
-        message: typeof body?.error?.message === "string" ? body?.error?.message : "Server error.",
+        message: typeof error.message === "string" ? error.message : "Server error.",
         isRetryable: true,
         responseBody,
       }

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  CodexAuthPlugin,
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
@@ -140,6 +141,60 @@ describe("plugin.codex", () => {
       expect(shouldKeepCodexOAuthModel("gpt-5.3", "gpt-5.3")).toBe(false)
       expect(shouldKeepCodexOAuthModel("gpt-4.1", "gpt-4.1")).toBe(false)
       expect(shouldKeepCodexOAuthModel("custom-model", "custom-model")).toBe(false)
+    })
+  })
+
+  describe("CodexAuthPlugin", () => {
+    test("overrides GPT-5.5 limits for OAuth Codex plans", async () => {
+      const provider = {
+        models: {
+          "gpt-5.5": {
+            id: "gpt-5.5",
+            api: { id: "gpt-5.5" },
+            cost: {
+              input: 2,
+              output: 8,
+              cache: { read: 1, write: 2 },
+            },
+            limit: {
+              context: 1_050_000,
+              input: 922_000,
+              output: 128_000,
+            },
+          },
+        },
+      }
+      const hooks = await CodexAuthPlugin({
+        client: {} as never,
+        project: {} as never,
+        directory: "",
+        worktree: "",
+        experimental_workspace: {
+          register() {},
+        },
+      } as never)
+
+      await hooks.auth!.loader!(
+        async () =>
+          ({
+            type: "oauth",
+            access: "access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          }) as never,
+        provider as never,
+      )
+
+      expect(provider.models["gpt-5.5"].limit).toEqual({
+        context: 400_000,
+        input: 272_000,
+        output: 128_000,
+      })
+      expect(provider.models["gpt-5.5"].cost).toEqual({
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      })
     })
   })
 

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -5,6 +5,7 @@ import {
   extractAccountIdFromClaims,
   extractAccountId,
   formatOAuthFailure,
+  hasCodexOAuthGpt55Limit,
   shouldKeepCodexOAuthModel,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
@@ -144,6 +145,20 @@ describe("plugin.codex", () => {
     })
   })
 
+  describe("hasCodexOAuthGpt55Limit", () => {
+    test("matches GPT-5.5 API ids and explicit variants", () => {
+      expect(hasCodexOAuthGpt55Limit("gpt-5.5")).toBe(true)
+      expect(hasCodexOAuthGpt55Limit("gpt-5.5-codex")).toBe(true)
+      expect(hasCodexOAuthGpt55Limit("gpt-5.5-mini")).toBe(true)
+    })
+
+    test("does not match unrelated future models", () => {
+      expect(hasCodexOAuthGpt55Limit("gpt-5.50")).toBe(false)
+      expect(hasCodexOAuthGpt55Limit("chatgpt-5.5")).toBe(false)
+      expect(hasCodexOAuthGpt55Limit("gpt-5.6")).toBe(false)
+    })
+  })
+
   describe("CodexAuthPlugin", () => {
     test("overrides GPT-5.5 limits for OAuth Codex plans", async () => {
       const provider = {
@@ -164,6 +179,13 @@ describe("plugin.codex", () => {
           },
         },
       }
+
+      expect(provider.models["gpt-5.5"].limit).toEqual({
+        context: 1_050_000,
+        input: 922_000,
+        output: 128_000,
+      })
+
       const hooks = await CodexAuthPlugin({
         client: {} as never,
         project: {} as never,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -294,4 +294,23 @@ describe("session.message-v2.fromError", () => {
     const result = MessageV2.fromError(error, { providerID: ProviderID.make("openai") }) as MessageV2.APIError
     expect(result.data.isRetryable).toBe(true)
   })
+
+  test("converts OpenAI server_error stream chunks to retryable APIError", () => {
+    const result = MessageV2.fromError(
+      {
+        message: JSON.stringify({
+          type: "error",
+          error: {
+            code: "server_error",
+            message: "An error occurred while processing your request.",
+          },
+        }),
+      },
+      { providerID: ProviderID.make("openai") },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect(SessionRetry.retryable(result)).toBe("An error occurred while processing your request.")
+  })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -313,4 +313,41 @@ describe("session.message-v2.fromError", () => {
     expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
     expect(SessionRetry.retryable(result)).toBe("An error occurred while processing your request.")
   })
+
+  test("uses fallback message for OpenAI server_error stream chunks without message", () => {
+    const result = MessageV2.fromError(
+      {
+        message: JSON.stringify({
+          type: "error",
+          error: {
+            code: "server_error",
+          },
+        }),
+      },
+      { providerID: ProviderID.make("openai") },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.message).toBe("Server error.")
+    expect(SessionRetry.retryable(result)).toBe("Server error.")
+  })
+
+  test("does not convert unknown OpenAI stream error chunks to retryable APIError", () => {
+    const result = MessageV2.fromError(
+      {
+        message: JSON.stringify({
+          type: "error",
+          error: {
+            code: "bad_request",
+            message: "Bad request",
+          },
+        }),
+      },
+      { providerID: ProviderID.make("openai") },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(false)
+    expect(SessionRetry.retryable(result)).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

Syncs the first missed upstream runtime/provider fixes tracked in #298.

- Backports anomalyco/opencode#24212 so OpenAI OAuth/Codex `gpt-5.5` uses the effective Codex plan limits: `context: 400_000`, `input: 272_000`, `output: 128_000`.
- Backports anomalyco/opencode#24063 so OpenAI stream `server_error` chunks wrapped inside a `message` JSON string become retryable API errors instead of unknown errors.

## Why

PawWork was showing API-side GPT-5.5 context metadata for OpenAI OAuth sessions even though OAuth requests are routed through the Codex backend. That made the context UI and proactive compaction threshold look safe near 270K tokens while the effective Codex limit was smaller. The retry parser fix is part of the same upstream OpenAI runtime follow-up batch.

## Related Issue

Refs #298

## How To Verify

```bash
bun install --frozen-lockfile
bun test test/plugin/codex.test.ts --timeout 30000
bun test test/session/retry.test.ts --timeout 30000
bun run --cwd packages/opencode typecheck
```

## Screenshots or Recordings

No visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-specific token limits for GPT-5.5 in OAuth-authenticated flows.

* **Bug Fixes**
  * Improved stream error parsing and payload handling.
  * Recognize server-side errors as retryable API errors and better extract error messages.

* **Tests**
  * Added unit and integration tests for GPT-5.5 OAuth handling and for retry behavior on streaming errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->