### PR TITLE
fix: use canonical four-toe logo mark

### DIFF
--- a/packages/ui/src/components/logo.css
+++ b/packages/ui/src/components/logo.css
@@ -1,4 +1,4 @@
 [data-component="logo-mark"] {
   width: 16px;
-  aspect-ratio: 4/5;
+  aspect-ratio: 1/1;
 }

--- a/packages/ui/src/components/logo.test.ts
+++ b/packages/ui/src/components/logo.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+
+const logoSource = await Bun.file(new URL("./logo.tsx", import.meta.url)).text()
+
+const canonicalToeCoordinates = ['cx="24.8"', 'cx="39.2"', 'cx="18.3"', 'cx="45.75"']
+const canonicalPadPath =
+  "M32 29.2 C24.2 29.2 19.8 37.6 19.8 42.6 C19.8 46.4 23.3 47.9 28.3 46.1 C30.1 45.4 33.9 45.4 35.8 46.1 C40.8 47.9 44.2 46.4 44.2 42.6 C44.2 37.6 39.8 29.2 32 29.2 Z"
+
+describe("PawWork logo geometry", () => {
+  test("logo components use the canonical four-toe paw mark", () => {
+    expect(logoSource.match(/<circle\b/g)?.length).toBe(4)
+    expect(logoSource.match(/viewBox="0 0 64 64"/g)?.length).toBe(3)
+    for (const coordinate of canonicalToeCoordinates) {
+      expect(logoSource).toContain(coordinate)
+    }
+    expect(logoSource).toContain(canonicalPadPath)
+    expect(logoSource).not.toContain('cx="50"')
+    expect(logoSource).not.toContain('ry="13"')
+  })
+})

--- a/packages/ui/src/components/logo.test.ts
+++ b/packages/ui/src/components/logo.test.ts
@@ -1,20 +1,27 @@
 import { describe, expect, test } from "bun:test"
 
 const logoSource = await Bun.file(new URL("./logo.tsx", import.meta.url)).text()
+const logoCssSource = await Bun.file(new URL("./logo.css", import.meta.url)).text()
 
