### PR TITLE
docs(release): use versioned asset names

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -28,9 +28,9 @@ Create or update the GitHub Release body before publishing the release. Use Engl
 ```md
 ## Downloads
 
-- [macOS Apple Silicon](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64.dmg)
-- [macOS Intel](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64.dmg)
-- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64.exe)
+- [macOS Apple Silicon](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64-X.Y.Z.dmg)
+- [macOS Intel](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64-X.Y.Z.dmg)
+- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64-X.Y.Z.exe)
 
 ## App Update Notice
 
@@ -55,9 +55,9 @@ Create or update the GitHub Release body before publishing the release. Use Engl
 
 ### 下载
 
-- [macOS Apple 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64.dmg)
-- [macOS Intel 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64.dmg)
-- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64.exe)
+- [macOS Apple 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-arm64-X.Y.Z.dmg)
+- [macOS Intel 芯片](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-mac-x64-X.Y.Z.dmg)
+- [Windows](https://github.com/Astro-Han/pawwork/releases/download/vX.Y.Z/pawwork-win-x64-X.Y.Z.exe)
 
 ### 主要更新
 
@@ -133,12 +133,12 @@ The helper verifies:
 
 - The GitHub Release is not a draft.
 - The GitHub Release is not a prerelease.
-- `pawwork-mac-arm64.dmg` exists.
-- `pawwork-mac-x64.dmg` exists.
-- `pawwork-win-x64.exe` exists.
-- updater `.zip` and `.blockmap` assets exist.
-- `latest.yml` points to `pawwork-win-x64.exe`.
-- `latest-mac.yml` includes both `pawwork-mac-arm64.zip` and `pawwork-mac-x64.zip`.
+- `pawwork-mac-arm64-X.Y.Z.dmg` exists.
+- `pawwork-mac-x64-X.Y.Z.dmg` exists.
+- `pawwork-win-x64-X.Y.Z.exe` exists.
+- versioned updater `.zip` and `.blockmap` assets exist.
+- `latest.yml` points to `pawwork-win-x64-X.Y.Z.exe`.
+- `latest-mac.yml` includes both `pawwork-mac-arm64-X.Y.Z.zip` and `pawwork-mac-x64-X.Y.Z.zip`.
 
 Also verify a fresh packaged startup before closing startup-blocking issues. The command below is for macOS; override `PAWWORK_RELEASE_APP_PATH` and `PAWWORK_RELEASE_STARTUP_LOG` if the app or log is in a custom location.
 


### PR DESCRIPTION
## Summary

- Updates the release notes download link template to use versioned installer asset names.
- Updates the release verifier description to match the versioned installer and updater asset names checked by the helper.

## Why

The release checklist still showed unversioned asset names in the Release Notes template and verifier summary, which could point maintainers at the wrong GitHub release assets.

## Related Issue

No linked issue; this is a small release-process documentation fix.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please confirm the placeholder asset names match the verifier's `pawwork-<platform>-<arch>-X.Y.Z` naming convention.

## Risk Notes

None. Documentation-only change.

## How To Verify

```text
Diff check: git diff --check -- .github/RELEASE_CHECKLIST.md completed with no output
Manual diff review: confirmed only .github/RELEASE_CHECKLIST.md changed
Repository check: gh repo view confirmed Astro-Han/pawwork with default branch dev
```

## Screenshots or Recordings

Not required; no visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Maintainer labeling request: please add appropriate type, scope, and priority labels if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release checklist to reflect versioned installer asset filenames for macOS and Windows downloads, ensuring post-release verification processes align with current release naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->