### PR TITLE
fix(app): keep send scroll anchored to bottom

### DIFF
--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -5,6 +5,7 @@ export const terminalSelector = `${desktopTerminalSelector}, ${mobileTerminalSel
 export const sessionComposerDockSelector = '[data-component="session-prompt-dock"]'
 export const sessionTurnListSelector = '[data-slot="session-turn-list"]'
 export const sessionMessageItemSelector = "[data-message-id]"
+export const scrollViewportSelector = '[data-component="scroll-viewport"]'
 export const questionDockSelector = '[data-component="dock-prompt"][data-kind="question"]'
 export const permissionDockSelector = '[data-component="dock-prompt"][data-kind="permission"]'
 export const sessionTodoToggleButtonSelector = '[data-action="session-todo-toggle-button"]'

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -15,6 +15,10 @@ type TimelineMetrics = {
   distanceFromBottom: number
 }
 
+type TimelineScrollSample = TimelineMetrics & {
+  url: string
+}
+
 function timelineMetrics(page: Page) {
   return page.evaluate((turnListSelector) => {
     const list = document.querySelector(turnListSelector)
@@ -44,6 +48,83 @@ async function scrollTimelineToBottom(page: Page) {
     return true
   }, sessionTurnListSelector)
   expect(found, "session timeline viewport should exist").toBe(true)
+}
+
+async function installTimelineScrollProbe(page: Page) {
+  await page.evaluate(
+    ({ maxSamples, turnListSelector }) => {
+      const read = () => {
+        const list = document.querySelector(turnListSelector)
+        const viewport = list?.closest(".scroll-view__viewport")
+        if (!(viewport instanceof HTMLElement)) return null
+        return {
+          url: window.location.href,
+          top: viewport.scrollTop,
+          height: viewport.scrollHeight,
+          client: viewport.clientHeight,
+          distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+        }
+      }
+      const changed = (a: NonNullable<ReturnType<typeof read>>, b: NonNullable<ReturnType<typeof read>>) =>
+        a.url !== b.url ||
+        a.top !== b.top ||
+        a.height !== b.height ||
+        a.client !== b.client ||
+        a.distanceFromBottom !== b.distanceFromBottom
+      const samples: NonNullable<ReturnType<typeof read>>[] = []
+      const push = () => {
+        const next = read()
+        if (!next) return
+        const prev = samples[samples.length - 1]
+        if (prev && !changed(prev, next)) return
+        if (samples.length < maxSamples) samples.push(next)
+      }
+      push()
+      let frame = requestAnimationFrame(function tick() {
+        push()
+        frame = requestAnimationFrame(tick)
+      })
+      const observer = new MutationObserver(push)
+      observer.observe(document.body, { childList: true, subtree: true })
+      const first = read()
+      const viewport = first
+        ? document.querySelector(turnListSelector)?.closest(".scroll-view__viewport")
+        : undefined
+      if (viewport instanceof HTMLElement) viewport.addEventListener("scroll", push, { passive: true })
+      const win = window as typeof window & {
+        __opencode_e2e?: Record<string, unknown> & {
+          timelineScrollProbe?: { stop: () => unknown }
+        }
+      }
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        timelineScrollProbe: {
+          stop() {
+            cancelAnimationFrame(frame)
+            observer.disconnect()
+            if (viewport instanceof HTMLElement) viewport.removeEventListener("scroll", push)
+            push()
+            delete win.__opencode_e2e?.timelineScrollProbe
+            return samples
+          },
+        },
+      }
+    },
+    { maxSamples: 256, turnListSelector: sessionTurnListSelector },
+  )
+}
+
+async function stopTimelineScrollProbe(page: Page) {
+  return page.evaluate(() => {
+    const win = window as typeof window & {
+      __opencode_e2e?: {
+        timelineScrollProbe?: { stop: () => unknown }
+      }
+    }
+    const probe = win.__opencode_e2e?.timelineScrollProbe
+    if (!probe) throw new Error("timeline scroll probe was not installed")
+    return probe.stop()
+  }) as Promise<TimelineScrollSample[]>
 }
 
 async function sendVisiblePrompt(input: { page: Page; text: string }) {
@@ -166,6 +247,56 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
       items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
     )
     expect(rendered.at(-1)).not.toBe(oldID)
+  })
+})
+
+test("does not jump to the top after sending from an old message hash", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e send top guard ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 18 })
+
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+      timeout: 30_000,
+    })
+    await scrollTimelineToBottom(page)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
+
+    const ids = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
+      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+    )
+    const oldID = ids[1]
+    if (!oldID) throw new Error("expected an older rendered message id")
+
+    await page.goto(`${page.url()}#message-${oldID}`)
+    await expect(page.locator(`#message-${oldID}`)).toBeVisible()
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeGreaterThan(100)
+
+    await installTimelineScrollProbe(page)
+    let samples: TimelineScrollSample[] = []
+    try {
+      await sendVisiblePrompt({ page, text: `top guard ${Date.now()}` })
+      await expect.poll(() => page.url()).not.toContain("#message-")
+      await expect
+        .poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom, { timeout: 30_000 })
+        .toBeLessThan(40)
+    } finally {
+      samples = await stopTimelineScrollProbe(page)
+    }
+
+    const topJumps = samples.filter(
+      (sample) =>
+        sample.height > sample.client + 100 &&
+        sample.top < 20 &&
+        sample.distanceFromBottom > 100,
+    )
+    expect(topJumps).toEqual([])
   })
 })
 

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -1,7 +1,13 @@
 import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { withSession } from "../actions"
