### PR TITLE
perf(app): stabilize long session timelines

### DIFF
--- a/packages/app/src/context/global-sdk-event-queue.test.ts
+++ b/packages/app/src/context/global-sdk-event-queue.test.ts
@@ -1,0 +1,73 @@
+import type { Event, SessionStatus } from "@opencode-ai/sdk/v2/client"
+import { describe, expect, test } from "bun:test"
+import { coalesceQueuedEvents, type QueuedGlobalEvent } from "./global-sdk-event-queue"
+
+const directory = "/repo"
+
+const delta = (partID: string, value: string, messageID = "msg_1"): Event => ({
+  type: "message.part.delta",
+  properties: { sessionID: "ses_1", messageID, partID, field: "text", delta: value },
+})
+
+const updated = (partID: string, messageID = "msg_1"): Event =>
+  ({
+    type: "message.part.updated",
+    properties: {
+      sessionID: "ses_1",
+      time: 1,
+      part: { id: partID, sessionID: "ses_1", messageID, type: "text", text: "full" },
+    },
+  }) as Event
+
+const status = (sessionID = "ses_1", type: "busy" | "idle" | "retry" = "busy"): Event => ({
+  type: "session.status",
+  properties: {
+    sessionID,
+    status: type === "retry" ? ({ type, attempt: 1, message: "retry", next: 1 } satisfies SessionStatus) : { type },
+  },
+})
+
+const queued = (...events: Event[]): QueuedGlobalEvent[] => events.map((payload) => ({ directory, payload }))
+const eventTypes = (events: QueuedGlobalEvent[]) => events.map((event) => event.payload.type)
+const deltas = (events: QueuedGlobalEvent[]) =>
+  events
+    .filter((event) => event.payload.type === "message.part.delta")
+    .map((event) => (event.payload as Extract<Event, { type: "message.part.delta" }>).properties.delta)
+
+describe("global SDK event queue coalescing", () => {
+  test("combines only contiguous deltas for the same part", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "a"), delta("prt_1", "b")))
+
+    expect(events).toHaveLength(1)
+    expect(deltas(events)).toEqual(["ab"])
+  })
+
+  test("does not merge same-part deltas across another part delta", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "a"), delta("prt_2", "x"), delta("prt_1", "b")))
+
+    expect(deltas(events)).toEqual(["a", "x", "b"])
+  })
+
+  test("does not merge deltas across non-delta barriers", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "a"), status(), delta("prt_1", "b")))
+
+    expect(eventTypes(events)).toEqual(["message.part.delta", "session.status", "message.part.delta"])
+    expect(deltas(events)).toEqual(["a", "b"])
+  })
+
+  test("drops stale deltas before a full part update but keeps later deltas", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "stale"), updated("prt_1"), delta("prt_1", "fresh")))
+
+    expect(eventTypes(events)).toEqual(["message.part.updated", "message.part.delta"])
+    expect(deltas(events)).toEqual(["fresh"])
+  })
+
+  test("keeps replaceable event indexes correct after stale delta removal", () => {
+    const events = coalesceQueuedEvents(
+      queued(delta("prt_1", "stale"), status("ses_1", "busy"), updated("prt_1"), status("ses_1", "idle")),
+    )
+
+    expect(eventTypes(events)).toEqual(["session.status", "message.part.updated"])
+    expect(events[0].payload).toEqual(status("ses_1", "idle"))
+  })
+})

--- a/packages/app/src/context/global-sdk-event-queue.test.ts
+++ b/packages/app/src/context/global-sdk-event-queue.test.ts
@@ -109,4 +109,14 @@ describe("global SDK event queue coalescing", () => {
     expect(deltas(events)).toEqual([])
     expect(events.map((event) => event.directory)).toEqual(["/repo-a", "/repo-b"])
   })
+
+  test("does not collide composite keys when directories contain separators", () => {
+    const events = coalesceQueuedEvents([
+      ...queuedIn("/repo:msg_1", delta("prt_1", "a", "prt_2")),
+      ...queuedIn("/repo", delta("msg_1:prt_1", "b", "prt_2")),
+    ])
+
+    expect(deltas(events)).toEqual(["a", "b"])
+    expect(events.map((event) => event.directory)).toEqual(["/repo:msg_1", "/repo"])
+  })
 })

--- a/packages/app/src/context/global-sdk-event-queue.test.ts
+++ b/packages/app/src/context/global-sdk-event-queue.test.ts
@@ -4,9 +4,9 @@ import { coalesceQueuedEvents, type QueuedGlobalEvent } from "./global-sdk-event
 
 const directory = "/repo"
 
-const delta = (partID: string, value: string, messageID = "msg_1"): Event => ({
+const delta = (partID: string, value: string, messageID = "msg_1", field = "text"): Event => ({
   type: "message.part.delta",
-  properties: { sessionID: "ses_1", messageID, partID, field: "text", delta: value },
+  properties: { sessionID: "ses_1", messageID, partID, field, delta: value },
 })
 
 const updated = (partID: string, messageID = "msg_1"): Event =>
@@ -57,11 +57,33 @@ describe("global SDK event queue coalescing", () => {
     expect(deltas(events)).toEqual(["a", "b"])
   })
 
+  test("does not merge same-part deltas for different fields", () => {
+    const events = coalesceQueuedEvents(
+      queued(delta("prt_1", "a", "msg_1", "text"), delta("prt_1", "b", "msg_1", "metadata")),
+    )
+
+    expect(deltas(events)).toEqual(["a", "b"])
+  })
+
   test("drops stale deltas before a full part update but keeps later deltas", () => {
     const events = coalesceQueuedEvents(queued(delta("prt_1", "stale"), updated("prt_1"), delta("prt_1", "fresh")))
 
     expect(eventTypes(events)).toEqual(["message.part.updated", "message.part.delta"])
     expect(deltas(events)).toEqual(["fresh"])
+  })
+
+  test("keeps only the full update and later delta for delta-update-delta ordering", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "before"), updated("prt_1"), delta("prt_1", "after")))
+
+    expect(eventTypes(events)).toEqual(["message.part.updated", "message.part.delta"])
+    expect(deltas(events)).toEqual(["after"])
+  })
+
+  test("handles multiple full updates for the same part without resurrecting stale deltas", () => {
+    const events = coalesceQueuedEvents(queued(delta("prt_1", "stale"), updated("prt_1"), updated("prt_1")))
+
+    expect(eventTypes(events)).toEqual(["message.part.updated", "message.part.updated"])
+    expect(deltas(events)).toEqual([])
   })
 
   test("keeps replaceable event indexes correct after stale delta removal", () => {

--- a/packages/app/src/context/global-sdk-event-queue.test.ts
+++ b/packages/app/src/context/global-sdk-event-queue.test.ts
@@ -28,6 +28,8 @@ const status = (sessionID = "ses_1", type: "busy" | "idle" | "retry" = "busy"): 
 })
 
 const queued = (...events: Event[]): QueuedGlobalEvent[] => events.map((payload) => ({ directory, payload }))
