### PR TITLE
feat(session): gate repeated successful tool calls

### DIFF
--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -558,8 +558,8 @@ export namespace SessionDiagnostics {
       const s = state.signatures[sigKey]
       if (!s) continue
       if (s.completedCount >= LOOP_THRESHOLDS.reminderAt && s.recoverEmitted) {
-        const nextOccurrenceCount = s.completedCount + 1
-        if (nextOccurrenceCount >= LOOP_THRESHOLDS.stopAt && (state.autoResumeSpent || s.blockEmitted)) {
+        const nextOccurrenceCount = s.completedCount + (s.blockEmitted ? 2 : 1)
+        if (nextOccurrenceCount >= LOOP_THRESHOLDS.stopAt && state.autoResumeSpent) {
           return {
             action: "stop",
             sigKey,
@@ -585,6 +585,14 @@ export namespace SessionDiagnostics {
     }
 
     return { action: "observe" }
+  }
+
+  export function chooseGateDecision(failureDecision: GateDecision, successDecision: GateDecision): GateDecision {
+    if (failureDecision.action === "stop") return failureDecision
+    if (successDecision.action === "stop") return successDecision
+    if (failureDecision.action === "block") return failureDecision
+    if (successDecision.action === "block") return successDecision
+    return failureDecision
   }
 
   export function mergeMetadata<T extends Record<string, any> | undefined>(current: T, update: Metadata): NonNullable<T> & Metadata {

--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -18,11 +18,19 @@ export namespace SessionDiagnostics {
   }
 
   export type SignatureKind = "input" | "target"
+  export type LoopOutcome = "success" | "failure"
   export type LoopAction = "observe" | "block" | "stop"
+  export const LOOP_THRESHOLDS = {
+    reminderAt: 3,
+    blockAt: 4,
+    stopAt: 5,
+  } as const
 
   export type SignatureState = {
+    outcome: LoopOutcome
     kind: SignatureKind
-    completedFailures: number
+    completedCount: number
+    completedFailures?: number
     recoverEmitted: boolean
     blockEmitted: boolean
     lastInput?: unknown
@@ -36,8 +44,24 @@ export namespace SessionDiagnostics {
 
   export type GateDecision =
     | { action: "observe" }
-    | { action: "block"; sigKey: string; kind: SignatureKind; completedFailures: number }
-    | { action: "stop"; sigKey: string; kind: SignatureKind; completedFailures: number }
+    | {
+        action: "block"
+        sigKey: string
+        outcome: LoopOutcome
+        kind: SignatureKind
+        completedCount: number
+        completedFailures?: number
+        nextOccurrenceCount: number
+      }
+    | {
+        action: "stop"
+        sigKey: string
+        outcome: LoopOutcome
+        kind: SignatureKind
+        completedCount: number
+        completedFailures?: number
+        nextOccurrenceCount: number
+      }
 
   export type LoopMetadata = {
     inputHash?: string
@@ -48,6 +72,7 @@ export namespace SessionDiagnostics {
     newTarget?: boolean
     errorFingerprint?: string
     errorRepeatCount?: number
+    outcome?: LoopOutcome
     reminders?: Reminder[]
     modelID?: string
     providerID?: string
@@ -60,12 +85,14 @@ export namespace SessionDiagnostics {
     truncated?: boolean
     loopAction?: LoopAction
     loopType?: SignatureKind
+    loopCompletedCount?: number
     loopCompletedFailures?: number
     loopSigKey?: string
     loopRecoverFiredFor?: string[]
     targetHashIsFallback?: boolean
     loopLastInput?: unknown
     loopLastError?: unknown
+    stepIndex?: number
   }
 
   export type Metadata = {
@@ -97,6 +124,15 @@ export namespace SessionDiagnostics {
 
   export function hash(value: string) {
     return createHash("sha256").update(value).digest("hex").slice(0, 16)
+  }
+
+  export function signatureKey(input: {
+    outcome: LoopOutcome
+    kind: SignatureKind
+    tool: string
+    hash: string
+  }) {
+    return `${input.outcome}:${input.kind}:${input.tool}:${input.hash}`
   }
 
   const RENDERER_BYTE_LIMIT = 1024
@@ -185,13 +221,41 @@ export namespace SessionDiagnostics {
     const summaryResult = targetSummary(input.tool, input.input)
     const summary = summaryResult.summary
     const targetHash = hash(summary)
+    const successfulRecords = input.records.filter((record) => {
+      const loop = record.metadata.diagnostics?.loop
+      return loop?.outcome !== "failure" && !loop?.errorFingerprint && !loop?.loopAction
+    })
     const inputRepeatCount =
-      input.records.filter((record) => record.parentID === input.parentID && record.tool === input.tool && record.inputHash === normalized.hash).length + 1
+      successfulRecords.filter((record) => record.parentID === input.parentID && record.tool === input.tool && record.inputHash === normalized.hash).length + 1
     const targetRepeatCount =
-      input.records.filter(
+      successfulRecords.filter(
         (record) =>
           record.parentID === input.parentID && record.tool === input.tool && record.targetHash === targetHash,
       ).length + 1
+    const newReminders: Reminder[] = []
+    const recoverFiredFor: string[] = []
+    const inputSigKey = signatureKey({ outcome: "success", kind: "input", tool: input.tool, hash: normalized.hash })
+    if (inputRepeatCount === LOOP_THRESHOLDS.reminderAt) {
+      newReminders.push({
+        key: inputSigKey,
+        type: "input_repeat",
+        status: "pending",
+        count: inputRepeatCount,
+        createdAt: Date.now(),
+      })
+      recoverFiredFor.push(inputSigKey)
+    }
+    if (!summaryResult.isFallback && targetRepeatCount === LOOP_THRESHOLDS.reminderAt) {
+      const targetSigKey = signatureKey({ outcome: "success", kind: "target", tool: input.tool, hash: targetHash })
+      newReminders.push({
+        key: targetSigKey,
+        type: "target_repeat",
+        status: "pending",
+        count: targetRepeatCount,
+        createdAt: Date.now(),
+      })
+      recoverFiredFor.push(targetSigKey)
+    }
 
     const record: ToolCallRecord = {
       sessionID: input.sessionID,
@@ -209,7 +273,9 @@ export namespace SessionDiagnostics {
             targetHashIsFallback: summaryResult.isFallback,
             targetRepeatCount,
             newTarget: targetRepeatCount === 1,
-            reminders: [],
+            outcome: "success",
+            reminders: newReminders,
+            loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
             modelID: input.modelID,
             providerID: input.providerID,
             agent: input.agent,
@@ -274,6 +340,7 @@ export namespace SessionDiagnostics {
           diagnostics: {
             loop: {
               errorFingerprint: fingerprint,
+              outcome: "failure",
               reminders: [],
               loopLastInput: lastInput,
               loopLastError: lastError,
@@ -298,14 +365,14 @@ export namespace SessionDiagnostics {
       matcher: (r: ToolErrorRecord) => boolean
     }> = []
     candidates.push({
-      sigKey: `input:${input.tool}:${effectiveInputHash}`,
+      sigKey: signatureKey({ outcome: "failure", kind: "input", tool: input.tool, hash: effectiveInputHash }),
       kind: "input",
       matcher: (r) => r.inputHash === effectiveInputHash,
     })
     if (effectiveTargetHash) {
       const targetHash = effectiveTargetHash
       candidates.push({
-        sigKey: `target:${input.tool}:${targetHash}`,
+        sigKey: signatureKey({ outcome: "failure", kind: "target", tool: input.tool, hash: targetHash }),
         kind: "target",
         matcher: (r) => r.targetHash === targetHash,
       })
@@ -313,12 +380,14 @@ export namespace SessionDiagnostics {
 
     const newReminders: Reminder[] = []
     const recoverFiredFor: string[] = []
+    let maxCompletedFailures = 0
     for (const { sigKey, kind, matcher } of candidates) {
       const completedFailures = real.filter(matcher).length + 1
+      maxCompletedFailures = Math.max(maxCompletedFailures, completedFailures)
       const alreadyFired = real.some((r) =>
         (r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? []).includes(sigKey),
       )
-      if (completedFailures >= 3 && !alreadyFired) {
+      if (completedFailures === LOOP_THRESHOLDS.reminderAt && !alreadyFired) {
         newReminders.push({
           key: sigKey,
           type: kind === "target" ? "target_repeat" : "input_repeat",
@@ -345,8 +414,10 @@ export namespace SessionDiagnostics {
       metadata: {
         diagnostics: {
           loop: {
+            outcome: "failure",
             errorFingerprint: fingerprint,
             errorRepeatCount,
+            loopCompletedCount: maxCompletedFailures,
             reminders: newReminders,
             loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
             loopLastInput: lastInput,
@@ -359,23 +430,67 @@ export namespace SessionDiagnostics {
   }
 
   export function deriveParentLoopState(input: {
+    successRecords?: ToolCallRecord[]
     errorRecords: ToolErrorRecord[]
     syntheticBlockSigKeys: string[]
     parentID: MessageID
+    currentStepIndex?: number
   }): ParentLoopState {
     const signatures: Record<string, SignatureState> = {}
+
+    const isFromPreviousStep = (record: { metadata: Metadata }) => {
+      if (input.currentStepIndex === undefined) return true
+      const stepIndex = record.metadata.diagnostics?.loop?.stepIndex
+      return typeof stepIndex === "number" && stepIndex < input.currentStepIndex
+    }
+
+    const successes = (input.successRecords ?? []).filter(
+      (r) =>
+        r.parentID === input.parentID &&
+        r.metadata.diagnostics?.loop?.loopAction !== "block" &&
+        r.metadata.diagnostics?.loop?.loopAction !== "stop" &&
+        r.inputHash !== "" &&
+        isFromPreviousStep(r),
+    )
+
+    for (const r of successes) {
+      const loop = r.metadata.diagnostics?.loop
+      const inputSigKey = r.inputHash
+        ? signatureKey({ outcome: "success", kind: "input", tool: r.tool, hash: r.inputHash })
+        : null
+      const targetSigKey = r.targetHash && !loop?.targetHashIsFallback
+        ? signatureKey({ outcome: "success", kind: "target", tool: r.tool, hash: r.targetHash })
+        : null
+      const fired = loop?.loopRecoverFiredFor ?? []
+      for (const [sigKey, kind] of [
+        [inputSigKey, "input"] as const,
+        [targetSigKey, "target"] as const,
+      ]) {
+        if (!sigKey) continue
+        const s = (signatures[sigKey] ??= {
+          outcome: "success",
+          kind,
+          completedCount: 0,
+          recoverEmitted: false,
+          blockEmitted: false,
+        })
+        s.completedCount += 1
+        if (fired.includes(sigKey)) s.recoverEmitted = true
+      }
+    }
 
     const real = input.errorRecords.filter(
       (r) =>
         r.parentID === input.parentID &&
         r.metadata.diagnostics?.loop?.loopAction !== "block" &&
         r.metadata.diagnostics?.loop?.loopAction !== "stop" &&
-        r.inputHash !== "",
+        r.inputHash !== "" &&
+        isFromPreviousStep(r),
     )
 
     for (const r of real) {
-      const inputSigKey = r.inputHash ? `input:${r.tool}:${r.inputHash}` : null
-      const targetSigKey = r.targetHash ? `target:${r.tool}:${r.targetHash}` : null
+      const inputSigKey = r.inputHash ? signatureKey({ outcome: "failure", kind: "input", tool: r.tool, hash: r.inputHash }) : null
+      const targetSigKey = r.targetHash ? signatureKey({ outcome: "failure", kind: "target", tool: r.tool, hash: r.targetHash }) : null
       const fired = r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? []
       for (const [sigKey, kind] of [
         [inputSigKey, "input"] as const,
@@ -383,12 +498,15 @@ export namespace SessionDiagnostics {
       ]) {
         if (!sigKey) continue
         const s = (signatures[sigKey] ??= {
+          outcome: "failure",
           kind,
+          completedCount: 0,
           completedFailures: 0,
           recoverEmitted: false,
           blockEmitted: false,
         })
-        s.completedFailures += 1
+        s.completedCount += 1
+        s.completedFailures = (s.completedFailures ?? 0) + 1
         if (fired.includes(sigKey)) s.recoverEmitted = true
         if (r.lastInput !== undefined) s.lastInput = r.lastInput
         if (r.lastError !== undefined) s.lastError = r.lastError
@@ -396,10 +514,15 @@ export namespace SessionDiagnostics {
     }
 
     for (const sigKey of input.syntheticBlockSigKeys) {
-      const kind: SignatureKind = sigKey.startsWith("target:") ? "target" : "input"
+      const parts = sigKey.split(":")
+      const hasOutcome = parts[0] === "success" || parts[0] === "failure"
+      const outcome: LoopOutcome = hasOutcome ? parts[0] as LoopOutcome : "failure"
+      const kind: SignatureKind = (hasOutcome ? parts[1] : parts[0]) === "target" ? "target" : "input"
       const s = (signatures[sigKey] ??= {
+        outcome,
         kind,
-        completedFailures: 0,
+        completedCount: 0,
+        completedFailures: outcome === "failure" ? 0 : undefined,
         recoverEmitted: false,
         blockEmitted: false,
       })
@@ -417,10 +540,12 @@ export namespace SessionDiagnostics {
     tool: string
     inputHash: string
     targetHash?: string
+    outcome?: LoopOutcome
   }): GateDecision {
     const { parentLoopState: state, tool, inputHash, targetHash } = input
-    const inputKey = `input:${tool}:${inputHash}`
-    const targetKey = targetHash ? `target:${tool}:${targetHash}` : null
+    const outcome = input.outcome ?? "failure"
+    const inputKey = signatureKey({ outcome, kind: "input", tool, hash: inputHash })
+    const targetKey = targetHash ? signatureKey({ outcome, kind: "target", tool, hash: targetHash }) : null
 
     // Iteration order is intentional: target is checked first because the spec treats
     // same_target as the more general signal (the model is hitting the same goal in
@@ -432,9 +557,30 @@ export namespace SessionDiagnostics {
       if (!sigKey) continue
       const s = state.signatures[sigKey]
       if (!s) continue
-      if (s.completedFailures >= 5 && s.recoverEmitted) {
-        const action: LoopAction = state.autoResumeSpent || s.blockEmitted ? "stop" : "block"
-        return { action, sigKey, kind: s.kind, completedFailures: s.completedFailures }
+      if (s.completedCount >= LOOP_THRESHOLDS.reminderAt && s.recoverEmitted) {
+        const nextOccurrenceCount = s.completedCount + 1
+        if (nextOccurrenceCount >= LOOP_THRESHOLDS.stopAt && (state.autoResumeSpent || s.blockEmitted)) {
+          return {
+            action: "stop",
+            sigKey,
+            outcome: s.outcome,
+            kind: s.kind,
+            completedCount: s.completedCount,
+            completedFailures: s.completedFailures,
+            nextOccurrenceCount,
+          }
+        }
+        if (nextOccurrenceCount >= LOOP_THRESHOLDS.blockAt) {
+          return {
+            action: "block",
+            sigKey,
+            outcome: s.outcome,
+            kind: s.kind,
+            completedCount: s.completedCount,
+            completedFailures: s.completedFailures,
+            nextOccurrenceCount,
+          }
+        }
       }
     }
 
@@ -502,30 +648,47 @@ export namespace SessionDiagnostics {
 
     if (!pending.length) return { parts }
     const lines: string[] = ["<system-reminder>"]
-    const sawInput = pending.some((r) => r.key.startsWith("input:"))
-    const sawTarget = pending.some((r) => r.key.startsWith("target:"))
+    const parsed = pending.map((r) => parseReminderKey(r.key))
+    const sawSuccess = parsed.some((r) => r.outcome === "success")
+    const sawFailureInput = parsed.some((r) => (r.outcome === "failure" || r.legacy) && r.kind === "input")
+    const sawFailureTarget = parsed.some((r) => (r.outcome === "failure" || r.legacy) && r.kind === "target")
     // Backward-compat: v0 reminders persisted with `error:` (or other) prefixes. Without this
     // fallback they get silently consumed (status flipped to "injected") with no model-facing
     // text, which loses the warning entirely. Emit the legacy generic copy so old sessions still
     // surface a reminder during migration.
-    const sawLegacy = pending.some((r) => !r.key.startsWith("input:") && !r.key.startsWith("target:"))
-    if (sawInput) {
+    const sawLegacy = parsed.some((r) => r.legacy && !r.kind)
+    if (sawSuccess) {
+      lines.push(
+        "You are repeating the same tool request. Change strategy: summarize what you already learned, choose a different target or method, or answer the user directly. Do not repeat the same request in this turn.",
+      )
+    }
+    if (sawFailureInput) {
       lines.push(
         "Detected that you have repeated the same tool input 3 times. Do not call the same input again. Reuse the existing result, change strategy, or summarize the current blocker.",
       )
     }
-    if (sawTarget) {
+    if (sawFailureTarget) {
       lines.push(
         "Detected that you have failed against the same target multiple times even though the errors differ. Do not keep retrying. Change approach, identify why the target is unreachable, or summarize the current blocker.",
       )
     }
-    if (sawLegacy && !sawInput && !sawTarget) {
+    if (sawLegacy && !sawFailureInput && !sawFailureTarget) {
       lines.push(
         "Detected that you have hit the same class of tool error multiple times. Do not keep retrying blindly. Identify the failure layer, change strategy, or summarize the current blocker.",
       )
     }
     lines.push("</system-reminder>")
     return { text: lines.join("\n"), parts }
+  }
+
+  function parseReminderKey(key: string): { outcome?: LoopOutcome; kind?: SignatureKind; legacy: boolean } {
+    const parts = key.split(":")
+    if (parts[0] === "success" || parts[0] === "failure") {
+      const kind = parts[1] === "target" ? "target" : parts[1] === "input" ? "input" : undefined
+      return { outcome: parts[0], kind, legacy: false }
+    }
+    if (parts[0] === "input" || parts[0] === "target") return { kind: parts[0], legacy: true }
+    return { legacy: true }
   }
 
   function normalizeValue(value: unknown): unknown {

--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -87,6 +87,7 @@ export namespace SessionDiagnostics {
     loopType?: SignatureKind
     loopCompletedCount?: number
     loopCompletedFailures?: number
+    loopOccurrenceCount?: number
     loopSigKey?: string
     loopRecoverFiredFor?: string[]
     targetHashIsFallback?: boolean

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -139,6 +139,7 @@ export namespace Export {
           tool: string
           outcome?: "success" | "failure"
           completedCount?: number
+          occurrenceCount?: number
           completedFailures: number
         }
       }
@@ -160,6 +161,7 @@ export namespace Export {
         tool: string
         outcome?: "success" | "failure"
         completedCount?: number
+        occurrenceCount?: number
         completedFailures: number
       }
     }
@@ -173,6 +175,7 @@ export namespace Export {
           tool: string
           outcome?: "success" | "failure"
           completedCount?: number
+          occurrenceCount?: number
           completedFailures: number
         }
       | undefined
@@ -189,6 +192,7 @@ export namespace Export {
                 outcome?: "success" | "failure"
                 loopCompletedCount?: number
                 loopCompletedFailures?: number
+                loopOccurrenceCount?: number
               }
             | undefined
           if (!loop || (loop.loopAction !== "block" && loop.loopAction !== "stop")) continue
@@ -208,6 +212,7 @@ export namespace Export {
             tool: part.tool,
             outcome: loop.outcome,
             completedCount,
+            occurrenceCount: loop.loopOccurrenceCount,
             completedFailures: loop.loopCompletedFailures ?? completedCount,
           }
         }

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -137,6 +137,8 @@ export namespace Export {
           type: "same_input" | "same_target"
           action: "block" | "stop"
           tool: string
+          outcome?: "success" | "failure"
+          completedCount?: number
           completedFailures: number
         }
       }
@@ -156,6 +158,8 @@ export namespace Export {
         type: "same_input" | "same_target"
         action: "block" | "stop"
         tool: string
+        outcome?: "success" | "failure"
+        completedCount?: number
         completedFailures: number
       }
     }
@@ -167,6 +171,8 @@ export namespace Export {
           type: "same_input" | "same_target"
           action: "block" | "stop"
           tool: string
+          outcome?: "success" | "failure"
+          completedCount?: number
           completedFailures: number
         }
       | undefined
@@ -180,11 +186,14 @@ export namespace Export {
             | {
                 loopAction?: string
                 loopType?: string
+                outcome?: "success" | "failure"
+                loopCompletedCount?: number
                 loopCompletedFailures?: number
               }
             | undefined
           if (!loop || (loop.loopAction !== "block" && loop.loopAction !== "stop")) continue
-          if (!loop.loopType || typeof loop.loopCompletedFailures !== "number" || !message.info.parentID) continue
+          const completedCount = loop.loopCompletedCount ?? loop.loopCompletedFailures
+          if (!loop.loopType || typeof completedCount !== "number" || !message.info.parentID) continue
           let at = -Infinity
           if ("time" in part.state) {
             const t = part.state.time
@@ -197,7 +206,9 @@ export namespace Export {
             type: loop.loopType === "input" ? "same_input" : "same_target",
             action: loop.loopAction,
             tool: part.tool,
-            completedFailures: loop.loopCompletedFailures,
+            outcome: loop.outcome,
+            completedCount,
+            completedFailures: loop.loopCompletedFailures ?? completedCount,
           }
         }
       }

--- a/packages/opencode/src/session/loop-renderer.ts
+++ b/packages/opencode/src/session/loop-renderer.ts
@@ -13,6 +13,13 @@ export namespace LoopRenderer {
     const scrubbedError = errorLine ? scrubErrorText(errorLine) : undefined
     const truncatedError = scrubbedError ? SessionDiagnostics.truncateForRenderer(scrubbedError) : undefined
     const isZh = (locale ?? "").toLowerCase().startsWith("zh")
+    const completedFailures = state.completedFailures ?? state.completedCount
+
+    if (state.outcome === "success") {
+      return isZh
+        ? "我刚才在重复检查同一处，已停止重复。\n下一步需要换个办法继续。"
+        : "I was repeating the same check, so I stopped the repetition.\nNext, I need to continue with a different approach."
+    }
 
     if (tool === "webfetch") {
       const rawURL = extractURL(state.lastInput)
@@ -21,50 +28,50 @@ export namespace LoopRenderer {
       if (state.kind === "input") {
         if (isZh) {
           return truncatedURL
-            ? `我重复调用了相同的请求 ${state.completedFailures} 次没成功，已停止。请求：webfetch ${truncatedURL}`
-            : `我重复调用了相同的请求 ${state.completedFailures} 次没成功，已停止。`
+            ? `我重复调用了相同的请求 ${completedFailures} 次没成功，已停止。请求：webfetch ${truncatedURL}`
+            : `我重复调用了相同的请求 ${completedFailures} 次没成功，已停止。`
         }
         return truncatedURL
-          ? `I made the same request ${state.completedFailures} times without success and stopped. Request: webfetch ${truncatedURL}`
-          : `I made the same request ${state.completedFailures} times without success and stopped.`
+          ? `I made the same request ${completedFailures} times without success and stopped. Request: webfetch ${truncatedURL}`
+          : `I made the same request ${completedFailures} times without success and stopped.`
       }
       if (isZh) {
         if (truncatedURL && truncatedError)
-          return `我重复抓取同一个目标 ${state.completedFailures} 次都失败，已停止。目标：${truncatedURL} 错误：${truncatedError}`
+          return `我重复抓取同一个目标 ${completedFailures} 次都失败，已停止。目标：${truncatedURL} 错误：${truncatedError}`
         if (truncatedURL)
-          return `我重复抓取同一个目标 ${state.completedFailures} 次都失败，已停止。目标：${truncatedURL}`
+          return `我重复抓取同一个目标 ${completedFailures} 次都失败，已停止。目标：${truncatedURL}`
         if (truncatedError)
-          return `我重复抓取同一个目标 ${state.completedFailures} 次都失败，已停止。错误：${truncatedError}`
-        return `我重复抓取同一个目标 ${state.completedFailures} 次都失败，已停止。`
+          return `我重复抓取同一个目标 ${completedFailures} 次都失败，已停止。错误：${truncatedError}`
+        return `我重复抓取同一个目标 ${completedFailures} 次都失败，已停止。`
       }
       if (truncatedURL && truncatedError)
-        return `I failed to fetch the same target ${state.completedFailures} times and stopped. Target: ${truncatedURL} Error: ${truncatedError}`
+        return `I failed to fetch the same target ${completedFailures} times and stopped. Target: ${truncatedURL} Error: ${truncatedError}`
       if (truncatedURL)
-        return `I failed to fetch the same target ${state.completedFailures} times and stopped. Target: ${truncatedURL}`
+        return `I failed to fetch the same target ${completedFailures} times and stopped. Target: ${truncatedURL}`
       if (truncatedError)
-        return `I failed to fetch the same target ${state.completedFailures} times and stopped. Error: ${truncatedError}`
-      return `I failed to fetch the same target ${state.completedFailures} times and stopped.`
+        return `I failed to fetch the same target ${completedFailures} times and stopped. Error: ${truncatedError}`
+      return `I failed to fetch the same target ${completedFailures} times and stopped.`
     }
 
     if (state.kind === "target") {
       if (isZh) {
         return truncatedError
-          ? `我重复在同一个目标上失败了 ${state.completedFailures} 次，已停止。工具：${tool} 错误：${truncatedError}`
-          : `我重复在同一个目标上失败了 ${state.completedFailures} 次，已停止。工具：${tool}`
+          ? `我重复在同一个目标上失败了 ${completedFailures} 次，已停止。工具：${tool} 错误：${truncatedError}`
+          : `我重复在同一个目标上失败了 ${completedFailures} 次，已停止。工具：${tool}`
       }
       return truncatedError
-        ? `I failed against the same target ${state.completedFailures} times and stopped. Tool: ${tool} Error: ${truncatedError}`
-        : `I failed against the same target ${state.completedFailures} times and stopped. Tool: ${tool}`
+        ? `I failed against the same target ${completedFailures} times and stopped. Tool: ${tool} Error: ${truncatedError}`
+        : `I failed against the same target ${completedFailures} times and stopped. Tool: ${tool}`
     }
 
     if (isZh) {
       return truncatedError
-        ? `我重复调用了 ${tool} ${state.completedFailures} 次都失败，已停止。最近一次错误：${truncatedError}`
-        : `我重复调用了 ${tool} ${state.completedFailures} 次都失败，已停止。`
+        ? `我重复调用了 ${tool} ${completedFailures} 次都失败，已停止。最近一次错误：${truncatedError}`
+        : `我重复调用了 ${tool} ${completedFailures} 次都失败，已停止。`
     }
     return truncatedError
-      ? `I called ${tool} ${state.completedFailures} times without success and stopped. Last error: ${truncatedError}`
-      : `I called ${tool} ${state.completedFailures} times without success and stopped.`
+      ? `I called ${tool} ${completedFailures} times without success and stopped. Last error: ${truncatedError}`
+      : `I called ${tool} ${completedFailures} times without success and stopped.`
   }
 
   function extractURL(value: unknown): string | undefined {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -214,7 +214,7 @@ export const layer: Layer.Layer<
             if (part.type !== "tool") return []
             if (part.state.status !== "completed") return []
             const loop = toolDiagnostics(part)?.loop
-            if (!loop?.inputHash || !loop.targetHash) return []
+            if (!loop?.inputHash) return []
             if (loop.errorFingerprint || loop.loopAction) return []
             return [
               {
@@ -222,7 +222,7 @@ export const layer: Layer.Layer<
                 parentID,
                 tool: part.tool,
                 inputHash: loop.inputHash,
-                targetHash: loop.targetHash,
+                targetHash: loop.targetHash ?? "",
                 metadata: { diagnostics: { loop } },
               } satisfies SessionDiagnostics.ToolCallRecord,
             ]
@@ -313,18 +313,25 @@ export const layer: Layer.Layer<
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
           let stepIndex = 0
           let sawStepStart = false
+          let afterStepFinish = false
           for (const part of message.parts) {
             if (part.type === "step-start") {
               sawStepStart = true
+              afterStepFinish = false
               stepIndex += 1
               continue
             }
             const currentMessage = message.info.id === ctx.assistantMessage.id
-            if (currentMessage) currentStepIndex = sawStepStart ? stepIndex : stepIndex + 1
+            const activeStepIndex = !sawStepStart || afterStepFinish ? stepIndex + 1 : stepIndex
+            if (currentMessage) currentStepIndex = activeStepIndex
+            if (part.type === "step-finish") {
+              afterStepFinish = true
+              continue
+            }
             if (part.type !== "tool") continue
             const loop = toolDiagnostics(part)?.loop
             if (!loop) continue
-            const observedStepIndex = currentMessage ? (sawStepStart ? stepIndex : stepIndex + 1) : -1
+            const observedStepIndex = currentMessage ? activeStepIndex : -1
             const loopWithStep = { ...loop, stepIndex: loop.stepIndex ?? observedStepIndex }
             if (loop.loopAction === "stop") hasStoppedOut = true
             if (loop.loopAction === "block" && loop.loopSigKey) syntheticBlockSigKeysOut.push(loop.loopSigKey)
@@ -853,6 +860,7 @@ export const layer: Layer.Layer<
               outcome: input.outcome,
               loopCompletedCount: input.completedCount,
               loopCompletedFailures: input.completedFailures ?? input.completedCount,
+              loopOccurrenceCount: input.nextOccurrenceCount,
             },
           },
         })
@@ -918,6 +926,7 @@ export const layer: Layer.Layer<
               outcome: input.outcome,
               loopCompletedCount: input.completedCount,
               loopCompletedFailures: input.completedFailures ?? input.completedCount,
+              loopOccurrenceCount: input.nextOccurrenceCount,
             },
           },
         })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -47,16 +47,21 @@ export interface Handle {
   readonly syntheticBlockSigKeys: (parentID: MessageV2.Assistant["parentID"]) => string[]
   readonly hasStopped: (parentID: MessageV2.Assistant["parentID"]) => boolean
   readonly buildLoopContext: (parentID: MessageV2.Assistant["parentID"]) => {
+    successRecords: SessionDiagnostics.ToolCallRecord[]
     errorRecords: SessionDiagnostics.ToolErrorRecord[]
     syntheticBlockSigKeys: string[]
     hasStopped: boolean
+    currentStepIndex?: number
   }
   readonly recordSyntheticBlock: (input: {
     toolCallId: string
     tool: string
     sigKey: string
     kind: SessionDiagnostics.SignatureKind
-    completedFailures: number
+    outcome: SessionDiagnostics.LoopOutcome
+    completedCount: number
+    completedFailures?: number
+    nextOccurrenceCount: number
     errorMessage: string
   }) => Effect.Effect<void>
   readonly recordSyntheticStop: (input: {
@@ -64,7 +69,10 @@ export interface Handle {
     tool: string
     sigKey: string
     kind: SessionDiagnostics.SignatureKind
-    completedFailures: number
+    outcome: SessionDiagnostics.LoopOutcome
+    completedCount: number
+    completedFailures?: number
+    nextOccurrenceCount: number
     renderedText: string
     toolErrorMessage: string
   }) => Effect.Effect<void>
@@ -204,8 +212,10 @@ export const layer: Layer.Layer<
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) return []
           return message.parts.flatMap((part) => {
             if (part.type !== "tool") return []
+            if (part.state.status !== "completed") return []
             const loop = toolDiagnostics(part)?.loop
             if (!loop?.inputHash || !loop.targetHash) return []
+            if (loop.errorFingerprint || loop.loopAction) return []
             return [
               {
                 sessionID: ctx.sessionID,
@@ -285,20 +295,46 @@ export const layer: Layer.Layer<
       // call errorRecords + syntheticBlockSigKeys + hasStopped (three full O(n) scans of the message
       // stream); this helper folds them into one scan.
       const buildLoopContext = (parentID: MessageV2.Assistant["parentID"]) => {
+        const successRecordsOut: SessionDiagnostics.ToolCallRecord[] = []
         const errorRecordsOut: SessionDiagnostics.ToolErrorRecord[] = []
         const syntheticBlockSigKeysOut: string[] = []
         let hasStoppedOut = false
+        let currentStepIndex: number | undefined
         if (!parentID) {
-          return { errorRecords: errorRecordsOut, syntheticBlockSigKeys: syntheticBlockSigKeysOut, hasStopped: hasStoppedOut }
+          return {
+            successRecords: successRecordsOut,
+            errorRecords: errorRecordsOut,
+            syntheticBlockSigKeys: syntheticBlockSigKeysOut,
+            hasStopped: hasStoppedOut,
+            currentStepIndex,
+          }
         }
         for (const message of Array.from(MessageV2.stream(ctx.sessionID))) {
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
+          let stepIndex = 0
           for (const part of message.parts) {
+            if (part.type === "step-start") {
+              stepIndex += 1
+              continue
+            }
+            if (message.info.id === ctx.assistantMessage.id) currentStepIndex = stepIndex
             if (part.type !== "tool") continue
             const loop = toolDiagnostics(part)?.loop
             if (!loop) continue
+            const observedStepIndex = message.info.id === ctx.assistantMessage.id ? stepIndex : -1
+            const loopWithStep = { ...loop, stepIndex: loop.stepIndex ?? observedStepIndex }
             if (loop.loopAction === "stop") hasStoppedOut = true
             if (loop.loopAction === "block" && loop.loopSigKey) syntheticBlockSigKeysOut.push(loop.loopSigKey)
+            if (part.state.status === "completed" && loop.inputHash && !loop.errorFingerprint && !loop.loopAction) {
+              successRecordsOut.push({
+                sessionID: ctx.sessionID,
+                parentID,
+                tool: part.tool,
+                inputHash: loop.inputHash,
+                targetHash: loop.targetHash ?? "",
+                metadata: { diagnostics: { loop: loopWithStep } },
+              } satisfies SessionDiagnostics.ToolCallRecord)
+            }
             if (loop.errorFingerprint || loop.loopAction === "block" || loop.loopAction === "stop") {
               const targetHash = loop.targetHashIsFallback ? undefined : loop.targetHash
               errorRecordsOut.push({
@@ -310,12 +346,18 @@ export const layer: Layer.Layer<
                 errorFingerprint: loop.errorFingerprint ?? "",
                 lastInput: loop.loopLastInput,
                 lastError: loop.loopLastError,
-                metadata: { diagnostics: { loop } },
+                metadata: { diagnostics: { loop: loopWithStep } },
               } satisfies SessionDiagnostics.ToolErrorRecord)
             }
           }
         }
-        return { errorRecords: errorRecordsOut, syntheticBlockSigKeys: syntheticBlockSigKeysOut, hasStopped: hasStoppedOut }
+        return {
+          successRecords: successRecordsOut,
+          errorRecords: errorRecordsOut,
+          syntheticBlockSigKeys: syntheticBlockSigKeysOut,
+          hasStopped: hasStoppedOut,
+          currentStepIndex,
+        }
       }
 
       const completeToolCall = Effect.fn("SessionProcessor.completeToolCall")(function* (
@@ -760,7 +802,10 @@ export const layer: Layer.Layer<
         tool: string
         sigKey: string
         kind: SessionDiagnostics.SignatureKind
-        completedFailures: number
+        outcome: SessionDiagnostics.LoopOutcome
+        completedCount: number
+        completedFailures?: number
+        nextOccurrenceCount: number
         errorMessage: string
       }) {
         const match = yield* readToolCall(input.toolCallId)
@@ -802,7 +847,9 @@ export const layer: Layer.Layer<
               loopAction: "block",
               loopType: input.kind,
               loopSigKey: input.sigKey,
-              loopCompletedFailures: input.completedFailures,
+              outcome: input.outcome,
+              loopCompletedCount: input.completedCount,
+              loopCompletedFailures: input.completedFailures ?? input.completedCount,
             },
           },
         })
@@ -826,7 +873,10 @@ export const layer: Layer.Layer<
         tool: string
         sigKey: string
         kind: SessionDiagnostics.SignatureKind
-        completedFailures: number
+        outcome: SessionDiagnostics.LoopOutcome
+        completedCount: number
+        completedFailures?: number
+        nextOccurrenceCount: number
         renderedText: string
         toolErrorMessage: string
       }) {
@@ -862,7 +912,9 @@ export const layer: Layer.Layer<
               loopAction: "stop",
               loopType: input.kind,
               loopSigKey: input.sigKey,
-              loopCompletedFailures: input.completedFailures,
+              outcome: input.outcome,
+              loopCompletedCount: input.completedCount,
+              loopCompletedFailures: input.completedFailures ?? input.completedCount,
             },
           },
         })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -312,16 +312,19 @@ export const layer: Layer.Layer<
         for (const message of Array.from(MessageV2.stream(ctx.sessionID))) {
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
           let stepIndex = 0
+          let sawStepStart = false
           for (const part of message.parts) {
             if (part.type === "step-start") {
+              sawStepStart = true
               stepIndex += 1
               continue
             }
-            if (message.info.id === ctx.assistantMessage.id) currentStepIndex = stepIndex
+            const currentMessage = message.info.id === ctx.assistantMessage.id
+            if (currentMessage) currentStepIndex = sawStepStart ? stepIndex : stepIndex + 1
             if (part.type !== "tool") continue
             const loop = toolDiagnostics(part)?.loop
             if (!loop) continue
-            const observedStepIndex = message.info.id === ctx.assistantMessage.id ? stepIndex : -1
+            const observedStepIndex = currentMessage ? (sawStepStart ? stepIndex : stepIndex + 1) : -1
             const loopWithStep = { ...loop, stepIndex: loop.stepIndex ?? observedStepIndex }
             if (loop.loopAction === "stop") hasStoppedOut = true
             if (loop.loopAction === "block" && loop.loopSigKey) syntheticBlockSigKeysOut.push(loop.loopSigKey)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -148,7 +148,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
     targetHash,
     outcome: "success",
   })
-  const decision = failureDecision.action !== "observe" ? failureDecision : successDecision
+  const decision = SessionDiagnostics.chooseGateDecision(failureDecision, successDecision)
 
   if (decision.action === "observe") return { kind: "observe" } satisfies GateOutcome
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -127,17 +127,28 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
   const targetHash = targetSummaryRes.isFallback ? undefined : SessionDiagnostics.hash(targetSummaryRes.summary)
 
   const parentLoopState = SessionDiagnostics.deriveParentLoopState({
+    successRecords: loopCtx.successRecords,
     errorRecords: loopCtx.errorRecords,
     syntheticBlockSigKeys: loopCtx.syntheticBlockSigKeys,
     parentID,
+    currentStepIndex: loopCtx.currentStepIndex,
   })
 
-  const decision = SessionDiagnostics.queryGateAction({
+  const failureDecision = SessionDiagnostics.queryGateAction({
     parentLoopState,
     tool: toolId,
     inputHash: inputHashRes.hash,
     targetHash,
+    outcome: "failure",
   })
+  const successDecision = SessionDiagnostics.queryGateAction({
+    parentLoopState,
+    tool: toolId,
+    inputHash: inputHashRes.hash,
+    targetHash,
+    outcome: "success",
+  })
+  const decision = failureDecision.action !== "observe" ? failureDecision : successDecision
 
   if (decision.action === "observe") return { kind: "observe" } satisfies GateOutcome
 
@@ -145,26 +156,38 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
   if (!sigState) return { kind: "observe" } satisfies GateOutcome
 
   if (decision.action === "block") {
-    const userFacing = `${LOOP_GATE_BLOCK_PREFIX}: this signature has already failed ${decision.completedFailures} times in this turn`
+    const userFacing =
+      decision.outcome === "success"
+        ? `${LOOP_GATE_BLOCK_PREFIX}: repeated tool request blocked before occurrence ${decision.nextOccurrenceCount}`
+        : `${LOOP_GATE_BLOCK_PREFIX}: repeated failed tool request blocked before occurrence ${decision.nextOccurrenceCount}`
     yield* processor.recordSyntheticBlock({
       toolCallId,
       tool: toolId,
       sigKey: decision.sigKey,
       kind: decision.kind,
+      outcome: decision.outcome,
+      completedCount: decision.completedCount,
       completedFailures: decision.completedFailures,
+      nextOccurrenceCount: decision.nextOccurrenceCount,
       errorMessage: userFacing,
     })
     return { kind: "block", userFacing } satisfies GateOutcome
   }
 
   const renderedText = LoopRenderer.render({ tool: toolId, state: sigState, locale })
-  const toolErrorMessage = `${LOOP_GATE_STOP_PREFIX}: stop after repeated failures (${decision.completedFailures})`
+  const toolErrorMessage =
+    decision.outcome === "success"
+      ? `${LOOP_GATE_STOP_PREFIX}: stop after repeated successful tool request (${decision.nextOccurrenceCount})`
+      : `${LOOP_GATE_STOP_PREFIX}: stop after repeated failures (${decision.nextOccurrenceCount})`
   yield* processor.recordSyntheticStop({
     toolCallId,
     tool: toolId,
     sigKey: decision.sigKey,
     kind: decision.kind,
+    outcome: decision.outcome,
+    completedCount: decision.completedCount,
     completedFailures: decision.completedFailures,
+    nextOccurrenceCount: decision.nextOccurrenceCount,
     renderedText,
     toolErrorMessage,
   })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -159,7 +159,7 @@ function fake(
     errorRecords: () => [],
     syntheticBlockSigKeys: () => [],
     hasStopped: () => false,
-    buildLoopContext: () => ({ errorRecords: [], syntheticBlockSigKeys: [], hasStopped: false }),
+    buildLoopContext: () => ({ successRecords: [], errorRecords: [], syntheticBlockSigKeys: [], hasStopped: false }),
     recordSyntheticBlock: Effect.fn("TestSessionProcessor.recordSyntheticBlock")(() => Effect.void),
     recordSyntheticStop: Effect.fn("TestSessionProcessor.recordSyntheticStop")(() => Effect.void),
   } satisfies SessionProcessorModule.SessionProcessor.Handle

--- a/packages/opencode/test/session/diagnostics.test.ts
+++ b/packages/opencode/test/session/diagnostics.test.ts
@@ -40,11 +40,12 @@ describe("SessionDiagnostics.normalizeInput", () => {
 })
 
 describe("SessionDiagnostics.observeToolCall", () => {
-  test("does not create reminders on repeated calls (firing moved to observeToolError)", () => {
+  test("creates a success-repeat reminder on the 3rd identical successful call", () => {
     let records: SessionDiagnostics.ToolCallRecord[] = []
     const input = { url: "https://example.com/article" }
-    for (let i = 0; i < 5; i++) {
-      const observed = SessionDiagnostics.observeToolCall({
+    let observed: ReturnType<typeof SessionDiagnostics.observeToolCall> | undefined
+    for (let i = 0; i < 3; i++) {
+      observed = SessionDiagnostics.observeToolCall({
         records,
         sessionID,
         parentID,
@@ -56,9 +57,14 @@ describe("SessionDiagnostics.observeToolCall", () => {
       })
       records = [...records, observed.record]
     }
-    for (const record of records) {
-      expect(record.metadata.diagnostics?.loop?.reminders ?? []).toHaveLength(0)
-    }
+    const reminder = observed?.record.metadata.diagnostics?.loop?.reminders?.[0]
+    expect(reminder).toMatchObject({
+      key: `success:input:webfetch:${inputHashFor(input)}`,
+      type: "input_repeat",
+      status: "pending",
+      count: 3,
+    })
+    expect(observed?.record.metadata.diagnostics?.loop?.outcome).toBe("success")
   })
 
   test("does not count the same input across different user blocks", () => {
@@ -120,6 +126,60 @@ describe("SessionDiagnostics.observeToolCall", () => {
 
     expect(records.flatMap((record) => loop(record.metadata).reminders ?? [])).toHaveLength(0)
   })
+
+  test("does not count failed observations toward successful repeat reminders", () => {
+    const input = { url: "https://example.com/article" }
+    const records: SessionDiagnostics.ToolCallRecord[] = [
+      {
+        sessionID,
+        parentID,
+        tool: "webfetch",
+        inputHash: inputHashFor(input),
+        targetHash: targetHashFor(input.url),
+        metadata: {
+          diagnostics: {
+            loop: {
+              inputHash: inputHashFor(input),
+              targetHash: targetHashFor(input.url),
+              outcome: "failure",
+              errorFingerprint: "timeout",
+            },
+          },
+        },
+      },
+      {
+        sessionID,
+        parentID,
+        tool: "webfetch",
+        inputHash: inputHashFor(input),
+        targetHash: targetHashFor(input.url),
+        metadata: {
+          diagnostics: {
+            loop: {
+              inputHash: inputHashFor(input),
+              targetHash: targetHashFor(input.url),
+              outcome: "failure",
+              errorFingerprint: "not-found",
+            },
+          },
+        },
+      },
+    ]
+
+    const observed = SessionDiagnostics.observeToolCall({
+      records,
+      sessionID,
+      parentID,
+      tool: "webfetch",
+      input,
+      agent: "build",
+      modelID,
+      providerID,
+    })
+
+    expect(loop(observed.record.metadata).inputRepeatCount).toBe(1)
+    expect(loop(observed.record.metadata).reminders ?? []).toHaveLength(0)
+  })
 })
 
 describe("SessionDiagnostics.observeToolError", () => {
@@ -144,7 +204,7 @@ describe("SessionDiagnostics.observeToolError", () => {
       records.push(observed.record)
     }
     const fired = records.flatMap((r) => r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? [])
-    expect(fired.filter((k) => k.startsWith("input:"))).toHaveLength(1)
+    expect(fired.filter((k) => k.startsWith("failure:input:"))).toHaveLength(1)
   })
 })
 
@@ -169,8 +229,8 @@ describe("SessionDiagnostics.observeToolError v1 firing", () => {
       records.push(observed.record)
     }
     const fired = records.flatMap((r) => r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? [])
-    expect(fired.filter((k) => k.startsWith("input:"))).toHaveLength(1)
-    expect(fired.filter((k) => k.startsWith("target:"))).toHaveLength(1)
+    expect(fired.filter((k) => k.startsWith("failure:input:"))).toHaveLength(1)
+    expect(fired.filter((k) => k.startsWith("failure:target:"))).toHaveLength(1)
   })
 
   test("persists raw lastInput and string lastError on every record", () => {
@@ -206,8 +266,8 @@ describe("SessionDiagnostics.observeToolError v1 firing", () => {
       records.push(observed.record)
     }
     const fired = records.flatMap((r) => r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? [])
-    expect(fired.some((k) => k.startsWith("target:"))).toBe(false)
-    expect(fired.filter((k) => k.startsWith("input:"))).toHaveLength(1)
+    expect(fired.some((k) => k.startsWith("failure:target:"))).toBe(false)
+    expect(fired.filter((k) => k.startsWith("failure:input:"))).toHaveLength(1)
   })
 
   test("labels input vs target reminders correctly via Reminder.type", () => {
@@ -227,8 +287,8 @@ describe("SessionDiagnostics.observeToolError v1 firing", () => {
       records.push(observed.record)
     }
     const allReminders = records.flatMap((r) => r.metadata.diagnostics?.loop?.reminders ?? [])
-    const inputReminder = allReminders.find((r) => r.key.startsWith("input:"))
-    const targetReminder = allReminders.find((r) => r.key.startsWith("target:"))
+    const inputReminder = allReminders.find((r) => r.key.startsWith("failure:input:"))
+    const targetReminder = allReminders.find((r) => r.key.startsWith("failure:target:"))
     expect(inputReminder?.type).toBe("input_repeat")
     expect(targetReminder?.type).toBe("target_repeat")
   })
@@ -250,7 +310,7 @@ describe("SessionDiagnostics.observeToolError v1 firing", () => {
       records.push(observed.record)
     }
     const fired = records.flatMap((r) => r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? [])
-    expect(fired.filter((k) => k.startsWith("input:"))).toHaveLength(1)
+    expect(fired.filter((k) => k.startsWith("failure:input:"))).toHaveLength(1)
   })
 
   test("recomputes targetHash from originalInput when in-flight metadata missing", () => {
@@ -275,7 +335,7 @@ describe("SessionDiagnostics.observeToolError v1 firing", () => {
       records.push(observed.record)
     }
     const fired = records.flatMap((r) => r.metadata.diagnostics?.loop?.loopRecoverFiredFor ?? [])
-    expect(fired.filter((k) => k.startsWith("target:"))).toHaveLength(1)
+    expect(fired.filter((k) => k.startsWith("failure:target:"))).toHaveLength(1)
     // And the persisted record carries the recovered targetHash for future iterations.
     const last = records[records.length - 1]
     expect(typeof last?.targetHash).toBe("string")

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -343,6 +343,7 @@ describe("Export.deriveSnapshotDiagnostics", () => {
     expect(result.loop?.last?.action).toBe("stop")
     expect(result.loop?.last?.outcome).toBe("success")
     expect(result.loop?.last?.completedCount).toBe(4)
+    expect(result.loop?.last?.occurrenceCount).toBe(5)
     expect(result.loop?.last?.completedFailures).toBe(4)
   })
 })
@@ -441,6 +442,7 @@ function successStopToolPartAt(messageID: MessageID, count: number, tag: string)
             loopType: "input",
             outcome: "success",
             loopCompletedCount: count,
+            loopOccurrenceCount: 5,
             loopSigKey: "success:input:grep:" + tag,
           },
         },

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -325,6 +325,26 @@ describe("Export.deriveSnapshotDiagnostics", () => {
     const result = Export.deriveSnapshotDiagnostics(tree)
     expect(result.loop?.last?.action).toBe("stop")
   })
+
+  test("exports success loop diagnostics with neutral completed count", () => {
+    const info = makeAssistantInfo()
+    const stop = successStopToolPartAt(info.id, 4, "success-stop")
+    const tree: Export.Tree = {
+      ...makeTree(),
+      messages: [
+        {
+          info,
+          parts: [stop],
+        },
+      ],
+      children: [],
+    }
+    const result = Export.deriveSnapshotDiagnostics(tree)
+    expect(result.loop?.last?.action).toBe("stop")
+    expect(result.loop?.last?.outcome).toBe("success")
+    expect(result.loop?.last?.completedCount).toBe(4)
+    expect(result.loop?.last?.completedFailures).toBe(4)
+  })
 })
 
 let assistantSeq = 0
@@ -398,6 +418,34 @@ function stopToolPartAt(messageID: MessageID, end: number, tag: string): Message
         },
       },
       time: { start: 1, end },
+    },
+  }
+}
+
+function successStopToolPartAt(messageID: MessageID, count: number, tag: string): MessageV2.ToolPart {
+  return {
+    id: PartID.make("prt_success_stop_" + tag),
+    messageID,
+    sessionID: SessionID.make("ses_diag"),
+    type: "tool",
+    tool: "grep",
+    callID: "call_success_stop_" + tag,
+    state: {
+      status: "error",
+      input: { pattern: "compaction", path: "/tmp/src" },
+      error: "halted by PawWork",
+      metadata: {
+        diagnostics: {
+          loop: {
+            loopAction: "stop",
+            loopType: "input",
+            outcome: "success",
+            loopCompletedCount: count,
+            loopSigKey: "success:input:grep:" + tag,
+          },
+        },
+      },
+      time: { start: 1, end: count },
     },
   }
 }

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -157,7 +157,6 @@ describe("SessionDiagnostics.queryGateAction", () => {
         successfulCallRecord(url),
         successfulCallRecord(url),
         successfulCallRecord(url, [sigKey]),
-        successfulCallRecord(url),
       ],
       errorRecords: [],
       syntheticBlockSigKeys: [sigKey],
@@ -174,6 +173,29 @@ describe("SessionDiagnostics.queryGateAction", () => {
 
     expect(decision.action).toBe("stop")
     if (decision.action === "stop") expect(decision.nextOccurrenceCount).toBe(5)
+  })
+
+  test("chooses stop over block across success and failure decisions", () => {
+    const successStop = {
+      action: "stop",
+      sigKey: "success:input:webfetch:aaa",
+      outcome: "success",
+      kind: "input",
+      completedCount: 3,
+      nextOccurrenceCount: 5,
+    } satisfies SessionDiagnostics.GateDecision
+    const failureBlock = {
+      action: "block",
+      sigKey: "failure:input:webfetch:aaa",
+      outcome: "failure",
+      kind: "input",
+      completedCount: 3,
+      completedFailures: 3,
+      nextOccurrenceCount: 4,
+    } satisfies SessionDiagnostics.GateDecision
+
+    expect(SessionDiagnostics.chooseGateDecision(failureBlock, successStop)).toBe(successStop)
+    expect(SessionDiagnostics.chooseGateDecision(successStop, failureBlock)).toBe(successStop)
   })
 
   test("does not block same-step parallel successful repeats before the model can react", () => {
@@ -363,8 +385,6 @@ describe("SessionDiagnostics.queryGateAction", () => {
       failingErrorRecord(url),
       failingErrorRecord(url),
       failingErrorRecord(url, [sigKey]),
-      failingErrorRecord(url),
-      failingErrorRecord(url),
     ]
     const state = SessionDiagnostics.deriveParentLoopState({
       errorRecords: records,

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -32,7 +32,44 @@ const failingErrorRecord = (
   },
 })
 
+const successfulCallRecord = (
+  url: string,
+  recoverFiredFor: string[] = [],
+): SessionDiagnostics.ToolCallRecord => ({
+  sessionID,
+  parentID,
+  tool: "webfetch",
+  inputHash: inputHashFor({ url }),
+  targetHash: targetHashFor(url),
+  metadata: {
+    diagnostics: {
+      loop: {
+        inputHash: inputHashFor({ url }),
+        targetHash: targetHashFor(url),
+        outcome: "success",
+        targetRepeatCount: 1,
+        loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
+      },
+    },
+  },
+})
+
 describe("SessionDiagnostics.deriveParentLoopState", () => {
+  test("keeps success and failure counts in separate signature buckets", () => {
+    const url = "https://x.com/a"
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [successfulCallRecord(url), successfulCallRecord(url)],
+      errorRecords: [failingErrorRecord(url)],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    const successKey = `success:target:webfetch:${targetHashFor(url)}`
+    const failureKey = `failure:target:webfetch:${targetHashFor(url)}`
+    expect(state.signatures[successKey]?.completedCount).toBe(2)
+    expect(state.signatures[failureKey]?.completedCount).toBe(1)
+  })
+
   test("populates SignatureState.lastInput/lastError from latest matching record", () => {
     const url = "https://x.com/a"
     // Two distinct records; the second one's lastError must win — proves "latest", not
@@ -43,7 +80,7 @@ describe("SessionDiagnostics.deriveParentLoopState", () => {
       syntheticBlockSigKeys: [],
       parentID,
     })
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
+    const sigKey = `failure:target:webfetch:${targetHashFor(url)}`
     expect(state.signatures[sigKey]?.lastInput).toEqual({ url })
     expect(state.signatures[sigKey]?.lastError).toBe("500")
   })
@@ -56,7 +93,7 @@ describe("SessionDiagnostics.deriveParentLoopState", () => {
       syntheticBlockSigKeys: [],
       parentID,
     })
-    const sigKey = `input:webfetch:${inputHashFor({ url })}`
+    const sigKey = `failure:input:webfetch:${inputHashFor({ url })}`
     expect(state.signatures[sigKey]?.completedFailures).toBe(2)
   })
 
@@ -71,7 +108,7 @@ describe("SessionDiagnostics.deriveParentLoopState", () => {
 
   test("blockEmitted set on the matched signature", () => {
     const url = "https://x.com/a"
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
+    const sigKey = `failure:target:webfetch:${targetHashFor(url)}`
     const state = SessionDiagnostics.deriveParentLoopState({
       errorRecords: [failingErrorRecord(url)],
       syntheticBlockSigKeys: [sigKey],
@@ -82,6 +119,156 @@ describe("SessionDiagnostics.deriveParentLoopState", () => {
 })
 
 describe("SessionDiagnostics.queryGateAction", () => {
+  test("blocks the 4th successful occurrence after a 3rd-occurrence reminder", () => {
+    const url = "https://x.com/a"
+    const sigKey = `success:target:webfetch:${targetHashFor(url)}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulCallRecord(url),
+        successfulCallRecord(url),
+        successfulCallRecord(url, [sigKey]),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "webfetch",
+      inputHash: inputHashFor({ url }),
+      targetHash: targetHashFor(url),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("block")
+    if (decision.action === "block") {
+      expect(decision.kind).toBe("target")
+      expect(decision.completedCount).toBe(3)
+      expect(decision.nextOccurrenceCount).toBe(4)
+    }
+  })
+
+  test("stops the 5th successful occurrence after quarantine", () => {
+    const url = "https://x.com/a"
+    const sigKey = `success:target:webfetch:${targetHashFor(url)}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulCallRecord(url),
+        successfulCallRecord(url),
+        successfulCallRecord(url, [sigKey]),
+        successfulCallRecord(url),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [sigKey],
+      parentID,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "webfetch",
+      inputHash: inputHashFor({ url }),
+      targetHash: targetHashFor(url),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("stop")
+    if (decision.action === "stop") expect(decision.nextOccurrenceCount).toBe(5)
+  })
+
+  test("does not block same-step parallel successful repeats before the model can react", () => {
+    const url = "https://x.com/a"
+    const sigKey = `success:target:webfetch:${targetHashFor(url)}`
+    const records = [
+      successfulCallRecord(url),
+      successfulCallRecord(url),
+      successfulCallRecord(url, [sigKey]),
+    ].map((record) => ({
+      ...record,
+      metadata: {
+        diagnostics: {
+          loop: {
+            ...record.metadata.diagnostics?.loop,
+            stepIndex: 1,
+          },
+        },
+      },
+    }))
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: records,
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+      currentStepIndex: 1,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "webfetch",
+      inputHash: inputHashFor({ url }),
+      targetHash: targetHashFor(url),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("observe")
+  })
+
+  test("does not block when current step index is unavailable", () => {
+    const url = "https://x.com/a"
+    const sigKey = `success:target:webfetch:${targetHashFor(url)}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulCallRecord(url),
+        successfulCallRecord(url),
+        successfulCallRecord(url, [sigKey]),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+      currentStepIndex: 1,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "webfetch",
+      inputHash: inputHashFor({ url }),
+      targetHash: targetHashFor(url),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("observe")
+  })
+
+  test("fallback-target successful repeats gate by exact signature only", () => {
+    const input = { payload: "same opaque request" }
+    let records: SessionDiagnostics.ToolCallRecord[] = []
+    for (let i = 0; i < 3; i++) {
+      const observed = SessionDiagnostics.observeToolCall({
+        records,
+        sessionID,
+        parentID,
+        tool: "unknown_mcp",
+        input,
+        agent: "build",
+        modelID: "model" as any,
+        providerID: "provider" as any,
+      })
+      records = [...records, observed.record]
+    }
+
+    const inputHash = inputHashFor(input)
+    const inputSigKey = `success:input:unknown_mcp:${inputHash}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: records,
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    expect(state.signatures[inputSigKey]?.completedCount).toBe(3)
+    expect(Object.keys(state.signatures).some((key) => key.startsWith("success:target:unknown_mcp:"))).toBe(false)
+  })
+
   test("observe when no failures", () => {
     const state = SessionDiagnostics.deriveParentLoopState({
       errorRecords: [],
@@ -97,13 +284,10 @@ describe("SessionDiagnostics.queryGateAction", () => {
     expect(decision.action).toBe("observe")
   })
 
-  test("observe when failures < 5", () => {
+  test("observe before the failure reminder threshold", () => {
     const url = "https://x.com/a"
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
     const records = [
       failingErrorRecord(url),
-      failingErrorRecord(url),
-      failingErrorRecord(url, [sigKey]),
       failingErrorRecord(url),
     ]
     const state = SessionDiagnostics.deriveParentLoopState({
@@ -122,7 +306,7 @@ describe("SessionDiagnostics.queryGateAction", () => {
 
   test("block at >= 5 with target recover emitted and budget unspent", () => {
     const url = "https://x.com/a"
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
+    const sigKey = `failure:target:webfetch:${targetHashFor(url)}`
     const records = [
       failingErrorRecord(url),
       failingErrorRecord(url),
@@ -150,7 +334,7 @@ describe("SessionDiagnostics.queryGateAction", () => {
 
   test("stop when autoResumeSpent", () => {
     const url = "https://x.com/a"
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
+    const sigKey = `failure:target:webfetch:${targetHashFor(url)}`
     const records = [
       failingErrorRecord(url),
       failingErrorRecord(url),
@@ -160,7 +344,7 @@ describe("SessionDiagnostics.queryGateAction", () => {
     ]
     const state = SessionDiagnostics.deriveParentLoopState({
       errorRecords: records,
-      syntheticBlockSigKeys: ["input:other:zzz"],
+      syntheticBlockSigKeys: ["failure:input:other:zzz"],
       parentID,
     })
     const decision = SessionDiagnostics.queryGateAction({
@@ -174,7 +358,7 @@ describe("SessionDiagnostics.queryGateAction", () => {
 
   test("stop when blockEmitted on this same signature", () => {
     const url = "https://x.com/a"
-    const sigKey = `target:webfetch:${targetHashFor(url)}`
+    const sigKey = `failure:target:webfetch:${targetHashFor(url)}`
     const records = [
       failingErrorRecord(url),
       failingErrorRecord(url),
@@ -198,7 +382,7 @@ describe("SessionDiagnostics.queryGateAction", () => {
 
   test("only same_input matches when targetHash absent", () => {
     const inputHash = inputHashFor({ k: "v" })
-    const sigKey = `input:webfetch:${inputHash}`
+    const sigKey = `failure:input:webfetch:${inputHash}`
     const make = (recoverFiredFor: string[] = []): SessionDiagnostics.ToolErrorRecord => ({
       ...failingErrorRecord("u", recoverFiredFor),
       inputHash,

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -198,6 +198,28 @@ describe("SessionDiagnostics.queryGateAction", () => {
     expect(SessionDiagnostics.chooseGateDecision(successStop, failureBlock)).toBe(successStop)
   })
 
+  test("chooses failure block over success block when neither outcome stops", () => {
+    const successBlock = {
+      action: "block",
+      sigKey: "success:input:webfetch:aaa",
+      outcome: "success",
+      kind: "input",
+      completedCount: 3,
+      nextOccurrenceCount: 4,
+    } satisfies SessionDiagnostics.GateDecision
+    const failureBlock = {
+      action: "block",
+      sigKey: "failure:input:webfetch:aaa",
+      outcome: "failure",
+      kind: "input",
+      completedCount: 3,
+      completedFailures: 3,
+      nextOccurrenceCount: 4,
+    } satisfies SessionDiagnostics.GateDecision
+
+    expect(SessionDiagnostics.chooseGateDecision(failureBlock, successBlock)).toBe(failureBlock)
+  })
+
   test("does not block same-step parallel successful repeats before the model can react", () => {
     const url = "https://x.com/a"
     const sigKey = `success:target:webfetch:${targetHashFor(url)}`

--- a/packages/opencode/test/session/loop-renderer.test.ts
+++ b/packages/opencode/test/session/loop-renderer.test.ts
@@ -5,7 +5,9 @@ import { SessionDiagnostics } from "../../src/session/diagnostics"
 const makeState = (
   overrides: Partial<SessionDiagnostics.SignatureState> = {},
 ): SessionDiagnostics.SignatureState => ({
+  outcome: "failure",
   kind: "input",
+  completedCount: 5,
   completedFailures: 5,
   recoverEmitted: true,
   blockEmitted: true,
@@ -13,6 +15,21 @@ const makeState = (
 })
 
 describe("LoopRenderer.render", () => {
+  test("renders concise Chinese success-repeat stop text", () => {
+    const text = LoopRenderer.render({
+      tool: "grep",
+      state: makeState({
+        outcome: "success",
+        kind: "target",
+        completedCount: 4,
+        completedFailures: undefined,
+        lastError: undefined,
+      }),
+      locale: "zh-Hans",
+    })
+    expect(text).toBe("我刚才在重复检查同一处，已停止重复。\n下一步需要换个办法继续。")
+  })
+
   test("webfetch same_input shows the URL", () => {
     const text = LoopRenderer.render({
       tool: "webfetch",

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -506,7 +506,7 @@ it.live("loop continues when finish is tool-calls", () =>
   ),
 )
 
-it.live("loop gate blocks then stops after autoResume budget on repeated tool errors", () =>
+it.live("loop gate records same-step repeated tool errors without block or stop", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -526,7 +526,9 @@ it.live("loop gate blocks then stops after autoResume budget on repeated tool er
         // Always read the same nonexistent path so input + (fallback target) hashes are stable.
         const filePath = path.join(dir, "loop-gate-nonexistent.txt")
         const input = { filePath }
-        for (let i = 0; i < 7; i++) yield* llm.tool("read", input)
+        let sameStep = reply()
+        for (let i = 0; i < 7; i++) sameStep = sameStep.tool("read", input)
+        yield* llm.push(sameStep)
         yield* llm.text("done")
 
         const result = yield* prompt.loop({ sessionID: session.id })
@@ -544,39 +546,8 @@ it.live("loop gate blocks then stops after autoResume budget on repeated tool er
 
         const blockParts = errorParts.filter((p) => p.state.metadata?.diagnostics?.loop?.loopAction === "block")
         const stopParts = errorParts.filter((p) => p.state.metadata?.diagnostics?.loop?.loopAction === "stop")
-        expect(blockParts).toHaveLength(1)
-        expect(stopParts).toHaveLength(1)
-
-        const blockMeta = blockParts[0]!.state.metadata!.diagnostics!.loop!
-        expect(blockMeta.loopType).toBe("target")
-        expect(blockMeta.loopCompletedFailures).toBe(5)
-        expect(blockParts[0]!.state.error).toContain("blocked by PawWork")
-
-        const stopMeta = stopParts[0]!.state.metadata!.diagnostics!.loop!
-        expect(stopMeta.loopType).toBe("target")
-        expect(stopParts[0]!.state.error).toContain("halted by PawWork")
-
-        const stopIdx = allParts.indexOf(stopParts[0]!)
-        const trailing = allParts.slice(stopIdx + 1)
-        // After the synthetic stop, the turn must be terminal: exactly one trailing text part
-        // (the rendered stop summary) and no trailing tool parts. Just looking at the FIRST
-        // text part would still pass if a queued model text leaked through after stop.
-        const trailingTexts = trailing.filter((p): p is MessageV2.TextPart => p.type === "text")
-        expect(trailingTexts).toHaveLength(1)
-        expect(trailingTexts[0]!.synthetic).toBe(true)
-        // Default locale (test fixture sends no user-message locale) → English template.
-        expect(trailingTexts[0]!.text).toContain("stopped")
-        expect(trailing.filter((p) => p.type === "tool")).toHaveLength(0)
-
-        // Recovery fires per-sigKey; in this scenario read+filePath produces both `input:` and
-        // `target:` candidates, so loopRecoverFiredFor can carry either prefix. Accept both —
-        // narrowing to one was a false-failure risk without catching real regressions.
-        const recoverFired = errorParts.some((p) =>
-          (p.state.metadata?.diagnostics?.loop?.loopRecoverFiredFor ?? []).some(
-            (k: string) => k.startsWith("input:") || k.startsWith("target:"),
-          ),
-        )
-        expect(recoverFired).toBe(true)
+        expect(blockParts).toHaveLength(0)
+        expect(stopParts).toHaveLength(0)
 
         const requests = yield* llm.inputs
         // Extract user/system message text fields rather than stringifying the whole request
@@ -597,16 +568,52 @@ it.live("loop gate blocks then stops after autoResume budget on repeated tool er
             return []
           })
         })
-        // Either same-input or same-target reminder is acceptable in this scenario — the
-        // read+filePath path produces both signatures and either flavor is a valid recovery
-        // signal. Narrowing to one would fail spuriously without any behavior regression.
         expect(
           flattenedText.some(
             (t) =>
               t.includes("repeated the same tool input 3 times") ||
               t.includes("failed against the same target multiple times"),
           ),
-        ).toBe(true)
+        ).toBe(false)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop gate blocks repeated tool errors across model steps", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate cross-step",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "read missing repeatedly" }],
+        })
+
+        const input = { filePath: path.join(dir, "loop-gate-cross-step-missing.txt") }
+        for (let i = 0; i < 4; i++) yield* llm.tool("read", input)
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const blockParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "block",
+        )
+        expect(blockParts).toHaveLength(1)
+        expect(blockParts[0].state.metadata?.diagnostics?.loop?.loopCompletedFailures).toBe(3)
       }),
     { git: true, config: providerCfg },
   ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -669,9 +669,60 @@ it.live("loop gate stops repeated successful tools across model steps", () =>
         expect(stopParts).toHaveLength(1)
         expect(stopParts[0].state.metadata?.diagnostics?.loop?.outcome).toBe("success")
         expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopCompletedCount).toBe(3)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopOccurrenceCount).toBe(5)
         expect(result.parts.some((part) => part.type === "text" && part.text.includes("stopped the repetition"))).toBe(
           true,
         )
+        expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(false)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop gate stops repeated tool errors across model steps", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate failure stop",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "read missing until stop" }],
+        })
+
+        const input = { filePath: path.join(dir, "loop-gate-failure-stop-missing.txt") }
+        for (let i = 0; i < 5; i++) yield* llm.tool("read", input)
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const blockParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "block",
+        )
+        const stopParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "stop",
+        )
+
+        expect(blockParts).toHaveLength(1)
+        expect(stopParts).toHaveLength(1)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.outcome).toBe("failure")
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopCompletedCount).toBe(3)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopOccurrenceCount).toBe(5)
         expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(false)
       }),
     { git: true, config: providerCfg },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -619,6 +619,65 @@ it.live("loop gate blocks repeated tool errors across model steps", () =>
   ),
 )
 
+it.live("loop gate stops repeated successful tools across model steps", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate successful stop",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "repeat glob" }],
+        })
+        const file = path.join(dir, "loop-gate-success-stop.txt")
+        yield* Effect.promise(() => Bun.write(file, "probe"))
+
+        const input = { pattern: "**/*.txt" }
+        for (let i = 0; i < 5; i++) yield* llm.tool("glob", input)
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const completedGlobParts = allParts.filter(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "glob" && part.state.status === "completed",
+        )
+        const blockParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "block",
+        )
+        const stopParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "stop",
+        )
+
+        expect(completedGlobParts).toHaveLength(3)
+        expect(blockParts).toHaveLength(1)
+        expect(stopParts).toHaveLength(1)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.outcome).toBe("success")
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopCompletedCount).toBe(3)
+        expect(result.parts.some((part) => part.type === "text" && part.text.includes("stopped the repetition"))).toBe(
+          true,
+        )
+        expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(false)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("glob tool keeps instance context during prompt runs", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
## Summary

Implement a unified structural loop gate for repeated tool calls:

- Count repeated successful tool calls separately from repeated failures.
- Use the shared 3 / 4 / 5 occurrence ladder: reminder, synthetic block, then stop.
- Keep same-step parallel calls observable but non-escalating until the model has a chance to react.
- Keep failure-loop compatibility while intentionally moving failure escalation to the same 3 / 4 / 5 occurrence ladder.
- Export success-loop diagnostics while keeping backward-compatible `completedFailures`.

## Why

#279 showed that PawWork could detect repeated failures, but repeated successful low-value tool calls could still loop until the user interrupted. #378 improved provider/tool-call matching, but it does not solve successful-repeat loops.

## Related Issue

Closes #279.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on loop-gate semantics:

- Success and failure counters stay independent.
- Same assistant-step parallel calls do not trigger block/stop too early.
- Fallback target hashes do not trigger target-level blocking.
- Failure reminders remain compatible, while failure block/stop thresholds are intentionally unified with success at 3 / 4 / 5.

## Risk Notes

Behavior change in the session tool loop gate. Failure loops now use the same 3 / 4 / 5 occurrence ladder as success loops instead of the older looser thresholds. The main residual risk is real-provider streaming timing around highly parallel tool calls, though local prompt-effect coverage exercises the same-step and cross-step boundaries.

No dependencies, migrations, generated files, credentials, permissions, or visible UI changes.

## How To Verify

```text
Focused session tests: 144 passed
bun --cwd packages/opencode test test/session/diagnostics.test.ts test/session/loop-gate.test.ts test/session/loop-renderer.test.ts test/session/prompt-effect.test.ts test/session/export.test.ts

Full session tests: 470 passed, 4 skipped, 1 todo, 0 failed
bun --cwd packages/opencode test test/session

Typecheck: passed
bun run --cwd packages/opencode typecheck

Diff check: no whitespace errors
git diff --check

Final reviewer pass: no findings
Reviewer checked success/failure separation, same-step behavior, failure compatibility, and export compatibility.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer loop diagnostics with explicit success/failure outcomes, occurrence counts, and reminder/block/stop thresholds; snapshot export now surfaces loop outcome, completedCount and occurrenceCount.

* **Bug Fixes**
  * Reminder counting now only tallies successful repeats; gating decisions use per-step context and thresholds to reduce false positives and improve block/stop accuracy.
  * Renderer messages consistently report failure counts.

* **Tests**
  * Expanded coverage for outcome-prefixed reminders, gating scenarios, snapshot exports, and renderer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


