### PR TITLE
fix(app): paginate release notes by version instead of bullet

### DIFF
--- a/packages/app/src/components/dialog-release-notes.tsx
+++ b/packages/app/src/components/dialog-release-notes.tsx
@@ -32,7 +32,9 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
   createEffect(() => {
     // Reset scroll position when page changes
     index()
-    if (descriptionRef) descriptionRef.scrollTop = 0
+    queueMicrotask(() => {
+      if (descriptionRef) descriptionRef.scrollTop = 0
+    })
   })
 
   function handleNext() {

--- a/packages/app/src/components/dialog-release-notes.tsx
+++ b/packages/app/src/components/dialog-release-notes.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js"
+import { createEffect, createSignal } from "solid-js"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
@@ -20,6 +20,7 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
   const language = useLanguage()
   const settings = useSettings()
   const [index, setIndex] = createSignal(0)
+  let descriptionRef: HTMLParagraphElement | undefined
 
   const total = () => props.highlights.length
   const last = () => Math.max(0, total() - 1)
@@ -27,6 +28,12 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
   const isFirst = () => index() === 0
   const isLast = () => index() >= last()
   const paged = () => total() > 1
+
+  createEffect(() => {
+    // Reset scroll position when page changes
+    index()
+    if (descriptionRef) descriptionRef.scrollTop = 0
+  })
 
   function handleNext() {
     if (isLast()) return
@@ -77,6 +84,7 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
               </h1>
             </div>
             <p
+              ref={descriptionRef}
               role="region"
               aria-labelledby="release-notes-title"
               tabIndex={0}

--- a/packages/app/src/components/dialog-release-notes.tsx
+++ b/packages/app/src/components/dialog-release-notes.tsx
@@ -68,20 +68,19 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
     >
       <div class="flex flex-1 min-w-0 min-h-0" tabIndex={0} autofocus onKeyDown={handleKeyDown}>
         {/* Left side - Text content */}
-        <div class="flex flex-col flex-1 min-w-0 p-8">
+        <div class="flex flex-col flex-1 min-w-0 min-h-0 p-8">
           {/* Top section - feature content (fixed position from top) */}
-          <div class="flex flex-col gap-2 pt-22">
-            <div class="flex items-center gap-2">
+          <div class="flex flex-col flex-1 min-h-0 gap-2 pt-22 pb-4">
+            <div class="flex items-center gap-2 shrink-0">
               <h1 class="text-16-medium text-text-strong">{feature()?.title ?? ""}</h1>
             </div>
-            <p class="text-13-regular text-text-base">{feature()?.description ?? ""}</p>
+            <p class="text-13-regular text-text-base whitespace-pre-line overflow-y-auto min-h-0 flex-1 pr-2">
+              {feature()?.description ?? ""}
+            </p>
           </div>
 
-          {/* Spacer to push buttons to bottom */}
-          <div class="flex-1" />
-
           {/* Bottom section - buttons and indicators (fixed position) */}
-          <div class="flex flex-col gap-12">
+          <div class="flex flex-col gap-12 shrink-0">
             <div class="flex flex-col items-start gap-3">
               {isLast() ? (
                 <Button variant="primary" size="large" onClick={handleClose}>

--- a/packages/app/src/components/dialog-release-notes.tsx
+++ b/packages/app/src/components/dialog-release-notes.tsx
@@ -72,9 +72,16 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
           {/* Top section - feature content (fixed position from top) */}
           <div class="flex flex-col flex-1 min-h-0 gap-2 pt-22 pb-4">
             <div class="flex items-center gap-2 shrink-0">
-              <h1 class="text-16-medium text-text-strong">{feature()?.title ?? ""}</h1>
+              <h1 id="release-notes-title" class="text-16-medium text-text-strong">
+                {feature()?.title ?? ""}
+              </h1>
             </div>
-            <p class="text-13-regular text-text-base whitespace-pre-line overflow-y-auto min-h-0 flex-1 pr-2">
+            <p
+              role="region"
+              aria-labelledby="release-notes-title"
+              tabIndex={0}
+              class="text-13-regular text-text-base whitespace-pre-line overflow-y-auto min-h-0 flex-1 pr-2"
+            >
               {feature()?.description ?? ""}
             </p>
           </div>

--- a/packages/app/src/context/highlights.test.ts
+++ b/packages/app/src/context/highlights.test.ts
@@ -305,4 +305,55 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     expect(highlights).toHaveLength(2)
     expect(highlights.map((highlight) => highlight.title)).toEqual(["Card A", "Card B"])
   })
+
+  test("keeps structured highlight cap independent from release-body version cap", () => {
+    const payload = [
+      {
+        tag: "v0.2.5",
+        highlights: [
+          {
+            source: "desktop",
+            items: Array.from({ length: 6 }, (_, index) => ({
+              title: `Card ${index + 1}`,
+              description: `Description ${index + 1}`,
+            })),
+          },
+        ],
+      },
+    ]
+
+    const highlights = loadReleaseHighlights(payload, "0.2.5", "0.2.4", "en")
+
+    expect(highlights).toHaveLength(6)
+    expect(highlights.map((highlight) => highlight.title)).toEqual([
+      "Card 1",
+      "Card 2",
+      "Card 3",
+      "Card 4",
+      "Card 5",
+      "Card 6",
+    ])
+  })
+
+  test("keeps structured highlight limit at fifteen cards", () => {
+    const payload = [
+      {
+        tag: "v0.2.5",
+        highlights: [
+          {
+            source: "desktop",
+            items: Array.from({ length: 16 }, (_, index) => ({
+              title: `Card ${index + 1}`,
+              description: `Description ${index + 1}`,
+            })),
+          },
+        ],
+      },
+    ]
+
+    const highlights = loadReleaseHighlights(payload, "0.2.5", "0.2.4", "en")
+
+    expect(highlights).toHaveLength(15)
+    expect(highlights.at(-1)?.title).toBe("Card 15")
+  })
 })