+const queuedIn = (directory: string, ...events: Event[]): QueuedGlobalEvent[] =>
+  events.map((payload) => ({ directory, payload }))
 const eventTypes = (events: QueuedGlobalEvent[]) => events.map((event) => event.payload.type)
 const deltas = (events: QueuedGlobalEvent[]) =>
   events
@@ -69,5 +71,20 @@ describe("global SDK event queue coalescing", () => {
 
     expect(eventTypes(events)).toEqual(["session.status", "message.part.updated"])
     expect(events[0].payload).toEqual(status("ses_1", "idle"))
+  })
+
+  test("keeps delta merging and stale pruning isolated by directory", () => {
+    const events = coalesceQueuedEvents([
+      ...queuedIn("/repo-a", delta("prt_1", "a")),
+      ...queuedIn("/repo-b", delta("prt_1", "b")),
+      ...queuedIn("/repo-a", delta("prt_1", "c")),
+      ...queuedIn("/repo-a", updated("prt_1")),
+      ...queuedIn("/repo-b", delta("prt_1", "d")),
+      ...queuedIn("/repo-b", updated("prt_1")),
+    ])
+
+    expect(eventTypes(events)).toEqual(["message.part.updated", "message.part.updated"])
+    expect(deltas(events)).toEqual([])
+    expect(events.map((event) => event.directory)).toEqual(["/repo-a", "/repo-b"])
   })
 })

--- a/packages/app/src/context/global-sdk-event-queue.ts
+++ b/packages/app/src/context/global-sdk-event-queue.ts
@@ -40,14 +40,21 @@ const appendDelta = (event: QueuedGlobalEvent, delta: string): QueuedGlobalEvent
 }
 
 export function coalesceQueuedEvents(events: QueuedGlobalEvent[]): QueuedGlobalEvent[] {
-  const result: QueuedGlobalEvent[] = []
+  const result: (QueuedGlobalEvent | undefined)[] = []
   const replaceable = new Map<string, number>()
-  const rebuildReplaceable = () => {
-    replaceable.clear()
-    for (const [index, event] of result.entries()) {
-      const key = replaceableKey(event)
-      if (key) replaceable.set(key, index)
+  const deltaIndexesByPart = new Map<string, Set<number>>()
+  const pushEvent = (event: QueuedGlobalEvent) => {
+    const index = result.length
+    result.push(event)
+
+    const key = partKey(event)
+    if (event.payload.type === "message.part.delta" && key) {
+      const indexes = deltaIndexesByPart.get(key) ?? new Set<number>()
+      indexes.add(index)
+      deltaIndexesByPart.set(key, indexes)
     }
+
+    return index
   }
 
   for (const event of events) {
@@ -58,19 +65,19 @@ export function coalesceQueuedEvents(events: QueuedGlobalEvent[]): QueuedGlobalE
         result[index] = event
         continue
       }
-      replaceable.set(replaceKey, result.length)
-      result.push(event)
+      replaceable.set(replaceKey, pushEvent(event))
       continue
     }
 
     if (event.payload.type === "message.part.updated") {
       const updatedKey = partKey(event)
-      for (let index = result.length - 1; index >= 0; index--) {
-        if (partKey(result[index]) !== updatedKey) continue
-        if (result[index].payload.type === "message.part.delta") result.splice(index, 1)
+      if (updatedKey) {
+        for (const index of deltaIndexesByPart.get(updatedKey) ?? []) {
+          result[index] = undefined
+        }
+        deltaIndexesByPart.delete(updatedKey)
       }
-      rebuildReplaceable()
-      result.push(event)
+      pushEvent(event)
       continue
     }
 
@@ -82,8 +89,8 @@ export function coalesceQueuedEvents(events: QueuedGlobalEvent[]): QueuedGlobalE
       }
     }
 
-    result.push(event)
+    pushEvent(event)
   }
 
-  return result
+  return result.filter((event): event is QueuedGlobalEvent => event !== undefined)
 }

--- a/packages/app/src/context/global-sdk-event-queue.ts
+++ b/packages/app/src/context/global-sdk-event-queue.ts
@@ -1,0 +1,89 @@
+import type { Event } from "@opencode-ai/sdk/v2/client"
+
+export type QueuedGlobalEvent = { directory: string; payload: Event }
+
+const deltaKey = (event: QueuedGlobalEvent) => {
+  if (event.payload.type !== "message.part.delta") return
+  const props = event.payload.properties
+  return `${event.directory}:${props.messageID}:${props.partID}:${props.field}`
+}
+
+const partKey = (event: QueuedGlobalEvent) => {
+  if (event.payload.type === "message.part.delta") {
+    const props = event.payload.properties
+    return `${event.directory}:${props.messageID}:${props.partID}`
+  }
+  if (event.payload.type === "message.part.updated") {
+    const part = event.payload.properties.part
+    return `${event.directory}:${part.messageID}:${part.id}`
+  }
+}
+
+const replaceableKey = (event: QueuedGlobalEvent) => {
+  if (event.payload.type === "session.status")
+    return `session.status:${event.directory}:${event.payload.properties.sessionID}`
+  if (event.payload.type === "lsp.updated") return `lsp.updated:${event.directory}`
+}
+
+const appendDelta = (event: QueuedGlobalEvent, delta: string): QueuedGlobalEvent => {
+  if (event.payload.type !== "message.part.delta") return event
+  return {
+    ...event,
+    payload: {
+      ...event.payload,
+      properties: {
+        ...event.payload.properties,
+        delta: event.payload.properties.delta + delta,
+      },
+    },
+  }
+}
+
+export function coalesceQueuedEvents(events: QueuedGlobalEvent[]): QueuedGlobalEvent[] {
+  const result: QueuedGlobalEvent[] = []
+  const replaceable = new Map<string, number>()
+  const rebuildReplaceable = () => {
+    replaceable.clear()
+    for (const [index, event] of result.entries()) {
+      const key = replaceableKey(event)
+      if (key) replaceable.set(key, index)
+    }
+  }
+
+  for (const event of events) {
+    const replaceKey = replaceableKey(event)
+    if (replaceKey) {
+      const index = replaceable.get(replaceKey)
+      if (index !== undefined) {
+        result[index] = event
+        continue
+      }
+      replaceable.set(replaceKey, result.length)
+      result.push(event)
+      continue
+    }
+
+    if (event.payload.type === "message.part.updated") {
+      const updatedKey = partKey(event)
+      for (let index = result.length - 1; index >= 0; index--) {
+        if (partKey(result[index]) !== updatedKey) continue
+        if (result[index].payload.type === "message.part.delta") result.splice(index, 1)
+      }
+      rebuildReplaceable()
+      result.push(event)
+      continue
+    }
+
+    if (event.payload.type === "message.part.delta") {
+      const last = result[result.length - 1]
+      if (last?.payload.type === "message.part.delta" && deltaKey(last) === deltaKey(event)) {
+        result[result.length - 1] = appendDelta(last, event.payload.properties.delta)
+        continue
+      }
+    }
+
+    result.push(event)
+  }
+
+  return result
+}

