### PR TITLE
fix: stabilize session navigation ordering

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -79,6 +79,7 @@ import {
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
+  pawworkSidebarSessionTime,
   pawworkSessionDirectories,
   resolvePawworkProjectLabels,
   sortPawworkSidebarSessions,
@@ -538,21 +539,11 @@ export default function Layout(props: ParentProps) {
 
         const [dirStore] = globalSync.child(directory, { bootstrap: true })
         for (const session of sortedRootSessions(dirStore)) {
-          const messages = dirStore.message[session.id]
-          let lastUserAt = 0
-          if (messages?.length) {
-            for (let i = messages.length - 1; i >= 0; i--) {
-              if (messages[i].role === "user") {
-                lastUserAt = messages[i].time?.created ?? 0
-                break
-              }
-            }
-          }
           result.push({
             session,
             slug: base64Encode(session.directory),
             projectLabel: labels.get(project.worktree) ?? displayName(project),
-            created: lastUserAt || session.time?.updated || session.time?.created || 0,
+            created: pawworkSidebarSessionTime(session, dirStore.message[session.id]),
           })
         }
       }

--- a/packages/app/src/pages/layout/pawwork-session-source.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { resolvePawworkProjectLabels, sortPawworkSidebarSessions } from "./pawwork-session-source"
+import {
+  pawworkSidebarSessionTime,
+  resolvePawworkProjectLabels,
+  sortPawworkSidebarSessions,
+} from "./pawwork-session-source"
 
 describe("resolvePawworkProjectLabels", () => {
   test("keeps unique project names unchanged", () => {
@@ -48,5 +52,135 @@ describe("sortPawworkSidebarSessions", () => {
     ])
 
     expect(result.map((item) => item.id)).toEqual(["alpha", "zebra", "zeta"])
+  })
+
+  test("sorts by the latest loaded user message time", () => {
+    const result = sortPawworkSidebarSessions([
+      {
+        id: "older-session-with-new-user-message",
+        created: pawworkSidebarSessionTime(
+          { time: { created: 100, updated: 400 } },
+          [
+            { id: "msg_1", role: "user", time: { created: 300 } },
+            { id: "msg_2", role: "assistant", time: { created: 500 } },
+          ],
+        ),
+        projectLabel: "pawwork",
+      },
+      {
+        id: "newer-session-with-older-user-message",
+        created: pawworkSidebarSessionTime(
+          { time: { created: 200, updated: 600 } },
+          [
+            { id: "msg_3", role: "user", time: { created: 250 } },
+            { id: "msg_4", role: "assistant", time: { created: 700 } },
+          ],
+        ),
+        projectLabel: "opencli",
+      },
+    ])
+
+    expect(result.map((item) => item.id)).toEqual([
+      "older-session-with-new-user-message",
+      "newer-session-with-older-user-message",
+    ])
+  })
+
+  test("falls back to creation time instead of update time when user messages are not loaded", () => {
+    const result = sortPawworkSidebarSessions([
+      {
+        id: "old-recently-updated",
+        created: pawworkSidebarSessionTime(
+          { time: { created: 1777610000000, updated: 1777689073008 } },
+          undefined,
+        ),
+        projectLabel: "pawwork",
+      },
+      {
+        id: "newer-session",
+        created: pawworkSidebarSessionTime(
+          { time: { created: 1777680000000, updated: 1777681000000 } },
+          undefined,
+        ),
+        projectLabel: "opencli",
+      },
+    ])
+
+    expect(result.map((item) => item.id)).toEqual(["newer-session", "old-recently-updated"])
+  })
+
+  test("does not promote sessions from assistant-only message caches", () => {
+    const result = sortPawworkSidebarSessions([
+      {
+        id: "old-with-new-assistant",
+        created: pawworkSidebarSessionTime(
+          { time: { created: 100, updated: 900 } },
+          [{ id: "msg_1", role: "assistant", time: { created: 800 } }],
+        ),
+        projectLabel: "pawwork",
+      },
+      {
+        id: "newer-session",
+        created: pawworkSidebarSessionTime({ time: { created: 200, updated: 300 } }, undefined),
+        projectLabel: "opencli",
+      },
+    ])
+
+    expect(result.map((item) => item.id)).toEqual(["newer-session", "old-with-new-assistant"])
+  })
+})
+
+describe("pawworkSidebarSessionTime", () => {
+  test("uses the latest loaded user message time", () => {
+    expect(
+      pawworkSidebarSessionTime(
+        {
+          time: {
+            created: 100,
+            updated: 600,
+          },
+        },
+        [
+          { id: "msg_1", role: "assistant", time: { created: 700 } },
+          { id: "msg_2", role: "user", time: { created: 300 } },
+          { id: "msg_3", role: "user", time: { created: 500 } },
+        ],
+      ),
+    ).toBe(500)
+  })
+
+  test("ignores user messages without a valid created time", () => {
+    expect(
+      pawworkSidebarSessionTime(
+        {
+          time: {
+            created: 100,
+            updated: 600,
+          },
+        },
+        [
+          { id: "msg_1", role: "user", time: { created: 300 } },
+          { id: "msg_2", role: "user", time: {} },
+        ],
+      ),
+    ).toBe(300)
+  })
+
+  test("uses the session creation time instead of last update time when messages are missing", () => {
+    expect(
+      pawworkSidebarSessionTime(
+        {
+          time: {
+            created: 100,
+            updated: 300,
+          },
+        },
+        undefined,
+      ),
+    ).toBe(100)
+  })
+
+  test("falls back to 0 when creation time is missing", () => {
+    expect(pawworkSidebarSessionTime({ time: { updated: 300 } })).toBe(0)
   })
 })

--- a/packages/app/src/pages/layout/pawwork-session-source.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.test.ts
@@ -166,6 +166,24 @@ describe("pawworkSidebarSessionTime", () => {
     ).toBe(300)
   })
 
