### PR TITLE
chore: bump version to 2026.5.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "2026.4.29",
+      "version": "2026.5.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -110,7 +110,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.4.29",
+      "version": "2026.5.1",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "effect": "catalog:",
@@ -175,7 +175,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "2026.4.29",
+      "version": "2026.5.1",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -401,7 +401,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "2026.4.29",
+      "version": "2026.5.1",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.4.29",
+  "version": "2026.5.1",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.4.29",
+  "version": "2026.5.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.4.29",
+  "version": "2026.5.1",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.4.29",
+  "version": "2026.5.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump PawWork package versions from 2026.4.29 to 2026.5.1 for the next stable desktop release.

## Changes

- Updated `packages/app`, `packages/opencode`, `packages/util`, and `packages/desktop-electron` package versions to `2026.5.1`.
- Updated `bun.lock` workspace package metadata to match.

## Verification

- `bun install --frozen-lockfile`
- `bun --cwd packages/desktop-electron test scripts/release-workflow-contract.test.ts scripts/electron-builder-app-update.test.ts`
- `git diff --check`
- `bun run --cwd packages/desktop-electron typecheck:release`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions from 2026.4.29 to 2026.5.1 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->