--- a/packages/app/src/context/global-sdk-event-queue.ts
+++ b/packages/app/src/context/global-sdk-event-queue.ts
@@ -5,24 +5,24 @@ export type QueuedGlobalEvent = { directory: string; payload: Event }
 const deltaKey = (event: QueuedGlobalEvent) => {
   if (event.payload.type !== "message.part.delta") return
   const props = event.payload.properties
-  return `${event.directory}:${props.messageID}:${props.partID}:${props.field}`
+  return JSON.stringify([event.directory, props.messageID, props.partID, props.field])
 }
 
 const partKey = (event: QueuedGlobalEvent) => {
   if (event.payload.type === "message.part.delta") {
     const props = event.payload.properties
-    return `${event.directory}:${props.messageID}:${props.partID}`
+    return JSON.stringify([event.directory, props.messageID, props.partID])
   }
   if (event.payload.type === "message.part.updated") {
     const part = event.payload.properties.part
-    return `${event.directory}:${part.messageID}:${part.id}`
+    return JSON.stringify([event.directory, part.messageID, part.id])
   }
 }
 
 const replaceableKey = (event: QueuedGlobalEvent) => {
   if (event.payload.type === "session.status")
-    return `session.status:${event.directory}:${event.payload.properties.sessionID}`
-  if (event.payload.type === "lsp.updated") return `lsp.updated:${event.directory}`
+    return JSON.stringify(["session.status", event.directory, event.payload.properties.sessionID])
+  if (event.payload.type === "lsp.updated") return JSON.stringify(["lsp.updated", event.directory])
 }
 
 const appendDelta = (event: QueuedGlobalEvent, delta: string): QueuedGlobalEvent => {

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -5,6 +5,7 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 import { batch, onCleanup, onMount } from "solid-js"
 import z from "zod"
 import { createSdkForServer } from "@/utils/server"
+import { coalesceQueuedEvents, type QueuedGlobalEvent } from "./global-sdk-event-queue"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
@@ -44,28 +45,14 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       [key: string]: Event
     }>()
 
-    type Queued = { directory: string; payload: Event }
     const FLUSH_FRAME_MS = 16
     const STREAM_YIELD_MS = 8
     const RECONNECT_DELAY_MS = 250
 
-    let queue: Queued[] = []
-    let buffer: Queued[] = []
-    const coalesced = new Map<string, number>()
-    const staleDeltas = new Set<string>()
+    let queue: QueuedGlobalEvent[] = []
+    let buffer: QueuedGlobalEvent[] = []
     let timer: ReturnType<typeof setTimeout> | undefined
     let last = 0
-
-    const deltaKey = (directory: string, messageID: string, partID: string) => `${directory}:${messageID}:${partID}`
-
-    const key = (directory: string, payload: Event) => {
-      if (payload.type === "session.status") return `session.status:${directory}:${payload.properties.sessionID}`
-      if (payload.type === "lsp.updated") return `lsp.updated:${directory}`
-      if (payload.type === "message.part.updated") {
-        const part = payload.properties.part
-        return `message.part.updated:${directory}:${part.messageID}:${part.id}`
-      }
-    }
 
     const flush = () => {
       if (timer) clearTimeout(timer)
@@ -73,21 +60,14 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
 
       if (queue.length === 0) return
 
-      const events = queue
-      const skip = staleDeltas.size > 0 ? new Set(staleDeltas) : undefined
+      const events = coalesceQueuedEvents(queue)
       queue = buffer
       buffer = events
       queue.length = 0
-      coalesced.clear()
-      staleDeltas.clear()
 
       last = Date.now()
       batch(() => {
         for (const event of events) {
-          if (skip && event.payload.type === "message.part.delta") {
-            const props = event.payload.properties
-            if (skip.has(deltaKey(event.directory, props.messageID, props.partID))) continue
-          }
           emitter.emit(event.directory, event.payload)
         }
       })
@@ -159,19 +139,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
               const payload = event.payload as Event | { type: "sync" }
               if (payload.type === "sync") {
                 continue
-              }
-              const k = key(directory, payload)
-              if (k) {
-                const i = coalesced.get(k)
-                if (i !== undefined) {
-                  queue[i] = { directory, payload }
-                  if (payload.type === "message.part.updated") {
-                    const part = payload.properties.part
-                    staleDeltas.add(deltaKey(directory, part.messageID, part.id))
-                  }
-                  continue
-                }
-                coalesced.set(k, queue.length)
               }
               queue.push({ directory, payload })
               schedule()

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -14,3 +14,19 @@ describe("messageIdFromHash", () => {
     expect(messageIdFromHash("#review-panel")).toBeUndefined()
   })
 })