+  test("ignores user messages with non-finite created times", () => {
+    expect(
+      pawworkSidebarSessionTime(
+        {
+          time: {
+            created: 100,
+            updated: 600,
+          },
+        },
+        [
+          { id: "msg_1", role: "user", time: { created: 300 } },
+          { id: "msg_2", role: "user", time: { created: Number.NaN } },
+          { id: "msg_3", role: "user", time: { created: Number.POSITIVE_INFINITY } },
+        ],
+      ),
+    ).toBe(300)
+  })
+
   test("uses the session creation time instead of last update time when messages are missing", () => {
     expect(
       pawworkSidebarSessionTime(
@@ -178,6 +196,10 @@ describe("pawworkSidebarSessionTime", () => {
         undefined,
       ),
     ).toBe(100)
+  })
+
+  test("falls back to 0 when creation time is non-finite", () => {
+    expect(pawworkSidebarSessionTime({ time: { created: Number.NaN, updated: 300 } })).toBe(0)
   })
 
   test("falls back to 0 when creation time is missing", () => {

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -14,6 +14,21 @@ type SessionLike = {
   projectLabel: string
 }
 
+type SessionTimeLike = {
+  time?: {
+    created?: number
+    updated?: number
+  }
+}
+
+type MessageTimeLike = {
+  id?: string
+  role?: string
+  time?: {
+    created?: number
+  }
+}
+
 const shortenHome = (value: string, home?: string) => {
   if (!home) return value
   const normalized = home.endsWith("/") ? home : `${home}/`
@@ -44,6 +59,16 @@ export function sortPawworkSidebarSessions<T extends SessionLike>(sessions: T[])
     if (project !== 0) return project
     return a.id.localeCompare(b.id)
   })
+}
+
+export function pawworkSidebarSessionTime(session: SessionTimeLike, messages?: MessageTimeLike[]) {
+  for (let i = (messages?.length ?? 0) - 1; i >= 0; i--) {
+    const message = messages?.[i]
+    if (message?.role !== "user") continue
+    const created = message.time?.created
+    if (typeof created === "number") return created
+  }
+  return session.time?.created ?? 0
 }
 
 export function pawworkSessionDirectories(input: {

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -29,6 +29,8 @@ type MessageTimeLike = {
   }
 }
 
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value)
+
 const shortenHome = (value: string, home?: string) => {
   if (!home) return value
   const normalized = home.endsWith("/") ? home : `${home}/`
@@ -66,9 +68,10 @@ export function pawworkSidebarSessionTime(session: SessionTimeLike, messages?: M
     const message = messages?.[i]
     if (message?.role !== "user") continue
     const created = message.time?.created
-    if (typeof created === "number") return created
+    if (isFiniteNumber(created)) return created
   }
-  return session.time?.created ?? 0
+  const sessionCreated = session.time?.created
+  return isFiniteNumber(sessionCreated) ? sessionCreated : 0
 }
 
 export function pawworkSessionDirectories(input: {

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -31,4 +31,26 @@ describe("session review state", () => {
 
     expect(files.map((file) => file.path)).toEqual(["/repo/created.md", "/repo/updated.md"])
   })
+
+  test("treats missing turn diffs as no files while a session is loading", () => {
+    const files = deriveReviewArtifactFiles({
+      directory: "/repo",
+      sessionID: "ses_1",
+      history: { sessionID: "ses_2", artifacts: [{ file: "stale.md", kind: "added" }] },
+      turnDiffs: undefined,
+    })
+
+    expect(files).toEqual([])
+  })
+
+  test("does not throw before turn diffs arrive for the selected session", () => {
+    expect(() =>
+      deriveReviewArtifactFiles({
+        directory: "/repo",
+        sessionID: "ses_1",
+        history: { sessionID: "ses_1", artifacts: [] },
+        turnDiffs: undefined,
+      }),
+    ).not.toThrow()
+  })
 })

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -21,16 +21,17 @@ export function deriveReviewArtifactFiles(input: {
   directory: string
   sessionID: string | undefined
   history: { sessionID: string; artifacts: SessionArtifactFile[] } | undefined
-  turnDiffs: Array<{ file: string; status?: string }>
+  turnDiffs?: Array<{ file: string; status?: string }>
 }) {
   const history = input.history
   if (history && history.sessionID === input.sessionID && history.artifacts.length > 0) {
     return deriveArtifactFiles(input.directory, history.artifacts)
   }
 
+  const turnDiffs = input.turnDiffs ?? []
   return deriveArtifactFiles(
     input.directory,
-    input.turnDiffs.flatMap((diff) => {
+    turnDiffs.flatMap((diff) => {
       if (diff.status !== "added" && diff.status !== "modified") return []
       return [{ file: diff.file, kind: diff.status as "added" | "modified" }]
     }),


### PR DESCRIPTION
## Summary

- Prevent the session review file derivation from crashing while turn diffs are still loading.
- Sort PawWork sidebar sessions by the latest loaded user message timestamp, with a creation-time fallback when messages are missing or invalid.
- Reject non-finite timestamp values before they can reach sidebar sorting.
- Add focused regression coverage for missing turn diffs, missing message caches, assistant-only caches, malformed user timestamps, and non-finite timestamps.

## Why

A newer build could throw `Cannot read properties of undefined (reading 'flatMap')` when opening a session before `turnDiffs` arrived. The sidebar also used `session.time.updated` as a fallback, which let assistant/background updates promote older conversations and made timestamps/order feel wrong. The helper keeps the ordering tied to user activity when available and avoids using update time as a fallback. Review also identified that `NaN` or `Infinity` timestamps could still reach the numeric sort key, so the helper now accepts only finite numbers.

## Related Issue

No linked issue. This came from local regression triage against real session logs.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the fallback ordering contract in `pawworkSidebarSessionTime`: use the latest valid loaded user message time, otherwise fall back to `session.time.created`, never `session.time.updated`, and never return non-finite numbers. Also check that treating missing `turnDiffs` as an empty list does not hide legitimate review files once data arrives.

## Risk Notes

Low. This changes sidebar ordering behavior and a loading-state fallback only. No persistence, dependency, migration, permissions, updater, or generated-file changes are included.

## How To Verify

```text
TDD red check: malformed user timestamp regression failed before the helper fix with 1 failing test.
Review TDD red check: non-finite timestamp regressions failed before the finite-number guard with 2 failing tests.
Focused sorting test: bun --cwd packages/app test --preload ./happydom.ts ./src/pages/layout/pawwork-session-source.test.ts -> 656 pass, 0 fail
Focused regression tests: bun --cwd packages/app test --preload ./happydom.ts ./src/pages/layout/pawwork-session-source.test.ts ./src/pages/session/use-session-review-state.test.ts -> 656 pass, 0 fail
Typecheck: bun run --cwd packages/app typecheck -> tsgo -b completed successfully
Diff check: git diff --check -> no output
Manual dev check: ran dev against a copied production PawWork DB and clicked real sessions without reproducing the crash; verified sessions without loaded messages fall back to creation time rather than updated time.
Scope check: PR diff contains only app source/test files; unrelated models snapshot change and .pawwork-verify/ were left out.
```

## Screenshots or Recordings

Not captured. This is a behavior and loading-state fix with no visual layout or copy change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English