### PR TITLE
fix(app): stabilize session view state

### DIFF
--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -1,14 +1,15 @@
 import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import { withSession } from "../actions"
+import { openSidebar, withSession } from "../actions"
 import {
   promptSelector,
   scrollViewportSelector,
+  sessionComposerDockSelector,
   sessionItemSelector,
   sessionMessageItemSelector,
   sessionTurnListSelector,
 } from "../selectors"
-import { createSdk } from "../utils"
+import { createSdk, modKey } from "../utils"
 
 type Sdk = ReturnType<typeof createSdk>
 
@@ -26,18 +27,40 @@ type TimelineScrollSample = TimelineMetrics & {
   url: string
 }
 
+type SessionTransitionSample = TimelineMetrics & {
+  at: number
+  url: string
+  routeSessionID?: string
+  messageOwners: string[]
+  messages: number
+  composerDock: number
+  composerHeight: number
+  messageList: number
+  removedComposerDock: boolean
+  removedMessageList: boolean
+}
+
+type CapturedPageError = {
+  type: string
+  message: string
+  detail?: string
+}
+
 function timelineMetrics(page: Page) {
-  return page.evaluate(({ scrollViewportSelector, turnListSelector }) => {
-    const list = document.querySelector(turnListSelector)
-    const viewport = list?.closest(scrollViewportSelector)
-    if (!(viewport instanceof HTMLElement)) return null
-    return {
-      top: viewport.scrollTop,
-      height: viewport.scrollHeight,
-      client: viewport.clientHeight,
-      distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
-    }
-  }, { scrollViewportSelector, turnListSelector: sessionTurnListSelector }) as Promise<TimelineMetrics | null>
+  return page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return null
+      return {
+        top: viewport.scrollTop,
+        height: viewport.scrollHeight,
+        client: viewport.clientHeight,
+        distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+      }
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  ) as Promise<TimelineMetrics | null>
 }
 
 async function expectTimelineMetrics(page: Page) {
@@ -47,13 +70,16 @@ async function expectTimelineMetrics(page: Page) {
 }
 
 async function scrollTimelineToBottom(page: Page) {
-  const found = await page.evaluate(({ scrollViewportSelector, turnListSelector }) => {
-    const list = document.querySelector(turnListSelector)
-    const viewport = list?.closest(scrollViewportSelector)
-    if (!(viewport instanceof HTMLElement)) return false
-    viewport.scrollTop = viewport.scrollHeight
-    return true
-  }, { scrollViewportSelector, turnListSelector: sessionTurnListSelector })
+  const found = await page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.scrollTop = viewport.scrollHeight
+      return true
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
   expect(found, "session timeline viewport should exist").toBe(true)
 }
 
@@ -95,9 +121,7 @@ async function installTimelineScrollProbe(page: Page) {
       const observer = new MutationObserver(push)
       observer.observe(document.body, { childList: true, subtree: true })
       const first = read()
-      const viewport = first
-        ? document.querySelector(turnListSelector)?.closest(scrollViewportSelector)
-        : undefined
+      const viewport = first ? document.querySelector(turnListSelector)?.closest(scrollViewportSelector) : undefined
       if (viewport instanceof HTMLElement) viewport.addEventListener("scroll", push, { passive: true })
       const win = window as typeof window & {
         __opencode_e2e?: Record<string, unknown> & {
@@ -135,13 +159,74 @@ async function stopTimelineScrollProbe(page: Page) {
   }) as Promise<TimelineScrollSample[]>
 }
 
-async function sendVisiblePrompt(input: { page: Page; text: string }) {
+async function sendVisiblePrompt(input: { page: Page; text: string; submitKey?: string }) {
   const prompt = input.page.locator(promptSelector)
   await expect(prompt).toBeVisible()
   await prompt.click()
   await input.page.keyboard.insertText(input.text)
   await expect.poll(async () => (await prompt.textContent())?.replace(/\u200B/g, "").trim()).toBe(input.text)
-  await input.page.keyboard.press("Enter")
+  await input.page.keyboard.press(input.submitKey ?? "Enter")
+}
+
+async function installPageErrorProbe(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as typeof window & {
+      __opencode_session_page_errors?: CapturedPageError[]
+    }
+    win.__opencode_session_page_errors = []
+    const describe = (value: unknown) => {
+      if (value instanceof Error) return value.stack || value.message
+      if (typeof value === "string") return value
+      try {
+        return JSON.stringify(value)
+      } catch {
+        return String(value)
+      }
+    }
+    window.addEventListener("error", (event) => {
+      win.__opencode_session_page_errors?.push({
+        type: "error",
+        message: event.message,
+        detail: describe(event.error),
+      })
+    })
+    window.addEventListener("unhandledrejection", (event) => {
+      win.__opencode_session_page_errors?.push({
+        type: "unhandledrejection",
+        message: describe(event.reason),
+      })
+    })
+  })
+}
+
+async function readPageErrorProbe(page: Page) {
+  return page.evaluate(() => {
+    const win = window as typeof window & {
+      __opencode_session_page_errors?: CapturedPageError[]
+    }
+    return win.__opencode_session_page_errors ?? []
+  }) as Promise<CapturedPageError[]>
+}
+
+function collectPageErrors(page: Page) {
+  const errors: CapturedPageError[] = []
+  const describe = (value: unknown) => {
+    if (value instanceof Error) return value.stack || value.message
+    if (typeof value === "string") return value
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  const handler = (error: Error) => {
+    errors.push({ type: "pageerror", message: describe(error) })
+  }
+  page.on("pageerror", handler)
+  return {
+    errors,
+    dispose: () => page.off("pageerror", handler),
+  }
 }
 
 async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: number }) {
@@ -159,59 +244,126 @@ async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: num
   }
 }
 
