### PR TITLE
fix(app): harden session delete menu

### DIFF
--- a/packages/app/src/components/dialog-delete-session.test.ts
+++ b/packages/app/src/components/dialog-delete-session.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const source = readFileSync(new URL("./dialog-delete-session.tsx", import.meta.url), "utf8")
+
+describe("DialogDeleteSession source contract", () => {
+  test("does not depend on SyncProvider context", () => {
+    expect(source).not.toContain("@/context/sync")
+    expect(source).not.toContain("useSync(")
+    expect(source).not.toContain("@/context/sdk")
+    expect(source).not.toContain("useSDK(")
+  })
+
+  test("receives the session name from its caller", () => {
+    expect(source).toContain("name: string")
+    expect(source).toContain("props.name")
+  })
+})

--- a/packages/app/src/components/dialog-delete-session.tsx
+++ b/packages/app/src/components/dialog-delete-session.tsx
@@ -1,23 +1,16 @@
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { createMemo, createSignal } from "solid-js"
+import { createSignal } from "solid-js"
 import { useLanguage } from "@/context/language"
-import { useSync } from "@/context/sync"
-import { sessionTitle } from "@/utils/session-title"
 
 export function DialogDeleteSession(props: {
-  sessionID: string
+  name: string
   onConfirm: () => Promise<void> | void
 }) {
-  const sync = useSync()
   const language = useLanguage()
   const dialog = useDialog()
   const [deleting, setDeleting] = createSignal(false)
-
-  const name = createMemo(
-    () => sessionTitle(sync.session.get(props.sessionID)?.title) ?? language.t("command.session.new"),
-  )
 
   const handleDelete = async () => {
     if (deleting()) return
@@ -35,7 +28,7 @@ export function DialogDeleteSession(props: {
       <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
         <div class="flex flex-col gap-1">
           <span class="text-13-regular text-text-strong">
-            {language.t("session.delete.confirm", { name: name() })}
+            {language.t("session.delete.confirm", { name: props.name })}
           </span>
         </div>
         <div class="flex justify-end gap-2">

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -93,6 +93,7 @@ import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sid
 import { PawworkTitlebar } from "./layout/pawwork-titlebar"
 import { SettingsPage, type SettingsPageTab } from "@/components/settings-page"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
+import { sessionTitle } from "@/utils/session-title"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -1097,7 +1098,9 @@ export default function Layout(props: ParentProps) {
     })
   }
 
-  async function deleteSession(session: Session) {
+  type SessionDeleteTarget = Pick<Session, "id" | "directory">
+
+  async function deleteSession(session: SessionDeleteTarget) {
     const [store, setStore] = globalSync.child(session.directory)
     const sessions = (store.session ?? []).filter((s) => !s.parentID && !s.time?.archived)
     const index = sessions.findIndex((s) => s.id === session.id)
@@ -1112,10 +1115,10 @@ export default function Layout(props: ParentProps) {
           description: errorMessage(err, language.t("common.requestFailed")),
           variant: "error",
         })
-        return false
+        return undefined
       })
 
-    if (!result) return false
+    if (!result) return
 
     setStore(
       produce((draft) => {
@@ -1151,12 +1154,13 @@ export default function Layout(props: ParentProps) {
     if (session.id === params.id) {
       navigate(nextSession ? `/${params.dir}/session/${nextSession.id}` : `/${params.dir}/session`)
     }
-    return true
   }
 
   function confirmDeleteSession(session: Session) {
+    const target: SessionDeleteTarget = { id: session.id, directory: session.directory }
+    const name = sessionTitle(session.title) ?? language.t("command.session.new")
     dialog.show(() => (
-      <DialogDeleteSession sessionID={session.id} onConfirm={() => void deleteSession(session)} />
+      <DialogDeleteSession name={name} onConfirm={() => deleteSession(target)} />
     ))
   }
 

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "@/context/language"
 import { getRelativeTime } from "@/utils/time"
 import { createInlineEditorController } from "./inline-editor"
 import { buildPawworkSessionSections, type PawworkSortMode } from "./pawwork-session-nav"
+import { buildSessionMenuActions, type SessionMenuAction } from "./session-menu-actions"
 import { SessionItem } from "./sidebar-items"
 import "./sidebar.css"
 
@@ -96,8 +97,56 @@ export const PawworkSidebar = (props: {
   const renderSessionItem = (entry: { item: PawworkSidebarSession }) => {
     const session = entry.item.session
     const isPinned = createMemo(() => props.pinnedIDs().includes(session.id))
-    const pinLabel = () =>
-      isPinned() ? language.t("sidebar.pawwork.unpinSession") : language.t("sidebar.pawwork.pinSession")
+    const menuLabels = () => ({
+      pin: language.t("sidebar.pawwork.pinSession"),
+      unpin: language.t("sidebar.pawwork.unpinSession"),
+      rename: language.t("common.rename"),
+      export: language.t("session.export.action.export"),
+      delete: language.t("common.delete"),
+    })
+    const menuActions = (target: Session, onRenameSession: (session: Session) => void) =>
+      buildSessionMenuActions({
+        session: target,
+        pinned: props.pinnedIDs().includes(target.id),
+        exportAvailable: props.exportSessionAvailable(),
+        labels: menuLabels(),
+        onTogglePinnedSession: props.onTogglePinnedSession,
+        onRenameSession,
+        onExportSession: props.onExportSession,
+        onDeleteSession: props.onDeleteSession,
+      })
+    const renderDropdownActions = (actions: SessionMenuAction[]) => (
+      <>
+        <For each={actions}>
+          {(action) => (
+            <>
+              <Show when={action.separatorBefore}>
+                <DropdownMenu.Separator />
+              </Show>
+              <DropdownMenu.Item onSelect={() => void action.run()}>
+                <DropdownMenu.ItemLabel>{action.label}</DropdownMenu.ItemLabel>
+              </DropdownMenu.Item>
+            </>
+          )}
+        </For>
+      </>
+    )
+    const renderContextActions = (actions: SessionMenuAction[]) => (
+      <>
+        <For each={actions}>
+          {(action) => (
+            <>
+              <Show when={action.separatorBefore}>
+                <ContextMenu.Separator />
+              </Show>
+              <ContextMenu.Item onSelect={() => void action.run()}>
+                <ContextMenu.ItemLabel>{action.label}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+            </>
+          )}
+        </For>
+      </>
+    )
 
     return (
       <ContextMenu>
@@ -152,27 +201,11 @@ export const PawworkSidebar = (props: {
                       })
                     }}
                   >
-                    <DropdownMenu.Item onSelect={() => props.onTogglePinnedSession(rowSession.id)}>
-                      <DropdownMenu.ItemLabel>{pinLabel()}</DropdownMenu.ItemLabel>
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      onSelect={() => {
+                    {renderDropdownActions(
+                      menuActions(rowSession, () => {
                         setPendingRenameID(rowSession.id)
-                      }}
-                    >
-                      <DropdownMenu.ItemLabel>{language.t("common.rename")}</DropdownMenu.ItemLabel>
-                    </DropdownMenu.Item>
-                    <Show when={props.exportSessionAvailable()}>
-                      <DropdownMenu.Item onSelect={() => void props.onExportSession(rowSession)}>
-                        <DropdownMenu.ItemLabel>
-                          {language.t("session.export.action.export")}
-                        </DropdownMenu.ItemLabel>
-                      </DropdownMenu.Item>
-                    </Show>
-                    <DropdownMenu.Separator />
-                    <DropdownMenu.Item onSelect={() => props.onDeleteSession(rowSession)}>
-                      <DropdownMenu.ItemLabel>{language.t("common.delete")}</DropdownMenu.ItemLabel>
-                    </DropdownMenu.Item>
+                      }),
+                    )}
                   </DropdownMenu.Content>
                 </DropdownMenu.Portal>
               </DropdownMenu>
@@ -181,25 +214,11 @@ export const PawworkSidebar = (props: {
         </ContextMenu.Trigger>
         <ContextMenu.Portal>
           <ContextMenu.Content>
-            <ContextMenu.Item onSelect={() => props.onTogglePinnedSession(session.id)}>
-              <ContextMenu.ItemLabel>{pinLabel()}</ContextMenu.ItemLabel>
-            </ContextMenu.Item>
-            <ContextMenu.Item
-              onSelect={() => {
+            {renderContextActions(
+              menuActions(session, () => {
                 editor.openEditor(`pawwork-session:${session.id}`, session.title ?? "")
-              }}
-            >
-              <ContextMenu.ItemLabel>{language.t("common.rename")}</ContextMenu.ItemLabel>
-            </ContextMenu.Item>
-            <Show when={props.exportSessionAvailable()}>
-              <ContextMenu.Item onSelect={() => void props.onExportSession(session)}>
-                <ContextMenu.ItemLabel>{language.t("session.export.action.export")}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-            </Show>
-            <ContextMenu.Separator />
-            <ContextMenu.Item onSelect={() => props.onDeleteSession(session)}>
-              <ContextMenu.ItemLabel>{language.t("common.delete")}</ContextMenu.ItemLabel>
-            </ContextMenu.Item>
+              }),
+            )}
           </ContextMenu.Content>
         </ContextMenu.Portal>
       </ContextMenu>

--- a/packages/app/src/pages/layout/session-menu-actions.test.ts
+++ b/packages/app/src/pages/layout/session-menu-actions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { buildSessionMenuActions } from "./session-menu-actions"
+
+const session = { id: "ses_123", title: "Bug hunt", directory: "/repo" } as Session
+
+const labels = {
+  pin: "Pin",
+  unpin: "Unpin",
+  rename: "Rename",
+  export: "Export",
+  delete: "Delete",
+}
+
+describe("buildSessionMenuActions", () => {
+  test("builds the shared visible action order for session menus", () => {
+    const actions = buildSessionMenuActions({
+      session,
+      pinned: false,
+      exportAvailable: true,
+      labels,
+      onTogglePinnedSession: () => undefined,
+      onRenameSession: () => undefined,
+      onExportSession: () => undefined,
+      onDeleteSession: () => undefined,
+    })
+
+    expect(actions.map((action) => action.id)).toEqual(["pin", "rename", "export", "delete"])
+    expect(actions.map((action) => action.label)).toEqual(["Pin", "Rename", "Export", "Delete"])
+    expect(actions.find((action) => action.id === "delete")?.separatorBefore).toBe(true)
+  })
+
+  test("uses unpin label for pinned sessions and omits export when unavailable", () => {
+    const actions = buildSessionMenuActions({
+      session,
+      pinned: true,
+      exportAvailable: false,
+      labels,
+      onTogglePinnedSession: () => undefined,
+      onRenameSession: () => undefined,
+      onExportSession: () => undefined,
+      onDeleteSession: () => undefined,
+    })
+
+    expect(actions.map((action) => [action.id, action.label])).toEqual([
+      ["pin", "Unpin"],
+      ["rename", "Rename"],
+      ["delete", "Delete"],
+    ])
+  })
+
+  test("binds each action to the target session", () => {
+    const calls: string[] = []
+    const actions = buildSessionMenuActions({
+      session,
+      pinned: false,
+      exportAvailable: true,
+      labels,
+      onTogglePinnedSession: (sessionID) => calls.push(`pin:${sessionID}`),
+      onRenameSession: (item) => {
+        calls.push(`rename:${item.id}`)
+      },
+      onExportSession: (item) => {
+        calls.push(`export:${item.id}`)
+      },
+      onDeleteSession: (item) => calls.push(`delete:${item.id}`),
+    })
+
+    for (const action of actions) void action.run()
+
+    expect(calls).toEqual(["pin:ses_123", "rename:ses_123", "export:ses_123", "delete:ses_123"])
+  })
+})

--- a/packages/app/src/pages/layout/session-menu-actions.ts
+++ b/packages/app/src/pages/layout/session-menu-actions.ts
@@ -1,0 +1,57 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+export type SessionMenuActionID = "pin" | "rename" | "export" | "delete"
+
+export type SessionMenuAction = {
+  id: SessionMenuActionID
+  label: string
+  separatorBefore?: boolean
+  run: () => Promise<void> | void
+}
+
+export function buildSessionMenuActions(input: {
+  session: Session
+  pinned: boolean
+  exportAvailable: boolean
+  labels: {
+    pin: string
+    unpin: string
+    rename: string
+    export: string
+    delete: string
+  }
+  onTogglePinnedSession: (sessionID: string) => void
+  onRenameSession: (session: Session) => Promise<void> | void
+  onExportSession: (session: Session) => Promise<void> | void
+  onDeleteSession: (session: Session) => void
+}): SessionMenuAction[] {
+  const actions: SessionMenuAction[] = [
+    {
+      id: "pin",
+      label: input.pinned ? input.labels.unpin : input.labels.pin,
+      run: () => input.onTogglePinnedSession(input.session.id),
+    },
+    {
+      id: "rename",
+      label: input.labels.rename,
+      run: () => input.onRenameSession(input.session),
+    },
+  ]
+
+  if (input.exportAvailable) {
+    actions.push({
+      id: "export",
+      label: input.labels.export,
+      run: () => input.onExportSession(input.session),
+    })
+  }
+
+  actions.push({
+    id: "delete",
+    label: input.labels.delete,
+    separatorBefore: true,
+    run: () => input.onDeleteSession(input.session),
+  })
+
+  return actions
+}


### PR DESCRIPTION
## Summary

Fixes the sidebar session delete crash and tightens the session menu architecture. The delete confirmation dialog no longer depends on directory-scoped sync context, and the sidebar dropdown plus right-click menu now share one canonical session action list.

## Why

Right-clicking a session and choosing Delete could throw `Sync context must be used within a context provider`. The delete dialog was rendered through the root dialog stack, outside the directory-scoped `SyncProvider`, while the extracted dialog still called `useSync()`.

The fix keeps the dialog dumb and moves session-name resolution back to the layout controller. It also avoids another one-off menu patch by centralizing Pin/Rename/Export/Delete action ordering and visibility in `session-menu-actions.ts`.

## Related Issue

No GitHub issue. Reported directly from the current PawWork session.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm `DialogDeleteSession` stays free of directory-scoped context such as `useSync()` or `useSDK()`.
- Confirm dropdown and right-click session menus consume the same `buildSessionMenuActions` contract.
- Confirm the delete flow still resolves the correct session title before opening the confirmation dialog.

## Risk Notes

Low. The change is limited to sidebar session menu wiring and the delete confirmation dialog boundary. No persistence, backend, packaging, dependency, or migration changes.

## How To Verify

```text
Focused tests: 5 passed for session menu action contract and delete dialog context boundary
Typecheck: packages/app tsgo -b passed
Diff check: no whitespace errors
Fresh review: independent reviewer found no Critical or Important issues; minor test hardening was applied
```

## Screenshots or Recordings

Not required. This keeps the visible menu behavior unchanged and fixes the action architecture/crash path.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated sidebar session menu handling with a shared action builder for consistent ordering, labels, and conditional export availability
  * Simplified session deletion dialog to accept a session name directly and adjusted deletion flow to use a narrowed delete target

* **Tests**
  * Added tests for session menu action generation and a contract test for the delete-dialog component
<!-- end of auto-generated comment: release notes by coderabbit.ai -->