### PR TITLE
fix(app): add fallback for lost question.asked SSE events

### DIFF
--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -1,5 +1,5 @@
-import { createEffect, createMemo, on, onCleanup, onMount } from "solid-js"
-import { createStore } from "solid-js/store"
+import { batch, createEffect, createMemo, on, onCleanup, onMount } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import type { PermissionRequest, QuestionRequest, Todo } from "@opencode-ai/sdk/v2"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -28,6 +28,65 @@ export function createSessionComposerState(input: { sessionID: () => string | un
   const questionRequest = createMemo((): QuestionRequest | undefined => {
     return sessionQuestionRequest(sync.data.session, sync.data.question, activeSessionID())
   })
+
+  // Fallback: if a running "question" tool part exists in message parts but no
+  // question request was received (e.g. the question.asked SSE event was lost),
+  // re-fetch the pending question list from the backend.
+  let questionRefetchInflight = false
+  createEffect(
+    on(
+      () => {
+        const sessionID = activeSessionID()
+        if (!sessionID) return undefined
+        if (questionRequest()) return undefined
+        const messages = sync.data.message[sessionID]
+        if (!messages?.length) return undefined
+        for (let i = messages.length - 1; i >= Math.max(0, messages.length - 5); i--) {
+          const parts = sync.data.part[messages[i].id]
+          if (!parts) continue
+          for (const p of parts) {
+            if (p.type === "tool" && p.tool === "question" && p.state.status === "running") {
+              return sessionID
+            }
+          }
+        }
+        return undefined
+      },
+      (sessionID) => {
+        if (!sessionID || questionRefetchInflight) return
+        questionRefetchInflight = true
+        sdk.client.question
+          .list()
+          .then((result) => {
+            const questions = (result.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID)
+            if (questions.length === 0) return
+            const grouped = new Map<string, QuestionRequest[]>()
+            for (const q of questions) {
+              const list = grouped.get(q.sessionID)
+              if (list) list.push(q)
+              else grouped.set(q.sessionID, [q])
+            }
+            batch(() => {
+              for (const [sid, qs] of grouped) {
+                sync.set(
+                  "question",
+                  sid,
+                  reconcile(
+                    qs.sort((a, b) => (a.id < b.id ? -1 : 1)),
+                    { key: "id" },
+                  ),
+                )
+              }
+            })
+          })
+          .catch(() => {})
+          .finally(() => {
+            questionRefetchInflight = false
+          })
+      },
+      { defer: true },
+    ),
+  )
 
   const permissionRequest = createMemo((): PermissionRequest | undefined => {
     return sessionPermissionRequest(sync.data.session, sync.data.permission, activeSessionID(), (item) => {

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -84,7 +84,6 @@ export function createSessionComposerState(input: { sessionID: () => string | un
             questionRefetchInflight = false
           })
       },
-      { defer: true },
     ),
   )
 


### PR DESCRIPTION
## Summary

Add a self-healing fallback in `session-composer-state` that detects running `question` tool parts in message parts when the `questionRequest()` memo is empty, and re-fetches the pending question list from the backend via `sdk.client.question.list()`.

## Why

The question dock relies exclusively on `sync.data.question` to render, which is populated by two paths:
1. **Bootstrap**: `sdk.question.list()` called once at startup
2. **SSE events**: `question.asked` real-time push

If the SSE event is lost (stream disconnect, transient error, reconnect gap), the question data never enters the frontend store. The dock never renders, the model waits forever for an answer, and the session appears stuck — even though the backend question is still pending and the message parts already contain the `question` tool in `running` state.

This was observed in a real session where the model called the `question` tool, the backend dispatched it (state = running), but the frontend never showed the question dock. The session froze with no way to recover.

## Related Issue

None.

## Human Review Status

Pending.

## Review Focus

- The fallback effect logic in `session-composer-state.ts` lines 32–89: correct detection of running question parts, proper guard against re-fetch loops, correct store update via `sync.set` + `reconcile`
- Whether scanning the last 5 messages is sufficient and performant

## Risk Notes

- The fallback only activates when there is a mismatch (running question part exists but no question request in store). It is a no-op under normal conditions.
- `questionRefetchInflight` prevents duplicate fetches but is module-scoped (shared across session switches). This is intentional — re-fetches are rare and a single inflight guard is sufficient.
- The fix does not address the root cause (SSE event reliability). A follow-up should consider event replay on reconnect.

## How To Verify

```text
Typecheck: passes (npx tsc --noEmit --project packages/app/tsconfig.json)
Existing tests: 7/7 pass (session-composer-state.test.ts)
Event reducer tests: 13/13 pass (event-reducer.test.ts)
Manual: the fallback activates when a running question tool part exists but questionRequest() is undefined
```

## Screenshots or Recordings

Not applicable — no visible UI change. The fix ensures the question dock appears when it should.

## Checklist

- [x] Human review status is stated above as pending
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I considered macOS and Windows impact — no platform-specific changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant — none
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

## Architectural Follow-up

This fix treats the symptom (missing question data) at the UI layer. The root cause is that the SSE event stream has no replay/recovery mechanism. Consider:

1. **Event replay on reconnect**: client sends last-seen event ID, server replays missed events. This fixes the problem for all event types (question, permission, session status, etc.)
2. **Parts as source of truth**: message parts are persisted and loaded via message sync (not SSE-dependent). The question dock could derive its state from parts directly, using events only as a "new data available" signal.
3. **Polling fallback at the sync layer**: rather than each UI component adding its own fallback, the sync layer could periodically reconcile its event-driven state against the backend API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session composer stability: automatically detects and recovers missing or incomplete question data by refetching pending questions, preventing potential data loss and ensuring questions remain available during session composition. Refetching is protected against duplicate requests and silently handles transient errors to avoid user disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->