### PR TITLE
fix(session): sync session edge fixes

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -19,6 +19,7 @@ interface RunHandle<A, E> {
 interface ShellHandle<A, E> {
   id: number
   ready: Deferred.Deferred<void>
+  cancelled: Deferred.Deferred<void>
   fiber: Fiber.Fiber<A, E>
 }
 
@@ -99,7 +100,12 @@ export const make = <A, E = never>(
       }),
     ).pipe(Effect.flatten)
 
-  const stopShell = (shell: ShellHandle<A, E>) => Fiber.interrupt(shell.fiber)
+  const stopShell = (shell: ShellHandle<A, E>) =>
+    Effect.gen(function* () {
+      yield* awaitShellReady(shell)
+      yield* Deferred.succeed(shell.cancelled, undefined).pipe(Effect.asVoid)
+      yield* Fiber.interrupt(shell.fiber)
+    })
 
   const awaitShellReady = (shell: ShellHandle<A, E>) =>
     Deferred.await(shell.ready).pipe(Effect.raceFirst(Fiber.await(shell.fiber).pipe(Effect.asVoid)), Effect.ignore)
@@ -149,18 +155,28 @@ export const make = <A, E = never>(
         }
         yield* busy
         const id = next()
+        const cancelled = yield* Deferred.make<void>()
         const ready =
           options?.ready ??
           (yield* Deferred.make<void>().pipe(
             Effect.tap((ready) => Deferred.succeed(ready, undefined)),
           ))
         const fiber = yield* work.pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
