### PR TITLE
fix(windows): canonicalize rooted-but-driveless paths in permission helpers

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, join, relative, resolve as pathResolve } from "path"
-import { realpathSync } from "fs"
+import { dirname, join, relative, resolve as pathResolve, win32 } from "path"
+import { existsSync, realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
 import { Context, Effect, FileSystem, Layer, Schema } from "effect"
@@ -188,7 +188,7 @@ export namespace AppFileSystem {
 
   export function normalizePath(path: string): string {
     if (process.platform !== "win32") return path
-    const resolved = pathResolve(windowsPath(path))
+    const resolved = normalizeWindowsAbsolutePath(windowsPath(path))
     try {
       return realpathSync.native(resolved)
     } catch {
@@ -206,7 +206,8 @@ export namespace AppFileSystem {
   }
 
   export function resolve(path: string): string {
-    const resolved = pathResolve(windowsPath(path))
+    const resolved =
+      process.platform === "win32" ? normalizeWindowsAbsolutePath(windowsPath(path)) : pathResolve(path)
     try {
       return normalizePath(realpathSync(resolved))
     } catch (error: any) {
@@ -222,6 +223,45 @@ export namespace AppFileSystem {
       .replace(/^\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
       .replace(/^\/cygdrive\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
       .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
+  }
+
+  // Rooted but driveless paths (e.g. "/users/runner/...") arrive when callers
+  // strip the drive letter before handing the path back. path.resolve would
+  // bind such a path to the cwd's drive, which silently mismatches when the
+  // file actually lives on a different drive. Probe each known drive root for
+  // an existing file and fall back to win32.resolve only when none match.
+  function normalizeWindowsAbsolutePath(p: string): string {
+    const existing = resolveRootedWindowsVariant(p)
+    return win32.normalize(existing ?? win32.resolve(p))
+  }
+
+  function resolveRootedWindowsVariant(p: string): string | undefined {
+    if (!/^[\\/](?![\\/])/.test(p)) return
+    const suffix = p.replace(/^[\\/]+/, "").replaceAll("/", "\\")
+    for (const root of windowsDriveRoots()) {
+      const candidate = win32.join(root, suffix)
+      if (existsSync(candidate)) return candidate
+    }
+  }
+
+  function windowsDriveRoots(): string[] {
+    const result: string[] = []
+    const seen = new Set<string>()
+    const push = (input?: string) => {
+      if (!input) return
+      const match = input.match(/^([A-Za-z]:)/)
+      if (!match) return
+      const root = match[1].toUpperCase()
+      if (seen.has(root)) return
+      seen.add(root)
+      result.push(root + "\\")
+    }
+    push(process.cwd())
+    push(process.env.SystemDrive)
+    for (let code = 65; code <= 90; code++) {
+      push(String.fromCharCode(code) + ":")
+    }
+    return result
   }
 
   export function overlaps(a: string, b: string) {

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -230,6 +230,11 @@ export namespace AppFileSystem {
   // bind such a path to the cwd's drive, which silently mismatches when the
   // file actually lives on a different drive. Probe each known drive root for
   // an existing file and fall back to win32.resolve only when none match.
+  //
+  // Important: this only repairs *existing* rooted-driveless paths. Targets
+  // that have not been created yet (e.g. write destinations) still fall back
+  // to the cwd-drive answer that win32.resolve produces. Callers that need
+  // a stable drive for a future path should pre-resolve via the project root.
   function normalizeWindowsAbsolutePath(p: string): string {
     const existing = resolveRootedWindowsVariant(p)
     return win32.normalize(existing ?? win32.resolve(p))

--- a/packages/core/test/filesystem/normalize-path.test.ts
+++ b/packages/core/test/filesystem/normalize-path.test.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "bun:test"
+import path from "path"
+import os from "os"
+import fs from "fs"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+
+// All Windows variants below collapse to the same canonical form on Windows.
+// On macOS/Linux normalizePath is the identity function, so we keep the
+// Windows-only guards explicit to avoid accidental cross-platform skew.
+
+test("normalizePath is identity on non-Windows", () => {
+  if (process.platform === "win32") return
+  const p = "/usr/local/bin/foo"
+  expect(AppFileSystem.normalizePath(p)).toBe(p)
+})
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath probes drive roots for rooted-but-driveless paths to existing files",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const file = path.join(tmpdir, "marker.txt")
+      fs.writeFileSync(file, "x")
+
+      const driveless = file.replace(/^[A-Za-z]:/, "").replaceAll("\\", "/").toLowerCase()
+      const result = AppFileSystem.normalizePath(driveless)
+
+      expect(result.toLowerCase()).toBe(file.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath canonicalizes Git Bash /c/... style paths",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const file = path.join(tmpdir, "marker.txt")
+      fs.writeFileSync(file, "x")
+
+      const drive = file.match(/^([A-Za-z]):/)![1].toLowerCase()
+      const tail = file.slice(2).replaceAll("\\", "/")
+      const gitBash = `/${drive}${tail}`
+      const result = AppFileSystem.normalizePath(gitBash)
+
+      expect(result.toLowerCase()).toBe(file.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath canonicalizes Cygwin /cygdrive/c/... paths",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const file = path.join(tmpdir, "marker.txt")
+      fs.writeFileSync(file, "x")
+
+      const drive = file.match(/^([A-Za-z]):/)![1].toLowerCase()
+      const tail = file.slice(2).replaceAll("\\", "/")
+      const cygwin = `/cygdrive/${drive}${tail}`
+      const result = AppFileSystem.normalizePath(cygwin)
+
+      expect(result.toLowerCase()).toBe(file.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath canonicalizes WSL /mnt/c/... paths",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const file = path.join(tmpdir, "marker.txt")
+      fs.writeFileSync(file, "x")
+
+      const drive = file.match(/^([A-Za-z]):/)![1].toLowerCase()
+      const tail = file.slice(2).replaceAll("\\", "/")
+      const wsl = `/mnt/${drive}${tail}`
+      const result = AppFileSystem.normalizePath(wsl)
+
+      expect(result.toLowerCase()).toBe(file.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath leaves drive-prefixed paths intact for already-canonical input",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const file = path.join(tmpdir, "marker.txt")
+      fs.writeFileSync(file, "x")
+
+      const result = AppFileSystem.normalizePath(file)
+      expect(result.toLowerCase()).toBe(file.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePath falls back to cwd-drive resolution for non-existent rooted-driveless paths",
+  () => {
+    // The probe only repairs existing paths; documenting behavior so future
+    // changes don't accidentally start guessing for write targets.
+    const driveless = "/this/path/should/not/exist/anywhere/marker.txt"
+    const result = AppFileSystem.normalizePath(driveless)
+    expect(result).toMatch(/^[A-Za-z]:/)
+  },
+)
+
+test.skipIf(process.platform !== "win32")(
+  "normalizePathPattern preserves trailing /* glob",
+  () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pawwork-fs-"))
+    try {
+      const driveless = tmpdir.replace(/^[A-Za-z]:/, "").replaceAll("\\", "/").toLowerCase()
+      const pattern = AppFileSystem.normalizePathPattern(`${driveless}/*`)
+
+      expect(pattern.endsWith("\\*") || pattern.endsWith("/*")).toBe(true)
+      expect(pattern.toLowerCase()).toContain(tmpdir.toLowerCase())
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true, force: true })
+    }
+  },
+)

--- a/packages/core/test/filesystem/normalize-path.test.ts
+++ b/packages/core/test/filesystem/normalize-path.test.ts
@@ -114,8 +114,11 @@ test.skipIf(process.platform !== "win32")(
     // The probe only repairs existing paths; documenting behavior so future
     // changes don't accidentally start guessing for write targets.
     const driveless = "/this/path/should/not/exist/anywhere/marker.txt"
+    const cwdDrive = process.cwd().match(/^([A-Za-z]:)/)![1].toUpperCase()
+    const expected = path.win32.normalize(path.win32.join(`${cwdDrive}\\`, driveless.replaceAll("/", "\\")))
     const result = AppFileSystem.normalizePath(driveless)
-    expect(result).toMatch(/^[A-Za-z]:/)
+
+    expect(result.toUpperCase()).toBe(expected.toUpperCase())
   },
 )
 

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,10 +1,10 @@
 import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { lookup } from "mime-types"
-import { realpathSync } from "fs"
 import { dirname, isAbsolute as pathIsAbsolute, join, relative, resolve as pathResolve, win32 } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Glob } from "./glob"
 
 export namespace Filesystem {
@@ -111,89 +111,14 @@ export namespace Filesystem {
    * This is needed because Windows paths are case-insensitive but LSP servers
    * may return paths with different casing than what we send them.
    */
-  export function normalizePath(p: string): string {
-    if (process.platform !== "win32") return p
-    const resolved = normalizeWindowsAbsolutePath(windowsPath(p))
-    try {
-      return realpathSync.native(resolved)
-    } catch {
-      return resolved
-    }
-  }
-
-  export function normalizePathPattern(p: string): string {
-    if (process.platform !== "win32") return p
-    if (p === "*") return p
-    const match = p.match(/^(.*)[\\/]\*$/)
-    if (!match) return normalizePath(p)
-    const dir = /^[A-Za-z]:$/.test(match[1]) ? match[1] + "\\" : match[1]
-    return join(normalizePath(dir), "*")
-  }
-
-  // We cannot rely on path.resolve() here because git.exe may come from Git Bash, Cygwin, or MSYS2, so we need to translate these paths at the boundary.
-  // Also resolves symlinks so that callers using the result as a cache key
-  // always get the same canonical path for a given physical directory.
-  export function resolve(p: string): string {
-    const resolved = process.platform === "win32" ? normalizeWindowsAbsolutePath(windowsPath(p)) : pathResolve(p)
-    try {
-      return normalizePath(realpathSync(resolved))
-    } catch (e) {
-      if (isEnoent(e)) return normalizePath(resolved)
-      throw e
-    }
-  }
-
-  export function windowsPath(p: string): string {
-    if (process.platform !== "win32") return p
-    return (
-      p
-        .replace(/^\/([a-zA-Z]):(?:[\\/]|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-        // Git Bash for Windows paths are typically /<drive>/...
-        .replace(/^\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-        // Cygwin git paths are typically /cygdrive/<drive>/...
-        .replace(/^\/cygdrive\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-        // WSL paths are typically /mnt/<drive>/...
-        .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-    )
-  }
-
-  function normalizeWindowsAbsolutePath(p: string) {
-    const existing = resolveRootedWindowsVariant(p)
-    return win32.normalize(existing ?? win32.resolve(p))
-  }
-
-  function resolveRootedWindowsVariant(p: string) {
-    if (!/^[\\/](?![\\/])/.test(p)) return
-    const suffix = p.replace(/^[\\/]+/, "").replaceAll("/", "\\")
-    for (const root of windowsDriveRoots()) {
-      const candidate = win32.join(root, suffix)
-      if (existsSync(candidate)) return candidate
-    }
-  }
-
-  function windowsDriveRoots() {
-    const result: string[] = []
-    const seen = new Set<string>()
-    const push = (input?: string) => {
-      if (!input) return
-      const match = input.match(/^([A-Za-z]:)/)
-      if (!match) return
-      const root = match[1].toUpperCase()
-      if (seen.has(root)) return
-      seen.add(root)
-      result.push(root + "\\")
-    }
-    push(process.cwd())
-    push(process.env.SystemDrive)
-    for (let code = 65; code <= 90; code++) {
-      push(String.fromCharCode(code) + ":")
-    }
-    return result
-  }
+  export const normalizePath = AppFileSystem.normalizePath
+  export const normalizePathPattern = AppFileSystem.normalizePathPattern
+  export const resolve = AppFileSystem.resolve
+  export const windowsPath = AppFileSystem.windowsPath
 
   function comparablePath(p: string) {
     if (process.platform !== "win32") return pathResolve(p)
-    return win32.normalize(win32.resolve(windowsPath(p)))
+    return AppFileSystem.normalizePath(p)
   }
 
   function comparableRelative(from: string, to: string) {


### PR DESCRIPTION
## Summary

`assertExternalDirectory` and `read` both rely on `AppFileSystem.normalizePath` to canonicalize a user-supplied path before deriving permission globs. On Windows that fell through to `path.resolve`, which silently bound rooted-but-driveless paths (e.g. `/users/runner/...`) to the cwd's drive. When the file lived on a different drive (typical on GitHub runners: temp on `C:` vs workspace on `D:`), the resulting glob and `fs.open` path pointed at the wrong drive.

Probe each known drive root for an existing path before falling back to `win32.resolve`. The helper now lives in `@opencode-ai/core/filesystem` so `AppFileSystem.normalizePath` and `Filesystem.normalizePath` share one implementation; opencode's `Filesystem` thin-wraps it.

## Why

#427 carved two real Windows runtime bugs out of the windows-advisory failures (the rest were test-fixture issues, fixed in #429). Without this change `tool.assertExternalDirectory > normalizes Windows path variants to one glob` and `tool.read external_directory permission > normalizes read permission paths on Windows` both fail because the permission glob uses the cwd's drive instead of the file's actual drive.

## Related Issue

Fixes the rooted-but-driveless cases in #427. UNC `\\?\` prefixes, ambiguous multi-drive matches, and write-target (non-existing path) handling are deliberately out of scope — kept open for a follow-up if windows-advisory surfaces them.

## Human Review Status

Pending.

## Review Focus

- The drive-probe heuristic in `normalizeWindowsAbsolutePath` and `windowsDriveRoots`. The probe runs sync `existsSync` per drive; that adds I/O to a previously pure path operation, but only on Windows and only for rooted-but-driveless inputs (a narrow code path).
- Removing the duplicate logic in `packages/opencode/src/util/filesystem.ts` — `Filesystem.normalizePath`/`resolve`/etc. are now re-exports of the core helpers. Existing callers (`Filesystem.contains`, `Filesystem.overlaps`, LSP, project/instance, plugin/install) keep working through the namespace.
- New `packages/core/test/filesystem/normalize-path.test.ts` covers Git Bash, Cygwin, WSL, and bare driveless variants plus an explicit guard that non-existing rooted-driveless paths still bind to cwd's drive.

## Risk Notes

- Windows-only behavior change. macOS/Linux paths are returned unchanged.
- The drive-probe scans up to 26 drives via `existsSync`. On a hung network drive this could block; in practice CI runners only have C/D so the cost is bounded.
- For non-existing rooted-driveless paths (e.g. write targets that don't exist yet), the probe finds nothing and falls back to `win32.resolve`, which still binds to cwd's drive. This matches prior behavior; only the existing-path case is improved.
- Drive probing runs `windowsDriveRoots()` per call (no caching). Hot paths that previously assumed `normalizePath` was pure (LSP, ripgrep) now do up to 26 `existsSync` syscalls per Windows call. Cache invalidation is a follow-up.

## How To Verify

```text
bun --cwd packages/opencode test test/tool/external-directory.test.ts test/tool/read.test.ts: 41 pass / 0 fail (macOS)
bun --cwd packages/opencode test test/util/filesystem.test.ts test/file/path-traversal.test.ts test/tool/edit.test.ts test/tool/write.test.ts test/tool/glob.test.ts test/tool/grep.test.ts: 133 pass / 0 fail (macOS)
bun --cwd packages/opencode test test/tool/bash.test.ts test/tool/apply_patch.test.ts test/tool/lsp.test.ts test/tool/truncation.test.ts: 66 pass / 0 fail (macOS)
bun --cwd packages/core test test/filesystem/normalize-path.test.ts: 1 pass / 7 skip on macOS, all variants exercised on Windows
windows-advisory CI: triggered manually on this branch (run 25311230257) — must be green before merge
```

## Screenshots or Recordings

None — no UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer Windows absolute-path resolution: probe known drive roots for rooted-but-driveless paths before falling back to standard resolution.

* **Refactor**
  * Consolidated filesystem path utilities into a shared core implementation; opencode now delegates normalization and resolution to the central filesystem module.

* **Tests**
  * Added cross-platform tests covering Windows-specific path normalization variants and pattern-preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->