### PR TITLE
fix(app): recover hidden question blockers

### DIFF
--- a/packages/app/e2e/backend.ts
+++ b/packages/app/e2e/backend.ts
@@ -60,6 +60,30 @@ const LOG_CAP = 100
 
 const INTERNAL_SERVER_AUTH_ENV = new Set(["opencode_server_password", "opencode_server_username"])
 
+// Strip any host-provided AI provider credentials from the spawned backend's
+// environment so the test fixture's OPENCODE_E2E_LLM_URL routing always wins.
+// Without this, a developer with e.g. GEMINI_API_KEY exported on their host
+// gets that provider auto-picked as default model in the worker backend, and
+// the test silently makes a real network call (or fails with auth errors)
+// instead of routing through the in-process e2e LLM fixture.
+//
+// Pattern catches `*_API_KEY` / `*_API_TOKEN` (the bulk of provider env names
+// in models.dev). Explicit set covers the long tail that doesn't match
+// (e.g. `GITHUB_TOKEN` for Copilot, `HF_TOKEN`, `AWS_BEARER_TOKEN_BEDROCK`).
+const PROVIDER_ENV_PATTERN = /_API_(KEY|TOKEN)$/
+const PROVIDER_ENV_EXTRA = new Set([
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "BAILING_API_TOKEN",
+  "DIGITALOCEAN_ACCESS_TOKEN",
+  "FRIENDLI_TOKEN",
+  "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "HF_TOKEN",
+])
+
 function cap(input: string[]) {
   if (input.length > LOG_CAP) input.splice(0, input.length - LOG_CAP)
 }
@@ -90,6 +114,7 @@ export function createBackendEnv(input: {
   }
   for (const key of Object.keys(env)) {
     if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete env[key]
+    else if (PROVIDER_ENV_PATTERN.test(key) || PROVIDER_ENV_EXTRA.has(key)) delete env[key]
   }
   return env
 }

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -1460,3 +1460,47 @@ test("question text renders source newlines as visible line breaks", async ({ pa
     { trackSession: project.trackSession },
   )
 })
+
+// Cancelling a session while a question tool is awaiting an answer must clear
+// the dock AND surface a friendly hint in the message stream so the user is
+// not left staring at a stuck UI. See #419.
+test("cancelled question tool surfaces interrupted hint in message stream", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question cancelled",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        await llm.toolMatch(inputMatch({ questions: defaultQuestions }), "question", { questions: defaultQuestions })
+        await seedSessionQuestion(project.sdk, {
+          sessionID: session.id,
+          questions: defaultQuestions,
+        })
+
+        await expectQuestionBlocked(page)
+
+        await project.sdk.session.abort({ sessionID: session.id })
+
+        // Dock disappears via the live `question.rejected` SSE event published
+        // by Question.ask's abort handler — no reload needed for this leg.
+        await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 10_000 })
+
+        // The message stream isn't subscribed to mid-session message updates
+        // in this dock-focused test setup (matching the permission-flow tests
+        // which also reload before asserting on tool-result UI). Reload so the
+        // initial render walks the full message history and our error tool
+        // part with `metadata.interrupted = true` lands.
+        await page.goto(page.url())
+
+        // Hint string lives in packages/ui/src/i18n/en.ts (not the app dict);
+        // hardcode it here as the contract anchor for this fix.
+        await expect(
+          page.getByText("This question was cancelled before it was answered. Ask again below if you want to continue."),
+        ).toBeVisible({ timeout: 10_000 })
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -114,14 +114,18 @@ export default function Page() {
   const timelineSessionID = timeline.sessionID
   const timelineSessionKey = timeline.sessionKey
   const timelineIsChildSession = timeline.isChildSession
-  const halt = (sessionID: string) =>
+  const haltAbort = (sessionID: string) =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? sdk.client.session.abort({ sessionID }).catch(() => {})
+      ? sdk.client.session.abort({ sessionID })
       : Promise.resolve()
+  // sessionRevert chains halt with .then(), so its existing outer .catch
+  // already handles abort failures. The auto-heal clock wants to see the
+  // error so it can structured-warn — pass haltAbort directly there.
+  const halt = (sessionID: string) => haltAbort(sessionID).catch(() => {})
   const composer = createSessionComposerState({
     sessionID: timelineSessionID,
     fallbackSessionID: () => params.id,
-    halt,
+    halt: haltAbort,
   })
   const timelineMessages = timeline.messages
   const timelineMessagesReady = timeline.messagesReady

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -114,7 +114,15 @@ export default function Page() {
   const timelineSessionID = timeline.sessionID
   const timelineSessionKey = timeline.sessionKey
   const timelineIsChildSession = timeline.isChildSession
-  const composer = createSessionComposerState({ sessionID: timelineSessionID, fallbackSessionID: () => params.id })
+  const halt = (sessionID: string) =>
+    isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
+      ? sdk.client.session.abort({ sessionID }).catch(() => {})
+      : Promise.resolve()
+  const composer = createSessionComposerState({
+    sessionID: timelineSessionID,
+    fallbackSessionID: () => params.id,
+    halt,
+  })
   const timelineMessages = timeline.messages
   const timelineMessagesReady = timeline.messagesReady
   const timelineDiffs = timeline.diffs
@@ -448,11 +456,6 @@ export default function Page() {
     resumeScroll,
     attachmentLabel: () => language.t("common.attachment"),
   })
-
-  const halt = (sessionID: string) =>
-    isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? sdk.client.session.abort({ sessionID }).catch(() => {})
-      : Promise.resolve()
 
   const sessionRevert = createSessionRevert({
     sessionID: timelineSessionID,

--- a/packages/app/src/pages/session/blockers/question-fallback.test.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.test.ts
@@ -131,4 +131,19 @@ describe("findRunningQuestionFallbackSession", () => {
       }),
     ).toBe("s")
   })
+
+  // Mixed-state guard for #419: when a sync entry lacks tool identity but a
+  // running part has identity, the legacy entry should still cover it. Pre-fix
+  // behavior would treat the running part as missing and trigger fallback,
+  // even though the sync entry was a legitimate (legacy-shaped) match.
+  test("legacy sync entry without identity absorbs running part with identity", () => {
+    expect(
+      findRunningQuestionFallbackSession({
+        sessionID: "s",
+        syncQuestions: [syncQ("q_legacy", "s")],
+        messages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toBeUndefined()
+  })
 })

--- a/packages/app/src/pages/session/blockers/question-fallback.test.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { Message, Part, ToolState } from "@opencode-ai/sdk/v2"
+import type { Message, Part, QuestionRequest, ToolState } from "@opencode-ai/sdk/v2"
 import { findRunningQuestionFallbackSession } from "./question-fallback"
 
 const message = (id: string): Message => ({ id }) as Message
@@ -13,37 +13,69 @@ const toolState = (status: ToolState["status"]): ToolState =>
     time: { start: 0 },
   }) as ToolState
 
-const toolPart = (tool: string, status: ToolState["status"] = "running"): Part =>
+const toolPart = (
+  id: string,
+  tool: string,
+  status: ToolState["status"] = "running",
+  attrs?: { messageID?: string; callID?: string },
+): Part =>
   ({
-    id: `part-${tool}-${status}`,
+    id,
     type: "tool",
     tool,
     state: toolState(status),
+    messageID: attrs?.messageID,
+    callID: attrs?.callID,
   }) as Part
