### PR TITLE
fix: isolate internal auth env from user commands

### DIFF
--- a/packages/app/e2e/backend.test.ts
+++ b/packages/app/e2e/backend.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { createBackendEnv } from "./backend"
+
+describe("createBackendEnv", () => {
+  test("does not pass inherited OpenCode server auth into isolated e2e backend", () => {
+    const env = createBackendEnv({
+      base: {
+        PATH: "/usr/bin",
+        OPENCODE_SERVER_USERNAME: "PawWork",
+        OPENCODE_SERVER_PASSWORD: "secret",
+        opencode_server_password: "mixed-case-secret",
+        CUSTOM_VALUE: "kept",
+      },
+      sandbox: "/tmp/pawwork-e2e",
+    })
+
+    expect(env.OPENCODE_SERVER_USERNAME).toBeUndefined()
+    expect(env.OPENCODE_SERVER_PASSWORD).toBeUndefined()
+    expect(env.opencode_server_password).toBeUndefined()
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.CUSTOM_VALUE).toBe("kept")
+    expect(env.OPENCODE_CLIENT).toBe("app")
+  })
+})

--- a/packages/app/e2e/backend.ts
+++ b/packages/app/e2e/backend.ts
@@ -58,6 +58,8 @@ async function waitExit(proc: ReturnType<typeof spawn>, timeout = 10_000) {
 
 const LOG_CAP = 100
 
+const INTERNAL_SERVER_AUTH_ENV = new Set(["opencode_server_password", "opencode_server_username"])
+
 function cap(input: string[]) {
   if (input.length > LOG_CAP) input.splice(0, input.length - LOG_CAP)
 }
@@ -66,26 +68,38 @@ function tail(input: string[]) {
   return input.slice(-40).join("")
 }
 
+export function createBackendEnv(input: {
+  base?: NodeJS.ProcessEnv
+  sandbox: string
+  llmUrl?: string
+}): Record<string, string | undefined> {
+  const env = {
+    ...(input.base ?? process.env),
+    OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
+    OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+    OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+    OPENCODE_TEST_HOME: path.join(input.sandbox, "home"),
+    XDG_DATA_HOME: path.join(input.sandbox, "share"),
+    XDG_CACHE_HOME: path.join(input.sandbox, "cache"),
+    XDG_CONFIG_HOME: path.join(input.sandbox, "config"),
+    XDG_STATE_HOME: path.join(input.sandbox, "state"),
+    OPENCODE_CLIENT: "app",
+    OPENCODE_STRICT_CONFIG_DEPS: "true",
+    OPENCODE_E2E_LLM_URL: input.llmUrl,
+  }
+  for (const key of Object.keys(env)) {
+    if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete env[key]
+  }
+  return env
+}
+
 export async function startBackend(label: string, input?: { llmUrl?: string }): Promise<Handle> {
   const port = await freePort()
   const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), `opencode-e2e-${label}-`))
   const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
   const repoDir = path.resolve(appDir, "../..")
   const opencodeDir = path.join(repoDir, "packages", "opencode")
