### PR TITLE
fix(build): handle missing GitHub release in updater metadata download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,7 +359,7 @@ jobs:
             if gh release download "$tag" --pattern "$pattern" --dir "$existing_dir" --repo "$GITHUB_REPOSITORY" 2>"$err"; then
               return 0
             fi
-            if grep -qiE 'no assets to download|no matches found|no assets match|could not find any assets' "$err"; then
+            if grep -qiE 'no assets to download|no matches found|no assets match|could not find any assets|release not found' "$err"; then
               echo "No existing $pattern found; expected for first release."
               return 0
             fi


### PR DESCRIPTION
## Summary

Add `release not found` to the `download_or_warn` grep pattern so first-time
builds for a new tag don't fail when there's no existing GitHub release yet.

## Why

`gh release download` returns `release not found` when a release hasn't been
created yet. The existing patterns only handle cases where the release exists
but has no matching assets, not where the release itself is missing.
This broke the v2026.5.3 macOS build.

## How To Verify

Trigger a `phase=full` build for a tag that has no existing GitHub release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow reliability by improving error detection for release deployment scenarios, enabling smoother initial release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->