### PR TITLE
chore(release): bump version to 2026.5.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "2026.5.3",
+      "version": "2026.5.4",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -97,7 +97,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.3",
+      "version": "2026.5.4",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",
@@ -145,7 +145,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "2026.5.3",
+      "version": "2026.5.4",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -371,7 +371,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "2026.5.3",
+      "version": "2026.5.4",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.5.3",
+  "version": "2026.5.4",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.3",
+  "version": "2026.5.4",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.5.3",
+  "version": "2026.5.4",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.5.3",
+  "version": "2026.5.4",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump PawWork package versions from `2026.5.3` to `2026.5.4` for the next production release.

## Changed

- Update workspace package versions to `2026.5.4`
- Sync `bun.lock` workspace version entries

## Verification

- `bun install --frozen-lockfile`
- `bun --cwd packages/desktop-electron typecheck:release`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2026.5.4 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->