-async function installMessageCountProbe(page: Page) {
+async function installSessionTransitionProbe(page: Page, messageOwners: Record<string, string>) {
   await page.evaluate(
-    ({ maxSamples, messageSelector }) => {
-      const read = () => ({
-        url: window.location.href,
-        messages: document.querySelectorAll(messageSelector).length,
-      })
+    ({
+      composerDockSelector,
+      maxSamples,
+      messageOwners,
+      messageSelector,
+      scrollViewportSelector,
+      turnListSelector,
+    }) => {
+      const routeSessionID = () => window.location.pathname.match(/\/session\/([^/?#]+)/)?.[1]
+      const removedMatches = (node: Node, selector: string) =>
+        node instanceof Element && (node.matches(selector) || !!node.querySelector(selector))
+      const read = (removed?: { composerDock?: boolean; messageList?: boolean }) => {
+        const list = document.querySelector(turnListSelector)
+        const viewport = list?.closest(scrollViewportSelector)
+        const timeline = viewport instanceof HTMLElement ? viewport : undefined
+        const composer = document.querySelector(composerDockSelector)
+        const ownerList = Array.from(document.querySelectorAll(messageSelector))
+          .map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined))
+          .filter((id): id is string => !!id)
+          .map((id) => messageOwners[id] ?? "unknown")
+
+        return {
+          at: performance.now(),
+          url: window.location.href,
+          routeSessionID: routeSessionID(),
+          messageOwners: Array.from(new Set(ownerList)),
+          messages: ownerList.length,
+          composerDock: document.querySelectorAll(composerDockSelector).length,
+          composerHeight: composer instanceof HTMLElement ? composer.getBoundingClientRect().height : 0,
+          messageList: document.querySelectorAll(turnListSelector).length,
+          removedComposerDock: removed?.composerDock ?? false,
+          removedMessageList: removed?.messageList ?? false,
+          top: timeline?.scrollTop ?? 0,
+          height: timeline?.scrollHeight ?? 0,
+          client: timeline?.clientHeight ?? 0,
+          distanceFromBottom: timeline ? timeline.scrollHeight - timeline.clientHeight - timeline.scrollTop : 0,
+        }
+      }
+      const changed = (a: ReturnType<typeof read>, b: ReturnType<typeof read>) =>
+        a.url !== b.url ||
+        a.routeSessionID !== b.routeSessionID ||
+        a.messages !== b.messages ||
+        a.composerDock !== b.composerDock ||
+        a.composerHeight !== b.composerHeight ||
+        a.messageList !== b.messageList ||
+        a.removedComposerDock !== b.removedComposerDock ||
+        a.removedMessageList !== b.removedMessageList ||
+        a.top !== b.top ||
+        a.height !== b.height ||
+        a.client !== b.client ||
+        a.distanceFromBottom !== b.distanceFromBottom ||
+        a.messageOwners.join(",") !== b.messageOwners.join(",")
       const samples = [read()]
       const push = () => {
         const next = read()
         const prev = samples[samples.length - 1]
-        if (prev && prev.url === next.url && prev.messages === next.messages) return
+        if (prev && !changed(prev, next)) return
+        if (samples.length < maxSamples) samples.push(next)
+      }
+      const pushRemoved = (removed: { composerDock?: boolean; messageList?: boolean }) => {
+        const next = read(removed)
         if (samples.length < maxSamples) samples.push(next)
       }
       let frame = requestAnimationFrame(function tick() {
         push()
         frame = requestAnimationFrame(tick)
       })
-      const observer = new MutationObserver(push)
+      const observer = new MutationObserver((records) => {
+        for (const record of records) {
+          for (const node of record.removedNodes) {
+            const composerDock = removedMatches(node, composerDockSelector)
+            const messageList = removedMatches(node, turnListSelector)
+            if (composerDock || messageList) pushRemoved({ composerDock, messageList })
+          }
+        }
+        push()
+      })
       observer.observe(document.body, { childList: true, subtree: true })
       const win = window as typeof window & {
         __opencode_e2e?: Record<string, unknown> & {
-          messageCountProbe?: { stop: () => unknown }
+          sessionTransitionProbe?: { stop: () => unknown }
         }
       }
       win.__opencode_e2e = {
         ...win.__opencode_e2e,
-        messageCountProbe: {
+        sessionTransitionProbe: {
           stop() {
             cancelAnimationFrame(frame)
             observer.disconnect()
             push()
-            delete win.__opencode_e2e?.messageCountProbe
+            delete win.__opencode_e2e?.sessionTransitionProbe
             return samples
           },
         },
       }
     },
-    { maxSamples: 256, messageSelector: sessionMessageItemSelector },
+    {
+      composerDockSelector: sessionComposerDockSelector,
+      maxSamples: 512,
+      messageOwners,
+      messageSelector: sessionMessageItemSelector,
+      scrollViewportSelector,
+      turnListSelector: sessionTurnListSelector,
+    },
   )
 }
 
-async function stopMessageCountProbe(page: Page) {
+async function stopSessionTransitionProbe(page: Page) {
   return page.evaluate(() => {
     const win = window as typeof window & {
       __opencode_e2e?: {
-        messageCountProbe?: { stop: () => unknown }
+        sessionTransitionProbe?: { stop: () => unknown }
       }
     }
-    const probe = win.__opencode_e2e?.messageCountProbe
-    if (!probe) throw new Error("message count probe was not installed")
+    const probe = win.__opencode_e2e?.sessionTransitionProbe
+    if (!probe) throw new Error("session transition probe was not installed")
     return probe.stop()
-  }) as Promise<Array<{ url: string; messages: number }>>
+  }) as Promise<SessionTransitionSample[]>
 }
 
 test("keeps the latest turn in view when sending from an old message hash", async ({ page, project }) => {
@@ -232,9 +384,11 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
     await scrollTimelineToBottom(page)
     await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
 
-    const ids = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
-      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
-    )
+    const ids = await page
+      .locator(sessionMessageItemSelector)
+      .evaluateAll((items) =>
+        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+      )
     const oldID = ids[2]
     if (!oldID) throw new Error("expected an older rendered message id")
 
@@ -251,9 +405,11 @@ test("keeps the latest turn in view when sending from an old message hash", asyn
     await expect
       .poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom, { timeout: 30_000 })
       .toBeLessThan(40)
-    const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
-      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
-    )
+    const rendered = await page
+      .locator(sessionMessageItemSelector)
+      .evaluateAll((items) =>
+        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+      )
     expect(rendered.at(-1)).not.toBe(oldID)
   })
 })
@@ -276,9 +432,11 @@ test("does not jump to the top after sending from an old message hash", async ({
     await scrollTimelineToBottom(page)
     await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
 
-    const ids = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
-      items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
-    )
+    const ids = await page
+      .locator(sessionMessageItemSelector)
+      .evaluateAll((items) =>
+        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+      )
     const oldID = ids[1]
     if (!oldID) throw new Error("expected an older rendered message id")
 
@@ -303,10 +461,59 @@ test("does not jump to the top after sending from an old message hash", async ({
     const relevantSamples = samples.filter((sample) => sample.at >= sendStartedAt)
     expect(relevantSamples.length).toBeGreaterThan(0)
     const topJumps = relevantSamples.filter(
-      (sample) =>
-        sample.height > sample.client + 100 &&
-        sample.top < 20 &&
-        sample.distanceFromBottom > 100,
+      (sample) => sample.height > sample.client + 100 && sample.top < 20 && sample.distanceFromBottom > 100,
+    )
+    expect(topJumps).toEqual([])
+  })
+})
+
+test("does not jump to the top after mod-enter submit from an old message hash", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e old hash mod enter ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 18 })
+
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+      timeout: 30_000,
+    })
+    await scrollTimelineToBottom(page)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(20)
+
+    const ids = await page
+      .locator(sessionMessageItemSelector)
+      .evaluateAll((items) =>
+        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+      )
+    const oldID = ids[1]
+    if (!oldID) throw new Error("expected an older rendered message id")
+
+    await page.goto(`${page.url()}#message-${oldID}`)
+    await expect(page.locator(`#message-${oldID}`)).toBeVisible()
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeGreaterThan(100)
+
+    await installTimelineScrollProbe(page)
+    let samples: TimelineScrollSample[] = []
+    const sendStartedAt = await page.evaluate(() => performance.now())
+    try {
+      await sendVisiblePrompt({ page, text: `mod enter top guard ${Date.now()}`, submitKey: `${modKey}+Enter` })
+      await expect.poll(() => page.url()).not.toContain("#message-")
+      await expect
+        .poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom, { timeout: 30_000 })
+        .toBeLessThan(40)
+    } finally {
+      samples = await stopTimelineScrollProbe(page)
+    }
+
+    expect(samples.length).toBeGreaterThan(0)
+    const relevantSamples = samples.filter((sample) => sample.at >= sendStartedAt)
+    expect(relevantSamples.length).toBeGreaterThan(0)
+    const topJumps = relevantSamples.filter(
+      (sample) => sample.height > sample.client + 100 && sample.top < 20 && sample.distanceFromBottom > 100,
     )
     expect(topJumps).toEqual([])
   })