+
+describe("useSessionHashScroll", () => {
+  test("clearing a message hash notifies the timeline to leave hash history mode", async () => {
+    const source = await Bun.file(new URL("./use-session-hash-scroll.ts", import.meta.url)).text()
+
+    expect(source).toContain("onMessageHashCleared")
+    expect(source).toContain("input.onMessageHashCleared?.()")
+  })
+
+  test("timeline wires hash clearing to guarded latest-window recovery", async () => {
+    const source = await Bun.file(new URL("./use-session-timeline-interaction.ts", import.meta.url)).text()
+
+    expect(source).toContain("onMessageHashCleared")
+    expect(source).toContain("historyWindow.returnToLatestIfFollowing()")
+  })
+})

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -27,6 +27,6 @@ describe("useSessionHashScroll", () => {
     const source = await Bun.file(new URL("./use-session-timeline-interaction.ts", import.meta.url)).text()
 
     expect(source).toContain("onMessageHashCleared")
-    expect(source).toContain("historyWindow.returnToLatestIfFollowing()")
+    expect(source).toContain("historyWindow.clearHashTarget()")
   })
 })

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -16,7 +16,7 @@ export const useSessionHashScroll = (input: {
   pendingMessage: () => string | undefined
   setPendingMessage: (value: string | undefined) => void
   setActiveMessage: (message: UserMessage | undefined) => void
-  setTurnStart: (value: number) => void
+  markHashTarget: (index: number) => void
   autoScroll: { pause: () => void; forceScrollToBottom: () => void }
   scroller: () => HTMLDivElement | undefined
   anchor: (id: string) => string
@@ -91,9 +91,8 @@ export const useSessionHashScroll = (input: {
     if (input.currentMessageId() !== message.id) input.setActiveMessage(message)
 
     const index = messageIndex().get(message.id) ?? -1
+    if (index !== -1) input.markHashTarget(index)
     if (index !== -1 && index < input.turnStart()) {
-      input.setTurnStart(index)
-
       queue(() => {
         seek(message.id, behavior)
       })

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -22,6 +22,7 @@ export const useSessionHashScroll = (input: {
   anchor: (id: string) => string
   scheduleScrollState: (el: HTMLDivElement) => void
   consumePendingMessage: (key: string) => string | undefined
+  onMessageHashCleared?: () => void
 }) => {
   const visibleUserMessages = createMemo(() => input.visibleUserMessages())
   const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
@@ -52,6 +53,7 @@ export const useSessionHashScroll = (input: {
     if (!location.hash) return
     clearingHash = location.hash
     navigate(location.pathname + location.search, { replace: true })
+    input.onMessageHashCleared?.()
   }
 
   const updateHash = (id: string) => {

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -1,6 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { createRoot, createSignal } from "solid-js"
+import { createRoot } from "solid-js"
 import { createSessionHistoryWindow, resolveHistoryTurnStart } from "./use-session-history-window"
 
 const userMessage = (id: number) =>
@@ -14,24 +14,28 @@ const userMessages = (count: number) => Array.from({ length: count }, (_, index)
 const ids = (start: number, end: number) => Array.from({ length: end - start }, (_, index) => `msg_${start + index}`)
 
 const createHarness = (input: { count: number; userScrolled?: boolean }) => {
-  const [messages, setMessages] = createSignal(userMessages(input.count))
-  const [userScrolled, setUserScrolled] = createSignal(input.userScrolled ?? false)
+  let messages = userMessages(input.count)
+  let userScrolled = input.userScrolled ?? false
   const history = createSessionHistoryWindow({
     sessionID: () => "ses_1",
     messagesReady: () => true,
-    loaded: () => messages().length,
-    visibleUserMessages: messages,
+    loaded: () => messages.length,
+    visibleUserMessages: () => messages,
     historyMore: () => false,
     historyLoading: () => false,
     loadMore: async () => undefined,
-    userScrolled,
+    userScrolled: () => userScrolled,
     scroller: () => undefined,
   })
 
   return {
     history,
-    setCount: (count: number) => setMessages(userMessages(count)),
-    setUserScrolled,
+    setCount: (count: number) => {
+      messages = userMessages(count)
+    },
+    setUserScrolled: (value: boolean) => {
+      userScrolled = value
+    },
   }
 }
 
@@ -119,6 +123,42 @@ describe("session history window extraction", () => {
       expect(state.history.mode()).toBe("bottom")
       expect(state.history.turnStart()).toBe(20)
       expect(state.history.renderedUserMessages().map((message) => message.id)).toEqual(ids(20, 30))
+      dispose()
+    })
+  })
+
+  test("manual scroll back to bottom returns to bottom mode and bounds later appends", () => {
+    createRoot((dispose) => {
+      const state = createHarness({ count: 30 })
+
+      state.history.expandForReading(0)
+      expect(state.history.mode()).toBe("reading")
+
+      state.setUserScrolled(false)
+      state.history.returnToLatestIfFollowing()
+      state.setCount(40)
+      state.history.returnToLatestIfFollowing()
+
+      expect(state.history.mode()).toBe("bottom")
+      expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 20, length: 40, userScrolled: false })).toBe(30)
+      dispose()
+    })
+  })
+
+  test("cleared hash target returns to bottom mode before later appends", () => {
+    createRoot((dispose) => {
+      const state = createHarness({ count: 30 })
+
+      state.history.markHashTarget(12)
+      expect(state.history.mode()).toBe("hash")
+
+      state.setUserScrolled(false)
+      state.history.returnToLatestIfFollowing()
+      state.setCount(40)
+      state.history.returnToLatestIfFollowing()
+
+      expect(state.history.mode()).toBe("bottom")
+      expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 20, length: 40, userScrolled: false })).toBe(30)
       dispose()
     })
   })

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -1,7 +1,7 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { createRoot } from "solid-js"
-import { createSessionHistoryWindow } from "./use-session-history-window"
+import { createRoot, createSignal } from "solid-js"
+import { createSessionHistoryWindow, resolveHistoryTurnStart } from "./use-session-history-window"
 
 const userMessage = (id: number) =>
   ({
@@ -9,6 +9,31 @@ const userMessage = (id: number) =>
     role: "user",
     time: { created: Date.now() },
   }) as UserMessage
+
+const userMessages = (count: number) => Array.from({ length: count }, (_, index) => userMessage(index))
+const ids = (start: number, end: number) => Array.from({ length: end - start }, (_, index) => `msg_${start + index}`)
+
+const createHarness = (input: { count: number; userScrolled?: boolean }) => {
+  const [messages, setMessages] = createSignal(userMessages(input.count))
+  const [userScrolled, setUserScrolled] = createSignal(input.userScrolled ?? false)
+  const history = createSessionHistoryWindow({
+    sessionID: () => "ses_1",
+    messagesReady: () => true,
+    loaded: () => messages().length,
+    visibleUserMessages: messages,
+    historyMore: () => false,
+    historyLoading: () => false,
+    loadMore: async () => undefined,
+    userScrolled,
+    scroller: () => undefined,
+  })
+
+  return {
+    history,
+    setCount: (count: number) => setMessages(userMessages(count)),
+    setUserScrolled,
+  }
+}
 
 describe("session history window extraction", () => {
   test("renders only the last ten messages for long sessions", () => {
@@ -50,9 +75,50 @@ describe("session history window extraction", () => {
       })
 
       expect(history.turnStart()).toBe(0)
-      expect(history.renderedUserMessages().map((message) => message.id)).toEqual(
-        messages.map((message) => message.id),
-      )
+      expect(history.renderedUserMessages().map((message) => message.id)).toEqual(messages.map((message) => message.id))
+      dispose()
+    })
+  })
+
+  test("bottom mode keeps same-session rendered turns bounded as new turns append", () => {
+    expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 0, length: 25, userScrolled: false })).toBe(15)
+  })
+
+  test("reading mode does not slide the window when the user scrolls upward inside the rendered range", () => {
+    expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 15, length: 26, userScrolled: true })).toBe(15)
+  })
+
+  test("expanded history stays expanded when new turns append", () => {
+    expect(resolveHistoryTurnStart({ mode: "reading", storedTurnStart: 0, length: 26, userScrolled: false })).toBe(0)
+  })
+
+  test("hash mode keeps the target rendered across appends", () => {
+    expect(resolveHistoryTurnStart({ mode: "hash", storedTurnStart: 4, length: 31, userScrolled: false })).toBe(4)
+  })
+
+  test("hash mode is entered even when the target is already inside the rendered bottom window", () => {
+    createRoot((dispose) => {
+      const state = createHarness({ count: 30 })
+
+      state.history.markHashTarget(24)
+      state.setCount(40)
+
+      expect(state.history.mode()).toBe("hash")
+      expect(state.history.renderedUserMessages().map((message) => message.id)).toContain("msg_24")
+      dispose()
+    })
+  })
+
+  test("jump to latest returns to bottom mode and latest bounded window", () => {
+    createRoot((dispose) => {
+      const state = createHarness({ count: 30 })
+
+      state.history.expandForReading(0)
+      state.history.resumeLatestWindow()
+
+      expect(state.history.mode()).toBe("bottom")
+      expect(state.history.turnStart()).toBe(20)
+      expect(state.history.renderedUserMessages().map((message) => message.id)).toEqual(ids(20, 30))
       dispose()
     })
   })

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -1,7 +1,11 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionHistoryWindow, resolveHistoryTurnStart } from "./use-session-history-window"
+import {
+  createSessionHistoryWindow,
+  resolveClearedHashTarget,
+  resolveHistoryTurnStart,
+} from "./use-session-history-window"
 
 const userMessage = (id: number) =>
   ({
@@ -203,13 +207,27 @@ describe("session history window extraction", () => {
       expect(state.history.mode()).toBe("hash")
 
       state.setUserScrolled(false)
-      state.history.returnToLatestIfFollowing()
+      state.history.clearHashTarget()
       state.setCount(40)
       state.history.returnToLatestIfFollowing()
 
       expect(state.history.mode()).toBe("bottom")
       expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 20, length: 40, userScrolled: false })).toBe(30)
       dispose()
+    })
+  })
+
+  test("cleared hash target away from bottom becomes reading without losing the current window", () => {
+    expect(resolveClearedHashTarget({ atBottom: false, currentTurnStart: 12, length: 40 })).toEqual({
+      mode: "reading",
+      turnStart: 12,
+    })
+  })
+
+  test("cleared hash target at bottom returns to the latest bounded window", () => {
+    expect(resolveClearedHashTarget({ atBottom: true, currentTurnStart: 12, length: 40 })).toEqual({
+      mode: "bottom",
+      turnStart: 30,
     })
   })
 })

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -88,7 +88,7 @@ describe("session history window extraction", () => {
     expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 0, length: 25, userScrolled: false })).toBe(15)
   })
 
