### PR TITLE
fix(provider): harden Kimi Moonshot tool-call compatibility

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1513,6 +1513,11 @@ const layer: Layer.Layer<
             }
           }
 
+          if (model.api.npm === "@ai-sdk/openai-compatible" && opts.body && opts.method === "POST") {
+            const body = JSON.parse(opts.body as string)
+            opts.body = JSON.stringify(ProviderTransform.openAICompatibleRequestBody(model, body))
+          }
+
           const res = await fetchFn(input, {
             ...opts,
             // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1513,7 +1513,7 @@ const layer: Layer.Layer<
             }
           }
 
-          if (model.api.npm === "@ai-sdk/openai-compatible" && opts.body && opts.method === "POST") {
+          if (model.api.npm.includes("@ai-sdk/openai-compatible") && opts.body && opts.method === "POST") {
             const body = JSON.parse(opts.body as string)
             opts.body = JSON.stringify(ProviderTransform.openAICompatibleRequestBody(model, body))
           }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1514,8 +1514,7 @@ const layer: Layer.Layer<
           }
 
           if (model.api.npm.includes("@ai-sdk/openai-compatible") && opts.body && opts.method === "POST") {
-            const body = JSON.parse(opts.body as string)
-            opts.body = JSON.stringify(ProviderTransform.openAICompatibleRequestBody(model, body))
+            opts.body = ProviderTransform.openAICompatibleRequestBodyText(model, opts.body) ?? opts.body
           }
 
           const res = await fetchFn(input, {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1289,12 +1289,22 @@ export function openAICompatibleRequestBody(model: Provider.Model, body: Record<
   }
 }
 
+export function openAICompatibleRequestBodyText(model: Provider.Model, body: unknown): string | undefined {
+  if (typeof body !== "string") return undefined
+  try {
+    return JSON.stringify(openAICompatibleRequestBody(model, JSON.parse(body)))
+  } catch {
+    return undefined
+  }
+}
+
 const ProviderTransformOptionsValue = options
 const ProviderTransformMessageValue = message
 const ProviderTransformVariantsValue = variants
 const ProviderTransformProviderOptionsValue = providerOptions
 const ProviderTransformSchemaValue = schema
 const ProviderTransformOpenAICompatibleRequestBodyValue = openAICompatibleRequestBody
+const ProviderTransformOpenAICompatibleRequestBodyTextValue = openAICompatibleRequestBodyText
 const ProviderTransformOutputTokenMaxValue = OUTPUT_TOKEN_MAX
 const ProviderTransformMaxOutputTokensValue = maxOutputTokens
 const ProviderTransformTemperatureValue = temperature
@@ -1310,6 +1320,7 @@ export namespace ProviderTransform {
   export const providerOptions = ProviderTransformProviderOptionsValue
   export const schema = ProviderTransformSchemaValue
   export const openAICompatibleRequestBody = ProviderTransformOpenAICompatibleRequestBodyValue
+  export const openAICompatibleRequestBodyText = ProviderTransformOpenAICompatibleRequestBodyTextValue
   export const maxOutputTokens = ProviderTransformMaxOutputTokensValue
   export const temperature = ProviderTransformTemperatureValue
   export const topP = ProviderTransformTopPValue

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -74,6 +74,60 @@ function isKimiMoonshotModel(model: Provider.Model) {
   return ids.includes("moonshot") || ids.includes("kimi") || /(^|[/:])k2p\d*(?:[.\-/]|$)/.test(ids)
 }
 
+function isPlainObject(node: unknown): node is Record<string, unknown> {
+  return node !== null && typeof node === "object" && !Array.isArray(node)
+}
+
+const COMBINATOR_SCHEMA_KEYS = ["anyOf", "oneOf", "allOf", "not", "if", "then", "else", "$ref"]
+const OBJECT_SCHEMA_KEYS = [
+  "properties",
+  "additionalProperties",
+  "patternProperties",
+  "propertyNames",
+  "required",
+  "minProperties",
+  "maxProperties",
+]
+const ARRAY_SCHEMA_KEYS = ["items", "prefixItems", "minItems", "maxItems", "uniqueItems", "contains"]
+const STRING_SCHEMA_KEYS = ["minLength", "maxLength", "pattern", "format"]
+const NUMBER_SCHEMA_KEYS = ["minimum", "maximum", "multipleOf", "exclusiveMinimum", "exclusiveMaximum"]
+
+function schemaTypeFromValues(values: unknown[]): string {
+  const types = new Set(
+    values.map((value) => {
+      if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number"
+      if (Array.isArray(value)) return "array"
+      if (value === null) return "null"
+      return typeof value
+    }),
+  )
+  if (types.size === 1) return types.values().next().value ?? "string"
+  if (types.size === 2 && types.has("integer") && types.has("number")) return "number"
+  return "string"
+}
+
+function inferSchemaType(node: Record<string, unknown>): string {
+  const enumValues = node.enum
+  if (Array.isArray(enumValues) && enumValues.length > 0) return schemaTypeFromValues(enumValues)
+  if ("const" in node) return schemaTypeFromValues([node.const])
+  if (OBJECT_SCHEMA_KEYS.some((key) => key in node)) return "object"
+  if (ARRAY_SCHEMA_KEYS.some((key) => key in node)) return "array"
+  if (STRING_SCHEMA_KEYS.some((key) => key in node)) return "string"
+  if (NUMBER_SCHEMA_KEYS.some((key) => key in node)) return "number"
+  return "string"
+}
+
+function shouldSkipSchemaType(node: Record<string, unknown>) {
+  return COMBINATOR_SCHEMA_KEYS.some((key) => key in node)
+}
+
+function isEffectivelyEmptyOpenAIContent(content: unknown) {
+  if (content === null || content === undefined) return true
+  if (typeof content === "string") return content.trim() === ""
+  if (!Array.isArray(content)) return false
+  return content.every((part) => isPlainObject(part) && part.type === "text" && String(part.text ?? "").trim() === "")
+}
+
 function normalizeMessages(
   msgs: ModelMessage[],
   model: Provider.Model,
@@ -1097,11 +1151,25 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
   */
 
   if (isKimiMoonshotModel(model)) {
-    const sanitizeMoonshot = (obj: unknown): unknown => {
+    const sanitizeMoonshot = (obj: unknown, schemaPosition = false): unknown => {
       if (obj === null || typeof obj !== "object") return obj
-      if (Array.isArray(obj)) return obj.map(sanitizeMoonshot)
+      if (Array.isArray(obj)) return obj.map((value) => sanitizeMoonshot(value, schemaPosition))
       const result = Object.fromEntries(
-        Object.entries(obj).map(([key, value]) => [key, sanitizeMoonshot(value)]),
+        Object.entries(obj).map(([key, value]) => {
+          if ((key === "properties" || key === "$defs" || key === "definitions") && isPlainObject(value)) {
+            return [key, Object.fromEntries(Object.entries(value).map(([k, v]) => [k, sanitizeMoonshot(v, true)]))]
+          }
+          if (key === "items") {
+            if (Array.isArray(value)) return [key, value.map((item) => sanitizeMoonshot(item, true))]
+            if (isPlainObject(value)) return [key, sanitizeMoonshot(value, true)]
+          }
+          if (key === "additionalProperties" && isPlainObject(value)) return [key, sanitizeMoonshot(value, true)]
+          if (["anyOf", "oneOf", "allOf"].includes(key) && Array.isArray(value)) {
+            return [key, value.map((item) => sanitizeMoonshot(item, true))]
+          }
+          if (["not", "if", "then", "else"].includes(key) && isPlainObject(value)) return [key, sanitizeMoonshot(value, true)]
+          return [key, sanitizeMoonshot(value)]
+        }),
       ) as Record<string, unknown>
       if (typeof result.$ref === "string") {
         const refOnly: Record<string, unknown> = { $ref: result.$ref }
@@ -1110,12 +1178,8 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
         return refOnly
       }
       if (Array.isArray(result.items)) result.items = result.items[0] ?? {}
-      if (!("type" in result)) {
-        if (result.properties && typeof result.properties === "object") result.type = "object"
-        else if (result.items && typeof result.items === "object") result.type = "array"
-        else if (Array.isArray(result.enum) && result.enum.every((value) => typeof value === "string")) {
-          result.type = "string"
-        }
+      if (schemaPosition && !("type" in result) && !shouldSkipSchemaType(result)) {
+        result.type = inferSchemaType(result)
       }
       return result
     }
@@ -1205,11 +1269,31 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
   return schema as JSONSchema7
 }
 
+export function openAICompatibleRequestBody(model: Provider.Model, body: Record<string, unknown>): Record<string, unknown> {
+  if (!isKimiMoonshotModel(model)) return body
+  if (!Array.isArray(body.messages)) return body
+
+  return {
+    ...body,
+    messages: body.messages.map((message) => {
+      if (!isPlainObject(message)) return message
+      if (message.role !== "assistant") return message
+      if (!Array.isArray(message.tool_calls) || message.tool_calls.length === 0) return message
+      if (!("content" in message) || !isEffectivelyEmptyOpenAIContent(message.content)) return message
+
+      const result = { ...message }
+      delete result.content
+      return result
+    }),
+  }
+}
+
 const ProviderTransformOptionsValue = options
 const ProviderTransformMessageValue = message
 const ProviderTransformVariantsValue = variants
 const ProviderTransformProviderOptionsValue = providerOptions
 const ProviderTransformSchemaValue = schema
+const ProviderTransformOpenAICompatibleRequestBodyValue = openAICompatibleRequestBody
 const ProviderTransformOutputTokenMaxValue = OUTPUT_TOKEN_MAX
 const ProviderTransformMaxOutputTokensValue = maxOutputTokens
 const ProviderTransformTemperatureValue = temperature
@@ -1224,6 +1308,7 @@ export namespace ProviderTransform {
   export const variants = ProviderTransformVariantsValue
   export const providerOptions = ProviderTransformProviderOptionsValue
   export const schema = ProviderTransformSchemaValue
+  export const openAICompatibleRequestBody = ProviderTransformOpenAICompatibleRequestBodyValue
   export const maxOutputTokens = ProviderTransformMaxOutputTokensValue
   export const temperature = ProviderTransformTemperatureValue
   export const topP = ProviderTransformTopPValue

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -69,6 +69,11 @@ function isLegacyDeepSeekVariantID(id: string) {
   return /(^|[/:])deepseek-(?:chat|reasoner|r1|v3)(?:[.\-/]|$)/.test(id.toLowerCase())
 }
 
+function isKimiMoonshotModel(model: Provider.Model) {
+  const ids = [model.id, model.providerID, model.name, model.api.id].filter(Boolean).join(" ").toLowerCase()
+  return ids.includes("moonshot") || ids.includes("kimi") || /(^|[/:])k2p\d*(?:[.\-/]|$)/.test(ids)
+}
+
 function normalizeMessages(
   msgs: ModelMessage[],
   model: Provider.Model,
@@ -82,6 +87,10 @@ function normalizeMessages(
 
   // Bedrock specific transforms
   if (model.api.npm === "@ai-sdk/amazon-bedrock") {
+    msgs = msgs.map(filterEmptyMessageContent).filter((msg): msg is ModelMessage => msg !== undefined)
+  }
+
+  if (isKimiMoonshotModel(model)) {
     msgs = msgs.map(filterEmptyMessageContent).filter((msg): msg is ModelMessage => msg !== undefined)
   }
 
@@ -1087,7 +1096,7 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
   }
   */
 
-  if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {
+  if (isKimiMoonshotModel(model)) {
     const sanitizeMoonshot = (obj: unknown): unknown => {
       if (obj === null || typeof obj !== "object") return obj
       if (Array.isArray(obj)) return obj.map(sanitizeMoonshot)
@@ -1101,6 +1110,13 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
         return refOnly
       }
       if (Array.isArray(result.items)) result.items = result.items[0] ?? {}
+      if (!("type" in result)) {
+        if (result.properties && typeof result.properties === "object") result.type = "object"
+        else if (result.items && typeof result.items === "object") result.type = "array"
+        else if (Array.isArray(result.enum) && result.enum.every((value) => typeof value === "string")) {
+          result.type = "string"
+        }
+      }
       return result
     }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -70,8 +70,8 @@ function isLegacyDeepSeekVariantID(id: string) {
 }
 
 function isKimiMoonshotModel(model: Provider.Model) {
-  const ids = [model.id, model.providerID, model.name, model.api.id].filter(Boolean).join(" ").toLowerCase()
-  return ids.includes("moonshot") || ids.includes("kimi") || /(^|[/:])k2p\d*(?:[.\-/]|$)/.test(ids)
+  const ids = [model.id, model.providerID, model.api.id].filter(Boolean).map((id) => id.toLowerCase())
+  return ids.some((id) => id.includes("moonshot") || id.includes("kimi") || /(^|[/:])k2p\d*(?:[.\-/]|$)/.test(id))
 }
 
 function isPlainObject(node: unknown): node is Record<string, unknown> {
@@ -92,7 +92,7 @@ const ARRAY_SCHEMA_KEYS = ["items", "prefixItems", "minItems", "maxItems", "uniq
 const STRING_SCHEMA_KEYS = ["minLength", "maxLength", "pattern", "format"]
 const NUMBER_SCHEMA_KEYS = ["minimum", "maximum", "multipleOf", "exclusiveMinimum", "exclusiveMaximum"]
 
-function schemaTypeFromValues(values: unknown[]): string {
+function schemaTypeFromValues(values: unknown[]): string | undefined {
   const types = new Set(
     values.map((value) => {
       if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number"
@@ -101,12 +101,12 @@ function schemaTypeFromValues(values: unknown[]): string {
       return typeof value
     }),
   )
-  if (types.size === 1) return types.values().next().value ?? "string"
+  if (types.size === 1) return types.values().next().value
   if (types.size === 2 && types.has("integer") && types.has("number")) return "number"
-  return "string"
+  return undefined
 }
 
-function inferSchemaType(node: Record<string, unknown>): string {
+function inferSchemaType(node: Record<string, unknown>): string | undefined {
   const enumValues = node.enum
   if (Array.isArray(enumValues) && enumValues.length > 0) return schemaTypeFromValues(enumValues)
   if ("const" in node) return schemaTypeFromValues([node.const])
@@ -114,7 +114,7 @@ function inferSchemaType(node: Record<string, unknown>): string {
   if (ARRAY_SCHEMA_KEYS.some((key) => key in node)) return "array"
   if (STRING_SCHEMA_KEYS.some((key) => key in node)) return "string"
   if (NUMBER_SCHEMA_KEYS.some((key) => key in node)) return "number"
-  return "string"
+  return undefined
 }
 
 function shouldSkipSchemaType(node: Record<string, unknown>) {
@@ -1179,7 +1179,8 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
       }
       if (Array.isArray(result.items)) result.items = result.items[0] ?? {}
       if (schemaPosition && !("type" in result) && !shouldSkipSchemaType(result)) {
-        result.type = inferSchemaType(result)
+        const inferredType = inferSchemaType(result)
+        if (inferredType) result.type = inferredType
       }
       return result
     }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1191,6 +1191,43 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
     expect(result.properties.referenced).toEqual({ $ref: "#/$defs/Referenced" })
     expect(result.$defs.Referenced.type).toBe("object")
   })
+
+  test("infers missing property types for consts, numeric constraints, and nested schema positions", () => {
+    const result = ProviderTransform.schema(
+      moonshotModel,
+      {
+        type: "object",
+        properties: {
+          limit: {
+            minimum: 1,
+          },
+          enabled: {
+            const: true,
+          },
+          metadata: {
+            additionalProperties: {
+              enum: ["small", "large"],
+            },
+          },
+          choice: {
+            anyOf: [{ enum: [1, 2] }, { const: "auto" }],
+          },
+          flexible: {
+            anyOf: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      } as any,
+    ) as any
+
+    expect(result.properties.limit.type).toBe("number")
+    expect(result.properties.enabled.type).toBe("boolean")
+    expect(result.properties.metadata.type).toBe("object")
+    expect(result.properties.metadata.additionalProperties.type).toBe("string")
+    expect(result.properties.choice.type).toBeUndefined()
+    expect(result.properties.choice.anyOf[0].type).toBe("integer")
+    expect(result.properties.choice.anyOf[1].type).toBe("string")
+    expect(result.properties.flexible.type).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
@@ -1905,6 +1942,40 @@ describe("ProviderTransform.message - Kimi/Moonshot empty content filtering", ()
     expect(result[0].content).toEqual([
       { type: "tool-call", toolCallId: "call_1", toolName: "bash", input: { command: "pwd" } },
     ])
+  })
+
+  test("omits empty content from final OpenAI-compatible assistant tool-call payloads", () => {
+    const result = ProviderTransform.openAICompatibleRequestBody(kimiModel, {
+      model: "k2p6",
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "bash", arguments: "{\"command\":\"pwd\"}" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "not empty" }],
+          tool_calls: [
+            {
+              id: "call_2",
+              type: "function",
+              function: { name: "bash", arguments: "{\"command\":\"ls\"}" },
+            },
+          ],
+        },
+      ],
+    }) as any
+
+    expect(result.messages[0]).not.toHaveProperty("content")
+    expect(result.messages[0].tool_calls).toHaveLength(1)
+    expect(result.messages[1].content).toEqual([{ type: "text", text: "not empty" }])
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1098,6 +1098,36 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
     })
   })
 
+  test("also sanitizes Kimi for Coding aliases that do not include kimi in api id", () => {
+    const result = ProviderTransform.schema(
+      {
+        id: "kimi-for-coding/k2p6",
+        providerID: "kimi-for-coding",
+        api: {
+          id: "k2p6",
+        },
+      } as any,
+      {
+        type: "object",
+        properties: {
+          value: {
+            $ref: "#/$defs/Value",
+            description: "Moonshot rejects this sibling after ref expansion.",
+          },
+        },
+        $defs: {
+          Value: {
+            type: "object",
+          },
+        },
+      } as any,
+    ) as any
+
+    expect(result.properties.value).toEqual({
+      $ref: "#/$defs/Value",
+    })
+  })
+
   test("converts tuple-style array items to a single item schema", () => {
     const result = ProviderTransform.schema(
       moonshotModel,
@@ -1117,6 +1147,49 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
     expect(result.properties.renderedSize.items).toEqual({
       type: "number",
     })
+  })
+
+  test("fills missing property types using conservative schema intent", () => {
+    const result = ProviderTransform.schema(
+      moonshotModel,
+      {
+        type: "object",
+        properties: {
+          options: {
+            properties: {
+              enabled: { type: "boolean" },
+            },
+          },
+          tags: {
+            items: { type: "string" },
+          },
+          mode: {
+            enum: ["read", "write"],
+          },
+          count: {
+            type: "integer",
+            enum: [1, 2],
+          },
+          referenced: {
+            $ref: "#/$defs/Referenced",
+          },
+        },
+        $defs: {
+          Referenced: {
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+      } as any,
+    ) as any
+
+    expect(result.properties.options.type).toBe("object")
+    expect(result.properties.tags.type).toBe("array")
+    expect(result.properties.mode.type).toBe("string")
+    expect(result.properties.count.type).toBe("integer")
+    expect(result.properties.referenced).toEqual({ $ref: "#/$defs/Referenced" })
+    expect(result.$defs.Referenced.type).toBe("object")
   })
 })
 
@@ -1771,6 +1844,67 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
         { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
       ],
     })
+  })
+})
+
+describe("ProviderTransform.message - Kimi/Moonshot empty content filtering", () => {
+  const kimiModel = {
+    id: "kimi-for-coding/k2p6",
+    providerID: "kimi-for-coding",
+    api: {
+      id: "k2p6",
+      url: "https://api.moonshot.cn",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Kimi K2.6",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: true, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 262144, output: 32768 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("drops empty string and empty array messages for Kimi-compatible requests", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "" },
+      { role: "assistant", content: [] },
+      { role: "user", content: "World" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, kimiModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result.map((msg) => msg.content)).toEqual(["Hello", "World"])
+  })
+
+  test("removes empty text around assistant tool calls while preserving the tool call", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "tool-call", toolCallId: "call_1", toolName: "bash", input: { command: "pwd" } },
+          { type: "reasoning", text: "" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, kimiModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toEqual([
+      { type: "tool-call", toolCallId: "call_1", toolName: "bash", input: { command: "pwd" } },
+    ])
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2045,6 +2045,20 @@ describe("ProviderTransform.message - Kimi/Moonshot empty content filtering", ()
     expect(result.messages[1].content).toEqual([{ type: "text", text: "not empty" }])
   })
 
+  test("does not omit empty content from assistant messages without tool calls", () => {
+    const result = ProviderTransform.openAICompatibleRequestBody(kimiModel, {
+      model: "k2p6",
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+        },
+      ],
+    }) as any
+
+    expect(result.messages[0].content).toBe("")
+  })
+
   test("does not omit empty content from non-Kimi OpenAI-compatible payloads", () => {
     const result = ProviderTransform.openAICompatibleRequestBody(
       {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1128,6 +1128,65 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
     })
   })
 
+  test("sanitizes k2p aliases from canonical api ids", () => {
+    const result = ProviderTransform.schema(
+      {
+        id: "custom-provider/model",
+        providerID: "custom-provider",
+        api: {
+          id: "k2p6",
+        },
+      } as any,
+      {
+        type: "object",
+        properties: {
+          value: {
+            $ref: "#/$defs/Value",
+            description: "Moonshot rejects this sibling after ref expansion.",
+          },
+        },
+        $defs: {
+          Value: {
+            type: "object",
+          },
+        },
+      } as any,
+    ) as any
+
+    expect(result.properties.value).toEqual({
+      $ref: "#/$defs/Value",
+    })
+  })
+
+  test("does not opt in based on display name alone", () => {
+    const result = ProviderTransform.schema(
+      {
+        id: "custom-provider/model",
+        providerID: "custom-provider",
+        name: "Kimi-compatible proxy",
+        api: {
+          id: "model",
+        },
+      } as any,
+      {
+        type: "object",
+        properties: {
+          value: {
+            $ref: "#/$defs/Value",
+            description: "should remain",
+          },
+        },
+        $defs: {
+          Value: {
+            type: "object",
+          },
+        },
+      } as any,
+    ) as any
+
+    expect(result.properties.value.description).toBe("should remain")
+  })
+
   test("converts tuple-style array items to a single item schema", () => {
     const result = ProviderTransform.schema(
       moonshotModel,
@@ -1215,6 +1274,12 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
           flexible: {
             anyOf: [{ type: "string" }, { type: "number" }],
           },
+          mixedEnum: {
+            enum: [1, "1"],
+          },
+          described: {
+            description: "optional field",
+          },
         },
       } as any,
     ) as any
@@ -1227,6 +1292,8 @@ describe("ProviderTransform.schema - Moonshot/Kimi tool schemas", () => {
     expect(result.properties.choice.anyOf[0].type).toBe("integer")
     expect(result.properties.choice.anyOf[1].type).toBe("string")
     expect(result.properties.flexible.type).toBeUndefined()
+    expect(result.properties.mixedEnum.type).toBeUndefined()
+    expect(result.properties.described.type).toBeUndefined()
   })
 })
 
@@ -1976,6 +2043,39 @@ describe("ProviderTransform.message - Kimi/Moonshot empty content filtering", ()
     expect(result.messages[0]).not.toHaveProperty("content")
     expect(result.messages[0].tool_calls).toHaveLength(1)
     expect(result.messages[1].content).toEqual([{ type: "text", text: "not empty" }])
+  })
+
+  test("does not omit empty content from non-Kimi OpenAI-compatible payloads", () => {
+    const result = ProviderTransform.openAICompatibleRequestBody(
+      {
+        ...kimiModel,
+        id: "custom-provider/model",
+        providerID: "custom-provider",
+        name: "Kimi-compatible proxy",
+        api: {
+          ...kimiModel.api,
+          id: "model",
+        },
+      },
+      {
+        model: "model",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "bash", arguments: "{\"command\":\"pwd\"}" },
+              },
+            ],
+          },
+        ],
+      },
+    ) as any
+
+    expect(result.messages[0].content).toBe("")
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2077,6 +2077,35 @@ describe("ProviderTransform.message - Kimi/Moonshot empty content filtering", ()
 
     expect(result.messages[0].content).toBe("")
   })
