### PR TITLE
fix(session): relax successful same-target loop gate

### DIFF
--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -30,6 +30,7 @@ export namespace SessionDiagnostics {
     outcome: LoopOutcome
     kind: SignatureKind
     completedCount: number
+    outputHash?: string
     completedFailures?: number
     recoverEmitted: boolean
     blockEmitted: boolean
@@ -66,6 +67,7 @@ export namespace SessionDiagnostics {
   export type LoopMetadata = {
     inputHash?: string
     inputRepeatCount?: number
+    outputHash?: string
     targetSummary?: string
     targetHash?: string
     targetRepeatCount?: number
@@ -95,6 +97,7 @@ export namespace SessionDiagnostics {
     loopLastError?: unknown
     attemptedInput?: unknown
     stepIndex?: number
+    mutationEpoch?: number
   }
 
   export type Metadata = {
@@ -109,6 +112,8 @@ export namespace SessionDiagnostics {
     tool: string
     inputHash: string
     targetHash: string
+    outputHash?: string
+    mutationEpoch?: number
     metadata: Metadata
   }
 
@@ -128,6 +133,12 @@ export namespace SessionDiagnostics {
     return createHash("sha256").update(value).digest("hex").slice(0, 16)
   }
 
+  export function outputHash(output: unknown) {
+    const value = normalizeValue(output)
+    const serialized = JSON.stringify(value) ?? String(value)
+    return hash(serialized)
+  }
+
   export function signatureKey(input: {
     outcome: LoopOutcome
     kind: SignatureKind
@@ -138,6 +149,7 @@ export namespace SessionDiagnostics {
   }
 
   const RENDERER_BYTE_LIMIT = 1024
+  const DIAGNOSTIC_VALUE_BYTE_LIMIT = 4096
 
   export function truncateForRenderer(value: unknown): string {
     let s: string
@@ -166,6 +178,20 @@ export namespace SessionDiagnostics {
       return slice + "…"
     }
     return "…"
+  }
+
+  export function compactDiagnosticValue(value: unknown): unknown {
+    let s: string
+    try {
+      s = JSON.stringify(value) ?? String(value)
+    } catch {
+      s = String(value)
+    }
+    if (Buffer.byteLength(s, "utf8") <= DIAGNOSTIC_VALUE_BYTE_LIMIT) return value
+    return {
+      truncated: true,
+      preview: truncateForRenderer(value),
+    }
   }
 
   export function normalizeInput(input: unknown): { value: unknown; serialized: string; hash: string } {
@@ -437,6 +463,7 @@ export namespace SessionDiagnostics {
     syntheticBlockSigKeys: string[]
     parentID: MessageID
     currentStepIndex?: number
+    currentMutationEpoch?: number
   }): ParentLoopState {
     const signatures: Record<string, SignatureState> = {}
 
@@ -455,6 +482,22 @@ export namespace SessionDiagnostics {
         isFromPreviousStep(r),
     )
 
+    const successInputBuckets = new Map<
+      string,
+      {
+        sigKey: string
+        kind: "input"
+        outputHash: string
+        completedCount: number
+        recoverEmitted: boolean
+      }
+    >()
+
+    const sameMutationEpoch = (record: ToolCallRecord) => {
+      if (input.currentMutationEpoch === undefined) return true
+      return (record.mutationEpoch ?? record.metadata.diagnostics?.loop?.mutationEpoch ?? 0) === input.currentMutationEpoch
+    }
+
     for (const r of successes) {
       const loop = r.metadata.diagnostics?.loop
       const inputSigKey = r.inputHash
@@ -464,20 +507,46 @@ export namespace SessionDiagnostics {
         ? signatureKey({ outcome: "success", kind: "target", tool: r.tool, hash: r.targetHash })
         : null
       const fired = loop?.loopRecoverFiredFor ?? []
-      for (const [sigKey, kind] of [
-        [inputSigKey, "input"] as const,
-        [targetSigKey, "target"] as const,
-      ]) {
-        if (!sigKey) continue
-        const s = (signatures[sigKey] ??= {
+      if (inputSigKey && sameMutationEpoch(r)) {
+        const outHash = r.outputHash ?? loop?.outputHash
+        if (outHash) {
+          const bucketKey = `${inputSigKey}:${outHash}`
+          const bucket = (successInputBuckets.get(bucketKey) ?? {
+            sigKey: inputSigKey,
+            kind: "input" as const,
+            outputHash: outHash,
+            completedCount: 0,
+            recoverEmitted: false,
+          })
+          bucket.completedCount += 1
+          if (fired.includes(inputSigKey)) bucket.recoverEmitted = true
+          successInputBuckets.set(bucketKey, bucket)
+        }
+      }
+
+      if (targetSigKey) {
+        const s = (signatures[targetSigKey] ??= {
           outcome: "success",
-          kind,
+          kind: "target",
           completedCount: 0,
           recoverEmitted: false,
           blockEmitted: false,
         })
         s.completedCount += 1
-        if (fired.includes(sigKey)) s.recoverEmitted = true
+        if (fired.includes(targetSigKey)) s.recoverEmitted = true
+      }
+    }
+
+    for (const bucket of successInputBuckets.values()) {
+      const existing = signatures[bucket.sigKey]
+      if (existing && existing.completedCount > bucket.completedCount) continue
+      signatures[bucket.sigKey] = {
+        outcome: "success",
+        kind: bucket.kind,
+        completedCount: bucket.completedCount,
+        outputHash: bucket.outputHash,
+        recoverEmitted: bucket.recoverEmitted || existing?.recoverEmitted === true,
+        blockEmitted: existing?.blockEmitted ?? false,
       }
     }
 
@@ -657,7 +726,8 @@ export namespace SessionDiagnostics {
     if (!pending.length) return { parts }
     const lines: string[] = ["<system-reminder>"]
     const parsed = pending.map((r) => parseReminderKey(r.key))
-    const sawSuccess = parsed.some((r) => r.outcome === "success")
+    const sawSuccessInput = parsed.some((r) => r.outcome === "success" && r.kind === "input")
+    const sawSuccessTarget = parsed.some((r) => r.outcome === "success" && r.kind === "target")
     const sawFailureInput = parsed.some((r) => (r.outcome === "failure" || r.legacy) && r.kind === "input")
     const sawFailureTarget = parsed.some((r) => (r.outcome === "failure" || r.legacy) && r.kind === "target")
     // Backward-compat: v0 reminders persisted with `error:` (or other) prefixes. Without this
@@ -665,9 +735,14 @@ export namespace SessionDiagnostics {
     // text, which loses the warning entirely. Emit the legacy generic copy so old sessions still
     // surface a reminder during migration.
     const sawLegacy = parsed.some((r) => r.legacy && !r.kind)
-    if (sawSuccess) {
+    if (sawSuccessInput) {
       lines.push(
         "You are repeating the same tool request. Change strategy: summarize what you already learned, choose a different target or method, or answer the user directly. Do not repeat the same request in this turn.",
+      )
+    }
+    if (sawSuccessTarget) {
+      lines.push(
+        "You are looking at the same target again. Summarize what you already learned; if you continue, use a new range, query, or hypothesis.",
       )
     }
     if (sawFailureInput) {

--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -93,6 +93,7 @@ export namespace SessionDiagnostics {
     targetHashIsFallback?: boolean
     loopLastInput?: unknown
     loopLastError?: unknown
+    attemptedInput?: unknown
     stepIndex?: number
   }
 
@@ -548,13 +549,11 @@ export namespace SessionDiagnostics {
     const inputKey = signatureKey({ outcome, kind: "input", tool, hash: inputHash })
     const targetKey = targetHash ? signatureKey({ outcome, kind: "target", tool, hash: targetHash }) : null
 
-    // Iteration order is intentional: target is checked first because the spec treats
-    // same_target as the more general signal (the model is hitting the same goal in
-    // different ways). When same_input and same_target both reach threshold, we fire on
-    // the target sigKey only; the input sigKey's blockEmitted stays false. This is fine
-    // in practice because same_input ⊆ same_target (same input always has same target),
-    // so the model can't evade by varying targets without also changing input.
-    for (const sigKey of [targetKey, inputKey] as const) {
+    // Successful same_target repeats are weak evidence: reading different ranges of the same
+    // file or fetching the same URL after context changes can be normal progress. Keep hard
+    // gating for successful exact-input repeats, while failed repeats still check target first.
+    const candidates = outcome === "success" ? [inputKey] as const : [targetKey, inputKey] as const
+    for (const sigKey of candidates) {
       if (!sigKey) continue
       const s = state.signatures[sigKey]
       if (!s) continue

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -403,6 +403,16 @@ export namespace Export {
     return Object.keys(value).length ? { redacted: `${kind}:${id}` } : value
   }
 
+  function dataValue(kind: string, id: string, value: unknown) {
+    if (value === undefined || value === null) return value
+    if (typeof value === "string") return redact(kind, id, value)
+    if (typeof value === "object") {
+      if (Array.isArray(value)) return value.length ? { redacted: `${kind}:${id}` } : value
+      return Object.keys(value as Record<string, unknown>).length ? { redacted: `${kind}:${id}` } : value
+    }
+    return value
+  }
+
   function span(id: string, value: { value: string; start: number; end: number }) {
     return {
       ...value,
@@ -676,10 +686,25 @@ export namespace Export {
     }
   }
 
+  function sanitizeDiagnostics(diagnostics: Snapshot["diagnostics"]): Snapshot["diagnostics"] {
+    const last = diagnostics.loop?.last
+    if (!last) return diagnostics
+    return {
+      ...diagnostics,
+      loop: {
+        ...diagnostics.loop,
+        last: {
+          ...last,
+          attemptedInput: dataValue("loop-attempted-input", last.parentID, last.attemptedInput),
+        },
+      },
+    }
+  }
+
   // Snapshot-level sanitize. Wraps sanitizeTree (the conversation tree) AND redacts top-level
-  // runtime_context fields that may carry user-machine paths (instruction_sources). Other
-  // runtime_context fields (app_version, build_channel, locale, timezone, model_refs, stats)
-  // are not user-identifying and are kept verbatim.
+  // runtime_context/diagnostic fields that may carry user-machine paths or raw tool args.
+  // Other runtime_context fields (app_version, build_channel, locale, timezone, model_refs,
+  // stats) are not user-identifying and are kept verbatim.
   export function sanitizeSnapshot(snap: Snapshot): Snapshot {
     return {
       ...snap,
@@ -691,6 +716,7 @@ export namespace Export {
           url: s.url === undefined ? undefined : redact("instruction-url", String(i), s.url),
         })),
       },
+      diagnostics: sanitizeDiagnostics(snap.diagnostics),
       session: sanitizeTree(snap.session),
     }
   }

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -142,7 +142,8 @@ export namespace Export {
           outcome?: "success" | "failure"
           completedCount?: number
           occurrenceCount?: number
-          completedFailures: number
+          completedFailures?: number
+          attemptedInput?: unknown
         }
       }
     }
@@ -164,7 +165,8 @@ export namespace Export {
         outcome?: "success" | "failure"
         completedCount?: number
         occurrenceCount?: number
-        completedFailures: number
+        completedFailures?: number
+        attemptedInput?: unknown
       }
     }
   } {
@@ -178,7 +180,8 @@ export namespace Export {
           outcome?: "success" | "failure"
           completedCount?: number
           occurrenceCount?: number
-          completedFailures: number
+          completedFailures?: number
+          attemptedInput?: unknown
         }
       | undefined
     const walk = (t: Tree) => {
@@ -195,6 +198,7 @@ export namespace Export {
                 loopCompletedCount?: number
                 loopCompletedFailures?: number
                 loopOccurrenceCount?: number
+                attemptedInput?: unknown
               }
             | undefined
           if (!loop || (loop.loopAction !== "block" && loop.loopAction !== "stop")) continue
@@ -215,7 +219,8 @@ export namespace Export {
             outcome: loop.outcome,
             completedCount,
             occurrenceCount: loop.loopOccurrenceCount,
-            completedFailures: loop.loopCompletedFailures ?? completedCount,
+            completedFailures: loop.loopCompletedFailures,
+            attemptedInput: loop.attemptedInput,
           }
         }
       }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -214,34 +214,34 @@ export const layer: Layer.Layer<
 
       const loopRecords = (parentID: MessageV2.Assistant["parentID"]) => {
         if (!parentID) return []
-        return Array.from(MessageV2.stream(ctx.sessionID)).flatMap((message) => {
-          if (message.info.role !== "assistant" || message.info.parentID !== parentID) return []
-          let mutationEpoch = 0
-          return message.parts.flatMap((part) => {
+        const out: SessionDiagnostics.ToolCallRecord[] = []
+        let mutationEpoch = 0
+        for (const message of Array.from(MessageV2.stream(ctx.sessionID)).reverse()) {
+          if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
+          for (const part of message.parts) {
             if (part.type === "patch") {
               mutationEpoch += 1
-              return []
+              continue
             }
-            if (part.type !== "tool") return []
-            if (part.state.status !== "completed") return []
+            if (part.type !== "tool") continue
+            if (part.state.status !== "completed") continue
             const loop = toolDiagnostics(part)?.loop
-            if (!loop?.inputHash) return []
-            if (loop.errorFingerprint || loop.loopAction) return []
+            if (!loop?.inputHash) continue
+            if (loop.errorFingerprint || loop.loopAction) continue
             const loopWithEpoch = { ...loop, mutationEpoch: loop.mutationEpoch ?? mutationEpoch }
-            return [
-              {
-                sessionID: ctx.sessionID,
-                parentID,
-                tool: part.tool,
-                inputHash: loop.inputHash,
-                targetHash: loop.targetHash ?? "",
-                outputHash: loop.outputHash,
-                mutationEpoch: loopWithEpoch.mutationEpoch,
-                metadata: { diagnostics: { loop: loopWithEpoch } },
-              } satisfies SessionDiagnostics.ToolCallRecord,
-            ]
-          })
-        })
+            out.push({
+              sessionID: ctx.sessionID,
+              parentID,
+              tool: part.tool,
+              inputHash: loop.inputHash,
+              targetHash: loop.targetHash ?? "",
+              outputHash: loop.outputHash,
+              mutationEpoch: loopWithEpoch.mutationEpoch,
+              metadata: { diagnostics: { loop: loopWithEpoch } },
+            } satisfies SessionDiagnostics.ToolCallRecord)
+          }
+        }
+        return out
       }
 
       // Surface tool parts that represent a loop-relevant failure: real tool errors (carry
@@ -314,6 +314,7 @@ export const layer: Layer.Layer<
         const syntheticBlockSigKeysOut: string[] = []
         let hasStoppedOut = false
         let currentStepIndex: number | undefined
+        let mutationEpoch = 0
         let currentMutationEpoch = 0
         if (!parentID) {
           return {
@@ -325,14 +326,14 @@ export const layer: Layer.Layer<
             currentMutationEpoch,
           }
         }
-        for (const message of Array.from(MessageV2.stream(ctx.sessionID))) {
+        for (const message of Array.from(MessageV2.stream(ctx.sessionID)).reverse()) {
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
           let stepIndex = 0
-          let mutationEpoch = 0
           let sawStepStart = false
           let afterStepFinish = false
+          const currentMessage = message.info.id === ctx.assistantMessage.id
+          if (currentMessage) currentMutationEpoch = mutationEpoch
           for (const part of message.parts) {
-            const currentMessage = message.info.id === ctx.assistantMessage.id
             if (part.type === "patch") {
               mutationEpoch += 1
               if (currentMessage) currentMutationEpoch = mutationEpoch

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -53,6 +53,7 @@ export interface Handle {
     syntheticBlockSigKeys: string[]
     hasStopped: boolean
     currentStepIndex?: number
+    currentMutationEpoch?: number
   }
   readonly recordSyntheticBlock: (input: {
     toolCallId: string
@@ -215,12 +216,18 @@ export const layer: Layer.Layer<
         if (!parentID) return []
         return Array.from(MessageV2.stream(ctx.sessionID)).flatMap((message) => {
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) return []
+          let mutationEpoch = 0
           return message.parts.flatMap((part) => {
+            if (part.type === "patch") {
+              mutationEpoch += 1
+              return []
+            }
             if (part.type !== "tool") return []
             if (part.state.status !== "completed") return []
             const loop = toolDiagnostics(part)?.loop
             if (!loop?.inputHash) return []
             if (loop.errorFingerprint || loop.loopAction) return []
+            const loopWithEpoch = { ...loop, mutationEpoch: loop.mutationEpoch ?? mutationEpoch }
             return [
               {
                 sessionID: ctx.sessionID,
@@ -228,7 +235,9 @@ export const layer: Layer.Layer<
                 tool: part.tool,
                 inputHash: loop.inputHash,
                 targetHash: loop.targetHash ?? "",
-                metadata: { diagnostics: { loop } },
+                outputHash: loop.outputHash,
+                mutationEpoch: loopWithEpoch.mutationEpoch,
+                metadata: { diagnostics: { loop: loopWithEpoch } },
               } satisfies SessionDiagnostics.ToolCallRecord,
             ]
           })
@@ -305,6 +314,7 @@ export const layer: Layer.Layer<
         const syntheticBlockSigKeysOut: string[] = []
         let hasStoppedOut = false
         let currentStepIndex: number | undefined
+        let currentMutationEpoch = 0
         if (!parentID) {
           return {
             successRecords: successRecordsOut,
@@ -312,21 +322,28 @@ export const layer: Layer.Layer<
             syntheticBlockSigKeys: syntheticBlockSigKeysOut,
             hasStopped: hasStoppedOut,
             currentStepIndex,
+            currentMutationEpoch,
           }
         }
         for (const message of Array.from(MessageV2.stream(ctx.sessionID))) {
           if (message.info.role !== "assistant" || message.info.parentID !== parentID) continue
           let stepIndex = 0
+          let mutationEpoch = 0
           let sawStepStart = false
           let afterStepFinish = false
           for (const part of message.parts) {
+            const currentMessage = message.info.id === ctx.assistantMessage.id
+            if (part.type === "patch") {
+              mutationEpoch += 1
+              if (currentMessage) currentMutationEpoch = mutationEpoch
+              continue
+            }
             if (part.type === "step-start") {
               sawStepStart = true
               afterStepFinish = false
               stepIndex += 1
               continue
             }
-            const currentMessage = message.info.id === ctx.assistantMessage.id
             const activeStepIndex = !sawStepStart || afterStepFinish ? stepIndex + 1 : stepIndex
             if (currentMessage) currentStepIndex = activeStepIndex
             if (part.type === "step-finish") {
@@ -337,7 +354,11 @@ export const layer: Layer.Layer<
             const loop = toolDiagnostics(part)?.loop
             if (!loop) continue
             const observedStepIndex = currentMessage ? activeStepIndex : -1
-            const loopWithStep = { ...loop, stepIndex: loop.stepIndex ?? observedStepIndex }
+            const loopWithStep = {
+              ...loop,
+              stepIndex: loop.stepIndex ?? observedStepIndex,
+              mutationEpoch: loop.mutationEpoch ?? mutationEpoch,
+            }
             if (loop.loopAction === "stop") hasStoppedOut = true
             if (loop.loopAction === "block" && loop.loopSigKey) syntheticBlockSigKeysOut.push(loop.loopSigKey)
             if (part.state.status === "completed" && loop.inputHash && !loop.errorFingerprint && !loop.loopAction) {
@@ -347,6 +368,8 @@ export const layer: Layer.Layer<
                 tool: part.tool,
                 inputHash: loop.inputHash,
                 targetHash: loop.targetHash ?? "",
+                outputHash: loop.outputHash,
+                mutationEpoch: loopWithStep.mutationEpoch,
                 metadata: { diagnostics: { loop: loopWithStep } },
               } satisfies SessionDiagnostics.ToolCallRecord)
             }
@@ -372,6 +395,7 @@ export const layer: Layer.Layer<
           syntheticBlockSigKeys: syntheticBlockSigKeysOut,
           hasStopped: hasStoppedOut,
           currentStepIndex,
+          currentMutationEpoch,
         }
       }
 
@@ -393,7 +417,17 @@ export const layer: Layer.Layer<
             status: "completed",
             input: match.part.state.input,
             output: output.output,
-            metadata: diagnostics ? SessionDiagnostics.mergeMetadata(output.metadata, { diagnostics }) : output.metadata,
+            metadata: diagnostics
+              ? SessionDiagnostics.mergeMetadata(output.metadata, {
+                  diagnostics: {
+                    ...diagnostics,
+                    loop: {
+                      ...diagnostics.loop,
+                      outputHash: SessionDiagnostics.outputHash(output.output),
+                    },
+                  },
+                })
+              : output.metadata,
             title: output.title,
             time: { start: match.part.state.time.start, end: Date.now() },
             attachments: output.attachments,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -63,6 +63,7 @@ export interface Handle {
     completedCount: number
     completedFailures?: number
     nextOccurrenceCount: number
+    attemptedInput?: unknown
     errorMessage: string
   }) => Effect.Effect<void>
   readonly recordSyntheticStop: (input: {
@@ -74,6 +75,7 @@ export interface Handle {
     completedCount: number
     completedFailures?: number
     nextOccurrenceCount: number
+    attemptedInput?: unknown
     renderedText: string
     toolErrorMessage: string
   }) => Effect.Effect<void>
@@ -820,6 +822,7 @@ export const layer: Layer.Layer<
         completedCount: number
         completedFailures?: number
         nextOccurrenceCount: number
+        attemptedInput?: unknown
         errorMessage: string
       }) {
         const match = yield* readToolCall(input.toolCallId)
@@ -863,8 +866,9 @@ export const layer: Layer.Layer<
               loopSigKey: input.sigKey,
               outcome: input.outcome,
               loopCompletedCount: input.completedCount,
-              loopCompletedFailures: input.completedFailures ?? input.completedCount,
+              loopCompletedFailures: input.completedFailures,
               loopOccurrenceCount: input.nextOccurrenceCount,
+              attemptedInput: input.attemptedInput,
             },
           },
         })
@@ -892,6 +896,7 @@ export const layer: Layer.Layer<
         completedCount: number
         completedFailures?: number
         nextOccurrenceCount: number
+        attemptedInput?: unknown
         renderedText: string
         toolErrorMessage: string
       }) {
@@ -929,8 +934,9 @@ export const layer: Layer.Layer<
               loopSigKey: input.sigKey,
               outcome: input.outcome,
               loopCompletedCount: input.completedCount,
-              loopCompletedFailures: input.completedFailures ?? input.completedCount,
+              loopCompletedFailures: input.completedFailures,
               loopOccurrenceCount: input.nextOccurrenceCount,
+              attemptedInput: input.attemptedInput,
             },
           },
         })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -169,6 +169,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
       completedCount: decision.completedCount,
       completedFailures: decision.completedFailures,
       nextOccurrenceCount: decision.nextOccurrenceCount,
+      attemptedInput: args,
       errorMessage: userFacing,
     })
     return { kind: "block", userFacing } satisfies GateOutcome
@@ -188,6 +189,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
     completedCount: decision.completedCount,
     completedFailures: decision.completedFailures,
     nextOccurrenceCount: decision.nextOccurrenceCount,
+    attemptedInput: args,
     renderedText,
     toolErrorMessage,
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -132,6 +132,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
     syntheticBlockSigKeys: loopCtx.syntheticBlockSigKeys,
     parentID,
     currentStepIndex: loopCtx.currentStepIndex,
+    currentMutationEpoch: loopCtx.currentMutationEpoch,
   })
 
   const failureDecision = SessionDiagnostics.queryGateAction({
@@ -169,7 +170,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
       completedCount: decision.completedCount,
       completedFailures: decision.completedFailures,
       nextOccurrenceCount: decision.nextOccurrenceCount,
-      attemptedInput: args,
+      attemptedInput: SessionDiagnostics.compactDiagnosticValue(args),
       errorMessage: userFacing,
     })
     return { kind: "block", userFacing } satisfies GateOutcome
@@ -189,7 +190,7 @@ const applyLoopGate = Effect.fn("SessionPrompt.applyLoopGate")(function* (input:
     completedCount: decision.completedCount,
     completedFailures: decision.completedFailures,
     nextOccurrenceCount: decision.nextOccurrenceCount,
-    attemptedInput: args,
+    attemptedInput: SessionDiagnostics.compactDiagnosticValue(args),
     renderedText,
     toolErrorMessage,
   })

--- a/packages/opencode/test/session/diagnostics.test.ts
+++ b/packages/opencode/test/session/diagnostics.test.ts
@@ -39,6 +39,19 @@ describe("SessionDiagnostics.normalizeInput", () => {
   })
 })
 
+describe("SessionDiagnostics.compactDiagnosticValue", () => {
+  test("keeps small diagnostic inputs raw and truncates large values", () => {
+    const small = { command: "bun test" }
+    expect(SessionDiagnostics.compactDiagnosticValue(small)).toEqual(small)
+
+    const large = { command: "x".repeat(5000) }
+    expect(SessionDiagnostics.compactDiagnosticValue(large)).toMatchObject({
+      truncated: true,
+      preview: expect.any(String),
+    })
+  })
+})
+
 describe("SessionDiagnostics.observeToolCall", () => {
   test("creates a success-repeat reminder on the 3rd identical successful call", () => {
     let records: SessionDiagnostics.ToolCallRecord[] = []
@@ -713,5 +726,63 @@ describe("SessionDiagnostics.consumeReminders", () => {
     const result = SessionDiagnostics.consumeReminders({ messages, parentID, now: 10 })
     expect(result.text).toContain("failed against the same target")
     expect(result.text).not.toContain("class of tool error")
+  })
+
+  test("success target reminder asks for a new range or hypothesis without a hard retry ban", () => {
+    const part: MessageV2.ToolPart = {
+      id: PartID.make("prt_success_target"),
+      messageID: MessageID.make("msg_assistant_success_target"),
+      sessionID,
+      type: "tool",
+      tool: "read",
+      callID: "call_success_target",
+      state: {
+        status: "completed",
+        input: { filePath: "/tmp/a.ts", offset: 120, limit: 80 },
+        output: "ok",
+        title: "ok",
+        metadata: {
+          diagnostics: {
+            loop: {
+              reminders: [
+                {
+                  key: "success:target:read:abc",
+                  type: "target_repeat",
+                  status: "pending",
+                  count: 3,
+                  createdAt: 1,
+                },
+              ],
+            },
+          },
+        },
+        time: { start: 1, end: 2 },
+      },
+    }
+    const messages: MessageV2.WithParts[] = [
+      {
+        info: {
+          id: MessageID.make("msg_assistant_success_target"),
+          role: "assistant",
+          sessionID,
+          mode: "build",
+          agent: "build",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID,
+          providerID,
+          parentID,
+          time: { created: 1 },
+        },
+        parts: [part],
+      },
+    ]
+
+    const result = SessionDiagnostics.consumeReminders({ messages, parentID, now: 10 })
+
+    expect(result.text).toContain("same target again")
+    expect(result.text).toContain("new range, query, or hypothesis")
+    expect(result.text).not.toContain("Do not repeat the same request")
   })
 })

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -395,7 +395,36 @@ describe("Export.deriveSnapshotDiagnostics", () => {
     expect(result.loop?.last?.outcome).toBe("success")
     expect(result.loop?.last?.completedCount).toBe(4)
     expect(result.loop?.last?.occurrenceCount).toBe(5)
-    expect(result.loop?.last?.completedFailures).toBe(4)
+    expect(result.loop?.last?.completedFailures).toBeUndefined()
+  })
+
+  test("exports attempted input for synthetic block diagnostics", () => {
+    const info = makeAssistantInfo()
+    const block = blockToolPartAt(info.id, 100, "attempted-input")
+    const attemptedInput = { filePath: "/tmp/project/src/session.ts", offset: 360, limit: 80 }
+    if (block.state.status !== "error") throw new Error("expected error tool state")
+    block.state.metadata = {
+      ...block.state.metadata,
+      diagnostics: {
+        loop: {
+          ...block.state.metadata?.diagnostics?.loop,
+          attemptedInput,
+        },
+      },
+    }
+    const tree: Export.Tree = {
+      ...makeTree(),
+      messages: [
+        {
+          info,
+          parts: [block],
+        },
+      ],
+      children: [],
+    }
+
+    const result = Export.deriveSnapshotDiagnostics(tree)
+    expect(result.loop?.last?.attemptedInput).toEqual(attemptedInput)
   })
 })
 

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -683,6 +683,85 @@ describe("redactPart", () => {
     expect(sources[0].hash).toBe("sha256:abc")
   })
 
+  test("sanitizeSnapshot redacts loop attemptedInput and tool errors", () => {
+    const messageID = MessageID.make("msg_sensitive_loop")
+    const fakeSnapshot: Export.Snapshot = {
+      schema_version: 1,
+      format: "pawwork-session-export",
+      exported_at: 0,
+      root_session_id: SessionID.make("ses_x"),
+      runtime_context: {
+        app_version: "test",
+        runtime_namespace: "pawwork",
+        platform: "darwin",
+        os_version: "0",
+        locale: "en-US",
+        timezone: "UTC",
+        instruction_sources: [],
+        model_refs: {},
+        stats: { session_count: 0, message_count: 0, part_count: 0, omitted_attachment_count: 0 },
+      },
+      diagnostics: {
+        loop: {
+          last: {
+            parentID: "msg_user",
+            type: "same_input",
+            action: "block",
+            tool: "bash",
+            attemptedInput: { command: "cat /Users/secret/.env", token: "sk-secret" },
+          },
+        },
+      },
+      session: {
+        info: { id: SessionID.make("ses_x"), title: "t", directory: "/dir" } as never,
+        had_cloud_share: false,
+        diffs: [],
+        messages: [
+          {
+            info: {
+              id: messageID,
+              role: "assistant",
+              sessionID: SessionID.make("ses_x"),
+              mode: "build",
+              agent: "build",
+              path: { cwd: "/tmp", root: "/tmp" },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: "test-model",
+              providerID: "test",
+              parentID: MessageID.make("msg_user"),
+              time: { created: 1 },
+            } as MessageV2.Assistant,
+            parts: [
+              {
+                id: PartID.make("prt_error"),
+                messageID,
+                sessionID: SessionID.make("ses_x"),
+                type: "tool",
+                tool: "bash",
+                callID: "call_error",
+                state: {
+                  status: "error",
+                  input: { command: "cat /Users/secret/.env" },
+                  error: "failed to read /Users/secret/.env",
+                  time: { start: 1, end: 2 },
+                },
+              },
+            ],
+          },
+        ],
+        children: [],
+      },
+    }
+
+    const sanitized = Export.sanitizeSnapshot(fakeSnapshot)
+    expect(sanitized.diagnostics.loop?.last?.attemptedInput).toEqual({ redacted: "loop-attempted-input:msg_user" })
+    const tool = sanitized.session.messages[0].parts[0]
+    if (tool.type !== "tool" || tool.state.status !== "error") throw new Error("expected error tool part")
+    expect(tool.state.input).toEqual({ redacted: "tool-input:prt_error" })
+    expect(tool.state.error).toBe("[redacted:tool-error:prt_error]")
+  })
+
   test("redacts data: url inside completed tool attachments", () => {
     const ctx = { count: { omitted: 0 } }
     const part: MessageV2.ToolPart = {

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -200,7 +200,9 @@ describe("SessionDiagnostics.queryGateAction", () => {
   test("does not block successful read calls for different ranges of the same file", () => {
     const filePath = "/tmp/project/src/session.ts"
     const targetHash = targetHashForInput("read", { filePath, offset: 1, limit: 80 })
+    const queryTargetHash = targetHashForInput("read", { filePath, offset: 360, limit: 80 })
     const targetSigKey = `success:target:read:${targetHash}`
+    expect(queryTargetHash).toBe(targetHash)
     const state = SessionDiagnostics.deriveParentLoopState({
       successRecords: [
         successfulToolCallRecord("read", { filePath, offset: 1, limit: 80 }),
@@ -211,12 +213,13 @@ describe("SessionDiagnostics.queryGateAction", () => {
       syntheticBlockSigKeys: [],
       parentID,
     })
+    expect(state.signatures[targetSigKey]?.completedCount).toBe(3)
 
     const decision = SessionDiagnostics.queryGateAction({
       parentLoopState: state,
       tool: "read",
       inputHash: inputHashFor({ filePath, offset: 360, limit: 80 }),
-      targetHash,
+      targetHash: queryTargetHash,
       outcome: "success",
     })
 

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -40,6 +40,8 @@ const failingErrorRecord = (
 const successfulCallRecord = (
   url: string,
   recoverFiredFor: string[] = [],
+  output = "ok",
+  mutationEpoch = 0,
 ): SessionDiagnostics.ToolCallRecord => ({
   sessionID,
   parentID,
@@ -51,6 +53,8 @@ const successfulCallRecord = (
       loop: {
         inputHash: inputHashFor({ url }),
         targetHash: targetHashFor(url),
+        outputHash: SessionDiagnostics.outputHash(output),
+        mutationEpoch,
         outcome: "success",
         targetRepeatCount: 1,
         loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
@@ -63,6 +67,8 @@ const successfulToolCallRecord = (
   tool: string,
   input: unknown,
   recoverFiredFor: string[] = [],
+  output = "ok",
+  mutationEpoch = 0,
 ): SessionDiagnostics.ToolCallRecord => ({
   sessionID,
   parentID,
@@ -74,6 +80,8 @@ const successfulToolCallRecord = (
       loop: {
         inputHash: inputHashFor(input),
         targetHash: targetHashForInput(tool, input),
+        outputHash: SessionDiagnostics.outputHash(output),
+        mutationEpoch,
         outcome: "success",
         targetRepeatCount: 1,
         loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
@@ -258,6 +266,61 @@ describe("SessionDiagnostics.queryGateAction", () => {
     }
   })
 
+  test("does not block successful exact-input repeats when output changes", () => {
+    const input = { command: "bun test" }
+    const inputHash = inputHashFor(input)
+    const inputSigKey = `success:input:bash:${inputHash}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulToolCallRecord("bash", input, [], "1 test failed"),
+        successfulToolCallRecord("bash", input, [], "all tests passed"),
+        successfulToolCallRecord("bash", input, [inputSigKey], "all tests passed\ncached"),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "bash",
+      inputHash,
+      targetHash: targetHashForInput("bash", input),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("observe")
+    expect(state.signatures[inputSigKey]?.completedCount).toBe(1)
+  })
+
+  test("does not block successful exact-input repeats across mutation epochs", () => {
+    const input = { command: "bun test" }
+    const inputHash = inputHashFor(input)
+    const inputSigKey = `success:input:bash:${inputHash}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulToolCallRecord("bash", input, [], "all tests passed", 0),
+        successfulToolCallRecord("bash", input, [], "all tests passed", 0),
+        successfulToolCallRecord("bash", input, [inputSigKey], "all tests passed", 0),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+      currentMutationEpoch: 1,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "bash",
+      inputHash,
+      targetHash: targetHashForInput("bash", input),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("observe")
+    expect(state.signatures[inputSigKey]).toBeUndefined()
+  })
+
   test("chooses stop over block across success and failure decisions", () => {
     const successStop = {
       action: "stop",
@@ -380,7 +443,21 @@ describe("SessionDiagnostics.queryGateAction", () => {
         modelID: "model" as any,
         providerID: "provider" as any,
       })
-      records = [...records, observed.record]
+      records = [
+        ...records,
+        {
+          ...observed.record,
+          outputHash: SessionDiagnostics.outputHash("ok"),
+          metadata: {
+            diagnostics: {
+              loop: {
+                ...observed.record.metadata.diagnostics?.loop,
+                outputHash: SessionDiagnostics.outputHash("ok"),
+              },
+            },
+          },
+        },
+      ]
     }
 
     const inputHash = inputHashFor(input)

--- a/packages/opencode/test/session/loop-gate.test.ts
+++ b/packages/opencode/test/session/loop-gate.test.ts
@@ -7,6 +7,11 @@ const parentID = MessageID.make("msg_user")
 
 const inputHashFor = (input: unknown) => SessionDiagnostics.normalizeInput(input).hash
 const targetHashFor = (url: string) => SessionDiagnostics.hash("url:" + SessionDiagnostics.hash(url))
+const targetHashForInput = (tool: string, input: unknown) => {
+  const target = SessionDiagnostics.targetSummary(tool, input)
+  if (target.isFallback) throw new Error("expected recognized target")
+  return SessionDiagnostics.hash(target.summary)
+}
 
 const failingErrorRecord = (
   url: string,
@@ -46,6 +51,29 @@ const successfulCallRecord = (
       loop: {
         inputHash: inputHashFor({ url }),
         targetHash: targetHashFor(url),
+        outcome: "success",
+        targetRepeatCount: 1,
+        loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
+      },
+    },
+  },
+})
+
+const successfulToolCallRecord = (
+  tool: string,
+  input: unknown,
+  recoverFiredFor: string[] = [],
+): SessionDiagnostics.ToolCallRecord => ({
+  sessionID,
+  parentID,
+  tool,
+  inputHash: inputHashFor(input),
+  targetHash: targetHashForInput(tool, input),
+  metadata: {
+    diagnostics: {
+      loop: {
+        inputHash: inputHashFor(input),
+        targetHash: targetHashForInput(tool, input),
         outcome: "success",
         targetRepeatCount: 1,
         loopRecoverFiredFor: recoverFiredFor.length ? recoverFiredFor : undefined,
@@ -119,7 +147,7 @@ describe("SessionDiagnostics.deriveParentLoopState", () => {
 })
 
 describe("SessionDiagnostics.queryGateAction", () => {
-  test("blocks the 4th successful occurrence after a 3rd-occurrence reminder", () => {
+  test("does not hard block successful same-target repeats", () => {
     const url = "https://x.com/a"
     const sigKey = `success:target:webfetch:${targetHashFor(url)}`
     const state = SessionDiagnostics.deriveParentLoopState({
@@ -141,15 +169,10 @@ describe("SessionDiagnostics.queryGateAction", () => {
       outcome: "success",
     })
 
-    expect(decision.action).toBe("block")
-    if (decision.action === "block") {
-      expect(decision.kind).toBe("target")
-      expect(decision.completedCount).toBe(3)
-      expect(decision.nextOccurrenceCount).toBe(4)
-    }
+    expect(decision.action).toBe("observe")
   })
 
-  test("stops the 5th successful occurrence after quarantine", () => {
+  test("does not stop successful same-target repeats after quarantine", () => {
     const url = "https://x.com/a"
     const sigKey = `success:target:webfetch:${targetHashFor(url)}`
     const state = SessionDiagnostics.deriveParentLoopState({
@@ -171,8 +194,65 @@ describe("SessionDiagnostics.queryGateAction", () => {
       outcome: "success",
     })
 
-    expect(decision.action).toBe("stop")
-    if (decision.action === "stop") expect(decision.nextOccurrenceCount).toBe(5)
+    expect(decision.action).toBe("observe")
+  })
+
+  test("does not block successful read calls for different ranges of the same file", () => {
+    const filePath = "/tmp/project/src/session.ts"
+    const targetHash = targetHashForInput("read", { filePath, offset: 1, limit: 80 })
+    const targetSigKey = `success:target:read:${targetHash}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulToolCallRecord("read", { filePath, offset: 1, limit: 80 }),
+        successfulToolCallRecord("read", { filePath, offset: 120, limit: 80 }),
+        successfulToolCallRecord("read", { filePath, offset: 240, limit: 80 }, [targetSigKey]),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "read",
+      inputHash: inputHashFor({ filePath, offset: 360, limit: 80 }),
+      targetHash,
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("observe")
+  })
+
+  test("blocks successful exact-input repeats by signature", () => {
+    const input = { pattern: "**/*.txt" }
+    const inputHash = inputHashFor(input)
+    const inputSigKey = `success:input:glob:${inputHash}`
+    const state = SessionDiagnostics.deriveParentLoopState({
+      successRecords: [
+        successfulToolCallRecord("glob", input),
+        successfulToolCallRecord("glob", input),
+        successfulToolCallRecord("glob", input, [inputSigKey]),
+      ],
+      errorRecords: [],
+      syntheticBlockSigKeys: [],
+      parentID,
+    })
+
+    const decision = SessionDiagnostics.queryGateAction({
+      parentLoopState: state,
+      tool: "glob",
+      inputHash,
+      targetHash: targetHashForInput("glob", input),
+      outcome: "success",
+    })
+
+    expect(decision.action).toBe("block")
+    if (decision.action === "block") {
+      expect(decision.kind).toBe("input")
+      expect(decision.completedCount).toBe(3)
+      expect(decision.completedFailures).toBeUndefined()
+      expect(decision.nextOccurrenceCount).toBe(4)
+    }
   })
 
   test("chooses stop over block across success and failure decisions", () => {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -14,6 +14,7 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionProcessor } from "../../src/session/processor"
+import { SessionDiagnostics } from "../../src/session/diagnostics"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
@@ -183,6 +184,30 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+const completedLoopToolPart = (
+  input: Record<string, any>,
+  loop: SessionDiagnostics.LoopMetadata,
+): MessageV2.ToolPart => ({
+  id: PartID.ascending(),
+  messageID: MessageID.make("placeholder"),
+  sessionID: SessionID.make("placeholder"),
+  type: "tool",
+  tool: "glob",
+  callID: PartID.ascending(),
+  state: {
+    status: "completed",
+    input,
+    output: "same result",
+    title: "glob",
+    metadata: {
+      diagnostics: {
+        loop,
+      },
+    },
+    time: { start: 1, end: 2 },
+  },
+})
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -229,6 +254,84 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
         expect(value).toBe("continue")
         expect(calls).toBe(1)
         expect(parts.some((part) => part.type === "text" && part.text === "hello")).toBe(true)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor builds mutation epoch across assistant messages under one parent", () =>
+  provideTmpdirServer(
+    ({ dir }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "repeat after edit")
+        const prior = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const current = yield* assistant(chat.id, parent.id, path.resolve(dir))
+
+        const input = { pattern: "**/*.txt" }
+        const inputHash = SessionDiagnostics.normalizeInput(input).hash
+        const target = SessionDiagnostics.targetSummary("glob", input)
+        if (target.isFallback) throw new Error("expected glob target")
+        const targetHash = SessionDiagnostics.hash(target.summary)
+        const outputHash = SessionDiagnostics.outputHash("same result")
+        const inputSigKey = SessionDiagnostics.signatureKey({
+          outcome: "success",
+          kind: "input",
+          tool: "glob",
+          hash: inputHash,
+        })
+
+        for (let i = 0; i < 3; i++) {
+          const part = completedLoopToolPart(input, {
+            inputHash,
+            targetHash,
+            outputHash,
+            outcome: "success",
+            loopRecoverFiredFor: i === 2 ? [inputSigKey] : undefined,
+          })
+          yield* session.updatePart({
+            ...part,
+            id: PartID.ascending(),
+            messageID: prior.id,
+            sessionID: chat.id,
+            callID: `call-${i}`,
+          })
+        }
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          messageID: prior.id,
+          sessionID: chat.id,
+          type: "patch",
+          hash: "patch-hash",
+          files: [path.join(dir, "changed.txt")],
+        })
+
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: current,
+          sessionID: chat.id,
+          model: mdl,
+        })
+        const loopCtx = handle.buildLoopContext(parent.id)
+        const state = SessionDiagnostics.deriveParentLoopState({
+          successRecords: loopCtx.successRecords,
+          errorRecords: loopCtx.errorRecords,
+          syntheticBlockSigKeys: loopCtx.syntheticBlockSigKeys,
+          parentID: parent.id,
+          currentMutationEpoch: loopCtx.currentMutationEpoch,
+        })
+        const decision = SessionDiagnostics.queryGateAction({
+          parentLoopState: state,
+          tool: "glob",
+          inputHash,
+          targetHash,
+          outcome: "success",
+        })
+
+        expect(loopCtx.currentMutationEpoch).toBe(1)
+        expect(loopCtx.successRecords.map((record) => record.mutationEpoch)).toEqual([0, 0, 0])
+        expect(decision.action).toBe("observe")
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -682,6 +682,59 @@ it.live("loop gate stops repeated successful tools across model steps", () =>
   ),
 )
 
+it.live("loop gate allows successful read calls for different ranges of the same file", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate read ranges",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const file = path.join(dir, "loop-gate-read-ranges.txt")
+        yield* Effect.promise(() =>
+          Bun.write(
+            file,
+            Array.from({ length: 60 }, (_, index) => `line ${index + 1}`).join("\n"),
+          ),
+        )
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "read ranges" }],
+        })
+        for (const offset of [1, 10, 20, 30]) {
+          yield* llm.tool("read", { filePath: file, offset, limit: 5 })
+        }
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const completedReadParts = allParts.filter(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "read" && part.state.status === "completed",
+        )
+        const loopGateParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction !== undefined,
+        )
+
+        expect(completedReadParts).toHaveLength(4)
+        expect(loopGateParts).toHaveLength(0)
+        expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop gate stops repeated tool errors across model steps", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -735,6 +735,51 @@ it.live("loop gate allows successful read calls for different ranges of the same
   ),
 )
 
+unix("bash file mutation records a patch part for mutation epoch tracking", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate bash mutation patch",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const file = path.join(dir, "loop-gate-bash-mutation.txt")
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "write file with bash" }],
+        })
+        yield* llm.tool("bash", {
+          command: `printf 'changed\\n' > ${JSON.stringify(file)}`,
+          description: "write test file",
+        })
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const completedBashParts = allParts.filter(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "bash" && part.state.status === "completed",
+        )
+        const patchParts = allParts.filter((part): part is MessageV2.PatchPart => part.type === "patch")
+
+        expect(completedBashParts).toHaveLength(1)
+        expect(patchParts.length).toBeGreaterThan(0)
+        expect(patchParts.flatMap((part) => part.files).some((item) => item.endsWith("loop-gate-bash-mutation.txt"))).toBe(
+          true,
+        )
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop gate stops repeated tool errors across model steps", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -616,6 +616,7 @@ it.live("loop gate blocks repeated tool errors across model steps", () =>
         )
         expect(blockParts).toHaveLength(1)
         expect(blockParts[0].state.metadata?.diagnostics?.loop?.loopCompletedFailures).toBe(3)
+        expect(blockParts[0].state.metadata?.diagnostics?.loop?.attemptedInput).toEqual(input)
       }),
     { git: true, config: providerCfg },
   ),
@@ -725,6 +726,7 @@ it.live("loop gate stops repeated tool errors across model steps", () =>
         expect(stopParts[0].state.metadata?.diagnostics?.loop?.outcome).toBe("failure")
         expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopCompletedCount).toBe(3)
         expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopOccurrenceCount).toBe(5)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.attemptedInput).toEqual(input)
         expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(false)
       }),
     { git: true, config: providerCfg },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -735,7 +735,7 @@ it.live("loop gate allows successful read calls for different ranges of the same
   ),
 )
 
-unix("bash file mutation records a patch part for mutation epoch tracking", () =>
+unix("bash file mutation resets successful exact-input loop gating", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -753,10 +753,11 @@ unix("bash file mutation records a patch part for mutation epoch tracking", () =
           noReply: true,
           parts: [{ type: "text", text: "write file with bash" }],
         })
-        yield* llm.tool("bash", {
-          command: `printf 'changed\\n' > ${JSON.stringify(file)}`,
+        const input = {
+          command: `printf 'changed\\n' > ${JSON.stringify(file)} && printf 'ok\\n'`,
           description: "write test file",
-        })
+        }
+        for (let i = 0; i < 4; i++) yield* llm.tool("bash", input)
         yield* llm.text("done")
 
         const result = yield* prompt.loop({ sessionID: session.id })
@@ -768,13 +769,21 @@ unix("bash file mutation records a patch part for mutation epoch tracking", () =
           (part): part is CompletedToolPart =>
             part.type === "tool" && part.tool === "bash" && part.state.status === "completed",
         )
+        const loopGateParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction !== undefined,
+        )
         const patchParts = allParts.filter((part): part is MessageV2.PatchPart => part.type === "patch")
 
-        expect(completedBashParts).toHaveLength(1)
+        expect(completedBashParts).toHaveLength(4)
+        expect(loopGateParts).toHaveLength(0)
         expect(patchParts.length).toBeGreaterThan(0)
         expect(patchParts.flatMap((part) => part.files).some((item) => item.endsWith("loop-gate-bash-mutation.txt"))).toBe(
           true,
         )
+        expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
       }),
     { git: true, config: providerCfg },
   ),


### PR DESCRIPTION
## Summary

- Stop hard-blocking successful same-target repeats.
- Gate successful exact-input repeats only when prior completed records have the same output and no intervening parent-turn mutation epoch.
- Track mutationEpoch across assistant messages under the same parent turn, not per assistant message.
- Preserve attemptedInput on synthetic loop block/stop diagnostics, with size guarding before storage and export redaction.
- Export success loop diagnostics without pretending they are failures.

## Why

PR #406 made repeated successful tool calls observable, but the same-target hard gate was too broad. A normal debugging session can read different ranges of the same file, which repeats the target while still making progress. The exported quick-river session showed this exact shape: successful read calls against the same file with different offsets were blocked and then stopped.

The follow-up review also identified a second false-positive shape: repeating the same successful input after edits or after output changes can be valid verification. This update keeps hard stops for true no-progress success loops, but requires exact input plus same output within the same parent-turn mutation epoch before escalating.

## Related Issue

No issue. Follow-up to the merged #406 behavior after a false-positive exported-session diagnosis.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on loop-gate policy semantics:

- Successful same-target repeats should not hard block or stop.
- Successful exact-input repeats hard gate only when the completed output also repeats.
- Successful exact-input repeats across a mutation epoch should not hard gate.
- mutationEpoch is scoped to the parent turn across assistant messages.
- bash file writes produce patch parts and reset exact-input success gating after mutation.
- Failure same-target and same-input gates still work.
- Synthetic block/stop diagnostics include attempted input, while large attemptedInput values are compacted and exports still redact them.

## Compatibility Notes

- Success loop exports intentionally do not populate completedFailures. Consumers should use completedCount for success-loop events.
- completedFailures remains present for failure-loop events.

## Risk Notes

Behavior change in the session loop gate. This intentionally reduces hard stops for successful same-target repeats and for repeated successful inputs when output or mutation state changed, while preserving the stricter failure loop gate and same-output success gate. No migrations, dependencies, generated files, permissions, credentials, or visible UI changes.

## How To Verify

```text
Review follow-up focused tests: 117 passed
bun --cwd packages/opencode test test/session/loop-gate.test.ts test/session/diagnostics.test.ts test/session/processor-effect.test.ts test/session/prompt-effect.test.ts

Full session tests: 502 passed, 4 skipped, 1 todo, 0 failed
bun --cwd packages/opencode test test/session

Typecheck: passed
bun run --cwd packages/opencode typecheck

Diff check: no whitespace errors
git diff --check
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Diagnostics now capture output hashes, mutation epochs, and attempted tool inputs; large diagnostic values are compacted/truncated. Reminders now distinguish input vs. target successes. Gate matching refined: successful repeats match by exact input; non-success cases prioritize target then input. Snapshot exports redact attempted inputs.

* **Tests**
  * Added/updated tests for diagnostic compaction, snapshot redaction, gate behavior, mutation-epoch handling, and loop-gate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->