-  test("reading mode does not slide the window when the user scrolls upward inside the rendered range", () => {
+  test("bottom mode preserves storedTurnStart when user has scrolled inside rendered range", () => {
     expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 15, length: 26, userScrolled: true })).toBe(15)
   })
 

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -1,6 +1,7 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
 import { createSessionHistoryWindow, resolveHistoryTurnStart } from "./use-session-history-window"
 
 const userMessage = (id: number) =>
@@ -14,27 +15,29 @@ const userMessages = (count: number) => Array.from({ length: count }, (_, index)
 const ids = (start: number, end: number) => Array.from({ length: end - start }, (_, index) => `msg_${start + index}`)
 
 const createHarness = (input: { count: number; userScrolled?: boolean }) => {
-  let messages = userMessages(input.count)
-  let userScrolled = input.userScrolled ?? false
+  const [state, setState] = createStore({
+    messages: userMessages(input.count),
+    userScrolled: input.userScrolled ?? false,
+  })
   const history = createSessionHistoryWindow({
     sessionID: () => "ses_1",
     messagesReady: () => true,
-    loaded: () => messages.length,
-    visibleUserMessages: () => messages,
+    loaded: () => state.messages.length,
+    visibleUserMessages: () => state.messages,
     historyMore: () => false,
     historyLoading: () => false,
     loadMore: async () => undefined,
-    userScrolled: () => userScrolled,
+    userScrolled: () => state.userScrolled,
     scroller: () => undefined,
   })
 
   return {
     history,
     setCount: (count: number) => {
-      messages = userMessages(count)
+      setState("messages", userMessages(count))
     },
     setUserScrolled: (value: boolean) => {
-      userScrolled = value
+      setState("userScrolled", value)
     },
   }
 }

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -1,7 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { createRoot } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createRoot, createSignal } from "solid-js"
 import { createSessionHistoryWindow, resolveHistoryTurnStart } from "./use-session-history-window"
 
 const userMessage = (id: number) =>
@@ -14,30 +13,36 @@ const userMessage = (id: number) =>
 const userMessages = (count: number) => Array.from({ length: count }, (_, index) => userMessage(index))
 const ids = (start: number, end: number) => Array.from({ length: end - start }, (_, index) => `msg_${start + index}`)
 