+
+  test("rewrites OpenAI-compatible request body text only when it is valid JSON", () => {
+    const result = ProviderTransform.openAICompatibleRequestBodyText(
+      kimiModel,
+      JSON.stringify({
+        model: "k2p6",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "bash", arguments: "{\"command\":\"pwd\"}" },
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(JSON.parse(result ?? "{}").messages[0]).not.toHaveProperty("content")
+  })
+
+  test("leaves invalid or non-string OpenAI-compatible request bodies unchanged", () => {
+    expect(ProviderTransform.openAICompatibleRequestBodyText(kimiModel, "not json")).toBeUndefined()
+    expect(ProviderTransform.openAICompatibleRequestBodyText(kimiModel, new Uint8Array([1, 2, 3]))).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.message - strip openai metadata when store=false", () => {


### PR DESCRIPTION
## Summary

- Add a shared Kimi/Moonshot model detector for provider transform compatibility.
- Filter empty message content for Kimi/Moonshot-compatible requests before provider calls.
- Extend Moonshot/Kimi schema sanitization to cover Kimi for Coding aliases and infer missing property `type` values in schema positions, following Kimi Code CLI's stricter-schema compatibility pattern.
- Sanitize final OpenAI-compatible chat request bodies so assistant tool-call messages with effectively empty content omit the `content` field, matching Kimi Code CLI's empty-content workaround.

## Why

Kimi/Moonshot-compatible endpoints are stricter than many OpenAI-compatible providers about empty message content and JSON schema shape. PawWork already sanitized `$ref` siblings and preserved root `$defs` / `definitions`, but Kimi for Coding aliases such as `kimi-for-coding/k2p6` could miss that path, and schemas with obvious intent but missing `type` could still be rejected.

This keeps the fix at the provider protocol layer. It does not add Kimi-specific GitHub behavior, prompt tuning, compaction changes, or loop containment. The repeated successful tool-call loop work remains tracked separately by #279.

## Related Issue

Closes #377

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether `isKimiMoonshotModel` is narrow enough for known Kimi/Moonshot aliases, whether final request-body `content` omission is correctly limited to empty assistant tool-call messages, and whether missing-type normalization stays limited to schema positions instead of metadata containers.

## Risk Notes

Low to moderate provider-layer risk. The empty-content filtering, final request-body cleanup, and schema type normalization are gated to Kimi/Moonshot-compatible models, but that detector intentionally includes `k2p*` aliases so Kimi for Coding paths are covered.

## How To Verify

```text
Red test check: targeted Kimi/Moonshot tests failed before implementation with expected failures for alias coverage, missing schema types, and final empty content handling.
Targeted tests: bun --cwd packages/opencode test test/provider/transform.test.ts --test-name-pattern "Moonshot/Kimi|Kimi/Moonshot empty" -> 10 pass, 0 fail.
Provider transform tests: bun --cwd packages/opencode test test/provider/transform.test.ts -> 160 pass, 0 fail.
Typecheck: bun run --cwd packages/opencode typecheck -> exit 0.
Diff check: git diff --check -> exit 0.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant messages with effectively empty content are now omitted when tool-calls are present for compatible models; POST payloads are rewritten to be OpenAI-compatible for those models.
  * JSON schema sanitization improved to better infer and populate missing type fields and remove improper sibling descriptions.

* **Tests**
  * Added comprehensive tests covering message filtering, request-body behavior, and schema type inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->