### PR TITLE
fix(app): stabilize sidebar session history

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -248,27 +248,27 @@ describe("applyDirectoryEvent", () => {
     }
   })
 
-  test("cleans caches for trimmed sessions on session.created", () => {
-    const dropped = rootSession({ id: "ses_b", created: 1 })
-    const kept = rootSession({ id: "ses_a", created: 2 })
-    const message = userMessage("msg_1", dropped.id)
+  test("keeps expanded session history stable on session.created", () => {
+    const existing = rootSession({ id: "ses_b", created: 1 })
+    const created = rootSession({ id: "ses_a", created: 2 })
+    const message = userMessage("msg_1", existing.id)
     const todos: string[] = []
     const [store, setStore] = createStore(
       baseState({
         limit: 1,
-        session: [dropped],
-        message: { [dropped.id]: [message] },
-        part: { [message.id]: [textPart("prt_1", dropped.id, message.id)] },
-        session_diff: { [dropped.id]: [] },
-        todo: { [dropped.id]: [] },
-        permission: { [dropped.id]: [] },
-        question: { [dropped.id]: [] },
-        session_status: { [dropped.id]: { type: "busy" } },
+        session: [existing],
+        message: { [existing.id]: [message] },
+        part: { [message.id]: [textPart("prt_1", existing.id, message.id)] },
+        session_diff: { [existing.id]: [] },
+        todo: { [existing.id]: [] },
+        permission: { [existing.id]: [] },
+        question: { [existing.id]: [] },
+        session_status: { [existing.id]: { type: "busy" } },
       }),
     )
 
     applyDirectoryEvent({
-      event: { type: "session.created", properties: { info: kept } },
+      event: { type: "session.created", properties: { info: created } },
       store,
       setStore,
       push() {},
@@ -280,15 +280,15 @@ describe("applyDirectoryEvent", () => {
       },
     })
 
-    expect(store.session.map((x) => x.id)).toEqual([kept.id])
-    expect(store.message[dropped.id]).toBeUndefined()
-    expect(store.part[message.id]).toBeUndefined()
-    expect(store.session_diff[dropped.id]).toBeUndefined()
-    expect(store.todo[dropped.id]).toBeUndefined()
-    expect(store.permission[dropped.id]).toBeUndefined()
-    expect(store.question[dropped.id]).toBeUndefined()
-    expect(store.session_status[dropped.id]).toBeUndefined()
-    expect(todos).toEqual([dropped.id])
+    expect(store.session.map((x) => x.id)).toEqual([created.id, existing.id])
+    expect(store.message[existing.id]).toEqual([message])
+    expect(store.part[message.id]).toEqual([textPart("prt_1", existing.id, message.id)])
+    expect(store.session_diff[existing.id]).toEqual([])
+    expect(store.todo[existing.id]).toEqual([])
+    expect(store.permission[existing.id]).toEqual([])
+    expect(store.question[existing.id]).toEqual([])
+    expect(store.session_status[existing.id]).toEqual({ type: "busy" })
+    expect(todos).toEqual([])
   })
 
   test("cleanupDroppedSessionCaches clears part-only orphan state", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -111,9 +111,7 @@ export function applyDirectoryEvent(input: {
       }
       const next = input.store.session.slice()
       next.splice(result.index, 0, info)
-      const trimmed = trimSessions(next, { limit: input.store.limit, permission: input.store.permission })
-      input.setStore("session", reconcile(trimmed, { key: "id" }))
-      cleanupDroppedSessionCaches(input.store, input.setStore, trimmed, input.setSessionTodo)
+      input.setStore("session", reconcile(next, { key: "id" }))
       if (!info.parentID) input.setStore("sessionTotal", (value) => value + 1)
       break
     }
@@ -140,9 +138,7 @@ export function applyDirectoryEvent(input: {
       }
       const next = input.store.session.slice()
       next.splice(result.index, 0, info)
-      const trimmed = trimSessions(next, { limit: input.store.limit, permission: input.store.permission })
-      input.setStore("session", reconcile(trimmed, { key: "id" }))
-      cleanupDroppedSessionCaches(input.store, input.setStore, trimmed, input.setSessionTodo)
+      input.setStore("session", reconcile(next, { key: "id" }))
       break
     }
     case "session.deleted": {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -227,6 +227,7 @@ export const dict = {
   "common.goForward": "Navigate forward",
   "common.loading": "Loading",
   "common.loading.ellipsis": "...",
+  "common.showMore": "Show more",
   "common.cancel": "Cancel",
   "common.open": "Open",
   "common.connect": "Connect",
@@ -779,6 +780,7 @@ export const dict = {
   "sidebar.pawwork.unpinSession": "Unpin session",
   "sidebar.pawwork.sort.byProject": "Group by project",
   "sidebar.pawwork.sort.byTime": "Sort by time",
+  "sidebar.pawwork.searchHistory": "Use Search for older sessions",
 
   "debugBar.ariaLabel": "Development performance diagnostics",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -246,6 +246,7 @@ export const dict = {
   "common.goForward": "前进",
   "common.loading": "加载中",
   "common.loading.ellipsis": "...",
+  "common.showMore": "显示更多",
   "common.cancel": "取消",
   "common.connect": "连接",
   "common.disconnect": "断开连接",
@@ -693,6 +694,7 @@ export const dict = {
   "sidebar.pawwork.unpinSession": "取消置顶",
   "sidebar.pawwork.sort.byProject": "按项目分组",
   "sidebar.pawwork.sort.byTime": "按时间排序",
+  "sidebar.pawwork.searchHistory": "搜索历史会话",
 
   "app.name.desktop": "爪印",
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -650,17 +650,19 @@ export default function Layout(props: ParentProps) {
 
   const upsertPawworkWindowSession = (info: Session) => {
     if (info.parentID || info.time?.archived) return
-    setPawworkSessionWindowState("normal", (current) =>
-      sortPawworkSessionWindowSessions([...current.filter((session) => session.id !== info.id), info]),
-    )
-    if (store.pawworkPinnedSessions.includes(info.id)) {
-      setPawworkSessionWindowState("pinned", (current) =>
+    batch(() => {
+      setPawworkSessionWindowState("normal", (current) =>
         sortPawworkSessionWindowSessions([...current.filter((session) => session.id !== info.id), info]),
       )
-    }
-    if (params.id === info.id) {
-      setPawworkSessionWindowState("active", info)
-    }
+      if (store.pawworkPinnedSessions.includes(info.id)) {
+        setPawworkSessionWindowState("pinned", (current) =>
+          sortPawworkSessionWindowSessions([...current.filter((session) => session.id !== info.id), info]),
+        )
+      }
+      if (params.id === info.id) {
+        setPawworkSessionWindowState("active", info)
+      }
+    })
   }
 
   const removePawworkWindowSession = (sessionID: string) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -24,7 +24,7 @@ import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { Button } from "@opencode-ai/ui/button"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { getFilename } from "@opencode-ai/util/path"
-import { Session, type Message } from "@opencode-ai/sdk/v2/client"
+import { Session, type GlobalSession, type Message } from "@opencode-ai/sdk/v2/client"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -79,11 +79,15 @@ import {
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
-  pawworkSidebarSessionTime,
   pawworkSessionDirectories,
-  resolvePawworkProjectLabels,
   sortPawworkSidebarSessions,
 } from "./layout/pawwork-session-source"
+import {
+  buildPawworkSessionWindow,
+  nextPawworkSessionWindowLimit,
+  PAWWORK_SESSION_WINDOW_INITIAL,
+  sortPawworkSessionWindowSessions,
+} from "./layout/pawwork-session-window"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { PawworkTitlebar } from "./layout/pawwork-titlebar"
@@ -526,33 +530,168 @@ export default function Layout(props: ParentProps) {
     return result
   })
 
-  const collectPawworkSessions = (projects: LocalProject[]) => {
-    const seen = new Set<string>()
-    const result: PawworkSidebarSession[] = []
-    const labels = resolvePawworkProjectLabels(projects, globalSync.data.path.home)
+  const [pawworkSessionWindowState, setPawworkSessionWindowState] = createStore({
+    limit: PAWWORK_SESSION_WINDOW_INITIAL,
+    normal: [] as Session[],
+    pinned: [] as Session[],
+    active: undefined as Session | undefined,
+    hasMore: false,
+    loading: false,
+  })
+  let pawworkSessionWindowRev = 0
 
-    for (const project of projects) {
-      for (const directory of workspaceIds(project)) {
-        const key = workspaceKey(directory)
-        if (seen.has(key)) continue
-        seen.add(key)
-
-        const [dirStore] = globalSync.child(directory, { bootstrap: true })
-        for (const session of sortedRootSessions(dirStore)) {
-          result.push({
-            session,
-            slug: base64Encode(session.directory),
-            projectLabel: labels.get(project.worktree) ?? displayName(project),
-            created: pawworkSidebarSessionTime(session, dirStore.message[session.id]),
-          })
-        }
-      }
+  const findLoadedSession = (sessionID: string | undefined) => {
+    if (!sessionID) return
+    for (const directory of visibleSessionDirs()) {
+      const [dirStore] = globalSync.child(directory, { bootstrap: false })
+      const found = dirStore.session.find((session) => session.id === sessionID)
+      if (found && !found.time?.archived) return found
     }
-
-    return sortPawworkSidebarSessions(result.map((item) => ({ ...item, id: item.session.id }))).map(({ id: _, ...item }) => item)
+    return pawworkSessionWindowState.normal.find((session) => session.id === sessionID)
   }
 
-  const pawworkSessions = createMemo(() => collectPawworkSessions(layout.projects.list()))
+  const loadSessionByID = async (sessionID: string | undefined) => {
+    if (!sessionID) return
+    const loaded = findLoadedSession(sessionID)
+    if (loaded) return loaded
+    try {
+      const response = await globalSDK.client.session.get({ sessionID })
+      return response.data && !response.data.time?.archived ? response.data : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  const projectLabelForSession = (session: Session | GlobalSession) => {
+    const project = "project" in session ? session.project : undefined
+    if (project?.name) return project.name
+    if (project?.worktree) return getFilename(project.worktree)
+    const localProject = layout.projects.list().find((item) => workspaceKey(item.worktree) === workspaceKey(session.directory))
+    if (localProject) return displayName(localProject)
+    return getFilename(session.directory)
+  }
+
+  const pawworkSessionWindow = createMemo(() =>
+    buildPawworkSessionWindow({
+      normal: pawworkSessionWindowState.normal,
+      pinned: pawworkSessionWindowState.pinned,
+      active: pawworkSessionWindowState.active,
+      limit: pawworkSessionWindowState.limit,
+      hasMore: pawworkSessionWindowState.hasMore,
+    }),
+  )
+
+  const pawworkSessions = createMemo(() => {
+    const rows = pawworkSessionWindow().sessions.map((session) => ({
+      session,
+      slug: base64Encode(session.directory),
+      projectLabel: projectLabelForSession(session),
+      created: session.time.created,
+    }))
+    return sortPawworkSidebarSessions(rows.map((item) => ({ ...item, id: item.session.id }))).map(({ id: _, ...item }) => item)
+  })
+
+  async function loadPawworkSessionWindow() {
+    if (!pageReady()) return
+    if (!layoutReady()) return
+    if (!globalSync.ready) return
+    const rev = ++pawworkSessionWindowRev
+    setPawworkSessionWindowState("loading", true)
+    try {
+      const response = await globalSDK.client.experimental.session.list({
+        roots: true,
+        limit: pawworkSessionWindowState.limit,
+        sort: "created",
+      })
+      if (rev !== pawworkSessionWindowRev) return
+      const normal = ((response.data ?? []) as Session[]).filter((session) => !session.time?.archived)
+      const loaded = new Map(normal.map((session) => [session.id, session]))
+      const pinned = (
+        await Promise.all(
+          store.pawworkPinnedSessions.map(async (id) => loaded.get(id) ?? (await loadSessionByID(id))),
+        )
+      ).filter((session): session is Session => !!session)
+      const active = params.id ? (loaded.get(params.id) ?? (await loadSessionByID(params.id))) : undefined
+
+      if (rev !== pawworkSessionWindowRev) return
+      batch(() => {
+        setPawworkSessionWindowState("normal", reconcile(sortPawworkSessionWindowSessions(normal), { key: "id" }))
+        setPawworkSessionWindowState("pinned", reconcile(pinned, { key: "id" }))
+        setPawworkSessionWindowState("active", active)
+        setPawworkSessionWindowState("hasMore", !!response.response.headers.get("x-next-cursor"))
+        setPawworkSessionWindowState("loading", false)
+      })
+    } catch (error) {
+      if (rev !== pawworkSessionWindowRev) return
+      setPawworkSessionWindowState("loading", false)
+      showToast({
+        title: language.t("toast.session.listFailed.title", { project: "PawWork" }),
+        description: errorMessage(error, language.t("common.requestFailed")),
+      })
+    }
+  }
+
+  createEffect(
+    on(
+      () => [
+        pageReady(),
+        layoutReady(),
+        globalSync.ready,
+        globalSDK.url,
+        pawworkSessionWindowState.limit,
+        store.pawworkPinnedSessions.join("\0"),
+        params.id,
+      ] as const,
+      () => {
+        void loadPawworkSessionWindow()
+      },
+    ),
+  )
+
+  const upsertPawworkWindowSession = (info: Session) => {
+    if (info.parentID || info.time?.archived) return
+    setPawworkSessionWindowState("normal", (current) =>
+      sortPawworkSessionWindowSessions([...current.filter((session) => session.id !== info.id), info]),
+    )
+    if (store.pawworkPinnedSessions.includes(info.id)) {
+      setPawworkSessionWindowState("pinned", (current) =>
+        sortPawworkSessionWindowSessions([...current.filter((session) => session.id !== info.id), info]),
+      )
+    }
+    if (params.id === info.id) {
+      setPawworkSessionWindowState("active", info)
+    }
+  }
+
+  const removePawworkWindowSession = (sessionID: string) => {
+    setPawworkSessionWindowState("normal", (current) => current.filter((session) => session.id !== sessionID))
+    setPawworkSessionWindowState("pinned", (current) => current.filter((session) => session.id !== sessionID))
+    if (pawworkSessionWindowState.active?.id === sessionID) {
+      setPawworkSessionWindowState("active", undefined)
+    }
+  }
+
+  onCleanup(
+    globalSDK.event.listen((event) => {
+      const details = event.details
+      if (details.type === "session.created") {
+        upsertPawworkWindowSession(details.properties.info)
+        return
+      }
+      if (details.type === "session.updated") {
+        const info = details.properties.info
+        if (info.time?.archived) {
+          removePawworkWindowSession(info.id)
+          return
+        }
+        upsertPawworkWindowSession(info)
+        return
+      }
+      if (details.type === "session.deleted") {
+        removePawworkWindowSession(details.properties.info.id)
+      }
+    }),
+  )
 
   type PrefetchQueue = {
     inflight: Set<string>
@@ -1996,6 +2135,10 @@ export default function Layout(props: ParentProps) {
   }
 
   const projects = () => layout.projects.list()
+  const showMorePawworkSessions = () => {
+    if (pawworkSessionWindowState.loading) return
+    setPawworkSessionWindowState("limit", (limit) => nextPawworkSessionWindowLimit(limit))
+  }
   const renderPawworkPanel = (
     sessions: Accessor<PawworkSidebarSession[]>,
     options?: { directory?: string; scope?: "main" | "peek" },
@@ -2003,6 +2146,11 @@ export default function Layout(props: ParentProps) {
     <PawworkSidebar
       scope={options?.scope}
       sessions={sessions}
+      sessionWindow={() => ({
+        canShowMore: pawworkSessionWindow().canShowMore,
+        capReached: pawworkSessionWindow().capReached,
+        loading: pawworkSessionWindowState.loading,
+      })}
       showProjectEmptyState={projects().length === 0}
       activeSessionID={() => params.id}
       pinnedIDs={() => store.pawworkPinnedSessions}
@@ -2015,6 +2163,8 @@ export default function Layout(props: ParentProps) {
       onExportSession={exportSession}
       onDeleteSession={confirmDeleteSession}
       onSetSortMode={setPawworkSortMode}
+      onShowMore={showMorePawworkSessions}
+      onSearchOlderSessions={() => command.show()}
       onNew={() => openPawworkHome(options?.directory)}
       onSearch={() => command.show()}
       onOpenProject={chooseProject}

--- a/packages/app/src/pages/layout/pawwork-session-window.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.test.ts
@@ -61,6 +61,29 @@ describe("buildPawworkSessionWindow", () => {
     expect(result.capReached).toBe(false)
   })
 
+  test("does not count pinned or active sessions against the normal window", () => {
+    const normal = Array.from({ length: 32 }, (_, index) => session(`ses_${index}`, 10_000 - index))
+    const pinned = normal[0]!
+    const active = normal[1]!
+
+    const result = buildPawworkSessionWindow({
+      normal,
+      pinned: [pinned],
+      active,
+      limit: 30,
+      hasMore: true,
+    })
+
+    expect(result.normalIDs).toHaveLength(30)
+    expect(result.normalIDs).not.toContain(pinned.id)
+    expect(result.normalIDs).not.toContain(active.id)
+    expect(result.sessions.map((item) => item.id)).toEqual([
+      ...result.normalIDs,
+      active.id,
+      pinned.id,
+    ].sort())
+  })
+
   test("shows search prompt instead of show more at the cap", () => {
     const normal = Array.from({ length: 90 }, (_, index) => session(`ses_${index}`, 10_000 - index))
 

--- a/packages/app/src/pages/layout/pawwork-session-window.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import {
+  PAWWORK_SESSION_WINDOW_INITIAL,
+  PAWWORK_SESSION_WINDOW_MAX,
+  PAWWORK_SESSION_WINDOW_STEP,
+  buildPawworkSessionWindow,
+  nextPawworkSessionWindowLimit,
+} from "./pawwork-session-window"
+
+const session = (id: string, created: number, directory = "/repo") =>
+  ({
+    id,
+    directory,
+    title: id,
+    time: { created, updated: created },
+  }) as Session
+
+describe("nextPawworkSessionWindowLimit", () => {
+  test("moves 30 to 60 to 90 and caps there", () => {
+    expect(nextPawworkSessionWindowLimit(30)).toBe(60)
+    expect(nextPawworkSessionWindowLimit(60)).toBe(90)
+    expect(nextPawworkSessionWindowLimit(90)).toBe(90)
+    expect(PAWWORK_SESSION_WINDOW_INITIAL).toBe(30)
+    expect(PAWWORK_SESSION_WINDOW_STEP).toBe(30)
+    expect(PAWWORK_SESSION_WINDOW_MAX).toBe(90)
+  })
+})
+
+describe("buildPawworkSessionWindow", () => {
+  test("keeps the normal window capped while preserving pinned and active sessions", () => {
+    const normal = Array.from({ length: 35 }, (_, index) => session(`ses_${index}`, 10_000 - index))
+    const pinned = session("pinned_old", 1)
+    const active = session("active_old", 2)
+
+    const result = buildPawworkSessionWindow({
+      normal,
+      pinned: [pinned],
+      active,
+      limit: 30,
+      hasMore: true,
+    })
+
+    expect(result.sessions.map((item) => item.id)).toContain("pinned_old")
+    expect(result.sessions.map((item) => item.id)).toContain("active_old")
+    expect(result.normalIDs).toHaveLength(30)
+    expect(result.canShowMore).toBe(true)
+    expect(result.capReached).toBe(false)
+  })
+
+  test("shows search prompt instead of show more at the cap", () => {
+    const normal = Array.from({ length: 90 }, (_, index) => session(`ses_${index}`, 10_000 - index))
+
+    const result = buildPawworkSessionWindow({
+      normal,
+      pinned: [],
+      active: undefined,
+      limit: 90,
+      hasMore: true,
+    })
+
+    expect(result.canShowMore).toBe(false)
+    expect(result.capReached).toBe(true)
+  })
+})

--- a/packages/app/src/pages/layout/pawwork-session-window.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.test.ts
@@ -6,6 +6,7 @@ import {
   PAWWORK_SESSION_WINDOW_STEP,
   buildPawworkSessionWindow,
   nextPawworkSessionWindowLimit,
+  sortPawworkSessionWindowSessions,
 } from "./pawwork-session-window"
 
 const session = (id: string, created: number, directory = "/repo") =>
@@ -28,6 +29,18 @@ describe("nextPawworkSessionWindowLimit", () => {
 })
 
 describe("buildPawworkSessionWindow", () => {
+  test("sorts the normal window by creation time before applying the limit", () => {
+    const result = buildPawworkSessionWindow({
+      normal: [session("old", 1), session("new", 3), session("middle", 2)],
+      pinned: [],
+      active: undefined,
+      limit: 30,
+      hasMore: false,
+    })
+
+    expect(result.normalIDs).toEqual(["new", "middle", "old"])
+  })
+
   test("keeps the normal window capped while preserving pinned and active sessions", () => {
     const normal = Array.from({ length: 35 }, (_, index) => session(`ses_${index}`, 10_000 - index))
     const pinned = session("pinned_old", 1)
@@ -61,5 +74,14 @@ describe("buildPawworkSessionWindow", () => {
 
     expect(result.canShowMore).toBe(false)
     expect(result.capReached).toBe(true)
+  })
+})
+
+describe("sortPawworkSessionWindowSessions", () => {
+  test("uses id as the creation-time tiebreaker", () => {
+    expect(sortPawworkSessionWindowSessions([session("z", 1), session("a", 1)]).map((item) => item.id)).toEqual([
+      "a",
+      "z",
+    ])
   })
 })

--- a/packages/app/src/pages/layout/pawwork-session-window.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.ts
@@ -1,0 +1,47 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+export const PAWWORK_SESSION_WINDOW_INITIAL = 30
+export const PAWWORK_SESSION_WINDOW_STEP = 30
+export const PAWWORK_SESSION_WINDOW_MAX = 90
+
+const byID = (a: Session, b: Session) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+
+export function nextPawworkSessionWindowLimit(current: number) {
+  return Math.min(
+    PAWWORK_SESSION_WINDOW_MAX,
+    Math.max(PAWWORK_SESSION_WINDOW_INITIAL, current) + PAWWORK_SESSION_WINDOW_STEP,
+  )
+}
+
+export function mergeSessionsByID(...lists: Array<Session[] | undefined>) {
+  const map = new Map<string, Session>()
+  for (const list of lists) {
+    for (const item of list ?? []) {
+      if (!item?.id || item.time?.archived) continue
+      map.set(item.id, item)
+    }
+  }
+  return [...map.values()].sort(byID)
+}
+
+export function buildPawworkSessionWindow(input: {
+  normal: Session[]
+  pinned: Session[]
+  active?: Session
+  limit: number
+  hasMore: boolean
+}) {
+  const limit = Math.min(PAWWORK_SESSION_WINDOW_MAX, Math.max(PAWWORK_SESSION_WINDOW_INITIAL, input.limit))
+  const normal = input.normal.slice(0, limit)
+  const normalIDs = normal.map((item) => item.id)
+  const sessions = mergeSessionsByID(normal, input.pinned, input.active ? [input.active] : [])
+  const capReached = limit >= PAWWORK_SESSION_WINDOW_MAX && input.hasMore
+
+  return {
+    sessions,
+    normalIDs,
+    limit,
+    canShowMore: input.hasMore && !capReached,
+    capReached,
+  }
+}

--- a/packages/app/src/pages/layout/pawwork-session-window.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.ts
@@ -41,7 +41,13 @@ export function buildPawworkSessionWindow(input: {
   hasMore: boolean
 }) {
   const limit = Math.min(PAWWORK_SESSION_WINDOW_MAX, Math.max(PAWWORK_SESSION_WINDOW_INITIAL, input.limit))
-  const normal = sortPawworkSessionWindowSessions(input.normal).slice(0, limit)
+  const reservedIDs = new Set([
+    ...input.pinned.map((item) => item.id),
+    ...(input.active?.id ? [input.active.id] : []),
+  ])
+  const normal = sortPawworkSessionWindowSessions(input.normal)
+    .filter((item) => !reservedIDs.has(item.id))
+    .slice(0, limit)
   const normalIDs = normal.map((item) => item.id)
   const sessions = mergeSessionsByID(normal, input.pinned, input.active ? [input.active] : [])
   const capReached = limit >= PAWWORK_SESSION_WINDOW_MAX && input.hasMore

--- a/packages/app/src/pages/layout/pawwork-session-window.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.ts
@@ -5,6 +5,11 @@ export const PAWWORK_SESSION_WINDOW_STEP = 30
 export const PAWWORK_SESSION_WINDOW_MAX = 90
 
 const byID = (a: Session, b: Session) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+const byCreatedDesc = (a: Session, b: Session) => {
+  const created = b.time.created - a.time.created
+  if (created !== 0) return created
+  return byID(a, b)
+}
 
 export function nextPawworkSessionWindowLimit(current: number) {
   return Math.min(
@@ -24,6 +29,10 @@ export function mergeSessionsByID(...lists: Array<Session[] | undefined>) {
   return [...map.values()].sort(byID)
 }
 
+export function sortPawworkSessionWindowSessions(sessions: Session[]) {
+  return sessions.filter((item) => !!item?.id && !item.time?.archived).slice().sort(byCreatedDesc)
+}
+
 export function buildPawworkSessionWindow(input: {
   normal: Session[]
   pinned: Session[]
@@ -32,7 +41,7 @@ export function buildPawworkSessionWindow(input: {
   hasMore: boolean
 }) {
   const limit = Math.min(PAWWORK_SESSION_WINDOW_MAX, Math.max(PAWWORK_SESSION_WINDOW_INITIAL, input.limit))
-  const normal = input.normal.slice(0, limit)
+  const normal = sortPawworkSessionWindowSessions(input.normal).slice(0, limit)
   const normalIDs = normal.map((item) => item.id)
   const sessions = mergeSessionsByID(normal, input.pinned, input.active ? [input.active] : [])
   const capReached = limit >= PAWWORK_SESSION_WINDOW_MAX && input.hasMore

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -32,6 +32,7 @@ const FilterIcon = (props: { size?: number }) => {
 export const PawworkSidebar = (props: {
   scope?: "main" | "peek"
   sessions: Accessor<PawworkSidebarSession[]>
+  sessionWindow: Accessor<{ canShowMore: boolean; capReached: boolean; loading: boolean }>
   showProjectEmptyState: boolean
   activeSessionID?: Accessor<string | undefined>
   pinnedIDs: Accessor<string[]>
@@ -44,6 +45,8 @@ export const PawworkSidebar = (props: {
   onExportSession: (session: Session) => Promise<void>
   onDeleteSession: (session: Session) => void
   onSetSortMode: (mode: PawworkSortMode) => void
+  onShowMore: () => void
+  onSearchOlderSessions: () => void
   onNew: () => void
   onSearch: () => void
   onOpenProject: () => void
@@ -329,6 +332,27 @@ export const PawworkSidebar = (props: {
                     </section>
                   )}
                 </For>
+              </Show>
+              <Show when={props.sessionWindow().canShowMore}>
+                <button
+                  type="button"
+                  data-action="pawwork-session-show-more"
+                  disabled={props.sessionWindow().loading}
+                  onClick={props.onShowMore}
+                  class="mt-2 w-full rounded-md px-2 py-1.5 text-left text-13-regular text-text-weak transition-colors hover:bg-surface-raised-base-hover hover:text-text-base focus:outline-none focus-visible:bg-surface-raised-base-hover disabled:opacity-50"
+                >
+                  {props.sessionWindow().loading ? language.t("common.loading") : language.t("common.showMore")}
+                </button>
+              </Show>
+              <Show when={props.sessionWindow().capReached}>
+                <button
+                  type="button"
+                  data-action="pawwork-session-search-history"
+                  onClick={props.onSearchOlderSessions}
+                  class="mt-2 w-full rounded-md px-2 py-1.5 text-left text-13-regular text-text-weak transition-colors hover:bg-surface-raised-base-hover hover:text-text-base focus:outline-none focus-visible:bg-surface-raised-base-hover"
+                >
+                  {language.t("sidebar.pawwork.searchHistory")}
+                </button>
               </Show>
             </nav>
           </Show>

--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -412,6 +412,7 @@ export const ExperimentalRoutes = lazy(() =>
         const hasMore = sessions.length > limit
         const list = hasMore ? sessions.slice(0, limit) : sessions
         if (hasMore && list.length > 0) {
+          c.header("Access-Control-Expose-Headers", "X-Next-Cursor")
           c.header(
             "x-next-cursor",
             query.sort === "created"

--- a/packages/opencode/src/session/execution-context-store.ts
+++ b/packages/opencode/src/session/execution-context-store.ts
@@ -7,7 +7,12 @@ type Tx = Pick<Database.Transaction, "select" | "update">
 
 export function backfillExecutionContextRows(d: Tx) {
   const rows = d
-    .select({ id: SessionTable.id, directory: SessionTable.directory, project_id: SessionTable.project_id })
+    .select({
+      id: SessionTable.id,
+      directory: SessionTable.directory,
+      project_id: SessionTable.project_id,
+      time_updated: SessionTable.time_updated,
+    })
     .from(SessionTable)
     .where(isNull(SessionTable.execution_context))
     .all()
@@ -16,7 +21,10 @@ export function backfillExecutionContextRows(d: Tx) {
     const ownerDirectoryRaw = project?.vcs === "git" ? (project.worktree ?? row.directory) : row.directory
     const ownerDirectory = canonicalDirectory(ownerDirectoryRaw)
     const ctx = rootContext(ownerDirectory)
-    d.update(SessionTable).set({ execution_context: ctx }).where(eq(SessionTable.id, row.id)).run()
+    d.update(SessionTable)
+      .set({ execution_context: ctx, time_updated: row.time_updated })
+      .where(eq(SessionTable.id, row.id))
+      .run()
   }
   return rows.length
 }

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -284,6 +284,7 @@ describe("session.listGlobal", () => {
         expect(first.status).toBe(200)
         const cursor = first.headers.get("x-next-cursor")
         expect(cursor).toBeTruthy()
+        expect(first.headers.get("Access-Control-Expose-Headers")).toContain("X-Next-Cursor")
         const firstBody = (await first.json()) as SessionNs.GlobalInfo[]
         expect(firstBody).toHaveLength(1)
 

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -265,6 +265,33 @@ describe("session.created event", () => {
     })
   })
 
+  test("backfill preserves legacy session updated time", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await SessionNs.create({ title: "legacy-updated-time" })
+        const originalUpdated = session.time.updated - 10_000
+        Database.use((db) =>
+          db
+            .update(SessionTable)
+            .set({ execution_context: null, time_updated: originalUpdated })
+            .where(eq(SessionTable.id, session.id))
+            .run(),
+        )
+
+        const count = await Effect.runPromise(SessionNs.backfillExecutionContext)
+        expect(count).toBeGreaterThanOrEqual(1)
+
+        const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, session.id)).get())
+        expect(row?.time_updated).toBe(originalUpdated)
+
+        await SessionNs.remove(session.id)
+      },
+    })
+  })
+
   test("backfills legacy executionContext rows with canonical project roots", async () => {
     await using tmp = await tmpdir({ git: true })
     const projectLink = path.join(tmp.path, "project-link")


### PR DESCRIPTION
## Summary

- Add a reusable PawWork sidebar session window: 30 sessions by default, global Show more in +30 steps, capped at 90.
- Keep pinned and active sessions visible outside the normal window.
- Switch the cap state to the existing Search entry for older sessions.
- Preserve expanded sidebar history when session events arrive, and expose the experimental pagination cursor to browser clients.
- Preserve legacy session `time_updated` during execution context backfill.

## Why

Issue #382 is a bad data-loss-looking UI bug: older root sessions disappear from the sidebar, and creating/updating sessions could collapse already loaded history. The fix keeps the sidebar small by default while making older history reachable without per-project overfetching.

## Related Issue

Closes #382

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the global session window matches the accepted behavior: Time and Projects only change presentation, not pagination semantics.
- Confirm pinned and active sessions are not counted against the 90 normal-session cap.
- Confirm `session.created` / `session.updated` no longer trim expanded sidebar history.
- Confirm exposing `X-Next-Cursor` is limited to the experimental route and only when a next page exists.

## Risk Notes

- Visible sidebar behavior changes for users with more than 30 root sessions.
- No database migration or dependency changes.
- Electron verification used a copied installed-app database in the dev app data directory only; the installed database was not modified.

## How To Verify

```text
App focused tests: 31 passed across pawwork-session-window, pawwork-session-nav, event-reducer, and global-sync tests
Session tests: 22 passed, including executionContext backfill preserving legacy updated time
Global session list tests: 14 passed, including exposed X-Next-Cursor header
App typecheck: passed (tsgo -b)
Diff check: no whitespace errors
Electron + Computer Use: copied installed DB into dev DB, verified 30-session default, Show more expands to 60, second Show more reaches 90, and 搜索历史会话 opens the existing Search modal
```

## Screenshots or Recordings

Not attached because the Electron verification used a copied installed-app database containing private local session titles. Manual Computer Use verification covered the visible UI flow: 30 sessions, Show more, 60 sessions, Show more, 90-session cap, and Search entry.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pawwork sidebar: windowed session list with pagination, “Show more” button, and a “Search history” prompt when cap reached; pinned and active sessions stay visible while older sessions are paginated.

* **Bug Fixes**
  * Pagination header exposed for browser clients to allow next-page navigation.
  * Backfill now preserves existing session update timestamps.

* **Localization**
  * Added English and Chinese strings for “Show more” and search-history prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->