-const createHarness = (input: { count: number; userScrolled?: boolean }) => {
-  const [state, setState] = createStore({
-    messages: userMessages(input.count),
+const createHarness = (input: { count: number; userScrolled?: boolean; atBottom?: boolean; historyMore?: boolean }) => {
+  const [state, setState] = createSignal({
+    count: input.count,
     userScrolled: input.userScrolled ?? false,
+    atBottom: input.atBottom ?? !(input.userScrolled ?? false),
+    historyMore: input.historyMore ?? false,
   })
   const history = createSessionHistoryWindow({
     sessionID: () => "ses_1",
     messagesReady: () => true,
-    loaded: () => state.messages.length,
-    visibleUserMessages: () => state.messages,
-    historyMore: () => false,
+    loaded: () => state().count,
+    visibleUserMessages: () => userMessages(state().count),
+    historyMore: () => state().historyMore,
     historyLoading: () => false,
     loadMore: async () => undefined,
-    userScrolled: () => state.userScrolled,
+    userScrolled: () => state().userScrolled,
+    isAtBottom: () => state().atBottom,
     scroller: () => undefined,
   })
 
   return {
     history,
     setCount: (count: number) => {
-      setState("messages", userMessages(count))
+      setState((prev) => ({ ...prev, count }))
     },
     setUserScrolled: (value: boolean) => {
-      setState("userScrolled", value)
+      setState((prev) => ({ ...prev, userScrolled: value }))
+    },
+    setAtBottom: (value: boolean) => {
+      setState((prev) => ({ ...prev, atBottom: value }))
     },
   }
 }
@@ -55,6 +60,7 @@ describe("session history window extraction", () => {
         historyLoading: () => false,
         loadMore: async () => undefined,
         userScrolled: () => false,
+        isAtBottom: () => true,
         scroller: () => undefined,
       })
 
@@ -78,6 +84,7 @@ describe("session history window extraction", () => {
         historyLoading: () => false,
         loadMore: async () => undefined,
         userScrolled: () => false,
+        isAtBottom: () => true,
         scroller: () => undefined,
       })
 
@@ -145,6 +152,46 @@ describe("session history window extraction", () => {
       expect(state.history.mode()).toBe("bottom")
       expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 20, length: 40, userScrolled: false })).toBe(30)
       dispose()
+    })
+  })
+
+  test("reading mode returns to latest only when the viewport is actually at bottom", () => {
+    createRoot((dispose) => {
+      const state = createHarness({ count: 30, userScrolled: true, atBottom: false })
+
+      state.history.expandForReading(0)
+      state.setUserScrolled(false)
+      state.setAtBottom(false)
+      state.history.returnToLatestIfFollowing()
+
+      expect(state.history.mode()).toBe("reading")
+
+      state.setAtBottom(true)
+      state.setCount(40)
+      state.history.returnToLatestIfFollowing()
+
+      expect(state.history.mode()).toBe("bottom")
+      expect(resolveHistoryTurnStart({ mode: "bottom", storedTurnStart: 20, length: 40, userScrolled: false })).toBe(30)
+      dispose()
+    })
+  })
+
+  test("loadAndReveal does not collapse reading window before the viewport is at bottom", async () => {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const state = createHarness({ count: 30, userScrolled: false, atBottom: false, historyMore: true })
+
+        void state.history.loadAndReveal().then(() => {
+          state.setCount(40)
+
+          expect(state.history.mode()).toBe("reading")
+          expect(
+            resolveHistoryTurnStart({ mode: "reading", storedTurnStart: 0, length: 40, userScrolled: false }),
+          ).toBe(0)
+          dispose()
+          resolve()
+        })
+      })
     })
   })
 

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -91,6 +91,10 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   }
   const resumeLatestWindow = () =>
     setTurnStart(initialTurnStart(input.visibleUserMessages().length), { mode: "bottom" })
+  const returnToLatestIfFollowing = () => {
+    if (input.userScrolled()) return
+    resumeLatestWindow()
+  }
   const mode = () => state.mode
 
   const renderedUserMessages = createMemo(
@@ -273,8 +277,11 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
           setState("mode", "reading")
           return
         }
-        if (state.mode !== "bottom") return
-        setTurnStart(initialTurnStart(len), { mode: "bottom" })
+        if (!userScrolled && state.mode !== "bottom") {
+          returnToLatestIfFollowing()
+          return
+        }
+        returnToLatestIfFollowing()
       },
       { defer: true },
     ),
@@ -287,6 +294,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     expandForHash,
     markHashTarget,
     resumeLatestWindow,
