### PR TITLE
chore: bump release version to 2026.4.29

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "2026.4.28",
+      "version": "2026.4.29",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -110,7 +110,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.4.28",
+      "version": "2026.4.29",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -175,7 +175,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "2026.4.28",
+      "version": "2026.4.29",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -402,7 +402,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "2026.4.28",
+      "version": "2026.4.29",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.4.28",
+  "version": "2026.4.29",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.4.28",
+  "version": "2026.4.29",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.4.28",
+  "version": "2026.4.29",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.4.28",
+  "version": "2026.4.29",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump PawWork release package versions from 2026.4.28 to 2026.4.29.

## Why

Prepare the April 29, 2026 stable desktop release after the repository migrated release tags and artifact names to the YYYY.M.D CalVer format.

## Related Issue

No issue. This is a release preparation version bump.

## How To Verify

```bash
bun install --frozen-lockfile
cd packages/desktop-electron
bun test scripts/verify-release.test.ts
git diff --check
git tag -l v2026.4.29
gh release view v2026.4.29 --repo Astro-Han/pawwork
```

`gh release view v2026.4.29` returned `release not found`, confirming the release does not already exist.

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English