### PR TITLE
fix(desktop): deny new window creation on shift-click

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -87,6 +87,9 @@ export function createMainWindow() {
   })
 
   state.manage(win)
+
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }))
+
   loadWindow(win, "index.html")
   wireZoom(win)
 


### PR DESCRIPTION
## Summary
- Add `webContents.setWindowOpenHandler({ action: 'deny' })` in `createMainWindow()` to prevent Electron from spawning new windows on shift+click or `window.open()` calls.
- Root cause: SolidJS Router intentionally skips `preventDefault()` when shiftKey is pressed, letting the browser/Electron handle the click — which defaults to opening a new window.
- Fix is at the Electron layer so it covers all `<a>` tag shift+clicks, not just sidebar conversation items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop application's window management to prevent new windows or tabs from being opened when triggered from within the application. This change enhances application stability and ensures a more consistent and predictable user experience during regular usage and interaction with the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->