-  const env = {
-    ...process.env,
-    OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
-    OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
-    OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
-    OPENCODE_TEST_HOME: path.join(sandbox, "home"),
-    XDG_DATA_HOME: path.join(sandbox, "share"),
-    XDG_CACHE_HOME: path.join(sandbox, "cache"),
-    XDG_CONFIG_HOME: path.join(sandbox, "config"),
-    XDG_STATE_HOME: path.join(sandbox, "state"),
-    OPENCODE_CLIENT: "app",
-    OPENCODE_STRICT_CONFIG_DEPS: "true",
-    OPENCODE_E2E_LLM_URL: input?.llmUrl,
-  } satisfies Record<string, string | undefined>
+  const env = createBackendEnv({ sandbox, llmUrl: input?.llmUrl })
   const out: string[] = []
   const err: string[] = []
   const proc = spawn(

--- a/packages/app/test/e2e-backend-env.test.ts
+++ b/packages/app/test/e2e-backend-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { createBackendEnv } from "./backend"
+import { createBackendEnv } from "../e2e/backend"
 
 describe("createBackendEnv", () => {
   test("does not pass inherited OpenCode server auth into isolated e2e backend", () => {
@@ -8,6 +8,7 @@ describe("createBackendEnv", () => {
         PATH: "/usr/bin",
         OPENCODE_SERVER_USERNAME: "PawWork",
         OPENCODE_SERVER_PASSWORD: "secret",
+        opencode_server_username: "mixed-case-user",
         opencode_server_password: "mixed-case-secret",
         CUSTOM_VALUE: "kept",
       },
@@ -16,6 +17,7 @@ describe("createBackendEnv", () => {
 
     expect(env.OPENCODE_SERVER_USERNAME).toBeUndefined()
     expect(env.OPENCODE_SERVER_PASSWORD).toBeUndefined()
+    expect(env.opencode_server_username).toBeUndefined()
     expect(env.opencode_server_password).toBeUndefined()
     expect(env.PATH).toBe("/usr/bin")
     expect(env.CUSTOM_VALUE).toBe("kept")

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -9,6 +9,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
+import { withoutInternalServerAuthEnv } from "@/util/env"
 import { PtyID } from "./schema"
 import { Effect, Layer, Context } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
@@ -183,13 +184,19 @@ export namespace Pty {
 
         const cwd = input.cwd || s.dir
         const shell = yield* plugin.trigger("shell.env", { cwd }, { env: {} })
-        const env = {
+        const env = withoutInternalServerAuthEnv({
           ...process.env,
           ...input.env,
           ...shell.env,
           TERM: "xterm-256color",
           OPENCODE_TERMINAL: "1",
-        } as Record<string, string>
+        } as Record<string, string>)
+        // bun-pty merges with the parent process environment internally, so
+        // deleting these keys is not enough for PTY sessions. Override with
+        // empty values to prevent PawWork's internal server credentials from
+        // being visible inside user terminals.
+        env.OPENCODE_SERVER_USERNAME = ""
+        env.OPENCODE_SERVER_PASSWORD = ""
 
         if (process.platform === "win32") {
           env.LC_ALL = "C.UTF-8"

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -9,7 +9,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
-import { withoutInternalServerAuthEnv } from "@/util/env"
+import { envValueCaseInsensitive, withoutInternalServerAuthEnv } from "@/util/env"
 import { PtyID } from "./schema"
 import { Effect, Layer, Context } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
@@ -195,8 +195,8 @@ export namespace Pty {
         // deleting these keys is not enough for PTY sessions. Override with
         // empty values to prevent PawWork's internal server credentials from
         // being visible inside user terminals.
-        env.OPENCODE_SERVER_USERNAME = ""
-        env.OPENCODE_SERVER_PASSWORD = ""
+        env.OPENCODE_SERVER_USERNAME = envValueCaseInsensitive(input.env, "OPENCODE_SERVER_USERNAME") ?? ""
+        env.OPENCODE_SERVER_PASSWORD = envValueCaseInsensitive(input.env, "OPENCODE_SERVER_PASSWORD") ?? ""
 
         if (process.platform === "win32") {
           env.LC_ALL = "C.UTF-8"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -47,6 +47,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import { withoutInternalServerAuthEnv } from "@/util/env"
 import { Cause, Deferred, Effect, Exit, Layer, Option, Scope, Context } from "effect"
 import { EffectLogger } from "@/effect"
 import { InstanceState } from "@/effect"
@@ -1004,15 +1005,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             ),
           )
 
-          const env = {
+          const env = withoutInternalServerAuthEnv({
+            ...process.env,
             ...shellEnv.env,
             TERM: "dumb",
             ...(shellName === "zsh" || shellName === "bash" ? { OPENCODE_SHELL_CWD: cwd } : {}),
-          }
+          })
 
           const cmd = ChildProcess.make(sh, args, {
             cwd,
-            extendEnv: true,
+            extendEnv: false,
             env,
             stdin: "ignore",
             forceKillAfter: "3 seconds",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -20,6 +20,7 @@ import { Plugin } from "@/plugin"
 import { Effect, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { withoutInternalServerAuthEnv } from "@/util/env"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -403,11 +404,11 @@ export const BashTool = Tool.define(
       const bundledToolsDir = resourcesPath ? path.join(resourcesPath, "tools") : ""
       const extraEnv = extra.env as Record<string, string>
       const currentPath = extraEnv.PATH || process.env.PATH || ""
-      return {
+      return withoutInternalServerAuthEnv({
         ...process.env,
         ...extraEnv,
         PATH: bundledToolsDir ? `${bundledToolsDir}${path.delimiter}${currentPath}` : currentPath,
-      }
+      })
     })
 
     const run = Effect.fn("BashTool.run")(function* (

--- a/packages/opencode/src/util/env.ts
+++ b/packages/opencode/src/util/env.ts
@@ -1,0 +1,8 @@
+const INTERNAL_SERVER_AUTH_ENV = new Set(["opencode_server_password", "opencode_server_username"])
+
+export function withoutInternalServerAuthEnv<T extends Record<string, string | undefined>>(env: T): T {
+  for (const key of Object.keys(env)) {
+    if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete env[key]
+  }
+  return env
+}

--- a/packages/opencode/src/util/env.ts
+++ b/packages/opencode/src/util/env.ts
@@ -1,10 +1,11 @@
 const INTERNAL_SERVER_AUTH_ENV = new Set(["opencode_server_password", "opencode_server_username"])
 
 export function withoutInternalServerAuthEnv<T extends Record<string, string | undefined>>(env: T): T {
-  for (const key of Object.keys(env)) {
-    if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete env[key]
+  const sanitized = { ...env }
+  for (const key of Object.keys(sanitized)) {
+    if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete sanitized[key]
   }
-  return env
+  return sanitized
 }
 
 export function envValueCaseInsensitive(env: Record<string, string | undefined> | undefined, name: string) {

--- a/packages/opencode/src/util/env.ts
+++ b/packages/opencode/src/util/env.ts
@@ -6,3 +6,8 @@ export function withoutInternalServerAuthEnv<T extends Record<string, string | u
   }
   return env
 }
+
+export function envValueCaseInsensitive(env: Record<string, string | undefined> | undefined, name: string) {
+  const normalized = name.toLowerCase()
+  return Object.entries(env ?? {}).find(([key]) => key.toLowerCase() === normalized)?.[1]
+}

--- a/packages/opencode/test/pty/pty-session.test.ts
+++ b/packages/opencode/test/pty/pty-session.test.ts
@@ -147,4 +147,61 @@ describe("pty", () => {
       else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
     }
   })
+
+  test("preserves explicit terminal auth env overrides", async () => {
+    if (process.platform === "win32") return
+
+    const previousUsername = process.env.OPENCODE_SERVER_USERNAME
+    const previousPassword = process.env.OPENCODE_SERVER_PASSWORD
+    process.env.OPENCODE_SERVER_USERNAME = "PawWork"
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+
+    try {
+      await using dir = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          let id: PtyID | undefined
+          try {
+            const info = await Pty.create({
+              command: "/bin/sh",
+              title: "explicit-env",
+              env: {
+                OPENCODE_SERVER_USERNAME: "explicit-user",
+                OPENCODE_SERVER_PASSWORD: "explicit-password",
+              },
+            })
+            id = info.id
+
+            const output: string[] = []
+            await Pty.connect(info.id, {
+              readyState: 1,
+              send: (data: unknown) => output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
+              close: () => undefined,
+            } as any)
+
+            await Pty.write(
+              info.id,
+              'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}"\nexit\n',
+            )
+            await wait(() => output.join("").includes("password="))
+
+            const text = output.join("")
+            expect(text).toContain("username=explicit-user")
+            expect(text).toContain("password=explicit-password")
+            expect(text).not.toContain("secret")
+            expect(text).not.toContain("PawWork")
+          } finally {
+            if (id) await Pty.remove(id)
+          }
+        },
+      })
+    } finally {
+      if (previousUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+      else process.env.OPENCODE_SERVER_USERNAME = previousUsername
+      if (previousPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+      else process.env.OPENCODE_SERVER_PASSWORD = previousPassword
+    }
+  })
 })

--- a/packages/opencode/test/pty/pty-session.test.ts
+++ b/packages/opencode/test/pty/pty-session.test.ts
@@ -89,4 +89,62 @@ describe("pty", () => {
       },
     })
   })
+
+  test("does not expose internal server auth env to terminal sessions", async () => {
+    if (process.platform === "win32") return
+
+    const previousUsername = process.env.OPENCODE_SERVER_USERNAME
+    const previousPassword = process.env.OPENCODE_SERVER_PASSWORD
+    const previousCustom = process.env.PAWWORK_E2E_CUSTOM_ENV
+    process.env.OPENCODE_SERVER_USERNAME = "PawWork"
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+    process.env.PAWWORK_E2E_CUSTOM_ENV = "kept"
+
+    try {
+      await using dir = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: dir.path,
+        fn: async () => {
+          let id: PtyID | undefined
+          try {
+            const info = await Pty.create({
+              command: "/bin/sh",
+              title: "env",
+            })
+            id = info.id
+
+            const output: string[] = []
+            await Pty.connect(info.id, {
+              readyState: 1,
+              send: (data: unknown) => output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
+              close: () => undefined,
+            } as any)
+
+            await Pty.write(
+              info.id,
+              'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}" && printf "custom=%s\\n" "${PAWWORK_E2E_CUSTOM_ENV-unset}"\nexit\n',
+            )
+            await wait(() => output.join("").includes("custom="))
+
+            const text = output.join("")
+            expect(text).toContain("username=")
+            expect(text).toContain("password=")
+            expect(text).toContain("custom=kept")
+            expect(text).not.toContain("secret")
+            expect(text).not.toContain("PawWork")
+          } finally {
+            if (id) await Pty.remove(id)
+          }
+        },
+      })
+    } finally {
+      if (previousUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+      else process.env.OPENCODE_SERVER_USERNAME = previousUsername
+      if (previousPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+      else process.env.OPENCODE_SERVER_PASSWORD = previousPassword
+      if (previousCustom === undefined) delete process.env.PAWWORK_E2E_CUSTOM_ENV
+      else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
+    }
+  })
 })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1249,6 +1249,45 @@ unix("shell captures stdout and stderr in completed tool output", () =>
   ),
 )
 
+unix("shell does not expose internal server auth env", () =>
+  provideTmpdirInstance(
+    (_dir) =>
+      Effect.gen(function* () {
+        const previousUsername = process.env.OPENCODE_SERVER_USERNAME
+        const previousPassword = process.env.OPENCODE_SERVER_PASSWORD
+        const previousCustom = process.env.PAWWORK_E2E_CUSTOM_ENV
+        process.env.OPENCODE_SERVER_USERNAME = "PawWork"
+        process.env.OPENCODE_SERVER_PASSWORD = "secret"
+        process.env.PAWWORK_E2E_CUSTOM_ENV = "kept"
+
+        try {
+          const { prompt, chat } = yield* boot()
+          const result = yield* prompt.shell({
+            sessionID: chat.id,
+            agent: "build",
+            command:
+              'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME-unset}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD-unset}" && printf "custom=%s\\n" "${PAWWORK_E2E_CUSTOM_ENV-unset}"',
+          })
+          const tool = completedTool(result.parts)
+          if (!tool) return
+
+          expect(tool.state.output).toContain("username=unset")
+          expect(tool.state.output).toContain("password=unset")
+          expect(tool.state.output).toContain("custom=kept")
+          expect(tool.state.output).not.toContain("secret")
+        } finally {
+          if (previousUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+          else process.env.OPENCODE_SERVER_USERNAME = previousUsername
+          if (previousPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+          else process.env.OPENCODE_SERVER_PASSWORD = previousPassword
+          if (previousCustom === undefined) delete process.env.PAWWORK_E2E_CUSTOM_ENV
+          else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
+        }
+      }),
+    { git: true, config: cfg },
+  ),
+)
+
 unix("shell completes a fast command on the preferred shell", () =>
   provideTmpdirInstance(
     (dir) =>

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -156,14 +156,20 @@ describe("tool.bash", () => {
 
   each("does not expose internal server auth env to user commands", async () => {
     const previousUsername = process.env.OPENCODE_SERVER_USERNAME
+    const previousLowerUsername = process.env.opencode_server_username
     const previousPassword = process.env.OPENCODE_SERVER_PASSWORD
+    const previousLowerPassword = process.env.opencode_server_password
     const previousCustom = process.env.PAWWORK_E2E_CUSTOM_ENV
     process.env.OPENCODE_SERVER_USERNAME = "PawWork"
+    process.env.opencode_server_username = "lower-user"
     process.env.OPENCODE_SERVER_PASSWORD = "secret"
+    process.env.opencode_server_password = "lower-secret"
     process.env.PAWWORK_E2E_CUSTOM_ENV = "kept"
     const code = [
       'console.log("username=" + (process.env.OPENCODE_SERVER_USERNAME ?? "unset"))',
+      'console.log("usernameLower=" + (process.env.opencode_server_username ?? "unset"))',
       'console.log("password=" + (process.env.OPENCODE_SERVER_PASSWORD ?? "unset"))',
+      'console.log("passwordLower=" + (process.env.opencode_server_password ?? "unset"))',
       'console.log("custom=" + (process.env.PAWWORK_E2E_CUSTOM_ENV ?? "unset"))',
     ].join(";")
     const command = `${PS.has(sh()) ? "& " : ""}${bin} -e ${evalarg(code)}`
@@ -185,16 +191,24 @@ describe("tool.bash", () => {
 
           expect(result.metadata.exit).toBe(0)
           expect(result.output).toContain("username=unset")
+          expect(result.output).toContain("usernameLower=unset")
           expect(result.output).toContain("password=unset")
+          expect(result.output).toContain("passwordLower=unset")
           expect(result.output).toContain("custom=kept")
           expect(result.output).not.toContain("secret")
+          expect(result.output).not.toContain("lower-user")
+          expect(result.output).not.toContain("lower-secret")
         },
       })
     } finally {
       if (previousUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
       else process.env.OPENCODE_SERVER_USERNAME = previousUsername
+      if (previousLowerUsername === undefined) delete process.env.opencode_server_username
+      else process.env.opencode_server_username = previousLowerUsername
       if (previousPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
       else process.env.OPENCODE_SERVER_PASSWORD = previousPassword
+      if (previousLowerPassword === undefined) delete process.env.opencode_server_password
+      else process.env.opencode_server_password = previousLowerPassword
       if (previousCustom === undefined) delete process.env.PAWWORK_E2E_CUSTOM_ENV
       else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
     }

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -153,6 +153,52 @@ describe("tool.bash", () => {
       },
     })
   })
+
+  each("does not expose internal server auth env to user commands", async () => {
+    const previousUsername = process.env.OPENCODE_SERVER_USERNAME
+    const previousPassword = process.env.OPENCODE_SERVER_PASSWORD
+    const previousCustom = process.env.PAWWORK_E2E_CUSTOM_ENV
+    process.env.OPENCODE_SERVER_USERNAME = "PawWork"
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+    process.env.PAWWORK_E2E_CUSTOM_ENV = "kept"
+    const code = [
+      'console.log("username=" + (process.env.OPENCODE_SERVER_USERNAME ?? "unset"))',
+      'console.log("password=" + (process.env.OPENCODE_SERVER_PASSWORD ?? "unset"))',
+      'console.log("custom=" + (process.env.PAWWORK_E2E_CUSTOM_ENV ?? "unset"))',
+    ].join(";")
+    const command = `${PS.has(sh()) ? "& " : ""}${bin} -e ${evalarg(code)}`
+
+    try {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const bash = await initBash()
+          const result = await Effect.runPromise(
+            bash.execute(
+              {
+                command,
+                description: "Print selected environment variables",
+              },
+              ctx,
+            ),
+          )
+
+          expect(result.metadata.exit).toBe(0)
+          expect(result.output).toContain("username=unset")
+          expect(result.output).toContain("password=unset")
+          expect(result.output).toContain("custom=kept")
+          expect(result.output).not.toContain("secret")
+        },
+      })
+    } finally {
+      if (previousUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+      else process.env.OPENCODE_SERVER_USERNAME = previousUsername
+      if (previousPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+      else process.env.OPENCODE_SERVER_PASSWORD = previousPassword
+      if (previousCustom === undefined) delete process.env.PAWWORK_E2E_CUSTOM_ENV
+      else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
+    }
+  })
 })
 
 describe("tool.bash permissions", () => {

--- a/packages/opencode/test/util/env.test.ts
+++ b/packages/opencode/test/util/env.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { withoutInternalServerAuthEnv } from "../../src/util/env"
+
+describe("util.env", () => {
+  test("does not mutate caller-owned env objects", () => {
+    const env: Record<string, string> = {
+      OPENCODE_SERVER_USERNAME: "PawWork",
+      OPENCODE_SERVER_PASSWORD: "secret",
+      PAWWORK_E2E_CUSTOM_ENV: "kept",
+    }
+
+    const sanitized = withoutInternalServerAuthEnv(env)
+
+    expect(sanitized).toEqual({ PAWWORK_E2E_CUSTOM_ENV: "kept" })
+    expect(env).toEqual({
+      OPENCODE_SERVER_USERNAME: "PawWork",
+      OPENCODE_SERVER_PASSWORD: "secret",
+      PAWWORK_E2E_CUSTOM_ENV: "kept",
+    })
+    expect(sanitized).not.toBe(env)
+  })
+})

--- a/packages/opencode/test/util/env.test.ts
+++ b/packages/opencode/test/util/env.test.ts
@@ -19,4 +19,22 @@ describe("util.env", () => {
     })
     expect(sanitized).not.toBe(env)
   })
+
+  test("removes internal auth keys regardless of case", () => {
+    const env: Record<string, string> = {
+      OpEnCoDe_Server_UserName: "PawWork",
+      opencode_server_password: "secret",
+      PAWWORK_E2E_CUSTOM_ENV: "kept",
+    }
+
+    const sanitized = withoutInternalServerAuthEnv(env)
+
+    expect(sanitized).toEqual({ PAWWORK_E2E_CUSTOM_ENV: "kept" })
+    expect(env).toEqual({
+      OpEnCoDe_Server_UserName: "PawWork",
+      opencode_server_password: "secret",
+      PAWWORK_E2E_CUSTOM_ENV: "kept",
+    })
+    expect(sanitized).not.toBe(env)
+  })
 })


### PR DESCRIPTION
## Summary

- Filter PawWork/OpenCode internal server auth variables out of Bash tool, Session.shell, and PTY user command environments while preserving ordinary user env.
- Prevent app E2E isolated backends from inheriting internal auth env so health checks do not hit unexpected Basic Auth.
- Add regression coverage for Bash tool, Session.shell, PTY terminal sessions, and app E2E backend env construction.

## Why

Fixes #326. PawWork can run with `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD` in its internal server environment. Those values were leaking into user command subprocesses and isolated E2E backends, causing `/global/health` to return 401 and exposing internal auth values to commands/terminals.

## Related Issue

Fixes #326

## How To Verify

```bash
bun --cwd packages/opencode test test/tool/bash.test.ts -t "does not expose internal server auth env"
bun --cwd packages/opencode test test/session/prompt-effect.test.ts -t "shell does not expose internal server auth env"
bun --cwd packages/opencode test test/pty/pty-session.test.ts -t "does not expose internal server auth env"
bun test ./e2e/backend.test.ts
OPENCODE_SERVER_PASSWORD=test OPENCODE_SERVER_USERNAME=test bun test:e2e -- session/session-composer-dock.spec.ts -g "todo dock transitions and collapse behavior"
bun --cwd packages/opencode typecheck
bun --cwd packages/app typecheck
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized backend environment construction for E2E runs for consistent env handling.

* **Bug Fixes**
  * Enhanced security: internal server authentication env vars are stripped from spawned shells, terminals, prompts, and subprocess environments.

* **Tests**
  * Added tests validating environment isolation, preservation of non-sensitive vars, and that sensitive credentials are not exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->