### PR TITLE
feat: replace in-app Toast notifications with native OS notifications

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -61,8 +61,8 @@ const notify: Platform["notify"] = async (title, description, href) => {
       ? await Notification.requestPermission().catch(() => "denied")
       : Notification.permission
 
-  if (permission !== "granted") {
-    // Fallback to Toast when OS notification permission is denied
+  if (permission === "denied") {
+    // Fallback to Toast when OS notification permission is explicitly denied
     console.warn("OS notification permission denied; falling back to in-app toast. Enable notifications in system settings for the best experience.")
     showToast({
       title,
@@ -71,6 +71,8 @@ const notify: Platform["notify"] = async (title, description, href) => {
     })
     return
   }
+
+  if (permission !== "granted") return
 
   const notification = new Notification(title, {
     body: description ?? "",

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -6,6 +6,7 @@ import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
 import { handleNotificationClick } from "@/utils/notification-click"
+import { showToast } from "@opencode-ai/ui/toast"
 import pkg from "../package.json"
 import { ServerConnection } from "./context/server"
 
@@ -60,10 +61,16 @@ const notify: Platform["notify"] = async (title, description, href) => {
       ? await Notification.requestPermission().catch(() => "denied")
       : Notification.permission
 
-  if (permission !== "granted") return
-
-  const inView = document.visibilityState === "visible" && document.hasFocus()
-  if (inView) return
+  if (permission !== "granted") {
+    // Fallback to Toast when OS notification permission is denied
+    console.warn("OS notification permission denied; falling back to in-app toast. Enable notifications in system settings for the best experience.")
+    showToast({
+      title,
+      description,
+      variant: "default",
+    })
+    return
+  }
 
   const notification = new Notification(title, {
     body: description ?? "",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -419,17 +419,8 @@ export default function Layout(props: ParentProps) {
 
   const useSDKNotificationToasts = () =>
     onMount(() => {
-      const toastBySession = new Map<string, number>()
       const alertedAtBySession = new Map<string, number>()
       const cooldownMs = 5000
-
-      const dismissSessionAlert = (sessionKey: string) => {
-        const toastId = toastBySession.get(sessionKey)
-        if (toastId === undefined) return
-        toaster.dismiss(toastId)
-        toastBySession.delete(sessionKey)
-        alertedAtBySession.delete(sessionKey)
-      }
 
       const unsub = globalSDK.event.listen((e) => {
         if (e.details?.type === "worktree.ready") {
@@ -451,7 +442,7 @@ export default function Layout(props: ParentProps) {
         ) {
           const props = e.details.properties as { sessionID: string }
           const sessionKey = `${e.name}:${props.sessionID}`
-          dismissSessionAlert(sessionKey)
+          alertedAtBySession.delete(sessionKey)
           return
         }
 
@@ -460,7 +451,6 @@ export default function Layout(props: ParentProps) {
           e.details.type === "permission.asked"
             ? language.t("notification.permission.title")
             : language.t("notification.question.title")
-        const icon = e.details.type === "permission.asked" ? ("checklist" as const) : ("bubble-5" as const)
         const directory = e.name
         const props = e.details.properties
         if (e.details.type === "permission.asked" && permission.autoResponds(e.details.properties, directory)) return
@@ -496,44 +486,8 @@ export default function Layout(props: ParentProps) {
             void platform.notify(title, description, href)
           }
         }
-
-        const currentSession = params.id
-        if (workspaceKey(directory) === workspaceKey(currentDir()) && props.sessionID === currentSession) return
-        if (workspaceKey(directory) === workspaceKey(currentDir()) && session?.parentID === currentSession) return
-
-        dismissSessionAlert(sessionKey)
-
-        const toastId = showToast({
-          persistent: true,
-          icon,
-          title,
-          description,
-          actions: [
-            {
-              label: language.t("notification.action.goToSession"),
-              onClick: () => navigate(href),
-            },
-            {
-              label: language.t("common.dismiss"),
-              onClick: "dismiss",
-            },
-          ],
-        })
-        toastBySession.set(sessionKey, toastId)
       })
       onCleanup(unsub)
-
-      createEffect(() => {
-        const currentSession = params.id
-        if (!currentDir() || !currentSession) return
-        const sessionKey = `${currentDir()}:${currentSession}`
-        dismissSessionAlert(sessionKey)
-        const [store] = globalSync.child(currentDir(), { bootstrap: false })
-        const childSessions = store.session.filter((s) => s.parentID === currentSession)
-        for (const child of childSessions) {
-          dismissSessionAlert(`${currentDir()}:${child.id}`)
-        }
-      })
     })
 
   useUpdatePolling()

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -479,7 +479,9 @@ export default function Layout(props: ParentProps) {
           if (settings.notifications.permissions()) {
             // Only notify for background sessions, not the one the user is currently viewing
             const currentSession = params.id
-            const isCurrentSession = workspaceKey(directory) === workspaceKey(currentDir()) && 
+            const isCurrentSession =
+              !!currentSession &&
+              workspaceKey(directory) === workspaceKey(currentDir()) &&
               (props.sessionID === currentSession || session?.parentID === currentSession)
             if (!isCurrentSession) {
               void platform.notify(title, description, href)
@@ -491,7 +493,9 @@ export default function Layout(props: ParentProps) {
           if (settings.notifications.agent()) {
             // Only notify for background sessions, not the one the user is currently viewing
             const currentSession = params.id
-            const isCurrentSession = workspaceKey(directory) === workspaceKey(currentDir()) && 
+            const isCurrentSession =
+              !!currentSession &&
+              workspaceKey(directory) === workspaceKey(currentDir()) &&
               (props.sessionID === currentSession || session?.parentID === currentSession)
             if (!isCurrentSession) {
               void platform.notify(title, description, href)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -477,13 +477,25 @@ export default function Layout(props: ParentProps) {
             void playSoundById(settings.sounds.permissions())
           }
           if (settings.notifications.permissions()) {
-            void platform.notify(title, description, href)
+            // Only notify for background sessions, not the one the user is currently viewing
+            const currentSession = params.id
+            const isCurrentSession = workspaceKey(directory) === workspaceKey(currentDir()) && 
+              (props.sessionID === currentSession || session?.parentID === currentSession)
+            if (!isCurrentSession) {
+              void platform.notify(title, description, href)
+            }
           }
         }
 
         if (e.details.type === "question.asked") {
           if (settings.notifications.agent()) {
-            void platform.notify(title, description, href)
+            // Only notify for background sessions, not the one the user is currently viewing
+            const currentSession = params.id
+            const isCurrentSession = workspaceKey(directory) === workspaceKey(currentDir()) && 
+              (props.sessionID === currentSession || session?.parentID === currentSession)
+            if (!isCurrentSession) {
+              void platform.notify(title, description, href)
+            }
           }
         }
       })

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -392,6 +392,24 @@ export function registerIpcHandlers(deps: Deps) {
     new Notification({ title, body }).show()
   })
 
+  ipcMain.handle("flash-frame", (event: IpcMainInvokeEvent) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) return
+
+    if (process.platform === "darwin") {
+      // macOS: bounce the Dock icon once
+      app.dock?.bounce()
+    } else {
+      // Windows/Linux: flash the taskbar button
+      win.flashFrame(true)
+      // Stop flashing after 1 second (single flash effect)
+      // Note: This doesn't cancel on window focus — accepted trade-off
+      setTimeout(() => {
+        win.flashFrame(false)
+      }, 1000)
+    }
+  })
+
   ipcMain.handle("get-window-count", () => BrowserWindow.getAllWindows().length)
 
   ipcMain.handle("get-window-focused", (event: IpcMainInvokeEvent) => {

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -392,6 +392,8 @@ export function registerIpcHandlers(deps: Deps) {
     new Notification({ title, body }).show()
   })
 
+  const flashFrameTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
   ipcMain.handle("flash-frame", (event: IpcMainInvokeEvent) => {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win) return
@@ -401,12 +403,18 @@ export function registerIpcHandlers(deps: Deps) {
       app.dock?.bounce()
     } else {
       // Windows/Linux: flash the taskbar button
+      // Clear any existing timer for this window
+      const existing = flashFrameTimers.get(win.id)
+      if (existing !== undefined) clearTimeout(existing)
+
       win.flashFrame(true)
-      // Stop flashing after 1 second (single flash effect)
-      // Note: This doesn't cancel on window focus — accepted trade-off
-      setTimeout(() => {
-        win.flashFrame(false)
-      }, 1000)
+      flashFrameTimers.set(
+        win.id,
+        setTimeout(() => {
+          flashFrameTimers.delete(win.id)
+          if (!win.isDestroyed()) win.flashFrame(false)
+        }, 1000),
+      )
     }
   })
 

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -95,6 +95,7 @@ const api: ElectronAPI = {
       ipcRenderer.removeListener("about:open", wrapped)
     }
   },
+  flashFrame: () => ipcRenderer.invoke("flash-frame"),
 }
 
 contextBridge.exposeInMainWorld("api", api)

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -113,4 +113,5 @@ export type ElectronAPI = {
   removeExaApiKey: () => Promise<WebSearchStatus>
   getAboutInfo: () => Promise<AboutInfo>
   onAboutOpen: (handler: () => void) => () => void
+  flashFrame: () => Promise<void>
 }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -246,9 +246,6 @@ const createPlatform = (): Platform => {
     },
 
     notify: async (title, description, href) => {
-      const focused = await window.api.getWindowFocused().catch(() => document.hasFocus())
-      if (focused) return
-
       // Omit `icon`; macOS/Windows fall back to the packaged app icon, which
       // is the PawWork paw-print. Any explicit URL here would pin us to an
       // external asset and reintroduce OpenCode branding in notifications.
@@ -261,6 +258,9 @@ const createPlatform = (): Platform => {
         handleNotificationClick(href)
         notification.close()
       }
+
+      // Flash Dock/taskbar to attract attention
+      void window.api.flashFrame()
     },
 
     fetch: (input, init) => {

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -249,14 +249,19 @@ const createPlatform = (): Platform => {
       // Omit `icon`; macOS/Windows fall back to the packaged app icon, which
       // is the PawWork paw-print. Any explicit URL here would pin us to an
       // external asset and reintroduce OpenCode branding in notifications.
-      const notification = new Notification(title, {
-        body: description ?? "",
-      })
-      notification.onclick = () => {
-        void window.api.showWindow()
-        void window.api.setWindowFocus()
-        handleNotificationClick(href)
-        notification.close()
+      try {
+        const notification = new Notification(title, {
+          body: description ?? "",
+        })
+        notification.onclick = () => {
+          void window.api.showWindow()
+          void window.api.setWindowFocus()
+          handleNotificationClick(href)
+          notification.close()
+        }
+      } catch {
+        // Fallback to IPC-based notification if native Notification fails
+        window.api.showNotification(title, description)
       }
 
       // Flash Dock/taskbar to attract attention


### PR DESCRIPTION
## Summary

Replace in-app Toast notifications with native OS notifications + Dock/taskbar flash feedback. This removes the annoying bottom-right popups that block UI elements.

Changes:
- Remove focus checks from both web and desktop `notify` functions so system notifications fire regardless of window focus
- Add `flashFrame` IPC with platform-specific behavior (macOS: Dock bounce, Windows/Linux: taskbar flash)
- Remove notification-related Toast calls and associated dead code from layout.tsx
- Add fallback to Toast when OS notification permission is denied (web platform)

## Why

The current notification system uses in-app Toast popups in the bottom-right corner that:
- Block the send/submit buttons
- Create visual noise when multiple notifications stack
- Mix important (permission requests) with less important (status updates) notifications

Users want native OS notifications like Codex App, which don't interfere with the app UI.

## Related Issue

Closes #332

## How To Verify

```bash
bun --cwd packages/desktop-electron typecheck
bun --cwd packages/app typecheck
```

Manual testing:
1. Run `bun run dev:desktop`
2. Trigger a permission request or question from an agent
3. Verify system notification appears (not Toast popup)
4. Verify Dock icon bounces (macOS) or taskbar flashes (Windows)
5. Verify click notification brings window to front and navigates to session
6. Deny OS notification permission → verify Toast fallback works

## Screenshots or Recordings

N/A — notification behavior change, no visual UI change

## Checklist

- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I listed the relevant verification steps, including tests when behavior changed
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated/local file changes when relevant
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop attention indicator added (Dock bounce on macOS, taskbar flash on Windows/Linux).

* **Improvements**
  * If OS notification permission is explicitly denied, a warning is logged and an in-app toast is shown.
  * Notifications are not sent for the currently active session to avoid distractions; throttling still applies.
  * Native notification delivery now uses a safe fallback and always attempts to attract attention.

* **Bug Fixes**
  * Removed persistent per-session toasts so alerts no longer linger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->