+    returnToLatestIfFollowing,
     mode,
     renderedUserMessages,
     loadAndReveal,

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -38,6 +38,22 @@ export function resolveHistoryTurnStart(input: {
   return input.storedTurnStart
 }
 
+export function resolveClearedHashTarget(input: {
+  atBottom: boolean
+  currentTurnStart: number
+  length: number
+  initialWindow?: number
+}) {
+  const initialWindow = input.initialWindow ?? 10
+  if (input.atBottom) {
+    return {
+      mode: "bottom" as HistoryWindowMode,
+      turnStart: input.length > initialWindow ? input.length - initialWindow : 0,
+    }
+  }
+  return { mode: "reading" as HistoryWindowMode, turnStart: input.currentTurnStart > 0 ? input.currentTurnStart : 0 }
+}
+
 /**
  * Maintains the rendered history window for a session timeline.
  *
@@ -61,6 +77,8 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   })
 
   const initialTurnStart = (len: number) => (len > turnInit ? len - turnInit : 0)
+  let latestTurnID: string | undefined
+  let latestTurnStart = 0
 
   const turnStart = createMemo(() => {
     const id = input.sessionID()
@@ -81,9 +99,13 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     const next = start > 0 ? start : 0
     const mode = opts?.mode ?? state.mode
     if (!id) {
+      latestTurnID = undefined
+      latestTurnStart = next
       setState({ turnID: undefined, turnStart: next, mode })
       return
     }
+    latestTurnID = id
+    latestTurnStart = next
     setState({ turnID: id, turnStart: next, mode })
   }
 
@@ -98,6 +120,15 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   const returnToLatestIfFollowing = () => {
     if (!input.isAtBottom()) return
     resumeLatestWindow()
+  }
+  const clearHashTarget = () => {
+    const next = resolveClearedHashTarget({
+      atBottom: input.isAtBottom(),
+      currentTurnStart: latestTurnID === input.sessionID() ? latestTurnStart : turnStart(),
+      length: input.visibleUserMessages().length,
+      initialWindow: turnInit,
+    })
+    setTurnStart(next.turnStart, { mode: next.mode })
   }
   const mode = () => state.mode
 
@@ -306,6 +337,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     markHashTarget,
     resumeLatestWindow,
     returnToLatestIfFollowing,
+    clearHashTarget,
     mode,
     renderedUserMessages,
     loadAndReveal,

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -13,6 +13,7 @@ export type SessionHistoryWindowInput = {
   historyLoading: () => boolean
   loadMore: (sessionID: string) => Promise<void>
   userScrolled: () => boolean
+  isAtBottom: () => boolean
   scroller: () => HTMLDivElement | undefined
 }
 
@@ -28,7 +29,10 @@ export function resolveHistoryTurnStart(input: {
   const initialWindow = input.initialWindow ?? 10
   const initial = input.length > initialWindow ? input.length - initialWindow : 0
   if (input.length <= 0) return 0
+  // bottom follows the newest turns unless the user has moved away from the latest viewport.
   if (input.mode === "bottom") return input.userScrolled ? Math.min(input.storedTurnStart, initial) : initial
+  // reading keeps the user's current window stable while new turns append.
+  // hash uses the same stable-window behavior so the target message stays mounted.
   if (input.storedTurnStart <= 0) return 0
   if (input.storedTurnStart >= input.length) return initial
   return input.storedTurnStart
@@ -92,7 +96,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   const resumeLatestWindow = () =>
     setTurnStart(initialTurnStart(input.visibleUserMessages().length), { mode: "bottom" })
   const returnToLatestIfFollowing = () => {
-    if (input.userScrolled()) return
+    if (!input.isAtBottom()) return
     resumeLatestWindow()
   }
   const mode = () => state.mode
@@ -270,7 +274,13 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   createEffect(
     on(
       () =>
-        [input.sessionID(), input.messagesReady(), input.visibleUserMessages().length, input.userScrolled()] as const,
+        [
+          input.sessionID(),
+          input.messagesReady(),
+          input.visibleUserMessages().length,
+          input.userScrolled(),
+          input.isAtBottom(),
+        ] as const,
       ([id, ready, len, userScrolled]) => {
         if (!id || !ready) return
         if (userScrolled && state.mode === "bottom") {

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -277,10 +277,11 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
           setState("mode", "reading")
           return
         }
-        if (!userScrolled && state.mode !== "bottom") {
+        if (!userScrolled && state.mode === "reading") {
           returnToLatestIfFollowing()
           return
         }
+        if (state.mode === "hash") return
         returnToLatestIfFollowing()
       },
       { defer: true },

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -16,6 +16,24 @@ export type SessionHistoryWindowInput = {
   scroller: () => HTMLDivElement | undefined
 }
 
+type HistoryWindowMode = "bottom" | "reading" | "hash"
+
+export function resolveHistoryTurnStart(input: {
+  mode: HistoryWindowMode
+  storedTurnStart: number
+  length: number
+  userScrolled: boolean
+  initialWindow?: number
+}) {
+  const initialWindow = input.initialWindow ?? 10
+  const initial = input.length > initialWindow ? input.length - initialWindow : 0
+  if (input.length <= 0) return 0
+  if (input.mode === "bottom") return input.userScrolled ? Math.min(input.storedTurnStart, initial) : initial
+  if (input.storedTurnStart <= 0) return 0
+  if (input.storedTurnStart >= input.length) return initial
+  return input.storedTurnStart
+}
+
 /**
  * Maintains the rendered history window for a session timeline.
  *
@@ -35,6 +53,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     turnStart: 0,
     prefetchUntil: 0,
     prefetchNoGrowth: 0,
+    mode: "bottom" as HistoryWindowMode,
   })
 
   const initialTurnStart = (len: number) => (len > turnInit ? len - turnInit : 0)
@@ -44,20 +63,35 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     const len = input.visibleUserMessages().length
     if (!id || len <= 0) return 0
     if (state.turnID !== id) return initialTurnStart(len)
-    if (state.turnStart <= 0) return 0
-    if (state.turnStart >= len) return initialTurnStart(len)
-    return state.turnStart
+    return resolveHistoryTurnStart({
+      mode: state.mode,
+      storedTurnStart: state.turnStart,
+      length: len,
+      userScrolled: input.userScrolled(),
+      initialWindow: turnInit,
+    })
   })
 
-  const setTurnStart = (start: number) => {
+  const setTurnStart = (start: number, opts?: { mode?: HistoryWindowMode }) => {
     const id = input.sessionID()
     const next = start > 0 ? start : 0
+    const mode = opts?.mode ?? state.mode
     if (!id) {
-      setState({ turnID: undefined, turnStart: next })
+      setState({ turnID: undefined, turnStart: next, mode })
       return
     }
-    setState({ turnID: id, turnStart: next })
+    setState({ turnID: id, turnStart: next, mode })
   }
+
+  const expandForReading = (start: number) => setTurnStart(start, { mode: "reading" })
+  const expandForHash = (start: number) => setTurnStart(start, { mode: "hash" })
+  const markHashTarget = (index: number) => {
+    const current = turnStart()
+    expandForHash(index < current ? index : current)
+  }
+  const resumeLatestWindow = () =>
+    setTurnStart(initialTurnStart(input.visibleUserMessages().length), { mode: "bottom" })
+  const mode = () => state.mode
 
   const renderedUserMessages = createMemo(
     () => {
@@ -95,7 +129,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     const next = start - turnBatch
     const nextStart = next > 0 ? next : 0
 
-    preserveScroll(() => setTurnStart(nextStart))
+    preserveScroll(() => expandForReading(nextStart))
   }
 
   /** Button path: reveal all cached turns, fetch older history, reveal one batch. */
@@ -107,7 +141,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     const beforeVisible = input.visibleUserMessages().length
     let loaded = input.loaded()
 
-    if (start > 0) setTurnStart(0)
+    if (start > 0) expandForReading(0)
 
     if (!input.historyMore() || input.historyLoading()) return
 
@@ -137,7 +171,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     if (turnStart() !== 0) return
 
     const target = Math.min(afterVisible, beforeVisible + turnBatch)
-    setTurnStart(Math.max(0, afterVisible - target))
+    expandForReading(Math.max(0, afterVisible - target))
   }
 
   /** Scroll/prefetch path: fetch older history from server. */
@@ -189,7 +223,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
 
     if (opts?.prefetch) {
       const current = turnStart()
-      preserveScroll(() => setTurnStart(current + growth))
+      preserveScroll(() => expandForReading(current + growth))
       return
     }
 
@@ -198,7 +232,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     const currentRendered = renderedUserMessages().length
     const base = Math.max(beforeRendered, currentRendered)
     const target = Math.min(afterVisible, base + turnBatch)
