### PR TITLE
fix: keep todo dock after manual stop

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -24,6 +24,9 @@ const syncedDirectories: string[] = []
 const promptAsyncCalls: Array<Record<string, unknown>> = []
 const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
+const abortedSessions: string[] = []
+const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
+const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 
 let params: { id?: string } = {}
 let selected = "/repo/worktree-a"
@@ -66,7 +69,10 @@ const clientFor = (directory: string) => {
         commandCalls.push(input)
         return { data: undefined }
       },
-      abort: async () => ({ data: undefined }),
+      abort: async (input: { sessionID: string }) => {
+        abortedSessions.push(input.sessionID)
+        return { data: undefined }
+      },
     },
     worktree: {
       create: async () => ({ data: { directory: `${directory}/new` } }),
@@ -189,6 +195,10 @@ beforeAll(async () => {
         return [
           { session: storedSessions[directory] },
           (...args: unknown[]) => {
+            if (args[0] === "todo") {
+              childTodoSets.push({ directory, sessionID: String(args[1]), todos: args[2] })
+              return
+            }
             if (args[0] !== "session") return
             const next = args[1]
             if (typeof next === "function") {
@@ -200,6 +210,11 @@ beforeAll(async () => {
             }
           },
         ]
+      },
+      todo: {
+        set(sessionID: string, todos: unknown) {
+          globalTodoSets.push({ sessionID, todos })
+        },
       },
     }),
   }))
@@ -232,6 +247,9 @@ beforeEach(() => {
   promptAsyncCalls.length = 0
   commandCalls.length = 0
   commandDefinitions.length = 0
+  abortedSessions.length = 0
+  globalTodoSets.length = 0
+  childTodoSets.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
@@ -243,6 +261,34 @@ beforeEach(() => {
 })
 
 describe("prompt submit worktree selection", () => {
+  test("keeps cached todos when aborting an active session", async () => {
+    params = { id: "session-existing" }
+    const aborts: string[] = []
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => true,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onAbort: () => aborts.push("called"),
+    })
+
+    await submit.abort()
+
+    expect(aborts).toEqual(["called"])
+    expect(abortedSessions).toEqual(["session-existing"])
+    expect(globalTodoSets).toEqual([])
+    expect(childTodoSets).toEqual([])
+  })
+
   test("reads the latest worktree accessor value per submit", async () => {
     const submit = createPromptSubmit({
       info: () => undefined,

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -234,10 +234,6 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const sessionID = params.id
     if (!sessionID) return Promise.resolve()
 
-    globalSync.todo.set(sessionID, [])
-    const [, setStore] = globalSync.child(sdk.directory)
-    setStore("todo", sessionID, [])
-
     input.onAbort?.()
 
     const queued = pending.get(sessionID)


### PR DESCRIPTION
## Summary

Keep cached session todos intact when the user manually stops an active turn.

## Why

Fixes the manual Stop path from #319. The Todo dock already stays mounted while todo data exists, but the abort handler was clearing the local todo cache before the backend had cleared the todo list.

## Related Issue

Fixes #319.

## How To Verify

```bash
bun install --frozen-lockfile
bun --cwd packages/app test:unit src/components/prompt-input/submit.test.ts
bun --cwd packages/app typecheck
git diff --check
bun --cwd packages/app playwright test e2e/session/session-composer-dock.spec.ts --grep "todo dock"
```

## Screenshots or Recordings

Not attached. The change preserves existing UI state and does not alter visible copy. The behavior is covered by a focused unit regression and the existing Todo dock E2E.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
