### PR TITLE
fix: harden interaction locks and session routes

### DIFF
--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "../fixtures"
-import { openSidebar } from "../actions"
-import { pawworkSessionNewSelector, titlebarRightSelector } from "../selectors"
+import { cleanupSession, openSidebar } from "../actions"
+import { pawworkSessionNewSelector, promptSelector, titlebarRightSelector } from "../selectors"
 import { modKey } from "../utils"
 
 test("desktop right-panel tabs switch between review and files within a unified utility shell", async ({ page, gotoSession }) => {
@@ -37,20 +37,39 @@ test("desktop right-panel tabs switch between review and files within a unified 
   await expect(reviewTab).toHaveAttribute("aria-selected", "true")
 })
 
-test("desktop remains clickable after right-panel resize ends with mouseup", async ({ page, gotoSession, slug }) => {
-  await gotoSession()
-  await openSidebar(page)
+test("desktop remains clickable after right-panel resize ends with mouseup", async ({ page, gotoSession, slug, sdk }) => {
+  const stamp = Date.now()
+  const one = await sdk.session.create({ title: `e2e resize source ${stamp}` }).then((r) => r.data)
+  const two = await sdk.session.create({ title: `e2e resize target ${stamp}` }).then((r) => r.data)
 
-  const rightPanel = page.locator("#right-panel")
-  await page.keyboard.press(`${modKey}+Shift+R`)
-  await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+  if (!one?.id) throw new Error("Source session create did not return an id")
+  if (!two?.id) throw new Error("Target session create did not return an id")
 
-  await page.locator('[data-component="right-panel-resize-wrapper"]').dispatchEvent("pointerdown")
-  await page.mouse.up()
+  try {
+    await gotoSession(one.id)
+    await openSidebar(page)
 
-  await page.locator(pawworkSessionNewSelector).click()
-  await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
-  await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
+    const rightPanel = page.locator("#right-panel")
+    await page.keyboard.press(`${modKey}+Shift+R`)
+    await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
+
+    await page.locator('[data-component="right-panel-resize-wrapper"]').dispatchEvent("pointerdown")
+    await page.mouse.up()
+
+    await page.locator(pawworkSessionNewSelector).click()
+    await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
+    await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
+
+    await page.locator(`[data-session-id="${two.id}"] a`).first().click()
+    await expect(page).toHaveURL(new RegExp(`/${slug}/session/${two.id}(?:\\?|#|$)`))
+    await expect(page.locator(promptSelector)).toBeVisible()
+
+    await page.locator('[data-action="pawwork-open-settings"]').click()
+    await expect(page.locator('[data-component="settings-page"]')).toBeVisible()
+  } finally {
+    await cleanupSession({ sdk, sessionID: one.id })
+    await cleanupSession({ sdk, sessionID: two.id })
+  }
 })
 
 test("desktop session keeps a single right-panel toggle and icon-first utility tabs", async ({ page, gotoSession }) => {

--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -53,8 +53,36 @@ test("desktop remains clickable after right-panel resize ends with mouseup", asy
     await page.keyboard.press(`${modKey}+Shift+R`)
     await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
 
-    await page.locator('[data-component="right-panel-resize-wrapper"]').dispatchEvent("pointerdown")
+    const handle = page.locator('[data-component="right-panel-resize-wrapper"] [data-component="resize-handle"]')
+    await expect(handle).toBeVisible()
+    const box = await handle.boundingBox()
+    if (!box) throw new Error("Right-panel resize handle missing")
+
+    const start = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+    await handle.dispatchEvent("mousedown", {
+      button: 0,
+      buttons: 1,
+      clientX: start.x,
+      clientY: start.y,
+    })
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          overflow: document.body.style.overflow,
+          userSelect: document.body.style.userSelect,
+        })),
+      )
+      .toEqual({ overflow: "hidden", userSelect: "none" })
+    await page.mouse.move(start.x - 40, start.y)
     await page.mouse.up()
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          overflow: document.body.style.overflow,
+          userSelect: document.body.style.userSelect,
+        })),
+      )
+      .toEqual({ overflow: "", userSelect: "" })
 
     await page.locator(pawworkSessionNewSelector).click()
     await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))