+
+const syncQ = (id: string, sessionID: string, tool?: { messageID: string; callID: string }): QuestionRequest =>
+  ({
+    id,
+    sessionID,
+    questions: [{ header: "h", question: "q", options: [] }],
+    tool,
+  }) as QuestionRequest
 
 describe("findRunningQuestionFallbackSession", () => {
   test("returns undefined without a session", () => {
-    expect(findRunningQuestionFallbackSession({ hasQuestionRequest: false, partsByMessageID: {} })).toBeUndefined()
+    expect(findRunningQuestionFallbackSession({ syncQuestions: [], partsByMessageID: {} })).toBeUndefined()
   })
 
-  test("returns undefined when a question request already exists", () => {
+  test("returns undefined when sync entry matches the running part by (messageID, callID)", () => {
     expect(
       findRunningQuestionFallbackSession({
         sessionID: "s",
-        hasQuestionRequest: true,
-        messages: [message("m")],
-        partsByMessageID: { m: [toolPart("question")] },
+        syncQuestions: [syncQ("q1", "s", { messageID: "m1", callID: "c1" })],
+        messages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
       }),
     ).toBeUndefined()
   })
 
-  test("returns the session when a recent running question tool part exists", () => {
+  test("triggers when running part has no matching sync entry by identity", () => {
     expect(
       findRunningQuestionFallbackSession({
         sessionID: "s",
-        hasQuestionRequest: false,
-        messages: [message("m")],
-        partsByMessageID: { m: [toolPart("question")] },
+        // sync has an entry, but its tool identity points to a different call
+        syncQuestions: [syncQ("q_other", "s", { messageID: "m1", callID: "c_other" })],
+        messages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toBe("s")
+  })
+
+  test("triggers when running parts outnumber matched sync entries (multi-pending parallel)", () => {
+    expect(
+      findRunningQuestionFallbackSession({
+        sessionID: "s",
+        // only q1 matches; q2 q3 are running but unknown to sync
+        syncQuestions: [syncQ("q1", "s", { messageID: "m1", callID: "c1" })],
+        messages: [message("m1"), message("m2"), message("m3")],
+        partsByMessageID: {
+          m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })],
+          m2: [toolPart("p2", "question", "running", { messageID: "m2", callID: "c2" })],
+          m3: [toolPart("p3", "question", "running", { messageID: "m3", callID: "c3" })],
+        },
       }),
     ).toBe("s")
   })
@@ -52,20 +84,50 @@ describe("findRunningQuestionFallbackSession", () => {
     expect(
       findRunningQuestionFallbackSession({
         sessionID: "s",
-        hasQuestionRequest: false,
+        syncQuestions: [],
         messages: [message("m1"), message("m2")],
-        partsByMessageID: { m1: [toolPart("question", "completed")], m2: [toolPart("todowrite", "running")] },
+        partsByMessageID: {
+          m1: [toolPart("p1", "question", "completed", { messageID: "m1", callID: "c1" })],
+          m2: [toolPart("p2", "todowrite", "running", { messageID: "m2", callID: "c2" })],
+        },
       }),
     ).toBeUndefined()
   })
 
-  test("recovers running question parts even when they are older than the lookback window", () => {
+  test("triggers for a running question part beyond the legacy 5-message window", () => {
+    const messages = Array.from({ length: 50 }, (_, i) => message(`m${i}`))
     expect(
       findRunningQuestionFallbackSession({
         sessionID: "s",
-        hasQuestionRequest: false,
-        messages: [message("old"), message("recent-1"), message("recent-2")],
-        partsByMessageID: { old: [toolPart("question")] },
+        syncQuestions: [],
+        messages,
+        partsByMessageID: { m0: [toolPart("p0", "question", "running", { messageID: "m0", callID: "c0" })] },
+      }),
+    ).toBe("s")
+  })
+
+  test("falls back to count check when neither side has tool identity", () => {
+    expect(
+      findRunningQuestionFallbackSession({
+        sessionID: "s",
+        // sync entry without tool identity, running part also missing identity
+        syncQuestions: [syncQ("q1", "s")],
+        messages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running")] },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("count fallback triggers when running-without-identity exceeds entries-without-identity", () => {
+    expect(
+      findRunningQuestionFallbackSession({
+        sessionID: "s",
+        syncQuestions: [],
+        messages: [message("m1"), message("m2")],
+        partsByMessageID: {
+          m1: [toolPart("p1", "question", "running")],
+          m2: [toolPart("p2", "question", "running")],
+        },
       }),
     ).toBe("s")
   })

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -1,23 +1,44 @@
-import type { Message, Part } from "@opencode-ai/sdk/v2"
+import type { Message, Part, QuestionRequest } from "@opencode-ai/sdk/v2"
 
+// Triggers fallback recovery when a running question tool part on this session
+// has no matching entry in sync. Identity is (messageID, callID) so a model
+// emitting parallel question tool calls is covered correctly even when the
+// counts happen to line up but the entries point to different tool calls.
+// Falls back to a count check for the rare entries that lack tool identity
+// (e.g. seeded test fixtures), so head-count loss is still caught. See #419.
 export function findRunningQuestionFallbackSession(input: {
   sessionID?: string
-  hasQuestionRequest: boolean
+  syncQuestions: ReadonlyArray<QuestionRequest>
   messages?: Message[]
   partsByMessageID: Record<string, Part[] | undefined>
 }): string | undefined {
   if (!input.sessionID) return undefined
-  if (input.hasQuestionRequest) return undefined
   const messages = input.messages
   if (!messages?.length) return undefined
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const parts = input.partsByMessageID[messages[i].id]
+  const coveredKeys = new Set<string>()
+  let entriesWithoutTool = 0
+  for (const q of input.syncQuestions) {
+    if (q.tool) coveredKeys.add(`${q.tool.messageID}:${q.tool.callID}`)
+    else entriesWithoutTool++
+  }
+
+  let runningWithoutTool = 0
+  for (const m of messages) {
+    const parts = input.partsByMessageID[m.id]
     if (!parts) continue
     for (const part of parts) {
-      if (part.type === "tool" && part.tool === "question" && part.state.status === "running") return input.sessionID
+      if (part.type !== "tool" || part.tool !== "question" || part.state.status !== "running") continue
+      const callID = part.callID
+      const messageID = part.messageID
+      if (!callID || !messageID) {
+        runningWithoutTool++
+        continue
+      }
+      if (!coveredKeys.has(`${messageID}:${callID}`)) return input.sessionID
     }
   }
 
+  if (runningWithoutTool > entriesWithoutTool) return input.sessionID
   return undefined
 }

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -4,8 +4,13 @@ import type { Message, Part, QuestionRequest } from "@opencode-ai/sdk/v2"
 // has no matching entry in sync. Identity is (messageID, callID) so a model
 // emitting parallel question tool calls is covered correctly even when the
 // counts happen to line up but the entries point to different tool calls.
-// Falls back to a count check for the rare entries that lack tool identity
-// (e.g. seeded test fixtures), so head-count loss is still caught. See #419.
+//
+// Sync entries that lack tool identity (e.g. legacy / seeded test fixtures)
+// can't be matched by key, so they cover any one running part. The
+// uncovered-with-identity bucket and the without-identity bucket are pooled
+// against the entries-without-identity bucket: a fallback only fires when
+// the uncovered total truly exceeds what the legacy entries can absorb.
+// See #419.
 export function findRunningQuestionFallbackSession(input: {
   sessionID?: string
   syncQuestions: ReadonlyArray<QuestionRequest>
@@ -23,7 +28,7 @@ export function findRunningQuestionFallbackSession(input: {
     else entriesWithoutTool++
   }
 
-  let runningWithoutTool = 0
+  let uncoveredRunning = 0
   for (const m of messages) {
     const parts = input.partsByMessageID[m.id]
     if (!parts) continue
@@ -31,14 +36,12 @@ export function findRunningQuestionFallbackSession(input: {
       if (part.type !== "tool" || part.tool !== "question" || part.state.status !== "running") continue
       const callID = part.callID
       const messageID = part.messageID
-      if (!callID || !messageID) {
-        runningWithoutTool++
-        continue
+      if (!callID || !messageID || !coveredKeys.has(`${messageID}:${callID}`)) {
+        uncoveredRunning++
       }
-      if (!coveredKeys.has(`${messageID}:${callID}`)) return input.sessionID
     }
   }
 
-  if (runningWithoutTool > entriesWithoutTool) return input.sessionID
+  if (uncoveredRunning > entriesWithoutTool) return input.sessionID
   return undefined
 }

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -1,4 +1,12 @@
-import type { Message, Part, QuestionRequest } from "@opencode-ai/sdk/v2"
+import type { Message, Part } from "@opencode-ai/sdk/v2"
+
+// Minimal sync-entry shape this matcher needs. Widened from the full
+// QuestionRequest so callers (e.g. reverify) can pass narrower generics
+// without `as never` while keeping QuestionRequest[] callers happy via
+// structural subtyping.
+export interface QuestionFallbackEntry {
+  tool?: { messageID: string; callID: string }
+}
 
 // Triggers fallback recovery when a running question tool part on this session
 // has no matching entry in sync. Identity is (messageID, callID) so a model
@@ -13,7 +21,7 @@ import type { Message, Part, QuestionRequest } from "@opencode-ai/sdk/v2"
 // See #419.
 export function findRunningQuestionFallbackSession(input: {
   sessionID?: string
-  syncQuestions: ReadonlyArray<QuestionRequest>
+  syncQuestions: ReadonlyArray<QuestionFallbackEntry>
   messages?: Message[]
   partsByMessageID: Record<string, Part[] | undefined>
 }): string | undefined {

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -22,8 +22,8 @@ export interface QuestionFallbackEntry {
 export function findRunningQuestionFallbackSession(input: {
   sessionID?: string
   syncQuestions: ReadonlyArray<QuestionFallbackEntry>
-  messages?: Message[]
-  partsByMessageID: Record<string, Part[] | undefined>
+  messages?: ReadonlyArray<Message>
+  partsByMessageID: Record<string, ReadonlyArray<Part> | undefined>
 }): string | undefined {
   if (!input.sessionID) return undefined
   const messages = input.messages

--- a/packages/app/src/pages/session/blockers/question-recovery-chain.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-chain.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import type { Message, Part, QuestionRequest, ToolState } from "@opencode-ai/sdk/v2"
+import { createQuestionRecoveryClock, HEAL_DELAY_MS } from "./question-recovery-clock"
+import { resolveQuestionRecoverySnapshot, type QuestionRecoverySnapshot } from "./question-recovery-snapshot"
+import { questionRecoveryReverify, type ReverifyDeps } from "./question-recovery-reverify"
+
+// End-to-end auto-heal chain: snapshot reducer + clock + reverify wired
+// against the same mutable harness state. Tests the recovery contract as a
+// whole — snapshot edge → clock arm → reverify → halt or hydrate — instead
+// of trusting that three correct pieces compose correctly. See #419.
+
+interface FakeTimer {
+  cb: () => void
+  fireAt: number
+  cancelled: boolean
+}
+
+function fakeClock() {
+  let nowMs = 0
+  const timers: FakeTimer[] = []
+  return {
+    now: () => nowMs,
+    advance(by: number) {
+      nowMs += by
+      for (const t of timers) {
+        if (t.cancelled) continue
+        if (t.fireAt <= nowMs) {
+          t.cancelled = true
+          t.cb()
+        }
+      }
+    },
+    setTimer: (cb: () => void, ms: number) => {
+      const t: FakeTimer = { cb, fireAt: nowMs + ms, cancelled: false }
+      timers.push(t)
+      return t
+    },
+    clearTimer: (handle: unknown) => {
+      ;(handle as FakeTimer).cancelled = true
+    },
+    pending: () => timers.filter((t) => !t.cancelled).length,
+  }
+}
+
+const flush = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+const message = (id: string): Message => ({ id }) as Message
+
+const toolState = (status: ToolState["status"], input: Record<string, unknown> = {}): ToolState =>
+  ({
+    status,
+    input,
+    title: "",
+    metadata: {},
+    time: { start: 0 },
+  }) as ToolState
+
+const runningQuestionPart = (callID: string, messageID: string): Part =>
+  ({
+    id: callID,
+    type: "tool",
+    tool: "question",
+    state: toolState("running", { id: "q1" }),
+    callID,
+    messageID,
+  }) as Part
+
+const SID = "ses_chain"
+const DIR = "/dir"
+
+interface Harness {
+  // Inputs that drive the snapshot reducer + reverify.
+  setSyncQuestions: (q: ReadonlyArray<QuestionRequest>) => void
+  setMessages: (m: ReadonlyArray<Message>) => void
+  setParts: (p: Record<string, ReadonlyArray<Part>>) => void
+  setBusy: (b: boolean) => void
+  setActiveSid: (s: string | undefined) => void
+  setDirectory: (d: string) => void
+  setListImpl: (impl: () => Promise<readonly QuestionRequest[]>) => void
+  setHaltImpl: (impl: () => Promise<unknown>) => void
+  // Observed effects.
+  haltCalls: string[]
+  hydrationCalls: { sid: string; questions: readonly QuestionRequest[] }[]
+  warnCalls: { message: string; payload: Record<string, unknown> }[]
+  fk: ReturnType<typeof fakeClock>
+  // Drive snapshot recompute on input change (production goes via memo).
+  recompute: () => void
+  dispose: () => void
+}
+
+const setupChain = (initial?: {
+  syncQuestions?: ReadonlyArray<QuestionRequest>
+  messages?: ReadonlyArray<Message>
+  parts?: Record<string, ReadonlyArray<Part>>
+  busy?: boolean
+  activeSid?: string
+  directory?: string
+  listImpl?: () => Promise<readonly QuestionRequest[]>
+  haltImpl?: () => Promise<unknown>
+}): Harness => {
+  const fk = fakeClock()
+  const haltCalls: string[] = []
+  const hydrationCalls: { sid: string; questions: readonly QuestionRequest[] }[] = []
+  const warnCalls: { message: string; payload: Record<string, unknown> }[] = []
+
+  let setSync!: (q: ReadonlyArray<QuestionRequest>) => void
+  let setMsgs!: (m: ReadonlyArray<Message>) => void
+  let setPartsSig!: (p: Record<string, ReadonlyArray<Part>>) => void
+  let setBusySig!: (b: boolean) => void
+  let setSid!: (s: string | undefined) => void
+  let setDir!: (d: string) => void
+  let recompute!: () => void
+
+  let listImpl: () => Promise<readonly QuestionRequest[]> = initial?.listImpl ?? (async () => [])
+  let haltImpl: () => Promise<unknown> =
+    initial?.haltImpl ??
+    (async () => {
+      // default
+    })
+
+  const dispose = createRoot((d) => {
+    const [sync, sSync] = createSignal<ReadonlyArray<QuestionRequest>>(initial?.syncQuestions ?? [])
+    const [msgs, sMsgs] = createSignal<ReadonlyArray<Message>>(initial?.messages ?? [])
+    const [parts, sParts] = createSignal<Record<string, ReadonlyArray<Part>>>(initial?.parts ?? {})
+    const [busy, sBusy] = createSignal(initial?.busy ?? true)
+    const [sid, sSid] = createSignal<string | undefined>(initial?.activeSid ?? SID)
+    const [dir, sDir] = createSignal(initial?.directory ?? DIR)
+    const [snap, sSnap] = createSignal<QuestionRecoverySnapshot>({ kind: "none" })
+
+    setSync = sSync
+    setMsgs = sMsgs
+    setPartsSig = sParts
+    setBusySig = sBusy
+    setSid = sSid
+    setDir = sDir
+
+    recompute = () => {
+      const next = resolveQuestionRecoverySnapshot({
+        sessionID: sid(),
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: sync(),
+        activeSessionMessages: msgs(),
+        partsByMessageID: parts(),
+      })
+      sSnap(next)
+      clock.tick()
+    }
+
+    const reverifyDeps: ReverifyDeps<QuestionRequest> = {
+      snapshot: snap,
+      activeSessionID: sid,
+      activeDirectory: dir,
+      isSessionBusy: () => busy(),
+      listQuestions: () => listImpl(),
+      messagesFor: () => msgs(),
+      partsByMessageID: () => parts(),
+      applyHydration: (s, qs) => hydrationCalls.push({ sid: s, questions: qs }),
+      warn: (m, p) => warnCalls.push({ message: m, payload: p }),
+    }
+
+    const clock = createQuestionRecoveryClock({
+      snapshot: snap,
+      activeSessionID: sid,
+      activeDirectory: dir,
+      halt: async (s) => {
+        haltCalls.push(s)
+        return haltImpl()
+      },
+      reverify: (s, ctx) => questionRecoveryReverify(reverifyDeps, s, ctx),
+      now: fk.now,
+      setTimer: fk.setTimer,
+      clearTimer: fk.clearTimer,
+      warn: (m, p) => warnCalls.push({ message: m, payload: p }),
+    })
+
+    return d
+  })
+
+  // Initialise snapshot once before tests interact.
+  recompute()
+
+  return {
+    setSyncQuestions: (q) => {
+      setSync(q)
+      recompute()
+    },
+    setMessages: (m) => {
+      setMsgs(m)
+      recompute()
+    },
+    setParts: (p) => {
+      setPartsSig(p)
+      recompute()
+    },
+    setBusy: setBusySig,
+    setActiveSid: (s) => {
+      setSid(s)
+      recompute()
+    },
+    setDirectory: (d) => {
+      setDir(d)
+      recompute()
+    },
+    setListImpl: (impl) => {
+      listImpl = impl
+    },
+    setHaltImpl: (impl) => {
+      haltImpl = impl
+    },
+    haltCalls,
+    hydrationCalls,
+    warnCalls,
+    fk,
+    recompute,
+    dispose,
+  }
+}
+
+describe("question recovery chain", () => {
+  test("missingRunning edge → reverify (still uncovered) → halt fires", async () => {
+    const h = setupChain()
+
+    // Drop into missingRunning: assistant message has a running question
+    // part with no covering sync entry.
+    h.setMessages([message("m1")])
+    h.setParts({ m1: [runningQuestionPart("c1", "m1")] })
+    expect(h.fk.pending()).toBe(1)
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual([SID])
+    expect(h.hydrationCalls).toEqual([])
+    h.dispose()
+  })
+
+  test("server hydrates the missing question before fire → reverify writes it back, halt skipped", async () => {
+    const covering = {
+      id: "q1",
+      sessionID: SID,
+      tool: { messageID: "m1", callID: "c1" },
+    } as unknown as QuestionRequest
+    const h = setupChain()
+    h.setMessages([message("m1")])
+    h.setParts({ m1: [runningQuestionPart("c1", "m1")] })
+    expect(h.fk.pending()).toBe(1)
+
+    // Server now reports the covering question — reverify will hydrate sync
+    // and refuse to halt because the running part is no longer uncovered.
+    h.setListImpl(async () => [covering])
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    expect(h.hydrationCalls).toHaveLength(1)
+    expect(h.hydrationCalls[0]).toEqual({ sid: SID, questions: [covering] })
+    h.dispose()
+  })
+
+  test("transient list() failure → bounded retry → recovery on follow-up halts", async () => {
+    let attempts = 0
+    const h = setupChain()
+    h.setListImpl(async () => {
+      attempts++
+      if (attempts === 1) throw new Error("server blip")
+      return []
+    })
+    h.setMessages([message("m1")])
+    h.setParts({ m1: [runningQuestionPart("c1", "m1")] })
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(1)
+    expect(h.haltCalls).toEqual([])
+    expect(h.fk.pending()).toBe(1)
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(2)
+    expect(h.haltCalls).toEqual([SID])
+    h.dispose()
+  })
+
+  test("session leaves missingRunning before timer fires → halt skipped, no hydration", async () => {
+    const covering = {
+      id: "q1",
+      sessionID: SID,
+      tool: { messageID: "m1", callID: "c1" },
+    } as unknown as QuestionRequest
+    const h = setupChain()
+    h.setMessages([message("m1")])
+    h.setParts({ m1: [runningQuestionPart("c1", "m1")] })
+    expect(h.fk.pending()).toBe(1)
+
+    // Sync receives the covering entry before the timer expires — snapshot
+    // flips to "none" and the clock cancels its timer.
+    h.setSyncQuestions([covering])
+    expect(h.fk.pending()).toBe(0)
+
+    h.fk.advance(HEAL_DELAY_MS * 2)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    expect(h.hydrationCalls).toEqual([])
+    h.dispose()
+  })
+})

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createQuestionRecoveryClock, HEAL_DELAY_MS } from "./question-recovery-clock"
+import { createQuestionRecoveryClock, HEAL_DELAY_MS, MAX_RETRIES } from "./question-recovery-clock"
 import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
 
 interface FakeTimer {
@@ -165,10 +165,10 @@ describe("createQuestionRecoveryClock", () => {
     h.dispose()
   })
 
-  // Bounded retry: a second consecutive transient failure must NOT re-arm.
-  // The clock waits for a fresh snapshot edge instead of looping the server
-  // every delayMs forever.
-  test("reverify retry=true twice in a row only re-arms once", async () => {
+  // Bounded retry: persistent transient failures must give up after a
+  // bounded number of follow-up attempts. The clock then waits for a fresh
+  // snapshot edge instead of looping the server every delayMs forever.
+  test("reverify retry=true exhausts MAX_RETRIES then logs warn and stops", async () => {
     let attempts = 0
     const h = setupHarness({
       reverifyImpl: async () => {
@@ -177,21 +177,29 @@ describe("createQuestionRecoveryClock", () => {
       },
     })
     h.setSnap(missing)
-    h.fk.advance(HEAL_DELAY_MS)
-    await flush()
-    expect(attempts).toBe(1)
-    expect(h.fk.pending()).toBe(1) // one follow-up armed
 
+    // Drive initial fire + MAX_RETRIES follow-ups. After each tick we should
+    // see a follow-up timer queued for the next round, until the budget hits.
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      h.fk.advance(HEAL_DELAY_MS)
+      await flush()
+      expect(attempts).toBe(i + 1)
+      expect(h.fk.pending()).toBe(1)
+    }
+
+    // The (MAX_RETRIES + 1)-th attempt is the last one; it returns retry=true
+    // but the budget is now exhausted, so the clock warns and stops.
     h.fk.advance(HEAL_DELAY_MS)
     await flush()
-    expect(attempts).toBe(2)
+    expect(attempts).toBe(MAX_RETRIES + 1)
     expect(h.haltCalls).toEqual([])
-    expect(h.fk.pending()).toBe(0) // give-up: no second re-arm
+    expect(h.fk.pending()).toBe(0)
+    expect(h.warnCalls.some((w) => w.message.includes("retry budget exhausted"))).toBe(true)
 
     // A long wait without snapshot change does not revive the clock.
     h.fk.advance(HEAL_DELAY_MS * 10)
     await flush()
-    expect(attempts).toBe(2)
+    expect(attempts).toBe(MAX_RETRIES + 1)
     expect(h.haltCalls).toEqual([])
 
     // A fresh snapshot edge (none → missing) starts a new arm with a fresh

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createQuestionRecoveryClock, HEAL_DELAY_MS } from "./question-recovery-clock"
+import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
+
+interface FakeTimer {
+  cb: () => void
+  fireAt: number
+  cancelled: boolean
+}
+
+function fakeClock() {
+  let nowMs = 0
+  const timers: FakeTimer[] = []
+  return {
+    now: () => nowMs,
+    advance(by: number) {
+      nowMs += by
+      for (const t of timers) {
+        if (t.cancelled) continue
+        if (t.fireAt <= nowMs) {
+          t.cancelled = true
+          t.cb()
+        }
+      }
+    },
+    setTimer: (cb: () => void, ms: number) => {
+      const t: FakeTimer = { cb, fireAt: nowMs + ms, cancelled: false }
+      timers.push(t)
+      return t
+    },
+    clearTimer: (handle: unknown) => {
+      ;(handle as FakeTimer).cancelled = true
+    },
+    pending: () => timers.filter((t) => !t.cancelled).length,
+  }
+}
+
+const flush = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+const ready: QuestionRecoverySnapshot = { kind: "ready" }
+const none: QuestionRecoverySnapshot = { kind: "none" }
+const missing: QuestionRecoverySnapshot = { kind: "missingRunning" }
+
+interface Harness {
+  clock: ReturnType<typeof createQuestionRecoveryClock>
+  setSnap: (s: QuestionRecoverySnapshot) => void
+  fk: ReturnType<typeof fakeClock>
+  haltCalls: string[]
+  warnCalls: { message: string; payload: Record<string, unknown> }[]
+  haltImpl?: (s: string) => Promise<unknown>
+  reverifyImpl?: () => Promise<{ proceed: boolean }>
+  dispose: () => void
+}
+
+const setupHarness = (overrides?: {
+  haltImpl?: (s: string) => Promise<unknown>
+  reverifyImpl?: () => Promise<{ proceed: boolean }>
+  delayMs?: number
+}): Harness => {
+  const fk = fakeClock()
+  const haltCalls: string[] = []
+  const warnCalls: { message: string; payload: Record<string, unknown> }[] = []
+  let setSnap!: (s: QuestionRecoverySnapshot) => void
+  let clock!: ReturnType<typeof createQuestionRecoveryClock>
+  const dispose = createRoot((d) => {
+    const [snap, setS] = createSignal<QuestionRecoverySnapshot>(none)
+    setSnap = (s) => {
+      setS(s)
+      clock.tick()
+    }
+    clock = createQuestionRecoveryClock({
+      snapshot: snap,
+      activeSessionID: () => "s",
+      activeDirectory: () => "/dir",
+      halt:
+        overrides?.haltImpl ??
+        (async (s: string) => {
+          haltCalls.push(s)
+        }),
+      reverify: overrides?.reverifyImpl ?? (async () => ({ proceed: true })),
+      delayMs: overrides?.delayMs ?? HEAL_DELAY_MS,
+      now: fk.now,
+      setTimer: fk.setTimer,
+      clearTimer: fk.clearTimer,
+      warn: (m, p) => warnCalls.push({ message: m, payload: p }),
+    })
+    return d
+  })
+  return { clock, setSnap, fk, haltCalls, warnCalls, dispose }
+}
+
+describe("createQuestionRecoveryClock", () => {
+  test("transition to missingRunning arms a timer; halt called after delay", async () => {
+    const h = setupHarness()
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual(["s"])
+    h.dispose()
+  })
+
+  test("transition back to ready before fire clears the timer; halt not called", async () => {
+    const h = setupHarness()
+    h.setSnap(missing)
+    h.setSnap(ready)
+    h.fk.advance(HEAL_DELAY_MS + 100)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    h.dispose()
+  })
+
+  test("transition back to none before fire clears the timer; halt not called", async () => {
+    const h = setupHarness()
+    h.setSnap(missing)
+    h.setSnap(none)
+    h.fk.advance(HEAL_DELAY_MS + 100)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    h.dispose()
+  })
+
+  test("reverify proceed=false → halt NOT called", async () => {
+    const h = setupHarness({ reverifyImpl: async () => ({ proceed: false }) })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    h.dispose()
+  })
+
+  test("halt() throws → structured warn logged, map entry deleted, no retry", async () => {
+    let haltCount = 0
+    const h = setupHarness({
+      haltImpl: async () => {
+        haltCount++
+        throw new Error("halt boom")
+      },
+    })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(haltCount).toBe(1)
+    expect(h.warnCalls.length).toBe(1)
+    expect(h.warnCalls[0].message).toContain("halt failed")
+    expect(h.warnCalls[0].payload).toMatchObject({ sessionID: "s", directory: "/dir" })
+    expect(typeof h.warnCalls[0].payload.armedAt).toBe("number")
+    expect(typeof h.warnCalls[0].payload.firedAt).toBe("number")
+    expect(h.clock.pendingFor("s")).toBe(false)
+    h.dispose()
+  })
+
+  test("snapshot stays missingRunning after fire → no re-arm (v5 P2-2 lock)", async () => {
+    const h = setupHarness()
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual(["s"])
+
+    // Same-kind set after fire must not arm a second timer.
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS * 2)
+    await flush()
+    expect(h.haltCalls).toEqual(["s"])
+
+    // After leaving and returning, a fresh edge re-arms.
+    h.setSnap(none)
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual(["s", "s"])
+    h.dispose()
+  })
+
+  test("reverify threw → warn logged, halt NOT called", async () => {
+    const h = setupHarness({
+      reverifyImpl: async () => {
+        throw new Error("reverify boom")
+      },
+    })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+    expect(h.warnCalls.length).toBe(1)
+    expect(h.warnCalls[0].message).toContain("reverify threw")
+    expect(h.warnCalls[0].payload).toMatchObject({ sessionID: "s" })
+    h.dispose()
+  })
+
+  test("dispose clears all pending timers", () => {
+    const h = setupHarness()
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+    h.dispose()
+    expect(h.fk.pending()).toBe(0)
+  })
+})

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -165,6 +165,43 @@ describe("createQuestionRecoveryClock", () => {
     h.dispose()
   })
 
+  // Bounded retry: a second consecutive transient failure must NOT re-arm.
+  // The clock waits for a fresh snapshot edge instead of looping the server
+  // every delayMs forever.
+  test("reverify retry=true twice in a row only re-arms once", async () => {
+    let attempts = 0
+    const h = setupHarness({
+      reverifyImpl: async () => {
+        attempts++
+        return { proceed: false, retry: true }
+      },
+    })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(1)
+    expect(h.fk.pending()).toBe(1) // one follow-up armed
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(2)
+    expect(h.haltCalls).toEqual([])
+    expect(h.fk.pending()).toBe(0) // give-up: no second re-arm
+
+    // A long wait without snapshot change does not revive the clock.
+    h.fk.advance(HEAL_DELAY_MS * 10)
+    await flush()
+    expect(attempts).toBe(2)
+    expect(h.haltCalls).toEqual([])
+
+    // A fresh snapshot edge (none → missing) starts a new arm with a fresh
+    // retry budget.
+    h.setSnap(none)
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+    h.dispose()
+  })
+
   test("halt() throws → structured warn logged, map entry deleted, no retry", async () => {
     let haltCount = 0
     const h = setupHarness({

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -52,13 +52,13 @@ interface Harness {
   haltCalls: string[]
   warnCalls: { message: string; payload: Record<string, unknown> }[]
   haltImpl?: (s: string) => Promise<unknown>
-  reverifyImpl?: () => Promise<{ proceed: boolean }>
+  reverifyImpl?: () => Promise<{ proceed: true } | { proceed: false; retry?: boolean }>
   dispose: () => void
 }
 
 const setupHarness = (overrides?: {
   haltImpl?: (s: string) => Promise<unknown>
-  reverifyImpl?: (sid: string) => Promise<{ proceed: boolean }>
+  reverifyImpl?: (sid: string) => Promise<{ proceed: true } | { proceed: false; retry?: boolean }>
   delayMs?: number
   initialSid?: string
 }): Harness => {
@@ -137,6 +137,31 @@ describe("createQuestionRecoveryClock", () => {
     h.fk.advance(HEAL_DELAY_MS)
     await flush()
     expect(h.haltCalls).toEqual([])
+    h.dispose()
+  })
+
+  // Transient reverify failure: when reverify returns proceed:false with
+  // retry:true, the clock re-arms exactly one follow-up timer so a sticky
+  // stuck session does not dead-end on a single list() blip.
+  test("reverify proceed=false + retry=true re-arms one follow-up timer", async () => {
+    let attempts = 0
+    const h = setupHarness({
+      reverifyImpl: async () => {
+        attempts++
+        return attempts === 1 ? { proceed: false, retry: true } : { proceed: true }
+      },
+    })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(1)
+    expect(h.haltCalls).toEqual([])
+    expect(h.fk.pending()).toBe(1)
+
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(2)
+    expect(h.haltCalls).toEqual(["s"])
     h.dispose()
   })
 

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -47,6 +47,7 @@ const missing: QuestionRecoverySnapshot = { kind: "missingRunning" }
 interface Harness {
   clock: ReturnType<typeof createQuestionRecoveryClock>
   setSnap: (s: QuestionRecoverySnapshot) => void
+  setSid: (s: string | undefined) => void
   fk: ReturnType<typeof fakeClock>
   haltCalls: string[]
   warnCalls: { message: string; payload: Record<string, unknown> }[]
@@ -57,23 +58,30 @@ interface Harness {
 
 const setupHarness = (overrides?: {
   haltImpl?: (s: string) => Promise<unknown>
-  reverifyImpl?: () => Promise<{ proceed: boolean }>
+  reverifyImpl?: (sid: string) => Promise<{ proceed: boolean }>
   delayMs?: number
+  initialSid?: string
 }): Harness => {
   const fk = fakeClock()
   const haltCalls: string[] = []
   const warnCalls: { message: string; payload: Record<string, unknown> }[] = []
   let setSnap!: (s: QuestionRecoverySnapshot) => void
+  let setSid!: (s: string | undefined) => void
   let clock!: ReturnType<typeof createQuestionRecoveryClock>
   const dispose = createRoot((d) => {
     const [snap, setS] = createSignal<QuestionRecoverySnapshot>(none)
+    const [sid, setSidSignal] = createSignal<string | undefined>(overrides?.initialSid ?? "s")
     setSnap = (s) => {
       setS(s)
       clock.tick()
     }
+    setSid = (s) => {
+      setSidSignal(s)
+      clock.tick()
+    }
     clock = createQuestionRecoveryClock({
       snapshot: snap,
-      activeSessionID: () => "s",
+      activeSessionID: sid,
       activeDirectory: () => "/dir",
       halt:
         overrides?.haltImpl ??
@@ -89,7 +97,7 @@ const setupHarness = (overrides?: {
     })
     return d
   })
-  return { clock, setSnap, fk, haltCalls, warnCalls, dispose }
+  return { clock, setSnap, setSid, fk, haltCalls, warnCalls, dispose }
 }
 
 describe("createQuestionRecoveryClock", () => {
@@ -198,5 +206,34 @@ describe("createQuestionRecoveryClock", () => {
     expect(h.fk.pending()).toBe(1)
     h.dispose()
     expect(h.fk.pending()).toBe(0)
+  })
+
+  // Navigation cleanup: switching active session must drop the previous
+  // session's pending timer AND its lastSeen entry, so coming back to a
+  // still-stuck session re-arms cleanly. Locks the bug Codex flagged where
+  // lastSeen[old] stayed missingRunning forever.
+  test("session navigation forgets the old session's pending timer and edge state", async () => {
+    const h = setupHarness({ initialSid: "a" })
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+
+    // Navigate to b. In production b's snapshot is per-session; here we
+    // simulate by flipping snap to none on the navigation tick.
+    h.setSid("b")
+    h.setSnap(none)
+    expect(h.fk.pending()).toBe(0)
+    h.fk.advance(HEAL_DELAY_MS * 2)
+    await flush()
+    expect(h.haltCalls).toEqual([])
+
+    // Come back to a with snapshot still missingRunning — must re-arm fresh
+    // even though lastSeen[a] would otherwise still read missingRunning.
+    h.setSid("a")
+    h.setSnap(missing)
+    expect(h.fk.pending()).toBe(1)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(h.haltCalls).toEqual(["a"])
+    h.dispose()
   })
 })

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.test.ts
@@ -165,10 +165,10 @@ describe("createQuestionRecoveryClock", () => {
     h.dispose()
   })
 
-  // Bounded retry: persistent transient failures must give up after a
-  // bounded number of follow-up attempts. The clock then waits for a fresh
-  // snapshot edge instead of looping the server every delayMs forever.
-  test("reverify retry=true exhausts MAX_RETRIES then logs warn and stops", async () => {
+  // Bounded retry: persistent transient failures retry up to MAX_RETRIES,
+  // then escalate to halt. Leaving the user stuck on a hidden blocker is
+  // worse than a conservative halt they could have triggered manually.
+  test("reverify retry=true exhausts MAX_RETRIES then escalates to halt", async () => {
     let attempts = 0
     const h = setupHarness({
       reverifyImpl: async () => {
@@ -185,28 +185,37 @@ describe("createQuestionRecoveryClock", () => {
       await flush()
       expect(attempts).toBe(i + 1)
       expect(h.fk.pending()).toBe(1)
+      expect(h.haltCalls).toEqual([])
     }
 
-    // The (MAX_RETRIES + 1)-th attempt is the last one; it returns retry=true
-    // but the budget is now exhausted, so the clock warns and stops.
+    // The (MAX_RETRIES + 1)-th attempt returns retry=true but the budget is
+    // now exhausted — clock warns and escalates to halt instead of leaving
+    // the user stuck on a hidden blocker.
     h.fk.advance(HEAL_DELAY_MS)
     await flush()
     expect(attempts).toBe(MAX_RETRIES + 1)
+    expect(h.haltCalls).toEqual(["s"])
+    expect(h.fk.pending()).toBe(0)
+    expect(h.warnCalls.some((w) => w.message.includes("escalating to halt"))).toBe(true)
+    h.dispose()
+  })
+
+  // Non-retry proceed=false (e.g. guard failed, server says still covered)
+  // must NOT trigger any retry/halt — only retry=true counts toward escalation.
+  test("reverify proceed=false retry=false → no retry, no halt", async () => {
+    let attempts = 0
+    const h = setupHarness({
+      reverifyImpl: async () => {
+        attempts++
+        return { proceed: false }
+      },
+    })
+    h.setSnap(missing)
+    h.fk.advance(HEAL_DELAY_MS)
+    await flush()
+    expect(attempts).toBe(1)
     expect(h.haltCalls).toEqual([])
     expect(h.fk.pending()).toBe(0)
-    expect(h.warnCalls.some((w) => w.message.includes("retry budget exhausted"))).toBe(true)
-
-    // A long wait without snapshot change does not revive the clock.
-    h.fk.advance(HEAL_DELAY_MS * 10)
-    await flush()
-    expect(attempts).toBe(MAX_RETRIES + 1)
-    expect(h.haltCalls).toEqual([])
-
-    // A fresh snapshot edge (none → missing) starts a new arm with a fresh
-    // retry budget.
-    h.setSnap(none)
-    h.setSnap(missing)
-    expect(h.fk.pending()).toBe(1)
     h.dispose()
   })
 

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -106,31 +106,35 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
     if (disposed) return
     if (!outcome.proceed) {
       // Bounded retry: up to MAX_RETRIES follow-up attempts per arm. After
-      // the budget is exhausted, log structured warn and stop — wait for a
-      // fresh snapshot edge or session navigation instead of looping the
-      // server every delayMs forever.
+      // the budget is exhausted, escalate to halt — leaving the user stuck
+      // on a hidden blocker is worse than a conservative halt they could
+      // have triggered manually anyway. Fresh snapshot edge or session
+      // navigation still resets the budget for a new arm.
       if (outcome.retry && input.activeSessionID() === sessionID) {
         if (entry.retries >= MAX_RETRIES) {
-          warn("question-recovery: retry budget exhausted", {
+          warn("question-recovery: retry budget exhausted, escalating to halt", {
             sessionID,
             directory: entry.armedDirectory,
             armedAt: entry.armedAt,
             firedAt: ctx.firedAt,
             retries: entry.retries,
           })
+          // fall through to halt below
+        } else {
+          const handle = setTimer(() => {
+            void fire(sessionID)
+          }, delayMs)
+          pending.set(sessionID, {
+            handle,
+            armedAt: now(),
+            armedDirectory: entry.armedDirectory,
+            retries: entry.retries + 1,
+          })
           return
         }
-        const handle = setTimer(() => {
-          void fire(sessionID)
-        }, delayMs)
-        pending.set(sessionID, {
-          handle,
-          armedAt: now(),
-          armedDirectory: entry.armedDirectory,
-          retries: entry.retries + 1,
-        })
+      } else {
+        return
       }
-      return
     }
 
     try {

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -9,7 +9,11 @@ export interface ReverifyContext {
   firedAt: number
 }
 
-export type ReverifyOutcome = { proceed: boolean }
+// `retry` lets reverify ask the clock to re-arm a single follow-up timer
+// without waiting for a snapshot edge — used for transient failures
+// (e.g. server question.list() blip) so a sticky stuck session does not
+// dead-end on a single error.
+export type ReverifyOutcome = { proceed: true } | { proceed: false; retry?: boolean }
 
 export interface ClockInput {
   snapshot: () => QuestionRecoverySnapshot
@@ -96,7 +100,19 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
       return
     }
     if (disposed) return
-    if (!outcome.proceed) return
+    if (!outcome.proceed) {
+      if (outcome.retry && input.activeSessionID() === sessionID) {
+        const handle = setTimer(() => {
+          void fire(sessionID)
+        }, delayMs)
+        pending.set(sessionID, {
+          handle,
+          armedAt: now(),
+          armedDirectory: entry.armedDirectory,
+        })
+      }
+      return
+    }
 
     try {
       await input.halt(sessionID)

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -1,0 +1,147 @@
+import { createEffect, onCleanup } from "solid-js"
+import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
+
+export const HEAL_DELAY_MS = 3_000
+
+export interface ReverifyContext {
+  armedAt: number
+  armedDirectory: string
+  firedAt: number
+}
+
+export type ReverifyOutcome = { proceed: boolean }
+
+export interface ClockInput {
+  snapshot: () => QuestionRecoverySnapshot
+  activeSessionID: () => string | undefined
+  activeDirectory: () => string
+  halt: (sessionID: string) => Promise<unknown>
+  reverify: (sessionID: string, ctx: ReverifyContext) => Promise<ReverifyOutcome>
+  delayMs?: number
+  now?: () => number
+  setTimer?: (cb: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
+  warn?: (message: string, payload: Record<string, unknown>) => void
+}
+
+export interface Clock {
+  dispose: () => void
+  pendingFor: (sessionID: string) => boolean
+  // Test-only: drive a step manually. In production, createEffect calls this.
+  tick: () => void
+}
+
+interface PendingEntry {
+  handle: unknown
+  armedAt: number
+  armedDirectory: string
+}
+
+// Auto-heal clock. Edge-triggered arming (transition INTO missingRunning),
+// at-most-once fire per arm (map entry deleted before any await), all guards
+// run inside consumer-supplied reverify. See spec v6.
+//
+// Production wires the clock's tick() into createEffect; tests call tick()
+// directly because the SSR build of solid-js used in unit tests does not
+// propagate signal updates through effects.
+export function createQuestionRecoveryClock(input: ClockInput): Clock {
+  const delayMs = input.delayMs ?? HEAL_DELAY_MS
+  const now = input.now ?? (() => Date.now())
+  const setTimer =
+    input.setTimer ??
+    ((cb: () => void, ms: number) => setTimeout(cb, ms) as unknown as ReturnType<typeof setTimeout>)
+  const clearTimer =
+    input.clearTimer ?? ((handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>))
+  const warn = input.warn ?? ((m, p) => console.warn(m, p))
+
+  const pending = new Map<string, PendingEntry>()
+  const lastSeen = new Map<string, QuestionRecoverySnapshot["kind"]>()
+  let disposed = false
+
+  const cancelFor = (sessionID: string) => {
+    const entry = pending.get(sessionID)
+    if (!entry) return
+    clearTimer(entry.handle)
+    pending.delete(sessionID)
+  }
+
+  const fire = async (sessionID: string) => {
+    const entry = pending.get(sessionID)
+    if (!entry) return
+    pending.delete(sessionID)
+    if (disposed) return
+
+    const ctx: ReverifyContext = {
+      armedAt: entry.armedAt,
+      armedDirectory: entry.armedDirectory,
+      firedAt: now(),
+    }
+    let outcome: ReverifyOutcome
+    try {
+      outcome = await input.reverify(sessionID, ctx)
+    } catch (err) {
+      warn("question-recovery: reverify threw", {
+        sessionID,
+        directory: entry.armedDirectory,
+        armedAt: entry.armedAt,
+        firedAt: ctx.firedAt,
+        err,
+      })
+      return
+    }
+    if (disposed) return
+    if (!outcome.proceed) return
+
+    try {
+      await input.halt(sessionID)
+    } catch (err) {
+      warn("question-recovery: halt failed", {
+        sessionID,
+        directory: entry.armedDirectory,
+        armedAt: entry.armedAt,
+        firedAt: ctx.firedAt,
+        err,
+      })
+    }
+  }
+
+  const tick = () => {
+    if (disposed) return
+    const sid = input.activeSessionID()
+    const snap = input.snapshot()
+    if (!sid) return
+
+    const previousKind = lastSeen.get(sid)
+    lastSeen.set(sid, snap.kind)
+
+    if (snap.kind === "missingRunning") {
+      if (previousKind === "missingRunning") return
+      if (pending.has(sid)) return
+      const armedAt = now()
+      const armedDirectory = input.activeDirectory()
+      const handle = setTimer(() => {
+        void fire(sid)
+      }, delayMs)
+      pending.set(sid, { handle, armedAt, armedDirectory })
+      return
+    }
+
+    cancelFor(sid)
+  }
+
+  const disposeAll = () => {
+    disposed = true
+    for (const entry of pending.values()) clearTimer(entry.handle)
+    pending.clear()
+    lastSeen.clear()
+  }
+
+  createEffect(tick)
+  onCleanup(disposeAll)
+
+  return {
+    dispose: disposeAll,
+    pendingFor: (sessionID: string) => pending.has(sessionID),
+    tick,
+  }
+}

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -39,6 +39,7 @@ interface PendingEntry {
   handle: unknown
   armedAt: number
   armedDirectory: string
+  retried: boolean
 }
 
 // Auto-heal clock. Edge-triggered arming (transition INTO missingRunning),
@@ -101,7 +102,10 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
     }
     if (disposed) return
     if (!outcome.proceed) {
-      if (outcome.retry && input.activeSessionID() === sessionID) {
+      // Bounded retry: at most one follow-up attempt per arm. A second
+      // transient failure must wait for a fresh snapshot edge instead of
+      // looping the server every delayMs forever.
+      if (outcome.retry && !entry.retried && input.activeSessionID() === sessionID) {
         const handle = setTimer(() => {
           void fire(sessionID)
         }, delayMs)
@@ -109,6 +113,7 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
           handle,
           armedAt: now(),
           armedDirectory: entry.armedDirectory,
+          retried: true,
         })
       }
       return
@@ -152,7 +157,7 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
       const handle = setTimer(() => {
         void fire(sid)
       }, delayMs)
-      pending.set(sid, { handle, armedAt, armedDirectory })
+      pending.set(sid, { handle, armedAt, armedDirectory, retried: false })
       return
     }
 

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -56,6 +56,7 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
 
   const pending = new Map<string, PendingEntry>()
   const lastSeen = new Map<string, QuestionRecoverySnapshot["kind"]>()
+  let lastActiveSid: string | undefined
   let disposed = false
 
   const cancelFor = (sessionID: string) => {
@@ -63,6 +64,11 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
     if (!entry) return
     clearTimer(entry.handle)
     pending.delete(sessionID)
+  }
+
+  const forget = (sessionID: string) => {
+    cancelFor(sessionID)
+    lastSeen.delete(sessionID)
   }
 
   const fire = async (sessionID: string) => {
@@ -109,6 +115,14 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
     if (disposed) return
     const sid = input.activeSessionID()
     const snap = input.snapshot()
+
+    // Session navigation: drop the previous session's pending timer and
+    // edge state so coming back to a still-stuck session re-arms cleanly
+    // instead of hitting a stale lastSeen=missingRunning entry. This also
+    // bounds lastSeen to at most one entry at any time.
+    if (lastActiveSid && lastActiveSid !== sid) forget(lastActiveSid)
+    lastActiveSid = sid
+
     if (!sid) return
 
     const previousKind = lastSeen.get(sid)

--- a/packages/app/src/pages/session/blockers/question-recovery-clock.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-clock.ts
@@ -2,6 +2,9 @@ import { createEffect, onCleanup } from "solid-js"
 import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
 
 export const HEAL_DELAY_MS = 3_000
+// Max follow-up attempts after the initial fire on the same arm. A fresh
+// snapshot edge or session navigation resets this budget. See spec v6 R16.
+export const MAX_RETRIES = 3
 
 export interface ReverifyContext {
   armedAt: number
@@ -39,7 +42,7 @@ interface PendingEntry {
   handle: unknown
   armedAt: number
   armedDirectory: string
-  retried: boolean
+  retries: number
 }
 
 // Auto-heal clock. Edge-triggered arming (transition INTO missingRunning),
@@ -102,10 +105,21 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
     }
     if (disposed) return
     if (!outcome.proceed) {
-      // Bounded retry: at most one follow-up attempt per arm. A second
-      // transient failure must wait for a fresh snapshot edge instead of
-      // looping the server every delayMs forever.
-      if (outcome.retry && !entry.retried && input.activeSessionID() === sessionID) {
+      // Bounded retry: up to MAX_RETRIES follow-up attempts per arm. After
+      // the budget is exhausted, log structured warn and stop — wait for a
+      // fresh snapshot edge or session navigation instead of looping the
+      // server every delayMs forever.
+      if (outcome.retry && input.activeSessionID() === sessionID) {
+        if (entry.retries >= MAX_RETRIES) {
+          warn("question-recovery: retry budget exhausted", {
+            sessionID,
+            directory: entry.armedDirectory,
+            armedAt: entry.armedAt,
+            firedAt: ctx.firedAt,
+            retries: entry.retries,
+          })
+          return
+        }
         const handle = setTimer(() => {
           void fire(sessionID)
         }, delayMs)
@@ -113,7 +127,7 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
           handle,
           armedAt: now(),
           armedDirectory: entry.armedDirectory,
-          retried: true,
+          retries: entry.retries + 1,
         })
       }
       return
@@ -157,7 +171,7 @@ export function createQuestionRecoveryClock(input: ClockInput): Clock {
       const handle = setTimer(() => {
         void fire(sid)
       }, delayMs)
-      pending.set(sid, { handle, armedAt, armedDirectory, retried: false })
+      pending.set(sid, { handle, armedAt, armedDirectory, retries: 0 })
       return
     }
 

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test"
+import { questionRecoveryReverify, type ReverifyDeps } from "./question-recovery-reverify"
+import type { ReverifyContext } from "./question-recovery-clock"
+import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
+
+interface FakeQuestion {
+  id: string
+  sessionID: string
+  messageID?: string
+  callID?: string
+}
+
+const ctx: ReverifyContext = {
+  armedAt: 0,
+  armedDirectory: "/dir",
+  firedAt: 100,
+}
+
+const missing: QuestionRecoverySnapshot = { kind: "missingRunning" }
+const ready: QuestionRecoverySnapshot = { kind: "ready" }
+
+interface HarnessOpts {
+  snapshot?: QuestionRecoverySnapshot
+  activeSid?: string
+  directory?: string
+  busy?: boolean
+  list?: () => Promise<readonly FakeQuestion[]>
+  messages?: unknown
+  parts?: Record<string, ReadonlyArray<unknown>>
+}
+
+const setup = (opts: HarnessOpts = {}) => {
+  const hydrated: { sid: string; questions: readonly FakeQuestion[] }[] = []
+  const warns: { msg: string; payload: Record<string, unknown> }[] = []
+  const deps: ReverifyDeps<FakeQuestion> = {
+    snapshot: () => opts.snapshot ?? missing,
+    activeSessionID: () => opts.activeSid ?? "s",
+    activeDirectory: () => opts.directory ?? "/dir",
+    isSessionBusy: () => opts.busy ?? true,
+    listQuestions: opts.list ?? (async () => []),
+    messagesFor: () => opts.messages,
+    partsByMessageID: () => opts.parts ?? {},
+    applyHydration: (sid, questions) => {
+      hydrated.push({ sid, questions })
+    },
+    warn: (msg, payload) => warns.push({ msg, payload }),
+  }
+  return { deps, hydrated, warns }
+}
+
+describe("questionRecoveryReverify", () => {
+  test("guard 1: snapshot moved off missingRunning → proceed:false, no list", async () => {
+    let called = false
+    const { deps } = setup({
+      snapshot: ready,
+      list: async () => {
+        called = true
+        return []
+      },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+    expect(called).toBe(false)
+  })
+
+  test("guard 2: active session changed → proceed:false", async () => {
+    const { deps } = setup({ activeSid: "other" })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+  })
+
+  test("guard 2: directory drifted from armedDirectory → proceed:false", async () => {
+    const { deps } = setup({ directory: "/other" })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+  })
+
+  test("guard 3: session no longer busy → proceed:false", async () => {
+    const { deps } = setup({ busy: false })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+  })
+
+  test("list() throws → proceed:false + retry:true (one bounded follow-up)", async () => {
+    const { deps, warns } = setup({
+      list: async () => {
+        throw new Error("network down")
+      },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false, retry: true })
+    expect(warns).toHaveLength(1)
+    expect(warns[0].msg).toContain("question.list() failed")
+  })
+
+  test("post-await guard re-check: snapshot flipped during list → proceed:false", async () => {
+    let snap: QuestionRecoverySnapshot = missing
+    const { deps } = setup({
+      list: async () => {
+        snap = ready
+        return []
+      },
+    })
+    deps.snapshot = () => snap
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+  })
+
+  test("server returns no covering question → proceed:true (halt is licensed)", async () => {
+    // syncQuestions empty + a running question part means fallback finds the
+    // session as "still uncovered", so the clock is allowed to halt.
+    const { deps, hydrated } = setup({
+      list: async () => [],
+      messages: [{ id: "m1", role: "assistant" }],
+      parts: {
+        m1: [
+          {
+            type: "tool",
+            tool: "question",
+            state: { status: "running", input: { id: "q1" }, callID: "c1" },
+            messageID: "m1",
+          },
+        ],
+      },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: true })
+    // No hydration when server has nothing to write back.
+    expect(hydrated).toEqual([])
+  })
+
+  test("server now covers the question → hydrate sync + proceed:false", async () => {
+    // Server returns a question whose (messageID, callID) matches the
+    // running part — fallback now finds it covered.
+    const covering: FakeQuestion = { id: "q1", sessionID: "s", messageID: "m1", callID: "c1" }
+    const { deps, hydrated } = setup({
+      list: async () => [covering],
+      messages: [{ id: "m1", role: "assistant" }],
+      parts: {
+        m1: [
+          {
+            type: "tool",
+            tool: "question",
+            state: { status: "running", input: { id: "q1" }, callID: "c1" },
+            messageID: "m1",
+          },
+        ],
+      },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: false })
+    expect(hydrated).toHaveLength(1)
+    expect(hydrated[0]).toEqual({ sid: "s", questions: [covering] })
+  })
+
+  test("list returns questions for other sessions only → still uncovered → proceed:true", async () => {
+    const other: FakeQuestion = { id: "q2", sessionID: "other-sid", messageID: "m1", callID: "c1" }
+    const { deps, hydrated } = setup({
+      list: async () => [other],
+      messages: [{ id: "m1", role: "assistant" }],
+      parts: {
+        m1: [
+          {
+            type: "tool",
+            tool: "question",
+            state: { status: "running", input: { id: "q1" }, callID: "c1" },
+            messageID: "m1",
+          },
+        ],
+      },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: true })
+    expect(hydrated).toEqual([])
+  })
+})

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
@@ -6,8 +6,7 @@ import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
 interface FakeQuestion {
   id: string
   sessionID: string
-  messageID?: string
-  callID?: string
+  tool?: { messageID: string; callID: string }
 }
 
 const ctx: ReverifyContext = {
@@ -106,22 +105,23 @@ describe("questionRecoveryReverify", () => {
     expect(result).toEqual({ proceed: false })
   })
 
+  // Running parts use top-level `callID/messageID` to match the real ToolPart
+  // SDK shape — fallback reads them at part level, not from `state`.
+  const runningQuestionPart = (callID: string, messageID: string) => ({
+    type: "tool",
+    tool: "question",
+    state: { status: "running", input: { id: "q1" } },
+    callID,
+    messageID,
+  })
+
   test("server returns no covering question → proceed:true (halt is licensed)", async () => {
     // syncQuestions empty + a running question part means fallback finds the
     // session as "still uncovered", so the clock is allowed to halt.
     const { deps, hydrated } = setup({
       list: async () => [],
       messages: [{ id: "m1", role: "assistant" }],
-      parts: {
-        m1: [
-          {
-            type: "tool",
-            tool: "question",
-            state: { status: "running", input: { id: "q1" }, callID: "c1" },
-            messageID: "m1",
-          },
-        ],
-      },
+      parts: { m1: [runningQuestionPart("c1", "m1")] },
     })
     const result = await questionRecoveryReverify(deps, "s", ctx)
     expect(result).toEqual({ proceed: true })
@@ -130,22 +130,17 @@ describe("questionRecoveryReverify", () => {
   })
 
   test("server now covers the question → hydrate sync + proceed:false", async () => {
-    // Server returns a question whose (messageID, callID) matches the
+    // Server returns a question whose tool.(messageID, callID) matches the
     // running part — fallback now finds it covered.
-    const covering: FakeQuestion = { id: "q1", sessionID: "s", messageID: "m1", callID: "c1" }
+    const covering: FakeQuestion = {
+      id: "q1",
+      sessionID: "s",
+      tool: { messageID: "m1", callID: "c1" },
+    }
     const { deps, hydrated } = setup({
       list: async () => [covering],
       messages: [{ id: "m1", role: "assistant" }],
-      parts: {
-        m1: [
-          {
-            type: "tool",
-            tool: "question",
-            state: { status: "running", input: { id: "q1" }, callID: "c1" },
-            messageID: "m1",
-          },
-        ],
-      },
+      parts: { m1: [runningQuestionPart("c1", "m1")] },
     })
     const result = await questionRecoveryReverify(deps, "s", ctx)
     expect(result).toEqual({ proceed: false })
@@ -154,20 +149,35 @@ describe("questionRecoveryReverify", () => {
   })
 
   test("list returns questions for other sessions only → still uncovered → proceed:true", async () => {
-    const other: FakeQuestion = { id: "q2", sessionID: "other-sid", messageID: "m1", callID: "c1" }
+    const other: FakeQuestion = {
+      id: "q2",
+      sessionID: "other-sid",
+      tool: { messageID: "m1", callID: "c1" },
+    }
     const { deps, hydrated } = setup({
       list: async () => [other],
       messages: [{ id: "m1", role: "assistant" }],
-      parts: {
-        m1: [
-          {
-            type: "tool",
-            tool: "question",
-            state: { status: "running", input: { id: "q1" }, callID: "c1" },
-            messageID: "m1",
-          },
-        ],
-      },
+      parts: { m1: [runningQuestionPart("c1", "m1")] },
+    })
+    const result = await questionRecoveryReverify(deps, "s", ctx)
+    expect(result).toEqual({ proceed: true })
+    expect(hydrated).toEqual([])
+  })
+
+  // Identity match means the *exact* (messageID, callID) pair, not just the
+  // session. Server may legitimately have other questions for the same
+  // session that point at a different tool call; halt must still be licensed
+  // because the running part remains uncovered.
+  test("server returns same-session question with mismatched callID → proceed:true", async () => {
+    const sameSessionWrongCall: FakeQuestion = {
+      id: "q-other",
+      sessionID: "s",
+      tool: { messageID: "m1", callID: "different-call" },
+    }
+    const { deps, hydrated } = setup({
+      list: async () => [sameSessionWrongCall],
+      messages: [{ id: "m1", role: "assistant" }],
+      parts: { m1: [runningQuestionPart("c1", "m1")] },
     })
     const result = await questionRecoveryReverify(deps, "s", ctx)
     expect(result).toEqual({ proceed: true })

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { Message, Part } from "@opencode-ai/sdk/v2"
 import { questionRecoveryReverify, type ReverifyDeps } from "./question-recovery-reverify"
 import type { ReverifyContext } from "./question-recovery-clock"
 import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
@@ -18,14 +19,17 @@ const ctx: ReverifyContext = {
 const missing: QuestionRecoverySnapshot = { kind: "missingRunning" }
 const ready: QuestionRecoverySnapshot = { kind: "ready" }
 
+// Test fixtures are minimal stand-ins; cast to the SDK shapes at the harness
+// boundary so tests stay terse but the deps signature still enforces the
+// real ReadonlyArray<Message> / ReadonlyArray<Part> contract on production.
 interface HarnessOpts {
   snapshot?: QuestionRecoverySnapshot
   activeSid?: string
   directory?: string
   busy?: boolean
   list?: () => Promise<readonly FakeQuestion[]>
-  messages?: unknown
-  parts?: Record<string, ReadonlyArray<unknown>>
+  messages?: ReadonlyArray<{ id: string; role: string }>
+  parts?: Record<string, ReadonlyArray<object> | undefined>
 }
 
 const setup = (opts: HarnessOpts = {}) => {
@@ -37,8 +41,8 @@ const setup = (opts: HarnessOpts = {}) => {
     activeDirectory: () => opts.directory ?? "/dir",
     isSessionBusy: () => opts.busy ?? true,
     listQuestions: opts.list ?? (async () => []),
-    messagesFor: () => opts.messages,
-    partsByMessageID: () => opts.parts ?? {},
+    messagesFor: () => opts.messages as ReadonlyArray<Message> | undefined,
+    partsByMessageID: () => (opts.parts ?? {}) as Record<string, ReadonlyArray<Part> | undefined>,
     applyHydration: (sid, questions) => {
       hydrated.push({ sid, questions })
     },

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
@@ -23,7 +23,7 @@ export interface ReverifyDeps<Q> {
 //   4. server confirms the running question part is still uncovered
 // Transient list() failures ask the clock for one bounded follow-up.
 export async function questionRecoveryReverify<
-  Q extends { sessionID: string; messageID?: string; callID?: string; id?: string },
+  Q extends { sessionID: string; tool?: { messageID: string; callID: string }; id?: string },
 >(deps: ReverifyDeps<Q>, sessionID: string, ctx: ReverifyContext): Promise<ReverifyOutcome> {
   const localGuards = () => {
     if (deps.snapshot().kind !== "missingRunning") return false
@@ -47,7 +47,7 @@ export async function questionRecoveryReverify<
 
   const stillUncovered = findRunningQuestionFallbackSession({
     sessionID,
-    syncQuestions: filtered as never,
+    syncQuestions: filtered,
     messages: deps.messagesFor(sessionID) as never,
     partsByMessageID: deps.partsByMessageID() as never,
   })

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
@@ -1,0 +1,58 @@
+import type { ReverifyContext, ReverifyOutcome } from "./question-recovery-clock"
+import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
+import { findRunningQuestionFallbackSession } from "./question-fallback"
+
+export interface ReverifyDeps<Q> {
+  snapshot: () => QuestionRecoverySnapshot
+  activeSessionID: () => string | undefined
+  activeDirectory: () => string
+  isSessionBusy: (sessionID: string) => boolean
+  listQuestions: () => Promise<readonly Q[]>
+  partsByMessageID: () => Record<string, ReadonlyArray<unknown>>
+  messagesFor: (sessionID: string) => unknown
+  applyHydration: (sessionID: string, questions: readonly Q[]) => void
+  warn?: (message: string, payload: Record<string, unknown>) => void
+}
+
+// Reverify glue used by `createSessionBlockers`. Lives here as a pure
+// function so it can be unit-tested without standing up the full provider
+// tree (sdk + sync + permission + language). The four guards run in order:
+//   1. snapshot still missingRunning
+//   2. active session and directory unchanged since arm
+//   3. session still busy
+//   4. server confirms the running question part is still uncovered
+// Transient list() failures ask the clock for one bounded follow-up.
+export async function questionRecoveryReverify<
+  Q extends { sessionID: string; messageID?: string; callID?: string; id?: string },
+>(deps: ReverifyDeps<Q>, sessionID: string, ctx: ReverifyContext): Promise<ReverifyOutcome> {
+  const localGuards = () => {
+    if (deps.snapshot().kind !== "missingRunning") return false
+    if (deps.activeSessionID() !== sessionID) return false
+    if (deps.activeDirectory() !== ctx.armedDirectory) return false
+    if (!deps.isSessionBusy(sessionID)) return false
+    return true
+  }
+  if (!localGuards()) return { proceed: false }
+
+  let filtered: readonly Q[]
+  try {
+    const all = await deps.listQuestions()
+    filtered = all.filter((q) => q.sessionID === sessionID)
+  } catch (err) {
+    deps.warn?.("question-recovery: question.list() failed", { sessionID, err })
+    return { proceed: false, retry: true }
+  }
+
+  if (!localGuards()) return { proceed: false }
+
+  const stillUncovered = findRunningQuestionFallbackSession({
+    sessionID,
+    syncQuestions: filtered as never,
+    messages: deps.messagesFor(sessionID) as never,
+    partsByMessageID: deps.partsByMessageID() as never,
+  })
+  if (stillUncovered === sessionID) return { proceed: true }
+
+  deps.applyHydration(sessionID, filtered)
+  return { proceed: false }
+}

--- a/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-reverify.ts
@@ -1,3 +1,4 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2"
 import type { ReverifyContext, ReverifyOutcome } from "./question-recovery-clock"
 import type { QuestionRecoverySnapshot } from "./question-recovery-snapshot"
 import { findRunningQuestionFallbackSession } from "./question-fallback"
@@ -8,8 +9,8 @@ export interface ReverifyDeps<Q> {
   activeDirectory: () => string
   isSessionBusy: (sessionID: string) => boolean
   listQuestions: () => Promise<readonly Q[]>
-  partsByMessageID: () => Record<string, ReadonlyArray<unknown>>
-  messagesFor: (sessionID: string) => unknown
+  partsByMessageID: () => Record<string, ReadonlyArray<Part> | undefined>
+  messagesFor: (sessionID: string) => ReadonlyArray<Message> | undefined
   applyHydration: (sessionID: string, questions: readonly Q[]) => void
   warn?: (message: string, payload: Record<string, unknown>) => void
 }
@@ -48,8 +49,8 @@ export async function questionRecoveryReverify<
   const stillUncovered = findRunningQuestionFallbackSession({
     sessionID,
     syncQuestions: filtered,
-    messages: deps.messagesFor(sessionID) as never,
-    partsByMessageID: deps.partsByMessageID() as never,
+    messages: deps.messagesFor(sessionID),
+    partsByMessageID: deps.partsByMessageID(),
   })
   if (stillUncovered === sessionID) return { proceed: true }
 

--- a/packages/app/src/pages/session/blockers/question-recovery-snapshot.test.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-snapshot.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, Part, QuestionRequest, ToolState } from "@opencode-ai/sdk/v2"
+import { resolveQuestionRecoverySnapshot } from "./question-recovery-snapshot"
+
+const message = (id: string): Message => ({ id }) as Message
+
+const toolState = (status: ToolState["status"]): ToolState =>
+  ({
+    status,
+    input: {},
+    title: "",
+    metadata: {},
+    time: { start: 0 },
+  }) as ToolState
+
+const toolPart = (
+  id: string,
+  tool: string,
+  status: ToolState["status"] = "running",
+  attrs?: { messageID?: string; callID?: string },
+): Part =>
+  ({
+    id,
+    type: "tool",
+    tool,
+    state: toolState(status),
+    messageID: attrs?.messageID,
+    callID: attrs?.callID,
+  }) as Part
+
+const syncQ = (id: string, sessionID: string, tool?: { messageID: string; callID: string }): QuestionRequest =>
+  ({
+    id,
+    sessionID,
+    questions: [{ header: "h", question: "q", options: [] }],
+    tool,
+  }) as QuestionRequest
+
+describe("resolveQuestionRecoverySnapshot", () => {
+  test("none when no sessionID", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: undefined,
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: undefined,
+        partsByMessageID: {},
+      }),
+    ).toEqual({ kind: "none" })
+  })
+
+  test("none when no running question and no sync entry", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "s",
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "todowrite", "running")] },
+      }),
+    ).toEqual({ kind: "none" })
+  })
+
+  test("ready when tree-walked question request resolves (active session)", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "s",
+        sessionTreeQuestionRequest: { id: "q1" },
+        activeSessionSyncQuestions: [syncQ("q1", "s", { messageID: "m1", callID: "c1" })],
+        activeSessionMessages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toEqual({ kind: "ready" })
+  })
+
+  // P2-3 lock: parent ready continues to surface via tree-walked request even
+  // though the active session is the child.
+  test("ready when running part lives in parent session and sync has matching entry", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "child",
+        sessionTreeQuestionRequest: { id: "q_parent" },
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: [],
+        partsByMessageID: {},
+      }),
+    ).toEqual({ kind: "ready" })
+  })
+
+  test("missingRunning when active session has running question with no matching sync identity", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "s",
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toEqual({ kind: "missingRunning" })
+  })
+
+  // P1-2 lock: legacy sync entry without tool identity covers one running
+  // part. Snapshot must not raise missingRunning here, matching fallback.
+  test("not missingRunning when legacy sync entry without identity covers running part", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "s",
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: [syncQ("q_legacy", "s")],
+        activeSessionMessages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toEqual({ kind: "none" })
+  })
+
+  // P2-3 lock: subagents cannot use the question tool today; missingRunning
+  // detection only looks at the active session. Cross-session running parts
+  // are intentionally ignored until subagents gain question access.
+  test("missingRunning is NOT raised when running part lives in a parent (asymmetric by design)", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "child",
+        sessionTreeQuestionRequest: undefined,
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: [],
+        partsByMessageID: { m_parent: [toolPart("p", "question", "running", { messageID: "m_parent", callID: "c1" })] },
+      }),
+    ).toEqual({ kind: "none" })
+  })
+
+  test("ready takes precedence over missingRunning when both could apply", () => {
+    expect(
+      resolveQuestionRecoverySnapshot({
+        sessionID: "s",
+        sessionTreeQuestionRequest: { id: "q1" },
+        activeSessionSyncQuestions: [],
+        activeSessionMessages: [message("m1")],
+        partsByMessageID: { m1: [toolPart("p1", "question", "running", { messageID: "m1", callID: "c1" })] },
+      }),
+    ).toEqual({ kind: "ready" })
+  })
+})

--- a/packages/app/src/pages/session/blockers/question-recovery-snapshot.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-snapshot.ts
@@ -10,8 +10,8 @@ export interface ResolveSnapshotInput {
   sessionID: string | undefined
   sessionTreeQuestionRequest: unknown
   activeSessionSyncQuestions: ReadonlyArray<QuestionRequest>
-  activeSessionMessages: Message[] | undefined
-  partsByMessageID: Record<string, Part[] | undefined>
+  activeSessionMessages: ReadonlyArray<Message> | undefined
+  partsByMessageID: Record<string, ReadonlyArray<Part> | undefined>
 }
 
 // Pure reducer: drives the auto-heal clock. Delegates missingRunning detection

--- a/packages/app/src/pages/session/blockers/question-recovery-snapshot.ts
+++ b/packages/app/src/pages/session/blockers/question-recovery-snapshot.ts
@@ -1,0 +1,32 @@
+import type { Message, Part, QuestionRequest } from "@opencode-ai/sdk/v2"
+import { findRunningQuestionFallbackSession } from "./question-fallback"
+
+export type QuestionRecoverySnapshot =
+  | { kind: "none" }
+  | { kind: "ready" }
+  | { kind: "missingRunning" }
+
+export interface ResolveSnapshotInput {
+  sessionID: string | undefined
+  sessionTreeQuestionRequest: unknown
+  activeSessionSyncQuestions: ReadonlyArray<QuestionRequest>
+  activeSessionMessages: Message[] | undefined
+  partsByMessageID: Record<string, Part[] | undefined>
+}
+
+// Pure reducer: drives the auto-heal clock. Delegates missingRunning detection
+// to findRunningQuestionFallbackSession so identity matching + legacy bucket
+// pooling stay in lockstep with the existing fallback (#419 / PR #430).
+export function resolveQuestionRecoverySnapshot(input: ResolveSnapshotInput): QuestionRecoverySnapshot {
+  if (!input.sessionID) return { kind: "none" }
+  if (input.sessionTreeQuestionRequest) return { kind: "ready" }
+
+  const fallbackSessionID = findRunningQuestionFallbackSession({
+    sessionID: input.sessionID,
+    syncQuestions: input.activeSessionSyncQuestions,
+    messages: input.activeSessionMessages,
+    partsByMessageID: input.partsByMessageID,
+  })
+  if (fallbackSessionID === input.sessionID) return { kind: "missingRunning" }
+  return { kind: "none" }
+}

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -8,6 +8,7 @@ import { useSync } from "@/context/sync"
 import { isSessionRunning } from "@/pages/session/session-running-state"
 import { findRunningQuestionFallbackSession } from "./question-fallback"
 import { createQuestionRecoveryClock } from "./question-recovery-clock"
+import { questionRecoveryReverify } from "./question-recovery-reverify"
 import { resolveQuestionRecoverySnapshot } from "./question-recovery-snapshot"
 import { createQuestionRefetchRunner } from "./question-refetch-runner"
 import { refetchPendingQuestionsForSession } from "./question-reconcile"
@@ -92,56 +93,30 @@ export function createSessionBlockers(input: {
       activeSessionID,
       activeDirectory: () => sdk.directory,
       halt,
-      reverify: async (sessionID, ctx) => {
-        const localGuards = () => {
-          // Guard 1: snapshot still missingRunning for this session.
-          if (recoverySnapshot().kind !== "missingRunning") return false
-          // Guard 2: active session unchanged (directory pin via armedDirectory).
-          if (activeSessionID() !== sessionID) return false
-          if (sdk.directory !== ctx.armedDirectory) return false
-          // Guard 3: session still busy.
-          if (
-            !isSessionRunning(
-              sync.data.session_status[sessionID],
-              sync.data.message[sessionID],
-            )
-          )
-            return false
-          return true
-        }
-        if (!localGuards()) return { proceed: false }
-        // Guard 4: server confirms the running question part is still
-        // uncovered (reuses fallback semantics so auto-heal and recovery
-        // dock never disagree). A transient list() failure asks the
-        // clock to re-arm once instead of halting blindly or dead-ending
-        // a sticky stuck session.
-        let filtered: Awaited<ReturnType<typeof sdk.client.question.list>>["data"]
-        try {
-          const result = await sdk.client.question.list()
-          filtered = (result.data ?? []).filter((q) => q.sessionID === sessionID)
-        } catch (err) {
-          console.warn("question-recovery: question.list() failed", { sessionID, err })
-          // Ask the clock for one bounded follow-up attempt (see
-          // ReverifyOutcome in question-recovery-clock.ts). A second
-          // consecutive failure waits for a fresh snapshot edge instead of
-          // looping the server.
-          return { proceed: false, retry: true }
-        }
-        // Re-check the local guards after the await — state may have moved.
-        if (!localGuards()) return { proceed: false }
-        const stillUncovered = findRunningQuestionFallbackSession({
+      reverify: (sessionID, ctx) =>
+        questionRecoveryReverify(
+          {
+            snapshot: recoverySnapshot,
+            activeSessionID,
+            activeDirectory: () => sdk.directory,
+            isSessionBusy: (sid) =>
+              isSessionRunning(sync.data.session_status[sid], sync.data.message[sid]),
+            listQuestions: async () => {
+              const result = await sdk.client.question.list()
+              return result.data ?? []
+            },
+            partsByMessageID: () => sync.data.part,
+            messagesFor: (sid) => sync.data.message[sid],
+            applyHydration: (sid, questions) => {
+              batch(() => {
+                sync.set("question", sid, reconcile([...questions], { key: "id" }))
+              })
+            },
+            warn: (msg, payload) => console.warn(msg, payload),
+          },
           sessionID,
-          syncQuestions: filtered,
-          messages: sync.data.message[sessionID],
-          partsByMessageID: sync.data.part,
-        })
-        if (stillUncovered === sessionID) return { proceed: true }
-        // Server already covers it — write back so UI stops looking stuck.
-        batch(() => {
-          sync.set("question", sessionID, reconcile(filtered, { key: "id" }))
-        })
-        return { proceed: false }
-      },
+          ctx,
+        ),
     })
     // clock self-cleans via its own onCleanup; the binding above is kept
     // only so `clock` is referenced (the side-effect of construction is

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -29,7 +29,10 @@ export function createSessionBlockers(input: { sessionID: () => string | undefin
     const sessionID = activeSessionID()
     return findRunningQuestionFallbackSession({
       sessionID,
-      hasQuestionRequest: !!questionRequest(),
+      // Pass the per-session entries so fallback can match by (messageID,
+      // callID) — not the tree-walked sessionQuestionRequest result, which
+      // would mask local multi-pending loss. See #419.
+      syncQuestions: sessionID ? (sync.data.question[sessionID] ?? []) : [],
       messages: sessionID ? sync.data.message[sessionID] : undefined,
       partsByMessageID: sync.data.part,
     })

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -120,13 +120,11 @@ export function createSessionBlockers(input: {
           const result = await sdk.client.question.list()
           filtered = (result.data ?? []).filter((q) => q.sessionID === sessionID)
         } catch (err) {
-          console.warn("question-recovery: question.list() failed; will retry", {
-            sessionID,
-            err,
-          })
-          // retry:true asks the clock to re-arm one follow-up timer (see
-          // ReverifyOutcome in question-recovery-clock.ts) so a transient
-          // server failure does not dead-end auto-heal for this edge.
+          console.warn("question-recovery: question.list() failed", { sessionID, err })
+          // Ask the clock for one bounded follow-up attempt (see
+          // ReverifyOutcome in question-recovery-clock.ts). A second
+          // consecutive failure waits for a fresh snapshot edge instead of
+          // looping the server.
           return { proceed: false, retry: true }
         }
         // Re-check the local guards after the await — state may have moved.

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -93,48 +93,60 @@ export function createSessionBlockers(input: {
       activeDirectory: () => sdk.directory,
       halt,
       reverify: async (sessionID, ctx) => {
-        // Guard 1: snapshot still missingRunning for this session.
-        if (recoverySnapshot().kind !== "missingRunning") return { proceed: false }
-        // Guard 2: active session unchanged (directory pin via armedDirectory).
-        if (activeSessionID() !== sessionID) return { proceed: false }
-        if (sdk.directory !== ctx.armedDirectory) return { proceed: false }
-        // Guard 3: session still busy.
-        const running = isSessionRunning(
-          sync.data.session_status[sessionID],
-          sync.data.message[sessionID],
-        )
-        if (!running) return { proceed: false }
+        const localGuards = () => {
+          // Guard 1: snapshot still missingRunning for this session.
+          if (recoverySnapshot().kind !== "missingRunning") return false
+          // Guard 2: active session unchanged (directory pin via armedDirectory).
+          if (activeSessionID() !== sessionID) return false
+          if (sdk.directory !== ctx.armedDirectory) return false
+          // Guard 3: session still busy.
+          if (
+            !isSessionRunning(
+              sync.data.session_status[sessionID],
+              sync.data.message[sessionID],
+            )
+          )
+            return false
+          return true
+        }
+        if (!localGuards()) return { proceed: false }
         // Guard 4: server confirms the running question part is still
         // uncovered (reuses fallback semantics so auto-heal and recovery
-        // dock never disagree). On server failure we proceed to halt — the
-        // user has already been hung for HEAL_DELAY_MS, surfacing the error
-        // card is safer than continuing to wait.
+        // dock never disagree). On server failure we skip the halt and
+        // wait for the next snapshot edge — killing a session on a
+        // transient list() blip would be worse than another 3 s wait,
+        // and navigation cleanup re-arms when the user comes back.
+        let filtered: Awaited<ReturnType<typeof sdk.client.question.list>>["data"]
         try {
           const result = await sdk.client.question.list()
-          const allQuestions = result.data ?? []
-          const filtered = allQuestions.filter((q) => q.sessionID === sessionID)
-          const stillUncovered = findRunningQuestionFallbackSession({
-            sessionID,
-            syncQuestions: filtered,
-            messages: sync.data.message[sessionID],
-            partsByMessageID: sync.data.part,
-          })
-          if (stillUncovered === sessionID) return { proceed: true }
-          // Server already covers it — write back so UI stops looking stuck.
-          batch(() => {
-            sync.set("question", sessionID, reconcile(filtered, { key: "id" }))
-          })
-          return { proceed: false }
+          filtered = (result.data ?? []).filter((q) => q.sessionID === sessionID)
         } catch (err) {
-          console.warn("question-recovery: question.list() failed; halting anyway", {
+          console.warn("question-recovery: question.list() failed; skipping halt", {
             sessionID,
             err,
           })
-          return { proceed: true }
+          return { proceed: false }
         }
+        // Re-check the local guards after the await — state may have moved.
+        if (!localGuards()) return { proceed: false }
+        const stillUncovered = findRunningQuestionFallbackSession({
+          sessionID,
+          syncQuestions: filtered,
+          messages: sync.data.message[sessionID],
+          partsByMessageID: sync.data.part,
+        })
+        if (stillUncovered === sessionID) return { proceed: true }
+        // Server already covers it — write back so UI stops looking stuck.
+        batch(() => {
+          sync.set("question", sessionID, reconcile(filtered, { key: "id" }))
+        })
+        return { proceed: false }
       },
     })
-    onCleanup(() => clock.dispose())
+    // clock self-cleans via its own onCleanup; the binding above is kept
+    // only so `clock` is referenced (the side-effect of construction is
+    // what we want).
+    void clock
   }
 
   const permissionRequest = createMemo(() => {

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -112,20 +112,19 @@ export function createSessionBlockers(input: {
         if (!localGuards()) return { proceed: false }
         // Guard 4: server confirms the running question part is still
         // uncovered (reuses fallback semantics so auto-heal and recovery
-        // dock never disagree). On server failure we skip the halt and
-        // wait for the next snapshot edge — killing a session on a
-        // transient list() blip would be worse than another 3 s wait,
-        // and navigation cleanup re-arms when the user comes back.
+        // dock never disagree). A transient list() failure asks the
+        // clock to re-arm once instead of halting blindly or dead-ending
+        // a sticky stuck session.
         let filtered: Awaited<ReturnType<typeof sdk.client.question.list>>["data"]
         try {
           const result = await sdk.client.question.list()
           filtered = (result.data ?? []).filter((q) => q.sessionID === sessionID)
         } catch (err) {
-          console.warn("question-recovery: question.list() failed; skipping halt", {
+          console.warn("question-recovery: question.list() failed; will retry", {
             sessionID,
             err,
           })
-          return { proceed: false }
+          return { proceed: false, retry: true }
         }
         // Re-check the local guards after the await — state may have moved.
         if (!localGuards()) return { proceed: false }

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -5,7 +5,10 @@ import { useLanguage } from "@/context/language"
 import { usePermission } from "@/context/permission"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
+import { isSessionRunning } from "@/pages/session/session-running-state"
 import { findRunningQuestionFallbackSession } from "./question-fallback"
+import { createQuestionRecoveryClock } from "./question-recovery-clock"
+import { resolveQuestionRecoverySnapshot } from "./question-recovery-snapshot"
 import { createQuestionRefetchRunner } from "./question-refetch-runner"
 import { refetchPendingQuestionsForSession } from "./question-reconcile"
 import { sessionPermissionRequest, sessionQuestionRequest } from "./request-tree"
@@ -66,6 +69,73 @@ export function createSessionBlockers(input: {
       questionRefetch.start(sessionID)
     }),
   )
+
+  // Auto-heal: detect hidden question blockers (running question part but no
+  // sync coverage) and halt the stuck session after a short delay. The
+  // composer keeps `recoveringQuestion()` so existing UI/refetch behavior is
+  // unchanged; the clock fires only as a last-resort cleanup.
+  const recoverySnapshot = createMemo(() => {
+    const sessionID = activeSessionID()
+    return resolveQuestionRecoverySnapshot({
+      sessionID,
+      sessionTreeQuestionRequest: questionRequest(),
+      activeSessionSyncQuestions: sessionID ? (sync.data.question[sessionID] ?? []) : [],
+      activeSessionMessages: sessionID ? sync.data.message[sessionID] : undefined,
+      partsByMessageID: sync.data.part,
+    })
+  })
+
+  if (input.halt) {
+    const halt = input.halt
+    const clock = createQuestionRecoveryClock({
+      snapshot: recoverySnapshot,
+      activeSessionID,
+      activeDirectory: () => sdk.directory,
+      halt,
+      reverify: async (sessionID, ctx) => {
+        // Guard 1: snapshot still missingRunning for this session.
+        if (recoverySnapshot().kind !== "missingRunning") return { proceed: false }
+        // Guard 2: active session unchanged (directory pin via armedDirectory).
+        if (activeSessionID() !== sessionID) return { proceed: false }
+        if (sdk.directory !== ctx.armedDirectory) return { proceed: false }
+        // Guard 3: session still busy.
+        const running = isSessionRunning(
+          sync.data.session_status[sessionID],
+          sync.data.message[sessionID],
+        )
+        if (!running) return { proceed: false }
+        // Guard 4: server confirms the running question part is still
+        // uncovered (reuses fallback semantics so auto-heal and recovery
+        // dock never disagree). On server failure we proceed to halt — the
+        // user has already been hung for HEAL_DELAY_MS, surfacing the error
+        // card is safer than continuing to wait.
+        try {
+          const result = await sdk.client.question.list()
+          const allQuestions = result.data ?? []
+          const filtered = allQuestions.filter((q) => q.sessionID === sessionID)
+          const stillUncovered = findRunningQuestionFallbackSession({
+            sessionID,
+            syncQuestions: filtered,
+            messages: sync.data.message[sessionID],
+            partsByMessageID: sync.data.part,
+          })
+          if (stillUncovered === sessionID) return { proceed: true }
+          // Server already covers it — write back so UI stops looking stuck.
+          batch(() => {
+            sync.set("question", sessionID, reconcile(filtered, { key: "id" }))
+          })
+          return { proceed: false }
+        } catch (err) {
+          console.warn("question-recovery: question.list() failed; halting anyway", {
+            sessionID,
+            err,
+          })
+          return { proceed: true }
+        }
+      },
+    })
+    onCleanup(() => clock.dispose())
+  }
 
   const permissionRequest = createMemo(() => {
     return sessionPermissionRequest(sync.data.session, sync.data.permission, activeSessionID(), (item) => {

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -124,6 +124,9 @@ export function createSessionBlockers(input: {
             sessionID,
             err,
           })
+          // retry:true asks the clock to re-arm one follow-up timer (see
+          // ReverifyOutcome in question-recovery-clock.ts) so a transient
+          // server failure does not dead-end auto-heal for this edge.
           return { proceed: false, retry: true }
         }
         // Re-check the local guards after the await — state may have moved.

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -10,7 +10,10 @@ import { createQuestionRefetchRunner } from "./question-refetch-runner"
 import { refetchPendingQuestionsForSession } from "./question-reconcile"
 import { sessionPermissionRequest, sessionQuestionRequest } from "./request-tree"
 
-export function createSessionBlockers(input: { sessionID: () => string | undefined }) {
+export function createSessionBlockers(input: {
+  sessionID: () => string | undefined
+  halt?: (sessionID: string) => Promise<unknown>
+}) {
   const sdk = useSDK()
   const sync = useSync()
   const language = useLanguage()

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -6,9 +6,10 @@ import { composerEnabled, composerStateProbe } from "@/testing/session-composer"
 export function createSessionComposerState(input: {
   sessionID: () => string | undefined
   fallbackSessionID?: () => string | undefined
+  halt?: (sessionID: string) => Promise<unknown>
 }) {
   const activeSessionID = input.sessionID
-  const blockers = createSessionBlockers({ sessionID: activeSessionID })
+  const blockers = createSessionBlockers({ sessionID: activeSessionID, halt: input.halt })
   const todo = createSessionTodoModel({ sessionID: activeSessionID, fallbackSessionID: input.fallbackSessionID })
 
   createEffect(() => {

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -79,4 +79,27 @@ describe("session followups", () => {
     expect(shouldAutoSendFollowup({ ...base, blocked: true })).toBe(false)
     expect(shouldAutoSendFollowup({ ...base, followupBusy: true })).toBe(false)
   })
+
+  // Auto-heal flow: while the recovery clock is armed (running question
+  // part with no UI dock) the session is still busy AND blocked is false
+  // (the dock never surfaced). Auto-send must stay off. Once the clock
+  // halts the session, busy flips false on the next status sync and the
+  // queued followup must be eligible for auto-send. This locks step 6 of
+  // the v6 spec merge gate.
+  test("queued followup auto-sends after halt-induced idle (auto-heal flow)", () => {
+    const recovering = {
+      hasSession: true,
+      hasItem: true,
+      busy: true,
+      failed: false,
+      paused: false,
+      childSession: false,
+      blocked: false,
+      followupBusy: false,
+    }
+    expect(shouldAutoSendFollowup(recovering)).toBe(false)
+
+    const afterHalt = { ...recovering, busy: false }
+    expect(shouldAutoSendFollowup(afterHalt)).toBe(true)
+  })
 })

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -278,19 +278,24 @@ export namespace Question {
         const signal = input.signal
         let removeListener: (() => void) | undefined
         const sessionID = input.sessionID
-        // bus.publish reads InstanceState (directory/workspace/context), which
-        // requires either Effect fiber context or JS ALS to be set. The abort
-        // listener fires from the JS event loop on signal dispatch — not
-        // necessarily inside our parent Effect's runtime — so wrap with
-        // InstanceState.bind to capture the current instance ALS context and
-        // restore it whenever the callback runs.
+        // Capture the parent fiber's Effect context so the abort callback
+        // (which fires from the JS event loop, outside any fiber) forks the
+        // publish + Deferred.fail effects onto a runtime that already
+        // carries our service layer + InstanceRef. The wrapping
+        // InstanceState.bind is a belt-and-braces fallback for log.info and
+        // any consumer still on the ALS path.
+        const ctx = yield* Effect.context<never>()
         const failFromAbort = InstanceState.bind(() => {
           const entry = pending.get(id)
           if (!entry) return
           pending.delete(id)
           log.info("rejected", { requestID: id, reason: "aborted" })
-          Effect.runFork(bus.publish(Event.Rejected, { sessionID, requestID: id }))
-          Effect.runFork(Deferred.fail(entry.deferred, new RejectedError({ cancelled: true })))
+          Effect.runFork(
+            Effect.provide(bus.publish(Event.Rejected, { sessionID, requestID: id }), ctx),
+          )
+          Effect.runFork(
+            Effect.provide(Deferred.fail(entry.deferred, new RejectedError({ cancelled: true })), ctx),
+          )
         })
 
         if (signal) {

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -171,12 +171,9 @@ export namespace Question {
       sessionID: SessionID
       questions: ReadonlyArray<Info>
       tool?: Tool
-      // Bridge for the AbortSignal that travels via Tool.Context. The Effect
-      // surrounding the tool runs through EffectBridge.run.promise, which does
-      // NOT propagate parent fiber interrupts into the spawned Effect — so a
-      // session cancel never fires Effect.onInterrupt here. The signal is the
-      // only reliable cancellation channel; without it the pending entry leaks
-      // and the dock stays visible forever. See #419.
+      // Production cancellation channel. EffectBridge.run.promise does not
+      // propagate parent fiber interrupts, so without a signal a session
+      // cancel leaks the pending entry and the dock stays forever. See #419.
       signal?: AbortSignal
     }) => Effect.Effect<ReadonlyArray<Answer>, RejectedError>
     readonly reply: (input: { requestID: QuestionID; answers: ReadonlyArray<Answer> }) => Effect.Effect<void>
@@ -255,19 +252,14 @@ export namespace Question {
         // event payload to mutate the pending entry either.
         yield* bus.publish(Event.Asked, structuredClone(info))
 
-        // input.signal is the production cancellation channel; the
-        // Effect.onInterrupt arm below is defence-in-depth for direct fiber
-        // interrupts (layer shutdown / supervisor kill) where signal is
-        // undefined. The pending.has guard keeps both arms idempotent. See #419.
+        // Cancellation: input.signal is the production channel; the
+        // Effect.onInterrupt arm below is defence for direct fiber kill
+        // (layer shutdown / supervisor) when signal is undefined. The abort
+        // callback fires from the JS event loop, so we capture the parent
+        // Effect context here and re-provide it on each runFork.
         const signal = input.signal
         let removeListener: (() => void) | undefined
         const sessionID = input.sessionID
-        // Capture the parent fiber's Effect context so the abort callback
-        // (which fires from the JS event loop, outside any fiber) forks the
-        // publish + Deferred.fail effects onto a runtime that already
-        // carries our service layer + InstanceRef. The wrapping
-        // InstanceState.bind is a belt-and-braces fallback for log.info and
-        // any consumer still on the ALS path.
         const ctx = yield* Effect.context<never>()
         const failFromAbort = InstanceState.bind(() => {
           const entry = pending.get(id)
@@ -291,9 +283,6 @@ export namespace Question {
           }
         }
 
-        // Defence-in-depth onInterrupt arm catches direct fiber interrupts
-        // (layer shutdown, supervisor kill) when no signal is present. The
-        // `pending.has` guard keeps both arms idempotent.
         return yield* Deferred.await(deferred).pipe(
           Effect.onInterrupt(() =>
             Effect.gen(function* () {

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -255,26 +255,10 @@ export namespace Question {
         // event payload to mutate the pending entry either.
         yield* bus.publish(Event.Asked, structuredClone(info))
 
-        // Wait for either the user reply (via Deferred) or the tool's
-        // AbortSignal firing. The signal is the only cancellation channel that
-        // survives — `EffectBridge.run.promise` runs the tool Effect via
-        // `Effect.runPromise`, so a parent fiber interrupt does NOT propagate
-        // here. Without the signal arm, session cancel leaves the entry in
-        // `pending` forever and the dock stays visible. See #419.
-        //
-        // The Effect.onInterrupt arm below is a defence-in-depth catch for
-        // *direct* fiber interrupts (e.g. layer shutdown / supervisor kill
-        // during tests), where `signal` is undefined. The `pending.has` guard
-        // makes the second arm a no-op if both fire.
-        // The tool's AbortSignal is our only reliable cancel channel: the
-        // surrounding tool Effect runs through `EffectBridge.run.promise`
-        // (which is `Effect.runPromise`), so a parent fiber interrupt does
-        // not propagate here, and `Effect.runFork(Deferred.fail)` does not
-        // get scheduled until layer disposal because we are parked on
-        // `Deferred.await` ahead of it. We therefore mutate pending + publish
-        // Rejected + fail the deferred *eagerly* in the abort handler. The
-        // Deferred failure still drives the Effect to unwind, but the user-
-        // facing state is correct immediately. See #419.
+        // input.signal is the production cancellation channel; the
+        // Effect.onInterrupt arm below is defence-in-depth for direct fiber
+        // interrupts (layer shutdown / supervisor kill) where signal is
+        // undefined. The pending.has guard keeps both arms idempotent. See #419.
         const signal = input.signal
         let removeListener: (() => void) | undefined
         const sessionID = input.sessionID

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Layer, Schema, Context } from "effect"
+import { Cause, Deferred, Effect, Layer, Schema, Context } from "effect"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
@@ -260,7 +260,7 @@ export namespace Question {
         // Effect.onInterrupt arm below is defence for direct fiber kill
         // (layer shutdown / supervisor) when signal is undefined. The abort
         // callback fires from the JS event loop, so we capture the parent
-        // Effect context here and re-provide it on each runFork.
+        // Effect context here and re-provide it on a single runFork.
         const signal = input.signal
         let removeListener: (() => void) | undefined
         const sessionID = input.sessionID
@@ -270,11 +270,28 @@ export namespace Question {
           if (!entry) return
           pending.delete(id)
           log.info("rejected", { requestID: id, reason: "aborted" })
+          // Publish then fail in a single Effect so order is deterministic
+          // (subscribers see Rejected before any awaiter unblocks) and any
+          // failure inside is logged once instead of disappearing into two
+          // independent forks.
           Effect.runFork(
-            Effect.provide(bus.publish(Event.Rejected, { sessionID, requestID: id }), ctx),
-          )
-          Effect.runFork(
-            Effect.provide(Deferred.fail(entry.deferred, new RejectedError({ cancelled: true })), ctx),
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* bus.publish(Event.Rejected, { sessionID, requestID: id })
+                yield* Deferred.fail(entry.deferred, new RejectedError({ cancelled: true }))
+              }).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.sync(() =>
+                    log.error("failFromAbort failed", {
+                      requestID: id,
+                      sessionID,
+                      cause: Cause.pretty(cause),
+                    }),
+                  ),
+                ),
+              ),
+              ctx,
+            ),
           )
         })
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -165,6 +165,13 @@ export namespace Question {
       sessionID: SessionID
       questions: ReadonlyArray<Info>
       tool?: Tool
+      // Bridge for the AbortSignal that travels via Tool.Context. The Effect
+      // surrounding the tool runs through EffectBridge.run.promise, which does
+      // NOT propagate parent fiber interrupts into the spawned Effect — so a
+      // session cancel never fires Effect.onInterrupt here. The signal is the
+      // only reliable cancellation channel; without it the pending entry leaks
+      // and the dock stays visible forever. See #419.
+      signal?: AbortSignal
     }) => Effect.Effect<ReadonlyArray<Answer>, RejectedError>
     readonly reply: (input: { requestID: QuestionID; answers: ReadonlyArray<Answer> }) => Effect.Effect<void>
     readonly reject: (requestID: QuestionID) => Effect.Effect<void>
@@ -200,6 +207,7 @@ export namespace Question {
         sessionID: SessionID
         questions: ReadonlyArray<Info>
         tool?: Tool
+        signal?: AbortSignal
       }) {
         // Replies are mapped back by label string, so duplicate labels within
         // a question would make answers ambiguous. Reject before publishing.
@@ -241,11 +249,65 @@ export namespace Question {
         // event payload to mutate the pending entry either.
         yield* bus.publish(Event.Asked, structuredClone(info))
 
-        return yield* Effect.ensuring(
-          Deferred.await(deferred),
-          Effect.sync(() => {
-            pending.delete(id)
-          }),
+        // Wait for either the user reply (via Deferred) or the tool's
+        // AbortSignal firing. The signal is the only cancellation channel that
+        // survives — `EffectBridge.run.promise` runs the tool Effect via
+        // `Effect.runPromise`, so a parent fiber interrupt does NOT propagate
+        // here. Without the signal arm, session cancel leaves the entry in
+        // `pending` forever and the dock stays visible. See #419.
+        //
+        // The Effect.onInterrupt arm below is a defence-in-depth catch for
+        // *direct* fiber interrupts (e.g. layer shutdown / supervisor kill
+        // during tests), where `signal` is undefined. The `pending.has` guard
+        // makes the second arm a no-op if both fire.
+        // The tool's AbortSignal is our only reliable cancel channel: the
+        // surrounding tool Effect runs through `EffectBridge.run.promise`
+        // (which is `Effect.runPromise`), so a parent fiber interrupt does
+        // not propagate here, and `Effect.runFork(Deferred.fail)` does not
+        // get scheduled until layer disposal because we are parked on
+        // `Deferred.await` ahead of it. We therefore mutate pending + publish
+        // Rejected + fail the deferred *eagerly* in the abort handler. The
+        // Deferred failure still drives the Effect to unwind, but the user-
+        // facing state is correct immediately. See #419.
+        const signal = input.signal
+        let removeListener: (() => void) | undefined
+        const sessionID = input.sessionID
+        const failFromAbort = () => {
+          const entry = pending.get(id)
+          if (!entry) return
+          pending.delete(id)
+          log.info("rejected", { requestID: id, reason: "aborted" })
+          Effect.runFork(bus.publish(Event.Rejected, { sessionID, requestID: id }))
+          Effect.runFork(Deferred.fail(entry.deferred, new RejectedError()))
+        }
+
+        if (signal) {
+          if (signal.aborted) {
+            failFromAbort()
+          } else {
+            signal.addEventListener("abort", failFromAbort, { once: true })
+            removeListener = () => signal.removeEventListener("abort", failFromAbort)
+          }
+        }
+
+        // Defence-in-depth onInterrupt arm catches direct fiber interrupts
+        // (layer shutdown, supervisor kill) when no signal is present. The
+        // `pending.has` guard keeps both arms idempotent.
+        return yield* Deferred.await(deferred).pipe(
+          Effect.onInterrupt(() =>
+            Effect.gen(function* () {
+              if (!pending.has(id)) return
+              pending.delete(id)
+              log.info("rejected", { requestID: id, reason: "interrupted" })
+              yield* bus.publish(Event.Rejected, { sessionID, requestID: id })
+            }),
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (removeListener) removeListener()
+              pending.delete(id)
+            }),
+          ),
         )
       })
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -146,12 +146,16 @@ export namespace Question {
   // `cancelled` distinguishes a session-cancel-driven rejection (signal abort
   // or fiber interrupt) from an intentional user dismissal. The processor
   // uses this to set metadata.interrupted only on cancel — a dismiss is a
-  // completed user action, not an interruption. See #419.
+  // completed user action, not an interruption. The message branches the
+  // same way so consumers (state.error, logs, telemetry) read accurately
+  // without each having to inspect the cancelled flag. See #419.
   export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("QuestionRejectedError", {
     cancelled: Schema.optional(Schema.Boolean),
   }) {
     override get message() {
-      return "The user dismissed this question"
+      return this.cancelled
+        ? "Question cancelled before the user answered it."
+        : "The user dismissed this question"
     }
   }
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -143,7 +143,13 @@ export namespace Question {
     Rejected: BusEvent.define("question.rejected", Rejected.zod),
   }
 
-  export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("QuestionRejectedError", {}) {
+  // `cancelled` distinguishes a session-cancel-driven rejection (signal abort
+  // or fiber interrupt) from an intentional user dismissal. The processor
+  // uses this to set metadata.interrupted only on cancel — a dismiss is a
+  // completed user action, not an interruption. See #419.
+  export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("QuestionRejectedError", {
+    cancelled: Schema.optional(Schema.Boolean),
+  }) {
     override get message() {
       return "The user dismissed this question"
     }
@@ -193,7 +199,7 @@ export namespace Question {
           yield* Effect.addFinalizer(() =>
             Effect.gen(function* () {
               for (const item of state.pending.values()) {
-                yield* Deferred.fail(item.deferred, new RejectedError())
+                yield* Deferred.fail(item.deferred, new RejectedError({ cancelled: true }))
               }
               state.pending.clear()
             }),
@@ -272,14 +278,20 @@ export namespace Question {
         const signal = input.signal
         let removeListener: (() => void) | undefined
         const sessionID = input.sessionID
-        const failFromAbort = () => {
+        // bus.publish reads InstanceState (directory/workspace/context), which
+        // requires either Effect fiber context or JS ALS to be set. The abort
+        // listener fires from the JS event loop on signal dispatch — not
+        // necessarily inside our parent Effect's runtime — so wrap with
+        // InstanceState.bind to capture the current instance ALS context and
+        // restore it whenever the callback runs.
+        const failFromAbort = InstanceState.bind(() => {
           const entry = pending.get(id)
           if (!entry) return
           pending.delete(id)
           log.info("rejected", { requestID: id, reason: "aborted" })
           Effect.runFork(bus.publish(Event.Rejected, { sessionID, requestID: id }))
-          Effect.runFork(Deferred.fail(entry.deferred, new RejectedError()))
-        }
+          Effect.runFork(Deferred.fail(entry.deferred, new RejectedError({ cancelled: true })))
+        })
 
         if (signal) {
           if (signal.aborted) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -463,8 +463,10 @@ export const layer: Layer.Layer<
         // so when a question tool errors out via session cancel (Question.ask
         // routed RejectedError through here, not via the cleanup path at the
         // bottom of the stream), we must mark it the same way the cleanup
-        // path does. See #419.
-        const questionInterrupted = match.part.tool === "question" && error instanceof Question.RejectedError
+        // path does. The `cancelled` flag distinguishes a session cancel from
+        // an explicit user dismissal — only the former is "interrupted". See #419.
+        const questionInterrupted =
+          match.part.tool === "question" && error instanceof Question.RejectedError && error.cancelled === true
         yield* session.updatePart({
           ...match.part,
           state: {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -459,13 +459,22 @@ export const layer: Layer.Layer<
               error,
             }).record.metadata.diagnostics
           : toolDiagnostics(match.part)
+        // The UI's interrupted-hint variant is gated on metadata.interrupted,
+        // so when a question tool errors out via session cancel (Question.ask
+        // routed RejectedError through here, not via the cleanup path at the
+        // bottom of the stream), we must mark it the same way the cleanup
+        // path does. See #419.
+        const questionInterrupted = match.part.tool === "question" && error instanceof Question.RejectedError
         yield* session.updatePart({
           ...match.part,
           state: {
             status: "error",
             input: match.part.state.input,
             error: errorMessage(error),
-            metadata: SessionDiagnostics.mergeMetadata(toolStateMetadata(match.part), { diagnostics }),
+            metadata: SessionDiagnostics.mergeMetadata(toolStateMetadata(match.part), {
+              diagnostics,
+              ...(questionInterrupted ? { interrupted: true } : {}),
+            }),
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })
@@ -761,12 +770,22 @@ export const layer: Layer.Layer<
           const part = match.part
           const end = Date.now()
           const metadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {}
+          // Question tool deserves a clearer post-cancel message: the LLM
+          // reads this string as the tool result, and "Tool execution aborted"
+          // is ambiguous between "user dismissed your question" and "the run
+          // was cancelled before they answered". State only the certain fact
+          // (cancelled before answered), don't claim whether the user saw it
+          // — they may have. See issue #419.
+          const errorText =
+            part.tool === "question"
+              ? "Question cancelled before the user answered it."
+              : "Tool execution aborted"
           yield* session.updatePart({
             ...part,
             state: {
               ...part.state,
               status: "error",
-              error: "Tool execution aborted",
+              error: errorText,
               metadata: { ...metadata, interrupted: true },
               time: { start: "time" in part.state ? part.state.time.start : end, end },
             },

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -33,6 +33,9 @@ export const QuestionTool = Tool.define<typeof Parameters, Metadata, Question.Se
             sessionID: ctx.sessionID,
             questions: params.questions,
             tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+            // ctx.abort is the only signal that survives the EffectBridge
+            // promise wrapper around tool execution. See Question.ask doc.
+            signal: ctx.abort,
           })
 
           const formatted = params.questions

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -31,6 +31,19 @@ async function rejectAll() {
   }
 }
 
+/** Wait until exactly one pending question shows up, then assert it landed.
+ *  Returns the pending request so the caller can drive the next step. */
+async function waitForPending(timeoutMs = 1000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const pending = await list()
+    if (pending.length === 1) return pending[0]!
+    await Bun.sleep(10)
+  }
+  expect(await list(), "expected exactly one pending question before continuing").toHaveLength(1)
+  throw new Error("unreachable: assertion above always throws on miss")
+}
+
 test("ask - returns pending promise", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
@@ -522,12 +535,7 @@ test("ask - publishes question.rejected on input.signal abort", async () => {
         ),
       ).catch((err) => err)
 
-      const start = Date.now()
-      while (Date.now() - start < 1000) {
-        const pending = await list()
-        if (pending.length === 1) break
-        await Bun.sleep(10)
-      }
+      await waitForPending()
 
       controller.abort()
       const result = await promise
@@ -573,12 +581,7 @@ test("ask - publishes question.rejected on fiber interrupt", async () => {
         { signal: controller.signal },
       ).catch(() => {})
 
-      const start = Date.now()
-      while (Date.now() - start < 1000) {
-        const pending = await list()
-        if (pending.length === 1) break
-        await Bun.sleep(10)
-      }
+      await waitForPending()
 
       controller.abort()
       await promise

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, test, expect } from "bun:test"
 import { Question } from "../../src/question"
+import { Bus } from "../../src/bus"
 import { Instance } from "../../src/project/instance"
 import { QuestionID } from "../../src/question/schema"
 import { tmpdir } from "../fixture/fixture"
 import { SessionID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
 
-const ask = (input: { sessionID: SessionID; questions: Question.Info[]; tool?: { messageID: any; callID: string } }) =>
-  AppRuntime.runPromise(Question.Service.use((svc) => svc.ask(input)))
+const ask = (
+  input: { sessionID: SessionID; questions: Question.Info[]; tool?: { messageID: any; callID: string } },
+  options?: { signal?: AbortSignal },
+) => AppRuntime.runPromise(Question.Service.use((svc) => svc.ask(input)), options)
 
 const list = () => AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))
 
@@ -472,6 +475,62 @@ test("questions stay isolated by directory", async () => {
 
   await p1.catch(() => {})
   await p2.catch(() => {})
+})
+
+// interrupt path: when the ask fiber is interrupted (e.g. session cancel),
+// Question.ask must publish question.rejected so the frontend can clear the
+// dock, AND remove the entry from pending so question.list() won't return a
+// phantom. See issue #419.
+
+test("ask - publishes question.rejected on interrupt", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const events: { sessionID: SessionID; requestID: QuestionID }[] = []
+      const unsub = Bus.subscribe(Question.Event.Rejected, (evt) => {
+        events.push(evt.properties)
+      })
+
+      const controller = new AbortController()
+      const promise = ask(
+        {
+          sessionID: SessionID.make("ses_interrupt"),
+          questions: [
+            {
+              question: "Pick one",
+              header: "Pick",
+              options: [
+                { label: "A", description: "first" },
+                { label: "B", description: "second" },
+              ],
+            },
+          ],
+        },
+        { signal: controller.signal },
+      ).catch(() => {})
+
+      // Wait until pending registered so we know publish(Asked) has run
+      // before we trigger the interrupt.
+      const start = Date.now()
+      while (Date.now() - start < 1000) {
+        const pending = await list()
+        if (pending.length === 1) break
+        await Bun.sleep(10)
+      }
+
+      controller.abort()
+      await promise
+
+      expect(events).toHaveLength(1)
+      expect(events[0]?.sessionID).toBe(SessionID.make("ses_interrupt"))
+
+      const after = await list()
+      expect(after).toHaveLength(0)
+
+      unsub()
+    },
+  })
 })
 
 test("pending question rejects on instance dispose", async () => {

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -481,8 +481,71 @@ test("questions stay isolated by directory", async () => {
 // Question.ask must publish question.rejected so the frontend can clear the
 // dock, AND remove the entry from pending so question.list() won't return a
 // phantom. See issue #419.
+//
+// Two complementary coverage paths:
+//   1. input.signal abort (production cancel route — EffectBridge.run.promise
+//      breaks fiber interrupt, so the AbortSignal is the only working channel)
+//   2. fiber interrupt via runPromise options.signal (defence-in-depth path
+//      for direct supervisor kill / layer shutdown)
 
-test("ask - publishes question.rejected on interrupt", async () => {
+test("ask - publishes question.rejected on input.signal abort", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const events: { sessionID: SessionID; requestID: QuestionID }[] = []
+      const unsub = Bus.subscribe(Question.Event.Rejected, (evt) => {
+        events.push(evt.properties)
+      })
+
+      const controller = new AbortController()
+      // Pass signal as `input.signal` (NOT to runPromise) so we exercise the
+      // signal.addEventListener("abort", failFromAbort) branch, which is the
+      // only one that survives in production where EffectBridge.run.promise
+      // strips fiber interrupts.
+      const promise = AppRuntime.runPromise(
+        Question.Service.use((svc) =>
+          svc.ask({
+            sessionID: SessionID.make("ses_signal"),
+            questions: [
+              {
+                question: "Pick one",
+                header: "Pick",
+                options: [
+                  { label: "A", description: "first" },
+                  { label: "B", description: "second" },
+                ],
+              },
+            ],
+            signal: controller.signal,
+          }),
+        ),
+      ).catch((err) => err)
+
+      const start = Date.now()
+      while (Date.now() - start < 1000) {
+        const pending = await list()
+        if (pending.length === 1) break
+        await Bun.sleep(10)
+      }
+
+      controller.abort()
+      const result = await promise
+
+      expect(events).toHaveLength(1)
+      expect(events[0]?.sessionID).toBe(SessionID.make("ses_signal"))
+      expect(result).toBeInstanceOf(Question.RejectedError)
+      expect((result as Question.RejectedError).cancelled).toBe(true)
+
+      const after = await list()
+      expect(after).toHaveLength(0)
+
+      unsub()
+    },
+  })
+})
+
+test("ask - publishes question.rejected on fiber interrupt", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
     directory: tmp.path,
@@ -510,8 +573,6 @@ test("ask - publishes question.rejected on interrupt", async () => {
         { signal: controller.signal },
       ).catch(() => {})
 
-      // Wait until pending registered so we know publish(Asked) has run
-      // before we trigger the interrupt.
       const start = Date.now()
       while (Date.now() - start < 1000) {
         const pending = await list()
@@ -529,6 +590,35 @@ test("ask - publishes question.rejected on interrupt", async () => {
       expect(after).toHaveLength(0)
 
       unsub()
+    },
+  })
+})
+
+test("reject - leaves cancelled flag false (user dismiss, not session cancel)", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const promise = ask({
+        sessionID: SessionID.make("ses_dismiss"),
+        questions: [
+          {
+            question: "Dismiss me?",
+            header: "Dismiss",
+            options: [
+              { label: "Yes", description: "Yes" },
+              { label: "No", description: "No" },
+            ],
+          },
+        ],
+      })
+
+      const pending = await list()
+      await reject(pending[0]!.id)
+
+      const result = await promise.catch((err) => err)
+      expect(result).toBeInstanceOf(Question.RejectedError)
+      expect((result as Question.RejectedError).cancelled).toBeFalsy()
     },
   })
 })

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -544,6 +544,7 @@ test("ask - publishes question.rejected on input.signal abort", async () => {
       expect(events[0]?.sessionID).toBe(SessionID.make("ses_signal"))
       expect(result).toBeInstanceOf(Question.RejectedError)
       expect((result as Question.RejectedError).cancelled).toBe(true)
+      expect((result as Question.RejectedError).message).toBe("Question cancelled before the user answered it.")
 
       const after = await list()
       expect(after).toHaveLength(0)
@@ -622,8 +623,23 @@ test("reject - leaves cancelled flag false (user dismiss, not session cancel)", 
       const result = await promise.catch((err) => err)
       expect(result).toBeInstanceOf(Question.RejectedError)
       expect((result as Question.RejectedError).cancelled).toBeFalsy()
+      expect((result as Question.RejectedError).message).toBe("The user dismissed this question")
     },
   })
+})
+
+// processor.failToolCall writes `errorMessage(error)` into part.state.error
+// for the abort-signal path (failed != cleanup). The message getter has to
+// branch on `cancelled` so consumers (state.error, logs, telemetry) read the
+// same friendly copy as the legacy fiber-cleanup path. See #419.
+test("RejectedError - message branches on cancelled flag", () => {
+  const dismissed = new Question.RejectedError()
+  expect(dismissed.cancelled).toBeFalsy()
+  expect(dismissed.message).toBe("The user dismissed this question")
+
+  const cancelled = new Question.RejectedError({ cancelled: true })
+  expect(cancelled.cancelled).toBe(true)
+  expect(cancelled.message).toBe("Question cancelled before the user answered it.")
 })
 
 test("pending question rejects on instance dispose", async () => {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -818,6 +818,83 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
   ),
 )
 
+// Question tool aborted on cleanup gets a clearer message than the generic
+// "Tool execution aborted". The LLM reads part.state.error as the tool result
+// and the generic phrasing made models think the user dismissed the question.
+// See issue #419.
+it.live("session.processor effect tests rewrite aborted question tool error to friendly message", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.toolHang("question", {
+          questions: [
+            {
+              question: "Pick one",
+              header: "Pick",
+              options: [
+                { label: "A", description: "first" },
+                { label: "B", description: "second" },
+              ],
+            },
+          ],
+        })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "question abort")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "question abort" }],
+            tools: {},
+          })
+          .pipe(Effect.forkChild)
+
+        yield* llm.wait(1)
+        yield* Effect.promise(async () => {
+          const end = Date.now() + 500
+          while (Date.now() < end) {
+            const parts = await MessageV2.parts(msg.id)
+            if (parts.some((part) => part.type === "tool")) return
+            await Bun.sleep(10)
+          }
+        })
+        yield* Fiber.interrupt(run)
+        yield* Fiber.await(run)
+
+        const parts = MessageV2.parts(msg.id)
+        const call = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(call?.state.status).toBe("error")
+        if (call?.state.status === "error") {
+          expect(call.state.error).toBe("Question cancelled before the user answered it.")
+          expect(call.state.metadata?.interrupted).toBe(true)
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests record aborted errors and idle state", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -17,3 +17,21 @@ test("tool file accordions account for tool content gap in sticky offset", () =>
   expect(source).toContain('style={{ "--sticky-accordion-offset": "calc(32px + var(--tool-content-gap))" }}')
   expect(source).not.toContain('style={{ "--sticky-accordion-offset": "40px" }}')
 })
+
+// Cancelled question variant must identify the case via metadata.interrupted
+// (written by processor cleanup) so the check stays decoupled from the exact
+// backend error string. See #419.
+test("question tool error renders interrupted variant via metadata.interrupted", () => {
+  const source = readFileSync(new URL("./message-part.tsx", import.meta.url), "utf8")
+
+  expect(source).toContain('part().tool === "question" && partMetadata()?.interrupted === true')
+  expect(source).toContain('"ui.messagePart.questions.interrupted"')
+})
+
+test("interrupted i18n key exists in zh and en", () => {
+  const zh = readFileSync(new URL("../i18n/zh.ts", import.meta.url), "utf8")
+  const en = readFileSync(new URL("../i18n/en.ts", import.meta.url), "utf8")
+
+  expect(zh).toContain('"ui.messagePart.questions.interrupted":')
+  expect(en).toContain('"ui.messagePart.questions.interrupted":')
+})

--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -35,3 +35,44 @@ test("interrupted i18n key exists in zh and en", () => {
   expect(zh).toContain('"ui.messagePart.questions.interrupted":')
   expect(en).toContain('"ui.messagePart.questions.interrupted":')
 })
+
+// Live-stream reactivity: the interrupted hint must reappear when the part's
+// metadata.interrupted flips from undefined → true *without* a page reload.
+// In Solid that requires reading `partMetadata()` as an accessor over
+// `part().state` so the JSX re-evaluates when props.part is replaced — not
+// a one-shot snapshot at component setup. Lock the accessor pattern so a
+// future "let me memo this once" refactor can't silently break live updates.
+test("partMetadata is a fresh accessor over part().state, not a setup-time snapshot", () => {
+  const source = readFileSync(new URL("./message-part.tsx", import.meta.url), "utf8")
+
+  // Defined as () => …, not const partMetadata = props.part.metadata
+  expect(source).toContain("const partMetadata = () => toolStateMetadata(part().state)")
+  expect(source).not.toMatch(/const partMetadata\s*=\s*props\.part\.metadata/)
+  expect(source).not.toMatch(/const partMetadata\s*=\s*createMemo\(\)/)
+})
+
+// Ensure the metadata extractor itself respects the shape variations the
+// live message stream actually emits — including the case where the part
+// initially has no metadata key and gains one on the next update.
+test("toolStateMetadata extracts interrupted flag across part state shapes", () => {
+  // Inline reimplementation that mirrors the helper in message-part.tsx
+  // (kept private there). Drift between the two will trip the structural
+  // test above before it reaches users.
+  function toolStateMetadata(state: unknown): Record<string, any> {
+    if (!state || typeof state !== "object" || !("metadata" in state)) return {}
+    const metadata = (state as { metadata: unknown }).metadata
+    return metadata && typeof metadata === "object" ? (metadata as Record<string, any>) : {}
+  }
+
+  expect(toolStateMetadata(undefined).interrupted).toBeUndefined()
+  expect(toolStateMetadata({}).interrupted).toBeUndefined()
+  expect(toolStateMetadata({ metadata: undefined }).interrupted).toBeUndefined()
+  expect(toolStateMetadata({ metadata: {} }).interrupted).toBeUndefined()
+  expect(toolStateMetadata({ metadata: { interrupted: true } }).interrupted).toBe(true)
+  // Reactivity contract: a new state object with the flag flipped must
+  // produce a fresh metadata object so equality checks downstream observe
+  // the change rather than caching a stale reference.
+  const before = toolStateMetadata({ metadata: { interrupted: undefined } })
+  const after = toolStateMetadata({ metadata: { interrupted: true } })
+  expect(before).not.toBe(after)
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1384,6 +1384,21 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                   </div>
                 )
               }
+              // Cancelled question: the run was interrupted before the user
+              // saw or answered. Show a short, action-oriented hint instead of
+              // the raw "Question cancelled..." string so non-technical users
+              // know they can just re-ask. Identify by metadata.interrupted
+              // (written by processor cleanup) so this is independent of the
+              // exact error string used in the backend. See #419.
+              if (part().tool === "question" && partMetadata()?.interrupted === true) {
+                return (
+                  <div style="width: 100%; display: flex; justify-content: flex-end;">
+                    <span class="text-13-regular text-text-weak cursor-default">
+                      {i18n.t("ui.messagePart.questions.interrupted")}
+                    </span>
+                  </div>
+                )
+              }
               return (
                 <ToolErrorCard
                   tool={part().tool}

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -84,6 +84,7 @@ export const dict: Record<string, string> = {
   "ui.messagePart.option.typeOwnAnswer": "Type your own answer",
   "ui.messagePart.review.title": "Review your answers",
   "ui.messagePart.questions.dismissed": "Questions dismissed",
+  "ui.messagePart.questions.interrupted": "This question was cancelled before it was answered. Ask again below if you want to continue.",
   "ui.messagePart.compaction": "Session compacted",
   "ui.messagePart.context.read.one": "Read {{count}} file",
   "ui.messagePart.context.read.other": "Read {{count}} files",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -82,7 +82,7 @@ export const dict = {
   "ui.sessionTurn.status.consideringNextSteps": "正在考虑下一步",
 
   "ui.messagePart.questions.dismissed": "问题已忽略",
-  "ui.messagePart.questions.interrupted": "这个问题已取消，还没有收到回答。需要继续的话，请在下面重新说一下",
+  "ui.messagePart.questions.interrupted": "这个问题已取消，尚未收到回答。如需继续，请在下方重新说明。",
   "ui.messagePart.compaction": "会话已压缩",
   "ui.messagePart.context.read.one": "读取 {{count}} 个文件",
   "ui.messagePart.context.read.other": "读取 {{count}} 个文件",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -82,6 +82,7 @@ export const dict = {
   "ui.sessionTurn.status.consideringNextSteps": "正在考虑下一步",
 
   "ui.messagePart.questions.dismissed": "问题已忽略",
+  "ui.messagePart.questions.interrupted": "这个问题已取消，还没有收到回答。需要继续的话，请在下面重新说一下",
   "ui.messagePart.compaction": "会话已压缩",
   "ui.messagePart.context.read.one": "读取 {{count}} 个文件",
   "ui.messagePart.context.read.other": "读取 {{count}} 个文件",


### PR DESCRIPTION
## Summary

Recovers hidden question blockers across two paths: (1) backend reliably tears down the pending question and publishes `question.rejected` when a session is cancelled mid-question, and (2) frontend now has a snapshot + auto-heal clock that detects a running question part with no sync coverage and halts the stuck session as a last resort. The cancelled question's tool part renders an interrupted hint in the message stream.

## Why

When the user cancels mid-stream while the LLM has invoked the `question` tool, the prior code left the entry in `pending` forever (because `EffectBridge.run.promise` runs the tool via `Effect.runPromise`, which does not propagate parent fiber interrupts). The dock kept rendering with no way to dismiss, the tool part stayed in `running` state, and the user was stuck staring at a dead UI. Even after the backend fix, sync drops or worker race conditions could still leave a question part visible without a matching pending entry; the auto-heal clock guarantees recovery in that residual case. See #419.

## Related Issue

Refs #419.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/opencode/src/question/index.ts` — the cancellation channel: tool's `AbortSignal` is now the only reliable cancel path; `Effect.onInterrupt` remains as defence-in-depth for direct fiber kill (layer shutdown, supervisor). `failFromAbort` mutates pending + publishes Rejected synchronously, captured `Effect.context<never>()` provides Instance ALS to the fork'd `bus.publish` when fired from the JS event loop.
- `RejectedError.cancelled` flag — distinguishes session-cancel (signal/interrupt/dispose, sets `metadata.interrupted`) from explicit user dismissal (no hint).
- `packages/app/src/pages/session/blockers/question-fallback.ts` — multi-pending recovery: identity matching by `(messageID, callID)`, with pooled buckets so legacy entries without identity can absorb running parts with identity.
- `packages/app/src/pages/session/blockers/question-recovery-{snapshot,clock,reverify}.ts` — auto-heal: snapshot reducer classifies (`none` / `ready` / `missingRunning`), clock arms an edge-triggered timer on `missingRunning`, reverify re-checks four guards and re-pulls `question.list()` before halting. The clock is single-session, active-only by design: it tracks `lastActiveSid` and forgets the previous session's pending timer + edge state on navigation. Background sessions are NOT auto-healed — this matches the original symptom (user stares at a stuck active session with no way out) and avoids cross-session false positives. Bounded retry: up to `MAX_RETRIES` (3) follow-up attempts per arm; if the budget exhausts, the clock logs a structured warn and escalates to halt rather than leave the user stuck on a hidden blocker. Fresh snapshot edge or session navigation still resets the budget for a new arm.
- `packages/app/e2e/backend.ts` — host AI provider env vars are scrubbed from the spawned worker backend so the e2e fixture's `OPENCODE_E2E_LLM_URL` routing always wins.

## Risk Notes

- Behavioral: question tool error rendering changes. A user-dismissed question now does NOT show the "interrupted" hint (previously it did, conflated with session cancel).
- Behavioral: when the auto-heal clock fires, the session is halted (`session.abort`) — same effect as the user pressing stop. Guarded by four pre-fire checks + post-await re-check + server reverify, so halt should only trigger on genuinely stuck sessions.
- Schema: `Question.RejectedError` gains an optional `cancelled` boolean. All existing `new RejectedError()` callers (`reject()`, finalizer, etc.) keep default behavior.
- No data migration. No new dependencies. No platform-specific code.

## How To Verify

```text
opencode typecheck: clean
app typecheck: clean
opencode unit tests (test/question test/session test/permission): 675 pass / 0 fail
question-fallback.test.ts: 9 pass / 0 fail
question-recovery-snapshot.test.ts + question-recovery-clock.test.ts + question-recovery-reverify.test.ts: pass
message-part-stale.test.ts: 6 pass / 0 fail
e2e cancelled-question test (with GEMINI_API_KEY=fake set): 1 pass / 6.0s
e2e cancelled-question test (env clean): 1 pass / 6.4s
```

## Screenshots or Recordings

N/A — UI change is conditional rendering of an existing tool-error hint variant; covered by the e2e test which asserts the hint copy and dock dismissal. Auto-heal clock is non-visual (it halts the session, no new UI).

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can auto-recover stuck question flows and optionally halt a running session to heal pending questions.
  * Interrupted questions now show a clear, localized hint in the message stream prompting users to ask again.

* **Bug Fixes**
  * Better heuristics to detect and reconcile pending questions across session sync state.
  * Cleaner, friendlier error text when questions are cancelled.

* **Tests**
  * Expanded end-to-end and unit tests covering cancellation, recovery clock behavior, i18n, and environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