--- a/packages/app/src/context/highlights.test.ts
+++ b/packages/app/src/context/highlights.test.ts
@@ -157,7 +157,7 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     const highlights = loadReleaseHighlights(payload, "2026.4.29", "2026.4.28", "zh")
     expect(highlights).toHaveLength(1)
     expect(highlights[0].description).toBe(
-      "• 刷新桌面界面\n• 修复首次进入 Home 时左右侧栏默认打开的问题\n• 移除内置 Trash 工具\n• 提升 session 稳定性\n• 新增前台 subagent 生命周期支持\n• 默认启用 open permissions\n• 修复 Windows 拖拽上传",
+      "PawWork 2026.4.29 刷新桌面界面。\n• 刷新桌面界面\n• 修复首次进入 Home 时左右侧栏默认打开的问题\n• 移除内置 Trash 工具\n• 提升 session 稳定性\n• 新增前台 subagent 生命周期支持\n• 默认启用 open permissions\n• 修复 Windows 拖拽上传",
     )
   })
 
@@ -355,5 +355,28 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
 
     expect(highlights).toHaveLength(15)
     expect(highlights.at(-1)?.title).toBe("Card 15")
+  })
+
+  test("preserves intro prose before bullets in mixed content notices", () => {
+    const payload = [
+      {
+        tag_name: "v1.0.0",
+        body: [
+          "## App Update Notice",
+          "",
+          "Important migration note for this release.",
+          "",
+          "- Fixed crash on startup",
+          "- Added dark mode support",
+        ].join("\n"),
+      },
+    ]
+
+    const highlights = loadReleaseHighlights(payload, "1.0.0", "0.9.0", "en")
+
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe(
+      "Important migration note for this release.\n• Fixed crash on startup\n• Added dark mode support",
+    )
   })
 })

--- a/packages/app/src/context/highlights.test.ts
+++ b/packages/app/src/context/highlights.test.ts
@@ -379,4 +379,18 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
       "Important migration note for this release.\n• Fixed crash on startup\n• Added dark mode support",
     )
   })
+
+  test("does not fold trailing prose into the final bullet", () => {
+    const payload = [
+      {
+        tag_name: "v1.0.0",
+        body: ["## App Update Notice", "", "- Fixed sync", "", "Known issue: restart required."].join("\n"),
+      },
+    ]
+
+    const highlights = loadReleaseHighlights(payload, "1.0.0", "0.9.0", "en")
+
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe("• Fixed sync")
+  })
 })