@@ -315,6 +522,8 @@ test("does not jump to the top after sending from an old message hash", async ({
 test("renders the full initial session window when switching sessions", async ({ page, project }) => {
   test.setTimeout(120_000)
 
+  await installPageErrorProbe(page)
+  const pageErrorEvents = collectPageErrors(page)
   await project.open()
   const sdk = project.sdk
 
@@ -330,30 +539,59 @@ test("renders the full initial session window when switching sessions", async ({
     await withSession(sdk, `e2e switch target ${Date.now()}`, async (second) => {
       project.trackSession(second.id)
       await seedSessionTurns({ sdk, sessionID: second.id, count: 14 })
-      await expect(page.locator(sessionItemSelector(second.id))).toBeVisible({ timeout: 30_000 })
+      await openSidebar(page)
+      const targetSession = page.locator(`${sessionItemSelector(second.id)} a`).first()
+      await expect(targetSession).toBeVisible({ timeout: 30_000 })
 
-      await installMessageCountProbe(page)
-      await page.locator(sessionItemSelector(second.id)).click()
+      const firstMessages = await sdk.session.messages({ sessionID: first.id, limit: 100 }).then((r) => r.data ?? [])
+      const secondMessages = await sdk.session.messages({ sessionID: second.id, limit: 100 }).then((r) => r.data ?? [])
+      const messageOwners = Object.fromEntries([
+        ...firstMessages.map((item) => [item.info.id, first.id] as const),
+        ...secondMessages.map((item) => [item.info.id, second.id] as const),
+      ])
+
+      await installSessionTransitionProbe(page, messageOwners)
+      await targetSession.click()
       await expect.poll(() => new URL(page.url()).pathname.endsWith(`/session/${second.id}`)).toBe(true)
       await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
         timeout: 30_000,
       })
-      const samples = await stopMessageCountProbe(page)
-      const rendered = await page.locator(sessionMessageItemSelector).evaluateAll((items) =>
-        items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
-      )
-      const secondMessages = await sdk.session.messages({ sessionID: second.id, limit: 100 }).then((r) => r.data ?? [])
+      const samples = await stopSessionTransitionProbe(page)
+      const rendered = await page
+        .locator(sessionMessageItemSelector)
+        .evaluateAll((items) =>
+          items.map((item) => (item instanceof HTMLElement ? item.dataset.messageId : undefined)).filter(Boolean),
+        )
       const secondIDs = new Set(secondMessages.map((item) => item.info.id))
 
-      const switched = samples.filter((sample) => sample.url.includes(`/session/${second.id}`))
+      const switched = samples.filter((sample) => sample.routeSessionID === second.id)
+      const mixedOwnerFrames = switched.filter(
+        (sample) => sample.messageOwners.length > 1 || sample.messageOwners.includes("unknown"),
+      )
+      const removedMountFrames = samples.filter((sample) => sample.removedComposerDock || sample.removedMessageList)
+      const invalidComposerFrames = switched.filter((sample) => sample.composerDock !== 1 || sample.composerHeight <= 0)
+      const invalidMessageListFrames = switched.filter((sample) => sample.messageList !== 1)
+      const pageErrors = await readPageErrorProbe(page)
+
       expect(switched.length).toBeGreaterThan(0)
       expect(rendered.every((id) => secondIDs.has(id))).toBe(true)
       expect(switched.filter((sample) => sample.messages === 0)).toEqual([])
       expect(
-        switched.filter(
-          (sample) => sample.messages > 0 && sample.messages < INITIAL_SESSION_WINDOW_MESSAGES,
-        ),
+        switched.filter((sample) => sample.messages > 0 && sample.messages < INITIAL_SESSION_WINDOW_MESSAGES),
       ).toEqual([])
+      expect(mixedOwnerFrames).toEqual([])
+      expect(removedMountFrames).toEqual([])
+      expect(invalidComposerFrames).toEqual([])
+      expect(invalidMessageListFrames).toEqual([])
+      expect(pageErrors).toEqual([])
+
+      const current = new URL(page.url())
+      current.hash = ""
+      current.search = ""
+      current.pathname = current.pathname.replace(/\/session\/[^/]+$/, "/session")
+      await page.goto(current.toString())
     })
   })
+  expect(pageErrorEvents.errors).toEqual([])
+  pageErrorEvents.dispose()
 })

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -257,6 +257,8 @@ async function installSessionTransitionProbe(page: Page, messageOwners: Record<s
       const routeSessionID = () => window.location.pathname.match(/\/session\/([^/?#]+)/)?.[1]
       const removedMatches = (node: Node, selector: string) =>
         node instanceof Element && (node.matches(selector) || !!node.querySelector(selector))
+      const sameList = (a: string[], b: string[]) =>
+        a.length === b.length && a.every((item, index) => item === b[index])
       const read = (removed?: { composerDock?: boolean; messageList?: boolean }) => {
         const list = document.querySelector(turnListSelector)
         const viewport = list?.closest(scrollViewportSelector)
@@ -297,7 +299,7 @@ async function installSessionTransitionProbe(page: Page, messageOwners: Record<s
         a.height !== b.height ||
         a.client !== b.client ||
         a.distanceFromBottom !== b.distanceFromBottom ||
-        a.messageOwners.join(",") !== b.messageOwners.join(",")
+        !sameList(a.messageOwners, b.messageOwners)
       const samples = [read()]
       const push = () => {
         const next = read()

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -73,6 +73,8 @@ interface PromptInputProps {
   onAbort?: () => void
   onSubmit?: () => void
   onModeChange?: (mode: "normal" | "shell") => void
+  sessionID?: string
+  sessionIDControlled?: boolean
   selectedSkill?: () => PawworkSkillName | undefined
 }
 
@@ -121,6 +123,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const language = useLanguage()
   const platform = usePlatform()
   const { params, tabs, view } = useSessionLayout()
+  const activeSessionID = createMemo(() => (props.sessionIDControlled ? props.sessionID : params.id))
   let editorRef!: HTMLDivElement
   let fileInputRef: HTMLInputElement | undefined
   let scrollRef!: HTMLDivElement
@@ -177,7 +180,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }).activeFileTab
 
   const commentInReview = (path: string) => {
-    const sessionID = params.id
+    const sessionID = activeSessionID()
     if (!sessionID) return false
 
     const diffs = sync.data.session_diff[sessionID]
@@ -241,10 +244,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     return paths
   })
-  const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
+  const info = createMemo(() => (activeSessionID() ? sync.session.get(activeSessionID()!) : undefined))
   const status = createMemo(
     () =>
-      sync.data.session_status[params.id ?? ""] ?? {
+      sync.data.session_status[activeSessionID() ?? ""] ?? {
         type: "idle",
       },
   )
@@ -317,7 +320,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const hasUserPrompt = createMemo(() => {
-    const sessionID = params.id
+    const sessionID = activeSessionID()
     if (!sessionID) return false
     const messages = sync.data.message[sessionID]
     if (!messages) return false
@@ -545,8 +548,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   createEffect(() => {
-    params.id
-    if (params.id) return
+    activeSessionID()
+    if (activeSessionID()) return
     if (!suggest()) return
     const interval = setInterval(() => {
       setStore("placeholder", (prev) => (prev + 1) % EXAMPLES.length)
@@ -1075,12 +1078,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const variants = createMemo(() => ["default", ...local.model.variant.list()])
   const accepting = createMemo(() => {
-    const id = params.id
+    const id = activeSessionID()
     if (!id) return permission.isAutoAcceptingDirectory(sdk.directory)
     return permission.isAutoAccepting(id, sdk.directory)
   })
 
   const { abort, handleSubmit } = createPromptSubmit({
+    sessionID: activeSessionID,
+    isNewSession: () => props.homeMode === true || (!props.sessionIDControlled && !activeSessionID()),
     info,
     imageAttachments,
     commentCount,

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -261,11 +261,13 @@ beforeEach(() => {
 })
 
 describe("prompt submit worktree selection", () => {
-  test("keeps cached todos when aborting an active session", async () => {
-    params = { id: "session-existing" }
+  test("keeps cached todos when aborting the visible session", async () => {
+    params = { id: "session-route" }
     const aborts: string[] = []
     const submit = createPromptSubmit({
-      info: () => ({ id: "session-existing" }),
+      sessionID: () => "session-visible",
+      isNewSession: () => false,
+      info: () => ({ id: "session-visible" }),
       imageAttachments: () => [],
       commentCount: () => 0,
       autoAccept: () => false,
@@ -284,7 +286,7 @@ describe("prompt submit worktree selection", () => {
     await submit.abort()
 
     expect(aborts).toEqual(["called"])
-    expect(abortedSessions).toEqual(["session-existing"])
+    expect(abortedSessions).toEqual(["session-visible"])
     expect(globalTodoSets).toEqual([])
     expect(childTodoSets).toEqual([])
   })
@@ -385,6 +387,35 @@ describe("prompt submit worktree selection", () => {
         model: { providerID: "provider", modelID: "model", variant: "high" },
       },
     })
+  })
+
+  test("submits to the provided visible session instead of the route session", async () => {
+    params = { id: "session-route" }
+
+    const submit = createPromptSubmit({
+      sessionID: () => "session-visible",
+      isNewSession: () => false,
+      info: () => ({ id: "session-visible" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    expect(promptAsyncCalls.at(-1)?.sessionID).toBe("session-visible")
+    expect(optimistic.at(-1)?.sessionID).toBe("session-visible")
   })
 
   test("seeds new sessions before optimistic prompts are added", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -178,6 +178,8 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
 }
 
 type PromptSubmitInput = {
+  sessionID?: Accessor<string | undefined>
+  isNewSession?: Accessor<boolean>
   info: Accessor<{ id: string } | undefined>
   imageAttachments: Accessor<ImageAttachmentPart[]>
   commentCount: Accessor<number>
@@ -220,6 +222,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const layout = useLayout()
   const language = useLanguage()
   const params = useParams()
+  const sessionID = input.sessionID ?? (() => params.id)
+  const isNewSession = input.isNewSession ?? (() => !sessionID())
 
   const errorMessage = (err: unknown) => {
     if (err && typeof err === "object" && "data" in err) {
@@ -231,21 +235,21 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   }
 
   const abort = async () => {
-    const sessionID = params.id
-    if (!sessionID) return Promise.resolve()
+    const activeSessionID = sessionID()
+    if (!activeSessionID) return Promise.resolve()
 
     input.onAbort?.()
 
-    const queued = pending.get(sessionID)
+    const queued = pending.get(activeSessionID)
     if (queued) {
       queued.abort.abort()
       queued.cleanup()
-      pending.delete(sessionID)
+      pending.delete(activeSessionID)
       return Promise.resolve()
     }
     return sdk.client.session
       .abort({
-        sessionID,
+        sessionID: activeSessionID,
       })
       .catch(() => {})
   }
@@ -297,8 +301,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
-    const isNewSession = !params.id
-    const homeSkill = isNewSession && mode === "normal" ? input.selectedSkill?.() : undefined
+    const creatingNewSession = isNewSession()
+    const homeSkill = creatingNewSession && mode === "normal" ? input.selectedSkill?.() : undefined
 
     if (
       text.trim().length === 0 &&
@@ -313,7 +317,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const currentModel = local.model.current()
     const currentAgent = local.agent.current()
     const variant = local.model.variant.current()
-    if (!currentModel || (!currentAgent && !isNewSession)) {
+    if (!currentModel || (!currentAgent && !creatingNewSession)) {
       showToast({
         title: language.t("prompt.toast.modelAgentRequired.title"),
         description: language.t("prompt.toast.modelAgentRequired.description"),
@@ -328,13 +332,13 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     promptProbe.start()
 
     const projectDirectory = sdk.directory
-    const shouldAutoAccept = isNewSession && input.autoAccept()
+    const shouldAutoAccept = creatingNewSession && input.autoAccept()
     const worktreeSelection = input.newSessionWorktree?.() || "main"
 
     let sessionDirectory = projectDirectory
     let client = sdk.client
 
-    if (isNewSession) {
+    if (creatingNewSession) {
       if (worktreeSelection === "create") {
         const createdWorktree = await client.worktree
           .create({ directory: projectDirectory })
@@ -374,7 +378,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     let session = input.info()
-    if (!session && isNewSession) {
+    if (!session && creatingNewSession) {
       const created = await client.session
         .create()
         .then((x) => x.data ?? undefined)
@@ -407,7 +411,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       providerID: currentModel.provider.id,
     }
     const locale = language.intl()
-    const agent = isNewSession ? "build" : currentAgent!.name
+    const agent = creatingNewSession ? "build" : currentAgent!.name
     const context = prompt.context.items().slice()
     const outgoingTextOverride = buildHomeOverride(homeSkill, text)
     const draft: FollowupDraft = {
@@ -441,7 +445,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       })
     }
 
-    if (!isNewSession && mode === "normal" && input.shouldQueue?.()) {
+    if (!creatingNewSession && mode === "normal" && input.shouldQueue?.()) {
       input.onQueue?.(draft)
       clearContext()
       clearInput()

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -62,7 +62,7 @@ import {
   readUserMessages,
 } from "@/pages/session/session-messages"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
-import { createSessionRunning } from "@/pages/session/session-running-state"
+import { createSessionRunning, isSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { createSessionViewController } from "@/pages/session/session-view-controller"
 import { deriveArtifactFiles, nextFilesPanelAutoOpen, type SessionArtifactFile } from "@/pages/session/files-tab-state"
@@ -524,6 +524,12 @@ export default function Page() {
   })
   const timelineSessionID = sessionView.visible.id
   const timelineSessionKey = sessionView.visible.key
+  const timelineInfo = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return
+    return sync.session.get(id)
+  })
+  const timelineIsChildSession = createMemo(() => !!timelineInfo()?.parentID)
   const composer = createSessionComposerState({ sessionID: timelineSessionID })
   const timelineMessages = createMemo(
     () => {
@@ -960,7 +966,7 @@ export default function Page() {
   createEffect(
     on(
       () => {
-        const id = params.id
+        const id = timelineSessionID()
         return [
           sdk.directory,
           id,
@@ -981,7 +987,7 @@ export default function Page() {
           todoFrame = undefined
           todoTimer = window.setTimeout(() => {
             todoTimer = undefined
-            if (sdk.directory !== dir || params.id !== id) return
+            if (sdk.directory !== dir || timelineSessionID() !== id) return
             untrack(() => {
               void sync.session.todo(id, cached ? { force: true } : undefined)
             })
@@ -1165,7 +1171,7 @@ export default function Page() {
     }
 
     if (event.key.length === 1 && event.key !== "Unidentified" && !(event.ctrlKey || event.metaKey)) {
-      if (composer.blocked() || isChildSession()) return
+      if (composer.blocked() || timelineIsChildSession()) return
       inputRef?.focus()
     }
   }
@@ -1269,7 +1275,7 @@ export default function Page() {
   }
 
   const focusInput = () => {
-    if (isChildSession()) return
+    if (timelineIsChildSession()) return
     inputRef?.focus()
   }
 
@@ -1727,20 +1733,26 @@ export default function Page() {
       return out
     })
 
-  const currentRunning = createSessionRunning(
-    () => (params.id ? sync.data.session_status[params.id] : undefined),
-    () => (params.id ? sync.data.message[params.id] : undefined),
+  const timelineRunning = createSessionRunning(
+    () => {
+      const id = timelineSessionID()
+      return id ? sync.data.session_status[id] : undefined
+    },
+    () => {
+      const id = timelineSessionID()
+      return id ? sync.data.message[id] : undefined
+    },
   )
-  const busy = () => currentRunning()
+  const busy = () => timelineRunning()
 
   const queuedFollowups = createMemo(() => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return emptyFollowups
     return followup.items[id] ?? emptyFollowups
   })
 
   const editingFollowup = createMemo(() => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return
     return followup.edit[id]
   })
@@ -1775,16 +1787,16 @@ export default function Page() {
     followupMutation.isPending && followupMutation.variables?.sessionID === sessionID
 
   const sendingFollowup = createMemo(() => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return
     if (!followupBusy(id)) return
     return followupMutation.variables?.id
   })
 
   const queueEnabled = createMemo(() => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return false
-    return settings.general.followup() === "queue" && busy() && !composer.blocked() && !isChildSession()
+    return settings.general.followup() === "queue" && busy() && !composer.blocked() && !timelineIsChildSession()
   })
 
   const followupText = (item: FollowupDraft) => {
@@ -1825,7 +1837,7 @@ export default function Page() {
   }
 
   const editFollowup = (id: string) => {
-    const sessionID = params.id
+    const sessionID = timelineSessionID()
     if (!sessionID) return
     if (followupBusy(sessionID)) return
 
@@ -1842,18 +1854,20 @@ export default function Page() {
   }
 
   const clearFollowupEdit = () => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return
     setFollowup("edit", id, undefined)
   }
 
   const halt = (sessionID: string) =>
-    busy() ? sdk.client.session.abort({ sessionID }).catch(() => {}) : Promise.resolve()
+    isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
+      ? sdk.client.session.abort({ sessionID }).catch(() => {})
+      : Promise.resolve()
 
   const revertMutation = useMutation(() => ({
     mutationFn: async (input: { sessionID: string; messageID: string }) => {
       const prev = prompt.current().slice()
-      const last = info()?.revert
+      const last = sync.session.get(input.sessionID)?.revert
       const value = draft(input.messageID)
       batch(() => {
         roll(input.sessionID, { messageID: input.messageID })
@@ -1875,13 +1889,12 @@ export default function Page() {
   }))
 
   const restoreMutation = useMutation(() => ({
-    mutationFn: async (id: string) => {
-      const sessionID = params.id
-      if (!sessionID) return
+    mutationFn: async (input: { sessionID: string; id: string }) => {
+      const { sessionID, id } = input
 
-      const next = userMessages().find((item) => item.id > id)
+      const next = readUserMessages(readSessionMessages(sync.data.message[sessionID])).find((item) => item.id > id)
       const prev = prompt.current().slice()
-      const last = info()?.revert
+      const last = sync.session.get(sessionID)?.revert
 
       batch(() => {
         roll(sessionID, next ? { messageID: next.id } : undefined)
@@ -1916,7 +1929,12 @@ export default function Page() {
   }))
 
   const reverting = createMemo(() => revertMutation.isPending || restoreMutation.isPending)
-  const restoring = createMemo(() => (restoreMutation.isPending ? restoreMutation.variables : undefined))
+  const restoring = createMemo(() => {
+    if (!restoreMutation.isPending) return
+    const variables = restoreMutation.variables
+    if (variables?.sessionID !== timelineSessionID()) return
+    return variables.id
+  })
 
   const revert = (input: { sessionID: string; messageID: string }) => {
     if (reverting()) return
@@ -1924,14 +1942,15 @@ export default function Page() {
   }
 
   const restore = (id: string) => {
-    if (!params.id || reverting()) return
-    return restoreMutation.mutateAsync(id)
+    const sessionID = timelineSessionID()
+    if (!sessionID || reverting()) return
+    return restoreMutation.mutateAsync({ sessionID, id })
   }
 
   const rolled = createMemo(() => {
-    const id = revertMessageID()
+    const id = timelineRevertMessageID()
     if (!id) return []
-    return userMessages()
+    return timelineUserMessages()
       .filter((item) => item.id >= id)
       .map((item) => ({ id: item.id, text: line(item.id) }))
   })
@@ -1939,7 +1958,7 @@ export default function Page() {
   const actions = { revert }
 
   createEffect(() => {
-    const sessionID = params.id
+    const sessionID = timelineSessionID()
     if (!sessionID) return
 
     const item = queuedFollowups()[0]
@@ -1947,7 +1966,7 @@ export default function Page() {
     if (followupBusy(sessionID)) return
     if (followup.failed[sessionID] === item.id) return
     if (followup.paused[sessionID]) return
-    if (isChildSession()) return
+    if (timelineIsChildSession()) return
     if (composer.blocked()) return
     if (busy()) return
 
@@ -2050,7 +2069,7 @@ export default function Page() {
       onModeChange={ctx?.onModeChange}
       selectedSkill={ctx?.selectedSkill}
       followup={
-        params.id && !isChildSession()
+        variant === "session" && timelineSessionID() && !timelineIsChildSession()
           ? {
               queue: queueEnabled,
               items: followupDock(),
@@ -2058,12 +2077,14 @@ export default function Page() {
               edit: editingFollowup(),
               onQueue: queueFollowup,
               onAbort: () => {
-                const id = params.id
+                const id = timelineSessionID()
                 if (!id) return
                 setFollowup("paused", id, true)
               },
               onSend: (id) => {
-                void sendFollowup(params.id!, id, { manual: true })
+                const sessionID = timelineSessionID()
+                if (!sessionID) return
+                void sendFollowup(sessionID, id, { manual: true })
               },
               onEdit: editFollowup,
               onEditLoaded: clearFollowupEdit,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -506,12 +506,6 @@ export default function Page() {
   const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
-  const revertMessageID = createMemo(() => info()?.revert?.messageID)
-  const messages = createMemo(
-    () => readSessionMessages(params.id ? sync.data.message[params.id] : undefined),
-    emptyMessages,
-    { equals: same },
-  )
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
@@ -540,6 +534,11 @@ export default function Page() {
     { equals: same },
   )
   const timelineMessagesReady = sessionView.visible.ready
+  const timelineDiffs = createMemo(() => {
+    const id = timelineSessionID()
+    if (!id) return []
+    return list(sync.data.session_diff[id])
+  })
   const timelineUserMessages = createMemo(() => readUserMessages(timelineMessages()), emptyUserMessages, {
     equals: same,
   })
@@ -579,19 +578,7 @@ export default function Page() {
     if (!id) return false
     return sync.session.history.loading(id)
   })
-  const userMessages = createMemo(() => readUserMessages(messages()), emptyUserMessages, { equals: same })
-  const visibleUserMessages = createMemo(
-    () => {
-      const revert = revertMessageID()
-      if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
-    },
-    emptyUserMessages,
-    {
-      equals: same,
-    },
-  )
-  const lastUserMessage = createMemo(() => visibleUserMessages().at(-1))
+  const lastUserMessage = createMemo(() => timelineVisibleUserMessages().at(-1))
 
   createEffect(() => {
     const tab = activeFileTab()
@@ -749,7 +736,7 @@ export default function Page() {
 
   const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
   const [artifactHistory, { refetch: refetchArtifactHistory }] = createResource(
-    () => params.id,
+    timelineSessionID,
     async (sessionID) => ({
       sessionID,
       artifacts: await sdk.client.session
@@ -760,8 +747,9 @@ export default function Page() {
     { initialValue: { sessionID: "", artifacts: [] as SessionArtifactFile[] } },
   )
   const artifactFiles = createMemo(() => {
+    const sessionID = timelineSessionID()
     const history = artifactHistory.latest
-    if (history?.sessionID === params.id && history.artifacts.length > 0) {
+    if (history?.sessionID === sessionID && history.artifacts.length > 0) {
       return deriveArtifactFiles(sdk.directory, history.artifacts)
     }
 
@@ -1184,24 +1172,24 @@ export default function Page() {
   )
 
   createEffect(() => {
-    if (!params.id) return
+    if (!timelineSessionID()) return
     turnDiffs()
     void refetchArtifactHistory()
   })
 
   createEffect(() => {
-    const id = params.id
+    const id = timelineSessionID()
     if (!id) return
     if (sync.data.session_diff[id] === undefined) return
     void refetchArtifactHistory()
   })
 
   createEffect(() => {
-    if (!params.id) return
+    if (!timelineSessionID()) return
 
     // Use Snapshot diffs (SSE-pushed, authoritative) with turnDiffs as fallback
     // for reopened sessions where session_diff hasn't been fetched yet.
-    const source = diffs().length > 0 ? diffs() : turnDiffs()
+    const source = timelineDiffs().length > 0 ? timelineDiffs() : turnDiffs()
     const next = nextFilesPanelAutoOpen(
       {
         seenAdded: view().sidePanel.filesAutoOpenSeen(),

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -55,11 +55,16 @@ import {
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
-import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
+import {
+  emptyMessages,
+  emptyUserMessages,
+  readSessionMessages,
+  readUserMessages,
+} from "@/pages/session/session-messages"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
-import { nextTimelineSessionID } from "@/pages/session/timeline-session-state"
+import { createSessionViewController } from "@/pages/session/session-view-controller"
 import { deriveArtifactFiles, nextFilesPanelAutoOpen, type SessionArtifactFile } from "@/pages/session/files-tab-state"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
@@ -419,8 +424,6 @@ export default function Page() {
     },
   })
 
-  const composer = createSessionComposerState()
-
   const workspaceKey = createMemo(() => params.dir ?? "")
   const workspaceTabs = createMemo(() => layout.tabs(workspaceKey))
 
@@ -514,14 +517,14 @@ export default function Page() {
     if (!id) return true
     return sync.data.message[id] !== undefined
   })
-  const timelineSessionID = createMemo((current: string | undefined) =>
-    nextTimelineSessionID({
-      current,
-      route: params.id,
-      routeReady: messagesReady(),
-    }),
-  )
-  const timelineSessionKey = createMemo(() => `${params.dir}${timelineSessionID() ? `/${timelineSessionID()}` : ""}`)
+  const sessionView = createSessionViewController({
+    directory: () => params.dir ?? "",
+    routeSessionID: () => params.id,
+    routeMessagesReady: messagesReady,
+  })
+  const timelineSessionID = sessionView.visible.id
+  const timelineSessionKey = sessionView.visible.key
+  const composer = createSessionComposerState({ sessionID: timelineSessionID })
   const timelineMessages = createMemo(
     () => {
       const id = timelineSessionID()
@@ -530,16 +533,10 @@ export default function Page() {
     emptyMessages,
     { equals: same },
   )
-  const timelineMessagesReady = createMemo(() => {
-    const id = timelineSessionID()
-    if (!id) return true
-    return sync.data.message[id] !== undefined
+  const timelineMessagesReady = sessionView.visible.ready
+  const timelineUserMessages = createMemo(() => readUserMessages(timelineMessages()), emptyUserMessages, {
+    equals: same,
   })
-  const timelineUserMessages = createMemo(
-    () => readUserMessages(timelineMessages()),
-    emptyUserMessages,
-    { equals: same },
-  )
   const timelineRevertMessageID = createMemo(() => {
     const id = timelineSessionID()
     if (!id) return
@@ -576,11 +573,7 @@ export default function Page() {
     if (!id) return false
     return sync.session.history.loading(id)
   })
-  const userMessages = createMemo(
-    () => readUserMessages(messages()),
-    emptyUserMessages,
-    { equals: same },
-  )
+  const userMessages = createMemo(() => readUserMessages(messages()), emptyUserMessages, { equals: same })
   const visibleUserMessages = createMemo(
     () => {
       const revert = revertMessageID()
@@ -669,7 +662,7 @@ export default function Page() {
   )
 
   createComputed((prev) => {
-    const key = sessionKey()
+    const key = timelineSessionKey()
     if (key !== prev) {
       setStore("deferRender", true)
       requestAnimationFrame(() => {
@@ -677,7 +670,7 @@ export default function Page() {
       })
     }
     return key
-  }, sessionKey())
+  }, timelineSessionKey())
 
   let refreshFrame: number | undefined
   let refreshTimer: number | undefined
@@ -753,7 +746,10 @@ export default function Page() {
     () => params.id,
     async (sessionID) => ({
       sessionID,
-      artifacts: await sdk.client.session.artifacts({ sessionID }).then((res) => res.data ?? []).catch(() => []),
+      artifacts: await sdk.client.session
+        .artifacts({ sessionID })
+        .then((res) => res.data ?? [])
+        .catch(() => []),
     }),
     { initialValue: { sessionID: "", artifacts: [] as SessionArtifactFile[] } },
   )
@@ -765,11 +761,10 @@ export default function Page() {
 
     return deriveArtifactFiles(
       sdk.directory,
-      turnDiffs()
-        .flatMap((diff) => {
-          if (diff.status !== "added" && diff.status !== "modified") return []
-          return [{ file: diff.file, kind: diff.status as "added" | "modified" }]
-        }),
+      turnDiffs().flatMap((diff) => {
+        if (diff.status !== "added" && diff.status !== "modified") return []
+        return [{ file: diff.file, kind: diff.status as "added" | "modified" }]
+      }),
     )
   })
   const nogit = createMemo(() => !!sync.project && sync.project.vcs !== "git")
@@ -2038,7 +2033,9 @@ export default function Page() {
     <SessionComposerRegion
       variant={variant}
       state={composer}
-      ready={!store.deferRender && messagesReady()}
+      ready={!store.deferRender && timelineMessagesReady()}
+      displaySessionID={variant === "session" ? timelineSessionID() : undefined}
+      displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}
       centered={centered()}
       inputRef={(el) => {
         inputRef = el
@@ -2174,7 +2171,6 @@ export default function Page() {
             </Switch>
           </div>
           <Show when={params.id}>{renderComposerRegion("session")}</Show>
-
         </div>
 
         <SessionSidePanel

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -30,6 +30,8 @@ export function SessionComposerRegion(props: {
   onResponseSubmit: () => void
   onModeChange?: (mode: "normal" | "shell") => void
   selectedSkill?: () => PawworkSkillName | undefined
+  displaySessionID?: string
+  displaySessionKey?: string
   followup?: {
     queue: () => boolean
     items: { id: string; text: string }[]
@@ -54,9 +56,16 @@ export function SessionComposerRegion(props: {
   const language = useLanguage()
   const route = useSessionKey()
   const sync = useSync()
+  const displaySessionID = createMemo(() => (props.variant === "session" ? props.displaySessionID : route.params.id))
+  const displaySessionKey = createMemo(() =>
+    props.variant === "session" ? props.displaySessionKey : route.sessionKey(),
+  )
 
-  const handoffPrompt = createMemo(() => getSessionHandoff(route.sessionKey())?.prompt)
-  const info = createMemo(() => (route.params.id ? sync.session.get(route.params.id) : undefined))
+  const handoffPrompt = createMemo(() => {
+    const key = displaySessionKey()
+    return key ? getSessionHandoff(key)?.prompt : undefined
+  })
+  const info = createMemo(() => (displaySessionID() ? sync.session.get(displaySessionID()!) : undefined))
   const parentID = createMemo(() => info()?.parentID)
   const child = createMemo(() => !!parentID())
   const home = createMemo(() => props.variant === "home")
@@ -76,7 +85,9 @@ export function SessionComposerRegion(props: {
 
   createEffect(() => {
     if (!prompt.ready()) return
-    setSessionHandoff(route.sessionKey(), { prompt: previewPrompt() })
+    const key = displaySessionKey()
+    if (!key) return
+    setSessionHandoff(key, { prompt: previewPrompt() })
   })
 
   const [store, setStore] = createStore({
@@ -99,7 +110,7 @@ export function SessionComposerRegion(props: {
   }
 
   createEffect(() => {
-    route.sessionKey()
+    displaySessionKey()
     const ready = props.ready
     const delay = 140
 
@@ -217,7 +228,7 @@ export function SessionComposerRegion(props: {
               >
                 <div ref={(el) => setStore("body", el)}>
                   <SessionTodoDock
-                    sessionID={route.params.id}
+                    sessionID={displaySessionID()}
                     todos={props.state.todos()}
                     collapseLabel={language.t("session.todo.collapse")}
                     expandLabel={language.t("session.todo.expand")}
@@ -265,6 +276,8 @@ export function SessionComposerRegion(props: {
                     <PromptInput
                       ref={props.inputRef}
                       homeMode={home()}
+                      sessionID={displaySessionID()}
+                      sessionIDControlled={!home()}
                       newSessionWorktree={props.newSessionWorktree}
                       onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
                       edit={props.followup?.edit}

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -2,7 +2,6 @@ import { createEffect, createMemo, on, onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import type { PermissionRequest, QuestionRequest, Todo } from "@opencode-ai/sdk/v2"
-import { useParams } from "@solidjs/router"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -18,14 +17,13 @@ const todoTerminal = (todo: Todo) => todo.status === "completed" || todo.status 
 
 const todoSignature = (todos: Todo[]) => todos.map((todo) => `${todo.status}:${todo.content}`).join("\u0000")
 
-export function createSessionComposerState(input?: { sessionID: () => string | undefined }) {
-  const params = useParams()
+export function createSessionComposerState(input: { sessionID: () => string | undefined }) {
   const sdk = useSDK()
   const sync = useSync()
   const globalSync = useGlobalSync()
   const language = useLanguage()
   const permission = usePermission()
-  const activeSessionID = input?.sessionID ?? (() => params.id)
+  const activeSessionID = input.sessionID
 
   const questionRequest = createMemo((): QuestionRequest | undefined => {
     return sessionQuestionRequest(sync.data.session, sync.data.question, activeSessionID())

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -18,26 +18,27 @@ const todoTerminal = (todo: Todo) => todo.status === "completed" || todo.status 
 
 const todoSignature = (todos: Todo[]) => todos.map((todo) => `${todo.status}:${todo.content}`).join("\u0000")
 
-export function createSessionComposerState() {
+export function createSessionComposerState(input?: { sessionID: () => string | undefined }) {
   const params = useParams()
   const sdk = useSDK()
   const sync = useSync()
   const globalSync = useGlobalSync()
   const language = useLanguage()
   const permission = usePermission()
+  const activeSessionID = input?.sessionID ?? (() => params.id)
 
   const questionRequest = createMemo((): QuestionRequest | undefined => {
-    return sessionQuestionRequest(sync.data.session, sync.data.question, params.id)
+    return sessionQuestionRequest(sync.data.session, sync.data.question, activeSessionID())
   })
 
   const permissionRequest = createMemo((): PermissionRequest | undefined => {
-    return sessionPermissionRequest(sync.data.session, sync.data.permission, params.id, (item) => {
+    return sessionPermissionRequest(sync.data.session, sync.data.permission, activeSessionID(), (item) => {
       return !permission.autoResponds(item, sdk.directory)
     })
   })
 
   const blocked = createMemo(() => {
-    const id = params.id
+    const id = activeSessionID()
     if (!id) return false
     return !!permissionRequest() || !!questionRequest()
   })
@@ -48,7 +49,7 @@ export function createSessionComposerState() {
   })
 
   const pull = () => {
-    const id = params.id
+    const id = activeSessionID()
     if (!id) {
       setTest({ on: false, todos: undefined })
       return
@@ -70,11 +71,11 @@ export function createSessionComposerState() {
     if (!composerEnabled()) return
 
     pull()
-    createEffect(on(() => params.id, pull, { defer: true }))
+    createEffect(on(activeSessionID, pull, { defer: true }))
 
     const onEvent = (event: Event) => {
       const detail = (event as CustomEvent<{ sessionID?: string }>).detail
-      if (detail?.sessionID !== params.id) return
+      if (detail?.sessionID !== activeSessionID()) return
       pull()
     }
 
@@ -83,7 +84,7 @@ export function createSessionComposerState() {
 
   const todos = createMemo((): Todo[] => {
     if (test.on && test.todos !== undefined) return test.todos
-    const id = params.id
+    const id = activeSessionID()
     if (!id) return []
     // Todo data follows the backend list. Dock visibility is derived below so terminal todos can remain stored after the dock hides.
     return globalSync.data.session_todo[id] ?? []
@@ -135,8 +136,13 @@ export function createSessionComposerState() {
 
   createEffect(
     on(
-      () => ({ allDone: allDone(), count: todos().length, sessionID: params.id, signature: todoSignature(todos()) }),
-      ({ allDone: done, count, sessionID, signature }) => {
+      () => ({
+        allDone: allDone(),
+        count: todos().length,
+        sessionID: activeSessionID(),
+        signature: todoSignature(todos()),
+      }),
+      ({ allDone: done, count, sessionID: expectedSessionID, signature }) => {
         if (raf) cancelAnimationFrame(raf)
         raf = undefined
 
@@ -150,7 +156,7 @@ export function createSessionComposerState() {
           setStore({ dock: true, opening: false, completing: true })
           clearHideTimeout()
           hideTimeout = window.setTimeout(() => {
-            if (params.id === sessionID && allDone() && todoSignature(todos()) === signature) {
+            if (activeSessionID() === expectedSessionID && allDone() && todoSignature(todos()) === signature) {
               setStore({ dock: false, opening: false, completing: false })
             }
             hideTimeout = undefined
@@ -178,7 +184,7 @@ export function createSessionComposerState() {
 
   createEffect(() => {
     if (!composerEnabled()) return
-    const probe = composerStateProbe(params.id)
+    const probe = composerStateProbe(activeSessionID())
     probe.set({
       dock: store.dock,
       opening: store.opening,

--- a/packages/app/src/pages/session/session-view-controller.test.ts
+++ b/packages/app/src/pages/session/session-view-controller.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createSessionViewController, nextSessionViewState } from "./session-view-controller"
+
+describe("createSessionViewController", () => {
+  test("exposes route and visible session state through separate accessors", () => {
+    createRoot((dispose) => {
+      const controller = createSessionViewController({
+        directory: () => "repo",
+        routeSessionID: () => "ses_source",
+        routeMessagesReady: () => true,
+      })
+
+      expect(controller.route.id()).toBe("ses_source")
+      expect(controller.route.key()).toBe("repo/ses_source")
+      expect(controller.route.ready()).toBe(true)
+      expect(controller.visible.id()).toBe("ses_source")
+      expect(controller.visible.key()).toBe("repo/ses_source")
+      expect(controller.visible.ready()).toBe(true)
+      expect(controller.transitioning()).toBe(false)
+
+      dispose()
+    })
+  })
+
+  test("keeps route and visible state distinct while the route session is not ready", () => {
+    createRoot((dispose) => {
+      const controller = createSessionViewController({
+        directory: () => "repo",
+        routeSessionID: () => "ses_target",
+        routeMessagesReady: () => false,
+      })
+
+      expect(controller.route.id()).toBe("ses_target")
+      expect(controller.route.key()).toBe("repo/ses_target")
+      expect(controller.route.ready()).toBe(false)
+      expect(controller.visible.id()).toBeUndefined()
+      expect(controller.visible.key()).toBe("repo")
+      expect(controller.visible.ready()).toBe(false)
+      expect(controller.transitioning()).toBe(true)
+
+      dispose()
+    })
+  })
+})
+
+describe("nextSessionViewState", () => {
+  test("keeps visible session on the previous ready session while route session loads", () => {
+    const loading = nextSessionViewState({
+      currentVisibleSessionID: "ses_source",
+      directory: "repo",
+      routeSessionID: "ses_target",
+      routeMessagesReady: false,
+    })
+
+    expect(loading).toMatchObject({
+      routeSessionID: "ses_target",
+      routeReady: false,
+      visibleSessionID: "ses_source",
+      transitioning: true,
+      routeSessionKey: "repo/ses_target",
+      visibleSessionKey: "repo/ses_source",
+    })
+
+    const ready = nextSessionViewState({
+      currentVisibleSessionID: loading.visibleSessionID,
+      directory: "repo",
+      routeSessionID: "ses_target",
+      routeMessagesReady: true,
+    })
+
+    expect(ready).toMatchObject({
+      routeSessionID: "ses_target",
+      routeReady: true,
+      visibleSessionID: "ses_target",
+      transitioning: false,
+      routeSessionKey: "repo/ses_target",
+      visibleSessionKey: "repo/ses_target",
+    })
+  })
+
+  test("clears visible session when leaving a concrete session route", () => {
+    const next = nextSessionViewState({
+      currentVisibleSessionID: "ses_source",
+      directory: "repo",
+      routeSessionID: undefined,
+      routeMessagesReady: true,
+    })
+
+    expect(next.routeSessionID).toBeUndefined()
+    expect(next.routeSessionKey).toBe("repo")
+    expect(next.visibleSessionID).toBeUndefined()
+    expect(next.visibleSessionKey).toBe("repo")
+    expect(next.routeReady).toBe(true)
+    expect(next.transitioning).toBe(false)
+  })
+
+  test("does not carry visible session state across directories", () => {
+    const next = nextSessionViewState({
+      currentVisibleDirectory: "repo-a",
+      currentVisibleSessionID: "ses_source",
+      directory: "repo-b",
+      routeSessionID: "ses_target",
+      routeMessagesReady: false,
+    })
+
+    expect(next).toMatchObject({
+      routeSessionID: "ses_target",
+      routeReady: false,
+      visibleSessionID: undefined,
+      transitioning: true,
+      routeSessionKey: "repo-b/ses_target",
+      visibleSessionKey: "repo-b",
+    })
+  })
+})

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -1,0 +1,89 @@
+import { createMemo, type Accessor } from "solid-js"
+
+export type SessionViewStateInput = {
+  currentVisibleDirectory?: string
+  currentVisibleSessionID: string | undefined
+  directory: string
+  routeSessionID: string | undefined
+  routeMessagesReady: boolean
+}
+
+export type SessionViewControllerInput = {
+  directory: Accessor<string>
+  routeSessionID: Accessor<string | undefined>
+  routeMessagesReady: Accessor<boolean>
+}
+
+export function sessionKey(input: { directory: string; sessionID: string | undefined }) {
+  return `${input.directory}${input.sessionID ? `/${input.sessionID}` : ""}`
+}
+
+export function nextTimelineSessionID(input: {
+  current: string | undefined
+  route: string | undefined
+  routeReady: boolean
+}) {
+  if (!input.route) return undefined
+  if (input.routeReady) return input.route
+  return input.current
+}
+
+export function nextSessionViewState(input: SessionViewStateInput) {
+  const routeReady = !input.routeSessionID || input.routeMessagesReady
+  const currentVisibleSessionID =
+    input.currentVisibleDirectory && input.currentVisibleDirectory !== input.directory
+      ? undefined
+      : input.currentVisibleSessionID
+  const visibleSessionID = nextTimelineSessionID({
+    current: currentVisibleSessionID,
+    route: input.routeSessionID,
+    routeReady,
+  })
+
+  return {
+    routeSessionID: input.routeSessionID,
+    routeReady,
+    visibleSessionID,
+    transitioning: visibleSessionID !== input.routeSessionID,
+    routeSessionKey: sessionKey({ directory: input.directory, sessionID: input.routeSessionID }),
+    visibleSessionKey: sessionKey({ directory: input.directory, sessionID: visibleSessionID }),
+  }
+}
+
+export function createSessionViewController(input: SessionViewControllerInput) {
+  type State = ReturnType<typeof nextSessionViewState> & { directory: string }
+  const state = createMemo((current: State | undefined): State => {
+    const directory = input.directory()
+    return {
+      ...nextSessionViewState({
+        currentVisibleDirectory: current?.directory,
+        currentVisibleSessionID: current?.visibleSessionID,
+        directory,
+        routeSessionID: input.routeSessionID(),
+        routeMessagesReady: input.routeMessagesReady(),
+      }),
+      directory,
+    }
+  })
+
+  const visibleReady = () => {
+    const next = state()
+    if (!next.visibleSessionID) return !next.routeSessionID || next.routeReady
+    if (next.visibleSessionID !== next.routeSessionID) return true
+    return next.routeReady
+  }
+
+  return {
+    route: {
+      id: () => state().routeSessionID,
+      key: () => state().routeSessionKey,
+      ready: () => state().routeReady,
+    },
+    visible: {
+      id: () => state().visibleSessionID,
+      key: () => state().visibleSessionKey,
+      ready: visibleReady,
+    },
+    transitioning: () => state().transitioning,
+  }
+}

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -18,7 +18,7 @@ export function sessionKey(input: { directory: string; sessionID: string | undef
   return `${input.directory}${input.sessionID ? `/${input.sessionID}` : ""}`
 }
 
-export function nextTimelineSessionID(input: {
+export function nextVisibleSessionID(input: {
   current: string | undefined
   route: string | undefined
   routeReady: boolean
@@ -34,7 +34,7 @@ export function nextSessionViewState(input: SessionViewStateInput) {
     input.currentVisibleDirectory && input.currentVisibleDirectory !== input.directory
       ? undefined
       : input.currentVisibleSessionID
-  const visibleSessionID = nextTimelineSessionID({
+  const visibleSessionID = nextVisibleSessionID({
     current: currentVisibleSessionID,
     route: input.routeSessionID,
     routeReady,

--- a/packages/app/src/pages/session/timeline-session-state.test.ts
+++ b/packages/app/src/pages/session/timeline-session-state.test.ts
@@ -1,100 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { nextSessionViewState, nextTimelineSessionID, sessionKey } from "./timeline-session-state"
+import { nextSessionViewState, nextTimelineSessionID, nextVisibleSessionID, sessionKey } from "./timeline-session-state"
+import * as controller from "./session-view-controller"
 
-describe("nextTimelineSessionID", () => {
-  test("keeps the rendered timeline session while the target route session is not ready", () => {
-    expect(
-      nextTimelineSessionID({
-        current: "ses_source",
-        route: "ses_target",
-        routeReady: false,
-      }),
-    ).toBe("ses_source")
-  })
-
-  test("switches to the route session once its messages are ready", () => {
-    expect(
-      nextTimelineSessionID({
-        current: "ses_source",
-        route: "ses_target",
-        routeReady: true,
-      }),
-    ).toBe("ses_target")
-  })
-
-  test("clears the rendered timeline when leaving a session route", () => {
-    expect(
-      nextTimelineSessionID({
-        current: "ses_source",
-        route: undefined,
-        routeReady: true,
-      }),
-    ).toBeUndefined()
-  })
-})
-
-describe("sessionKey", () => {
-  test("keys a directory route without a session id", () => {
-    expect(sessionKey({ directory: "repo", sessionID: undefined })).toBe("repo")
-  })
-
-  test("keys a concrete session route", () => {
-    expect(sessionKey({ directory: "repo", sessionID: "ses_target" })).toBe("repo/ses_target")
-  })
-})
-
-describe("nextSessionViewState", () => {
-  test("keeps the visible session stable while the route session is still loading", () => {
-    expect(
-      nextSessionViewState({
-        currentVisibleSessionID: "ses_source",
-        directory: "repo",
-        routeSessionID: "ses_target",
-        routeMessagesReady: false,
-      }),
-    ).toEqual({
-      routeSessionID: "ses_target",
-      routeReady: false,
-      visibleSessionID: "ses_source",
-      transitioning: true,
-      routeSessionKey: "repo/ses_target",
-      visibleSessionKey: "repo/ses_source",
-    })
-  })
-
-  test("moves the visible session to the route session once the route is ready", () => {
-    expect(
-      nextSessionViewState({
-        currentVisibleSessionID: "ses_source",
-        directory: "repo",
-        routeSessionID: "ses_target",
-        routeMessagesReady: true,
-      }),
-    ).toEqual({
-      routeSessionID: "ses_target",
-      routeReady: true,
-      visibleSessionID: "ses_target",
-      transitioning: false,
-      routeSessionKey: "repo/ses_target",
-      visibleSessionKey: "repo/ses_target",
-    })
-  })
-
-  test("clears visible session state when leaving session routes", () => {
-    expect(
-      nextSessionViewState({
-        currentVisibleSessionID: "ses_source",
-        directory: "repo",
-        routeSessionID: undefined,
-        routeMessagesReady: true,
-      }),
-    ).toEqual({
-      routeSessionID: undefined,
-      routeReady: true,
-      visibleSessionID: undefined,
-      transitioning: false,
-      routeSessionKey: "repo",
-      visibleSessionKey: "repo",
-    })
+describe("timeline-session-state", () => {
+  test("keeps the legacy exports wired to the session view controller", () => {
+    expect(nextSessionViewState).toBe(controller.nextSessionViewState)
+    expect(nextVisibleSessionID).toBe(controller.nextVisibleSessionID)
+    expect(nextTimelineSessionID).toBe(controller.nextVisibleSessionID)
+    expect(sessionKey).toBe(controller.sessionKey)
   })
 })

--- a/packages/app/src/pages/session/timeline-session-state.test.ts
+++ b/packages/app/src/pages/session/timeline-session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { nextTimelineSessionID } from "./timeline-session-state"
+import { nextSessionViewState, nextTimelineSessionID, sessionKey } from "./timeline-session-state"
 
 describe("nextTimelineSessionID", () => {
   test("keeps the rendered timeline session while the target route session is not ready", () => {
@@ -30,5 +30,71 @@ describe("nextTimelineSessionID", () => {
         routeReady: true,
       }),
     ).toBeUndefined()
+  })
+})
+
+describe("sessionKey", () => {
+  test("keys a directory route without a session id", () => {
+    expect(sessionKey({ directory: "repo", sessionID: undefined })).toBe("repo")
+  })
+
+  test("keys a concrete session route", () => {
+    expect(sessionKey({ directory: "repo", sessionID: "ses_target" })).toBe("repo/ses_target")
+  })
+})
+
+describe("nextSessionViewState", () => {
+  test("keeps the visible session stable while the route session is still loading", () => {
+    expect(
+      nextSessionViewState({
+        currentVisibleSessionID: "ses_source",
+        directory: "repo",
+        routeSessionID: "ses_target",
+        routeMessagesReady: false,
+      }),
+    ).toEqual({
+      routeSessionID: "ses_target",
+      routeReady: false,
+      visibleSessionID: "ses_source",
+      transitioning: true,
+      routeSessionKey: "repo/ses_target",
+      visibleSessionKey: "repo/ses_source",
+    })
+  })
+
+  test("moves the visible session to the route session once the route is ready", () => {
+    expect(
+      nextSessionViewState({
+        currentVisibleSessionID: "ses_source",
+        directory: "repo",
+        routeSessionID: "ses_target",
+        routeMessagesReady: true,
+      }),
+    ).toEqual({
+      routeSessionID: "ses_target",
+      routeReady: true,
+      visibleSessionID: "ses_target",
+      transitioning: false,
+      routeSessionKey: "repo/ses_target",
+      visibleSessionKey: "repo/ses_target",
+    })
+  })
+
+  test("clears visible session state when leaving session routes", () => {
+    expect(
+      nextSessionViewState({
+        currentVisibleSessionID: "ses_source",
+        directory: "repo",
+        routeSessionID: undefined,
+        routeMessagesReady: true,
+      }),
+    ).toEqual({
+      routeSessionID: undefined,
+      routeReady: true,
+      visibleSessionID: undefined,
+      transitioning: false,
+      routeSessionKey: "repo",
+      visibleSessionKey: "repo",
+    })
   })
 })

--- a/packages/app/src/pages/session/timeline-session-state.ts
+++ b/packages/app/src/pages/session/timeline-session-state.ts
@@ -1,9 +1,2 @@
-export function nextTimelineSessionID(input: {
-  current: string | undefined
-  route: string | undefined
-  routeReady: boolean
-}) {
-  if (!input.route) return undefined
-  if (input.routeReady) return input.route
-  return input.current
-}
+export { nextSessionViewState, nextTimelineSessionID, sessionKey } from "./session-view-controller"
+export type { SessionViewStateInput } from "./session-view-controller"

--- a/packages/app/src/pages/session/timeline-session-state.ts
+++ b/packages/app/src/pages/session/timeline-session-state.ts
@@ -1,2 +1,7 @@
-export { nextSessionViewState, nextTimelineSessionID, sessionKey } from "./session-view-controller"
+export {
+  nextSessionViewState,
+  nextVisibleSessionID,
+  nextVisibleSessionID as nextTimelineSessionID,
+  sessionKey,
+} from "./session-view-controller"
 export type { SessionViewStateInput } from "./session-view-controller"


### PR DESCRIPTION
## Summary

- Add a session view controller that separates route session state from visible session state.
- Route timeline, composer state, prompt submit, abort, handoff, permission, question, and todo surfaces through the visible session while route data is still loading.
- Strengthen session scroll and switch E2E coverage so regressions catch top jumps, partial render windows, mixed-session frames, composer unmounts, and page errors.

## Why

Fixes the recurring session UI class behind #286, #312, and #313: URL route state could move ahead of the fully rendered session, while timeline and composer code read mixed sources. That could cause old-hash submit scroll jumps, session switch flicker, or composer actions targeting the wrong session during transition.

## Related Issue

Related to #286, #312, and #313.

## How To Verify

```bash
bun test --preload ./happydom.ts src/components/prompt-input/submit.test.ts src/pages/session/session-view-controller.test.ts src/pages/session/timeline-session-state.test.ts
bun run --cwd packages/app typecheck
git diff --check
bun run --cwd packages/app test:e2e -- session/session-scroll-position.spec.ts
```

## Screenshots or Recordings

No screenshot attached. This is a visible session-transition behavior fix covered by the targeted Playwright E2E checks listed above.

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer and prompt input can be driven by an externally provided session identity; timeline view separates route vs visible session state for smoother session rendering.

* **Tests**
  * New and expanded e2e and unit tests covering session view transitions, scroll-position preservation, submit-via-modifier behavior, and page-error capture.

* **Bug Fixes**
  * Improved session consistency during submissions, session switches, restores, and related UI transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->