### PR TITLE
fix: keep timeline visible while switching sessions

### DIFF
--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -177,15 +177,16 @@ test("renders the full initial session window when switching sessions", async ({
 
   await withSession(sdk, `e2e switch source ${Date.now()}`, async (first) => {
     project.trackSession(first.id)
+    await seedSessionTurns({ sdk, sessionID: first.id, count: 14 })
+
+    await project.gotoSession(first.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+      timeout: 30_000,
+    })
+
     await withSession(sdk, `e2e switch target ${Date.now()}`, async (second) => {
       project.trackSession(second.id)
-      await seedSessionTurns({ sdk, sessionID: first.id, count: 14 })
       await seedSessionTurns({ sdk, sessionID: second.id, count: 14 })
-
-      await project.gotoSession(first.id)
-      await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
-        timeout: 30_000,
-      })
       await expect(page.locator(sessionItemSelector(second.id))).toBeVisible({ timeout: 30_000 })
 
       await installMessageCountProbe(page)
@@ -204,6 +205,7 @@ test("renders the full initial session window when switching sessions", async ({
       const switched = samples.filter((sample) => sample.url.includes(`/session/${second.id}`))
       expect(switched.length).toBeGreaterThan(0)
       expect(rendered.every((id) => secondIDs.has(id))).toBe(true)
+      expect(switched.filter((sample) => sample.messages === 0)).toEqual([])
       expect(
         switched.filter(
           (sample) => sample.messages > 0 && sample.messages < INITIAL_SESSION_WINDOW_MESSAGES,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -849,7 +849,7 @@ export default function Page() {
   }
 
   function navigateMessageByOffset(offset: number) {
-    const msgs = visibleUserMessages()
+    const msgs = timelineVisibleUserMessages()
     if (msgs.length === 0) return
 
     const current = store.messageId && messageMark === scrollMark ? store.messageId : cursor()
@@ -999,7 +999,7 @@ export default function Page() {
 
   createEffect(
     on(
-      () => visibleUserMessages().at(-1)?.id,
+      () => timelineVisibleUserMessages().at(-1)?.id,
       (lastId, prevLastId) => {
         if (lastId && prevLastId && lastId > prevLastId) {
           setStore("messageId", undefined)
@@ -1982,12 +1982,12 @@ export default function Page() {
   )
 
   const { clearMessageHash, scrollToMessage } = useSessionHashScroll({
-    sessionKey,
-    sessionID: () => params.id,
-    messagesReady,
-    visibleUserMessages,
-    historyMore,
-    historyLoading,
+    sessionKey: timelineSessionKey,
+    sessionID: timelineSessionID,
+    messagesReady: timelineMessagesReady,
+    visibleUserMessages: timelineVisibleUserMessages,
+    historyMore: timelineHistoryMore,
+    historyLoading: timelineHistoryLoading,
     loadMore: (sessionID) => sync.session.history.loadMore(sessionID),
     turnStart: historyWindow.turnStart,
     currentMessageId: () => store.messageId,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -59,6 +59,7 @@ import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
+import { nextTimelineSessionID } from "@/pages/session/timeline-session-state"
 import { deriveArtifactFiles, nextFilesPanelAutoOpen, type SessionArtifactFile } from "@/pages/session/files-tab-state"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
@@ -513,6 +514,22 @@ export default function Page() {
     if (!id) return true
     return sync.data.message[id] !== undefined
   })
+  const timelineSessionID = createMemo((current: string | undefined) =>
+    nextTimelineSessionID({
+      current,
+      route: params.id,
+      routeReady: messagesReady(),
+    }),
+  )
+  const timelineSessionKey = createMemo(() => `${params.dir}${timelineSessionID() ? `/${timelineSessionID()}` : ""}`)
+  const timelineMessages = createMemo(
+    () => {
+      const id = timelineSessionID()
+      return readSessionMessages(id ? sync.data.message[id] : undefined)
+    },
+    emptyMessages,
+    { equals: same },
+  )
   const historyMore = createMemo(() => {
     const id = params.id
     if (!id) return false
@@ -1596,6 +1613,14 @@ export default function Page() {
     userScrolled: autoScroll.userScrolled,
     scroller: () => scroller,
   })
+  const timelineRenderedUserMessages = createMemo(
+    (previous: UserMessage[] = emptyUserMessages) => {
+      if (messagesReady()) return historyWindow.renderedUserMessages()
+      return previous
+    },
+    emptyUserMessages,
+    { equals: same },
+  )
 
   fill = () => {
     if (fillFrame !== undefined) return
@@ -2069,8 +2094,11 @@ export default function Page() {
           <div class="flex-1 min-h-0 overflow-hidden">
             <Switch>
               <Match when={params.id}>
-                <Show when={messagesReady()}>
+                <Show when={timelineSessionID()}>
                   <MessageTimeline
+                    sessionID={timelineSessionID()!}
+                    sessionKey={timelineSessionKey()}
+                    sessionMessages={timelineMessages()}
                     mobileChanges={mobileChanges()}
                     mobileFallback={reviewContent({
                       classes: {
@@ -2106,7 +2134,7 @@ export default function Page() {
                     onLoadEarlier={() => {
                       void historyWindow.loadAndReveal()
                     }}
-                    renderedUserMessages={historyWindow.renderedUserMessages()}
+                    renderedUserMessages={timelineRenderedUserMessages()}
                     anchor={anchor}
                   />
                 </Show>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -530,6 +530,42 @@ export default function Page() {
     emptyMessages,
     { equals: same },
   )
+  const timelineMessagesReady = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return true
+    return sync.data.message[id] !== undefined
+  })
+  const timelineUserMessages = createMemo(
+    () => readUserMessages(timelineMessages()),
+    emptyUserMessages,
+    { equals: same },
+  )
+  const timelineRevertMessageID = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return
+    return sync.session.get(id)?.revert?.messageID
+  })
+  const timelineVisibleUserMessages = createMemo(
+    () => {
+      const revert = timelineRevertMessageID()
+      if (!revert) return timelineUserMessages()
+      return timelineUserMessages().filter((m) => m.id < revert)
+    },
+    emptyUserMessages,
+    {
+      equals: same,
+    },
+  )
+  const timelineHistoryMore = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return false
+    return sync.session.history.more(id)
+  })
+  const timelineHistoryLoading = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return false
+    return sync.session.history.loading(id)
+  })
   const historyMore = createMemo(() => {
     const id = params.id
     if (!id) return false
@@ -1603,24 +1639,16 @@ export default function Page() {
   )
 
   const historyWindow = createSessionHistoryWindow({
-    sessionID: () => params.id,
-    messagesReady,
-    loaded: () => messages().length,
-    visibleUserMessages,
-    historyMore,
-    historyLoading,
+    sessionID: timelineSessionID,
+    messagesReady: timelineMessagesReady,
+    loaded: () => timelineMessages().length,
+    visibleUserMessages: timelineVisibleUserMessages,
+    historyMore: timelineHistoryMore,
+    historyLoading: timelineHistoryLoading,
     loadMore: (sessionID) => sync.session.history.loadMore(sessionID),
     userScrolled: autoScroll.userScrolled,
     scroller: () => scroller,
   })
-  const timelineRenderedUserMessages = createMemo(
-    (previous: UserMessage[] = emptyUserMessages) => {
-      if (messagesReady()) return historyWindow.renderedUserMessages()
-      return previous
-    },
-    emptyUserMessages,
-    { equals: same },
-  )
 
   fill = () => {
     if (fillFrame !== undefined) return
@@ -1628,13 +1656,13 @@ export default function Page() {
     fillFrame = requestAnimationFrame(() => {
       fillFrame = undefined
 
-      if (!params.id || !messagesReady()) return
-      if (autoScroll.userScrolled() || historyLoading()) return
+      if (!timelineSessionID() || !timelineMessagesReady()) return
+      if (autoScroll.userScrolled() || timelineHistoryLoading()) return
 
       const el = scroller
       if (!el) return
       if (el.scrollHeight > el.clientHeight + 1) return
-      if (historyWindow.turnStart() <= 0 && !historyMore()) return
+      if (historyWindow.turnStart() <= 0 && !timelineHistoryMore()) return
 
       void historyWindow.loadAndReveal()
     })
@@ -1645,14 +1673,15 @@ export default function Page() {
       () =>
         [
           params.id,
-          messagesReady(),
+          timelineSessionID(),
+          timelineMessagesReady(),
           historyWindow.turnStart(),
-          historyMore(),
-          historyLoading(),
+          timelineHistoryMore(),
+          timelineHistoryLoading(),
           autoScroll.userScrolled(),
-          visibleUserMessages().length,
+          timelineVisibleUserMessages().length,
         ] as const,
-      ([id, ready, start, more, loading, scrolled]) => {
+      ([, id, ready, start, more, loading, scrolled]) => {
         if (!id || !ready || loading || scrolled) return
         if (start <= 0 && !more) return
         fill()
@@ -2129,12 +2158,12 @@ export default function Page() {
                       if (root) scheduleScrollState(root)
                     }}
                     turnStart={historyWindow.turnStart()}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
+                    historyMore={timelineHistoryMore()}
+                    historyLoading={timelineHistoryLoading()}
                     onLoadEarlier={() => {
                       void historyWindow.loadAndReveal()
                     }}
-                    renderedUserMessages={timelineRenderedUserMessages()}
+                    renderedUserMessages={historyWindow.renderedUserMessages()}
                     anchor={anchor}
                   />
                 </Show>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -209,6 +209,9 @@ function createTimelineStaging(input: TimelineStageInput) {
 }
 
 export function MessageTimeline(props: {
+  sessionID: string
+  sessionKey: string
+  sessionMessages: MessageType[]
   mobileChanges: boolean
   mobileFallback: JSX.Element
   actions?: UserActions
@@ -240,7 +243,7 @@ export function MessageTimeline(props: {
   const dialog = useDialog()
   const language = useLanguage()
   const shellSurface = useShellSurface()
-  const { params, sessionKey } = useSessionKey()
+  const { params } = useSessionKey()
   const platform = usePlatform()
   const server = useServer()
   // Export hits the embedded sidecar via main-process IPC. When the user has switched the
@@ -249,12 +252,9 @@ export function MessageTimeline(props: {
   const exportAvailable = createMemo(() => !!platform.exportSession && server.current?.type === "sidecar")
 
   const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
-  const sessionID = createMemo(() => params.id)
-  const sessionMessages = createMemo(() => {
-    const id = sessionID()
-    if (!id) return emptyMessages
-    return sync.data.message[id] ?? emptyMessages
-  })
+  const sessionKey = createMemo(() => props.sessionKey)
+  const sessionID = createMemo(() => props.sessionID)
+  const sessionMessages = createMemo(() => props.sessionMessages)
   const webSearchToastSurfaced = new Set<string>()
   const webSearchPartCursor = new Map<string, number>()
   const webSearchPendingParts = new Map<string, Set<string>>()
@@ -381,7 +381,7 @@ export function MessageTimeline(props: {
   // Match the initial window cap so session switches do not reveal the window in partial batches.
   const stageCfg = { init: 10, batch: 3 }
   const staging = createTimelineStaging({
-    sessionKey,
+    sessionKey: () => props.sessionKey,
     turnStart: () => props.turnStart,
     messages: () => props.renderedUserMessages,
     config: stageCfg,

--- a/packages/app/src/pages/session/timeline-session-state.test.ts
+++ b/packages/app/src/pages/session/timeline-session-state.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { nextTimelineSessionID } from "./timeline-session-state"
+
+describe("nextTimelineSessionID", () => {
+  test("keeps the rendered timeline session while the target route session is not ready", () => {
+    expect(
+      nextTimelineSessionID({
+        current: "ses_source",
+        route: "ses_target",
+        routeReady: false,
+      }),
+    ).toBe("ses_source")
+  })
+
+  test("switches to the route session once its messages are ready", () => {
+    expect(
+      nextTimelineSessionID({
+        current: "ses_source",
+        route: "ses_target",
+        routeReady: true,
+      }),
+    ).toBe("ses_target")
+  })
+
+  test("clears the rendered timeline when leaving a session route", () => {
+    expect(
+      nextTimelineSessionID({
+        current: "ses_source",
+        route: undefined,
+        routeReady: true,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/session/timeline-session-state.ts
+++ b/packages/app/src/pages/session/timeline-session-state.ts
@@ -1,0 +1,9 @@
+export function nextTimelineSessionID(input: {
+  current: string | undefined
+  route: string | undefined
+  routeReady: boolean
+}) {
+  if (!input.route) return undefined
+  if (input.routeReady) return input.route
+  return input.current
+}


### PR DESCRIPTION
## Summary

Keep the previous rendered session timeline visible while the target session messages are still loading, then switch the timeline once the target message cache is ready. Add a small timeline-session state helper plus coverage for retaining the visible timeline session, and extend the session switching E2E probe to reject 0-message samples after navigation reaches the target session.

## Why

Fixes #311. Session switching could briefly route to the target session before its message cache existed, which made the session page unmount `MessageTimeline` and show an empty conversation frame.

## Related Issue

Fixes #311

## How To Verify

```bash
bun install --frozen-lockfile
bun --cwd packages/app test --preload ./happydom.ts ./src/pages/session/timeline-session-state.test.ts
bun run --cwd packages/app typecheck
bun run --cwd packages/app test:e2e -- session/session-scroll-position.spec.ts -g "renders the full initial session window when switching sessions"
bun run --cwd packages/app test:e2e -- session/session-scroll-position.spec.ts
git diff --check
```

## Screenshots or Recordings

Not included. This fixes a transient session-switch frame, and the behavior is covered by the E2E timeline sampling probe.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end and unit tests around session switching and message counts to catch unexpected zero-message observations.

* **Refactor**
  * Reworked timeline/session handling so the timeline lifecycle, message sets, and scroll behavior are scoped per timeline and render consistently.

* **UX**
  * Improved message visibility, history loading, and scroll restoration when switching between sessions; timeline only renders when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->