--- a/packages/app/src/context/highlights.test.ts
+++ b/packages/app/src/context/highlights.test.ts
@@ -37,14 +37,10 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.10", "0.2.9", "zh")
-    expect(highlights).toHaveLength(2)
+    expect(highlights).toHaveLength(1)
     expect(highlights[0]).toMatchObject({
       title: "爪印 v0.2.10",
-      description: "修复首条消息崩溃",
-    })
-    expect(highlights[1]).toMatchObject({
-      title: "爪印 v0.2.10",
-      description: "调整更新提示",
+      description: "• 修复首条消息崩溃\n• 调整更新提示",
     })
   })
 
@@ -52,18 +48,23 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     const payload = [
       {
         tag_name: "v0.2.10",
-        body: ["## App Update Notice", "", "- Fixed first-message crash", "", "## 中文版本", "", "- 修复首条消息崩溃", "- 调整更新提示"].join("\n"),
+        body: [
+          "## App Update Notice",
+          "",
+          "- Fixed first-message crash",
+          "",
+          "## 中文版本",
+          "",
+          "- 修复首条消息崩溃",
+          "- 调整更新提示",
+        ].join("\n"),
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.10", "0.2.9", "zh")
-    expect(highlights).toHaveLength(2)
+    expect(highlights).toHaveLength(1)
     expect(highlights[0]).toMatchObject({
       title: "爪印 v0.2.10",
-      description: "修复首条消息崩溃",
-    })
-    expect(highlights[1]).toMatchObject({
-      title: "爪印 v0.2.10",
-      description: "调整更新提示",
+      description: "• 修复首条消息崩溃\n• 调整更新提示",
     })
   })
 
@@ -78,7 +79,7 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     expect(highlights).toHaveLength(1)
     expect(highlights[0]).toMatchObject({
       title: "爪印 v0.2.10",
-      description: "Fixed first-message crash",
+      description: "• Fixed first-message crash",
     })
   })
 
@@ -86,7 +87,9 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     const payload = [
       {
         tag_name: "v0.2.10",
-        body: ["## App Update Notice", "", "Fixed first-message crash and improved", "the update notice parser."].join("\n"),
+        body: ["## App Update Notice", "", "Fixed first-message crash and improved", "the update notice parser."].join(
+          "\n",
+        ),
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.10", "0.2.9", "en")
@@ -102,21 +105,28 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.3.0", "0.2.3", "en")
-    expect(highlights.map((highlight) => highlight.description)).toEqual(["Added dark theme", "Fixed dock icon"])
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe("• Added dark theme\n• Fixed dock icon")
   })
 
   test("keeps wrapped bullet continuation lines", () => {
     const payload = [
       {
         tag_name: "v0.3.0",
-        body: ["## App Update Notice", "", "- Fixed first-message crash", "  when startup takes longer", "- Added update notice parser"].join("\n"),
+        body: [
+          "## App Update Notice",
+          "",
+          "- Fixed first-message crash",
+          "  when startup takes longer",
+          "- Added update notice parser",
+        ].join("\n"),
       },
     ]
     const highlights = loadReleaseHighlights(payload, "0.3.0", "0.2.3", "en")
-    expect(highlights.map((highlight) => highlight.description)).toEqual([
-      "Fixed first-message crash when startup takes longer",
-      "Added update notice parser",
-    ])
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe(
+      "• Fixed first-message crash when startup takes longer\n• Added update notice parser",
+    )
   })
 
   test("keeps all localized update notice bullets", () => {
@@ -145,18 +155,13 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
       },
     ]
     const highlights = loadReleaseHighlights(payload, "2026.4.29", "2026.4.28", "zh")
-    expect(highlights.map((highlight) => highlight.description)).toEqual([
-      "刷新桌面界面",
-      "修复首次进入 Home 时左右侧栏默认打开的问题",
-      "移除内置 Trash 工具",
-      "提升 session 稳定性",
-      "新增前台 subagent 生命周期支持",
-      "默认启用 open permissions",
-      "修复 Windows 拖拽上传",
-    ])
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe(
+      "• 刷新桌面界面\n• 修复首次进入 Home 时左右侧栏默认打开的问题\n• 移除内置 Trash 工具\n• 提升 session 稳定性\n• 新增前台 subagent 生命周期支持\n• 默认启用 open permissions\n• 修复 Windows 拖拽上传",
+    )
   })
 
