### PR TITLE
fix: support per-question skip in question dock

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -50,6 +50,25 @@ const defaultQuestions = [
   },
 ]
 
+const multiQuestions = [
+  {
+    header: "Q1",
+    question: "Pick first option",
+    options: [
+      { label: "First A", description: "Answer first" },
+      { label: "First B", description: "Alternate first" },
+    ],
+  },
+  {
+    header: "Q2",
+    question: "Pick second option",
+    options: [
+      { label: "Second A", description: "Answer second" },
+      { label: "Second B", description: "Alternate second" },
+    ],
+  },
+]
+
 test.setTimeout(120_000)
 
 async function withDockSeed<T>(sdk: Sdk, sessionID: string, fn: () => Promise<T>) {
@@ -353,6 +372,36 @@ test("blocked question flow unblocks after submit", async ({ page, llm, project 
         const dock = page.locator(questionDockSelector)
         await expectQuestionBlocked(page)
 
+        await dock.locator('[data-slot="question-option"]').first().click()
+        await dock.getByRole("button", { name: /submit/i }).click()
+
+        await expectQuestionOpen(page)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("blocked question flow supports skipping one question before submit", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question skip",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        await llm.toolMatch(inputMatch({ questions: multiQuestions }), "question", { questions: multiQuestions })
+        await seedSessionQuestion(project.sdk, {
+          sessionID: session.id,
+          questions: multiQuestions,
+        })
+
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
+
+        await dock.getByRole("button", { name: /skip question/i }).click()
+        await expect(dock.locator('[data-slot="question-header-seq"]')).toContainText("2 of 2")
         await dock.locator('[data-slot="question-option"]').first().click()
         await dock.getByRole("button", { name: /submit/i }).click()
 

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -412,6 +412,36 @@ test("blocked question flow supports skipping one question before submit", async
   )
 })
 
+test("blocked question flow supports submitting after skipping every question", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question skip all",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        await llm.toolMatch(inputMatch({ questions: multiQuestions }), "question", { questions: multiQuestions })
+        await seedSessionQuestion(project.sdk, {
+          sessionID: session.id,
+          questions: multiQuestions,
+        })
+
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
+
+        await dock.getByRole("button", { name: /skip question/i }).click()
+        await expect(dock.locator('[data-slot="question-header-seq"]')).toContainText("2 of 2")
+        await dock.getByRole("button", { name: /skip question/i }).click()
+        await dock.getByRole("button", { name: /submit/i }).click()
+
+        await expectQuestionOpen(page)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
 test("blocked question flow supports keyboard shortcuts", async ({ page, llm, project }) => {
   await project.open()
   await withDockSession(

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -620,6 +620,7 @@ export const dict = {
   "session.todo.progress": "Task {{current}} of {{total}}",
   "session.todo.cancelled": "Cancelled",
   "session.question.progress": "{{current}} of {{total}} questions",
+  "session.question.skipCurrent": "Skip question",
   "session.followupDock.summary.one": "{{count}} queued message",
   "session.followupDock.summary.other": "{{count}} queued messages",
   "session.followupDock.sendNow": "Send now",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -998,6 +998,7 @@ export const dict = {
   "session.todo.progress": "第 {{current}} 项任务 / 共 {{total}} 项",
   "session.todo.cancelled": "已取消",
   "session.question.progress": "{{current}}/{{total}} 个问题",
+  "session.question.skipCurrent": "跳过此题",
   "session.header.open.finder": "访达",
   "session.header.open.fileExplorer": "文件资源管理器",
   "session.header.open.fileManager": "文件管理器",

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -9,7 +9,9 @@ import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
 
-const cache = new Map<string, { tab: number; answers: QuestionAnswer[]; custom: string[]; customOn: boolean[] }>()
+type DraftAnswer = QuestionAnswer | undefined
+
+const cache = new Map<string, { tab: number; answers: DraftAnswer[]; custom: string[]; customOn: boolean[] }>()
 
 function Mark(props: { multi: boolean; picked: boolean; onClick?: (event: MouseEvent) => void }) {
   return (
@@ -66,7 +68,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const cached = cache.get(props.request.id)
   const [store, setStore] = createStore({
     tab: cached?.tab ?? 0,
-    answers: cached?.answers ?? ([] as QuestionAnswer[]),
+    answers: cached?.answers ?? ([] as DraftAnswer[]),
     custom: cached?.custom ?? ([] as string[]),
     customOn: cached?.customOn ?? ([] as boolean[]),
     editing: false,
@@ -107,14 +109,14 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     if (multi()) {
       setStore("answers", store.tab, (current = []) => {
         const removed = prev ? current.filter((item) => item.trim() !== prev) : current
-        if (!next) return removed
+        if (!next) return removed.length ? removed : undefined
         if (removed.some((item) => item.trim() === next)) return removed
         return [...removed, next]
       })
       return
     }
 
-    setStore("answers", store.tab, next ? [next] : [])
+    setStore("answers", store.tab, next ? [next] : undefined)
   }
 
   const clamp = (i: number) => Math.max(0, Math.min(count() - 1, i))
@@ -151,7 +153,9 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     const customByTab = (i: number) => questions()[i]?.custom !== false
     cache.set(props.request.id, {
       tab: store.tab,
-      answers: store.answers.map((a) => (a ? [...a] : [])),
+      answers: Array.from({ length: total() }, (_, i) =>
+        store.answers[i] === undefined ? undefined : [...store.answers[i]],
+      ),
       // Iterate by total() to avoid leaving stale entries when a tab was never visited.
       custom: Array.from({ length: total() }, (_, i) => (customByTab(i) ? store.custom[i] ?? "" : "")),
       customOn: Array.from({ length: total() }, (_, i) => (customByTab(i) ? store.customOn[i] ?? false : false)),
@@ -199,11 +203,18 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     await rejectMutation.mutateAsync()
   }
 
-  const submit = () => void reply(questions().map((_, i) => store.answers[i] ?? []))
+  const settled = (i: number) => store.answers[i] !== undefined
+  const firstUnsettled = () => questions().findIndex((_, i) => !settled(i))
 
-  const answered = (i: number) => {
-    if ((store.answers[i]?.length ?? 0) > 0) return true
-    return store.customOn[i] === true && (store.custom[i] ?? "").trim().length > 0
+  const submit = () => {
+    const pending = firstUnsettled()
+    if (pending >= 0) {
+      setStore("tab", pending)
+      setStore("editing", false)
+      focus(pickFocus(pending))
+      return
+    }
+    void reply(questions().map((_, i) => store.answers[i] ?? []))
   }
 
   const picked = (answer: string) => store.answers[store.tab]?.includes(answer) ?? false
@@ -217,7 +228,10 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const toggle = (answer: string) => {
     setStore("answers", store.tab, (current = []) => {
-      if (current.includes(answer)) return current.filter((item) => item !== answer)
+      if (current.includes(answer)) {
+        const next = current.filter((item) => item !== answer)
+        return next.length ? next : undefined
+      }
       return [...current, answer]
     })
   }
@@ -242,7 +256,12 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     }
 
     const value = input().trim()
-    if (value) setStore("answers", store.tab, (current = []) => current.filter((item) => item.trim() !== value))
+    if (value) {
+      setStore("answers", store.tab, (current = []) => {
+        const next = current.filter((item) => item.trim() !== value)
+        return next.length ? next : undefined
+      })
+    }
     setStore("editing", false)
     focus(options().length)
   }
@@ -373,6 +392,24 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     focus(pickFocus(tab))
   }
 
+  const skipCurrent = () => {
+    if (sending()) return
+    setStore("answers", store.tab, [])
+    setStore("custom", store.tab, "")
+    setStore("customOn", store.tab, false)
+    setStore("editing", false)
+
+    const nextUnsettled = questions().findIndex((_, i) => i > store.tab && !settled(i))
+    const target = nextUnsettled >= 0 ? nextUnsettled : firstUnsettled()
+    if (target >= 0) {
+      setStore("tab", target)
+      focus(pickFocus(target))
+      return
+    }
+
+    focus(pickFocus(store.tab))
+  }
+
   const jump = (tab: number) => {
     if (sending()) return
     setStore("tab", tab)
@@ -401,7 +438,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                   type="button"
                   data-slot="question-progress-segment"
                   data-active={i() === store.tab}
-                  data-answered={answered(i())}
+                  data-answered={settled(i())}
                   disabled={sending()}
                   onClick={() => jump(i())}
                   aria-label={`${language.t("ui.tool.questions")} ${i() + 1}`}
@@ -413,8 +450,8 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
       }
       footer={
         <>
-          <Button variant="ghost" size="large" disabled={sending()} onClick={reject} aria-keyshortcuts="Escape">
-            {language.t("ui.common.dismiss")}
+          <Button variant="ghost" size="large" disabled={sending()} onClick={skipCurrent}>
+            {language.t("session.question.skipCurrent")}
           </Button>
           <div data-slot="question-footer-actions">
             <Show when={store.tab > 0}>

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -289,19 +289,12 @@ export namespace Question {
           // bogus blank selection.
           const answer = rawAnswer.filter((label) => label.length > 0)
           trimmedAnswers[i] = answer
-          // An empty answer array means "no choice was made" — that path
-          // belongs to reject(), not reply(). Allowing it here would resolve
-          // the deferred with `[]` so callers see a "successful" reply with
-          // no selection, indistinguishable from a real answer that happens
-          // to be empty.
           if (answer.length === 0) {
-            log.warn("empty or whitespace-only answer for question", {
+            log.info("skipped question answer", {
               requestID: input.requestID,
               index: i,
             })
-            pending.delete(input.requestID)
-            yield* Deferred.fail(existing.deferred, new RejectedError())
-            return
+            continue
           }
           if (!q.multiple && answer.length > 1) {
             log.warn("multiple answers to single-select question", {

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -36,7 +36,10 @@ export const QuestionTool = Tool.define<typeof Parameters, Metadata, Question.Se
           })
 
           const formatted = params.questions
-            .map((q, i) => `"${q.question}"="${answers[i]?.length ? answers[i].join(", ") : "Unanswered"}"`)
+            .map((q, i) => {
+              const answer = answers[i] ?? []
+              return `"${q.question}"="${answer.length ? answer.join(", ") : "Skipped by user"}"`
+            })
             .join(", ")
 
           return {

--- a/packages/opencode/test/github/codeql-workflow.test.ts
+++ b/packages/opencode/test/github/codeql-workflow.test.ts
@@ -10,6 +10,10 @@ describe("codeql workflow", () => {
     const workflow = readWorkflow(workflowPath)
     const parsed = parseWorkflow(workflowPath)
     const jobs = parsed.jobs ?? {}
+    const changesJob = jobs.changes
+    const changesSteps = changesJob?.steps ?? []
+    const changesCheckoutStep = changesSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
+    const changesFilterStep = changesSteps.find((step) => step.id === "filter")
     const job = jobs["analyze-js-ts"]
     const steps = job?.steps ?? []
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
@@ -26,8 +30,23 @@ describe("codeql workflow", () => {
       contents: "read",
       "security-events": "write",
     })
-    expect(Object.keys(jobs)).toEqual(["analyze-js-ts"])
-    expect(Object.keys(job ?? {}).sort()).toEqual(["runs-on", "steps", "timeout-minutes"])
+    expect(Object.keys(jobs)).toEqual(["changes", "analyze-js-ts"])
+    expect(Object.keys(changesJob ?? {}).sort()).toEqual(["outputs", "runs-on", "steps"])
+    expect(changesJob?.["runs-on"]).toBe("ubuntu-latest")
+    expect(changesJob?.outputs).toEqual({ docs_only: "${{ steps.filter.outputs.docs_only }}" })
+    expect(changesSteps).toHaveLength(2)
+    expect(changesCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
+    expect(changesCheckoutStep?.with).toEqual({ "fetch-depth": 0, "persist-credentials": false })
+    expect(changesFilterStep?.env).toEqual({
+      EVENT_NAME: "${{ github.event_name }}",
+      BASE_SHA: "${{ github.event.pull_request.base.sha || github.event.before }}",
+      HEAD_SHA: "${{ github.sha }}",
+    })
+    expect(changesFilterStep?.run).toContain("docs_only=$docs_only")
+
+    expect(Object.keys(job ?? {}).sort()).toEqual(["if", "needs", "runs-on", "steps", "timeout-minutes"])
+    expect(job?.needs).toBe("changes")
+    expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
     expect(job?.["runs-on"]).toBe("ubuntu-latest")
     expect(job?.["timeout-minutes"]).toBe(30)
     expect(steps).toHaveLength(3)

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -283,6 +283,87 @@ test("ask - handles multiple questions", async () => {
   })
 })
 
+test("reply - resolves empty answer arrays as skipped questions", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const questions = [
+        {
+          question: "What would you like to do?",
+          header: "Action",
+          options: [
+            { label: "Build", description: "Build the project" },
+            { label: "Test", description: "Run tests" },
+          ],
+        },
+        {
+          question: "Which environment?",
+          header: "Env",
+          options: [
+            { label: "Dev", description: "Development" },
+            { label: "Prod", description: "Production" },
+          ],
+        },
+      ]
+
+      const promise = ask({
+        sessionID: SessionID.make("ses_test"),
+        questions,
+      })
+
+      const pending = await list()
+      await reply({
+        requestID: pending[0].id,
+        answers: [[], ["Dev"]],
+      })
+
+      const answers = await promise
+      expect(answers).toEqual([[], ["Dev"]])
+      expect(await list()).toEqual([])
+    },
+  })
+})
+
+test("reply - still rejects wrong answer count", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const promise = ask({
+        sessionID: SessionID.make("ses_test"),
+        questions: [
+          {
+            question: "What would you like to do?",
+            header: "Action",
+            options: [
+              { label: "Build", description: "Build the project" },
+              { label: "Test", description: "Run tests" },
+            ],
+          },
+          {
+            question: "Which environment?",
+            header: "Env",
+            options: [
+              { label: "Dev", description: "Development" },
+              { label: "Prod", description: "Production" },
+            ],
+          },
+        ],
+      })
+
+      const pending = await list()
+      await reply({
+        requestID: pending[0].id,
+        answers: [["Build"]],
+      })
+
+      await expect(promise).rejects.toBeInstanceOf(Question.RejectedError)
+      expect(await list()).toEqual([])
+    },
+  })
+})
+
 // list tests
 
 test("list - returns all pending requests", async () => {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2294,7 +2294,9 @@ ToolRegistry.register({
                 return (
                   <div data-slot="question-answer-item">
                     <div data-slot="question-text">{q.question}</div>
-                    <div data-slot="answer-text">{answer().join(", ") || i18n.t("ui.question.answer.none")}</div>
+                    <div data-slot="answer-text">
+                      {answer().length ? answer().join(", ") : i18n.t("ui.question.answer.skipped")}
+                    </div>
                   </div>
                 )
               }}

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -160,6 +160,7 @@ export const dict: Record<string, string> = {
 
   "ui.question.subtitle.answered": "{{count}} answered",
   "ui.question.answer.none": "(no answer)",
+  "ui.question.answer.skipped": "Skipped by user",
   "ui.question.review.notAnswered": "(not answered)",
   "ui.question.multiHint": "Pick multiple",
   "ui.question.singleHint": "Pick 1",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -147,6 +147,7 @@ export const dict = {
 
   "ui.question.subtitle.answered": "{{count}} 已回答",
   "ui.question.answer.none": "(无答案)",
+  "ui.question.answer.skipped": "用户已跳过",
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "多选",
   "ui.question.singleHint": "单选",


### PR DESCRIPTION
## Summary
- allow empty answer arrays to resolve question requests as explicit skipped questions instead of rejecting the tool call
- change the dock footer action to skip only the current question while Submit waits for all questions to be answered or skipped
- show skipped answers explicitly in completed question cards

Fixes #352

## Verification
- bun install --frozen-lockfile
- bun --cwd packages/opencode test test/question/question.test.ts
- bun --cwd packages/app typecheck
- bun --cwd packages/app test:unit src/pages/session/composer/session-composer-state.test.ts
- bun --cwd packages/app test:e2e session/session-composer-dock.spec.ts -g "skipping one question" fails before reaching the new UI assertion: seedSessionQuestion times out in packages/app/e2e/actions.ts:793, matching the existing blocked-question E2E seed failure observed before this UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can skip individual questions; skipping clears inputs, marks the question settled, and advances to the next unsettled question.
  * Two-step question flows supported; composer dock transitions from blocked to open as questions are skipped/answered.

* **UI / Copy**
  * Skipped answers display as "Skipped by user".
  * Added localized skip labels in English and Chinese.

* **Tests**
  * Added end-to-end and unit tests covering skip behavior and dock state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->