### PR TITLE
fix: prefer native worktree tool in description

### DIFF
--- a/packages/opencode/src/tool/enter-worktree.txt
+++ b/packages/opencode/src/tool/enter-worktree.txt
@@ -1,6 +1,6 @@
 Bind this session to a git worktree. Once entered, every subsequent tool call resolves relative paths from inside the worktree until ExitWorktree is called.
 
-Use this tool whenever the user asks to create, start, enter, open, switch to, or move current work into a worktree.
+Use this tool whenever the user asks to create, start, enter, open, or switch the session to a worktree.
 
 This is the authoritative PawWork mechanism for session worktrees. Prefer it over skill-based worktree workflows and over shell-based `git worktree` commands, because only this tool binds the session execution context and makes subsequent tool calls resolve inside the worktree.
 

--- a/packages/opencode/src/tool/enter-worktree.txt
+++ b/packages/opencode/src/tool/enter-worktree.txt
@@ -1,5 +1,11 @@
 Bind this session to a git worktree. Once entered, every subsequent tool call resolves relative paths from inside the worktree until ExitWorktree is called.
 
+Use this tool whenever the user asks to create, start, enter, open, switch to, or move current work into a worktree.
+
+This is the authoritative PawWork mechanism for session worktrees. Prefer it over skill-based worktree workflows and over shell-based `git worktree` commands, because only this tool binds the session execution context and makes subsequent tool calls resolve inside the worktree.
+
+Do not invoke a worktree skill first when this tool directly satisfies the user's request.
+
 Use only when the user explicitly asks for worktree usage, or project instructions require it.
 
 Modes:


### PR DESCRIPTION
## Summary

Clarify the `enter-worktree` tool description so PawWork's native worktree tool is the preferred path when users ask to create, enter, switch to, or move work into a worktree.

## Why

After #360 added native worktree session binding, models can still be pulled toward generic worktree skills or shell-based `git worktree` workflows. The native tool is the only path that updates PawWork session execution context, so its tool description should make that routing explicit.

## Related Issue

Follow-up to #360. No separate issue filed.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please review whether the wording is strong enough to steer tool selection without over-scoping beyond session worktree transitions.

## Risk Notes

Low risk. This changes only the `enter-worktree` tool description shown to models; it does not change execution behavior, permissions, Bash behavior, or skill routing.

## How To Verify

```text
Diff check: git diff --check passed for packages/opencode/src/tool/enter-worktree.txt
Final diff review: single tool-description text file changed, no generated files or dependency changes
```

## Screenshots or Recordings

Not applicable; no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified usage guidance for the worktree tool: when to invoke it, that it is the authoritative mechanism for session worktrees, and that it should be preferred over other workflows or shell commands. Also added an instruction not to invoke alternate worktree skills before using this tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->