-import { promptSelector, sessionItemSelector, sessionMessageItemSelector, sessionTurnListSelector } from "../selectors"
+import {
+  promptSelector,
+  scrollViewportSelector,
+  sessionItemSelector,
+  sessionMessageItemSelector,
+  sessionTurnListSelector,
+} from "../selectors"
 import { createSdk } from "../utils"
 
 type Sdk = ReturnType<typeof createSdk>
@@ -16,13 +22,14 @@ type TimelineMetrics = {
 }
 
 type TimelineScrollSample = TimelineMetrics & {
+  at: number
   url: string
 }
 
 function timelineMetrics(page: Page) {
-  return page.evaluate((turnListSelector) => {
+  return page.evaluate(({ scrollViewportSelector, turnListSelector }) => {
     const list = document.querySelector(turnListSelector)
-    const viewport = list?.closest(".scroll-view__viewport")
+    const viewport = list?.closest(scrollViewportSelector)
     if (!(viewport instanceof HTMLElement)) return null
     return {
       top: viewport.scrollTop,
@@ -30,7 +37,7 @@ function timelineMetrics(page: Page) {
       client: viewport.clientHeight,
       distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
     }
-  }, sessionTurnListSelector) as Promise<TimelineMetrics | null>
+  }, { scrollViewportSelector, turnListSelector: sessionTurnListSelector }) as Promise<TimelineMetrics | null>
 }
 
 async function expectTimelineMetrics(page: Page) {
@@ -40,24 +47,25 @@ async function expectTimelineMetrics(page: Page) {
 }
 
 async function scrollTimelineToBottom(page: Page) {
-  const found = await page.evaluate((turnListSelector) => {
+  const found = await page.evaluate(({ scrollViewportSelector, turnListSelector }) => {
     const list = document.querySelector(turnListSelector)
-    const viewport = list?.closest(".scroll-view__viewport")
+    const viewport = list?.closest(scrollViewportSelector)
     if (!(viewport instanceof HTMLElement)) return false
     viewport.scrollTop = viewport.scrollHeight
     return true
-  }, sessionTurnListSelector)
+  }, { scrollViewportSelector, turnListSelector: sessionTurnListSelector })
   expect(found, "session timeline viewport should exist").toBe(true)
 }
 
 async function installTimelineScrollProbe(page: Page) {
   await page.evaluate(
-    ({ maxSamples, turnListSelector }) => {
+    ({ maxSamples, scrollViewportSelector, turnListSelector }) => {
       const read = () => {
         const list = document.querySelector(turnListSelector)
-        const viewport = list?.closest(".scroll-view__viewport")
+        const viewport = list?.closest(scrollViewportSelector)
         if (!(viewport instanceof HTMLElement)) return null
         return {
+          at: performance.now(),
           url: window.location.href,
           top: viewport.scrollTop,
           height: viewport.scrollHeight,
@@ -88,7 +96,7 @@ async function installTimelineScrollProbe(page: Page) {
       observer.observe(document.body, { childList: true, subtree: true })
       const first = read()
       const viewport = first
-        ? document.querySelector(turnListSelector)?.closest(".scroll-view__viewport")
+        ? document.querySelector(turnListSelector)?.closest(scrollViewportSelector)
         : undefined
       if (viewport instanceof HTMLElement) viewport.addEventListener("scroll", push, { passive: true })
       const win = window as typeof window & {
@@ -97,7 +105,7 @@ async function installTimelineScrollProbe(page: Page) {
         }
       }
       win.__opencode_e2e = {
-        ...win.__opencode_e2e,
+        ...(win.__opencode_e2e ?? {}),
         timelineScrollProbe: {
           stop() {
             cancelAnimationFrame(frame)
@@ -110,7 +118,7 @@ async function installTimelineScrollProbe(page: Page) {
         },
       }
     },
-    { maxSamples: 256, turnListSelector: sessionTurnListSelector },
+    { maxSamples: 256, scrollViewportSelector, turnListSelector: sessionTurnListSelector },
   )
 }
 
@@ -280,6 +288,7 @@ test("does not jump to the top after sending from an old message hash", async ({
 
     await installTimelineScrollProbe(page)
     let samples: TimelineScrollSample[] = []
+    const sendStartedAt = await page.evaluate(() => performance.now())
     try {
       await sendVisiblePrompt({ page, text: `top guard ${Date.now()}` })
       await expect.poll(() => page.url()).not.toContain("#message-")
@@ -290,7 +299,10 @@ test("does not jump to the top after sending from an old message hash", async ({
       samples = await stopTimelineScrollProbe(page)
     }
 
-    const topJumps = samples.filter(
+    expect(samples.length).toBeGreaterThan(0)
+    const relevantSamples = samples.filter((sample) => sample.at >= sendStartedAt)
+    expect(relevantSamples.length).toBeGreaterThan(0)
+    const topJumps = relevantSamples.filter(
       (sample) =>
         sample.height > sample.client + 100 &&
         sample.top < 20 &&

--- a/packages/app/src/pages/session/session-auto-scroll.test.ts
+++ b/packages/app/src/pages/session/session-auto-scroll.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { createAutoScroll } from "@opencode-ai/ui/hooks"
+import { createRoot } from "solid-js"
+
+describe("session auto scroll", () => {
+  test("disables overflow anchoring before forcing the timeline to bottom", () => {
+    createRoot((dispose) => {
+      const el = document.createElement("div")
+      let top = 500
+      let anchorAtScroll = ""
+
+      Object.defineProperties(el, {
+        clientHeight: { value: 100, configurable: true },
+        scrollHeight: { value: 1000, configurable: true },
+        scrollTop: {
+          configurable: true,
+          get: () => top,
+          set: (value) => {
+            anchorAtScroll = el.style.overflowAnchor
+            top = value
+          },
+        },
+      })
+
+      const autoScroll = createAutoScroll({
+        working: () => true,
+        overflowAnchor: "dynamic",
+      })
+
+      autoScroll.scrollRef(el)
+      autoScroll.pause()
+      el.style.overflowAnchor = "auto"
+
+      expect(autoScroll.userScrolled()).toBe(true)
+      expect(el.style.overflowAnchor).toBe("auto")
+
+      autoScroll.forceScrollToBottom()
+
+      expect(anchorAtScroll).toBe("none")
+      expect(top).toBe(1000)
+
+      dispose()
+    })
+  })
+})

--- a/packages/ui/src/components/scroll-view.tsx
+++ b/packages/ui/src/components/scroll-view.tsx
@@ -194,6 +194,7 @@ export function ScrollView(props: ScrollViewProps) {
       {/* Viewport */}
       <div
         ref={viewportRef}
+        data-component="scroll-viewport"
         class="scroll-view__viewport"
         onScroll={(e) => {
           updateThumb()

--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -34,6 +34,22 @@ export function createAutoScroll(options: AutoScrollOptions) {
     return el.scrollHeight - el.clientHeight > 1
   }
 
+  const updateOverflowAnchor = (el: HTMLElement) => {
+    const mode = options.overflowAnchor ?? "dynamic"
+
+    if (mode === "none") {
+      el.style.overflowAnchor = "none"
+      return
+    }
+
+    if (mode === "auto") {
+      el.style.overflowAnchor = "auto"
+      return
+    }
+
+    el.style.overflowAnchor = store.userScrolled ? "auto" : "none"
+  }
+
   // Browsers can dispatch scroll events asynchronously. If new content arrives
   // between us calling `scrollTo()` and the subsequent `scroll` event firing,
   // the handler can see a non-zero `distanceFromBottom` and incorrectly assume
@@ -79,9 +95,13 @@ export function createAutoScroll(options: AutoScrollOptions) {
   const scrollToBottom = (force: boolean) => {
     if (!force && !active()) return
 
-    if (force && store.userScrolled) setStore("userScrolled", false)
-
     const el = store.scrollRef
+
+    if (force && store.userScrolled) {
+      setStore("userScrolled", false)
+      if (el) updateOverflowAnchor(el)
+    }
+
     if (!el) return
 
     if (!force && store.userScrolled) return
@@ -151,22 +171,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
     if (selection && selection.toString().length > 0) {
       stop()
     }
-  }
-
-  const updateOverflowAnchor = (el: HTMLElement) => {
-    const mode = options.overflowAnchor ?? "dynamic"
-
-    if (mode === "none") {
-      el.style.overflowAnchor = "none"
-      return
-    }
-
-    if (mode === "auto") {
-      el.style.overflowAnchor = "auto"
-      return
-    }
-
-    el.style.overflowAnchor = store.userScrolled ? "auto" : "none"
   }
 
   createResizeObserver(


### PR DESCRIPTION
## Summary

- Synchronize dynamic `overflow-anchor` updates before forced bottom scrolls.
- Add a focused regression test for the force-scroll ordering.
- Add E2E sampling to guard against send flows jumping the session timeline to the top.

## Why

When the session composer forces the timeline back to the latest turn after sending, dynamic overflow anchoring could still be in the user-scrolled `auto` state at the exact moment `scrollTop` is set to the bottom. That leaves a browser-level window where DOM changes can anchor the viewport back toward the previous position, which matches the reported "send jumps to top" behavior.

This PR updates the auto-scroll helper so forced bottom scrolls synchronously disable overflow anchoring before changing `scrollTop`.

## Related Issue

No dedicated issue for the send-scroll bug yet. The related session-switch flicker is tracked separately in #311 and intentionally not fixed here.

## How To Verify

```bash
bun test --preload ./happydom.ts ./src/pages/session/session-auto-scroll.test.ts
bun test:e2e -- session/session-scroll-position.spec.ts session/session-send-stability.spec.ts
bun typecheck
```

Also ran `bun test` in `packages/ui`; it still fails two existing diff text assertions in `apply-patch-file.test.ts` and `session-diff.test.ts`, unrelated to this scroll change.

## Screenshots or Recordings

Not attached. This is a scroll-position timing fix covered by unit and E2E tests.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position behavior when navigating to older messages to prevent sudden jumps and ensure stable viewport positioning.
  * Ensured forced auto-scroll applies the correct anchor behavior so scrolls reliably reach the bottom.

* **Tests**
  * Added end-to-end tests that validate scroll stability during message navigation.
  * Added automated tests for auto-scroll controller behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->