### PR TITLE
feat(release): support multiple releases per day with 4-segment CalVer

### DIFF
--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -79,7 +79,10 @@ describe("verify-release", () => {
     expect(() => normalizeTag("")).toThrow("Invalid release tag")
     expect(() => normalizeTag("v")).toThrow("Invalid release tag")
     expect(() => normalizeTag("abc")).toThrow("Invalid release tag")
-    expect(() => normalizeTag("2026.4.28.1")).toThrow("Invalid release tag")
+    expect(normalizeTag("2026.4.28.1")).toBe("v2026.4.28.1")
+    expect(normalizeTag("v2026.4.28.2")).toBe("v2026.4.28.2")
+    expect(normalizeTag("2026.4.28.0")).toBe("v2026.4.28.0")
+    expect(() => normalizeTag("2026.4.28.1234")).toThrow("Invalid release tag")
     expect(() => normalizeTag("2026.4.28-hotfix.1")).toThrow("Invalid release tag")
   })
 
@@ -255,11 +258,13 @@ path: pawwork-win-x64-2026.4.28.exe
   test("reports invalid release tags in release payloads without throwing", () => {
     expect(
       verifyReleasePayload({
-        release: { ...baseRelease, tag_name: "v2026.4.28.1" },
+        release: { ...baseRelease, tag_name: "v2026.4.28.1.1" },
         latestYml: "",
         latestMacYml: "",
       }),
-    ).toEqual(["Invalid release tag: v2026.4.28.1. Expected vYYYY.M.D or YYYY.M.D."])
+    ).toEqual([
+      "Invalid release tag: v2026.4.28.1.1. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).",
+    ])
   })
 
   test("accepts a complete startup log for the release version", () => {
@@ -380,7 +385,7 @@ path: pawwork-win-x64-2026.4.28.exe
 `,
         "v",
       ),
-    ).toEqual(["Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D."])
+    ).toEqual(["Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N)."])
   })
 
   test("reports invalid release tags with other startup failures", () => {
@@ -391,7 +396,7 @@ path: pawwork-win-x64-2026.4.28.exe
         "v",
       ),
     ).toEqual([
-      "Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D.",
+      "Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).",
       "Latest startup log does not include server ready",
       "Latest startup log does not include loading task finished",
       "Latest startup log does not include init step done",

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -231,8 +231,10 @@ export function verifyReleasePayload(input: VerificationInput) {
 
 export function normalizeTag(raw: string) {
   const normalized = raw.startsWith("v") ? raw : `v${raw}`
-  if (!/^v\d{4}\.\d{1,2}\.\d{1,2}$/.test(normalized)) {
-    throw new Error(`Invalid release tag: ${raw}. Expected vYYYY.M.D or YYYY.M.D.`)
+  if (!/^v\d{4}\.\d{1,2}\.\d{1,2}(\.\d{1,3})?$/.test(normalized)) {
+    throw new Error(
+      `Invalid release tag: ${raw}. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).`,
+    )
   }
   return normalized
 }


### PR DESCRIPTION
## Summary

Relax `normalizeTag()` regex to accept an optional 4th version segment (`YYYY.M.D.N`), enabling multiple releases on the same calendar day. Use dot-separated build number (e.g. `2026.5.2.2`) instead of hyphen-separated (`2026.5.2-2`) to avoid semver pre-release sorting issues.

## Why

Current `YYYY.M.D` CalVer format only allows one release per day — the version is tied to the calendar date with no room for a same-day second build. This blocks hotfixes and rapid iteration. OpenClaw uses a similar CalVer scheme and [hit a bug](https://github.com/openclaw/openclaw/issues/23647) with hyphen-separated build numbers (`YYYY.M.D-N`) because semver treats `-N` as a pre-release identifier, sorting it *lower* than the base version. Dot-separated (`YYYY.M.D.N`) is semver-correct and sorts properly.

## Related Issue

None.

## Human Review Status

Pending.

## Review Focus

- `normalizeTag()` regex change — confirm the optional group `(\.\d{1,3})?` is correct
- Test coverage for new valid and invalid tag formats
- Error message wording

## Risk Notes

None. The change is purely additive — existing 3-segment versions (`2026.5.2`) continue to work unchanged. No workflow, builder, or updater changes needed.

## How To Verify

```text
bun test scripts/verify-release.test.ts: 31 pass, 0 fail
bun test scripts/release-metadata-contract.test.ts: 9 pass, 0 fail
bun test scripts/release-workflow-contract.test.ts: 9 pass, 0 fail
```

## Screenshots or Recordings

Not applicable — no UI changes.

## Checklist

- [x] Human review status is stated above as pending
- [x] No related issue — standalone change
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] Not applicable — no visible UI or copy changes
- [x] I considered macOS and Windows impact — no platform-specific changes
- [x] Not applicable — no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English