--- a/packages/app/e2e/commands/panels.spec.ts
+++ b/packages/app/e2e/commands/panels.spec.ts
@@ -39,17 +39,22 @@ test("desktop right-panel tabs switch between review and files within a unified 
 
 test("desktop remains clickable after right-panel resize ends with mouseup", async ({ page, gotoSession, slug, sdk }) => {
   const stamp = Date.now()
-  const one = await sdk.session.create({ title: `e2e resize source ${stamp}` }).then((r) => r.data)
-  const two = await sdk.session.create({ title: `e2e resize target ${stamp}` }).then((r) => r.data)
-
-  if (!one?.id) throw new Error("Source session create did not return an id")
-  if (!two?.id) throw new Error("Target session create did not return an id")
+  let oneID: string | undefined
+  let twoID: string | undefined
 
   try {
-    await gotoSession(one.id)
+    const one = await sdk.session.create({ title: `e2e resize source ${stamp}` }).then((r) => r.data)
+    if (!one?.id) throw new Error("Source session create did not return an id")
+    oneID = one.id
+
+    const two = await sdk.session.create({ title: `e2e resize target ${stamp}` }).then((r) => r.data)
+    if (!two?.id) throw new Error("Target session create did not return an id")
+    twoID = two.id
+
+    await gotoSession(oneID)
     await openSidebar(page)
 
-    const rightPanel = page.locator("#right-panel")
+    const rightPanel = page.locator('[data-component="right-panel"]')
     await page.keyboard.press(`${modKey}+Shift+R`)
     await expect(rightPanel).toHaveAttribute("aria-hidden", "false")
 
@@ -88,15 +93,15 @@ test("desktop remains clickable after right-panel resize ends with mouseup", asy
     await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
     await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
 
-    await page.locator(`[data-session-id="${two.id}"] a`).first().click()
-    await expect(page).toHaveURL(new RegExp(`/${slug}/session/${two.id}(?:\\?|#|$)`))
+    await page.locator(`[data-session-id="${twoID}"] a`).first().click()
+    await expect(page).toHaveURL(new RegExp(`/${slug}/session/${twoID}(?:\\?|#|$)`))
     await expect(page.locator(promptSelector)).toBeVisible()
 
     await page.locator('[data-action="pawwork-open-settings"]').click()
     await expect(page.locator('[data-component="settings-page"]')).toBeVisible()
   } finally {
-    await cleanupSession({ sdk, sessionID: one.id })
-    await cleanupSession({ sdk, sessionID: two.id })
+    if (oneID) await cleanupSession({ sdk, sessionID: oneID })
+    if (twoID) await cleanupSession({ sdk, sessionID: twoID })
   }
 })
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -66,7 +66,9 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
-  projectSessionRouteTarget,
+  newSessionRoute,
+  openProjectRoute,
+  openSessionRoute,
   startupAutoselectDirectory,
   sortedRootSessions,
   workspaceKey,
@@ -1427,13 +1429,12 @@ export default function Layout(props: ParentProps) {
     if (!directory) return
     const root = projectRoot(directory)
     server.projects.touch(root)
-    const target = projectSessionRouteTarget(root)
-    navigate(`/${base64Encode(target.directory)}/session`)
+    navigate(openProjectRoute(root))
   }
 
   function navigateToSession(session: Session | undefined) {
     if (!session) return
-    navigate(`/${base64Encode(session.directory)}/session/${session.id}`)
+    navigate(openSessionRoute(session.directory, session.id))
   }
 
   function openPawworkHome(directory?: string) {
@@ -1442,12 +1443,12 @@ export default function Layout(props: ParentProps) {
       chooseProject()
       return
     }
-    navigate(`/${base64Encode(root)}/session`)
+    navigate(newSessionRoute(root))
   }
 
-  function openProject(directory: string, navigate = true) {
+  function openProject(directory: string, shouldNavigate = true) {
     layout.projects.open(directory)
-    if (navigate) return navigateToProject(directory)
+    if (shouldNavigate) return navigateToProject(directory)
   }
 
   const handleDeepLinks = (urls: string[]) => {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { base64Encode } from "@opencode-ai/util/encode"
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
@@ -14,6 +15,9 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  newSessionRoute,
+  openProjectRoute,
+  openSessionRoute,
   projectSessionRouteTarget,
   sortedRootSessions,
   startupAutoselectDirectory,
@@ -118,6 +122,14 @@ describe("layout workspace helpers", () => {
 
   test("opens projects to the new session route without selecting a session", () => {
     expect(projectSessionRouteTarget("/Users/demo/PawWork")).toEqual({ directory: "/Users/demo/PawWork" })
+  })
+
+  test("keeps project, new-session, and explicit-session routes separate", () => {
+    expect(openProjectRoute("/Users/demo/PawWork")).toBe(`/${base64Encode("/Users/demo/PawWork")}/session`)
+    expect(newSessionRoute("/Users/demo/worktree")).toBe(`/${base64Encode("/Users/demo/worktree")}/session`)
+    expect(openSessionRoute("/Users/demo/worktree", "ses_123")).toBe(
+      `/${base64Encode("/Users/demo/worktree")}/session/ses_123`,
+    )
   })
 
   test("normalizes trailing slash in workspace key", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -1,6 +1,7 @@
 import { getFilename } from "@opencode-ai/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import { compareSessionsByCreated } from "@/context/global-sync/utils"
+import { base64Encode } from "@opencode-ai/util/encode"
 
 type SessionStore = {
   session?: Session[]
@@ -88,3 +89,9 @@ export const startupAutoselectDirectory = (enabled: boolean, backendDirectory?: 
 }
 
 export const projectSessionRouteTarget = (root: string) => ({ directory: root })
+
+export const newSessionRoute = (directory: string) => `/${base64Encode(directory)}/session`
+
+export const openProjectRoute = (root: string) => newSessionRoute(projectSessionRouteTarget(root).directory)
+
+export const openSessionRoute = (directory: string, id: string) => `${newSessionRoute(directory)}/${id}`

--- a/packages/ui/src/components/resize-handle.test.ts
+++ b/packages/ui/src/components/resize-handle.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { createBodyInteractionLock } from "./resize-handle"
+
+describe("createBodyInteractionLock", () => {
+  test("releases body interaction styles on fallback stop events", () => {
+    const target = new EventTarget()
+    const body = { style: { userSelect: "", overflow: "" } }
+    const lock = createBodyInteractionLock(body, { target, fallbackMs: 1000 })
+
+    lock.start()
+    expect(body.style.userSelect).toBe("none")
+    expect(body.style.overflow).toBe("hidden")
+
+    target.dispatchEvent(new Event("blur"))
+
+    expect(body.style.userSelect).toBe("")
+    expect(body.style.overflow).toBe("")
+  })
+})

--- a/packages/ui/src/components/resize-handle.test.ts
+++ b/packages/ui/src/components/resize-handle.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, test } from "bun:test"
 import { createBodyInteractionLock } from "./resize-handle"
 
 describe("createBodyInteractionLock", () => {
-  test("releases body interaction styles on fallback stop events", () => {
+  test("releases body interaction styles on cancel events", () => {
     const target = new EventTarget()
     const body = { style: { userSelect: "", overflow: "" } }
-    const lock = createBodyInteractionLock(body, { target, fallbackMs: 1000 })
+    const releases: string[] = []
+    const lock = createBodyInteractionLock(body, {
+      target,
+      fallbackMs: 1000,
+      onRelease: (reason) => releases.push(reason),
+    })
 
     lock.start()
     expect(body.style.userSelect).toBe("none")
@@ -15,5 +20,66 @@ describe("createBodyInteractionLock", () => {
 
     expect(body.style.userSelect).toBe("")
     expect(body.style.overflow).toBe("")
+    expect(releases).toEqual(["cancel"])
+  })
+
+  test("treats pointerup as a completed resize release", () => {
+    const target = new EventTarget()
+    const body = { style: { userSelect: "", overflow: "" } }
+    const releases: string[] = []
+    const lock = createBodyInteractionLock(body, {
+      target,
+      fallbackMs: 1000,
+      onRelease: (reason) => releases.push(reason),
+    })
+
+    lock.start()
+    target.dispatchEvent(new Event("pointerup"))
+
+    expect(body.style.userSelect).toBe("")
+    expect(body.style.overflow).toBe("")
+    expect(releases).toEqual(["complete"])
+  })
+
+  test("restores previous styles and keeps repeated start idempotent", () => {
+    const target = new EventTarget()
+    const body = { style: { userSelect: "text", overflow: "auto" } }
+    const releases: string[] = []
+    const lock = createBodyInteractionLock(body, {
+      target,
+      fallbackMs: 1000,
+      onRelease: (reason) => releases.push(reason),
+    })
+
+    lock.start()
+    lock.start()
+    target.dispatchEvent(new Event("mouseup"))
+    target.dispatchEvent(new Event("mouseup"))
+
+    expect(body.style.userSelect).toBe("text")
+    expect(body.style.overflow).toBe("auto")
+    expect(releases).toEqual(["complete"])
+  })
+
+  test("releases on timeout once", async () => {
+    const target = new EventTarget()
+    const body = { style: { userSelect: "", overflow: "" } }
+    const releases: string[] = []
+    const timeoutLock = createBodyInteractionLock(body, {
+      target,
+      fallbackMs: 1,
+      onRelease: (reason) => releases.push(reason),
+    })
+
+    timeoutLock.start()
+    expect(body.style.userSelect).toBe("none")
+    expect(body.style.overflow).toBe("hidden")
+
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    timeoutLock.stop()
+
+    expect(body.style.userSelect).toBe("")
+    expect(body.style.overflow).toBe("")
+    expect(releases).toEqual(["timeout"])
   })
 })

--- a/packages/ui/src/components/resize-handle.test.ts
+++ b/packages/ui/src/components/resize-handle.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { createBodyInteractionLock } from "./resize-handle"
+import { createBodyInteractionLock, resizeInteractionFallbackMs } from "./resize-handle"
 
 describe("createBodyInteractionLock", () => {
+  test("uses a long default fallback timeout for manual resizing", () => {
+    expect(resizeInteractionFallbackMs).toBe(30_000)
+  })
+
   test("releases body interaction styles on cancel events", () => {
     const target = new EventTarget()
     const body = { style: { userSelect: "", overflow: "" } }

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -11,6 +11,69 @@ export interface ResizeHandleProps extends Omit<JSX.HTMLAttributes<HTMLDivElemen
   collapseThreshold?: number
 }
 
+export const resizeInteractionStopEvents = [
+  "mouseup",
+  "pointerup",
+  "pointercancel",
+  "touchend",
+  "touchcancel",
+  "blur",
+] as const
+
+type BodyInteractionLockTarget = {
+  style: {
+    userSelect: string
+    overflow: string
+  }
+}
+
+export function createBodyInteractionLock(
+  body: BodyInteractionLockTarget,
+  options: {
+    target?: EventTarget
+    fallbackMs?: number
+    onRelease?: () => void
+  } = {},
+) {
+  const target = options.target ?? window
+  const fallbackMs = options.fallbackMs ?? 5000
+  let active = false
+  let fallback: ReturnType<typeof setTimeout> | undefined
+  let previousUserSelect = ""
+  let previousOverflow = ""
+
+  const release = () => {
+    if (!active) return
+    active = false
+    body.style.userSelect = previousUserSelect
+    body.style.overflow = previousOverflow
+    if (fallback !== undefined) {
+      clearTimeout(fallback)
+      fallback = undefined
+    }
+    for (const event of resizeInteractionStopEvents) {
+      target.removeEventListener(event, release)
+    }
+    options.onRelease?.()
+  }
+
+  return {
+    start() {
+      if (active) return
+      active = true
+      previousUserSelect = body.style.userSelect
+      previousOverflow = body.style.overflow
+      body.style.userSelect = "none"
+      body.style.overflow = "hidden"
+      for (const event of resizeInteractionStopEvents) {
+        target.addEventListener(event, release)
+      }
+      fallback = setTimeout(release, fallbackMs)
+    },
+    stop: release,
+  }
+}
+
 export function ResizeHandle(props: ResizeHandleProps) {
   const [local, rest] = splitProps(props, [
     "direction",
@@ -32,9 +95,6 @@ export function ResizeHandle(props: ResizeHandleProps) {
     const startSize = local.size
     let current = startSize
 
-    document.body.style.userSelect = "none"
-    document.body.style.overflow = "hidden"
-
     const onMouseMove = (moveEvent: MouseEvent) => {
       const pos = local.direction === "horizontal" ? moveEvent.clientX : moveEvent.clientY
       const delta =
@@ -50,18 +110,29 @@ export function ResizeHandle(props: ResizeHandleProps) {
       local.onResize(clamped)
     }
 
-    const onMouseUp = () => {
-      document.body.style.userSelect = ""
-      document.body.style.overflow = ""
+    let finished = false
+    const finish = (collapse: boolean) => {
+      if (finished) return
+      finished = true
       document.removeEventListener("mousemove", onMouseMove)
       document.removeEventListener("mouseup", onMouseUp)
 
       const threshold = local.collapseThreshold ?? 0
-      if (local.onCollapse && threshold > 0 && current < threshold) {
+      if (collapse && local.onCollapse && threshold > 0 && current < threshold) {
         local.onCollapse()
       }
     }
 
+    const lock = createBodyInteractionLock(document.body, {
+      onRelease: () => finish(false),
+    })
+
+    const onMouseUp = () => {
+      finish(true)
+      lock.stop()
+    }
+
+    lock.start()
     document.addEventListener("mousemove", onMouseMove)
     document.addEventListener("mouseup", onMouseUp)
   }

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -32,6 +32,8 @@ export const resizeInteractionStopEvents = [
 
 export type BodyInteractionLockReleaseReason = "complete" | "cancel" | "timeout"
 
+export const resizeInteractionFallbackMs = 30_000
+
 type BodyInteractionLockTarget = {
   style: {
     userSelect: string
@@ -48,7 +50,7 @@ export function createBodyInteractionLock(
   } = {},
 ) {
   const target = options.target ?? window
-  const fallbackMs = options.fallbackMs ?? 5000
+  const fallbackMs = options.fallbackMs ?? resizeInteractionFallbackMs
   let active = false
   let fallback: ReturnType<typeof setTimeout> | undefined
   let previousUserSelect = ""

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -11,6 +11,15 @@ export interface ResizeHandleProps extends Omit<JSX.HTMLAttributes<HTMLDivElemen
   collapseThreshold?: number
 }
 
+export const resizeInteractionCompleteEvents = ["mouseup", "pointerup", "touchend"] as const
+
+export const resizeInteractionCancelEvents = [
+  "pointercancel",
+  "touchcancel",
+  "blur",
+  "pagehide",
+] as const
+
 export const resizeInteractionStopEvents = [
   "mouseup",
   "pointerup",
@@ -18,7 +27,10 @@ export const resizeInteractionStopEvents = [
   "touchend",
   "touchcancel",
   "blur",
+  "pagehide",
 ] as const
+
+export type BodyInteractionLockReleaseReason = "complete" | "cancel" | "timeout"
 
 type BodyInteractionLockTarget = {
   style: {
@@ -32,7 +44,7 @@ export function createBodyInteractionLock(
   options: {
     target?: EventTarget
     fallbackMs?: number
-    onRelease?: () => void
+    onRelease?: (reason: BodyInteractionLockReleaseReason) => void
   } = {},
 ) {
   const target = options.target ?? window
@@ -42,7 +54,7 @@ export function createBodyInteractionLock(
   let previousUserSelect = ""
   let previousOverflow = ""
 
-  const release = () => {
+  const release = (reason: BodyInteractionLockReleaseReason) => {
     if (!active) return
     active = false
     body.style.userSelect = previousUserSelect
@@ -52,10 +64,14 @@ export function createBodyInteractionLock(
       fallback = undefined
     }
     for (const event of resizeInteractionStopEvents) {
-      target.removeEventListener(event, release)
+      target.removeEventListener(event, complete)
+      target.removeEventListener(event, cancel)
     }
-    options.onRelease?.()
+    options.onRelease?.(reason)
   }
+  const complete = () => release("complete")
+  const cancel = () => release("cancel")
+  const timeout = () => release("timeout")
 
   return {
     start() {
@@ -65,12 +81,15 @@ export function createBodyInteractionLock(
       previousOverflow = body.style.overflow
       body.style.userSelect = "none"
       body.style.overflow = "hidden"
-      for (const event of resizeInteractionStopEvents) {
-        target.addEventListener(event, release)
+      for (const event of resizeInteractionCompleteEvents) {
+        target.addEventListener(event, complete)
       }
-      fallback = setTimeout(release, fallbackMs)
+      for (const event of resizeInteractionCancelEvents) {
+        target.addEventListener(event, cancel)
+      }
+      fallback = setTimeout(timeout, fallbackMs)
     },
-    stop: release,
+    stop: complete,
   }
 }
 
@@ -124,7 +143,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
     }
 
     const lock = createBodyInteractionLock(document.body, {
-      onRelease: () => finish(false),
+      onRelease: (reason) => finish(reason === "complete"),
     })
 
     const onMouseUp = () => {


### PR DESCRIPTION
## Summary

Hardens the two runtime boundaries tracked in #413:

- makes project, new-session, and explicit-session route targets separate helper actions
- wraps resize body interaction state in a releasable lock with complete/cancel/timeout release reasons
- expands post-resize e2e coverage to hit the actual `ResizeHandle` mousedown path and verify body style acquire/release
- verifies new session, existing session row, and settings remain clickable after resize release

## Why

#412 fixed the urgent packaged-app path, but the underlying boundaries were still easy to regress: temporary resize state could leave body-level interaction styles behind, and session/project navigation intent was still encoded as ad hoc route strings in layout code.

This PR keeps the existing route shapes and UI behavior, but makes the ownership rules easier to test and reuse.

Closes #413.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check:

- `openProjectRoute`, `newSessionRoute`, and `openSessionRoute` preserve the existing route shapes
- `createBodyInteractionLock` releases body styles reliably without changing normal resize behavior
- `pointerup` and `mouseup` are treated as completed resize releases so `onCollapse` semantics are preserved
- the expanded e2e test stays focused on post-resize clickability and does not depend on unrelated right-panel design assertions

## Risk Notes

Low-to-medium app/runtime risk. This touches shared navigation helper usage and the shared `ResizeHandle` component, but keeps behavior intentionally narrow: no route shape changes, no UI redesign, and no data-layer refactor.

## How To Verify

```text
App unit tests: bun --cwd packages/app test -> 784 passed
UI resize unit test: bun --cwd packages/ui test src/components/resize-handle.test.ts -> 4 passed
App typecheck: bun --cwd packages/app typecheck -> passed
UI typecheck: bun --cwd packages/ui typecheck -> passed
Diff check: git diff --check -> passed
Targeted resize e2e: bun --cwd packages/app test:e2e e2e/commands/panels.spec.ts --grep "desktop remains clickable after right-panel resize ends with mouseup" -> 1 passed
Sidebar route e2e: bun --cwd packages/app test:e2e e2e/sidebar/sidebar-session-links.spec.ts -> 2 passed
Full commands/panels.spec.ts: known unrelated failures remain in older right-panel design assertions; the targeted resize test passed
```

## Screenshots or Recordings

Not applicable. This is runtime hardening and regression coverage with no intended visual change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved panel resize behavior: dragging reliably locks/unlocks page interactions, collapse behavior is more consistent, and session/project navigation flows are simplified and more reliable.

* **Tests**
  * Expanded end-to-end and unit tests covering multi-session workflows, panel resize interactions (including state during drag and after release), and guaranteed cleanup of created sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->