### PR TITLE
fix: package native watcher in desktop builds

### DIFF
--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from "../fixtures"
-import { titlebarRightSelector } from "../selectors"
+import { openSidebar } from "../actions"
+import { pawworkSessionNewSelector, titlebarRightSelector } from "../selectors"
 import { modKey } from "../utils"
 
 test("desktop right-panel tabs switch between review and files within a unified utility shell", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
-  const rightPanel = page.locator("#right-panel")
+  const rightPanel = page.locator('[data-component="right-panel"]')
   await expect(rightToggle).toBeVisible()
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 
@@ -34,6 +35,22 @@ test("desktop right-panel tabs switch between review and files within a unified 
   await page.keyboard.press(`${modKey}+Shift+R`)
   await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
   await expect(reviewTab).toHaveAttribute("aria-selected", "true")
+})
+
+test("desktop remains clickable after right-panel resize ends with mouseup", async ({ page, gotoSession, slug }) => {
+  await gotoSession()
+  await openSidebar(page)
+
+  const rightPanel = page.locator("#right-panel")
+  await page.keyboard.press(`${modKey}+Shift+R`)
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+  await page.locator('[data-component="right-panel-resize-wrapper"]').dispatchEvent("pointerdown")
+  await page.mouse.up()
+
+  await page.locator(pawworkSessionNewSelector).click()
+  await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
+  await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
 })
 
 test("desktop session keeps a single right-panel toggle and icon-first utility tabs", async ({ page, gotoSession }) => {

--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -1,6 +1,20 @@
+import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { cleanupSession, cleanupTestProject, createTestProject, openSidebar, waitSession } from "../actions"
 import { promptSelector } from "../selectors"
+
+async function expectUrlToStayMatched(page: Page, pattern: RegExp, stableFor = 300) {
+  let stableSince = Date.now()
+  await expect
+    .poll(() => {
+      if (!pattern.test(page.url())) {
+        stableSince = Date.now()
+        return false
+      }
+      return Date.now() - stableSince >= stableFor
+    })
+    .toBe(true)
+}
 
 test("sidebar session links navigate to the selected session", async ({ page, slug, sdk, gotoSession }) => {
   const stamp = Date.now()
@@ -20,9 +34,15 @@ test("sidebar session links navigate to the selected session", async ({ page, sl
     await expect(target).toBeVisible()
     await target.click()
 
-    await expect(page).toHaveURL(new RegExp(`/${slug}/session/${two.id}(?:\\?|#|$)`))
+    const selectedSessionUrl = new RegExp(`/${slug}/session/${two.id}(?:\\?|#|$)`)
+    await expect(page).toHaveURL(selectedSessionUrl)
+    await expectUrlToStayMatched(page, selectedSessionUrl)
     await expect(page.locator(promptSelector)).toBeVisible()
     await expect(page.locator(`[data-session-id="${two.id}"] a`).first()).toHaveClass(/\bactive\b/)
+
+    await page.locator('[data-action="pawwork-session-new"]').click()
+    await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
+    await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
   } finally {
     await cleanupSession({ sdk, sessionID: one.id })
     await cleanupSession({ sdk, sessionID: two.id })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -94,6 +94,7 @@ import { PawworkTitlebar } from "./layout/pawwork-titlebar"
 import { SettingsPage, type SettingsPageTab } from "@/components/settings-page"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
 import { sessionTitle } from "@/utils/session-title"
+import { sizingStopEvents } from "@/pages/session/helpers"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -192,9 +193,7 @@ export default function Layout(props: ParentProps) {
 
   onMount(() => {
     const stop = () => setState("sizing", false)
-    makeEventListener(window, "pointerup", stop)
-    makeEventListener(window, "pointercancel", stop)
-    makeEventListener(window, "blur", stop)
+    for (const event of sizingStopEvents) makeEventListener(window, event, stop)
   })
 
   createEffect(() => {

--- a/packages/app/src/pages/session/helpers.test.ts
+++ b/packages/app/src/pages/session/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   createSessionTabs,
   focusTerminalById,
   getTabReorderIndex,
+  sizingStopEvents,
   shouldFocusTerminalOnKeyDown,
 } from "./helpers"
 
@@ -114,6 +115,12 @@ describe("getTabReorderIndex", () => {
 
   test("returns undefined for unknown droppable id", () => {
     expect(getTabReorderIndex(["a", "b", "c"], "a", "missing")).toBeUndefined()
+  })
+})
+
+describe("createSizing", () => {
+  test("listens for mouse and touch endings as resize fallbacks", () => {
+    expect(sizingStopEvents).toEqual(["pointerup", "pointercancel", "mouseup", "touchend", "touchcancel", "blur"])
   })
 })
 

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -153,6 +153,8 @@ export const getTabReorderIndex = (tabs: readonly string[], from: string, to: st
   return toIndex
 }
 
+export const sizingStopEvents = ["pointerup", "pointercancel", "mouseup", "touchend", "touchcancel", "blur"] as const
+
 export const createSizing = () => {
   const [state, setState] = createStore({ active: false })
   let t: number | undefined
@@ -174,9 +176,7 @@ export const createSizing = () => {
   }
 
   onMount(() => {
-    makeEventListener(window, "pointerup", stop)
-    makeEventListener(window, "pointercancel", stop)
-    makeEventListener(window, "blur", stop)
+    for (const event of sizingStopEvents) makeEventListener(window, event, stop)
   })
 
   onCleanup(() => {

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -263,6 +263,7 @@ export function SessionSidePanel(props: {
     <Show when={isDesktop()}>
       <aside
         id="right-panel"
+        data-component="right-panel"
         aria-label={language.t("session.panel.utility")}
         aria-hidden={!open()}
         inert={!open()}
@@ -275,7 +276,7 @@ export function SessionSidePanel(props: {
         style={{ width: panelWidth() }}
       >
         <div
-          data-testid="right-panel-resize-wrapper"
+          data-component="right-panel-resize-wrapper"
           onPointerDown={() => props.size.start()}
           class="absolute top-0 left-0 h-full z-10"
         >

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import type { Configuration } from "electron-builder"
-import { createConfig, getPublishConfig } from "./electron-builder.config"
+import {
+  createConfig,
+  getPublishConfig,
+  nativeWatcherFileSets,
+  nativeWatcherPackageNames,
+} from "./electron-builder.config"
 import { serializeAppUpdateConfig } from "./scripts/write-app-update-config"
 
 const roots: string[] = []
@@ -71,6 +76,38 @@ describe("electron builder app-update config", () => {
           to: "THIRD_PARTY_NOTICES.md",
         }),
       ]),
+    )
+  })
+
+  test("native watcher package list covers desktop targets", () => {
+    expect(nativeWatcherPackageNames()).toEqual([
+      "@parcel/watcher-darwin-arm64",
+      "@parcel/watcher-darwin-x64",
+      "@parcel/watcher-linux-arm64-glibc",
+      "@parcel/watcher-linux-arm64-musl",
+      "@parcel/watcher-linux-x64-glibc",
+      "@parcel/watcher-linux-x64-musl",
+      "@parcel/watcher-win32-arm64",
+      "@parcel/watcher-win32-x64",
+    ])
+  })
+
+  test("packages native file watcher bindings for the embedded server", () => {
+    const config = createConfig("prod")
+    const resources = nativeWatcherFileSets()
+
+    expect(config.extraResources).toEqual(
+      expect.arrayContaining(
+        resources.map((resource) =>
+          expect.objectContaining({
+            from: resource.from,
+            to: resource.to,
+          }),
+        ),
+      ),
+    )
+    expect(resources.map((resource) => resource.to)).toEqual(
+      nativeWatcherPackageNames().map((packageName) => join("node_modules", ...packageName.split("/"))),
     )
   })
 

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process"
 import { mkdir, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
@@ -10,6 +11,11 @@ import { writeAppUpdateConfig, type GitHubPublishConfig } from "./scripts/write-
 const execFileAsync = promisify(execFile)
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 const signScript = path.join(rootDir, "script", "sign-windows.ps1")
+const requireFromOpencode = createRequire(path.join(rootDir, "packages", "opencode", "package.json"))
+const opencodePackage = requireFromOpencode("./package.json") as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
 type Channel = "dev" | "beta" | "prod"
 const localizedMacDisplayNameByChannel: Record<Channel, string> = {
   dev: "爪印 Dev",
@@ -32,6 +38,50 @@ function currentChannel(): Channel {
   const raw = process.env.OPENCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
   return "dev"
+}
+
+const nativeWatcherPackages = [
+  "@parcel/watcher-darwin-arm64",
+  "@parcel/watcher-darwin-x64",
+  "@parcel/watcher-linux-arm64-glibc",
+  "@parcel/watcher-linux-arm64-musl",
+  "@parcel/watcher-linux-x64-glibc",
+  "@parcel/watcher-linux-x64-musl",
+  "@parcel/watcher-win32-arm64",
+  "@parcel/watcher-win32-x64",
+] as const
+
+export function nativeWatcherPackageNames() {
+  return [...nativeWatcherPackages]
+}
+
+function bunPackageFallbackDir(packageName: string) {
+  const version = opencodePackage.devDependencies?.[packageName] ?? opencodePackage.dependencies?.[packageName]
+  if (!version) throw new Error(`Missing ${packageName} in packages/opencode/package.json`)
+  return path.join(
+    rootDir,
+    "node_modules",
+    ".bun",
+    `${packageName.replace("/", "+")}@${version}`,
+    "node_modules",
+    ...packageName.split("/"),
+  )
+}
+
+function nativeWatcherPackageDir(packageName: string) {
+  try {
+    return path.dirname(requireFromOpencode.resolve(`${packageName}/package.json`))
+  } catch {
+    return bunPackageFallbackDir(packageName)
+  }
+}
+
+export function nativeWatcherFileSets() {
+  return nativeWatcherPackages.map((packageName) => ({
+    from: nativeWatcherPackageDir(packageName),
+    to: path.join("node_modules", ...packageName.split("/")),
+    filter: ["**/*"],
+  }))
 }
 
 export function getPublishConfig(channel: Channel): GitHubPublishConfig | undefined {
@@ -59,6 +109,7 @@ const getBase = (): Configuration => ({
   },
   files: ["out/**/*", "resources/**/*"],
   extraResources: [
+    ...nativeWatcherFileSets(),
     {
       from: path.join(rootDir, "skills"),
       to: "skills",

--- a/packages/desktop-electron/scripts/prepare-embedded-server.ts
+++ b/packages/desktop-electron/scripts/prepare-embedded-server.ts
@@ -4,4 +4,5 @@ import { resolveOpencodeRoot } from "./embedded-server-path"
 
 const opencodeRoot = resolveOpencodeRoot(import.meta.dir)
 
+await $`bun install --cwd ${opencodeRoot} --os="*" --cpu="*" --frozen-lockfile`
 await $`bun run --cwd ${opencodeRoot} build:embedded-server`


### PR DESCRIPTION
## Summary

Packages all desktop `@parcel/watcher-*` native bindings with desktop builds so the embedded sidecar can load its file watcher in packaged apps across macOS, Linux, and Windows targets.

Also closes the resize click-deadlock path by making both layout-level sizing and session panel sizing stop on `mouseup`, `touchend`, and `touchcancel`, not only pointer events. Sidebar route coverage now verifies both route stability and visible new-session UI.

## Why

The packaged app log showed the embedded server failing to load `@parcel/watcher-darwin-arm64`:

```text
Cannot find module '@parcel/watcher-darwin-arm64'
```

That leaves the sidecar without native file watching in packaged builds, which can break session/file refresh behavior.

A second failure mode matched the reported app-wide click symptoms: resize wrappers start sizing on pointer events while `ResizeHandle` ends drag with mouse events. If sizing never stops, the app can remain in a drag/sizing interaction state after the user releases the mouse.

## Related Issue

No issue linked. This is an urgent packaged-build and clickability regression found from local app diagnostics.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check:

- all watcher native packages are acceptable as packaged resources for urgent release safety
- `prepare-embedded-server.ts` installing optional packages with `--os="*" --cpu="*" --frozen-lockfile` is the right build-time hook
- `sizingStopEvents` covers the mixed pointer/mouse/touch resize paths without broad behavior changes

## Risk Notes

Desktop packaging change. The app package includes more native watcher packages than the current host platform needs, trading package size for release safety across target platforms. No runtime behavior change outside packaged resource inclusion and resize sizing cleanup.

## How To Verify

```text
Desktop builder config tests: 15 passed, including all-target watcher resource coverage
Embedded server packaging tests: 19 passed across app-update, embedded-server-build, embedded-server-contract, and prepare-embedded-server tests
Sizing unit test: 13 passed for session helpers, including mouse/touch stop event coverage
Resize click e2e: 1 passed, right-panel resize pointerdown followed by mouseup still allows PawWork new-session click
Sidebar route e2e: 2 passed, including delayed session route stability and visible new-session home
Desktop typecheck: passed
macOS desktop build: passed
macOS dir package: passed with electron-builder --mac dir --arm64
Packaged watcher resources: all 8 desktop watcher packages present under Resources/node_modules/@parcel
Packaged watcher resolution: ok, all 8 packages resolve from the generated app.asar main chunk context
Diff check: no whitespace errors
```

## Screenshots or Recordings

Not applicable. This is a packaging/runtime fix plus interaction regression coverage, with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and strengthened end-to-end tests for session navigation, sidebar links, right-panel resize interactions, and desktop packaging validations.

* **Bug Fixes / Improvements**
  * Broadened resize-stop handling to cover more input/end events for more reliable panel resizing and stable UI interaction after resize.
  * Improved UI selectors and stability checks to prevent flaky navigation assertions.

* **Chores**
  * Ensure native watcher assets are discovered and included in desktop packaging and run dependency install when preparing the embedded server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->