-  test("keeps skipped-version highlights beyond the old five item cap", () => {
+  test("keeps skipped-version highlights at version granularity", () => {
     const payload = [
       {
         tag_name: "v2026.4.29",
@@ -168,27 +173,47 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
       },
     ]
 
-    expect(loadReleaseHighlights(payload, "2026.4.29", "2026.4.27", "en").map((highlight) => highlight.description)).toEqual([
-      "A",
-      "B",
-      "C",
-      "D",
-      "E",
-      "F",
+    const highlights = loadReleaseHighlights(payload, "2026.4.29", "2026.4.27", "en")
+    expect(highlights).toHaveLength(2)
+    expect(highlights.map((highlight) => highlight.description)).toEqual(["• A\n• B\n• C", "• D\n• E\n• F"])
+  })
+
+  test("limits long skipped-version ranges to five version pages", () => {
+    const payload = Array.from({ length: 6 }, (_, index) => {
+      const patch = 6 - index
+
+      return {
+        tag_name: `v1.0.${patch}`,
+        body: `## App Update Notice\n\n- Item ${patch}\n`,
+      }
+    })
+
+    const highlights = loadReleaseHighlights(payload, "1.0.6", "1.0.0", "en")
+
+    expect(highlights).toHaveLength(5)
+    expect(highlights.map((highlight) => highlight.title)).toEqual([
+      "PawWork v1.0.6",
+      "PawWork v1.0.5",
+      "PawWork v1.0.4",
+      "PawWork v1.0.3",
+      "PawWork v1.0.2",
     ])
   })
 
-  test("limits long skipped-version highlight ranges", () => {
+  test("does not cap bullets inside a single version page", () => {
     const payload = [
       {
-        tag_name: "v2026.4.29",
-        body: ["## App Update Notice", "", ...Array.from({ length: 20 }, (_, index) => `- Item ${index + 1}`)].join("\n"),
+        tag_name: "v1.0.0",
+        body: ["## App Update Notice", "", "- Item 1", "- Item 2", "- Item 3", "- Item 4", "- Item 5", "- Item 6"].join(
+          "\n",
+        ),
       },
     ]
 
-    const highlights = loadReleaseHighlights(payload, "2026.4.29", "2026.4.28", "en")
-    expect(highlights).toHaveLength(15)
-    expect(highlights.at(-1)?.description).toBe("Item 15")
+    const highlights = loadReleaseHighlights(payload, "1.0.0", "0.9.0", "en")
+
+    expect(highlights).toHaveLength(1)
+    expect(highlights[0].description).toBe("• Item 1\n• Item 2\n• Item 3\n• Item 4\n• Item 5\n• Item 6")
   })
 
   test("truncates long summaries with an ellipsis", () => {
@@ -218,7 +243,7 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.6", "0.2.5", "en")
     expect(highlights).toHaveLength(1)
-    expect(highlights[0].description).toBe("Fixed update notices")
+    expect(highlights[0].description).toBe("• Fixed update notices")
   })
 
   test("returns no highlights when the body is empty or only headings", () => {
@@ -257,5 +282,27 @@ describe("loadReleaseHighlights (GitHub Releases API)", () => {
     ]
     const highlights = loadReleaseHighlights(payload, "0.2.5", "0.2.4", "zh")
     expect(highlights[0]?.title).toBe("PawWork card")
+  })
+
+  test("keeps structured highlight items as separate pages", () => {
+    const payload = [
+      {
+        tag: "v0.2.5",
+        highlights: [
+          {
+            source: "desktop",
+            items: [
+              { title: "Card A", description: "Description A" },
+              { title: "Card B", description: "Description B" },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const highlights = loadReleaseHighlights(payload, "0.2.5", "0.2.4", "en")
+
+    expect(highlights).toHaveLength(2)
+    expect(highlights.map((highlight) => highlight.title)).toEqual(["Card A", "Card B"])
   })
 })

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -100,6 +100,8 @@ type ParsedNotice =
   | {
       kind: "bullets"
       items: string[]
+      intro?: string
+      outro?: string
     }
   | {
       kind: "summary"
@@ -115,22 +117,34 @@ function parseNoticeContent(notice: string | undefined): ParsedNotice | undefine
     .filter((line) => line.length > 0 && !line.startsWith("#"))
 
   const bullets: string[] = []
+  const prose: string[] = []
   let currentBullet: string | undefined
+  let hasSeenBullet = false
+
   for (const line of lines) {
     const match = line.match(/^(?:[-*+]\s+|\d+\.\s+)(.+)$/)
     if (match) {
       if (currentBullet) bullets.push(trimNoticeItem(currentBullet))
       currentBullet = match[1].trim()
+      hasSeenBullet = true
       continue
     }
-    if (currentBullet) currentBullet += ` ${line}`
+
+    if (currentBullet) {
+      currentBullet += ` ${line}`
+    } else if (!hasSeenBullet) {
+      prose.push(line)
+    }
+    // trailing prose after last bullet is ignored (intentionally)
   }
   if (currentBullet) bullets.push(trimNoticeItem(currentBullet))
 
   if (bullets.length > 0) {
+    const intro = prose.length > 0 ? trimNoticeItem(prose.join(" ")) : undefined
     return {
       kind: "bullets",
       items: bullets,
+      ...(intro ? { intro } : {}),
     }
   }
 
@@ -153,7 +167,11 @@ function parseReleaseBodyNotice(body: string, locale: ReleaseLocale): ParsedNoti
 
 function formatReleaseNoticeDescription(notice: ParsedNotice) {
   if (notice.kind === "bullets") {
-    return notice.items.map((item) => `• ${item}`).join("\n")
+    const bullets = notice.items.map((item) => `• ${item}`).join("\n")
+    if (notice.intro) {
+      return `${notice.intro}\n${bullets}`
+    }
+    return bullets
   }
 
   return notice.text

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -9,7 +9,8 @@ import { persisted } from "@/utils/persist"
 import { DialogReleaseNotes, type Highlight } from "@/components/dialog-release-notes"
 
 const CHANGELOG_URL = "https://api.github.com/repos/Astro-Han/pawwork/releases"
-const MAX_RELEASE_HIGHLIGHTS = 5
+const MAX_RELEASE_VERSION_PAGES = 5
+const MAX_STRUCTURED_HIGHLIGHTS = 15
 
 type Store = {
   version?: string
@@ -18,6 +19,7 @@ type Store = {
 type ParsedRelease = {
   tag?: string
   highlights: Highlight[]
+  source: "release-body" | "structured"
 }
 
 type ReleaseLocale = Locale
@@ -104,7 +106,7 @@ type ParsedNotice =
       text: string
     }
 
-function parseNoticeDescriptions(notice: string | undefined): ParsedNotice | undefined {
+function parseNoticeContent(notice: string | undefined): ParsedNotice | undefined {
   if (!notice) return
 
   const lines = notice
@@ -143,10 +145,10 @@ function parseNoticeDescriptions(notice: string | undefined): ParsedNotice | und
 
 function parseReleaseBodyNotice(body: string, locale: ReleaseLocale): ParsedNotice | undefined {
   if (locale === "zh") {
-    const chinese = parseNoticeDescriptions(findChineseUpdateNotice(body))
+    const chinese = parseNoticeContent(findChineseUpdateNotice(body))
     if (chinese) return chinese
   }
-  return parseNoticeDescriptions(findAppUpdateNotice(body))
+  return parseNoticeContent(findAppUpdateNotice(body))
 }
 
 function formatReleaseNoticeDescription(notice: ParsedNotice) {
@@ -182,7 +184,7 @@ function parseRelease(value: unknown, locale: ReleaseLocale): ParsedRelease | un
       return [item]
     })
 
-    return { tag, highlights }
+    return { tag, highlights, source: "structured" }
   }
 
   const body = getText(value.body)
@@ -191,6 +193,7 @@ function parseRelease(value: unknown, locale: ReleaseLocale): ParsedRelease | un
     if (notice) {
       return {
         tag,
+        source: "release-body",
         highlights: [
           {
             title: releaseTitle(tag, locale),
@@ -201,7 +204,7 @@ function parseRelease(value: unknown, locale: ReleaseLocale): ParsedRelease | un
     }
   }
 
-  return { tag, highlights: [] }
+  return { tag, highlights: [], source: "release-body" }
 }
 
 function parseChangelog(value: unknown, locale: ReleaseLocale): ParsedRelease[] | undefined {
@@ -236,15 +239,36 @@ function sliceHighlights(input: { releases: ParsedRelease[]; current?: string; p
     return index === -1 ? releases.length : index
   })()
 
-  const highlights = releases.slice(start, end).flatMap((release) => release.highlights)
+  const selected = releases.slice(start, end)
+  const highlights: Highlight[] = []
+  let releaseBodyPages = 0
+  let structuredHighlights = 0
+
+  for (const release of selected) {
+    if (release.source === "release-body") {
+      if (release.highlights.length === 0) continue
+      if (releaseBodyPages >= MAX_RELEASE_VERSION_PAGES) continue
+
+      highlights.push(...release.highlights)
+      releaseBodyPages += 1
+      continue
+    }
+
+    const remaining = MAX_STRUCTURED_HIGHLIGHTS - structuredHighlights
+    if (remaining <= 0) continue
+
+    const next = release.highlights.slice(0, remaining)
+    highlights.push(...next)
+    structuredHighlights += next.length
+  }
+
   const seen = new Set<string>()
-  const unique = highlights.filter((highlight) => {
+  return highlights.filter((highlight) => {
     const key = dedupeKey(highlight)
     if (seen.has(key)) return false
     seen.add(key)
     return true
   })
-  return unique.slice(0, MAX_RELEASE_HIGHLIGHTS)
 }
 
 function dedupeKey(highlight: Highlight) {

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -114,7 +114,7 @@ function parseNoticeContent(notice: string | undefined): ParsedNotice | undefine
   const lines = notice
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .filter((line) => !line.startsWith("#"))
 
   const bullets: string[] = []
   const prose: string[] = []
@@ -122,6 +122,15 @@ function parseNoticeContent(notice: string | undefined): ParsedNotice | undefine
   let hasSeenBullet = false
 
   for (const line of lines) {
+    if (line.length === 0) {
+      // Empty line acts as a paragraph break: flush any active bullet
+      if (currentBullet) {
+        bullets.push(trimNoticeItem(currentBullet))
+        currentBullet = undefined
+      }
+      continue
+    }
+
     const match = line.match(/^(?:[-*+]\s+|\d+\.\s+)(.+)$/)
     if (match) {
       if (currentBullet) bullets.push(trimNoticeItem(currentBullet))
@@ -148,7 +157,7 @@ function parseNoticeContent(notice: string | undefined): ParsedNotice | undefine
     }
   }
 
-  const summary = trimNoticeItem(lines.join(" "))
+  const summary = trimNoticeItem(lines.filter((line) => line.length > 0).join(" "))
   if (!summary) return
 
   return {

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -101,7 +101,6 @@ type ParsedNotice =
       kind: "bullets"
       items: string[]
       intro?: string
-      outro?: string
     }
   | {
       kind: "summary"

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -9,7 +9,7 @@ import { persisted } from "@/utils/persist"
 import { DialogReleaseNotes, type Highlight } from "@/components/dialog-release-notes"
 
 const CHANGELOG_URL = "https://api.github.com/repos/Astro-Han/pawwork/releases"
-const MAX_RELEASE_HIGHLIGHTS = 15
+const MAX_RELEASE_HIGHLIGHTS = 5
 
 type Store = {
   version?: string
@@ -94,8 +94,18 @@ function trimNoticeItem(value: string) {
   return text.length > 200 ? text.slice(0, 200).trimEnd() + "…" : text
 }
 
-function parseNoticeDescriptions(notice: string | undefined): string[] {
-  if (!notice) return []
+type ParsedNotice =
+  | {
+      kind: "bullets"
+      items: string[]
+    }
+  | {
+      kind: "summary"
+      text: string
+    }
+
+function parseNoticeDescriptions(notice: string | undefined): ParsedNotice | undefined {
+  if (!notice) return
 
   const lines = notice
     .split(/\r?\n/)
@@ -115,18 +125,36 @@ function parseNoticeDescriptions(notice: string | undefined): string[] {
   }
   if (currentBullet) bullets.push(trimNoticeItem(currentBullet))
 
-  if (bullets.length > 0) return bullets
+  if (bullets.length > 0) {
+    return {
+      kind: "bullets",
+      items: bullets,
+    }
+  }
 
   const summary = trimNoticeItem(lines.join(" "))
-  return summary ? [summary] : []
+  if (!summary) return
+
+  return {
+    kind: "summary",
+    text: summary,
+  }
 }
 
-function parseReleaseBodyDescriptions(body: string, locale: ReleaseLocale) {
+function parseReleaseBodyNotice(body: string, locale: ReleaseLocale): ParsedNotice | undefined {
   if (locale === "zh") {
     const chinese = parseNoticeDescriptions(findChineseUpdateNotice(body))
-    if (chinese.length > 0) return chinese
+    if (chinese) return chinese
   }
   return parseNoticeDescriptions(findAppUpdateNotice(body))
+}
+
+function formatReleaseNoticeDescription(notice: ParsedNotice) {
+  if (notice.kind === "bullets") {
+    return notice.items.map((item) => `• ${item}`).join("\n")
+  }
+
+  return notice.text
 }
 
 function releaseTitle(tag: string, locale: ReleaseLocale) {
@@ -159,11 +187,16 @@ function parseRelease(value: unknown, locale: ReleaseLocale): ParsedRelease | un
 
   const body = getText(value.body)
   if (tag && body) {
-    const descriptions = parseReleaseBodyDescriptions(body, locale)
-    if (descriptions.length > 0) {
+    const notice = parseReleaseBodyNotice(body, locale)
+    if (notice) {
       return {
         tag,
-        highlights: descriptions.map((description) => ({ title: releaseTitle(tag, locale), description })),
+        highlights: [
+          {
+            title: releaseTitle(tag, locale),
+            description: formatReleaseNoticeDescription(notice),
+          },
+        ],
       }
     }
   }
@@ -218,7 +251,12 @@ function dedupeKey(highlight: Highlight) {
   return [highlight.title, highlight.description, highlight.media?.type ?? "", highlight.media?.src ?? ""].join("\n")
 }
 
-export function loadReleaseHighlights(value: unknown, current?: string, previous?: string, locale: ReleaseLocale = "en") {
+export function loadReleaseHighlights(
+  value: unknown,
+  current?: string,
+  previous?: string,
+  locale: ReleaseLocale = "en",
+) {
   const releases = parseChangelog(value, locale)
   if (!releases?.length) return []
   return sliceHighlights({ releases, current, previous })


### PR DESCRIPTION
## Summary

Fixes the release notes pagination regression where each bullet was rendered as a separate toast page. Now each release version maps to exactly one page, with all bullets merged into a scrollable description.

## Why

Issue #398: PR #372 introduced a behavior regression where `DialogReleaseNotes` paginated by individual bullet items instead of by version. A release with 7 bullets would show 7 toast pages. The intended behavior is one page per version.

## Related Issue

Closes #398

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

1. **Data boundary correctness**: `parseRelease` body path now returns exactly one `Highlight` per release version, while the structured `highlights` schema path remains unchanged with its own cap.
2. **Cap separation**: `sliceHighlights` now tracks `releaseBodyPages` and `structuredHighlights` separately. Release body is capped at 5 version pages; structured schema keeps its 15-item cap.
3. **UI scroll behavior**: The description area in `DialogReleaseNotes` is independently scrollable with `whitespace-pre-line` preserving bullet line breaks. Title and buttons stay fixed. Added `tabIndex={0}`, `role="region"`, and `aria-labelledby` for keyboard accessibility.

## Risk Notes

- Paragraph-only notices (non-bullet) remain without forced `•` prefix due to the `ParsedNotice` discriminated union.
- Very long bullet lists within a single version page are scrollable rather than paginated. This is the intended UX change.
- Structured `highlights` schema behavior is preserved; a regression test ensures 6+ items are not truncated by the 5-page release-body cap.

## How To Verify

```text
Focused tests: 22 passed, 0 failed
TypeScript typecheck: passed
```

From repo root:
```bash
bun --cwd packages/app test --preload ./happydom.ts ./src/context/highlights.test.ts
bun --cwd packages/app typecheck
```

## Manual UI Check

- Simulated one release with 6 bullets.
- Confirmed all bullets render on one page with `•` prefix and line breaks.
- Confirmed long description scrolls independently while title/buttons stay fixed.
- Confirmed no per-bullet pagination dots are created.
- Confirmed description region is keyboard-focusable.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [ ] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Release notes dialog redesigned with improved scrolling behavior and layout organization; added accessibility enhancements

* **Refactor**
  * Enhanced release highlights parsing and formatting for improved presentation of bullet points and sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->