-        const shell = { id, ready, fiber } satisfies ShellHandle<A, E>
+        const shell = { id, ready, cancelled, fiber } satisfies ShellHandle<A, E>
         return [
           Effect.gen(function* () {
             const exit = yield* Fiber.await(fiber)
             if (Exit.isSuccess(exit)) return exit.value
-            if (Cause.hasInterruptsOnly(exit.cause) && onInterrupt) return yield* onInterrupt
+            if (
+              Cause.hasInterruptsOnly(exit.cause) ||
+              ((yield* Deferred.isDone(cancelled)) &&
+                Cause.hasInterrupts(exit.cause) &&
+                !Cause.hasFails(exit.cause) &&
+                !Cause.hasDies(exit.cause))
+            ) {
+              if (onInterrupt) return yield* onInterrupt
+              return yield* Effect.die(new Cancelled())
+            }
             return yield* Effect.failCause(exit.cause)
           }),
           { _tag: "Shell", shell },
@@ -184,7 +200,6 @@ export const make = <A, E = never>(
       case "Shell":
         return [
           Effect.gen(function* () {
-            yield* awaitShellReady(st.shell)
             yield* stopShell(st.shell)
             yield* idleIfCurrent()
           }),
@@ -193,9 +208,8 @@ export const make = <A, E = never>(
       case "ShellThenRun":
         return [
           Effect.gen(function* () {
-            yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
-            yield* awaitShellReady(st.shell)
             yield* stopShell(st.shell)
+            yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
             yield* idleIfCurrent()
           }),
           { _tag: "Idle" } as const,

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -37,8 +37,8 @@ const PRUNE_PROTECTED_TOOLS = ["skill"]
 const DEFAULT_TAIL_TURNS = 2
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 8_000
-const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the section order unchanged:
----
+const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
+<template>
 ## Goal
 - [single-sentence task summary]
 
@@ -66,7 +66,7 @@ const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the se
 
 ## Relevant Files
 - [file or directory path: why it matters, or "(none)"]
----
+</template>
 
 Rules:
 - Keep every section, even when empty.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -958,6 +958,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const shellName = (
             process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
           ).toLowerCase()
+          const cwd = ctx.directory
           const invocations: Record<string, { args: string[] }> = {
             nu: { args: ["-c", input.command] },
             fish: { args: ["-c", input.command] },
@@ -966,12 +967,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 "-l",
                 "-c",
                 `
-                  __oc_cwd=$PWD
                   [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
                   [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-                  cd "$__oc_cwd"
+                  cd -- ${JSON.stringify(cwd)}
                   eval ${JSON.stringify(input.command)}
                 `,
+                "pawwork",
               ],
             },
             bash: {
@@ -979,12 +980,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 "-l",
                 "-c",
                 `
-                  __oc_cwd=$PWD
                   shopt -s expand_aliases
                   [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-                  cd "$__oc_cwd"
+                  cd -- ${JSON.stringify(cwd)}
                   eval ${JSON.stringify(input.command)}
                 `,
+                "pawwork",
               ],
             },
             cmd: { args: ["/c", input.command] },
@@ -994,7 +995,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           const args = (invocations[shellName] ?? invocations[""]).args
-          const cwd = ctx.directory
           const shellEnv = yield* restore(
             plugin.trigger(
               "shell.env",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -887,10 +887,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput, ready: Deferred.Deferred<void>) {
       let output = ""
       let aborted = false
-      const { run, msg, part, cmd, finish } = yield* Effect.uninterruptibleMask((restore) =>
+      const { msg, part, cmd, finish } = yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const ctx = yield* InstanceState.context
-          const run = yield* runner()
           const session = yield* sessions.get(input.sessionID)
           if (session.revert) {
             yield* revert.cleanup(session)
@@ -1034,35 +1033,34 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }),
           )
 
-          return { run, msg, part, cmd, finish }
+          return { msg, part, cmd, finish }
         }),
       )
 
       const exit = yield* Effect.gen(function* () {
         const handle = yield* spawner.spawn(cmd)
         yield* Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
-          Effect.sync(() => {
+          Effect.gen(function* () {
             output += chunk
             if (part.state.status === "running") {
               part.state.metadata = { ...part.state.metadata, output, description: "" }
-              void run.fork(sessions.updatePart(part))
+              yield* sessions.updatePart(part)
             }
           }),
         )
         yield* handle.exitCode
       }).pipe(
         Effect.scoped,
-        Effect.onInterrupt(() =>
-          Effect.sync(() => {
-            aborted = true
-          }),
-        ),
         Effect.orDie,
-        Effect.ensuring(finish),
         Effect.exit,
       )
 
-      if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
+      if (Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause) && !Cause.hasDies(exit.cause)) {
+        aborted = true
+      }
+      yield* finish
+
+      if (Exit.isFailure(exit) && !aborted && !Cause.hasInterruptsOnly(exit.cause)) {
         return yield* Effect.failCause(exit.cause)
       }
 

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -29,6 +29,9 @@ export const Parameters = Schema.Struct({
   character: Schema.Number.check(Schema.isInt())
     .check(Schema.isGreaterThanOrEqualTo(1))
     .annotate({ description: "The character offset (1-based, as shown in editors)" }),
+  query: Schema.optional(Schema.String).annotate({
+    description: "Search query for workspaceSymbol. Empty string requests all symbols.",
+  }),
 })
 
 export const LspTool = Tool.define(
@@ -39,10 +42,7 @@ export const LspTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (
-        args: { operation: (typeof operations)[number]; filePath: string; line: number; character: number },
-        ctx: Tool.Context,
-      ) =>
+      execute: (args: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
           yield* assertExternalDirectoryEffect(ctx, file)
@@ -89,7 +89,7 @@ export const LspTool = Tool.define(
               case "documentSymbol":
                 return lsp.documentSymbol(uri)
               case "workspaceSymbol":
-                return lsp.workspaceSymbol("")
+                return lsp.workspaceSymbol(args.query ?? "")
               case "goToImplementation":
                 return lsp.implementation(position)
               case "prepareCallHierarchy":

--- a/packages/opencode/src/tool/lsp.txt
+++ b/packages/opencode/src/tool/lsp.txt
@@ -5,7 +5,7 @@ Supported operations:
 - findReferences: Find all references to a symbol
 - hover: Get hover information (documentation, type info) for a symbol
 - documentSymbol: Get all symbols (functions, classes, variables) in a document
-- workspaceSymbol: Search for symbols across the entire workspace
+- workspaceSymbol: List project-wide symbols matching a query string
 - goToImplementation: Find implementations of an interface or abstract method
 - prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
 - incomingCalls: Find all functions/methods that call the function at a position
@@ -15,5 +15,10 @@ All operations require:
 - filePath: The file to operate on
 - line: The line number (1-based, as shown in editors)
 - character: The character offset (1-based, as shown in editors)
+
+workspaceSymbol also accepts:
+- query: A query string to filter symbols by. Empty string requests all symbols.
+
+For workspaceSymbol, filePath is not sent in the LSP workspace/symbol request. It is used by PawWork to select and start the matching LSP server.
 
 Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Deferred, Effect, Exit, Fiber, Ref, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Ref, Scope } from "effect"
 import { Runner } from "../../src/effect"
 import { it } from "../lib/effect"
 
@@ -331,6 +331,42 @@ describe("Runner", () => {
       expect(Exit.isFailure(shellExit)).toBe(true)
 
       yield* Deferred.succeed(gate, undefined).pipe(Effect.ignore)
+    }),
+  )
+
+  it.live(
+    "cancel does not mask shell defects",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s, { onInterrupt: Effect.succeed("interrupted") })
+
+      const sh = yield* runner
+        .startShell(Effect.never.pipe(Effect.ensuring(Effect.die("boom")), Effect.as("ignored")))
+        .pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancel
+      expect(Exit.isFailure(yield* Fiber.await(sh))).toBe(true)
+    }),
+  )
+
+  it.live(
+    "cancel does not mask shell typed failures",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string, string>(s, { onInterrupt: Effect.succeed("interrupted") })
+
+      const sh = yield* runner
+        .startShell(Effect.never.pipe(Effect.onInterrupt(() => Effect.fail("boom")), Effect.as("ignored")))
+        .pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancel
+      const exit = yield* Fiber.await(sh)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasFails(exit.cause)).toBe(true)
+      }
     }),
   )
 

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -221,6 +221,43 @@ describe("session.listGlobal", () => {
     }),
   )
 
