### PR TITLE
fix(app): open projects to new session

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -66,7 +66,7 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
-  latestRootSession,
+  projectSessionRouteTarget,
   startupAutoselectDirectory,
   sortedRootSessions,
   workspaceKey,
@@ -99,7 +99,6 @@ export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
     Persist.global("layout.page", ["layout.page.v1"]),
     createStore({
-      lastProjectSession: {} as { [directory: string]: { directory: string; id: string; at: number } },
       activeProject: undefined as string | undefined,
       activeWorkspace: undefined as string | undefined,
       workspaceOrder: {} as Record<string, string[]>,
@@ -1415,23 +1414,7 @@ export default function Layout(props: ParentProps) {
     return currentProject()?.worktree ?? projectRoot(directory)
   }
 
-  function rememberSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    setStore("lastProjectSession", root, { directory, id, at: Date.now() })
-    return root
-  }
-
-  function clearLastProjectSession(root: string) {
-    if (!store.lastProjectSession[root]) return
-    setStore(
-      "lastProjectSession",
-      produce((draft) => {
-        delete draft[root]
-      }),
-    )
-  }
-
   function syncSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    rememberSessionRoute(directory, id, root)
     notification.session.markViewed(id)
     const expanded = untrack(() => store.workspaceExpanded[directory])
     if (expanded === false) {
@@ -1445,71 +1428,8 @@ export default function Layout(props: ParentProps) {
     if (!directory) return
     const root = projectRoot(directory)
     server.projects.touch(root)
-    const project = layout.projects.list().find((item) => item.worktree === root)
-    let dirs = project
-      ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
-      : [root]
-    const canOpen = (value: string | undefined) => {
-      if (!value) return false
-      return dirs.some((item) => workspaceKey(item) === workspaceKey(value))
-    }
-    const refreshDirs = async (target?: string) => {
-      if (!target || target === root || canOpen(target)) return canOpen(target)
-      const listed = await globalSDK.client.worktree
-        .list({ directory: root })
-        .then((x) => x.data ?? [])
-        .catch(() => [])
-      dirs = effectiveWorkspaceOrder(root, [root, ...listed.map((item) => item.directory)], store.workspaceOrder[root])
-      return canOpen(target)
-    }
-    const openSession = async (target: { directory: string; id: string }) => {
-      if (!canOpen(target.directory)) return false
-      const [data] = globalSync.child(target.directory, { bootstrap: false })
-      if (data.session.some((item) => item.id === target.id)) {
-        setStore("lastProjectSession", root, { directory: target.directory, id: target.id, at: Date.now() })
-        navigate(`/${base64Encode(target.directory)}/session/${target.id}`)
-        return true
-      }
-      const resolved = await globalSDK.client.session
-        .get({ sessionID: target.id })
-        .then((x) => x.data)
-        .catch(() => undefined)
-      if (!resolved?.directory) return false
-      if (!canOpen(resolved.directory)) return false
-      setStore("lastProjectSession", root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
-      navigate(`/${base64Encode(resolved.directory)}/session/${resolved.id}`)
-      return true
-    }
-
-    const projectSession = store.lastProjectSession[root]
-    if (projectSession?.id) {
-      await refreshDirs(projectSession.directory)
-      const opened = await openSession(projectSession)
-      if (opened) return
-      clearLastProjectSession(root)
-    }
-
-    const latest = latestRootSession(dirs.map((item) => globalSync.child(item, { bootstrap: false })[0]))
-    if (latest && (await openSession(latest))) {
-      return
-    }
-
-    const fetched = latestRootSession(
-      await Promise.all(
-        dirs.map(async (item) => ({
-          path: { directory: item },
-          session: await globalSDK.client.session
-            .list({ directory: item, sort: "created" })
-            .then((x) => x.data ?? [])
-            .catch(() => []),
-        })),
-      ),
-    )
-    if (fetched && (await openSession(fetched))) {
-      return
-    }
-
-    navigate(`/${base64Encode(root)}/session`)
+    const target = projectSessionRouteTarget(root)
+    navigate(`/${base64Encode(target.directory)}/session`)
   }
 
   function navigateToSession(session: Session | undefined) {
@@ -1681,10 +1601,6 @@ export default function Layout(props: ParentProps) {
     setBusy(directory, false)
 
     if (!result) return
-
-    if (workspaceKey(store.lastProjectSession[root]?.directory ?? "") === workspaceKey(directory)) {
-      clearLastProjectSession(root)
-    }
 
     globalSync.set(
       "project",
@@ -1972,7 +1888,7 @@ export default function Layout(props: ParentProps) {
 
         if (root === activeRoute.sessionProject) return
         activeRoute.directory = dir
-        activeRoute.sessionProject = rememberSessionRoute(dir, id, root)
+        activeRoute.sessionProject = root
       },
     ),
   )

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  projectSessionRouteTarget,
   sortedRootSessions,
   startupAutoselectDirectory,
   workspaceKey,
@@ -113,6 +114,10 @@ describe("layout workspace helpers", () => {
   test("skips startup autoselect when disabled or missing a backend directory", () => {
     expect(startupAutoselectDirectory?.(false, "/Users/demo/PawWork")).toBeUndefined()
     expect(startupAutoselectDirectory?.(true, undefined)).toBeUndefined()
+  })
+
+  test("opens projects to the new session route without selecting a session", () => {
+    expect(projectSessionRouteTarget("/Users/demo/PawWork")).toEqual({ directory: "/Users/demo/PawWork" })
   })
 
   test("normalizes trailing slash in workspace key", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -86,3 +86,5 @@ export const startupAutoselectDirectory = (enabled: boolean, backendDirectory?: 
   if (!enabled) return
   return backendDirectory || undefined
 }
+
+export const projectSessionRouteTarget = (root: string) => ({ directory: root })


### PR DESCRIPTION
## Summary

Open PawWork projects to the project new-session route instead of automatically restoring a remembered or latest session. Remove the persisted `lastProjectSession` state and its route-writing paths.

## Why

Opening the app or a project should feel like a clean workspace. Automatically jumping into an old session can put users in stale context and make new prompts easy to send to the wrong conversation.

## Related Issue

No linked issue. This follows the maintainer discussion in Codex.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the project-open routing behavior in `packages/app/src/pages/layout.tsx`: explicit session entry points should still work, while project open/startup paths should land on `/{project}/session`.

## Risk Notes

Behavior change: users who previously relied on automatic restoration of a project-specific old session will now land on the project new-session route. Existing persisted `lastProjectSession` data is left unused rather than migrated.

## How To Verify

```text
Focused layout helper test: 26 passed, 0 failed (`bun test --preload ./happydom.ts src/pages/layout/helpers.test.ts` from packages/app)
App typecheck: passed (`bun run typecheck` from packages/app)
Diff check: no whitespace errors (`git diff --check`)
Source search: no `lastProjectSession`, `rememberSessionRoute`, or `clearLastProjectSession` references remain under packages/app/src
```

## Screenshots or Recordings

Not included. This changes startup/project routing behavior without changing visual styling or copy.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined project switching navigation with simplified session route handling
  * Reduced stored session metadata for improved efficiency

* **Tests**
  * Added test coverage for project session route targeting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->