### PR TITLE
fix: close home panels by default

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -319,10 +319,11 @@ export async function openSidebar(page: Page) {
 }
 
 export async function openRightPanel(page: Page) {
-  const panel = page.getByRole("complementary", { name: "Right utility panel" })
+  const panelName = "Right utility panel"
+  const panel = page.getByRole("complementary", { name: panelName })
   if (await panel.isVisible().catch(() => false)) return panel
 
-  await page.getByRole("button", { name: "Right utility panel" }).click()
+  await page.getByRole("button", { name: panelName }).click()
   await expect(panel).toBeVisible()
   return panel
 }

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -318,6 +318,15 @@ export async function openSidebar(page: Page) {
   await expect(button).toHaveAttribute("aria-expanded", "true")
 }
 
+export async function openRightPanel(page: Page) {
+  const panel = page.getByRole("complementary", { name: "Right utility panel" })
+  if (await panel.isVisible().catch(() => false)) return panel
+
+  await page.getByRole("button", { name: "Right utility panel" }).click()
+  await expect(panel).toBeVisible()
+  return panel
+}
+
 export async function closeSidebar(page: Page) {
   if (await isSidebarClosed(page)) return
 

--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../fixtures"
+import { openSidebar } from "../actions"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
 
 test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
@@ -6,11 +7,12 @@ test("@smoke root route renders seeded home entrypoints", async ({ page }) => {
 
   const home = page.locator('[data-component="session-new-home"]')
 
-  await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible()
   await expect(home).toBeVisible()
   await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
   await expect(home.locator(sessionComposerDockSelector)).toHaveCount(1)
+  await openSidebar(page)
+  await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
+  await expect(page.getByRole("button", { name: "New session" })).toBeVisible()
   await expect(page.getByText("No recent projects")).toHaveCount(0)
   await expect(page.getByText("Get started by opening a local project")).toHaveCount(0)
 })
@@ -23,7 +25,6 @@ test("@smoke home renders the hero composer and starter cards", async ({ page, p
   const firstCard = home.getByRole("button", { name: /Process docs/i })
   const workspaceChip = page.getByRole("button", { name: /Switch workspace|切换工作目录/i })
   await expect(home).toBeVisible()
-  await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
   await expect(page.getByRole("heading", { name: "Choose what to do" })).toBeVisible()
   await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
   await expect(composer).toHaveCount(1)
@@ -34,6 +35,8 @@ test("@smoke home renders the hero composer and starter cards", async ({ page, p
   await expect(page.getByRole("button", { name: /Start writing/i })).toBeVisible()
   await expect(page.getByRole("button", { name: "Right utility panel" })).toBeVisible()
   await expect(workspaceChip).toBeVisible()
+  await openSidebar(page)
+  await expect(page.getByRole("button", { name: "Open project" }).first()).toBeVisible()
 
   const cardBox = await firstCard.boundingBox()
   const composerBox = await composer.boundingBox()

--- a/packages/app/e2e/files/file-tree.spec.ts
+++ b/packages/app/e2e/files/file-tree.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { withSession } from "../actions"
+import { openRightPanel, withSession } from "../actions"
 
 // Historical context: before the right-panel-polish PR (#52), the Review tab
 // carried a sibling vertical file-tree pane (#file-tree-panel) that surfaced
@@ -13,7 +13,7 @@ test("@smoke review tab no longer renders the legacy file-tree sub-panel", async
   await withSession(project.sdk, `e2e review layout smoke ${Date.now()}`, async (session) => {
     await project.gotoSession(session.id)
 
-    const rightPanel = page.getByRole("complementary", { name: "Right utility panel" })
+    const rightPanel = await openRightPanel(page)
     const shellTabList = rightPanel.getByRole("tablist")
     await shellTabList.locator("button").last().click()
     await page.getByRole("menuitem", { name: "Review" }).click()

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import {
   clampRightPanelWidth,
+  createDefaultLayoutState,
   createSessionKeyReader,
   DEFAULT_RIGHT_PANEL_WIDTH,
   defaultSidePanelTab,
@@ -76,6 +77,15 @@ describe("pruneSessionKeys", () => {
     })
 
     expect(drop).toEqual([])
+  })
+})
+
+describe("default layout state", () => {
+  test("starts clean desktop profiles with both side panels closed", () => {
+    const state = createDefaultLayoutState()
+
+    expect(state.sidebar.opened).toBe(false)
+    expect(state.rightPanel.opened).toBe(false)
   })
 })
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -170,6 +170,45 @@ const normalizeStoredSessionTabs = (key: string, tabs: SessionTabs) => {
   }
 }
 
+export function createDefaultLayoutState() {
+  return {
+    sidebar: {
+      opened: false,
+      width: DEFAULT_SIDEBAR_WIDTH,
+      workspaces: {} as Record<string, boolean>,
+      workspacesDefault: false,
+    },
+    terminal: {
+      height: DEFAULT_TERMINAL_HEIGHT,
+      opened: false,
+    },
+    review: {
+      diffStyle: "unified" as ReviewDiffStyle,
+      panelOpened: false,
+    },
+    fileTree: {
+      opened: false,
+      width: DEFAULT_FILE_TREE_WIDTH,
+      tab: "changes" as "changes" | "all",
+    },
+    session: {
+      width: DEFAULT_SESSION_WIDTH,
+    },
+    rightPanel: {
+      width: DEFAULT_RIGHT_PANEL_WIDTH,
+      opened: false,
+    },
+    mobileSidebar: {
+      opened: false,
+    },
+    sessionTabs: {} as Record<string, SessionTabs>,
+    sessionView: {} as Record<string, SessionView>,
+    handoff: {
+      tabs: undefined as TabHandoff | undefined,
+    },
+  }
+}
+
 export function legacyRightPanelOpened(rightPanel: unknown, review: unknown, fileTree: unknown): boolean {
   if (isRecord(rightPanel) && typeof rightPanel.opened === "boolean") return rightPanel.opened
   if (isRecord(review) && typeof review.panelOpened === "boolean") return review.panelOpened
@@ -287,42 +326,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     const target = Persist.global("layout", ["layout.v6"])
     const [store, setStore, _, ready] = persisted(
       { ...target, migrate: migrateStoredLayout },
-      createStore({
-        sidebar: {
-          opened: true,
-          width: DEFAULT_SIDEBAR_WIDTH,
-          workspaces: {} as Record<string, boolean>,
-          workspacesDefault: false,
-        },
-        terminal: {
-          height: DEFAULT_TERMINAL_HEIGHT,
-          opened: false,
-        },
-        review: {
-          diffStyle: "unified" as ReviewDiffStyle,
-          panelOpened: false,
-        },
-        fileTree: {
-          opened: false,
-          width: DEFAULT_FILE_TREE_WIDTH,
-          tab: "changes" as "changes" | "all",
-        },
-        session: {
-          width: DEFAULT_SESSION_WIDTH,
-        },
-        rightPanel: {
-          width: DEFAULT_RIGHT_PANEL_WIDTH,
-          opened: true,
-        },
-        mobileSidebar: {
-          opened: false,
-        },
-        sessionTabs: {} as Record<string, SessionTabs>,
-        sessionView: {} as Record<string, SessionView>,
-        handoff: {
-          tabs: undefined as TabHandoff | undefined,
-        },
-      }),
+      createStore(createDefaultLayoutState()),
     )
 
     const MAX_SESSION_KEYS = 50
@@ -818,7 +822,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         const s = createMemo(() => store.sessionView[key()] ?? { scroll: {} })
         const terminalOpened = createMemo(() => store.terminal?.opened ?? false)
         const reviewPanelOpened = createMemo(() => store.review?.panelOpened ?? false)
-        const sidePanelOpened = createMemo(() => store.rightPanel?.opened ?? true)
+        const sidePanelOpened = createMemo(() => store.rightPanel?.opened ?? false)
         const shellTabState = createMemo(() =>
           normalizeShellTabs({
             openShellTabs: legacyOpenShellTabs(s().openShellTabs, s().sidePanelTab),
@@ -857,7 +861,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             return
           }
 
-          const value = current.opened ?? true
+          const value = current.opened ?? false
           if (value === next) return
           setStore("rightPanel", "opened", next)
         }


### PR DESCRIPTION
## Summary

Close the left project/session sidebar and the right utility panel by default for clean layout state. Add a focused regression test for the fresh-layout defaults.

## Why

Fixes #290. New users who land on the new-session home should see the composer-focused home screen first, not a multi-panel workspace with no session context yet.

## Related Issue

Fixes #290

## How To Verify

```bash
bun install --frozen-lockfile
bun test --preload ./happydom.ts ./src/context/layout.test.ts
bun --cwd packages/app typecheck
git diff --check
```

## Screenshots or Recordings

Not recorded. This changes the persisted layout default state and has focused unit coverage for clean profiles; it does not change copy or component styling.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Right-side utility panel now defaults to closed on initial load.

* **Tests**
  * E2E/home and file-tree tests improved to ensure sidebar and right panel are opened and visible before assertions.

* **Refactor**
  * Layout initialization consolidated to a single default state to standardize initial UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->