+  it.live(
+    "session routes omit undefined optional fields",
+    Effect.promise(async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await svc.create({ title: "route-optional-fields" })
+
+          const app = Server.Default().app
+          const response = await app.request(`/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=1`)
+          expect(response.status).toBe(200)
+          const body = (await response.json()) as Array<Record<string, any>>
+          expect(body).toHaveLength(1)
+          const item = body[0]
+
+          expect(Object.hasOwn(item, "parentID")).toBe(false)
+          expect(Object.hasOwn(item, "workspaceID")).toBe(false)
+          expect(Object.hasOwn(item, "summary")).toBe(false)
+          expect(Object.hasOwn(item, "share")).toBe(false)
+          expect(Object.hasOwn(item, "permission")).toBe(false)
+          expect(Object.hasOwn(item, "revert")).toBe(false)
+          expect(Object.hasOwn(item.time, "compacting")).toBe(false)
+          expect(Object.hasOwn(item.time, "archived")).toBe(false)
+
+          const global = await app.request(
+            `/experimental/session?directory=${encodeURIComponent(tmp.path)}&roots=true&limit=1`,
+          )
+          expect(global.status).toBe(200)
+          const globalBody = (await global.json()) as Array<Record<string, any>>
+          expect(globalBody).toHaveLength(1)
+          expect(Object.hasOwn(globalBody[0].project, "name")).toBe(false)
+        },
+      })
+    }),
+  )
+
   test("experimental route round-trips created-order cursor", async () => {
     await using tmp = await tmpdir({ git: true })
     const originalNow = Date.now

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -73,10 +73,14 @@ function defer<T>() {
 }
 
 function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
+  return withShell("/bin/sh", fx)
+}
+
+function withShell<A, E, R>(shell: string, fx: () => Effect.Effect<A, E, R>) {
   return Effect.acquireUseRelease(
     Effect.sync(() => {
       const prev = process.env.SHELL
-      process.env.SHELL = "/bin/sh"
+      process.env.SHELL = shell
       Shell.preferred.reset()
       return prev
     }),
@@ -1266,6 +1270,34 @@ unix("shell completes a fast command on the preferred shell", () =>
         yield* run.assertNotBusy(chat.id)
       }),
     { git: true, config: cfg },
+  ),
+)
+
+unix("shell commands can change directory after login startup", () =>
+  withShell("/bin/bash", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const { prompt, run, chat } = yield* boot()
+          const parent = path.dirname(dir)
+          const result = yield* prompt.shell({
+            sessionID: chat.id,
+            agent: "build",
+            command: 'printf "argc:%s\\n" "$#"; cd .. && pwd',
+          })
+
+          expect(result.info.role).toBe("assistant")
+          const tool = completedTool(result.parts)
+          if (!tool) return
+
+          expect(tool.state.output).toContain("argc:0")
+          expect(tool.state.output).toContain(parent)
+          expect(tool.state.metadata.output).toContain("argc:0")
+          expect(tool.state.metadata.output).toContain(parent)
+          yield* run.assertNotBusy(chat.id)
+        }),
+      { git: true, config: cfg },
+    ),
   ),
 )
 

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -209,6 +209,10 @@ exports[`tool parameters JSON Schema (wire shape) lsp 1`] = `
       ],
       "type": "string",
     },
+    "query": {
+      "description": "Search query for workspaceSymbol. Empty string requests all symbols.",
+      "type": "string",
+    },
   },
   "required": [
     "operation",

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { LSP } from "../../src/lsp"
+import { Instance } from "../../src/project/instance"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { LspTool } from "../../src/tool/lsp"
+import { Truncate } from "../../src/tool/truncate"
+import type * as Tool from "../../src/tool/tool"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { provideInstance, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const workspaceSymbolQueries: string[] = []
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(true),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed([]),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: (query) =>
+      Effect.sync(() => {
+        workspaceSymbolQueries.push(query)
+        return []
+      }),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+    shutdownAll: () => Effect.void,
+    invalidate: () => Effect.void,
+  }),
+)
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    AppFileSystem.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    lsp,
+    Truncate.defaultLayer,
+  ),
+)
+
+const ctx: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const run = Effect.fn("LspToolTest.run")(function* (args: Tool.InferParameters<typeof LspTool>) {
+  const info = yield* LspTool
+  const tool = yield* info.init()
+  return yield* tool.execute(args, ctx)
+})
+
+describe("tool.lsp", () => {
+  it.live(
+    "passes workspaceSymbol query to LSP",
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const file = `${dir}/test.ts`
+      yield* Effect.promise(() => Bun.write(file, "export function TestSymbol() {}\n"))
+      workspaceSymbolQueries.length = 0
+
+      yield* provideInstance(dir)(
+        Effect.gen(function* () {
+          yield* run({ operation: "workspaceSymbol", filePath: file, line: 1, character: 1, query: "TestSymbol" })
+          yield* run({ operation: "workspaceSymbol", filePath: file, line: 1, character: 1 })
+        }),
+      )
+
+      expect(workspaceSymbolQueries).toEqual(["TestSymbol", ""])
+    }),
+  )
+})


### PR DESCRIPTION
## Summary
- Preserve shell cwd across login shell startup and harden shell cancellation ordering so interrupted shell runs finalize cleanly without masking real defects.
- Pass `workspaceSymbol` queries through the LSP tool and update its parameter schema and description.
- Cover current session JSON optional-field omission behavior and remove compaction summary divider lines.

Refs #298

## Upstream coverage
- anomalyco/opencode#24215: ported shell cwd preservation.
- anomalyco/opencode#24553: ported shell cancellation hardening to PawWork's current `Deferred` ready flow.
- anomalyco/opencode#24576: ported LSP `workspaceSymbol.query`.
- anomalyco/opencode#24676: verified PawWork's Hono JSON routes already omit undefined optional fields and added route coverage instead of schema churn.
- anomalyco/opencode#24677: ported compaction summary divider removal.

## Verification
- `bun install --frozen-lockfile`
- `bun --cwd packages/opencode test test/session/prompt-effect.test.ts -t "shell commands can change directory after login startup|cancel"`
- `bun --cwd packages/opencode test test/effect/runner.test.ts -t "cancel"`
- `bun --cwd packages/opencode test test/tool/lsp.test.ts`
- `bun --cwd packages/opencode test test/server/global-session-list.test.ts -t "session routes omit undefined optional fields"`
- `bun --cwd packages/opencode test test/session/compaction.test.ts`
- `bun run --cwd packages/opencode typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LSP tool: optional workspace-symbol search query to filter results.

* **Bug Fixes**
  * More reliable shell working-directory handling and command execution.
  * Improved cancellation and interrupt handling so shells stop and report failures correctly.
  * Safer shell exit behavior during cancellations and failures.

* **Documentation**
  * Updated LSP tool docs to describe the optional query and behavior.

* **Tests**
  * New tests covering runner cancellation, LSP queries, session listing, shell E2E, and a parameterized shell test harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->