-    preserveScroll(() => setTurnStart(Math.max(0, afterVisible - target)))
+    preserveScroll(() => expandForReading(Math.max(0, afterVisible - target)))
   }
 
   const onScrollerScroll = () => {
@@ -223,7 +257,7 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     on(
       input.sessionID,
       () => {
-        setState({ prefetchUntil: 0, prefetchNoGrowth: 0 })
+        setState({ prefetchUntil: 0, prefetchNoGrowth: 0, mode: "bottom" })
       },
       { defer: true },
     ),
@@ -231,10 +265,16 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
 
   createEffect(
     on(
-      () => [input.sessionID(), input.messagesReady()] as const,
-      ([id, ready]) => {
+      () =>
+        [input.sessionID(), input.messagesReady(), input.visibleUserMessages().length, input.userScrolled()] as const,
+      ([id, ready, len, userScrolled]) => {
         if (!id || !ready) return
-        setTurnStart(initialTurnStart(input.visibleUserMessages().length))
+        if (userScrolled && state.mode === "bottom") {
+          setState("mode", "reading")
+          return
+        }
+        if (state.mode !== "bottom") return
+        setTurnStart(initialTurnStart(len), { mode: "bottom" })
       },
       { defer: true },
     ),
@@ -243,6 +283,11 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
   return {
     turnStart,
     setTurnStart,
+    expandForReading,
+    expandForHash,
+    markHashTarget,
+    resumeLatestWindow,
+    mode,
     renderedUserMessages,
     loadAndReveal,
     onScrollerScroll,

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -66,6 +66,11 @@ export function createSessionTimelineInteraction(input: {
     scroller: scrollDock.scroller,
   })
 
+  const resumeLatest = () => {
+    historyWindow.resumeLatestWindow()
+    resumeScroll()
+  }
+
   historyBackfill = createSessionHistoryBackfill({
     routeSessionID: input.routeSessionID,
     sessionID: input.sessionID,
@@ -91,7 +96,7 @@ export function createSessionTimelineInteraction(input: {
     pendingMessage: activeMessage.pendingMessage,
     setPendingMessage: activeMessage.setPendingMessage,
     setActiveMessage: activeMessage.setActiveMessage,
-    setTurnStart: historyWindow.setTurnStart,
+    markHashTarget: historyWindow.markHashTarget,
     autoScroll,
     scroller: scrollDock.scroller,
     anchor,
@@ -106,7 +111,7 @@ export function createSessionTimelineInteraction(input: {
     autoScroll,
     anchor,
     historyWindow,
-    resumeScroll,
+    resumeScroll: resumeLatest,
     scheduleScrollState: scrollDock.scheduleScrollState,
     scrollDock,
     setScrollRef: scrollDock.setScrollRef,

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -103,6 +103,7 @@ export function createSessionTimelineInteraction(input: {
     anchor,
     scheduleScrollState: scrollDock.scheduleScrollState,
     consumePendingMessage: input.consumePendingMessage,
+    onMessageHashCleared: () => historyWindow.returnToLatestIfFollowing(),
   })
   clearMessageHash = hashScroll.clearMessageHash
   activeMessage.setScrollToMessage(hashScroll.scrollToMessage)

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -63,6 +63,7 @@ export function createSessionTimelineInteraction(input: {
     historyLoading: input.historyLoading,
     loadMore: input.loadMore,
     userScrolled: autoScroll.userScrolled,
+    isAtBottom: () => scrollDock.scroll.bottom,
     scroller: scrollDock.scroller,
   })
 

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -103,7 +103,7 @@ export function createSessionTimelineInteraction(input: {
     anchor,
     scheduleScrollState: scrollDock.scheduleScrollState,
     consumePendingMessage: input.consumePendingMessage,
-    onMessageHashCleared: () => historyWindow.returnToLatestIfFollowing(),
+    onMessageHashCleared: () => historyWindow.clearHashTarget(),
   })
   clearMessageHash = hashScroll.clearMessageHash
   activeMessage.setScrollToMessage(hashScroll.scrollToMessage)


### PR DESCRIPTION
## Summary

- Keep long session timelines bounded around the latest turns while preserving reading and hash-target modes.
- Restore bottom history mode when the user manually returns to the bottom, so later appends stay bounded without requiring the jump-to-latest button.
- Coalesce contiguous streaming `message.part.delta` events safely before emitting them to the renderer.
- Add focused tests for history window behavior and event queue ordering barriers.

## Why

Long-running sessions could accumulate too many rendered turns during streaming, making the timeline more likely to flicker, jump, or become expensive to update.

## Related Issue

Part of #397. This PR covers the first-stage bounded rendering and safe delta coalescing work; broader follow-ups such as turn normalization, Markdown pacing, and true virtualization should stay in #397 or separate follow-up issues.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff, verification evidence, and CI.

## Review Focus

- History window mode transitions: bottom-follow, reading older content, hash target, manual return-to-bottom, and jump-to-latest.
- Event queue semantics: only contiguous same-key deltas are merged; non-delta events and other part deltas remain ordering barriers.
- Confirm no generated files or local docs are included.

## Risk Notes

Medium: this changes session timeline rendering behavior and global event flush preparation. The changes are intentionally scoped and covered by focused unit tests, but reviewers should pay close attention to scroll restoration and stream ordering.

## How To Verify

```text
Focused tests: bun --cwd packages/app test:unit src/context/global-sdk-event-queue.test.ts src/context/global-sync/event-reducer.test.ts → 735 pass, 0 fail
Focused tests: bun --cwd packages/app test:unit src/pages/session/use-session-history-window.test.ts src/pages/session/use-session-hash-scroll.test.ts → 737 pass, 0 fail
Typecheck: bun --cwd packages/app typecheck → tsgo -b completed successfully
Manual long-session check: isolated Electron profile with 2 longest sessions, max 347 messages / 1295 parts → scroll up, jump to latest, and session switching behaved normally
Manual multi-session check: isolated Electron profile with 30 sessions, 5260 messages, 18888 parts → sidebar scrolling and switching behaved normally; diagnostics did not show runaway jank or memory
```

## Screenshots or Recordings

Manual screenshots were captured locally from the isolated Electron run. No permanent artifact is attached because this is a performance/behavior fix rather than a visual design change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Maintainer labeling requested: please add type `perf`, scope `app`, and priority `P2` if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session history modes: bottom, reading, and hash; mark and clear hash targets and improved resume-latest behavior.

* **Refactor**
  * Centralized background event coalescing to reduce redundant message-part updates and ensure directory-scoped isolation.
  * History/window logic refactored for mode-aware scrolling, stable expansion, and resume behavior.

* **Tests**
  * Added comprehensive tests for event coalescing and history-window interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->