### PR TITLE
fix(opencode): stop loading skills from ~/.claude/skills/

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -21,7 +21,7 @@ import { Discovery } from "./discovery"
 export namespace Skill {
   const log = Log.create({ service: "skill" })
   const processWithResourcesPath = process as NodeJS.Process & { resourcesPath?: string }
-  const EXTERNAL_DIRS = [".claude", ".agents"]
+  const EXTERNAL_DIRS = [".agents"]
   const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
   const BUILTIN_SKILL_PATTERN = "*/SKILL.md"
   const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -12,13 +12,13 @@ afterEach(async () => {
 })
 
 async function createGlobalSkill(homeDir: string) {
-  const skillDir = path.join(homeDir, ".claude", "skills", "global-test-skill")
+  const skillDir = path.join(homeDir, ".agents", "skills", "global-test-skill")
   await fs.mkdir(skillDir, { recursive: true })
   await Bun.write(
     path.join(skillDir, "SKILL.md"),
     `---
 name: global-test-skill
-description: A global skill from ~/.claude/skills for testing.
+description: A global skill from ~/.agents/skills for testing.
 ---
 
 # Global Test Skill
@@ -174,19 +174,19 @@ Just some content without YAML frontmatter.
   })
 })
 
-test("discovers skills from .claude/skills/ directory", async () => {
+test("discovers skills from .agents/skills/ directory", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      const skillDir = path.join(dir, ".claude", "skills", "claude-skill")
+      const skillDir = path.join(dir, ".agents", "skills", "project-agent-skill")
       await Bun.write(
         path.join(skillDir, "SKILL.md"),
         `---
-name: claude-skill
-description: A skill in the .claude/skills directory.
+name: project-agent-skill
+description: A skill in the .agents/skills directory.
 ---
 
-# Claude Skill
+# Agent Skill
 `,
       )
     },
@@ -196,14 +196,14 @@ description: A skill in the .claude/skills directory.
     directory: tmp.path,
     fn: async () => {
       const skills = await Skill.all()
-      const claudeSkill = skills.find((s) => s.name === "claude-skill")
-      expect(claudeSkill).toBeDefined()
-      expect(claudeSkill!.location).toContain(path.join(".claude", "skills", "claude-skill", "SKILL.md"))
+      const agentSkill = skills.find((s) => s.name === "project-agent-skill")
+      expect(agentSkill).toBeDefined()
+      expect(agentSkill!.location).toContain(path.join(".agents", "skills", "project-agent-skill", "SKILL.md"))
     },
   })
 })
 
-test("discovers global skills from ~/.claude/skills/ directory", async () => {
+test("discovers global skills from ~/.agents/skills/ directory", async () => {
   await using tmp = await tmpdir({ git: true })
 
   const originalHome = process.env.OPENCODE_TEST_HOME
@@ -217,8 +217,8 @@ test("discovers global skills from ~/.claude/skills/ directory", async () => {
         const skills = await Skill.all()
         const skill = skills.find((item) => item.name === "global-test-skill")
         expect(skill).toBeDefined()
-        expect(skill!.description).toBe("A global skill from ~/.claude/skills for testing.")
-        expect(skill!.location).toContain(path.join(".claude", "skills", "global-test-skill", "SKILL.md"))
+        expect(skill!.description).toBe("A global skill from ~/.agents/skills for testing.")
+        expect(skill!.location).toContain(path.join(".agents", "skills", "global-test-skill", "SKILL.md"))
       },
     })
   } finally {
@@ -237,7 +237,6 @@ test("returns empty array when no skills exist", async () => {
         skills.find(
           (s) =>
             s.location.startsWith(path.join(tmp.path, ".opencode")) ||
-            s.location.startsWith(path.join(tmp.path, ".claude")) ||
             s.location.startsWith(path.join(tmp.path, ".agents")),
         ),
       ).toBeUndefined()
@@ -320,22 +319,11 @@ This skill is loaded from the global home directory.
   }
 })
 
-test("discovers skills from both .claude/skills/ and .agents/skills/", async () => {
+test("discovers skills from .agents/skills/ only", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      const claudeDir = path.join(dir, ".claude", "skills", "claude-skill")
       const agentDir = path.join(dir, ".agents", "skills", "agent-skill")
-      await Bun.write(
-        path.join(claudeDir, "SKILL.md"),
-        `---
-name: claude-skill
-description: A skill in the .claude/skills directory.
----
-
-# Claude Skill
-`,
-      )
       await Bun.write(
         path.join(agentDir, "SKILL.md"),
         `---
@@ -353,7 +341,6 @@ description: A skill in the .agents/skills directory.
     directory: tmp.path,
     fn: async () => {
       const skills = await Skill.all()
-      expect(skills.find((s) => s.name === "claude-skill")).toBeDefined()
       expect(skills.find((s) => s.name === "agent-skill")).toBeDefined()
     },
   })
@@ -365,18 +352,7 @@ test("properly resolves directories that skills live in", async () => {
     init: async (dir) => {
       const opencodeSkillDir = path.join(dir, ".opencode", "skill", "agent-skill")
       const opencodeSkillsDir = path.join(dir, ".opencode", "skills", "agent-skill")
-      const claudeDir = path.join(dir, ".claude", "skills", "claude-skill")
       const agentDir = path.join(dir, ".agents", "skills", "agent-skill")
-      await Bun.write(
-        path.join(claudeDir, "SKILL.md"),
-        `---
-name: claude-skill
-description: A skill in the .claude/skills directory.
----
-
-# Claude Skill
-`,
-      )
       await Bun.write(
         path.join(agentDir, "SKILL.md"),
         `---
@@ -416,7 +392,6 @@ description: A skill in the .opencode/skills directory.
       const dirs = await Skill.dirs()
       expect(dirs).toContain(path.join(tmp.path, ".opencode", "skill", "agent-skill"))
       expect(dirs).toContain(path.join(tmp.path, ".opencode", "skills", "agent-skill"))
-      expect(dirs).toContain(path.join(tmp.path, ".claude", "skills", "claude-skill"))
       expect(dirs).toContain(path.join(tmp.path, ".agents", "skills", "agent-skill"))
     },
   })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -11,23 +11,6 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
-async function createGlobalSkill(homeDir: string) {
-  const skillDir = path.join(homeDir, ".agents", "skills", "global-test-skill")
-  await fs.mkdir(skillDir, { recursive: true })
-  await Bun.write(
-    path.join(skillDir, "SKILL.md"),
-    `---
-name: global-test-skill
-description: A global skill from ~/.agents/skills for testing.
----
-
-# Global Test Skill
-
-This skill is loaded from the global home directory.
-`,
-  )
-}
-
 async function createBundledSkill(resourcesDir: string, name: string, description = "A bundled skill for testing.") {
   const skillDir = path.join(resourcesDir, "skills", name)
   await fs.mkdir(skillDir, { recursive: true })
@@ -174,58 +157,6 @@ Just some content without YAML frontmatter.
   })
 })
 
-test("discovers skills from .agents/skills/ directory", async () => {
-  await using tmp = await tmpdir({
-    git: true,
-    init: async (dir) => {
-      const skillDir = path.join(dir, ".agents", "skills", "project-agent-skill")
-      await Bun.write(
-        path.join(skillDir, "SKILL.md"),
-        `---
-name: project-agent-skill
-description: A skill in the .agents/skills directory.
----
-
-# Agent Skill
-`,
-      )
-    },
-  })
-
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      const skills = await Skill.all()
-      const agentSkill = skills.find((s) => s.name === "project-agent-skill")
-      expect(agentSkill).toBeDefined()
-      expect(agentSkill!.location).toContain(path.join(".agents", "skills", "project-agent-skill", "SKILL.md"))
-    },
-  })
-})
-
-test("discovers global skills from ~/.agents/skills/ directory", async () => {
-  await using tmp = await tmpdir({ git: true })
-
-  const originalHome = process.env.OPENCODE_TEST_HOME
-  process.env.OPENCODE_TEST_HOME = tmp.path
-
-  try {
-    await createGlobalSkill(tmp.path)
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const skills = await Skill.all()
-        const skill = skills.find((item) => item.name === "global-test-skill")
-        expect(skill).toBeDefined()
-        expect(skill!.description).toBe("A global skill from ~/.agents/skills for testing.")
-        expect(skill!.location).toContain(path.join(".agents", "skills", "global-test-skill", "SKILL.md"))
-      },
-    })
-  } finally {
-    process.env.OPENCODE_TEST_HOME = originalHome
-  }
-})
-
 test("returns empty array when no skills exist", async () => {
   await using tmp = await tmpdir({ git: true })
 
@@ -324,6 +255,7 @@ test("discovers skills from .agents/skills/ only", async () => {
     git: true,
     init: async (dir) => {
       const agentDir = path.join(dir, ".agents", "skills", "agent-skill")
+      const claudeDir = path.join(dir, ".claude", "skills", "claude-skill")
       await Bun.write(
         path.join(agentDir, "SKILL.md"),
         `---
@@ -334,6 +266,16 @@ description: A skill in the .agents/skills directory.
 # Agent Skill
 `,
       )
+      await Bun.write(
+        path.join(claudeDir, "SKILL.md"),
+        `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
+
+# Claude Skill
+`,
+      )
     },
   })
 
@@ -342,6 +284,7 @@ description: A skill in the .agents/skills directory.
     fn: async () => {
       const skills = await Skill.all()
       expect(skills.find((s) => s.name === "agent-skill")).toBeDefined()
+      expect(skills.find((s) => s.name === "claude-skill")).toBeUndefined()
     },
   })
 })


### PR DESCRIPTION
## Summary

Removes `.claude` from the `EXTERNAL_DIRS` list in opencode's skill discovery, so PawWork no longer loads skills from `~/.claude/skills/`. Updated all related tests to use `.agents` instead.

## Why

PawWork's engine (opencode) previously scanned both `~/.claude/skills/` and `~/.agents/skills/` to share skills across tools. However, `~/.claude/skills/` contains Claude Code-specific skills (crosscheck, direction, office-hours, deep-research, x-post, learn-code) that depend on Claude Code-only subagent types, scripts, and dispatch patterns. These skills appear in PawWork's skill list but do not function there, creating confusion.

The fix keeps `~/.agents/skills/` as the sole global skills directory, which already contains all PawWork-relevant skills.

## Related Issue

None.

## Human Review Status

Pending.

## Review Focus

The `EXTERNAL_DIRS` change is a single-line removal. The test changes are mechanical renames from `.claude` to `.agents`. Verify no other code paths depend on `.claude` skill loading.

## Risk Notes

Users who currently have skills only in `~/.claude/skills/` and not in `~/.agents/skills/` will lose access to those skills. In practice, most lark-* and other skills are duplicated in both directories under this user's setup, and Claude Code-specific skills should not have been loaded by PawWork in the first place.

## How To Verify

```
bun test packages/opencode/test/skill/skill.test.ts
```

```
16 pass, 0 fail, 112 expect() calls
```

## Checklist

- [x] Human review status is stated above as pending
- [x] I stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting dev, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * External skill discovery now uses the `.agents/skills` directory and no longer searches `~/.claude` or `.claude/skills`.
  * Skills placed under `.claude` will no longer be discovered by the scanner.

* **Tests**
  * Test suite updated to reflect the new external skill discovery locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->