-const canonicalToeCoordinates = ['cx="24.8"', 'cx="39.2"', 'cx="18.3"', 'cx="45.75"']
-const canonicalPadPath =
-  "M32 29.2 C24.2 29.2 19.8 37.6 19.8 42.6 C19.8 46.4 23.3 47.9 28.3 46.1 C30.1 45.4 33.9 45.4 35.8 46.1 C40.8 47.9 44.2 46.4 44.2 42.6 C44.2 37.6 39.8 29.2 32 29.2 Z"
+const canonicalToePatterns = [
+  /<circle\b(?=[^>]*\bcx="24\.8")(?=[^>]*\bcy="22")(?=[^>]*\br="4\.4")[^>]*\/>/,
+  /<circle\b(?=[^>]*\bcx="39\.2")(?=[^>]*\bcy="22")(?=[^>]*\br="4\.4")[^>]*\/>/,
+  /<circle\b(?=[^>]*\bcx="18\.3")(?=[^>]*\bcy="30\.75")(?=[^>]*\br="3\.8")[^>]*\/>/,
+  /<circle\b(?=[^>]*\bcx="45\.75")(?=[^>]*\bcy="30\.75")(?=[^>]*\br="3\.8")[^>]*\/>/,
+]
+const canonicalPadPattern =
+  /<path\b(?=[^>]*\bd="M32\s+29\.2\s+C24\.2\s+29\.2\s+19\.8\s+37\.6\s+19\.8\s+42\.6\s+C19\.8\s+46\.4\s+23\.3\s+47\.9\s+28\.3\s+46\.1\s+C30\.1\s+45\.4\s+33\.9\s+45\.4\s+35\.8\s+46\.1\s+C40\.8\s+47\.9\s+44\.2\s+46\.4\s+44\.2\s+42\.6\s+C44\.2\s+37\.6\s+39\.8\s+29\.2\s+32\s+29\.2\s+Z")[^>]*\/>/
 
 describe("PawWork logo geometry", () => {
   test("logo components use the canonical four-toe paw mark", () => {
     expect(logoSource.match(/<circle\b/g)?.length).toBe(4)
-    expect(logoSource.match(/viewBox="0 0 64 64"/g)?.length).toBe(3)
-    for (const coordinate of canonicalToeCoordinates) {
-      expect(logoSource).toContain(coordinate)
+    expect(logoSource.match(/<svg\b(?=[^>]*\bviewBox="0 0 64 64")[^>]*>/g)?.length).toBe(3)
+    for (const pattern of canonicalToePatterns) {
+      expect(logoSource).toMatch(pattern)
     }
-    expect(logoSource).toContain(canonicalPadPath)
-    expect(logoSource).not.toContain('cx="50"')
-    expect(logoSource).not.toContain('ry="13"')
+    expect(logoSource).toMatch(canonicalPadPattern)
+    expect(logoSource).toMatch(/data-component="logo"/)
+    expect(logoCssSource).toMatch(/\[data-component="logo-mark"\]\s*{[^}]*aspect-ratio:\s*1\/1;/)
+    expect(logoSource).not.toMatch(/cx=["']50["'][^>]*ry=["']13["']/)
   })
 })

--- a/packages/ui/src/components/logo.tsx
+++ b/packages/ui/src/components/logo.tsx
@@ -45,6 +45,7 @@ export const Logo = (props: { class?: string }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      data-component="logo"
       viewBox="0 0 64 64"
       fill="none"
       classList={{ [props.class ?? ""]: !!props.class }}

--- a/packages/ui/src/components/logo.tsx
+++ b/packages/ui/src/components/logo.tsx
@@ -1,21 +1,27 @@
 import { ComponentProps } from "solid-js"
 
+const PawMarkShape = (props: { fill: string }) => {
+  return (
+    <g fill={props.fill}>
+      <circle cx="24.8" cy="22" r="4.4" />
+      <circle cx="39.2" cy="22" r="4.4" />
+      <circle cx="18.3" cy="30.75" r="3.8" />
+      <circle cx="45.75" cy="30.75" r="3.8" />
+      <path d="M32 29.2 C24.2 29.2 19.8 37.6 19.8 42.6 C19.8 46.4 23.3 47.9 28.3 46.1 C30.1 45.4 33.9 45.4 35.8 46.1 C40.8 47.9 44.2 46.4 44.2 42.6 C44.2 37.6 39.8 29.2 32 29.2 Z" />
+    </g>
+  )
+}
+
 export const Mark = (props: { class?: string }) => {
   return (
     <svg
       data-component="logo-mark"
       classList={{ [props.class ?? ""]: !!props.class }}
-      viewBox="0 0 100 90"
+      viewBox="0 0 64 64"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <ellipse cx="24" cy="22" rx="11" ry="14" fill="var(--icon-strong-base)" />
-      <ellipse cx="50" cy="10" rx="10" ry="13" fill="var(--icon-strong-base)" />
-      <ellipse cx="76" cy="22" rx="11" ry="14" fill="var(--icon-strong-base)" />
-      <path
-        d="M22 50C22 38 34 33 44 39C47 41 50 41 50 41C50 41 53 41 56 39C66 33 78 38 78 50C78 67 64 80 50 80C36 80 22 67 22 50Z"
-        fill="var(--icon-strong-base)"
-      />
+      <PawMarkShape fill="var(--icon-strong-base)" />
     </svg>
   )
 }
@@ -26,17 +32,11 @@ export const Splash = (props: Pick<ComponentProps<"svg">, "ref" | "class">) => {
       ref={props.ref}
       data-component="logo-splash"
       classList={{ [props.class ?? ""]: !!props.class }}
-      viewBox="0 0 100 90"
+      viewBox="0 0 64 64"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <ellipse cx="24" cy="22" rx="11" ry="14" fill="var(--icon-base)" />
-      <ellipse cx="50" cy="10" rx="10" ry="13" fill="var(--icon-base)" />
-      <ellipse cx="76" cy="22" rx="11" ry="14" fill="var(--icon-base)" />
-      <path
-        d="M22 50C22 38 34 33 44 39C47 41 50 41 50 41C50 41 53 41 56 39C66 33 78 38 78 50C78 67 64 80 50 80C36 80 22 67 22 50Z"
-        fill="var(--icon-base)"
-      />
+      <PawMarkShape fill="var(--icon-base)" />
     </svg>
   )
 }
@@ -45,17 +45,11 @@ export const Logo = (props: { class?: string }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 100 90"
+      viewBox="0 0 64 64"
       fill="none"
       classList={{ [props.class ?? ""]: !!props.class }}
     >
-      <ellipse cx="24" cy="22" rx="11" ry="14" fill="var(--icon-strong-base)" />
-      <ellipse cx="50" cy="10" rx="10" ry="13" fill="var(--icon-strong-base)" />
-      <ellipse cx="76" cy="22" rx="11" ry="14" fill="var(--icon-strong-base)" />
-      <path
-        d="M22 50C22 38 34 33 44 39C47 41 50 41 50 41C50 41 53 41 56 39C66 33 78 38 78 50C78 67 64 80 50 80C36 80 22 67 22 50Z"
-        fill="var(--icon-strong-base)"
-      />
+      <PawMarkShape fill="var(--icon-strong-base)" />
     </svg>
   )
 }


### PR DESCRIPTION
## Summary

- Replace the legacy 3-toe logo geometry with the canonical 4-toe paw mark used by the desktop app icon.
- Share the mark shape across `Mark`, `Splash`, and `Logo` so the coordinates cannot drift between components.
- Add a focused regression test for the canonical toe coordinates, pad path, 64x64 viewBox, selector consistency, square mark CSS, and removed legacy center toe.

## Why

The in-product PawWork logo still used the obsolete 3-toe mascot while the desktop app icon already uses the canonical 4-toe mark. This made the dock/app icon and in-app surfaces show different mascot specs.

## Related Issue

Closes #361

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that the PR only swaps logo geometry and keeps the existing component API and color token behavior intact. The follow-up commit also aligns `logo-mark` CSS to the square viewBox and adds `data-component="logo"` for selector consistency.

## Risk Notes

Low. This is an SVG geometry/CSS selector UI change. Desktop-electron app icon and generated installer assets are unchanged.

## How To Verify

```text
Red check: logo geometry test failed before the implementation because the source had no canonical circle toes.
Focused test: bun --cwd packages/ui test src/components/logo.test.ts -> 1 pass, 0 fail, 10 expect() calls.
Typecheck: bun --cwd packages/ui typecheck -> exit 0.
Legacy coordinate check: git grep -n 'cx="50".*ry="13"' -- packages/ui/src/components/logo.tsx -> no matches.
Desktop startup check: bun run dev:desktop built main/preload, started Electron, and reached init done; process was then stopped manually.
Diff check: git diff --check -> no whitespace errors.
Review threads: all three Gemini review threads were replied to and resolved.
CI rerun: pushing the review-fix commit triggered a fresh Actions run; the prior failed unit-windows-desktop check is now rerunning on the latest head.
```

## Screenshots or Recordings

Not attached. I attempted a web screenshot, but the web-only dev route stayed in the shell state without a stable logo surface. The actual desktop dev startup path was checked instead, and the committed regression test locks the rendered SVG geometry.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
