### PR TITLE
chore(release): bump v2026.5.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "2026.5.2",
+      "version": "2026.5.3",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -97,7 +97,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.2",
+      "version": "2026.5.3",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",
@@ -145,7 +145,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "2026.5.2",
+      "version": "2026.5.3",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -371,7 +371,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "2026.5.2",
+      "version": "2026.5.3",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.5.2",
+  "version": "2026.5.3",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.2",
+  "version": "2026.5.3",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -79,10 +79,7 @@ describe("verify-release", () => {
     expect(() => normalizeTag("")).toThrow("Invalid release tag")
     expect(() => normalizeTag("v")).toThrow("Invalid release tag")
     expect(() => normalizeTag("abc")).toThrow("Invalid release tag")
-    expect(normalizeTag("2026.4.28.1")).toBe("v2026.4.28.1")
-    expect(normalizeTag("v2026.4.28.2")).toBe("v2026.4.28.2")
-    expect(normalizeTag("2026.4.28.0")).toBe("v2026.4.28.0")
-    expect(() => normalizeTag("2026.4.28.1234")).toThrow("Invalid release tag")
+    expect(() => normalizeTag("2026.4.28.1")).toThrow("Invalid release tag")
     expect(() => normalizeTag("2026.4.28-hotfix.1")).toThrow("Invalid release tag")
   })
 
@@ -258,13 +255,11 @@ path: pawwork-win-x64-2026.4.28.exe
   test("reports invalid release tags in release payloads without throwing", () => {
     expect(
       verifyReleasePayload({
-        release: { ...baseRelease, tag_name: "v2026.4.28.1.1" },
+        release: { ...baseRelease, tag_name: "v2026.4.28.1" },
         latestYml: "",
         latestMacYml: "",
       }),
-    ).toEqual([
-      "Invalid release tag: v2026.4.28.1.1. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).",
-    ])
+    ).toEqual(["Invalid release tag: v2026.4.28.1. Expected vYYYY.M.D or YYYY.M.D."])
   })
 
   test("accepts a complete startup log for the release version", () => {
@@ -385,7 +380,7 @@ path: pawwork-win-x64-2026.4.28.exe
 `,
         "v",
       ),
-    ).toEqual(["Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N)."])
+    ).toEqual(["Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D."])
   })
 
   test("reports invalid release tags with other startup failures", () => {
@@ -396,7 +391,7 @@ path: pawwork-win-x64-2026.4.28.exe
         "v",
       ),
     ).toEqual([
-      "Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).",
+      "Invalid release tag: v. Expected vYYYY.M.D or YYYY.M.D.",
       "Latest startup log does not include server ready",
       "Latest startup log does not include loading task finished",
       "Latest startup log does not include init step done",

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -231,10 +231,8 @@ export function verifyReleasePayload(input: VerificationInput) {
 
 export function normalizeTag(raw: string) {
   const normalized = raw.startsWith("v") ? raw : `v${raw}`
-  if (!/^v\d{4}\.\d{1,2}\.\d{1,2}(\.\d{1,3})?$/.test(normalized)) {
-    throw new Error(
-      `Invalid release tag: ${raw}. Expected vYYYY.M.D or YYYY.M.D, with optional build number (vYYYY.M.D.N).`,
-    )
+  if (!/^v\d{4}\.\d{1,2}\.\d{1,2}$/.test(normalized)) {
+    throw new Error(`Invalid release tag: ${raw}. Expected vYYYY.M.D or YYYY.M.D.`)
   }
   return normalized
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.5.2",
+  "version": "2026.5.3",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.5.2",
+  "version": "2026.5.3",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump version from 2026.5.2 to 2026.5.3 for the second release today.
Also reverts the 4-segment CalVer support from #374 — the 4-segment format
is incompatible with `electron-builder` and `electron-updater`, which both
use npm `semver` for validation and comparison.

## Why

Second same-day release. 4-segment CalVer (`2026.5.2.2`) is rejected by
`app-builder-lib` at build time and by `electron-updater` at runtime.
Revert to 3-segment bumping for same-day releases.

## Related Issue

None.

## Human Review Status

Pending.

## Review Focus

- Confirm all 4 package.json versions are bumped to 2026.5.3
- Confirm verify-release.ts normalizeTag regex is back to 3-segment only

## Risk Notes

None — version bump only.

## How To Verify

```text
bun test scripts/verify-release.test.ts
```

## Checklist

- [x] Human review status is stated above as pending
- [x] No related issue — version bump
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] Not applicable — no visible UI or copy changes
- [x] I considered macOS and Windows impact — no platform-specific changes
- [x] Not applicable — no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to 2026.5.3 across the workspace.
* **Chores**
  * Tightened release-tag validation to require three dot-separated numeric segments (no optional fourth build segment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->