### PR TITLE
fix(app): keep session timeline stable across worktree exit

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -77,6 +77,7 @@ interface PromptInputProps {
   sessionID?: string
   sessionIDControlled?: boolean
   actionReady?: () => boolean
+  abortReady?: () => boolean
   selectedSkill?: () => PawworkSkillName | undefined
 }
 
@@ -258,6 +259,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     prompt.current().filter((part): part is ImageAttachmentPart => part.type === "image"),
   )
   const actionReady = createMemo(() => props.actionReady?.() ?? true)
+  const abortReady = createMemo(() => props.abortReady?.() ?? actionReady())
 
   const [store, setStore] = createStore<{
     popover: "at" | "slash" | null
@@ -1105,6 +1107,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     mode: () => store.mode,
     working,
     actionReady,
+    abortReady,
     editor: () => editorRef,
     queueScroll,
     promptLength,
@@ -1632,10 +1635,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
             <div class="flex items-center gap-2 pointer-events-auto">
               <SessionContextUsage placement="top" />
-              <Tooltip placement="top" inactive={actionReady() && !working() && blank()} value={tip()}>
+              <Tooltip placement="top" inactive={(working() ? abortReady() : actionReady()) && !working() && blank()} value={tip()}>
                 <SendButton
                   stopping={stopping()}
-                  disabled={!actionReady() || (!working() && blank() && !props.selectedSkill?.())}
+                  disabled={working() ? !abortReady() : !actionReady() || (blank() && !props.selectedSkill?.())}
                   aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
                 />
               </Tooltip>

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -588,6 +588,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handleAtSelect = (option: AtOption | undefined) => {
+    if (!actionReady()) return
     if (!option) return
     addPart({ type: "file", path: option.path, content: "@" + option.path, start: 0, end: 0 })
   }
@@ -644,6 +645,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const handleSlashSelect = (cmd: SlashCommand | undefined) => {
+    if (!actionReady()) return
     if (!cmd) return
     promptProbe.select(cmd.id)
     closePopover()
@@ -1206,6 +1208,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const [variantOpen, setVariantOpen] = createSignal(false)
 
+  createEffect(() => {
+    if (actionReady()) return
+    closePopover()
+    setVariantOpen(false)
+    setStore("draggingType", null)
+  })
+
   const renderVariantControl = (triggerStyle: () => Record<string, string | number | undefined>) => (
     <div data-component="prompt-variant-control">
       <TooltipKeybind
@@ -1252,6 +1261,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     aria-checked={active()}
                     class="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-13-regular text-text-strong outline-none hover:bg-surface-raised-base-hover focus-visible:bg-surface-raised-base-hover"
                     onClick={() => {
+                      if (!actionReady()) return
                       local.model.variant.set(variant === "default" ? undefined : variant)
                       setVariantOpen(false)
                       restoreFocus()

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -58,6 +58,7 @@ import { PromptContextItems } from "./prompt-input/context-items"
 import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
+import { promptKeyActionReady, promptSendDisabled } from "./prompt-input/readiness"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
 import type { PawworkSkillName } from "@/components/session/pawwork-skill-meta"
 
@@ -301,9 +302,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const stopping = createMemo(() => working() && blank())
   const tip = () => {
-    if (!actionReady()) return language.t("prompt.loading")
-
-    if (stopping()) {
+    if (stopping() && abortReady()) {
       return (
         <div class="flex items-center gap-2">
           <span>{language.t("prompt.action.stop")}</span>
@@ -311,6 +310,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         </div>
       )
     }
+
+    if (!actionReady()) return language.t("prompt.loading")
 
     return (
       <div class="flex items-center gap-2">
@@ -1285,7 +1286,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   )
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (!actionReady()) {
+    if (
+      !promptKeyActionReady({
+        key: event.key,
+        working: working(),
+        stopping: stopping(),
+        actionReady: actionReady(),
+        abortReady: abortReady(),
+      })
+    ) {
       if (event.key === "Enter" || event.key === "Escape") {
         event.preventDefault()
         event.stopPropagation()
@@ -1438,16 +1447,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       if (event.repeat) return
-      if (
-        working() &&
-        prompt
-          .current()
-          .map((part) => ("content" in part ? part.content : ""))
-          .join("")
-          .trim().length === 0 &&
-        imageAttachments().length === 0 &&
-        commentCount() === 0
-      ) {
+      if (stopping()) {
+        handleSubmit(event)
         return
       }
       handleSubmit(event)
@@ -1638,7 +1639,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               <Tooltip placement="top" inactive={(working() ? abortReady() : actionReady()) && !working() && blank()} value={tip()}>
                 <SendButton
                   stopping={stopping()}
-                  disabled={working() ? !abortReady() : !actionReady() || (blank() && !props.selectedSkill?.())}
+                  disabled={promptSendDisabled({
+                    stopping: stopping(),
+                    actionReady: actionReady(),
+                    abortReady: abortReady(),
+                    blank: blank(),
+                    selectedSkill: !!props.selectedSkill?.(),
+                  })}
                   aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
                 />
               </Tooltip>

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -76,6 +76,7 @@ interface PromptInputProps {
   onModeChange?: (mode: "normal" | "shell") => void
   sessionID?: string
   sessionIDControlled?: boolean
+  actionReady?: () => boolean
   selectedSkill?: () => PawworkSkillName | undefined
 }
 
@@ -256,6 +257,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const imageAttachments = createMemo(() =>
     prompt.current().filter((part): part is ImageAttachmentPart => part.type === "image"),
   )
+  const actionReady = createMemo(() => props.actionReady?.() ?? true)
 
   const [store, setStore] = createStore<{
     popover: "at" | "slash" | null
@@ -297,6 +299,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const stopping = createMemo(() => working() && blank())
   const tip = () => {
+    if (!actionReady()) return language.t("prompt.loading")
+
     if (stopping()) {
       return (
         <div class="flex items-center gap-2">
@@ -356,14 +360,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   )
 
   const placeholder = createMemo(() =>
-    promptPlaceholder({
-      mode: store.mode,
-      commentCount: commentCount(),
-      example: suggest() ? language.t(EXAMPLES[store.placeholder]) : "",
-      suggest: suggest(),
-      selectedSkill: props.selectedSkill?.(),
-      t: (key, params) => language.t(key as Parameters<typeof language.t>[0], params as never),
-    }),
+    actionReady()
+      ? promptPlaceholder({
+          mode: store.mode,
+          commentCount: commentCount(),
+          example: suggest() ? language.t(EXAMPLES[store.placeholder]) : "",
+          suggest: suggest(),
+          selectedSkill: props.selectedSkill?.(),
+          t: (key, params) => language.t(key as Parameters<typeof language.t>[0], params as never),
+        })
+      : language.t("prompt.loading"),
   )
 
   const historyComments = () => {
@@ -455,6 +461,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const escBlur = () => platform.platform === "desktop" && platform.os === "macos"
 
   const pick = () => {
+    if (!actionReady()) return
     const openFilePickerDialog = platform.openFilePickerDialog
     void pickAttachments({
       openFilePickerDialog: canUseNativeFilePicker(platform) ? openFilePickerDialog : undefined,
@@ -464,6 +471,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const setMode = (mode: "normal" | "shell") => {
+    if (!actionReady()) return
     setStore("mode", mode)
     setStore("popover", null)
     requestAnimationFrame(() => editorRef?.focus())
@@ -478,7 +486,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       title: language.t("prompt.action.attachFile"),
       category: language.t("command.category.file"),
       keybind: "mod+u",
-      disabled: store.mode !== "normal",
+      disabled: store.mode !== "normal" || !actionReady(),
       onSelect: pick,
     },
     {
@@ -486,7 +494,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       title: language.t("command.prompt.mode.shell"),
       category: language.t("command.category.session"),
       keybind: shellModeKey,
-      disabled: store.mode === "shell",
+      disabled: store.mode === "shell" || !actionReady(),
       onSelect: () => setMode("shell"),
     },
     {
@@ -494,7 +502,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       title: language.t("command.prompt.mode.normal"),
       category: language.t("command.category.session"),
       keybind: normalModeKey,
-      disabled: store.mode === "normal",
+      disabled: store.mode === "normal" || !actionReady(),
       onSelect: () => setMode("normal"),
     },
   ])
@@ -1094,6 +1102,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     autoAccept: () => accepting(),
     mode: () => store.mode,
     working,
+    actionReady,
     editor: () => editorRef,
     queueScroll,
     promptLength,
@@ -1131,6 +1140,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               class="h-[28px]! min-w-0 px-1.5 justify-start! text-13-regular! text-text-base group rounded-xl! transition-colors hover:bg-surface-base-hover"
               style={triggerStyle()}
               onClick={() => {
+                if (!actionReady()) return
                 void import("@/components/dialog-select-model-unpaid").then((x) => {
                   dialog.show(() => <x.DialogSelectModelUnpaid model={local.model} />)
                 })
@@ -1170,6 +1180,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               class:
                 "h-[28px]! min-w-0 px-1.5 justify-start! text-13-regular! text-text-base group rounded-xl! transition-colors hover:bg-surface-base-hover",
               "data-action": "prompt-model",
+              disabled: !actionReady(),
             }}
             onClose={restoreFocus}
           >
@@ -1213,6 +1224,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               type: "button",
               "data-action": "prompt-model-variant",
               "aria-haspopup": "menu",
+              disabled: !actionReady(),
               style: triggerStyle(),
               class:
                 "h-[28px] px-2 max-w-[160px] @max-[20rem]/composer:max-w-[80px] inline-flex items-center gap-1.5 rounded-xl text-13-regular text-text-base transition-[max-width,colors] duration-200 ease-out hover:bg-surface-base-hover",
@@ -1220,9 +1232,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           }
           trigger={
             <>
-              <span class="truncate">
-                {translateVariant(language.t, local.model.variant.current() ?? "default")}
-              </span>
+              <span class="truncate">{translateVariant(language.t, local.model.variant.current() ?? "default")}</span>
               <Icon name="chevron-down" size="small" class="text-text-weak" />
             </>
           }
@@ -1262,6 +1272,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   )
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (!actionReady()) {
+      if (event.key === "Enter" || event.key === "Escape") {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+      return
+    }
+
     if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "u") {
       event.preventDefault()
       if (store.mode !== "normal") return
@@ -1445,6 +1463,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         classList={{
           "group/prompt-input @container/composer": true,
           "border-icon-info-active border-dashed": store.draggingType !== null,
+          "opacity-75": !actionReady(),
           [props.class ?? ""]: !!props.class,
         }}
       >
@@ -1500,7 +1519,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               role="textbox"
               aria-multiline="true"
               aria-label={placeholder()}
-              contenteditable="true"
+              aria-disabled={!actionReady()}
+              contenteditable={actionReady() ? "true" : "false"}
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
               autocorrect={store.mode === "normal" ? "on" : "off"}
               spellcheck={store.mode === "normal"}
@@ -1508,7 +1528,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               // @ts-expect-error
               autocomplete="off"
               onInput={handleInput}
-              onPaste={handlePaste}
+              onPaste={(event) => {
+                if (!actionReady()) {
+                  event.preventDefault()
+                  return
+                }
+                handlePaste(event)
+              }}
               onCompositionStart={handleCompositionStart}
               onCompositionEnd={handleCompositionEnd}
               onBlur={handleBlur}
@@ -1519,6 +1545,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 "[&_[data-type=file]]:text-syntax-property": true,
                 "[&_[data-type=agent]]:text-syntax-type": true,
                 "font-mono!": store.mode === "shell",
+                "cursor-wait text-text-weak": !actionReady(),
               }}
               style={{ "padding-bottom": space }}
             />
@@ -1577,7 +1604,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   class="size-7 shrink-0 p-0 rounded-xl!"
                   style={buttons()}
                   onClick={pick}
-                  disabled={store.mode !== "normal"}
+                  disabled={store.mode !== "normal" || !actionReady()}
                   tabIndex={store.mode === "normal" ? undefined : -1}
                   aria-label={language.t("prompt.action.attachFile")}
                 >
@@ -1595,10 +1622,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
             <div class="flex items-center gap-2 pointer-events-auto">
               <SessionContextUsage placement="top" />
-              <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
+              <Tooltip placement="top" inactive={actionReady() && !working() && blank()} value={tip()}>
                 <SendButton
                   stopping={stopping()}
-                  disabled={!working() && blank() && !props.selectedSkill?.()}
+                  disabled={!actionReady() || (!working() && blank() && !props.selectedSkill?.())}
                   aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
                 />
               </Tooltip>

--- a/packages/app/src/components/prompt-input/readiness.test.ts
+++ b/packages/app/src/components/prompt-input/readiness.test.ts
@@ -35,6 +35,18 @@ describe("promptKeyActionReady", () => {
       }),
     ).toBe(false)
   })
+
+  test("blocks non-stop keys while submit is blocked", () => {
+    expect(
+      promptKeyActionReady({
+        key: "ArrowUp",
+        working: false,
+        stopping: false,
+        actionReady: false,
+        abortReady: true,
+      }),
+    ).toBe(false)
+  })
 })
 
 describe("promptSendDisabled", () => {

--- a/packages/app/src/components/prompt-input/readiness.test.ts
+++ b/packages/app/src/components/prompt-input/readiness.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { promptKeyActionReady, promptSendDisabled } from "./readiness"
+
+describe("promptKeyActionReady", () => {
+  test("allows keyboard stop when submit is blocked but abort is ready", () => {
+    expect(
+      promptKeyActionReady({
+        key: "Escape",
+        working: true,
+        stopping: false,
+        actionReady: false,
+        abortReady: true,
+      }),
+    ).toBe(true)
+
+    expect(
+      promptKeyActionReady({
+        key: "Enter",
+        working: true,
+        stopping: true,
+        actionReady: false,
+        abortReady: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps submit keys blocked when neither submit nor abort is ready", () => {
+    expect(
+      promptKeyActionReady({
+        key: "Enter",
+        working: true,
+        stopping: true,
+        actionReady: false,
+        abortReady: false,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("promptSendDisabled", () => {
+  test("uses abort readiness only for the stop state", () => {
+    expect(
+      promptSendDisabled({
+        stopping: true,
+        actionReady: false,
+        abortReady: true,
+        blank: true,
+        selectedSkill: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("keeps nonblank send disabled when submit readiness is blocked", () => {
+    expect(
+      promptSendDisabled({
+        stopping: false,
+        actionReady: false,
+        abortReady: true,
+        blank: false,
+        selectedSkill: false,
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/app/src/components/prompt-input/readiness.ts
+++ b/packages/app/src/components/prompt-input/readiness.ts
@@ -8,7 +8,7 @@ export function promptKeyActionReady(input: {
   if (input.key === "Escape" && input.working) return input.abortReady
   if (input.key === "Enter" && input.stopping) return input.abortReady
   if (input.key === "Enter" || input.key === "Escape") return input.actionReady
-  return true
+  return input.actionReady
 }
 
 export function promptSendDisabled(input: {

--- a/packages/app/src/components/prompt-input/readiness.ts
+++ b/packages/app/src/components/prompt-input/readiness.ts
@@ -1,0 +1,23 @@
+export function promptKeyActionReady(input: {
+  key: string
+  working: boolean
+  stopping: boolean
+  actionReady: boolean
+  abortReady: boolean
+}) {
+  if (input.key === "Escape" && input.working) return input.abortReady
+  if (input.key === "Enter" && input.stopping) return input.abortReady
+  if (input.key === "Enter" || input.key === "Escape") return input.actionReady
+  return true
+}
+
+export function promptSendDisabled(input: {
+  stopping: boolean
+  actionReady: boolean
+  abortReady: boolean
+  blank: boolean
+  selectedSkill: boolean
+}) {
+  if (input.stopping) return !input.abortReady
+  return !input.actionReady || (input.blank && !input.selectedSkill)
+}

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -292,6 +292,40 @@ describe("prompt submit worktree selection", () => {
     expect(childTodoSets).toEqual([])
   })
 
+  test("does not abort or submit while session actions are not ready", async () => {
+    params = { id: "session-visible" }
+    const aborts: string[] = []
+    const submits: string[] = []
+    const submit = createPromptSubmit({
+      sessionID: () => "session-visible",
+      isNewSession: () => false,
+      info: () => ({ id: "session-visible" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => true,
+      actionReady: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => submits.push("history"),
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onAbort: () => aborts.push("called"),
+      onSubmit: () => submits.push("submit"),
+    })
+
+    await submit.abort()
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(aborts).toEqual([])
+    expect(submits).toEqual([])
+    expect(abortedSessions).toEqual([])
+    expect(promptAsyncCalls).toEqual([])
+  })
+
   test("reads the latest worktree accessor value per submit", async () => {
     const submit = createPromptSubmit({
       info: () => undefined,

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -306,6 +306,7 @@ describe("prompt submit worktree selection", () => {
       mode: () => "normal",
       working: () => true,
       actionReady: () => false,
+      abortReady: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
       promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
@@ -323,6 +324,41 @@ describe("prompt submit worktree selection", () => {
     expect(aborts).toEqual([])
     expect(submits).toEqual([])
     expect(abortedSessions).toEqual([])
+    expect(promptAsyncCalls).toEqual([])
+  })
+
+  test("allows abort while submit readiness is blocked", async () => {
+    params = { id: "session-visible" }
+    promptValue = [{ type: "text", content: "", start: 0, end: 0 }]
+    const aborts: string[] = []
+    const submits: string[] = []
+    const submit = createPromptSubmit({
+      sessionID: () => "session-visible",
+      isNewSession: () => false,
+      info: () => ({ id: "session-visible" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => true,
+      actionReady: () => false,
+      abortReady: () => true,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => submits.push("history"),
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onAbort: () => aborts.push("called"),
+      onSubmit: () => submits.push("submit"),
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(aborts).toEqual(["called"])
+    expect(abortedSessions).toEqual(["session-visible"])
+    expect(submits).toEqual([])
     expect(promptAsyncCalls).toEqual([])
   })
 

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -188,6 +188,7 @@ type PromptSubmitInput = {
   mode: Accessor<"normal" | "shell">
   working: Accessor<boolean>
   actionReady?: Accessor<boolean>
+  abortReady?: Accessor<boolean>
   editor: () => HTMLDivElement | undefined
   queueScroll: () => void
   promptLength: (prompt: Prompt) => number
@@ -227,6 +228,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const sessionID = input.sessionID ?? (() => params.id)
   const isNewSession = input.isNewSession ?? (() => !sessionID())
   const actionReady = input.actionReady ?? (() => true)
+  const abortReady = input.abortReady ?? actionReady
 
   const errorMessage = (err: unknown) => {
     if (err && typeof err === "object" && "data" in err) {
@@ -238,7 +240,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   }
 
   const abort = async () => {
-    if (!actionReady()) return Promise.resolve()
+    if (!abortReady()) return Promise.resolve()
 
     const activeSessionID = sessionID()
     if (!activeSessionID) return Promise.resolve()
@@ -301,7 +303,6 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
-    if (!actionReady()) return
 
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
@@ -319,6 +320,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       if (input.working()) abort()
       return
     }
+    if (!actionReady()) return
 
     const currentModel = local.model.current()
     const currentAgent = local.agent.current()

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -187,6 +187,7 @@ type PromptSubmitInput = {
   autoAccept: Accessor<boolean>
   mode: Accessor<"normal" | "shell">
   working: Accessor<boolean>
+  actionReady?: Accessor<boolean>
   editor: () => HTMLDivElement | undefined
   queueScroll: () => void
   promptLength: (prompt: Prompt) => number
@@ -225,6 +226,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const params = useParams()
   const sessionID = input.sessionID ?? (() => params.id)
   const isNewSession = input.isNewSession ?? (() => !sessionID())
+  const actionReady = input.actionReady ?? (() => true)
 
   const errorMessage = (err: unknown) => {
     if (err && typeof err === "object" && "data" in err) {
@@ -236,6 +238,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   }
 
   const abort = async () => {
+    if (!actionReady()) return Promise.resolve()
+
     const activeSessionID = sessionID()
     if (!activeSessionID) return Promise.resolve()
 
@@ -297,6 +301,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
+    if (!actionReady()) return
 
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -415,6 +415,27 @@ function createGlobalSync() {
     },
   }
 
+  const retainDirectory = (directory: string) => {
+    children.pin(directory)
+    let released = false
+    try {
+      const [store, setStore] = children.peek(directory, { bootstrap: false })
+      return {
+        directory,
+        store,
+        setStore,
+        release() {
+          if (released) return
+          released = true
+          children.unpin(directory)
+        },
+      }
+    } catch (err) {
+      children.unpin(directory)
+      throw err
+    }
+  }
+
   const updateConfig = async (config: Config) => {
     setGlobalStore("reload", "pending")
     return globalSDK.client.global.config
@@ -442,6 +463,7 @@ function createGlobalSync() {
     },
     child: children.child,
     peek: children.peek,
+    retainDirectory,
     bootstrap,
     updateConfig,
     project: projectApi,

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from "bun:test"
 import type { Config, Path, Project, ProviderListResponse, VcsInfo } from "@opencode-ai/sdk/v2/client"
 import { QueryClient } from "@tanstack/solid-query"
 import { createStore } from "solid-js/store"
-import { bootstrapDirectory } from "./bootstrap"
+import { activeSessionStatuses, bootstrapDirectory } from "./bootstrap"
 import { loadSessionsQuery } from "../global-sync"
 import type { State, VcsCache } from "./types"
 
@@ -57,6 +57,19 @@ async function waitFor(check: () => boolean, timeoutMs = 300) {
 }
 
 describe("bootstrapDirectory", () => {
+  test("keeps only active statuses while resetting status hydration", () => {
+    expect(
+      activeSessionStatuses({
+        idle: { type: "idle" },
+        busy: { type: "busy" },
+        retry: { type: "retry", attempt: 1, message: "retrying", next: 1 },
+      }),
+    ).toEqual({
+      busy: { type: "busy" },
+      retry: { type: "retry", attempt: 1, message: "retrying", next: 1 },
+    })
+  })
+
   test("refreshes directory providers even when sessions query cache is already populated", async () => {
     const directory = "/tmp/project"
     const queryClient = new QueryClient()
@@ -157,6 +170,8 @@ describe("bootstrapDirectory", () => {
     const directory = "/tmp/project"
     const queryClient = new QueryClient()
     const [store, setStore] = createStore(createState())
+    setStore("session_status", "ses_busy", { type: "busy" })
+    setStore("session_status", "ses_idle", { type: "idle" })
 
     const sdk = {
       app: { agents: async () => ({ data: [] }) },
@@ -199,7 +214,7 @@ describe("bootstrapDirectory", () => {
 
       expect(store.session_status_state).toBe("error")
       expect(store.session_status_ready).toBe(false)
-      expect(store.session_status).toEqual({})
+      expect(store.session_status).toEqual({ ses_busy: { type: "busy" } })
     } finally {
       console.error = originalError
     }

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -62,6 +62,7 @@ describe("bootstrapDirectory", () => {
     queryClient.setQueryData(loadSessionsQuery(directory).queryKey, null)
 
     const [store, setStore] = createStore(createState())
+    setStore("session_status", "ses_stale", { type: "idle" })
     const providers = [
       {
         all: [{ id: "dir-provider-a", name: "Dir Provider A", source: "custom", env: [], options: {}, models: {} }],
@@ -117,6 +118,7 @@ describe("bootstrapDirectory", () => {
       queryClient,
     })
 
+    expect(store.session_status).toEqual({})
     await waitFor(() => providerCalls === 1)
 
     expect(store.provider_ready).toBe(true)

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import type { Config, Path, Project, ProviderListResponse, VcsInfo } from "@opencode-ai/sdk/v2/client"
 import { QueryClient } from "@tanstack/solid-query"
 import { createStore } from "solid-js/store"
@@ -21,6 +21,7 @@ function createState(): State {
     session: [],
     sessionTotal: 0,
     session_status: {},
+    session_status_state: "loading",
     session_status_ready: false,
     session_diff: {},
     todo: {},
@@ -123,6 +124,7 @@ describe("bootstrapDirectory", () => {
 
     expect(store.provider_ready).toBe(true)
     expect(store.provider).toEqual(providers[0])
+    expect(store.session_status_state).toBe("ready")
     expect(store.session_status_ready).toBe(true)
 
     await bootstrapDirectory({
@@ -147,5 +149,59 @@ describe("bootstrapDirectory", () => {
     expect(providerCalls).toBe(2)
     expect(store.provider_ready).toBe(true)
     expect(store.provider).toEqual(providers[1])
+  })
+
+  test("marks session status as error when status hydration fails", async () => {
+    const originalError = console.error
+    console.error = mock(() => undefined) as typeof console.error
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => {
+          throw new Error("status failed")
+        },
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    try {
+      await bootstrapDirectory({
+        directory,
+        sdk,
+        store,
+        setStore,
+        vcsCache: createVcsCache(),
+        loadSessions: () => undefined,
+        translate: (key) => key,
+        global: {
+          config: {} as Config,
+          path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+          project: [] as Project[],
+          provider: { all: [], connected: [], default: {} },
+        },
+        queryClient,
+      })
+
+      await waitFor(() => store.provider_ready)
+
+      expect(store.session_status_state).toBe("error")
+      expect(store.session_status_ready).toBe(false)
+      expect(store.session_status).toEqual({})
+    } finally {
+      console.error = originalError
+    }
   })
 })

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -47,6 +47,14 @@ function createVcsCache(): VcsCache {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
 async function waitFor(check: () => boolean, timeoutMs = 300) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -218,5 +226,59 @@ describe("bootstrapDirectory", () => {
     } finally {
       console.error = originalError
     }
+  })
+
+  test("keeps active status events that arrive before the status snapshot resolves", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    const status = deferred<{ data: State["session_status"] }>()
+    let statusStarted = false
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => {
+          statusStarted = true
+          return status.promise
+        },
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => statusStarted)
+    setStore("session_status", "ses_1", { type: "busy" })
+
+    status.resolve({ data: { ses_1: { type: "idle" } } })
+    await waitFor(() => store.session_status_state === "ready")
+
+    expect(store.session_status.ses_1).toEqual({ type: "busy" })
+    expect(store.session_status_ready).toBe(true)
   })
 })

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -171,6 +171,7 @@ describe("bootstrapDirectory", () => {
 
     expect(store.session_status).toEqual({})
     await waitFor(() => providerCalls === 1)
+    await waitFor(() => store.session_status_state === "ready")
 
     expect(store.provider_ready).toBe(true)
     expect(store.provider).toEqual(providers[0])
@@ -309,5 +310,56 @@ describe("bootstrapDirectory", () => {
 
     expect(store.session_status.ses_1).toEqual({ type: "busy" })
     expect(store.session_status_ready).toBe(true)
+  })
+
+  test("refreshes providers before unrelated slow bootstrap work finishes", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    const permission = deferred<{ data: [] }>()
+    const providers = {
+      all: [{ id: "dir-provider", name: "Dir Provider", source: "custom", env: [], options: {}, models: {} }],
+      connected: ["dir-provider"],
+      default: {},
+    } satisfies ProviderListResponse
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => permission.promise },
+      question: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: providers }) },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => store.provider_ready)
+    expect(store.provider).toEqual(providers)
+
+    permission.resolve({ data: [] })
   })
 })

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -21,6 +21,7 @@ function createState(): State {
     session: [],
     sessionTotal: 0,
     session_status: {},
+    session_status_ready: false,
     session_diff: {},
     todo: {},
     permission: {},
@@ -120,6 +121,7 @@ describe("bootstrapDirectory", () => {
 
     expect(store.provider_ready).toBe(true)
     expect(store.provider).toEqual(providers[0])
+    expect(store.session_status_ready).toBe(true)
 
     await bootstrapDirectory({
       directory,

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -362,4 +362,73 @@ describe("bootstrapDirectory", () => {
 
     permission.resolve({ data: [] })
   })
+
+  test("latest provider refresh writes store when an older refresh resolves later", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    const first = deferred<{ data: ProviderListResponse }>()
+    let calls = 0
+    const oldProviders = {
+      all: [{ id: "old-provider", name: "Old Provider", source: "custom", env: [], options: {}, models: {} }],
+      connected: ["old-provider"],
+      default: {},
+    } satisfies ProviderListResponse
+    const newProviders = {
+      all: [{ id: "new-provider", name: "New Provider", source: "custom", env: [], options: {}, models: {} }],
+      connected: ["new-provider"],
+      default: {},
+    } satisfies ProviderListResponse
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: {
+        list: async () => {
+          calls += 1
+          if (calls === 1) return first.promise
+          return { data: newProviders }
+        },
+      },
+    } as any
+
+    const input = {
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key: string) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    }
+
+    await bootstrapDirectory(input)
+    await waitFor(() => calls === 1)
+    await bootstrapDirectory(input)
+    await waitFor(() => store.provider.all[0]?.id === "new-provider")
+
+    first.resolve({ data: oldProviders })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(store.provider).toEqual(newProviders)
+    expect(store.provider_ready).toBe(true)
+  })
 })

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from "bun:test"
 import type { Config, Path, Project, ProviderListResponse, VcsInfo } from "@opencode-ai/sdk/v2/client"
 import { QueryClient } from "@tanstack/solid-query"
 import { createStore } from "solid-js/store"
-import { activeSessionStatuses, bootstrapDirectory } from "./bootstrap"
+import { activeSessionStatuses, bootstrapDirectory, mergeSessionStatusSnapshot } from "./bootstrap"
 import { loadSessionsQuery } from "../global-sync"
 import type { State, VcsCache } from "./types"
 
@@ -75,6 +75,35 @@ describe("bootstrapDirectory", () => {
     ).toEqual({
       busy: { type: "busy" },
       retry: { type: "retry", attempt: 1, message: "retrying", next: 1 },
+    })
+  })
+
+  test("status snapshot clears stale active statuses from before the request", () => {
+    expect(
+      mergeSessionStatusSnapshot({
+        baseline: { ses_1: { type: "busy" } },
+        current: { ses_1: { type: "busy" } },
+        snapshot: { ses_1: { type: "idle" } },
+      }),
+    ).toEqual({ ses_1: { type: "idle" } })
+  })
+
+  test("status snapshot keeps active status events that arrive during the request", () => {
+    expect(
+      mergeSessionStatusSnapshot({
+        baseline: { stale: { type: "busy" } },
+        current: {
+          stale: { type: "busy" },
+          fresh: { type: "busy" },
+        },
+        snapshot: {
+          stale: { type: "idle" },
+          fresh: { type: "idle" },
+        },
+      }),
+    ).toEqual({
+      stale: { type: "idle" },
+      fresh: { type: "busy" },
     })
   })
 

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -166,13 +166,22 @@ export function activeSessionStatuses(input: State["session_status"]) {
   )
 }
 
+function sameSessionStatus(a: State["session_status"][string] | undefined, b: State["session_status"][string] | undefined) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
 export function mergeSessionStatusSnapshot(input: {
   current: State["session_status"]
   snapshot: State["session_status"]
+  baseline?: State["session_status"]
 }) {
+  const active = activeSessionStatuses(input.current)
+  const changedActive = Object.fromEntries(
+    Object.entries(active).filter(([sessionID, status]) => !sameSessionStatus(input.baseline?.[sessionID], status)),
+  )
   return {
     ...input.snapshot,
-    ...activeSessionStatuses(input.current),
+    ...changedActive,
   }
 }
 
@@ -234,13 +243,14 @@ export async function bootstrapDirectory(input: {
   if (loading || input.store.provider.all.length === 0) {
     input.setStore("provider_ready", false)
   }
+  const statusBaseline = activeSessionStatuses(input.store.session_status)
   input.setStore("mcp_ready", false)
   input.setStore("mcp", {})
   input.setStore("lsp_ready", false)
   input.setStore("lsp", [])
   input.setStore("session_status_state", "loading")
   input.setStore("session_status_ready", false)
-  input.setStore("session_status", reconcile(activeSessionStatuses(input.store.session_status)))
+  input.setStore("session_status", reconcile(statusBaseline))
   if (loading) input.setStore("status", "partial")
 
   const fast = [() => Promise.resolve(input.loadSessions(input.directory))]
@@ -276,6 +286,7 @@ export async function bootstrapDirectory(input: {
                 mergeSessionStatusSnapshot({
                   current: input.store.session_status,
                   snapshot: x.data!,
+                  baseline: statusBaseline,
                 }),
               ),
             )

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -223,6 +223,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("lsp_ready", false)
   input.setStore("lsp", [])
   input.setStore("session_status_ready", false)
+  input.setStore("session_status", reconcile({}))
   if (loading) input.setStore("status", "partial")
 
   const fast = [() => Promise.resolve(input.loadSessions(input.directory))]

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -222,6 +222,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("mcp", {})
   input.setStore("lsp_ready", false)
   input.setStore("lsp", [])
+  input.setStore("session_status_state", "loading")
   input.setStore("session_status_ready", false)
   input.setStore("session_status", reconcile({}))
   if (loading) input.setStore("status", "partial")
@@ -254,9 +255,14 @@ export async function bootstrapDirectory(input: {
         retry(() =>
           input.sdk.session.status().then((x) => {
             input.setStore("session_status", x.data!)
+            input.setStore("session_status_state", "ready")
             input.setStore("session_status_ready", true)
           }),
-        ),
+        ).catch((err) => {
+          input.setStore("session_status_state", "error")
+          input.setStore("session_status_ready", false)
+          throw err
+        }),
       () =>
         seededProject
           ? Promise.resolve()

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -222,6 +222,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("mcp", {})
   input.setStore("lsp_ready", false)
   input.setStore("lsp", [])
+  input.setStore("session_status_ready", false)
   if (loading) input.setStore("status", "partial")
 
   const fast = [() => Promise.resolve(input.loadSessions(input.directory))]
@@ -248,7 +249,13 @@ export async function bootstrapDirectory(input: {
             ),
         }),
       () => retry(() => input.sdk.config.get().then((x) => input.setStore("config", x.data!))),
-      () => retry(() => input.sdk.session.status().then((x) => input.setStore("session_status", x.data!))),
+      () =>
+        retry(() =>
+          input.sdk.session.status().then((x) => {
+            input.setStore("session_status", x.data!)
+            input.setStore("session_status_ready", true)
+          }),
+        ),
       () =>
         seededProject
           ? Promise.resolve()

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -267,6 +267,33 @@ export async function bootstrapDirectory(input: {
   }
 
   ;(async () => {
+    const refreshProviders = () => {
+      const rev = (providerRev.get(input.directory) ?? 0) + 1
+      providerRev.set(input.directory, rev)
+      return input.queryClient.fetchQuery({
+        ...loadProvidersQuery(input.directory),
+        queryFn: () =>
+          retry(() => input.sdk.provider.list())
+            .then((x) => {
+              if (providerRev.get(input.directory) !== rev) return
+              input.setStore("provider", normalizeProviderList(x.data!))
+              input.setStore("provider_ready", true)
+            })
+            .catch((err) => {
+              if (providerRev.get(input.directory) === rev) console.error("Failed to refresh provider list", err)
+              const project = getFilename(input.directory)
+              showToast({
+                variant: "error",
+                title: input.translate("toast.project.reloadFailed.title", { project }),
+                description: formatServerError(err, input.translate),
+              })
+            })
+            .then(() => null),
+      })
+    }
+
+    void refreshProviders()
+
     const slow = [
       () =>
         input.queryClient.ensureQueryData({
@@ -397,27 +424,5 @@ export async function bootstrapDirectory(input: {
 
     if (loading && errs.length === 0 && slowErrs.length === 0) input.setStore("status", "complete")
 
-    const rev = (providerRev.get(input.directory) ?? 0) + 1
-    providerRev.set(input.directory, rev)
-    void input.queryClient.fetchQuery({
-      ...loadProvidersQuery(input.directory),
-      queryFn: () =>
-        retry(() => input.sdk.provider.list())
-          .then((x) => {
-            if (providerRev.get(input.directory) !== rev) return
-            input.setStore("provider", normalizeProviderList(x.data!))
-            input.setStore("provider_ready", true)
-          })
-          .catch((err) => {
-            if (providerRev.get(input.directory) !== rev) console.error("Failed to refresh provider list", err)
-            const project = getFilename(input.directory)
-            showToast({
-              variant: "error",
-              title: input.translate("toast.project.reloadFailed.title", { project }),
-              description: formatServerError(err, input.translate),
-            })
-          })
-          .then(() => null),
-    })
   })()
 }

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -166,6 +166,16 @@ export function activeSessionStatuses(input: State["session_status"]) {
   )
 }
 
+export function mergeSessionStatusSnapshot(input: {
+  current: State["session_status"]
+  snapshot: State["session_status"]
+}) {
+  return {
+    ...input.snapshot,
+    ...activeSessionStatuses(input.current),
+  }
+}
+
 function warmSessions(input: {
   ids: string[]
   store: Store<State>
@@ -260,7 +270,15 @@ export async function bootstrapDirectory(input: {
       () =>
         retry(() =>
           input.sdk.session.status().then((x) => {
-            input.setStore("session_status", x.data!)
+            input.setStore(
+              "session_status",
+              reconcile(
+                mergeSessionStatusSnapshot({
+                  current: input.store.session_status,
+                  snapshot: x.data!,
+                }),
+              ),
+            )
             input.setStore("session_status_state", "ready")
             input.setStore("session_status_ready", true)
           }),

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -160,6 +160,12 @@ function mergeSession(setStore: SetStoreFunction<State>, session: Session) {
   })
 }
 
+export function activeSessionStatuses(input: State["session_status"]) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, status]) => status?.type === "busy" || status?.type === "retry"),
+  )
+}
+
 function warmSessions(input: {
   ids: string[]
   store: Store<State>
@@ -224,7 +230,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("lsp", [])
   input.setStore("session_status_state", "loading")
   input.setStore("session_status_ready", false)
-  input.setStore("session_status", reconcile({}))
+  input.setStore("session_status", reconcile(activeSessionStatuses(input.store.session_status)))
   if (loading) input.setStore("status", "partial")
 
   const fast = [() => Promise.resolve(input.loadSessions(input.directory))]

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -270,26 +270,23 @@ export async function bootstrapDirectory(input: {
     const refreshProviders = () => {
       const rev = (providerRev.get(input.directory) ?? 0) + 1
       providerRev.set(input.directory, rev)
-      return input.queryClient.fetchQuery({
-        ...loadProvidersQuery(input.directory),
-        queryFn: () =>
-          retry(() => input.sdk.provider.list())
-            .then((x) => {
-              if (providerRev.get(input.directory) !== rev) return
-              input.setStore("provider", normalizeProviderList(x.data!))
-              input.setStore("provider_ready", true)
-            })
-            .catch((err) => {
-              if (providerRev.get(input.directory) === rev) console.error("Failed to refresh provider list", err)
-              const project = getFilename(input.directory)
-              showToast({
-                variant: "error",
-                title: input.translate("toast.project.reloadFailed.title", { project }),
-                description: formatServerError(err, input.translate),
-              })
-            })
-            .then(() => null),
-      })
+      return retry(() => input.sdk.provider.list())
+        .then((x) => {
+          if (providerRev.get(input.directory) !== rev) return
+          input.queryClient.setQueryData(loadProvidersQuery(input.directory).queryKey, null)
+          input.setStore("provider", normalizeProviderList(x.data!))
+          input.setStore("provider_ready", true)
+        })
+        .catch((err) => {
+          if (providerRev.get(input.directory) !== rev) return
+          console.error("Failed to refresh provider list", err)
+          const project = getFilename(input.directory)
+          showToast({
+            variant: "error",
+            title: input.translate("toast.project.reloadFailed.title", { project }),
+            description: formatServerError(err, input.translate),
+          })
+        })
     }
 
     void refreshProviders()

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createRoot, getOwner } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { State } from "./types"
+import { MAX_DIR_STORES } from "./types"
 import { createChildStoreManager } from "./child-store"
 import { ChildStoreError, type ChildStorePersistedFactory } from "./child-store-error"
 
@@ -43,6 +44,26 @@ describe("createChildStoreManager", () => {
     manager.mark(directory)
 
     expect(manager.children[directory]).toBeDefined()
+  })
+
+  test("unpinned child access can evict old directories beyond the store limit", () => {
+    const manager = createManager((_target, store) => [
+      store[0],
+      store[1],
+      null,
+      Object.assign(() => true, { promise: undefined }),
+    ])
+
+    createRoot((dispose) => {
+      Array.from({ length: MAX_DIR_STORES + 1 }, (_, index) => `/tmp/project-${index}`).forEach((directory) => {
+        manager.child(directory, { bootstrap: false, pin: false })
+      })
+      dispose()
+    })
+
+    expect(Object.keys(manager.children)).toHaveLength(MAX_DIR_STORES)
+    expect(manager.children["/tmp/project-0"]).toBeUndefined()
+    expect(manager.children[`/tmp/project-${MAX_DIR_STORES}`]).toBeDefined()
   })
 
   test("rejects invalid runtime directories before persisted cache setup", () => {

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -185,6 +185,7 @@ export function createChildStoreManager(input: {
             session: [],
             sessionTotal: 0,
             session_status: {},
+            session_status_state: "loading",
             session_status_ready: false,
             session_diff: {},
             todo: {},

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -238,7 +238,7 @@ export function createChildStoreManager(input: {
 
   function child(directory: string, options: ChildOptions = {}) {
     const childStore = ensureChild(directory)
-    pinForOwner(directory)
+    if (options.pin !== false) pinForOwner(directory)
     const shouldBootstrap = options.bootstrap ?? true
     if (shouldBootstrap && childStore[0].status === "loading") {
       input.onBootstrap(directory)

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -185,6 +185,7 @@ export function createChildStoreManager(input: {
             session: [],
             sessionTotal: 0,
             session_status: {},
+            session_status_ready: false,
             session_diff: {},
             todo: {},
             permission: {},

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -72,6 +72,7 @@ const baseState = (input: Partial<State> = {}) =>
     session: [],
     sessionTotal: 0,
     session_status: {},
+    session_status_ready: true,
     session_diff: {},
     todo: {},
     permission: {},

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -72,6 +72,7 @@ const baseState = (input: Partial<State> = {}) =>
     session: [],
     sessionTotal: 0,
     session_status: {},
+    session_status_state: "ready",
     session_status_ready: true,
     session_diff: {},
     todo: {},

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -46,6 +46,7 @@ export type State = {
   session_status: {
     [sessionID: string]: SessionStatus
   }
+  session_status_ready: boolean
   session_diff: {
     [sessionID: string]: SnapshotFileDiff[]
   }

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -98,6 +98,7 @@ export type IconCache = {
 
 export type ChildOptions = {
   bootstrap?: boolean
+  pin?: boolean
 }
 
 export type DirState = {

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -30,6 +30,8 @@ export type ProjectMeta = {
   }
 }
 
+export type SessionStatusState = "loading" | "ready" | "error"
+
 export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
@@ -46,6 +48,7 @@ export type State = {
   session_status: {
     [sessionID: string]: SessionStatus
   }
+  session_status_state: SessionStatusState
   session_status_ready: boolean
   session_diff: {
     [sessionID: string]: SnapshotFileDiff[]

--- a/packages/app/src/context/local.test.ts
+++ b/packages/app/src/context/local.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { pruneLocalSavedStores, shouldRestoreLocalSessionModel } from "./local"
+
+const entry = (id: string, lastAccessAt: number, disposed: string[]) => ({
+  lastAccessAt,
+  dispose: () => disposed.push(id),
+})
+
+describe("shouldRestoreLocalSessionModel", () => {
+  test("restores only for the current session when no directory-local choice exists", () => {
+    expect(
+      shouldRestoreLocalSessionModel({
+        currentSessionID: "ses",
+        messageSessionID: "ses",
+        saved: undefined,
+        hasHandoff: false,
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps an existing directory-local session choice authoritative", () => {
+    expect(
+      shouldRestoreLocalSessionModel({
+        currentSessionID: "ses",
+        messageSessionID: "ses",
+        saved: { agent: "local" },
+        hasHandoff: false,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("pruneLocalSavedStores", () => {
+  test("evicts least-recent stores without clearing the current directory", () => {
+    const disposed: string[] = []
+    const stores = new Map([
+      ["oldest", entry("oldest", 1, disposed)],
+      ["current", entry("current", 2, disposed)],
+      ["newer", entry("newer", 3, disposed)],
+    ])
+
+    pruneLocalSavedStores(stores, "current", 2)
+
+    expect([...stores.keys()]).toEqual(["current", "newer"])
+    expect(disposed).toEqual(["oldest"])
+  })
+})

--- a/packages/app/src/context/local.test.ts
+++ b/packages/app/src/context/local.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, test } from "bun:test"
-import { pruneLocalSavedStores, shouldRestoreLocalSessionModel } from "./local"
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import type {
+  localSavedStoreKey as LocalSavedStoreKey,
+  pruneLocalSavedStores as PruneLocalSavedStores,
+  shouldRestoreLocalSessionModel as ShouldRestoreLocalSessionModel,
+} from "./local"
+
+let localSavedStoreKey: typeof LocalSavedStoreKey
+let pruneLocalSavedStores: typeof PruneLocalSavedStores
+let shouldRestoreLocalSessionModel: typeof ShouldRestoreLocalSessionModel
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useNavigate: () => () => undefined,
+    useParams: () => ({}),
+  }))
+
+  const mod = await import("./local")
+  localSavedStoreKey = mod.localSavedStoreKey
+  pruneLocalSavedStores = mod.pruneLocalSavedStores
+  shouldRestoreLocalSessionModel = mod.shouldRestoreLocalSessionModel
+})
 
 const entry = (id: string, lastAccessAt: number, disposed: string[]) => ({
   lastAccessAt,
@@ -13,9 +33,22 @@ describe("shouldRestoreLocalSessionModel", () => {
         currentSessionID: "ses",
         messageSessionID: "ses",
         saved: undefined,
+        savedReady: true,
         hasHandoff: false,
       }),
     ).toBe(true)
+  })
+
+  test("does not restore before the directory-local persisted store is ready", () => {
+    expect(
+      shouldRestoreLocalSessionModel({
+        currentSessionID: "ses",
+        messageSessionID: "ses",
+        saved: undefined,
+        savedReady: false,
+        hasHandoff: false,
+      }),
+    ).toBe(false)
   })
 
   test("keeps an existing directory-local session choice authoritative", () => {
@@ -24,9 +57,18 @@ describe("shouldRestoreLocalSessionModel", () => {
         currentSessionID: "ses",
         messageSessionID: "ses",
         saved: { agent: "local" },
+        savedReady: true,
         hasHandoff: false,
       }),
     ).toBe(false)
+  })
+})
+
+describe("localSavedStoreKey", () => {
+  test("does not create a persisted fallback bucket for an unknown directory", () => {
+    expect(localSavedStoreKey("")).toBeUndefined()
+    expect(localSavedStoreKey(undefined)).toBeUndefined()
+    expect(localSavedStoreKey("/repo")).toBe("/repo")
   })
 })
 

--- a/packages/app/src/context/local.test.ts
+++ b/packages/app/src/context/local.test.ts
@@ -1,11 +1,13 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test"
 import type {
   localSavedStoreKey as LocalSavedStoreKey,
+  localPersistReadyForAction as LocalPersistReadyForAction,
   pruneLocalSavedStores as PruneLocalSavedStores,
   shouldRestoreLocalSessionModel as ShouldRestoreLocalSessionModel,
 } from "./local"
 
 let localSavedStoreKey: typeof LocalSavedStoreKey
+let localPersistReadyForAction: typeof LocalPersistReadyForAction
 let pruneLocalSavedStores: typeof PruneLocalSavedStores
 let shouldRestoreLocalSessionModel: typeof ShouldRestoreLocalSessionModel
 
@@ -17,6 +19,7 @@ beforeAll(async () => {
 
   const mod = await import("./local")
   localSavedStoreKey = mod.localSavedStoreKey
+  localPersistReadyForAction = mod.localPersistReadyForAction
   pruneLocalSavedStores = mod.pruneLocalSavedStores
   shouldRestoreLocalSessionModel = mod.shouldRestoreLocalSessionModel
 })
@@ -61,6 +64,15 @@ describe("shouldRestoreLocalSessionModel", () => {
         hasHandoff: false,
       }),
     ).toBe(false)
+  })
+})
+
+describe("localPersistReadyForAction", () => {
+  test("allows manual actions after persisted init fails or times out", () => {
+    expect(localPersistReadyForAction({ ready: false, failed: false, timedOut: false })).toBe(false)
+    expect(localPersistReadyForAction({ ready: true, failed: false, timedOut: false })).toBe(true)
+    expect(localPersistReadyForAction({ ready: false, failed: true, timedOut: false })).toBe(true)
+    expect(localPersistReadyForAction({ ready: false, failed: false, timedOut: true })).toBe(true)
   })
 })
 

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -238,12 +238,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const key = handoffKey(sdk.directory, session)
       const next = handoff.get(key)
       if (!next) return
-      if (saved().session[session] !== undefined) {
+      const savedEntry = savedFor(sdk.directory)
+      if (!savedEntry?.readyForAction()) return
+      if (savedEntry.store.session[session] !== undefined) {
         handoff.delete(key)
         return
       }
 
-      setSavedSession(session, clone(next))
+      savedEntry.setStore("session", session, clone(next))
       handoff.delete(key)
     })
 
@@ -491,7 +493,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               currentSessionID: session,
               messageSessionID: msg.sessionID,
               saved: savedEntry?.store.session[session],
-              savedReady: savedEntry?.ready() ?? false,
+              savedReady: savedEntry?.readyForAction() ?? false,
               hasHandoff: handoff.has(handoffKey(sdk.directory, session)),
             })
           ) {

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -437,6 +437,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       model,
       agent,
       session: {
+        ready() {
+          return savedFor(sdk.directory)?.ready() ?? false
+        },
         reset() {
           setStore("draft", undefined)
         },

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -24,6 +24,7 @@ type Saved = {
 }
 
 const WORKSPACE_KEY = "__workspace__"
+const MAX_SAVED_STORES = 8
 const handoff = new Map<string, State>()
 
 const handoffKey = (dir: string, id: string) => `${dir}\n${id}`
@@ -56,6 +57,7 @@ type SavedEntry = {
   store: Store<Saved>
   setStore: SetStoreFunction<Saved>
   dispose: () => void
+  lastAccessAt: number
 }
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
@@ -84,18 +86,36 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             session: {},
           }),
         )
-        return { store, setStore, dispose } satisfies SavedEntry
+        return { store, setStore, dispose, lastAccessAt: Date.now() } satisfies SavedEntry
       })
+
+    const pruneSavedStores = (keep: string) => {
+      if (savedStores.size <= MAX_SAVED_STORES) return
+
+      const stale = [...savedStores.entries()]
+        .filter(([key]) => key !== keep)
+        .sort((left, right) => left[1].lastAccessAt - right[1].lastAccessAt)
+
+      for (const [key, entry] of stale) {
+        if (savedStores.size <= MAX_SAVED_STORES) return
+        entry.dispose()
+        savedStores.delete(key)
+      }
+    }
 
     const savedFor = (directory: string) => {
       const key = directory || "__unknown__"
       const cached = savedStores.get(key)
-      if (cached) return cached
+      if (cached) {
+        cached.lastAccessAt = Date.now()
+        return cached
+      }
 
       const entry = owner
         ? (runWithOwner(owner, () => createSavedEntry(key)) ?? createSavedEntry(key))
         : createSavedEntry(key)
       savedStores.set(key, entry)
+      pruneSavedStores(key)
       return entry
     }
 

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -1,7 +1,7 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useParams } from "@solidjs/router"
-import { batch, createEffect, createMemo, createRoot, getOwner, onCleanup, runWithOwner } from "solid-js"
+import { batch, createEffect, createMemo, createRoot, createSignal, getOwner, onCleanup, runWithOwner } from "solid-js"
 import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
 import { useModels } from "@/context/models"
 import { useProviders } from "@/hooks/use-providers"
@@ -25,6 +25,7 @@ type Saved = {
 
 const WORKSPACE_KEY = "__workspace__"
 export const LOCAL_SAVED_STORE_LIMIT = 8
+export const LOCAL_SAVED_READY_FALLBACK_MS = 5000
 const handoff = new Map<string, State>()
 
 const handoffKey = (dir: string, id: string) => `${dir}\n${id}`
@@ -57,8 +58,13 @@ type SavedEntry = {
   store: Store<Saved>
   setStore: SetStoreFunction<Saved>
   ready: () => boolean
+  readyForAction: () => boolean
   dispose: () => void
   lastAccessAt: number
+}
+
+export function localPersistReadyForAction(input: { ready: boolean; failed: boolean; timedOut: boolean }) {
+  return input.ready || input.failed || input.timedOut
 }
 
 export function pruneLocalSavedStores<T extends { dispose: () => void; lastAccessAt: number }>(
@@ -124,7 +130,27 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             session: {},
           }),
         )
-        return { store, setStore, ready, dispose, lastAccessAt: Date.now() } satisfies SavedEntry
+        const [failed, setFailed] = createSignal(false)
+        const [timedOut, setTimedOut] = createSignal(false)
+        const timer = ready.promise ? setTimeout(() => setTimedOut(true), LOCAL_SAVED_READY_FALLBACK_MS) : undefined
+        if (ready.promise) {
+          void ready.promise
+            .catch(() => setFailed(true))
+            .finally(() => {
+              if (timer !== undefined) clearTimeout(timer)
+            })
+        }
+        return {
+          store,
+          setStore,
+          ready,
+          readyForAction: () => localPersistReadyForAction({ ready: ready(), failed: failed(), timedOut: timedOut() }),
+          dispose() {
+            if (timer !== undefined) clearTimeout(timer)
+            dispose()
+          },
+          lastAccessAt: Date.now(),
+        } satisfies SavedEntry
       })
 
     const savedFor = (directory: string) => {
@@ -438,7 +464,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       agent,
       session: {
         ready() {
-          return savedFor(sdk.directory)?.ready() ?? false
+          return savedFor(sdk.directory)?.readyForAction() ?? false
         },
         reset() {
           setStore("draft", undefined)

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -56,6 +56,7 @@ const clone = (value: State | undefined) => {
 type SavedEntry = {
   store: Store<Saved>
   setStore: SetStoreFunction<Saved>
+  ready: () => boolean
   dispose: () => void
   lastAccessAt: number
 }
@@ -82,13 +83,19 @@ export function shouldRestoreLocalSessionModel(input: {
   currentSessionID: string | undefined
   messageSessionID: string
   saved: unknown
+  savedReady: boolean
   hasHandoff: boolean
 }) {
   if (!input.currentSessionID) return false
   if (input.messageSessionID !== input.currentSessionID) return false
+  if (!input.savedReady) return false
   if (input.saved !== undefined) return false
   if (input.hasHandoff) return false
   return true
+}
+
+export function localSavedStoreKey(directory: string | undefined) {
+  return directory || undefined
 }
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
@@ -108,7 +115,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const createSavedEntry = (directory: string) =>
       createRoot((dispose) => {
-        const [store, setStore] = persisted(
+        const [store, setStore, , ready] = persisted(
           {
             ...Persist.workspace(directory, "model-selection", ["model-selection.v1"]),
             migrate,
@@ -117,11 +124,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             session: {},
           }),
         )
-        return { store, setStore, dispose, lastAccessAt: Date.now() } satisfies SavedEntry
+        return { store, setStore, ready, dispose, lastAccessAt: Date.now() } satisfies SavedEntry
       })
 
     const savedFor = (directory: string) => {
-      const key = directory || "__unknown__"
+      const key = localSavedStoreKey(directory)
+      if (!key) return
       const cached = savedStores.get(key)
       if (cached) {
         cached.lastAccessAt = Date.now()
@@ -141,9 +149,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       savedStores.clear()
     })
 
-    const saved = createMemo<Store<Saved>>(() => savedFor(sdk.directory).store)
+    const emptySaved = { session: {} } satisfies Saved
+    const saved = createMemo<Store<Saved>>(() => savedFor(sdk.directory)?.store ?? emptySaved)
     const setSavedSession = (session: string, value: State | undefined) => {
-      savedFor(sdk.directory).setStore("session", session, value)
+      savedFor(sdk.directory)?.setStore("session", session, value)
     }
 
     const [store, setStore] = createStore<{
@@ -446,12 +455,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         restore(msg: { sessionID: string; agent: string; model: ModelKey }) {
           const session = id()
+          const savedEntry = savedFor(sdk.directory)
           if (!session) return
           if (
             !shouldRestoreLocalSessionModel({
               currentSessionID: session,
               messageSessionID: msg.sessionID,
-              saved: saved().session[session],
+              saved: savedEntry?.store.session[session],
+              savedReady: savedEntry?.ready() ?? false,
               hasHandoff: handoff.has(handoffKey(sdk.directory, session)),
             })
           ) {

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -24,7 +24,7 @@ type Saved = {
 }
 
 const WORKSPACE_KEY = "__workspace__"
-const MAX_SAVED_STORES = 8
+export const LOCAL_SAVED_STORE_LIMIT = 8
 const handoff = new Map<string, State>()
 
 const handoffKey = (dir: string, id: string) => `${dir}\n${id}`
@@ -60,6 +60,37 @@ type SavedEntry = {
   lastAccessAt: number
 }
 
+export function pruneLocalSavedStores<T extends { dispose: () => void; lastAccessAt: number }>(
+  savedStores: Map<string, T>,
+  keep: string,
+  max = LOCAL_SAVED_STORE_LIMIT,
+) {
+  if (savedStores.size <= max) return
+
+  const stale = [...savedStores.entries()]
+    .filter(([key]) => key !== keep)
+    .sort((left, right) => left[1].lastAccessAt - right[1].lastAccessAt)
+
+  for (const [key, entry] of stale) {
+    if (savedStores.size <= max) return
+    entry.dispose()
+    savedStores.delete(key)
+  }
+}
+
+export function shouldRestoreLocalSessionModel(input: {
+  currentSessionID: string | undefined
+  messageSessionID: string
+  saved: unknown
+  hasHandoff: boolean
+}) {
+  if (!input.currentSessionID) return false
+  if (input.messageSessionID !== input.currentSessionID) return false
+  if (input.saved !== undefined) return false
+  if (input.hasHandoff) return false
+  return true
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -89,20 +120,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         return { store, setStore, dispose, lastAccessAt: Date.now() } satisfies SavedEntry
       })
 
-    const pruneSavedStores = (keep: string) => {
-      if (savedStores.size <= MAX_SAVED_STORES) return
-
-      const stale = [...savedStores.entries()]
-        .filter(([key]) => key !== keep)
-        .sort((left, right) => left[1].lastAccessAt - right[1].lastAccessAt)
-
-      for (const [key, entry] of stale) {
-        if (savedStores.size <= MAX_SAVED_STORES) return
-        entry.dispose()
-        savedStores.delete(key)
-      }
-    }
-
     const savedFor = (directory: string) => {
       const key = directory || "__unknown__"
       const cached = savedStores.get(key)
@@ -115,7 +132,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         ? (runWithOwner(owner, () => createSavedEntry(key)) ?? createSavedEntry(key))
         : createSavedEntry(key)
       savedStores.set(key, entry)
-      pruneSavedStores(key)
+      pruneLocalSavedStores(savedStores, key)
       return entry
     }
 
@@ -430,9 +447,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         restore(msg: { sessionID: string; agent: string; model: ModelKey }) {
           const session = id()
           if (!session) return
-          if (msg.sessionID !== session) return
-          if (saved().session[session] !== undefined) return
-          if (handoff.has(handoffKey(sdk.directory, session))) return
+          if (
+            !shouldRestoreLocalSessionModel({
+              currentSessionID: session,
+              messageSessionID: msg.sessionID,
+              saved: saved().session[session],
+              hasHandoff: handoff.has(handoffKey(sdk.directory, session)),
+            })
+          ) {
+            return
+          }
 
           setSavedSession(session, {
             agent: msg.agent,

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -1,8 +1,8 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useParams } from "@solidjs/router"
-import { batch, createEffect, createMemo, onCleanup } from "solid-js"
-import { createStore } from "solid-js/store"
+import { batch, createEffect, createMemo, createRoot, getOwner, onCleanup, runWithOwner } from "solid-js"
+import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
 import { useModels } from "@/context/models"
 import { useProviders } from "@/hooks/use-providers"
 import { modelEnabled, modelProbe } from "@/testing/model-selection"
@@ -52,6 +52,12 @@ const clone = (value: State | undefined) => {
   } satisfies State
 }
 
+type SavedEntry = {
+  store: Store<Saved>
+  setStore: SetStoreFunction<Saved>
+  dispose: () => void
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -60,20 +66,48 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const providers = useProviders()
     const models = useModels()
+    const owner = getOwner()
+    const savedStores = new Map<string, SavedEntry>()
 
     const id = createMemo(() => params.id || undefined)
     const list = createMemo(() => sync.data.agent.filter((item) => item.mode !== "subagent" && !item.hidden))
     const connected = createMemo(() => new Set(providers.connected().map((item) => item.id)))
 
-    const [saved, setSaved] = persisted(
-      {
-        ...Persist.workspace(sdk.directory, "model-selection", ["model-selection.v1"]),
-        migrate,
-      },
-      createStore<Saved>({
-        session: {},
-      }),
-    )
+    const createSavedEntry = (directory: string) =>
+      createRoot((dispose) => {
+        const [store, setStore] = persisted(
+          {
+            ...Persist.workspace(directory, "model-selection", ["model-selection.v1"]),
+            migrate,
+          },
+          createStore<Saved>({
+            session: {},
+          }),
+        )
+        return { store, setStore, dispose } satisfies SavedEntry
+      })
+
+    const savedFor = (directory: string) => {
+      const key = directory || "__unknown__"
+      const cached = savedStores.get(key)
+      if (cached) return cached
+
+      const entry = owner
+        ? (runWithOwner(owner, () => createSavedEntry(key)) ?? createSavedEntry(key))
+        : createSavedEntry(key)
+      savedStores.set(key, entry)
+      return entry
+    }
+
+    onCleanup(() => {
+      for (const entry of savedStores.values()) entry.dispose()
+      savedStores.clear()
+    })
+
+    const saved = createMemo<Store<Saved>>(() => savedFor(sdk.directory).store)
+    const setSavedSession = (session: string, value: State | undefined) => {
+      savedFor(sdk.directory).setStore("session", session, value)
+    }
 
     const [store, setStore] = createStore<{
       current?: string
@@ -122,7 +156,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const scope = createMemo<State | undefined>(() => {
       const session = id()
       if (!session) return store.draft
-      return saved.session[session] ?? handoff.get(handoffKey(sdk.directory, session))
+      return saved().session[session] ?? handoff.get(handoffKey(sdk.directory, session))
     })
 
     createEffect(() => {
@@ -132,12 +166,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const key = handoffKey(sdk.directory, session)
       const next = handoff.get(key)
       if (!next) return
-      if (saved.session[session] !== undefined) {
+      if (saved().session[session] !== undefined) {
         handoff.delete(key)
         return
       }
 
-      setSaved("session", session, clone(next))
+      setSavedSession(session, clone(next))
       handoff.delete(key)
     })
 
@@ -200,7 +234,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           } satisfies State
           const session = id()
           if (session) {
-            setSaved("session", session, next)
+            setSavedSession(session, next)
             return
           }
           setStore("draft", next)
@@ -261,7 +295,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const session = id()
       if (session) {
-        setSaved("session", session, state)
+        setSavedSession(session, state)
         return
       }
       setStore("draft", state)
@@ -365,7 +399,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!next) return
 
           if (dir === sdk.directory) {
-            setSaved("session", session, next)
+            setSavedSession(session, next)
             setStore("draft", undefined)
             return
           }
@@ -377,10 +411,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const session = id()
           if (!session) return
           if (msg.sessionID !== session) return
-          if (saved.session[session] !== undefined) return
+          if (saved().session[session] !== undefined) return
           if (handoff.has(handoffKey(sdk.directory, session))) return
 
-          setSaved("session", session, {
+          setSavedSession(session, {
             agent: msg.agent,
             model: msg.model,
             variant: msg.model.variant ?? null,

--- a/packages/app/src/context/renderer-diagnostics.test.ts
+++ b/packages/app/src/context/renderer-diagnostics.test.ts
@@ -180,4 +180,30 @@ describe("renderer diagnostics", () => {
       }),
     ])
   })
+
+  test("does not flag an exit-worktree-like same-session refresh without remount, clear, or top jump", () => {
+    const detect = createRendererIncidentDetector()
+
+    expect(detect({ name: "session.timeline.mount", timeline_session_id: "session-1", data: {} })).toEqual([])
+    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } })).toEqual(
+      [],
+    )
+    expect(
+      detect({
+        name: "session.scroll.sample",
+        timeline_session_id: "session-1",
+        data: { scroll_top: 20451, distance_from_bottom: 0, client_height: 720, user_scrolled: false },
+      }),
+    ).toEqual([])
+    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } })).toEqual(
+      [],
+    )
+    expect(
+      detect({
+        name: "session.scroll.sample",
+        timeline_session_id: "session-1",
+        data: { scroll_top: 20440, distance_from_bottom: 12, client_height: 720, user_scrolled: false },
+      }),
+    ).toEqual([])
+  })
 })

--- a/packages/app/src/context/sync-current-child.test.ts
+++ b/packages/app/src/context/sync-current-child.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, getOwner } from "solid-js"
-import { createCurrentSyncChild } from "./sync"
+import { createCurrentSyncChild, syncChildOptionsForTarget } from "./sync"
 
 describe("createCurrentSyncChild", () => {
   test("keeps sync child lookup usable after the provider owner is disposed", () => {
@@ -84,5 +84,16 @@ describe("createCurrentSyncChild", () => {
     expect(calls).toEqual(["/tmp/project-a", "/tmp/project-b"])
 
     current.dispose()
+  })
+})
+
+describe("syncChildOptionsForTarget", () => {
+  test("uses unpinned non-bootstrapping access for non-current directory writes", () => {
+    expect(syncChildOptionsForTarget({ currentDirectory: "/repo", targetDirectory: "/repo" })).toBeUndefined()
+    expect(syncChildOptionsForTarget({ currentDirectory: "/repo", targetDirectory: undefined })).toBeUndefined()
+    expect(syncChildOptionsForTarget({ currentDirectory: "/repo", targetDirectory: "/repo-worktree" })).toEqual({
+      bootstrap: false,
+      pin: false,
+    })
   })
 })

--- a/packages/app/src/context/sync-current-child.test.ts
+++ b/packages/app/src/context/sync-current-child.test.ts
@@ -62,4 +62,27 @@ describe("createCurrentSyncChild", () => {
     expect(value[0].directory).toBe("/tmp/project")
     expect(calls).toEqual(["/tmp/project"])
   })
+
+  test("tracks directory changes while the provider owner stays mounted", () => {
+    let directory = "/tmp/project-a"
+    const calls: string[] = []
+
+    const current = createRoot((dispose) => {
+      const accessor = createCurrentSyncChild({
+        directory: () => directory,
+        child: (next) => {
+          calls.push(next)
+          return [{ directory: next }, () => {}] as const
+        },
+      })
+      return { accessor, dispose }
+    })
+
+    expect(current.accessor()[0].directory).toBe("/tmp/project-a")
+    directory = "/tmp/project-b"
+    expect(current.accessor()[0].directory).toBe("/tmp/project-b")
+    expect(calls).toEqual(["/tmp/project-a", "/tmp/project-b"])
+
+    current.dispose()
+  })
 })

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -1,4 +1,4 @@
-import { batch, createMemo } from "solid-js"
+import { batch, createEffect, createMemo, onCleanup } from "solid-js"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { Binary } from "@opencode-ai/util/binary"
 import { retry } from "@opencode-ai/util/retry"
@@ -191,9 +191,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     type Child = ReturnType<(typeof globalSync)["child"]>
     type Setter = Child[1]
 
+    createEffect(() => {
+      const directory = sdk.directory
+      if (!directory) return
+      const retained = globalSync.retainDirectory(directory)
+      onCleanup(() => retained.release())
+    })
+
     const current = createCurrentSyncChild({
       directory: () => sdk.directory,
-      child: globalSync.child,
+      child: (directory) => globalSync.child(directory, { pin: false }),
     })
     const target = (directory?: string) => {
       if (!directory || directory === sdk.directory) return current()

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -78,6 +78,11 @@ export function createCurrentSyncChild<Child>(input: { directory: () => string |
   }
 }
 
+export function syncChildOptionsForTarget(input: { currentDirectory: string | undefined; targetDirectory?: string }) {
+  if (!input.targetDirectory || input.targetDirectory === input.currentDirectory) return
+  return { bootstrap: false, pin: false } as const
+}
+
 type MessagePage = {
   session: Message[]
   part: { id: string; part: Part[] }[]
@@ -203,8 +208,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       child: (directory) => globalSync.child(directory, { pin: false }),
     })
     const target = (directory?: string) => {
-      if (!directory || directory === sdk.directory) return current()
-      return globalSync.child(directory)
+      const options = syncChildOptionsForTarget({ currentDirectory: sdk.directory, targetDirectory: directory })
+      if (!options || !directory) return current()
+      return globalSync.child(directory, options)
     }
     const retainTarget = (directory?: string) => {
       const targetDirectory = directory || sdk.directory

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -214,6 +214,18 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     }
     const retainTarget = (directory?: string) => {
       const targetDirectory = directory || sdk.directory
+      if (!targetDirectory) {
+        return {
+          directory: "",
+          get store() {
+            return current()[0]
+          },
+          get setStore() {
+            return current()[1]
+          },
+          release() {},
+        }
+      }
       return globalSync.retainDirectory(targetDirectory)
     }
     const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -397,6 +397,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       setFor(directory?: string): Setter {
         return target(directory)[1]
       },
+      storeFor(directory?: string): Child[0] {
+        return target(directory)[0]
+      },
       get status() {
         return current()[0].status
       },

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -199,6 +199,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       if (!directory || directory === sdk.directory) return current()
       return globalSync.child(directory)
     }
+    const retainTarget = (directory?: string) => {
+      const targetDirectory = directory || sdk.directory
+      return globalSync.retainDirectory(targetDirectory)
+    }
     const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
     const initialMessagePageSize = 80
     const historyMessagePageSize = 200
@@ -399,6 +403,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       },
       storeFor(directory?: string): Child[0] {
         return target(directory)[0]
+      },
+      retainDirectory(directory?: string) {
+        return retainTarget(directory)
       },
       get status() {
         return current()[0].status

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -394,6 +394,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       get set(): Setter {
         return current()[1]
       },
+      setFor(directory?: string): Setter {
+        return target(directory)[1]
+      },
       get status() {
         return current()[0].status
       },

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -2,23 +2,23 @@ import { DataProvider } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
-import { createEffect, createMemo, type ParentProps, Show } from "solid-js"
+import { createEffect, createMemo, type Accessor, type ParentProps, Show } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
 import { decode64 } from "@/utils/base64"
 
-function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
+function DirectoryDataProvider(props: ParentProps<{ directory: Accessor<string> }>) {
   const location = useLocation()
   const navigate = useNavigate()
   const params = useParams()
   const sync = useSync()
-  const slug = createMemo(() => base64Encode(props.directory))
+  const slug = createMemo(() => base64Encode(props.directory()))
 
   createEffect(() => {
     const next = sync.data.path.directory
-    if (!next || next === props.directory) return
+    if (!next || next === props.directory()) return
     const path = location.pathname.slice(slug().length + 1)
     navigate(`/${base64Encode(next)}${path}${location.search}${location.hash}`, { replace: true })
   })
@@ -32,7 +32,7 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   return (
     <DataProvider
       data={sync.data}
-      directory={props.directory}
+      directory={props.directory()}
       onNavigateToSession={(sessionID: string) => navigate(`/${slug()}/session/${sessionID}`)}
       onSessionHref={(sessionID: string) => `/${slug()}/session/${sessionID}`}
     >
@@ -70,11 +70,11 @@ export default function Layout(props: ParentProps) {
   })
 
   return (
-    <Show when={resolved()} keyed>
-      {(resolved) => (
-        <SDKProvider directory={() => resolved}>
+    <Show when={resolved()}>
+      {(directory) => (
+        <SDKProvider directory={directory}>
           <SyncProvider>
-            <DirectoryDataProvider directory={resolved}>
+            <DirectoryDataProvider directory={directory}>
               {props.children}
             </DirectoryDataProvider>
           </SyncProvider>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -71,15 +71,13 @@ export default function Layout(props: ParentProps) {
 
   return (
     <Show when={resolved()}>
-      {(directory) => (
-        <SDKProvider directory={directory}>
-          <SyncProvider>
-            <DirectoryDataProvider directory={directory}>
-              {props.children}
-            </DirectoryDataProvider>
-          </SyncProvider>
-        </SDKProvider>
-      )}
+      <SDKProvider directory={resolved}>
+        <SyncProvider>
+          <DirectoryDataProvider directory={resolved}>
+            {props.children}
+          </DirectoryDataProvider>
+        </SyncProvider>
+      </SDKProvider>
     </Show>
   )
 }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -538,7 +538,7 @@ export default function Page() {
     <SessionPageComposerRegion
       variant={variant}
       state={composer}
-      ready={!deferRender() && (variant === "home" ? workspaceSubmitReady() : sessionActionReady())}
+      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : sessionActionReady())}
       actionReady={variant === "home" ? workspaceSubmitReady() : submitReady()}
       abortReady={variant === "home" ? true : sessionActionReady()}
       displaySessionID={variant === "session" ? timelineSessionID() : undefined}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -115,6 +115,7 @@ export default function Page() {
   const timelineSessionKey = timeline.sessionKey
   const sessionActionReady = timeline.sessionActionReady
   const submitReady = timeline.actionReady
+  const workspaceSubmitReady = timeline.workspaceSubmitReady
   const timelineIsChildSession = timeline.isChildSession
   const haltAbort = (sessionID: string) =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
@@ -537,8 +538,8 @@ export default function Page() {
     <SessionPageComposerRegion
       variant={variant}
       state={composer}
-      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : sessionActionReady())}
-      actionReady={variant === "home" ? true : submitReady()}
+      ready={!deferRender() && (variant === "home" ? workspaceSubmitReady() : sessionActionReady())}
+      actionReady={variant === "home" ? workspaceSubmitReady() : submitReady()}
       abortReady={variant === "home" ? true : sessionActionReady()}
       displaySessionID={variant === "session" ? timelineSessionID() : undefined}
       displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -119,9 +119,12 @@ export default function Page() {
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
       ? sdk.client.session.abort({ sessionID })
       : Promise.resolve()
-  const haltWithClient = (client: typeof sdk.client, sessionID: string) =>
-    isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? client.session.abort({ sessionID })
+  const haltWithSnapshot = (
+    snapshot: ReturnType<typeof sync.retainDirectory> & { client: typeof sdk.client },
+    sessionID: string,
+  ) =>
+    isSessionRunning(snapshot.store.session_status[sessionID], snapshot.store.message[sessionID])
+      ? snapshot.client.session.abort({ sessionID })
       : Promise.resolve()
   // sessionRevert chains halt with .then(), so its existing outer .catch
   // already handles abort failures. The auto-heal clock wants to see the
@@ -490,15 +493,17 @@ export default function Page() {
     sync,
     snapshot: () => {
       const directory = sdk.directory
+      const handle = sync.retainDirectory(directory)
       return {
         client: sdk.createClient({ directory, throwOnError: true }),
-        store: sync.storeFor(directory),
-        setStore: sync.setFor(directory),
+        store: handle.store,
+        setStore: handle.setStore,
+        release: handle.release,
         directory,
       }
     },
     actionReady,
-    halt: haltWithClient,
+    halt: haltWithSnapshot,
     draft: draftFrom,
     fail,
     merge,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -498,6 +498,11 @@ export default function Page() {
         client: sdk.createClient({ directory, throwOnError: true }),
         store: handle.store,
         setStore: handle.setStore,
+        prompt: prompt.current().slice(),
+        promptScope: {
+          dir: params.dir ?? directory,
+          id: timelineSessionID(),
+        },
         release: handle.release,
         directory,
       }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -113,6 +113,7 @@ export default function Page() {
   const activeFileTab = tabState.activeFileTab
   const timelineSessionID = timeline.sessionID
   const timelineSessionKey = timeline.sessionKey
+  const actionReady = timeline.actionReady
   const timelineIsChildSession = timeline.isChildSession
   const haltAbort = (sessionID: string) =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
@@ -444,12 +445,13 @@ export default function Page() {
       return id ? sync.data.message[id] : undefined
     },
   )
-  const busy = () => timelineRunning()
+  const busy = () => !actionReady() || timelineRunning()
 
   const followups = createSessionFollowups({
     directory: () => sdk.directory,
     client: () => sdk.client,
     sessionID: timelineSessionID,
+    actionReady,
     isChildSession: timelineIsChildSession,
     busy,
     blocked: composer.blocked,
@@ -469,6 +471,7 @@ export default function Page() {
     prompt,
     sync,
     client: () => sdk.client,
+    actionReady,
     halt,
     draft,
     fail,
@@ -497,7 +500,7 @@ export default function Page() {
     <SessionPageComposerRegion
       variant={variant}
       state={composer}
-      ready={!deferRender() && timelineMessagesReady()}
+      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : actionReady())}
       displaySessionID={variant === "session" ? timelineSessionID() : undefined}
       displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}
       centered={centered()}
@@ -514,7 +517,7 @@ export default function Page() {
       onModeChange={ctx?.onModeChange}
       selectedSkill={ctx?.selectedSkill}
       followup={
-        variant === "session" && timelineSessionID() && !timelineIsChildSession()
+        variant === "session" && timelineSessionID() && actionReady() && !timelineIsChildSession()
           ? {
               queue: followups.queueEnabled,
               items: followups.followupDock(),
@@ -541,7 +544,7 @@ export default function Page() {
           ? {
               items: sessionRevert.rolled(),
               restoring: sessionRevert.restoring(),
-              disabled: sessionRevert.reverting(),
+              disabled: sessionRevert.reverting() || !actionReady(),
               onRestore: sessionRevert.restore,
             }
           : undefined

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -113,7 +113,8 @@ export default function Page() {
   const activeFileTab = tabState.activeFileTab
   const timelineSessionID = timeline.sessionID
   const timelineSessionKey = timeline.sessionKey
-  const actionReady = timeline.actionReady
+  const sessionActionReady = timeline.sessionActionReady
+  const submitReady = timeline.actionReady
   const timelineIsChildSession = timeline.isChildSession
   const haltAbort = (sessionID: string) =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
@@ -171,7 +172,7 @@ export default function Page() {
           visibleSessionID,
           routeReady: timeline.routeMessagesReady(),
           visibleReady: timelineMessagesReady(),
-          actionReady: actionReady(),
+          actionReady: submitReady(),
           messageCachePresent: timeline.messageCachePresent(),
           sessionInfoPresent: timeline.sessionInfoPresent(),
           statusKnown: timeline.statusKnown(),
@@ -466,13 +467,13 @@ export default function Page() {
       return id ? sync.data.message[id] : undefined
     },
   )
-  const busy = () => !actionReady() || timelineRunning()
+  const busy = () => !sessionActionReady() || timelineRunning()
 
   const followups = createSessionFollowups({
     directory: () => sdk.directory,
     client: () => sdk.client,
     sessionID: timelineSessionID,
-    actionReady,
+    actionReady: submitReady,
     isChildSession: timelineIsChildSession,
     busy,
     blocked: composer.blocked,
@@ -507,7 +508,7 @@ export default function Page() {
         directory,
       }
     },
-    actionReady,
+    actionReady: sessionActionReady,
     halt: haltWithSnapshot,
     draft: draftFrom,
     fail,
@@ -536,8 +537,9 @@ export default function Page() {
     <SessionPageComposerRegion
       variant={variant}
       state={composer}
-      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : actionReady())}
-      actionReady={variant === "home" ? true : actionReady()}
+      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : sessionActionReady())}
+      actionReady={variant === "home" ? true : submitReady()}
+      abortReady={variant === "home" ? true : sessionActionReady()}
       displaySessionID={variant === "session" ? timelineSessionID() : undefined}
       displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}
       centered={centered()}
@@ -554,7 +556,7 @@ export default function Page() {
       onModeChange={ctx?.onModeChange}
       selectedSkill={ctx?.selectedSkill}
       followup={
-        variant === "session" && timelineSessionID() && actionReady() && !timelineIsChildSession()
+        variant === "session" && timelineSessionID() && submitReady() && !timelineIsChildSession()
           ? {
               queue: followups.queueEnabled,
               items: followups.followupDock(),
@@ -581,7 +583,7 @@ export default function Page() {
           ? {
               items: sessionRevert.rolled(),
               restoring: sessionRevert.restoring(),
-              disabled: sessionRevert.reverting() || !actionReady(),
+              disabled: sessionRevert.reverting() || !sessionActionReady(),
               onRestore: sessionRevert.restore,
             }
           : undefined

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -357,7 +357,7 @@ export default function Page() {
 
   const timelineInteraction = createSessionTimelineInteraction({
     routeSessionID: () => params.id,
-    sessionKey,
+    sessionKey: timelineSessionKey,
     sessionID: timelineSessionID,
     messagesReady: timelineMessagesReady,
     loadedMessages: () => timelineMessages().length,
@@ -570,7 +570,7 @@ export default function Page() {
       setMobileTab={setMobileTab}
       language={language}
       routeSessionID={params.id}
-      routeReady={timeline.routeMessagesReady()}
+      routeReady={timelineMessagesReady()}
       transitioning={timeline.transitioning()}
       timelineSessionID={timelineSessionID()}
       timelineSessionKey={timelineSessionKey()}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -281,7 +281,7 @@ export default function Page() {
       : mobileChanges(),
   )
   const reviewState = createSessionReviewState({
-    directory: sdk.directory,
+    directory: () => sdk.directory,
     sessionKey,
     sessionID: timelineSessionID,
     sync,
@@ -447,8 +447,8 @@ export default function Page() {
   const busy = () => timelineRunning()
 
   const followups = createSessionFollowups({
-    directory: sdk.directory,
-    client: sdk.client,
+    directory: () => sdk.directory,
+    client: () => sdk.client,
     sessionID: timelineSessionID,
     isChildSession: timelineIsChildSession,
     busy,
@@ -468,7 +468,7 @@ export default function Page() {
     lineText: line,
     prompt,
     sync,
-    client: sdk.client,
+    client: () => sdk.client,
     halt,
     draft,
     fail,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -119,6 +119,10 @@ export default function Page() {
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
       ? sdk.client.session.abort({ sessionID })
       : Promise.resolve()
+  const haltWithClient = (client: typeof sdk.client, sessionID: string) =>
+    isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
+      ? client.session.abort({ sessionID })
+      : Promise.resolve()
   // sessionRevert chains halt with .then(), so its existing outer .catch
   // already handles abort failures. The auto-heal clock wants to see the
   // error so it can structured-warn — pass haltAbort directly there.
@@ -164,6 +168,10 @@ export default function Page() {
           visibleSessionID,
           routeReady: timeline.routeMessagesReady(),
           visibleReady: timelineMessagesReady(),
+          actionReady: actionReady(),
+          messageCachePresent: timeline.messageCachePresent(),
+          sessionInfoPresent: timeline.sessionInfoPresent(),
+          statusKnown: timeline.statusKnown(),
           transitioning: !!routeSessionID && !!visibleSessionID && routeSessionID !== visibleSessionID,
           messageCount: metrics.messageCount,
           partCount: metrics.partCount,
@@ -183,6 +191,10 @@ export default function Page() {
             timeline_session_id: state.visibleSessionID,
             route_ready: state.routeReady,
             visible_ready: state.visibleReady,
+            action_ready: state.actionReady,
+            message_cache_present: state.messageCachePresent,
+            session_info_present: state.sessionInfoPresent,
+            status_known: state.statusKnown,
             transitioning: state.transitioning,
             message_count: state.messageCount,
             part_count: state.partCount,
@@ -417,8 +429,9 @@ export default function Page() {
     })
   }
 
-  const merge = (next: NonNullable<ReturnType<typeof timeline.routeInfo>>) =>
-    sync.set("session", (list) => {
+  type SyncSetter = typeof sync.set
+  const merge = (setStore: SyncSetter, next: NonNullable<ReturnType<typeof timeline.routeInfo>>) =>
+    setStore("session", (list) => {
       const idx = list.findIndex((item) => item.id === next.id)
       if (idx < 0) return list
       const out = list.slice()
@@ -426,8 +439,12 @@ export default function Page() {
       return out
     })
 
-  const roll = (sessionID: string, next: NonNullable<ReturnType<typeof timeline.routeInfo>>["revert"]) =>
-    sync.set("session", (list) => {
+  const roll = (
+    setStore: SyncSetter,
+    sessionID: string,
+    next: NonNullable<ReturnType<typeof timeline.routeInfo>>["revert"],
+  ) =>
+    setStore("session", (list) => {
       const idx = list.findIndex((item) => item.id === sessionID)
       if (idx < 0) return list
       const out = list.slice()
@@ -470,9 +487,15 @@ export default function Page() {
     lineText: line,
     prompt,
     sync,
-    client: () => sdk.client,
+    snapshot: () => {
+      const directory = sdk.directory
+      return {
+        client: sdk.createClient({ directory, throwOnError: true }),
+        setStore: sync.setFor(directory),
+      }
+    },
     actionReady,
-    halt,
+    halt: haltWithClient,
     draft,
     fail,
     merge,
@@ -501,6 +524,7 @@ export default function Page() {
       variant={variant}
       state={composer}
       ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : actionReady())}
+      actionReady={variant === "home" ? true : actionReady()}
       displaySessionID={variant === "session" ? timelineSessionID() : undefined}
       displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}
       centered={centered()}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -405,14 +405,15 @@ export default function Page() {
     review: reviewTab,
   })
 
-  const draft = (id: string) =>
-    extractPromptFromParts(sync.data.part[id] ?? [], {
-      directory: sdk.directory,
+  type SyncStore = typeof sync.data
+  const draftFrom = (source: { directory: string; store: SyncStore }, id: string) =>
+    extractPromptFromParts(source.store.part[id] ?? [], {
+      directory: source.directory,
       attachmentName: language.t("common.attachment"),
     })
 
   const line = (id: string) => {
-    const text = draft(id)
+    const text = draftFrom({ directory: sdk.directory, store: sync.data }, id)
       .map((part) => (part.type === "image" ? `[image:${part.filename}]` : part.content))
       .join("")
       .replace(/\s+/g, " ")
@@ -491,12 +492,14 @@ export default function Page() {
       const directory = sdk.directory
       return {
         client: sdk.createClient({ directory, throwOnError: true }),
+        store: sync.storeFor(directory),
         setStore: sync.setFor(directory),
+        directory,
       }
     },
     actionReady,
     halt: haltWithClient,
-    draft,
+    draft: draftFrom,
     fail,
     merge,
     roll,

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -23,6 +23,7 @@ export function SessionComposerRegion(props: {
   state: SessionComposerState
   ready: boolean
   actionReady?: boolean
+  abortReady?: boolean
   centered: boolean
   inputRef: (el: HTMLDivElement) => void
   newSessionWorktree: string
@@ -292,6 +293,7 @@ export function SessionComposerRegion(props: {
                       onSubmit={props.onSubmit}
                       onModeChange={props.onModeChange}
                       actionReady={() => props.actionReady ?? true}
+                      abortReady={() => props.abortReady ?? props.actionReady ?? true}
                       selectedSkill={props.selectedSkill}
                     />
                   </Show>

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -22,6 +22,7 @@ export function SessionComposerRegion(props: {
   variant?: "session" | "home"
   state: SessionComposerState
   ready: boolean
+  actionReady?: boolean
   centered: boolean
   inputRef: (el: HTMLDivElement) => void
   newSessionWorktree: string
@@ -290,6 +291,7 @@ export function SessionComposerRegion(props: {
                       onAbort={props.followup?.onAbort}
                       onSubmit={props.onSubmit}
                       onModeChange={props.onModeChange}
+                      actionReady={() => props.actionReady ?? true}
                       selectedSkill={props.selectedSkill}
                     />
                   </Show>

--- a/packages/app/src/pages/session/session-composer-region.tsx
+++ b/packages/app/src/pages/session/session-composer-region.tsx
@@ -9,6 +9,7 @@ export function SessionPageComposerRegion(props: {
   state: ReturnType<typeof createSessionComposerState>
   ready: boolean
   actionReady?: boolean
+  abortReady?: boolean
   displaySessionID?: string
   displaySessionKey?: string
   centered: boolean

--- a/packages/app/src/pages/session/session-composer-region.tsx
+++ b/packages/app/src/pages/session/session-composer-region.tsx
@@ -8,6 +8,7 @@ export function SessionPageComposerRegion(props: {
   variant: "session" | "home"
   state: ReturnType<typeof createSessionComposerState>
   ready: boolean
+  actionReady?: boolean
   displaySessionID?: string
   displaySessionKey?: string
   centered: boolean

--- a/packages/app/src/pages/session/session-main-view.test.ts
+++ b/packages/app/src/pages/session/session-main-view.test.ts
@@ -32,6 +32,17 @@ describe("shouldShowSessionOpeningState", () => {
     ).toBe(false)
   })
 
+  test("does not replace an already-ready same-session timeline during a transient cache miss", () => {
+    expect(
+      shouldShowSessionOpeningState({
+        activeSessionID: "ses_target",
+        routeSessionID: "ses_target",
+        routeReady: true,
+        timelineSessionID: "ses_target",
+      }),
+    ).toBe(false)
+  })
+
   test("does not show loading for a mismatched timeline identity", () => {
     expect(
       shouldShowSessionOpeningState({

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -131,9 +131,7 @@ export function SessionMainView(props: {
               </Match>
               <Match
                 when={
-                  props.activeSessionID && props.timelineSessionID && props.timelineMessagesReady
-                    ? props.timelineSessionID
-                    : undefined
+                  props.activeSessionID && props.timelineSessionID ? props.timelineSessionID : undefined
                 }
               >
                 <MessageTimeline

--- a/packages/app/src/pages/session/session-model-helpers.test.ts
+++ b/packages/app/src/pages/session/session-model-helpers.test.ts
@@ -19,6 +19,9 @@ describe("syncSessionModel", () => {
     syncSessionModel(
       {
         session: {
+          ready() {
+            return true
+          },
           restore(value) {
             calls.push(value)
           },
@@ -40,6 +43,9 @@ describe("resetSessionModel", () => {
 
     resetSessionModel({
       session: {
+        ready() {
+          return true
+        },
         reset() {
           calls.push("reset")
         },

--- a/packages/app/src/pages/session/session-model-helpers.ts
+++ b/packages/app/src/pages/session/session-model-helpers.ts
@@ -2,6 +2,7 @@ import type { UserMessage } from "@opencode-ai/sdk/v2"
 
 type Local = {
   session: {
+    ready(): boolean
     reset(): void
     restore(msg: UserMessage): void
   }

--- a/packages/app/src/pages/session/session-view-controller.test.ts
+++ b/packages/app/src/pages/session/session-view-controller.test.ts
@@ -12,10 +12,10 @@ describe("createSessionViewController", () => {
       })
 
       expect(controller.route.id()).toBe("ses_source")
-      expect(controller.route.key()).toBe("repo/ses_source")
+      expect(controller.route.key()).toBe("ses_source")
       expect(controller.route.ready()).toBe(true)
       expect(controller.visible.id()).toBe("ses_source")
-      expect(controller.visible.key()).toBe("repo/ses_source")
+      expect(controller.visible.key()).toBe("ses_source")
       expect(controller.visible.ready()).toBe(true)
       expect(controller.transitioning()).toBe(false)
 
@@ -32,10 +32,10 @@ describe("createSessionViewController", () => {
       })
 
       expect(controller.route.id()).toBe("ses_target")
-      expect(controller.route.key()).toBe("repo/ses_target")
+      expect(controller.route.key()).toBe("ses_target")
       expect(controller.route.ready()).toBe(false)
       expect(controller.visible.id()).toBe("ses_target")
-      expect(controller.visible.key()).toBe("repo/ses_target")
+      expect(controller.visible.key()).toBe("ses_target")
       expect(controller.visible.ready()).toBe(false)
       expect(controller.transitioning()).toBe(true)
 
@@ -57,8 +57,8 @@ describe("nextSessionViewState", () => {
       routeReady: false,
       visibleSessionID: "ses_target",
       transitioning: true,
-      routeSessionKey: "repo/ses_target",
-      visibleSessionKey: "repo/ses_target",
+      routeSessionKey: "ses_target",
+      visibleSessionKey: "ses_target",
     })
 
     const ready = nextSessionViewState({
@@ -72,8 +72,8 @@ describe("nextSessionViewState", () => {
       routeReady: true,
       visibleSessionID: "ses_target",
       transitioning: false,
-      routeSessionKey: "repo/ses_target",
-      visibleSessionKey: "repo/ses_target",
+      routeSessionKey: "ses_target",
+      visibleSessionKey: "ses_target",
     })
   })
 
@@ -85,9 +85,9 @@ describe("nextSessionViewState", () => {
     })
 
     expect(next.routeSessionID).toBeUndefined()
-    expect(next.routeSessionKey).toBe("repo")
+    expect(next.routeSessionKey).toBe("")
     expect(next.visibleSessionID).toBeUndefined()
-    expect(next.visibleSessionKey).toBe("repo")
+    expect(next.visibleSessionKey).toBe("")
     expect(next.routeReady).toBe(true)
     expect(next.transitioning).toBe(false)
   })
@@ -104,8 +104,48 @@ describe("nextSessionViewState", () => {
       routeReady: false,
       visibleSessionID: "ses_target",
       transitioning: true,
-      routeSessionKey: "repo-b/ses_target",
-      visibleSessionKey: "repo-b/ses_target",
+      routeSessionKey: "ses_target",
+      visibleSessionKey: "ses_target",
     })
+  })
+
+  test("keeps the same timeline identity and ready state across a transient directory cache miss", () => {
+    const ready = nextSessionViewState({
+      directory: "repo-worktree",
+      routeSessionID: "ses_target",
+      routeMessagesReady: true,
+    })
+
+    const next = nextSessionViewState({
+      directory: "repo-root",
+      routeSessionID: "ses_target",
+      routeMessagesReady: false,
+      previous: ready,
+    })
+
+    expect(next.routeSessionKey).toBe("ses_target")
+    expect(next.visibleSessionKey).toBe("ses_target")
+    expect(next.routeReady).toBe(true)
+    expect(next.transitioning).toBe(false)
+  })
+
+  test("does not keep ready state when switching to another session", () => {
+    const ready = nextSessionViewState({
+      directory: "repo",
+      routeSessionID: "ses_source",
+      routeMessagesReady: true,
+    })
+
+    const next = nextSessionViewState({
+      directory: "repo",
+      routeSessionID: "ses_target",
+      routeMessagesReady: false,
+      previous: ready,
+    })
+
+    expect(next.routeSessionID).toBe("ses_target")
+    expect(next.visibleSessionID).toBe("ses_target")
+    expect(next.routeReady).toBe(false)
+    expect(next.transitioning).toBe(true)
   })
 })

--- a/packages/app/src/pages/session/session-view-controller.test.ts
+++ b/packages/app/src/pages/session/session-view-controller.test.ts
@@ -6,7 +6,6 @@ describe("createSessionViewController", () => {
   test("exposes route and visible session state through separate accessors", () => {
     createRoot((dispose) => {
       const controller = createSessionViewController({
-        directory: () => "repo",
         routeSessionID: () => "ses_source",
         routeMessagesReady: () => true,
       })
@@ -26,7 +25,6 @@ describe("createSessionViewController", () => {
   test("keeps route and visible identity aligned while the route session is not ready", () => {
     createRoot((dispose) => {
       const controller = createSessionViewController({
-        directory: () => "repo",
         routeSessionID: () => "ses_target",
         routeMessagesReady: () => false,
       })
@@ -47,7 +45,6 @@ describe("createSessionViewController", () => {
 describe("nextSessionViewState", () => {
   test("does not keep the previous visible session while the route session loads", () => {
     const loading = nextSessionViewState({
-      directory: "repo",
       routeSessionID: "ses_target",
       routeMessagesReady: false,
     })
@@ -62,7 +59,6 @@ describe("nextSessionViewState", () => {
     })
 
     const ready = nextSessionViewState({
-      directory: "repo",
       routeSessionID: "ses_target",
       routeMessagesReady: true,
     })
@@ -79,7 +75,6 @@ describe("nextSessionViewState", () => {
 
   test("clears visible session when leaving a concrete session route", () => {
     const next = nextSessionViewState({
-      directory: "repo",
       routeSessionID: undefined,
       routeMessagesReady: true,
     })
@@ -92,9 +87,8 @@ describe("nextSessionViewState", () => {
     expect(next.transitioning).toBe(false)
   })
 
-  test("uses the target route identity when changing directories", () => {
+  test("uses session identity without a directory input", () => {
     const next = nextSessionViewState({
-      directory: "repo-b",
       routeSessionID: "ses_target",
       routeMessagesReady: false,
     })
@@ -111,13 +105,11 @@ describe("nextSessionViewState", () => {
 
   test("keeps the same timeline identity and ready state across a transient directory cache miss", () => {
     const ready = nextSessionViewState({
-      directory: "repo-worktree",
       routeSessionID: "ses_target",
       routeMessagesReady: true,
     })
 
     const next = nextSessionViewState({
-      directory: "repo-root",
       routeSessionID: "ses_target",
       routeMessagesReady: false,
       previous: ready,
@@ -131,13 +123,11 @@ describe("nextSessionViewState", () => {
 
   test("does not keep ready state when switching to another session", () => {
     const ready = nextSessionViewState({
-      directory: "repo",
       routeSessionID: "ses_source",
       routeMessagesReady: true,
     })
 
     const next = nextSessionViewState({
-      directory: "repo",
       routeSessionID: "ses_target",
       routeMessagesReady: false,
       previous: ready,

--- a/packages/app/src/pages/session/session-view-controller.test.ts
+++ b/packages/app/src/pages/session/session-view-controller.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
-import { createSessionViewController, nextSessionViewState } from "./session-view-controller"
+import { createSessionViewController, nextSessionViewState, timelineIdentity } from "./session-view-controller"
+
+describe("timelineIdentity", () => {
+  test("uses stable session identity without directory input", () => {
+    expect(timelineIdentity({ sessionID: "ses_target" })).toBe("ses_target")
+    expect(timelineIdentity({ sessionID: undefined })).toBe("")
+  })
+})
 
 describe("createSessionViewController", () => {
   test("exposes route and visible session state through separate accessors", () => {

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -4,6 +4,16 @@ export type SessionViewStateInput = {
   directory: string
   routeSessionID: string | undefined
   routeMessagesReady: boolean
+  previous?: SessionViewState
+}
+
+export type SessionViewState = {
+  routeSessionID: string | undefined
+  routeReady: boolean
+  visibleSessionID: string | undefined
+  transitioning: boolean
+  routeSessionKey: string
+  visibleSessionKey: string
 }
 
 export type SessionViewControllerInput = {
@@ -12,12 +22,17 @@ export type SessionViewControllerInput = {
   routeMessagesReady: Accessor<boolean>
 }
 
-export function sessionKey(input: { directory: string; sessionID: string | undefined }) {
-  return `${input.directory}${input.sessionID ? `/${input.sessionID}` : ""}`
+export function sessionKey(input: { sessionID: string | undefined }) {
+  return input.sessionID ?? ""
 }
 
 export function nextSessionViewState(input: SessionViewStateInput) {
-  const routeReady = !input.routeSessionID || input.routeMessagesReady
+  const sameSession =
+    input.previous?.routeSessionID === input.routeSessionID &&
+    input.previous?.visibleSessionID === input.routeSessionID &&
+    !!input.routeSessionID
+  const keepReady = sameSession && !!input.previous?.routeReady && !input.routeMessagesReady
+  const routeReady = !input.routeSessionID || input.routeMessagesReady || keepReady
   const visibleSessionID = input.routeSessionID
 
   return {
@@ -25,13 +40,13 @@ export function nextSessionViewState(input: SessionViewStateInput) {
     routeReady,
     visibleSessionID,
     transitioning: !routeReady,
-    routeSessionKey: sessionKey({ directory: input.directory, sessionID: input.routeSessionID }),
-    visibleSessionKey: sessionKey({ directory: input.directory, sessionID: visibleSessionID }),
+    routeSessionKey: sessionKey({ sessionID: input.routeSessionID }),
+    visibleSessionKey: sessionKey({ sessionID: visibleSessionID }),
   }
 }
 
 export function createSessionViewController(input: SessionViewControllerInput) {
-  type State = ReturnType<typeof nextSessionViewState> & { directory: string }
+  type State = SessionViewState & { directory: string }
   const state = createMemo((current: State | undefined): State => {
     const directory = input.directory()
     return {
@@ -39,6 +54,7 @@ export function createSessionViewController(input: SessionViewControllerInput) {
         directory,
         routeSessionID: input.routeSessionID(),
         routeMessagesReady: input.routeMessagesReady(),
+        previous: current,
       }),
       directory,
     }

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -1,7 +1,6 @@
 import { createMemo, type Accessor } from "solid-js"
 
 export type SessionViewStateInput = {
-  directory: string
   routeSessionID: string | undefined
   routeMessagesReady: boolean
   previous?: SessionViewState
@@ -17,12 +16,12 @@ export type SessionViewState = {
 }
 
 export type SessionViewControllerInput = {
-  directory: Accessor<string>
   routeSessionID: Accessor<string | undefined>
   routeMessagesReady: Accessor<boolean>
 }
 
 export function sessionKey(input: { sessionID: string | undefined }) {
+  // Timeline identity follows the stable session only; execution directory is mutable.
   return input.sessionID ?? ""
 }
 
@@ -31,6 +30,7 @@ export function nextSessionViewState(input: SessionViewStateInput) {
     input.previous?.routeSessionID === input.routeSessionID &&
     input.previous?.visibleSessionID === input.routeSessionID &&
     !!input.routeSessionID
+  // A same-session directory cache miss is a loading state, not a timeline identity change.
   const keepReady = sameSession && !!input.previous?.routeReady && !input.routeMessagesReady
   const routeReady = !input.routeSessionID || input.routeMessagesReady || keepReady
   const visibleSessionID = input.routeSessionID
@@ -46,18 +46,12 @@ export function nextSessionViewState(input: SessionViewStateInput) {
 }
 
 export function createSessionViewController(input: SessionViewControllerInput) {
-  type State = SessionViewState & { directory: string }
-  const state = createMemo((current: State | undefined): State => {
-    const directory = input.directory()
-    return {
-      ...nextSessionViewState({
-        directory,
-        routeSessionID: input.routeSessionID(),
-        routeMessagesReady: input.routeMessagesReady(),
-        previous: current,
-      }),
-      directory,
-    }
+  const state = createMemo((current: SessionViewState | undefined): SessionViewState => {
+    return nextSessionViewState({
+      routeSessionID: input.routeSessionID(),
+      routeMessagesReady: input.routeMessagesReady(),
+      previous: current,
+    })
   })
 
   const visibleReady = () => state().routeReady

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -1,5 +1,7 @@
 import { createMemo, type Accessor } from "solid-js"
 
+export type TimelineIdentity = string
+
 export type SessionViewStateInput = {
   routeSessionID: string | undefined
   routeMessagesReady: boolean
@@ -11,8 +13,8 @@ export type SessionViewState = {
   routeReady: boolean
   visibleSessionID: string | undefined
   transitioning: boolean
-  routeSessionKey: string
-  visibleSessionKey: string
+  routeSessionKey: TimelineIdentity
+  visibleSessionKey: TimelineIdentity
 }
 
 export type SessionViewControllerInput = {
@@ -20,10 +22,12 @@ export type SessionViewControllerInput = {
   routeMessagesReady: Accessor<boolean>
 }
 
-export function sessionKey(input: { sessionID: string | undefined }) {
+export function timelineIdentity(input: { sessionID: string | undefined }): TimelineIdentity {
   // Timeline identity follows the stable session only; execution directory is mutable.
   return input.sessionID ?? ""
 }
+
+export const sessionKey = timelineIdentity
 
 export function nextSessionViewState(input: SessionViewStateInput) {
   const sameSession =
@@ -40,8 +44,8 @@ export function nextSessionViewState(input: SessionViewStateInput) {
     routeReady,
     visibleSessionID,
     transitioning: !routeReady,
-    routeSessionKey: sessionKey({ sessionID: input.routeSessionID }),
-    visibleSessionKey: sessionKey({ sessionID: visibleSessionID }),
+    routeSessionKey: timelineIdentity({ sessionID: input.routeSessionID }),
+    visibleSessionKey: timelineIdentity({ sessionID: visibleSessionID }),
   }
 }
 

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -1,9 +1,14 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
-import type { followupPreviewText as PreviewText, shouldAutoSendFollowup as ShouldAutoSend } from "./use-session-followups"
+import type {
+  followupDraftForDirectory as DraftForDirectory,
+  followupPreviewText as PreviewText,
+  shouldAutoSendFollowup as ShouldAutoSend,
+} from "./use-session-followups"
 
 let followupPreviewText: typeof PreviewText
 let shouldAutoSendFollowup: typeof ShouldAutoSend
+let followupDraftForDirectory: typeof DraftForDirectory
 
 const draft = (input: Pick<FollowupDraft, "prompt" | "context">): FollowupDraft => ({
   sessionID: "ses_1",
@@ -30,6 +35,7 @@ beforeAll(async () => {
   const mod = await import("./use-session-followups")
   followupPreviewText = mod.followupPreviewText
   shouldAutoSendFollowup = mod.shouldAutoSendFollowup
+  followupDraftForDirectory = mod.followupDraftForDirectory
 })
 
 describe("session followups", () => {
@@ -101,5 +107,24 @@ describe("session followups", () => {
 
     const afterHalt = { ...recovering, busy: false }
     expect(shouldAutoSendFollowup(afterHalt)).toBe(true)
+  })
+
+  test("rebases a queued followup to the current execution directory before send", () => {
+    const item = {
+      id: "msg_1",
+      ...draft({
+        prompt: [{ type: "text", content: "continue", start: 0, end: 8 }],
+        context: [],
+      }),
+    }
+
+    const next = followupDraftForDirectory(item, "/repo")
+    expect(next).toBe(item)
+
+    const rebased = followupDraftForDirectory(item, "/repo-root")
+    expect(rebased).not.toBe(item)
+    expect(rebased.sessionDirectory).toBe("/repo-root")
+    expect(rebased.sessionID).toBe(item.sessionID)
+    expect(rebased.prompt).toBe(item.prompt)
   })
 })

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -130,11 +130,25 @@ describe("session followups", () => {
   })
 
   test("rebases a queued followup to the current execution directory before send", () => {
+    const prompt = [
+      { type: "text", content: "check @src/app.ts", start: 0, end: 17 },
+      { type: "file", content: "@src/app.ts", start: 18, end: 29, path: "src/app.ts" },
+    ] as FollowupDraft["prompt"]
+    const context = [
+      {
+        key: "comment:1",
+        type: "file",
+        path: "src/app.ts",
+        comment: "review this",
+        commentID: "cmt_1",
+        commentOrigin: "review",
+      },
+    ] as FollowupDraft["context"]
     const item = {
       id: "msg_1",
       ...draft({
-        prompt: [{ type: "text", content: "continue", start: 0, end: 8 }],
-        context: [],
+        prompt,
+        context,
       }),
     }
 
@@ -146,5 +160,12 @@ describe("session followups", () => {
     expect(rebased.sessionDirectory).toBe("/repo-root")
     expect(rebased.sessionID).toBe(item.sessionID)
     expect(rebased.prompt).toBe(item.prompt)
+    expect(rebased.context).toBe(item.context)
+    expect(rebased.prompt[1]).toMatchObject({ type: "file", path: "src/app.ts" })
+    expect(rebased.context[0]).toMatchObject({
+      path: "src/app.ts",
+      commentID: "cmt_1",
+      commentOrigin: "review",
+    })
   })
 })

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -67,6 +67,7 @@ describe("session followups", () => {
     const base = {
       hasSession: true,
       hasItem: true,
+      actionReady: true,
       busy: false,
       failed: false,
       paused: false,
@@ -78,6 +79,7 @@ describe("session followups", () => {
     expect(shouldAutoSendFollowup(base)).toBe(true)
     expect(shouldAutoSendFollowup({ ...base, hasSession: false })).toBe(false)
     expect(shouldAutoSendFollowup({ ...base, hasItem: false })).toBe(false)
+    expect(shouldAutoSendFollowup({ ...base, actionReady: false })).toBe(false)
     expect(shouldAutoSendFollowup({ ...base, busy: true })).toBe(false)
     expect(shouldAutoSendFollowup({ ...base, failed: true })).toBe(false)
     expect(shouldAutoSendFollowup({ ...base, paused: true })).toBe(false)
@@ -96,6 +98,7 @@ describe("session followups", () => {
     const recovering = {
       hasSession: true,
       hasItem: true,
+      actionReady: true,
       busy: true,
       failed: false,
       paused: false,
@@ -107,6 +110,23 @@ describe("session followups", () => {
 
     const afterHalt = { ...recovering, busy: false }
     expect(shouldAutoSendFollowup(afterHalt)).toBe(true)
+  })
+
+  test("queued followup waits for current directory data after a directory switch", () => {
+    const switchingDirectory = {
+      hasSession: true,
+      hasItem: true,
+      actionReady: false,
+      busy: false,
+      failed: false,
+      paused: false,
+      childSession: false,
+      blocked: false,
+      followupBusy: false,
+    }
+
+    expect(shouldAutoSendFollowup(switchingDirectory)).toBe(false)
+    expect(shouldAutoSendFollowup({ ...switchingDirectory, actionReady: true })).toBe(true)
   })
 
   test("rebases a queued followup to the current execution directory before send", () => {

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -36,6 +36,7 @@ export function followupPreviewText(input: {
 export function shouldAutoSendFollowup(input: {
   hasSession: boolean
   hasItem: boolean
+  actionReady: boolean
   busy: boolean
   failed: boolean
   paused: boolean
@@ -46,6 +47,7 @@ export function shouldAutoSendFollowup(input: {
   return (
     input.hasSession &&
     input.hasItem &&
+    input.actionReady &&
     !input.busy &&
     !input.failed &&
     !input.paused &&
@@ -64,6 +66,7 @@ export function createSessionFollowups(input: {
   directory: () => string
   client: () => ReturnType<typeof useSDK>["client"]
   sessionID: () => string | undefined
+  actionReady: () => boolean
   isChildSession: () => boolean
   busy: () => boolean
   blocked: () => boolean
@@ -146,7 +149,13 @@ export function createSessionFollowups(input: {
   const queueEnabled = createMemo(() => {
     const id = input.sessionID()
     if (!id) return false
-    return input.settings.general.followup() === "queue" && input.busy() && !input.blocked() && !input.isChildSession()
+    return (
+      input.actionReady() &&
+      input.settings.general.followup() === "queue" &&
+      input.busy() &&
+      !input.blocked() &&
+      !input.isChildSession()
+    )
   })
 
   const queueFollowup = (draft: FollowupDraft) => {
@@ -166,6 +175,7 @@ export function createSessionFollowups(input: {
   )
 
   const sendFollowup = (sessionID: string, id: string, opts?: { manual?: boolean }) => {
+    if (!input.actionReady()) return Promise.resolve()
     if (input.sync.session.get(sessionID)?.parentID) return Promise.resolve()
     const item = (followup.items[sessionID] ?? []).find((entry) => entry.id === id)
     if (!item) return Promise.resolve()
@@ -205,6 +215,7 @@ export function createSessionFollowups(input: {
       !shouldAutoSendFollowup({
         hasSession: !!sessionID,
         hasItem: !!item,
+        actionReady: input.actionReady(),
         busy: input.busy(),
         failed: !!(sessionID && item && followup.failed[sessionID] === item.id),
         paused: !!(sessionID && followup.paused[sessionID]),

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -55,9 +55,14 @@ export function shouldAutoSendFollowup(input: {
   )
 }
 
+export function followupDraftForDirectory(item: FollowupItem, directory: string): FollowupItem {
+  if (item.sessionDirectory === directory) return item
+  return { ...item, sessionDirectory: directory }
+}
+
 export function createSessionFollowups(input: {
-  directory: string
-  client: ReturnType<typeof useSDK>["client"]
+  directory: () => string
+  client: () => ReturnType<typeof useSDK>["client"]
   sessionID: () => string | undefined
   isChildSession: () => boolean
   busy: () => boolean
@@ -70,7 +75,7 @@ export function createSessionFollowups(input: {
   attachmentLabel: () => string
 }) {
   const [followup, setFollowup] = persisted(
-    Persist.workspace(input.directory, "followup", ["followup.v1"]),
+    Persist.global("session-followup.v1", ["followup.v1"]),
     createStore<{
       items: Record<string, FollowupItem[] | undefined>
       failed: Record<string, string | undefined>
@@ -104,12 +109,14 @@ export function createSessionFollowups(input: {
       if (params.manual) setFollowup("paused", params.sessionID, undefined)
       setFollowup("failed", params.sessionID, undefined)
 
+      const directory = input.directory()
+      const draft = followupDraftForDirectory(item, directory)
       const ok = await sendFollowupDraft({
-        client: input.client,
+        client: input.client(),
         sync: input.sync,
         globalSync: input.globalSync,
-        draft: item,
-        optimisticBusy: item.sessionDirectory === input.directory,
+        draft,
+        optimisticBusy: draft.sessionDirectory === directory,
       }).catch((err) => {
         setFollowup("failed", params.sessionID, params.id)
         input.fail(err)

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -76,7 +76,8 @@ export function createSessionFollowups(input: {
 }) {
   // This persisted store intentionally moved from Persist.workspace(..., "followup", ["followup.v1"]) to
   // Persist.global("session-followup.v1"). Legacy workspace-scoped followup.v1 queues are not migrated
-  // because their saved execution directory can be stale after worktree exit.
+  // because their saved execution directory can be stale after worktree exit. Entries remain keyed by
+  // sessionID for Stage 1; server-scoped identity belongs with the later session-scoped store migration.
   const [followup, setFollowup] = persisted(
     Persist.global("session-followup.v1", ["followup.v1"]),
     createStore<{

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -74,6 +74,9 @@ export function createSessionFollowups(input: {
   resumeScroll: () => void
   attachmentLabel: () => string
 }) {
+  // This persisted store intentionally moved from Persist.workspace(..., "followup", ["followup.v1"]) to
+  // Persist.global("session-followup.v1"). Legacy workspace-scoped followup.v1 queues are not migrated
+  // because their saved execution directory can be stale after worktree exit.
   const [followup, setFollowup] = persisted(
     Persist.global("session-followup.v1", ["followup.v1"]),
     createStore<{

--- a/packages/app/src/pages/session/use-session-revert.test.ts
+++ b/packages/app/src/pages/session/use-session-revert.test.ts
@@ -1,6 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { nextRestoreTarget, rolledRevertItems } from "./use-session-revert"
+import { nextRestoreTarget, revertRequestPayload, rolledRevertItems } from "./use-session-revert"
 
 const message = (id: string) => ({ id, role: "user" }) as UserMessage
 
@@ -24,5 +24,23 @@ describe("session revert", () => {
     expect(nextRestoreTarget(messages, "msg_10")?.id).toBe("msg_2")
     expect(nextRestoreTarget(messages, "msg_30")).toBeUndefined()
     expect(nextRestoreTarget(messages, "missing")).toBeUndefined()
+  })
+
+  test("sends only the API payload for revert requests", () => {
+    const payload = revertRequestPayload({
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      snapshot: {
+        store: {},
+        client: {},
+        release: () => undefined,
+      },
+    } as never)
+
+    expect(payload).toEqual({ sessionID: "ses_1", messageID: "msg_1" })
+    expect("snapshot" in payload).toBe(false)
+    expect("store" in payload).toBe(false)
+    expect("client" in payload).toBe(false)
+    expect("release" in payload).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -18,6 +18,13 @@ type RevertSnapshot = {
 
 const findSession = (store: SyncStore, sessionID: string) => store.session.find((item) => item.id === sessionID)
 
+export function revertRequestPayload(input: { sessionID: string; messageID: string }) {
+  return {
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+  }
+}
+
 export function rolledRevertItems(input: {
   revertMessageID: string | undefined
   messages: UserMessage[]
@@ -65,7 +72,7 @@ export function createSessionRevert(input: {
         })
         await input
           .halt(snapshot, request.sessionID)
-          .then(() => snapshot.client.session.revert(request, { throwOnError: true }))
+          .then(() => snapshot.client.session.revert(revertRequestPayload(request), { throwOnError: true }))
           .then((result) => {
             if (result.data) input.merge(snapshot.setStore, result.data)
           })

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -13,6 +13,7 @@ type RevertSnapshot = {
   client: ReturnType<typeof useSDK>["client"]
   store: SyncStore
   setStore: SyncSetter
+  release: VoidFunction
 }
 
 const findSession = (store: SyncStore, sessionID: string) => store.session.find((item) => item.id === sessionID)
@@ -45,7 +46,7 @@ export function createSessionRevert(input: {
   sync: ReturnType<typeof useSync>
   snapshot: () => RevertSnapshot
   actionReady: () => boolean
-  halt: (client: ReturnType<typeof useSDK>["client"], sessionID: string) => Promise<unknown>
+  halt: (snapshot: RevertSnapshot, sessionID: string) => Promise<unknown>
   draft: (source: Pick<RevertSnapshot, "directory" | "store">, id: string) => Prompt
   fail: (err: unknown) => void
   merge: (setStore: SyncSetter, next: Session) => void
@@ -54,71 +55,79 @@ export function createSessionRevert(input: {
   const revertMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; messageID: string; snapshot: RevertSnapshot }) => {
       const snapshot = request.snapshot
-      const prev = input.prompt.current().slice()
-      const last = findSession(snapshot.store, request.sessionID)?.revert
-      const value = input.draft(snapshot, request.messageID)
-      batch(() => {
-        input.roll(snapshot.setStore, request.sessionID, { messageID: request.messageID })
-        input.prompt.set(value)
-      })
-      await input
-        .halt(snapshot.client, request.sessionID)
-        .then(() => snapshot.client.session.revert(request, { throwOnError: true }))
-        .then((result) => {
-          if (result.data) input.merge(snapshot.setStore, result.data)
+      try {
+        const prev = input.prompt.current().slice()
+        const last = findSession(snapshot.store, request.sessionID)?.revert
+        const value = input.draft(snapshot, request.messageID)
+        batch(() => {
+          input.roll(snapshot.setStore, request.sessionID, { messageID: request.messageID })
+          input.prompt.set(value)
         })
-        .catch((err) => {
-          batch(() => {
-            input.roll(snapshot.setStore, request.sessionID, last)
-            input.prompt.set(prev)
+        await input
+          .halt(snapshot, request.sessionID)
+          .then(() => snapshot.client.session.revert(request, { throwOnError: true }))
+          .then((result) => {
+            if (result.data) input.merge(snapshot.setStore, result.data)
           })
-          input.fail(err)
-        })
+          .catch((err) => {
+            batch(() => {
+              input.roll(snapshot.setStore, request.sessionID, last)
+              input.prompt.set(prev)
+            })
+            input.fail(err)
+          })
+      } finally {
+        snapshot.release()
+      }
     },
   }))
 
   const restoreMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; id: string; snapshot: RevertSnapshot }) => {
       const snapshot = request.snapshot
-      const messages = readUserMessages(readSessionMessages(snapshot.store.message[request.sessionID]))
-      const next = nextRestoreTarget(messages, request.id)
-      const prev = input.prompt.current().slice()
-      const last = findSession(snapshot.store, request.sessionID)?.revert
+      try {
+        const messages = readUserMessages(readSessionMessages(snapshot.store.message[request.sessionID]))
+        const next = nextRestoreTarget(messages, request.id)
+        const prev = input.prompt.current().slice()
+        const last = findSession(snapshot.store, request.sessionID)?.revert
 
-      batch(() => {
-        input.roll(snapshot.setStore, request.sessionID, next ? { messageID: next.id } : undefined)
-        if (next) {
-          input.prompt.set(input.draft(snapshot, next.id))
-        } else {
-          input.prompt.reset()
-        }
-      })
-
-      const task = !next
-        ? input
-            .halt(snapshot.client, request.sessionID)
-            .then(() => snapshot.client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
-        : input.halt(snapshot.client, request.sessionID).then(() =>
-            snapshot.client.session.revert(
-              {
-                sessionID: request.sessionID,
-                messageID: next.id,
-              },
-              { throwOnError: true },
-            ),
-          )
-
-      await task
-        .then((result) => {
-          if (result.data) input.merge(snapshot.setStore, result.data)
+        batch(() => {
+          input.roll(snapshot.setStore, request.sessionID, next ? { messageID: next.id } : undefined)
+          if (next) {
+            input.prompt.set(input.draft(snapshot, next.id))
+          } else {
+            input.prompt.reset()
+          }
         })
-        .catch((err) => {
-          batch(() => {
-            input.roll(snapshot.setStore, request.sessionID, last)
-            input.prompt.set(prev)
+
+        const task = !next
+          ? input
+              .halt(snapshot, request.sessionID)
+              .then(() => snapshot.client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
+          : input.halt(snapshot, request.sessionID).then(() =>
+              snapshot.client.session.revert(
+                {
+                  sessionID: request.sessionID,
+                  messageID: next.id,
+                },
+                { throwOnError: true },
+              ),
+            )
+
+        await task
+          .then((result) => {
+            if (result.data) input.merge(snapshot.setStore, result.data)
           })
-          input.fail(err)
-        })
+          .catch((err) => {
+            batch(() => {
+              input.roll(snapshot.setStore, request.sessionID, last)
+              input.prompt.set(prev)
+            })
+            input.fail(err)
+          })
+      } finally {
+        snapshot.release()
+      }
     },
   }))
 

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -13,6 +13,11 @@ type RevertSnapshot = {
   client: ReturnType<typeof useSDK>["client"]
   store: SyncStore
   setStore: SyncSetter
+  prompt: Prompt
+  promptScope: {
+    dir: string
+    id?: string
+  }
   release: VoidFunction
 }
 
@@ -63,12 +68,12 @@ export function createSessionRevert(input: {
     mutationFn: async (request: { sessionID: string; messageID: string; snapshot: RevertSnapshot }) => {
       const snapshot = request.snapshot
       try {
-        const prev = input.prompt.current().slice()
+        const prev = snapshot.prompt
         const last = findSession(snapshot.store, request.sessionID)?.revert
         const value = input.draft(snapshot, request.messageID)
         batch(() => {
           input.roll(snapshot.setStore, request.sessionID, { messageID: request.messageID })
-          input.prompt.set(value)
+          input.prompt.set(value, undefined, snapshot.promptScope)
         })
         await input
           .halt(snapshot, request.sessionID)
@@ -79,7 +84,7 @@ export function createSessionRevert(input: {
           .catch((err) => {
             batch(() => {
               input.roll(snapshot.setStore, request.sessionID, last)
-              input.prompt.set(prev)
+              input.prompt.set(prev, undefined, snapshot.promptScope)
             })
             input.fail(err)
           })
@@ -95,15 +100,15 @@ export function createSessionRevert(input: {
       try {
         const messages = readUserMessages(readSessionMessages(snapshot.store.message[request.sessionID]))
         const next = nextRestoreTarget(messages, request.id)
-        const prev = input.prompt.current().slice()
+        const prev = snapshot.prompt
         const last = findSession(snapshot.store, request.sessionID)?.revert
 
         batch(() => {
           input.roll(snapshot.setStore, request.sessionID, next ? { messageID: next.id } : undefined)
           if (next) {
-            input.prompt.set(input.draft(snapshot, next.id))
+            input.prompt.set(input.draft(snapshot, next.id), undefined, snapshot.promptScope)
           } else {
-            input.prompt.reset()
+            input.prompt.reset(snapshot.promptScope)
           }
         })
 
@@ -128,7 +133,7 @@ export function createSessionRevert(input: {
           .catch((err) => {
             batch(() => {
               input.roll(snapshot.setStore, request.sessionID, last)
-              input.prompt.set(prev)
+              input.prompt.set(prev, undefined, snapshot.promptScope)
             })
             input.fail(err)
           })

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -7,6 +7,15 @@ import type { useSync } from "@/context/sync"
 import { readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
 
 type SyncSetter = ReturnType<typeof useSync>["set"]
+type SyncStore = ReturnType<typeof useSync>["data"]
+type RevertSnapshot = {
+  directory: string
+  client: ReturnType<typeof useSDK>["client"]
+  store: SyncStore
+  setStore: SyncSetter
+}
+
+const findSession = (store: SyncStore, sessionID: string) => store.session.find((item) => item.id === sessionID)
 
 export function rolledRevertItems(input: {
   revertMessageID: string | undefined
@@ -34,23 +43,20 @@ export function createSessionRevert(input: {
   lineText: (id: string) => string
   prompt: ReturnType<typeof usePrompt>
   sync: ReturnType<typeof useSync>
-  snapshot: () => {
-    client: ReturnType<typeof useSDK>["client"]
-    setStore: SyncSetter
-  }
+  snapshot: () => RevertSnapshot
   actionReady: () => boolean
   halt: (client: ReturnType<typeof useSDK>["client"], sessionID: string) => Promise<unknown>
-  draft: (id: string) => Prompt
+  draft: (source: Pick<RevertSnapshot, "directory" | "store">, id: string) => Prompt
   fail: (err: unknown) => void
   merge: (setStore: SyncSetter, next: Session) => void
   roll: (setStore: SyncSetter, sessionID: string, next: Session["revert"]) => void
 }) {
   const revertMutation = useMutation(() => ({
-    mutationFn: async (request: { sessionID: string; messageID: string }) => {
-      const snapshot = input.snapshot()
+    mutationFn: async (request: { sessionID: string; messageID: string; snapshot: RevertSnapshot }) => {
+      const snapshot = request.snapshot
       const prev = input.prompt.current().slice()
-      const last = input.sync.session.get(request.sessionID)?.revert
-      const value = input.draft(request.messageID)
+      const last = findSession(snapshot.store, request.sessionID)?.revert
+      const value = input.draft(snapshot, request.messageID)
       batch(() => {
         input.roll(snapshot.setStore, request.sessionID, { messageID: request.messageID })
         input.prompt.set(value)
@@ -72,17 +78,17 @@ export function createSessionRevert(input: {
   }))
 
   const restoreMutation = useMutation(() => ({
-    mutationFn: async (request: { sessionID: string; id: string }) => {
-      const snapshot = input.snapshot()
-      const messages = readUserMessages(readSessionMessages(input.sync.data.message[request.sessionID]))
+    mutationFn: async (request: { sessionID: string; id: string; snapshot: RevertSnapshot }) => {
+      const snapshot = request.snapshot
+      const messages = readUserMessages(readSessionMessages(snapshot.store.message[request.sessionID]))
       const next = nextRestoreTarget(messages, request.id)
       const prev = input.prompt.current().slice()
-      const last = input.sync.session.get(request.sessionID)?.revert
+      const last = findSession(snapshot.store, request.sessionID)?.revert
 
       batch(() => {
         input.roll(snapshot.setStore, request.sessionID, next ? { messageID: next.id } : undefined)
         if (next) {
-          input.prompt.set(input.draft(next.id))
+          input.prompt.set(input.draft(snapshot, next.id))
         } else {
           input.prompt.reset()
         }
@@ -138,13 +144,13 @@ export function createSessionRevert(input: {
     revert(request: { sessionID: string; messageID: string }) {
       if (reverting()) return
       if (!input.actionReady()) return
-      return revertMutation.mutateAsync(request)
+      return revertMutation.mutateAsync({ ...request, snapshot: input.snapshot() })
     },
     restore(id: string) {
       const sessionID = input.sessionID()
       if (!sessionID || reverting()) return
       if (!input.actionReady()) return
-      return restoreMutation.mutateAsync({ sessionID, id })
+      return restoreMutation.mutateAsync({ sessionID, id, snapshot: input.snapshot() })
     },
   }
 }

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -6,6 +6,8 @@ import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
 
+type SyncSetter = ReturnType<typeof useSync>["set"]
+
 export function rolledRevertItems(input: {
   revertMessageID: string | undefined
   messages: UserMessage[]
@@ -32,33 +34,36 @@ export function createSessionRevert(input: {
   lineText: (id: string) => string
   prompt: ReturnType<typeof usePrompt>
   sync: ReturnType<typeof useSync>
-  client: () => ReturnType<typeof useSDK>["client"]
+  snapshot: () => {
+    client: ReturnType<typeof useSDK>["client"]
+    setStore: SyncSetter
+  }
   actionReady: () => boolean
-  halt: (sessionID: string) => Promise<unknown>
+  halt: (client: ReturnType<typeof useSDK>["client"], sessionID: string) => Promise<unknown>
   draft: (id: string) => Prompt
   fail: (err: unknown) => void
-  merge: (next: Session) => void
-  roll: (sessionID: string, next: Session["revert"]) => void
+  merge: (setStore: SyncSetter, next: Session) => void
+  roll: (setStore: SyncSetter, sessionID: string, next: Session["revert"]) => void
 }) {
   const revertMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; messageID: string }) => {
-      const client = input.client()
+      const snapshot = input.snapshot()
       const prev = input.prompt.current().slice()
       const last = input.sync.session.get(request.sessionID)?.revert
       const value = input.draft(request.messageID)
       batch(() => {
-        input.roll(request.sessionID, { messageID: request.messageID })
+        input.roll(snapshot.setStore, request.sessionID, { messageID: request.messageID })
         input.prompt.set(value)
       })
       await input
-        .halt(request.sessionID)
-        .then(() => client.session.revert(request, { throwOnError: true }))
+        .halt(snapshot.client, request.sessionID)
+        .then(() => snapshot.client.session.revert(request, { throwOnError: true }))
         .then((result) => {
-          if (result.data) input.merge(result.data)
+          if (result.data) input.merge(snapshot.setStore, result.data)
         })
         .catch((err) => {
           batch(() => {
-            input.roll(request.sessionID, last)
+            input.roll(snapshot.setStore, request.sessionID, last)
             input.prompt.set(prev)
           })
           input.fail(err)
@@ -68,14 +73,14 @@ export function createSessionRevert(input: {
 
   const restoreMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; id: string }) => {
-      const client = input.client()
+      const snapshot = input.snapshot()
       const messages = readUserMessages(readSessionMessages(input.sync.data.message[request.sessionID]))
       const next = nextRestoreTarget(messages, request.id)
       const prev = input.prompt.current().slice()
       const last = input.sync.session.get(request.sessionID)?.revert
 
       batch(() => {
-        input.roll(request.sessionID, next ? { messageID: next.id } : undefined)
+        input.roll(snapshot.setStore, request.sessionID, next ? { messageID: next.id } : undefined)
         if (next) {
           input.prompt.set(input.draft(next.id))
         } else {
@@ -85,10 +90,10 @@ export function createSessionRevert(input: {
 
       const task = !next
         ? input
-            .halt(request.sessionID)
-            .then(() => client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
-        : input.halt(request.sessionID).then(() =>
-            client.session.revert(
+            .halt(snapshot.client, request.sessionID)
+            .then(() => snapshot.client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
+        : input.halt(snapshot.client, request.sessionID).then(() =>
+            snapshot.client.session.revert(
               {
                 sessionID: request.sessionID,
                 messageID: next.id,
@@ -99,11 +104,11 @@ export function createSessionRevert(input: {
 
       await task
         .then((result) => {
-          if (result.data) input.merge(result.data)
+          if (result.data) input.merge(snapshot.setStore, result.data)
         })
         .catch((err) => {
           batch(() => {
-            input.roll(request.sessionID, last)
+            input.roll(snapshot.setStore, request.sessionID, last)
             input.prompt.set(prev)
           })
           input.fail(err)

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -33,6 +33,7 @@ export function createSessionRevert(input: {
   prompt: ReturnType<typeof usePrompt>
   sync: ReturnType<typeof useSync>
   client: () => ReturnType<typeof useSDK>["client"]
+  actionReady: () => boolean
   halt: (sessionID: string) => Promise<unknown>
   draft: (id: string) => Prompt
   fail: (err: unknown) => void
@@ -41,6 +42,7 @@ export function createSessionRevert(input: {
 }) {
   const revertMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; messageID: string }) => {
+      const client = input.client()
       const prev = input.prompt.current().slice()
       const last = input.sync.session.get(request.sessionID)?.revert
       const value = input.draft(request.messageID)
@@ -50,7 +52,7 @@ export function createSessionRevert(input: {
       })
       await input
         .halt(request.sessionID)
-        .then(() => input.client().session.revert(request, { throwOnError: true }))
+        .then(() => client.session.revert(request, { throwOnError: true }))
         .then((result) => {
           if (result.data) input.merge(result.data)
         })
@@ -66,6 +68,7 @@ export function createSessionRevert(input: {
 
   const restoreMutation = useMutation(() => ({
     mutationFn: async (request: { sessionID: string; id: string }) => {
+      const client = input.client()
       const messages = readUserMessages(readSessionMessages(input.sync.data.message[request.sessionID]))
       const next = nextRestoreTarget(messages, request.id)
       const prev = input.prompt.current().slice()
@@ -83,9 +86,9 @@ export function createSessionRevert(input: {
       const task = !next
         ? input
             .halt(request.sessionID)
-            .then(() => input.client().session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
+            .then(() => client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
         : input.halt(request.sessionID).then(() =>
-            input.client().session.revert(
+            client.session.revert(
               {
                 sessionID: request.sessionID,
                 messageID: next.id,
@@ -129,11 +132,13 @@ export function createSessionRevert(input: {
     rolled,
     revert(request: { sessionID: string; messageID: string }) {
       if (reverting()) return
+      if (!input.actionReady()) return
       return revertMutation.mutateAsync(request)
     },
     restore(id: string) {
       const sessionID = input.sessionID()
       if (!sessionID || reverting()) return
+      if (!input.actionReady()) return
       return restoreMutation.mutateAsync({ sessionID, id })
     },
   }

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -32,7 +32,7 @@ export function createSessionRevert(input: {
   lineText: (id: string) => string
   prompt: ReturnType<typeof usePrompt>
   sync: ReturnType<typeof useSync>
-  client: ReturnType<typeof useSDK>["client"]
+  client: () => ReturnType<typeof useSDK>["client"]
   halt: (sessionID: string) => Promise<unknown>
   draft: (id: string) => Prompt
   fail: (err: unknown) => void
@@ -50,7 +50,7 @@ export function createSessionRevert(input: {
       })
       await input
         .halt(request.sessionID)
-        .then(() => input.client.session.revert(request, { throwOnError: true }))
+        .then(() => input.client().session.revert(request, { throwOnError: true }))
         .then((result) => {
           if (result.data) input.merge(result.data)
         })
@@ -83,9 +83,9 @@ export function createSessionRevert(input: {
       const task = !next
         ? input
             .halt(request.sessionID)
-            .then(() => input.client.session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
+            .then(() => input.client().session.unrevert({ sessionID: request.sessionID }, { throwOnError: true }))
         : input.halt(request.sessionID).then(() =>
-            input.client.session.revert(
+            input.client().session.revert(
               {
                 sessionID: request.sessionID,
                 messageID: next.id,

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { deriveReviewArtifactFiles, shouldApplyVcsDiffResult } from "./use-session-review-state"
+import { deriveReviewArtifactFiles, shouldApplyVcsDiffResult, vcsTaskKey } from "./use-session-review-state"
 
 describe("session review state", () => {
   test("uses session artifact history when it matches the visible session", () => {
@@ -87,5 +87,10 @@ describe("session review state", () => {
         currentRun: 1,
       }),
     ).toBe(true)
+  })
+
+  test("keys pending VCS diff tasks by directory and mode", () => {
+    expect(vcsTaskKey("/repo-worktree", "unstaged")).not.toBe(vcsTaskKey("/repo-root", "unstaged"))
+    expect(vcsTaskKey("/repo-root", "unstaged")).not.toBe(vcsTaskKey("/repo-root", "staged"))
   })
 })

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { deriveReviewArtifactFiles } from "./use-session-review-state"
+import { deriveReviewArtifactFiles, shouldApplyVcsDiffResult } from "./use-session-review-state"
 
 describe("session review state", () => {
   test("uses session artifact history when it matches the visible session", () => {
@@ -67,5 +67,25 @@ describe("session review state", () => {
         turnDiffs: undefined,
       }),
     ).not.toThrow()
+  })
+
+  test("rejects stale VCS diff results from a previous execution directory", () => {
+    expect(
+      shouldApplyVcsDiffResult({
+        requestedDirectory: "/repo-worktree",
+        currentDirectory: "/repo-root",
+        requestedRun: 1,
+        currentRun: 1,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldApplyVcsDiffResult({
+        requestedDirectory: "/repo-root",
+        currentDirectory: "/repo-root",
+        requestedRun: 1,
+        currentRun: 1,
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -17,6 +17,21 @@ describe("session review state", () => {
     expect(files.map((file) => file.path)).not.toContain("/repo/fallback.md")
   })
 
+  test("falls back while artifact history belongs to a previous execution directory", () => {
+    const files = deriveReviewArtifactFiles({
+      directory: "/repo-root",
+      sessionID: "ses_1",
+      history: {
+        directory: "/repo-worktree",
+        sessionID: "ses_1",
+        artifacts: [{ file: "stale.md", kind: "added" }],
+      },
+      turnDiffs: [{ file: "fallback.md", status: "added" }],
+    })
+
+    expect(files.map((file) => file.path)).toEqual(["/repo-root/fallback.md"])
+  })
+
   test("falls back to added and modified turn diffs", () => {
     const files = deriveReviewArtifactFiles({
       directory: "/repo",

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -39,7 +39,7 @@ export function deriveReviewArtifactFiles(input: {
 }
 
 export function createSessionReviewState(input: {
-  directory: string
+  directory: () => string
   sessionKey: () => string
   sessionID: () => string | undefined
   sync: ReturnType<typeof useSync>
@@ -168,7 +168,7 @@ export function createSessionReviewState(input: {
   })
   const artifactFiles = createMemo(() =>
     deriveReviewArtifactFiles({
-      directory: input.directory,
+      directory: input.directory(),
       sessionID: input.sessionID(),
       history: artifactHistory.latest,
       turnDiffs: input.turnDiffs(),

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -43,6 +43,15 @@ export function deriveReviewArtifactFiles(input: {
   )
 }
 
+export function shouldApplyVcsDiffResult(input: {
+  requestedDirectory: string
+  currentDirectory: string
+  requestedRun: number
+  currentRun: number | undefined
+}) {
+  return input.requestedDirectory === input.currentDirectory && input.requestedRun === input.currentRun
+}
+
 export function createSessionReviewState(input: {
   directory: () => string
   sessionKey: () => string
@@ -91,6 +100,7 @@ export function createSessionReviewState(input: {
   const loadVcs = (mode: VcsReviewMode, force = false) => {
     if (input.sync.project?.vcs !== "git") return Promise.resolve()
     if (!force && vcs.ready[mode]) return Promise.resolve()
+    const directory = input.directory()
 
     if (force) {
       if (vcsTask.has(mode)) bumpVcs(mode)
@@ -101,16 +111,35 @@ export function createSessionReviewState(input: {
     const current = vcsTask.get(mode)
     if (current) return current
     const run = bumpVcs(mode)
+    const client = input.sdk.createClient({ directory, throwOnError: true })
 
-    const task = input.sdk.client.vcs
+    const task = client.vcs
       .diff({ mode })
       .then((result) => {
-        if (vcsRun.get(mode) !== run) return
+        if (
+          !shouldApplyVcsDiffResult({
+            requestedDirectory: directory,
+            currentDirectory: input.directory(),
+            requestedRun: run,
+            currentRun: vcsRun.get(mode),
+          })
+        ) {
+          return
+        }
         setVcs("diff", mode, list(result.data))
         setVcs("ready", mode, true)
       })
       .catch((error: unknown) => {
-        if (vcsRun.get(mode) !== run) return
+        if (
+          !shouldApplyVcsDiffResult({
+            requestedDirectory: directory,
+            currentDirectory: input.directory(),
+            requestedRun: run,
+            currentRun: vcsRun.get(mode),
+          })
+        ) {
+          return
+        }
         console.debug("[session-review] failed to load vcs diff", { mode, error })
         setVcs("diff", mode, [])
         setVcs("ready", mode, true)

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -154,7 +154,9 @@ export function createSessionReviewState(input: {
     async ({ directory, sessionID }) => ({
       directory,
       sessionID,
-      artifacts: await input.sdk.client.session
+      artifacts: await input.sdk
+        .createClient({ directory, throwOnError: true })
+        .session
         .artifacts({ sessionID })
         .then((res) => res.data ?? [])
         .catch(() => []),

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -20,11 +20,16 @@ type SessionReviewDiff = SnapshotFileDiff | VcsFileDiff
 export function deriveReviewArtifactFiles(input: {
   directory: string
   sessionID: string | undefined
-  history: { sessionID: string; artifacts: SessionArtifactFile[] } | undefined
+  history: { directory?: string; sessionID: string; artifacts: SessionArtifactFile[] } | undefined
   turnDiffs?: Array<{ file: string; status?: string }>
 }) {
   const history = input.history
-  if (history && history.sessionID === input.sessionID && history.artifacts.length > 0) {
+  if (
+    history &&
+    history.sessionID === input.sessionID &&
+    (history.directory === undefined || history.directory === input.directory) &&
+    history.artifacts.length > 0
+  ) {
     return deriveArtifactFiles(input.directory, history.artifacts)
   }
 
@@ -141,15 +146,20 @@ export function createSessionReviewState(input: {
   })
 
   const [artifactHistory, { refetch: refetchArtifactHistory }] = createResource(
-    input.sessionID,
-    async (sessionID) => ({
+    () => {
+      const sessionID = input.sessionID()
+      if (!sessionID) return
+      return { directory: input.directory(), sessionID }
+    },
+    async ({ directory, sessionID }) => ({
+      directory,
       sessionID,
       artifacts: await input.sdk.client.session
         .artifacts({ sessionID })
         .then((res) => res.data ?? [])
         .catch(() => []),
     }),
-    { initialValue: { sessionID: "", artifacts: [] as SessionArtifactFile[] } },
+    { initialValue: { directory: "", sessionID: "", artifacts: [] as SessionArtifactFile[] } },
   )
   let artifactHistoryFrame: number | undefined
   let artifactHistoryPending = false

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -52,6 +52,10 @@ export function shouldApplyVcsDiffResult(input: {
   return input.requestedDirectory === input.currentDirectory && input.requestedRun === input.currentRun
 }
 
+export function vcsTaskKey(directory: string, mode: VcsReviewMode) {
+  return `${directory}\n${mode}`
+}
+
 export function createSessionReviewState(input: {
   directory: () => string
   sessionKey: () => string
@@ -78,20 +82,23 @@ export function createSessionReviewState(input: {
     },
   })
 
-  const vcsTask = new Map<VcsReviewMode, Promise<void>>()
-  const vcsRun = new Map<VcsReviewMode, number>()
+  const vcsTask = new Map<string, Promise<void>>()
+  const vcsRun = new Map<string, number>()
 
-  const bumpVcs = (mode: VcsReviewMode) => {
-    const next = (vcsRun.get(mode) ?? 0) + 1
-    vcsRun.set(mode, next)
+  const bumpVcs = (directory: string, mode: VcsReviewMode) => {
+    const key = vcsTaskKey(directory, mode)
+    const next = (vcsRun.get(key) ?? 0) + 1
+    vcsRun.set(key, next)
     return next
   }
 
   const resetVcs = (mode?: VcsReviewMode) => {
+    const directory = input.directory()
     const modes = mode ? [mode] : (["unstaged", "staged", "branch"] as const)
     modes.forEach((item) => {
-      bumpVcs(item)
-      vcsTask.delete(item)
+      const key = vcsTaskKey(directory, item)
+      bumpVcs(directory, item)
+      vcsTask.delete(key)
       setVcs("diff", item, [])
       setVcs("ready", item, false)
     })
@@ -101,16 +108,17 @@ export function createSessionReviewState(input: {
     if (input.sync.project?.vcs !== "git") return Promise.resolve()
     if (!force && vcs.ready[mode]) return Promise.resolve()
     const directory = input.directory()
+    const key = vcsTaskKey(directory, mode)
 
     if (force) {
-      if (vcsTask.has(mode)) bumpVcs(mode)
-      vcsTask.delete(mode)
+      if (vcsTask.has(key)) bumpVcs(directory, mode)
+      vcsTask.delete(key)
       setVcs("ready", mode, false)
     }
 
-    const current = vcsTask.get(mode)
+    const current = vcsTask.get(key)
     if (current) return current
-    const run = bumpVcs(mode)
+    const run = bumpVcs(directory, mode)
     const client = input.sdk.createClient({ directory, throwOnError: true })
 
     const task = client.vcs
@@ -121,7 +129,7 @@ export function createSessionReviewState(input: {
             requestedDirectory: directory,
             currentDirectory: input.directory(),
             requestedRun: run,
-            currentRun: vcsRun.get(mode),
+            currentRun: vcsRun.get(key),
           })
         ) {
           return
@@ -135,7 +143,7 @@ export function createSessionReviewState(input: {
             requestedDirectory: directory,
             currentDirectory: input.directory(),
             requestedRun: run,
-            currentRun: vcsRun.get(mode),
+            currentRun: vcsRun.get(key),
           })
         ) {
           return
@@ -145,10 +153,10 @@ export function createSessionReviewState(input: {
         setVcs("ready", mode, true)
       })
       .finally(() => {
-        if (vcsTask.get(mode) === task) vcsTask.delete(mode)
+        if (vcsTask.get(key) === task) vcsTask.delete(key)
       })
 
-    vcsTask.set(mode, task)
+    vcsTask.set(key, task)
     return task
   }
 

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import { readTimelineMessages } from "./use-session-timeline-data"
+
+const userMessage = (id: string): Message =>
+  ({
+    id,
+    role: "user",
+    sessionID: "ses_target",
+    time: { created: 1 },
+  }) as Message
+
+describe("readTimelineMessages", () => {
+  test("keeps last-good messages for the same session when the current store briefly loses its cache", () => {
+    const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const ready = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toBe(loaded)
+    expect(missing.lastGood).toBe(ready.lastGood)
+  })
+
+  test("does not reuse last-good messages after switching to another session", () => {
+    const loaded = [userMessage("msg_1")]
+    const ready = readTimelineMessages({
+      sessionID: "ses_source",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toEqual([])
+    expect(missing.lastGood).toBe(ready.lastGood)
+  })
+
+  test("clears last-good messages when there is no active session", () => {
+    const loaded = [userMessage("msg_1")]
+    const ready = readTimelineMessages({
+      sessionID: "ses_source",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: undefined,
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toEqual([])
+    expect(missing.lastGood).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { readTimelineMessages, readTimelineMessagesFromCache } from "./use-session-timeline-data"
+import { readTimelineMessages, readTimelineMessagesFromCache, timelineModelSyncKey } from "./use-session-timeline-data"
 
 const userMessage = (id: string, sessionID = "ses_target"): Message =>
   ({
@@ -160,5 +160,13 @@ describe("readTimelineMessagesFromCache", () => {
 
     expect(missing.messages).toBe(loaded)
     expect(missing.lastGood).toBe(ready.lastGood)
+  })
+})
+
+describe("timelineModelSyncKey", () => {
+  test("changes when the directory changes even if the last user message is the same", () => {
+    expect(timelineModelSyncKey({ directory: "/worktree", messageID: "msg" })).not.toBe(
+      timelineModelSyncKey({ directory: "/root", messageID: "msg" }),
+    )
   })
 })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { readTimelineMessages, readTimelineMessagesFromCache, timelineModelSyncKey } from "./use-session-timeline-data"
+import {
+  currentSessionDataReady,
+  readTimelineMessages,
+  readTimelineMessagesFromCache,
+  timelineModelSyncKey,
+} from "./use-session-timeline-data"
 
 const userMessage = (id: string, sessionID = "ses_target"): Message =>
   ({
@@ -168,5 +173,25 @@ describe("timelineModelSyncKey", () => {
     expect(timelineModelSyncKey({ directory: "/worktree", messageID: "msg" })).not.toBe(
       timelineModelSyncKey({ directory: "/root", messageID: "msg" }),
     )
+  })
+})
+
+describe("currentSessionDataReady", () => {
+  test("waits for current session info and message cache before actions are ready", () => {
+    expect(
+      currentSessionDataReady({
+        sessionID: "ses",
+        sessionInfo: undefined,
+        rawMessages: undefined,
+      }),
+    ).toBe(false)
+
+    expect(
+      currentSessionDataReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
 import { readTimelineMessages } from "./use-session-timeline-data"
 
-const userMessage = (id: string): Message =>
+const userMessage = (id: string, sessionID = "ses_target"): Message =>
   ({
     id,
     role: "user",
-    sessionID: "ses_target",
+    sessionID,
     time: { created: 1 },
   }) as Message
 
@@ -48,7 +48,7 @@ describe("readTimelineMessages", () => {
   })
 
   test("does not reuse last-good messages after switching to another session", () => {
-    const loaded = [userMessage("msg_1")]
+    const loaded = [userMessage("msg_1", "ses_source")]
     const ready = readTimelineMessages({
       sessionID: "ses_source",
       raw: loaded,
@@ -69,14 +69,14 @@ describe("readTimelineMessages", () => {
     const loaded = [userMessage("msg_1")]
     const ready = readTimelineMessages({
       sessionID: "ses_target",
-      identity: "server-a:ses_target",
+      dataIdentity: "server-a:ses_target",
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
       sessionID: "ses_target",
-      identity: "server-b:ses_target",
+      dataIdentity: "server-b:ses_target",
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -85,8 +85,28 @@ describe("readTimelineMessages", () => {
     expect(missing.lastGood).toBe(ready.lastGood)
   })
 
+  test("keeps last-good messages when the same session cache misses before session info reloads", () => {
+    const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const ready = readTimelineMessages({
+      sessionID: "ses_target",
+      dataIdentity: "ses_target:123",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: "ses_target",
+      dataIdentity: undefined,
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toBe(loaded)
+    expect(missing.lastGood).toBe(ready.lastGood)
+  })
+
   test("clears last-good messages when there is no active session", () => {
-    const loaded = [userMessage("msg_1")]
+    const loaded = [userMessage("msg_1", "ses_source")]
     const ready = readTimelineMessages({
       sessionID: "ses_source",
       raw: loaded,

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
 import {
+  currentDirectoryProviderUsable,
   currentSessionActionReady,
   currentSessionCacheReady,
   readTimelineMessages,
@@ -213,7 +214,7 @@ describe("currentSessionActionReady", () => {
         rawMessages: [],
         statusReady: false,
         localReady: true,
-        providerReady: true,
+        providerUsable: true,
       }),
     ).toBe(false)
 
@@ -224,7 +225,7 @@ describe("currentSessionActionReady", () => {
         rawMessages: [],
         statusReady: true,
         localReady: true,
-        providerReady: true,
+        providerUsable: true,
       }),
     ).toBe(true)
   })
@@ -237,9 +238,9 @@ describe("currentSessionActionReady", () => {
       statusReady: true,
     }
 
-    expect(currentSessionActionReady({ ...ready, localReady: false, providerReady: true })).toBe(false)
-    expect(currentSessionActionReady({ ...ready, localReady: true, providerReady: false })).toBe(false)
-    expect(currentSessionActionReady({ ...ready, localReady: true, providerReady: true })).toBe(true)
+    expect(currentSessionActionReady({ ...ready, localReady: false, providerUsable: true })).toBe(false)
+    expect(currentSessionActionReady({ ...ready, localReady: true, providerUsable: false })).toBe(false)
+    expect(currentSessionActionReady({ ...ready, localReady: true, providerUsable: true })).toBe(true)
   })
 
   test("treats a loaded empty status list as idle for an otherwise hydrated session", () => {
@@ -250,9 +251,17 @@ describe("currentSessionActionReady", () => {
         rawMessages: [],
         statusReady: true,
         localReady: true,
-        providerReady: true,
+        providerUsable: true,
       }),
     ).toBe(true)
+  })
+})
+
+describe("currentDirectoryProviderUsable", () => {
+  test("allows seeded provider data before the directory refresh finishes", () => {
+    expect(currentDirectoryProviderUsable({ providerReady: false, providerCount: 0 })).toBe(false)
+    expect(currentDirectoryProviderUsable({ providerReady: false, providerCount: 1 })).toBe(true)
+    expect(currentDirectoryProviderUsable({ providerReady: true, providerCount: 0 })).toBe(true)
   })
 })
 
@@ -285,7 +294,7 @@ describe("sessionStatusKnown", () => {
         rawMessages: [],
         statusReady: sessionStatusKnown({ statusState: "error", status: undefined }),
         localReady: true,
-        providerReady: true,
+        providerUsable: true,
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { readTimelineMessages } from "./use-session-timeline-data"
+import { readTimelineMessages, readTimelineMessagesFromCache } from "./use-session-timeline-data"
 
 const userMessage = (id: string, sessionID = "ses_target"): Message =>
   ({
@@ -121,5 +121,27 @@ describe("readTimelineMessages", () => {
 
     expect(missing.messages).toEqual([])
     expect(missing.lastGood).toBeUndefined()
+  })
+})
+
+describe("readTimelineMessagesFromCache", () => {
+  test("keeps messages when directory switch makes session info and message cache briefly unavailable", () => {
+    const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const ready = readTimelineMessagesFromCache({
+      sessionID: "ses_target",
+      sessionCreated: 123,
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessagesFromCache({
+      sessionID: "ses_target",
+      sessionCreated: undefined,
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toBe(loaded)
+    expect(missing.lastGood).toBe(ready.lastGood)
   })
 })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -5,6 +5,7 @@ import {
   currentSessionCacheReady,
   readTimelineMessages,
   readTimelineMessagesFromCache,
+  sessionStatusKnown,
   timelineModelSyncKey,
 } from "./use-session-timeline-data"
 
@@ -225,6 +226,27 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: true,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe("sessionStatusKnown", () => {
+  test("does not trust stale idle status while the status list is refreshing", () => {
+    expect(sessionStatusKnown({ statusReady: false, status: { type: "idle" } })).toBe(false)
+  })
+
+  test("trusts active statuses before the status list finishes refreshing", () => {
+    expect(sessionStatusKnown({ statusReady: false, status: { type: "busy" } })).toBe(true)
+    expect(
+      sessionStatusKnown({
+        statusReady: false,
+        status: {
+          type: "retry",
+          attempt: 1,
+          message: "retrying",
+          next: Date.now(),
+        },
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -4,6 +4,7 @@ import {
   currentDirectoryProviderUsable,
   currentSessionActionReady,
   currentSessionCacheReady,
+  currentSessionSubmitReady,
   readTimelineMessages,
   readTimelineMessagesFromCache,
   sessionStatusKnown,
@@ -213,8 +214,6 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: false,
-        localReady: true,
-        providerUsable: true,
       }),
     ).toBe(false)
 
@@ -224,23 +223,19 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: true,
-        localReady: true,
-        providerUsable: true,
       }),
     ).toBe(true)
   })
 
-  test("waits for directory-local model selection and provider hydration", () => {
-    const ready = {
-      sessionID: "ses",
-      sessionInfo: { id: "ses" },
-      rawMessages: [],
-      statusReady: true,
-    }
-
-    expect(currentSessionActionReady({ ...ready, localReady: false, providerUsable: true })).toBe(false)
-    expect(currentSessionActionReady({ ...ready, localReady: true, providerUsable: false })).toBe(false)
-    expect(currentSessionActionReady({ ...ready, localReady: true, providerUsable: true })).toBe(true)
+  test("does not wait for model selection or provider hydration", () => {
+    expect(
+      currentSessionActionReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+        statusReady: true,
+      }),
+    ).toBe(true)
   })
 
   test("treats a loaded empty status list as idle for an otherwise hydrated session", () => {
@@ -250,10 +245,23 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: true,
-        localReady: true,
-        providerUsable: true,
       }),
     ).toBe(true)
+  })
+})
+
+describe("currentSessionSubmitReady", () => {
+  test("waits for directory-local model selection and provider hydration", () => {
+    const ready = {
+      sessionID: "ses",
+      sessionInfo: { id: "ses" },
+      rawMessages: [],
+      statusReady: true,
+    }
+
+    expect(currentSessionSubmitReady({ ...ready, localReady: false, providerUsable: true })).toBe(false)
+    expect(currentSessionSubmitReady({ ...ready, localReady: true, providerUsable: false })).toBe(false)
+    expect(currentSessionSubmitReady({ ...ready, localReady: true, providerUsable: true })).toBe(true)
   })
 })
 
@@ -288,7 +296,7 @@ describe("sessionStatusKnown", () => {
   test("allows degraded actions after status list hydration fails", () => {
     expect(sessionStatusKnown({ statusState: "error", status: undefined })).toBe(true)
     expect(
-      currentSessionActionReady({
+      currentSessionSubmitReady({
         sessionID: "ses",
         sessionInfo: { id: "ses" },
         rawMessages: [],

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -5,6 +5,7 @@ import {
   currentSessionActionReady,
   currentSessionCacheReady,
   currentSessionSubmitReady,
+  currentWorkspaceSubmitReady,
   readTimelineMessages,
   readTimelineMessagesFromCache,
   sessionStatusKnown,
@@ -262,6 +263,14 @@ describe("currentSessionSubmitReady", () => {
     expect(currentSessionSubmitReady({ ...ready, localReady: false, providerUsable: true })).toBe(false)
     expect(currentSessionSubmitReady({ ...ready, localReady: true, providerUsable: false })).toBe(false)
     expect(currentSessionSubmitReady({ ...ready, localReady: true, providerUsable: true })).toBe(true)
+  })
+})
+
+describe("currentWorkspaceSubmitReady", () => {
+  test("waits for model selection and provider readiness when there is no session", () => {
+    expect(currentWorkspaceSubmitReady({ localReady: false, providerUsable: true })).toBe(false)
+    expect(currentWorkspaceSubmitReady({ localReady: true, providerUsable: false })).toBe(false)
+    expect(currentWorkspaceSubmitReady({ localReady: true, providerUsable: true })).toBe(true)
   })
 })
 

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -198,13 +198,13 @@ describe("currentSessionCacheReady", () => {
 })
 
 describe("currentSessionActionReady", () => {
-  test("waits for current session status as well as cache hydration", () => {
+  test("waits for the directory status list as well as cache hydration", () => {
     expect(
       currentSessionActionReady({
         sessionID: "ses",
         sessionInfo: { id: "ses" },
         rawMessages: [],
-        status: undefined,
+        statusReady: false,
       }),
     ).toBe(false)
 
@@ -213,7 +213,18 @@ describe("currentSessionActionReady", () => {
         sessionID: "ses",
         sessionInfo: { id: "ses" },
         rawMessages: [],
-        status: { type: "idle" },
+        statusReady: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("treats a loaded empty status list as idle for an otherwise hydrated session", () => {
+    expect(
+      currentSessionActionReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+        statusReady: true,
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -233,20 +233,32 @@ describe("currentSessionActionReady", () => {
 
 describe("sessionStatusKnown", () => {
   test("does not trust stale idle status while the status list is refreshing", () => {
-    expect(sessionStatusKnown({ statusReady: false, status: { type: "idle" } })).toBe(false)
+    expect(sessionStatusKnown({ statusState: "loading", status: { type: "idle" } })).toBe(false)
   })
 
   test("trusts active statuses before the status list finishes refreshing", () => {
-    expect(sessionStatusKnown({ statusReady: false, status: { type: "busy" } })).toBe(true)
+    expect(sessionStatusKnown({ statusState: "loading", status: { type: "busy" } })).toBe(true)
     expect(
       sessionStatusKnown({
-        statusReady: false,
+        statusState: "loading",
         status: {
           type: "retry",
           attempt: 1,
           message: "retrying",
           next: Date.now(),
         },
+      }),
+    ).toBe(true)
+  })
+
+  test("allows degraded actions after status list hydration fails", () => {
+    expect(sessionStatusKnown({ statusState: "error", status: undefined })).toBe(true)
+    expect(
+      currentSessionActionReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+        statusReady: sessionStatusKnown({ statusState: "error", status: undefined }),
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -122,6 +122,23 @@ describe("readTimelineMessages", () => {
     expect(missing.messages).toEqual([])
     expect(missing.lastGood).toBeUndefined()
   })
+
+  test("treats an empty raw message array as authoritative loaded data", () => {
+    const ready = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: [userMessage("msg_1"), userMessage("msg_2")],
+      lastGood: undefined,
+    })
+
+    const empty = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: [],
+      lastGood: ready.lastGood,
+    })
+
+    expect(empty.messages).toEqual([])
+    expect(empty.lastGood?.messages).toEqual([])
+  })
 })
 
 describe("readTimelineMessagesFromCache", () => {

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
 import {
-  currentSessionDataReady,
+  currentSessionActionReady,
+  currentSessionCacheReady,
   readTimelineMessages,
   readTimelineMessagesFromCache,
   timelineModelSyncKey,
@@ -176,10 +177,10 @@ describe("timelineModelSyncKey", () => {
   })
 })
 
-describe("currentSessionDataReady", () => {
+describe("currentSessionCacheReady", () => {
   test("waits for current session info and message cache before actions are ready", () => {
     expect(
-      currentSessionDataReady({
+      currentSessionCacheReady({
         sessionID: "ses",
         sessionInfo: undefined,
         rawMessages: undefined,
@@ -187,10 +188,32 @@ describe("currentSessionDataReady", () => {
     ).toBe(false)
 
     expect(
-      currentSessionDataReady({
+      currentSessionCacheReady({
         sessionID: "ses",
         sessionInfo: { id: "ses" },
         rawMessages: [],
+      }),
+    ).toBe(true)
+  })
+})
+
+describe("currentSessionActionReady", () => {
+  test("waits for current session status as well as cache hydration", () => {
+    expect(
+      currentSessionActionReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+        status: undefined,
+      }),
+    ).toBe(false)
+
+    expect(
+      currentSessionActionReady({
+        sessionID: "ses",
+        sessionInfo: { id: "ses" },
+        rawMessages: [],
+        status: { type: "idle" },
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -212,6 +212,8 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: false,
+        localReady: true,
+        providerReady: true,
       }),
     ).toBe(false)
 
@@ -221,8 +223,23 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: true,
+        localReady: true,
+        providerReady: true,
       }),
     ).toBe(true)
+  })
+
+  test("waits for directory-local model selection and provider hydration", () => {
+    const ready = {
+      sessionID: "ses",
+      sessionInfo: { id: "ses" },
+      rawMessages: [],
+      statusReady: true,
+    }
+
+    expect(currentSessionActionReady({ ...ready, localReady: false, providerReady: true })).toBe(false)
+    expect(currentSessionActionReady({ ...ready, localReady: true, providerReady: false })).toBe(false)
+    expect(currentSessionActionReady({ ...ready, localReady: true, providerReady: true })).toBe(true)
   })
 
   test("treats a loaded empty status list as idle for an otherwise hydrated session", () => {
@@ -232,6 +249,8 @@ describe("currentSessionActionReady", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: true,
+        localReady: true,
+        providerReady: true,
       }),
     ).toBe(true)
   })
@@ -265,6 +284,8 @@ describe("sessionStatusKnown", () => {
         sessionInfo: { id: "ses" },
         rawMessages: [],
         statusReady: sessionStatusKnown({ statusState: "error", status: undefined }),
+        localReady: true,
+        providerReady: true,
       }),
     ).toBe(true)
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -172,8 +172,14 @@ describe("readTimelineMessagesFromCache", () => {
 
 describe("timelineModelSyncKey", () => {
   test("changes when the directory changes even if the last user message is the same", () => {
-    expect(timelineModelSyncKey({ directory: "/worktree", messageID: "msg" })).not.toBe(
-      timelineModelSyncKey({ directory: "/root", messageID: "msg" }),
+    expect(timelineModelSyncKey({ directory: "/worktree", messageID: "msg", localReady: true })).not.toBe(
+      timelineModelSyncKey({ directory: "/root", messageID: "msg", localReady: true }),
+    )
+  })
+
+  test("changes when the directory-local model selection store becomes ready", () => {
+    expect(timelineModelSyncKey({ directory: "/repo", messageID: "msg", localReady: false })).not.toBe(
+      timelineModelSyncKey({ directory: "/repo", messageID: "msg", localReady: true }),
     )
   })
 })

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -29,6 +29,24 @@ describe("readTimelineMessages", () => {
     expect(missing.lastGood).toBe(ready.lastGood)
   })
 
+  test("keeps a long session window during a same-session cache miss", () => {
+    const loaded = Array.from({ length: 80 }, (_, index) => userMessage(`msg_${index}`))
+    const ready = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: "ses_target",
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toHaveLength(80)
+    expect(missing.messages).toBe(loaded)
+  })
+
   test("does not reuse last-good messages after switching to another session", () => {
     const loaded = [userMessage("msg_1")]
     const ready = readTimelineMessages({

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -65,6 +65,26 @@ describe("readTimelineMessages", () => {
     expect(missing.lastGood).toBe(ready.lastGood)
   })
 
+  test("does not reuse last-good messages after the same session id gets a different identity scope", () => {
+    const loaded = [userMessage("msg_1")]
+    const ready = readTimelineMessages({
+      sessionID: "ses_target",
+      identity: "server-a:ses_target",
+      raw: loaded,
+      lastGood: undefined,
+    })
+
+    const missing = readTimelineMessages({
+      sessionID: "ses_target",
+      identity: "server-b:ses_target",
+      raw: undefined,
+      lastGood: ready.lastGood,
+    })
+
+    expect(missing.messages).toEqual([])
+    expect(missing.lastGood).toBe(ready.lastGood)
+  })
+
   test("clears last-good messages when there is no active session", () => {
     const loaded = [userMessage("msg_1")]
     const ready = readTimelineMessages({

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -51,6 +51,7 @@ export function createSessionTimelineData(input: {
   })
   const routeSessionCount = createMemo(() => Math.max(routeInfo()?.summary?.files ?? 0, routeDiffs().length))
   const routeHasSessionReview = createMemo(() => routeSessionCount() > 0)
+  // Route readiness is raw cache state. The timeline controller decides when to preserve the mounted view.
   const routeMessagesReady = createMemo(() => {
     const id = input.routeSessionID()
     if (!id) return true
@@ -58,7 +59,6 @@ export function createSessionTimelineData(input: {
   })
 
   const sessionView = createSessionViewController({
-    directory: input.directory,
     routeSessionID: input.routeSessionID,
     routeMessagesReady,
   })
@@ -71,6 +71,7 @@ export function createSessionTimelineData(input: {
     return input.sync.session.get(id)
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
+  // Only reuse last-good messages for a same-session transient cache miss.
   let lastGoodMessages: LastGoodMessages
   const messages = createMemo(
     () => {

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -12,10 +12,17 @@ import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { diffs as list } from "@/utils/diffs"
 import { same } from "@/utils/same"
 
-type LastGoodMessages = { sessionID: string; messages: ReturnType<typeof readSessionMessages> } | undefined
+type LastGoodMessages =
+  | {
+      identity: string
+      sessionID: string
+      messages: ReturnType<typeof readSessionMessages>
+    }
+  | undefined
 
 export function readTimelineMessages(input: {
   sessionID: string | undefined
+  identity?: string
   raw: unknown
   lastGood: LastGoodMessages
 }): { messages: ReturnType<typeof readSessionMessages>; lastGood: LastGoodMessages } {
@@ -23,12 +30,14 @@ export function readTimelineMessages(input: {
     return { messages: emptyMessages, lastGood: undefined }
   }
 
+  const identity = input.identity ?? input.sessionID
+
   if (input.raw !== undefined) {
     const messages = readSessionMessages(input.raw)
-    return { messages, lastGood: { sessionID: input.sessionID, messages } }
+    return { messages, lastGood: { identity, sessionID: input.sessionID, messages } }
   }
 
-  if (input.lastGood?.sessionID === input.sessionID) {
+  if (input.lastGood?.identity === identity && input.lastGood.sessionID === input.sessionID) {
     return { messages: input.lastGood.messages, lastGood: input.lastGood }
   }
 
@@ -78,6 +87,7 @@ export function createSessionTimelineData(input: {
       const id = sessionID()
       const next = readTimelineMessages({
         sessionID: id,
+        identity: id ? `${id}:${sessionInfo()?.time.created ?? ""}` : undefined,
         raw: id ? input.sync.data.message[id] : undefined,
         lastGood: lastGoodMessages,
       })

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -76,10 +76,14 @@ export function currentSessionActionReady(input: {
   rawMessages: unknown
   statusReady: boolean
   localReady: boolean
-  providerReady: boolean
+  providerUsable: boolean
 }) {
   if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.statusReady && input.localReady && input.providerReady
+  return currentSessionCacheReady(input) && input.statusReady && input.localReady && input.providerUsable
+}
+
+export function currentDirectoryProviderUsable(input: { providerReady: boolean; providerCount: number }) {
+  return input.providerReady || input.providerCount > 0
 }
 
 export function sessionStatusKnown(input: { statusState: SessionStatusState; status: SessionStatus | undefined }) {
@@ -170,7 +174,10 @@ export function createSessionTimelineData(input: {
       rawMessages: id ? input.sync.data.message[id] : undefined,
       statusReady: statusKnown(),
       localReady: input.local.session.ready(),
-      providerReady: input.sync.data.provider_ready,
+      providerUsable: currentDirectoryProviderUsable({
+        providerReady: input.sync.data.provider_ready,
+        providerCount: input.sync.data.provider.all.length,
+      }),
     })
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -75,11 +75,20 @@ export function currentSessionActionReady(input: {
   sessionInfo: unknown
   rawMessages: unknown
   statusReady: boolean
+}) {
+  if (!input.sessionID) return true
+  return currentSessionCacheReady(input) && input.statusReady
+}
+
+export function currentSessionSubmitReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+  statusReady: boolean
   localReady: boolean
   providerUsable: boolean
 }) {
-  if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.statusReady && input.localReady && input.providerUsable
+  return currentSessionActionReady(input) && input.localReady && input.providerUsable
 }
 
 export function currentDirectoryProviderUsable(input: { providerReady: boolean; providerCount: number }) {
@@ -166,9 +175,18 @@ export function createSessionTimelineData(input: {
       rawMessages: id ? input.sync.data.message[id] : undefined,
     })
   })
-  const actionReady = createMemo(() => {
+  const sessionActionReady = createMemo(() => {
     const id = sessionID()
     return currentSessionActionReady({
+      sessionID: id,
+      sessionInfo: sessionInfo(),
+      rawMessages: id ? input.sync.data.message[id] : undefined,
+      statusReady: statusKnown(),
+    })
+  })
+  const actionReady = createMemo(() => {
+    const id = sessionID()
+    return currentSessionSubmitReady({
       sessionID: id,
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
@@ -285,6 +303,7 @@ export function createSessionTimelineData(input: {
     messageCachePresent,
     statusKnown,
     currentSessionCacheReady: currentSessionCacheReadyMemo,
+    sessionActionReady,
     actionReady,
     isChildSession,
     messages,

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -75,9 +75,11 @@ export function currentSessionActionReady(input: {
   sessionInfo: unknown
   rawMessages: unknown
   statusReady: boolean
+  localReady: boolean
+  providerReady: boolean
 }) {
   if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.statusReady
+  return currentSessionCacheReady(input) && input.statusReady && input.localReady && input.providerReady
 }
 
 export function sessionStatusKnown(input: { statusState: SessionStatusState; status: SessionStatus | undefined }) {
@@ -167,6 +169,8 @@ export function createSessionTimelineData(input: {
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
       statusReady: statusKnown(),
+      localReady: input.local.session.ready(),
+      providerReady: input.sync.data.provider_ready,
     })
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -53,8 +53,12 @@ export function timelineDataIdentity(input: { sessionID: string | undefined; cre
   return `${input.sessionID}:${input.created}`
 }
 
-export function timelineModelSyncKey(input: { directory: string; messageID: string | undefined }) {
-  return `${input.directory}\n${input.messageID ?? ""}`
+export function timelineModelSyncKey(input: {
+  directory: string
+  messageID: string | undefined
+  localReady: boolean
+}) {
+  return `${input.directory}\n${input.messageID ?? ""}\n${input.localReady ? "ready" : "loading"}`
 }
 
 export function currentSessionCacheReady(input: {
@@ -230,7 +234,12 @@ export function createSessionTimelineData(input: {
 
   createEffect(
     on(
-      () => timelineModelSyncKey({ directory: input.directory(), messageID: lastUserMessage()?.id }),
+      () =>
+        timelineModelSyncKey({
+          directory: input.directory(),
+          messageID: lastUserMessage()?.id,
+          localReady: input.local.session.ready(),
+        }),
       () => {
         const msg = lastUserMessage()
         if (!msg) return

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -1,6 +1,7 @@
 import { createEffect, createMemo, on } from "solid-js"
 import type { useLocal } from "@/context/local"
 import type { useSync } from "@/context/sync"
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { createSessionViewController } from "@/pages/session/session-view-controller"
 import {
   emptyMessages,
@@ -74,6 +75,11 @@ export function currentSessionActionReady(input: {
   return currentSessionCacheReady(input) && input.statusReady
 }
 
+export function sessionStatusKnown(input: { statusReady: boolean; status: SessionStatus | undefined }) {
+  if (input.statusReady) return true
+  return input.status?.type === "busy" || input.status?.type === "retry"
+}
+
 export function readTimelineMessagesFromCache(input: {
   sessionID: string | undefined
   sessionCreated: number | undefined
@@ -136,7 +142,10 @@ export function createSessionTimelineData(input: {
   const statusKnown = createMemo(() => {
     const id = sessionID()
     if (!id) return true
-    return input.sync.data.session_status_ready || input.sync.data.session_status[id] !== undefined
+    return sessionStatusKnown({
+      statusReady: input.sync.data.session_status_ready,
+      status: input.sync.data.session_status[id],
+    })
   })
   const currentSessionCacheReadyMemo = createMemo(() => {
     const id = sessionID()

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -14,7 +14,7 @@ import { same } from "@/utils/same"
 
 type LastGoodMessages =
   | {
-      identity: string
+      dataIdentity: string
       sessionID: string
       messages: ReturnType<typeof readSessionMessages>
     }
@@ -22,7 +22,7 @@ type LastGoodMessages =
 
 export function readTimelineMessages(input: {
   sessionID: string | undefined
-  identity?: string
+  dataIdentity?: string
   raw: unknown
   lastGood: LastGoodMessages
 }): { messages: ReturnType<typeof readSessionMessages>; lastGood: LastGoodMessages } {
@@ -30,14 +30,15 @@ export function readTimelineMessages(input: {
     return { messages: emptyMessages, lastGood: undefined }
   }
 
-  const identity = input.identity ?? input.sessionID
+  const dataIdentity =
+    input.dataIdentity ?? (input.lastGood?.sessionID === input.sessionID ? input.lastGood.dataIdentity : input.sessionID)
 
   if (input.raw !== undefined) {
     const messages = readSessionMessages(input.raw)
-    return { messages, lastGood: { identity, sessionID: input.sessionID, messages } }
+    return { messages, lastGood: { dataIdentity, sessionID: input.sessionID, messages } }
   }
 
-  if (input.lastGood?.identity === identity && input.lastGood.sessionID === input.sessionID) {
+  if (input.lastGood?.dataIdentity === dataIdentity && input.lastGood.sessionID === input.sessionID) {
     return { messages: input.lastGood.messages, lastGood: input.lastGood }
   }
 
@@ -82,12 +83,18 @@ export function createSessionTimelineData(input: {
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
   // Only reuse last-good messages for a same-session transient cache miss.
   let lastGoodMessages: LastGoodMessages
+  const sessionDataIdentity = createMemo(() => {
+    const id = sessionID()
+    const created = sessionInfo()?.time.created
+    if (!id || created === undefined) return
+    return `${id}:${created}`
+  })
   const messages = createMemo(
     () => {
       const id = sessionID()
       const next = readTimelineMessages({
         sessionID: id,
-        identity: id ? `${id}:${sessionInfo()?.time.created ?? ""}` : undefined,
+        dataIdentity: sessionDataIdentity(),
         raw: id ? input.sync.data.message[id] : undefined,
         lastGood: lastGoodMessages,
       })

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -31,7 +31,8 @@ export function readTimelineMessages(input: {
   }
 
   const dataIdentity =
-    input.dataIdentity ?? (input.lastGood?.sessionID === input.sessionID ? input.lastGood.dataIdentity : input.sessionID)
+    input.dataIdentity ??
+    (input.lastGood?.sessionID === input.sessionID ? input.lastGood.dataIdentity : input.sessionID)
 
   if (input.raw !== undefined) {
     const messages = readSessionMessages(input.raw)
@@ -54,13 +55,23 @@ export function timelineModelSyncKey(input: { directory: string; messageID: stri
   return `${input.directory}\n${input.messageID ?? ""}`
 }
 
-export function currentSessionDataReady(input: {
+export function currentSessionCacheReady(input: {
   sessionID: string | undefined
   sessionInfo: unknown
   rawMessages: unknown
 }) {
   if (!input.sessionID) return true
   return input.sessionInfo !== undefined && input.rawMessages !== undefined
+}
+
+export function currentSessionActionReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+  status: unknown
+}) {
+  if (!input.sessionID) return true
+  return currentSessionCacheReady(input) && input.status !== undefined
 }
 
 export function readTimelineMessagesFromCache(input: {
@@ -112,12 +123,36 @@ export function createSessionTimelineData(input: {
     if (!id) return
     return input.sync.session.get(id)
   })
-  const actionReady = createMemo(() => {
+  const sessionInfoPresent = createMemo(() => {
     const id = sessionID()
-    return currentSessionDataReady({
+    if (!id) return true
+    return sessionInfo() !== undefined
+  })
+  const messageCachePresent = createMemo(() => {
+    const id = sessionID()
+    if (!id) return true
+    return input.sync.data.message[id] !== undefined
+  })
+  const statusKnown = createMemo(() => {
+    const id = sessionID()
+    if (!id) return true
+    return input.sync.data.session_status[id] !== undefined
+  })
+  const currentSessionCacheReadyMemo = createMemo(() => {
+    const id = sessionID()
+    return currentSessionCacheReady({
       sessionID: id,
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
+    })
+  })
+  const actionReady = createMemo(() => {
+    const id = sessionID()
+    return currentSessionActionReady({
+      sessionID: id,
+      sessionInfo: sessionInfo(),
+      rawMessages: id ? input.sync.data.message[id] : undefined,
+      status: id ? input.sync.data.session_status[id] : undefined,
     })
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
@@ -216,6 +251,10 @@ export function createSessionTimelineData(input: {
     sessionKey,
     transitioning,
     sessionInfo,
+    sessionInfoPresent,
+    messageCachePresent,
+    statusKnown,
+    currentSessionCacheReady: currentSessionCacheReadyMemo,
     actionReady,
     isChildSession,
     messages,

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -50,6 +50,10 @@ export function timelineDataIdentity(input: { sessionID: string | undefined; cre
   return `${input.sessionID}:${input.created}`
 }
 
+export function timelineModelSyncKey(input: { directory: string; messageID: string | undefined }) {
+  return `${input.directory}\n${input.messageID ?? ""}`
+}
+
 export function readTimelineMessagesFromCache(input: {
   sessionID: string | undefined
   sessionCreated: number | undefined
@@ -164,7 +168,7 @@ export function createSessionTimelineData(input: {
 
   createEffect(
     on(
-      () => ({ directory: input.directory(), messageID: lastUserMessage()?.id }),
+      () => timelineModelSyncKey({ directory: input.directory(), messageID: lastUserMessage()?.id }),
       () => {
         const msg = lastUserMessage()
         if (!msg) return

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -12,6 +12,29 @@ import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { diffs as list } from "@/utils/diffs"
 import { same } from "@/utils/same"
 
+type LastGoodMessages = { sessionID: string; messages: ReturnType<typeof readSessionMessages> } | undefined
+
+export function readTimelineMessages(input: {
+  sessionID: string | undefined
+  raw: unknown
+  lastGood: LastGoodMessages
+}): { messages: ReturnType<typeof readSessionMessages>; lastGood: LastGoodMessages } {
+  if (!input.sessionID) {
+    return { messages: emptyMessages, lastGood: undefined }
+  }
+
+  if (input.raw !== undefined) {
+    const messages = readSessionMessages(input.raw)
+    return { messages, lastGood: { sessionID: input.sessionID, messages } }
+  }
+
+  if (input.lastGood?.sessionID === input.sessionID) {
+    return { messages: input.lastGood.messages, lastGood: input.lastGood }
+  }
+
+  return { messages: emptyMessages, lastGood: input.lastGood }
+}
+
 export function createSessionTimelineData(input: {
   directory: () => string
   routeSessionID: () => string | undefined
@@ -48,10 +71,17 @@ export function createSessionTimelineData(input: {
     return input.sync.session.get(id)
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
+  let lastGoodMessages: LastGoodMessages
   const messages = createMemo(
     () => {
       const id = sessionID()
-      return readSessionMessages(id ? input.sync.data.message[id] : undefined)
+      const next = readTimelineMessages({
+        sessionID: id,
+        raw: id ? input.sync.data.message[id] : undefined,
+        lastGood: lastGoodMessages,
+      })
+      lastGoodMessages = next.lastGood
+      return next.messages
     },
     emptyMessages,
     { equals: same },

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -2,6 +2,7 @@ import { createEffect, createMemo, on } from "solid-js"
 import type { useLocal } from "@/context/local"
 import type { useSync } from "@/context/sync"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
+import type { SessionStatusState } from "@/context/global-sync/types"
 import { createSessionViewController } from "@/pages/session/session-view-controller"
 import {
   emptyMessages,
@@ -75,8 +76,8 @@ export function currentSessionActionReady(input: {
   return currentSessionCacheReady(input) && input.statusReady
 }
 
-export function sessionStatusKnown(input: { statusReady: boolean; status: SessionStatus | undefined }) {
-  if (input.statusReady) return true
+export function sessionStatusKnown(input: { statusState: SessionStatusState; status: SessionStatus | undefined }) {
+  if (input.statusState === "ready" || input.statusState === "error") return true
   return input.status?.type === "busy" || input.status?.type === "retry"
 }
 
@@ -143,7 +144,7 @@ export function createSessionTimelineData(input: {
     const id = sessionID()
     if (!id) return true
     return sessionStatusKnown({
-      statusReady: input.sync.data.session_status_ready,
+      statusState: input.sync.data.session_status_state,
       status: input.sync.data.session_status[id],
     })
   })

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -54,6 +54,15 @@ export function timelineModelSyncKey(input: { directory: string; messageID: stri
   return `${input.directory}\n${input.messageID ?? ""}`
 }
 
+export function currentSessionDataReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+}) {
+  if (!input.sessionID) return true
+  return input.sessionInfo !== undefined && input.rawMessages !== undefined
+}
+
 export function readTimelineMessagesFromCache(input: {
   sessionID: string | undefined
   sessionCreated: number | undefined
@@ -102,6 +111,14 @@ export function createSessionTimelineData(input: {
     const id = sessionID()
     if (!id) return
     return input.sync.session.get(id)
+  })
+  const actionReady = createMemo(() => {
+    const id = sessionID()
+    return currentSessionDataReady({
+      sessionID: id,
+      sessionInfo: sessionInfo(),
+      rawMessages: id ? input.sync.data.message[id] : undefined,
+    })
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
   // Only reuse last-good messages for a same-session transient cache miss.
@@ -199,6 +216,7 @@ export function createSessionTimelineData(input: {
     sessionKey,
     transitioning,
     sessionInfo,
+    actionReady,
     isChildSession,
     messages,
     messagesReady,

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -68,10 +68,10 @@ export function currentSessionActionReady(input: {
   sessionID: string | undefined
   sessionInfo: unknown
   rawMessages: unknown
-  status: unknown
+  statusReady: boolean
 }) {
   if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.status !== undefined
+  return currentSessionCacheReady(input) && input.statusReady
 }
 
 export function readTimelineMessagesFromCache(input: {
@@ -136,7 +136,7 @@ export function createSessionTimelineData(input: {
   const statusKnown = createMemo(() => {
     const id = sessionID()
     if (!id) return true
-    return input.sync.data.session_status[id] !== undefined
+    return input.sync.data.session_status_ready || input.sync.data.session_status[id] !== undefined
   })
   const currentSessionCacheReadyMemo = createMemo(() => {
     const id = sessionID()
@@ -152,7 +152,7 @@ export function createSessionTimelineData(input: {
       sessionID: id,
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
-      status: id ? input.sync.data.session_status[id] : undefined,
+      statusReady: statusKnown(),
     })
   })
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -91,6 +91,10 @@ export function currentSessionSubmitReady(input: {
   return currentSessionActionReady(input) && input.localReady && input.providerUsable
 }
 
+export function currentWorkspaceSubmitReady(input: { localReady: boolean; providerUsable: boolean }) {
+  return input.localReady && input.providerUsable
+}
+
 export function currentDirectoryProviderUsable(input: { providerReady: boolean; providerCount: number }) {
   return input.providerReady || input.providerCount > 0
 }
@@ -198,6 +202,15 @@ export function createSessionTimelineData(input: {
       }),
     })
   })
+  const workspaceSubmitReady = createMemo(() =>
+    currentWorkspaceSubmitReady({
+      localReady: input.local.session.ready(),
+      providerUsable: currentDirectoryProviderUsable({
+        providerReady: input.sync.data.provider_ready,
+        providerCount: input.sync.data.provider.all.length,
+      }),
+    }),
+  )
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
   // Only reuse last-good messages for a same-session transient cache miss.
   let lastGoodMessages: LastGoodMessages
@@ -305,6 +318,7 @@ export function createSessionTimelineData(input: {
     currentSessionCacheReady: currentSessionCacheReadyMemo,
     sessionActionReady,
     actionReady,
+    workspaceSubmitReady,
     isChildSession,
     messages,
     messagesReady,

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -45,6 +45,25 @@ export function readTimelineMessages(input: {
   return { messages: emptyMessages, lastGood: input.lastGood }
 }
 
+export function timelineDataIdentity(input: { sessionID: string | undefined; created: number | undefined }) {
+  if (!input.sessionID || input.created === undefined) return
+  return `${input.sessionID}:${input.created}`
+}
+
+export function readTimelineMessagesFromCache(input: {
+  sessionID: string | undefined
+  sessionCreated: number | undefined
+  raw: unknown
+  lastGood: LastGoodMessages
+}) {
+  return readTimelineMessages({
+    sessionID: input.sessionID,
+    dataIdentity: timelineDataIdentity({ sessionID: input.sessionID, created: input.sessionCreated }),
+    raw: input.raw,
+    lastGood: input.lastGood,
+  })
+}
+
 export function createSessionTimelineData(input: {
   directory: () => string
   routeSessionID: () => string | undefined
@@ -83,18 +102,12 @@ export function createSessionTimelineData(input: {
   const isChildSession = createMemo(() => !!sessionInfo()?.parentID)
   // Only reuse last-good messages for a same-session transient cache miss.
   let lastGoodMessages: LastGoodMessages
-  const sessionDataIdentity = createMemo(() => {
-    const id = sessionID()
-    const created = sessionInfo()?.time.created
-    if (!id || created === undefined) return
-    return `${id}:${created}`
-  })
   const messages = createMemo(
     () => {
       const id = sessionID()
-      const next = readTimelineMessages({
+      const next = readTimelineMessagesFromCache({
         sessionID: id,
-        dataIdentity: sessionDataIdentity(),
+        sessionCreated: sessionInfo()?.time.created,
         raw: id ? input.sync.data.message[id] : undefined,
         lastGood: lastGoodMessages,
       })

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -164,7 +164,7 @@ export function createSessionTimelineData(input: {
 
   createEffect(
     on(
-      () => lastUserMessage()?.id,
+      () => ({ directory: input.directory(), messageID: lastUserMessage()?.id }),
       () => {
         const msg = lastUserMessage()
         if (!msg) return


### PR DESCRIPTION
## Summary

Keep the current session timeline mounted when `exit-worktree` changes the active execution directory.

- Stop keying the directory route layout subtree by resolved directory.
- Make timeline identity session-scoped instead of `directory + sessionID`.
- Keep same-session ready state through transient message cache misses.
- Preserve last-good messages for the same session while the backing store refreshes, including the case where session info is temporarily missing.
- Split timeline render readiness from session-action readiness and submit readiness: timeline can stay mounted, stop/abort/revert can use current session cache/status readiness, while submit/follow-up additionally wait for usable directory model/provider state.
- Avoid permanent action locks: seeded provider data is usable before provider refresh completes, provider refresh starts before unrelated slow bootstrap work, and local model-selection persisted failures/timeouts only block auto-restore, not manual operation.
- Keep provider refresh writes guarded by the latest refresh revision without query-cache in-flight dedupe leaving `provider_ready` stuck.
- Keep session follow-up/revert/review helpers reading or snapshotting the correct current directory/client after the subtree stays mounted.
- Keep revert/restore optimistic store writes and prompt writes pinned to the directory/prompt scope captured at click time.
- Keep LocalProvider model-selection persistence scoped to the current directory without remounting the timeline subtree.
- Restore same-session model selection again when the directory or directory-local persisted cache readiness changes, and bound cached LocalProvider directory stores.
- Keep existing per-directory saved model selection authoritative, wait for persisted model-selection hydration before restore, and cover that priority with tests.
- Refetch review artifact history when the execution directory changes, using a client created for the resource source directory.
- Guard VCS diff tasks/results by execution directory so an old directory cannot block or overwrite the current review state.

## Why

Fixes #432.

`exit-worktree` changes where subsequent tools execute. It should not make the current session timeline look like a new timeline. The previous route/provider/timeline keys allowed directory changes and short cache misses to tear down `MessageTimeline`, resetting staged rendering and scroll state.

## Related Issue

Fixes #432

Follow-up architecture work: #441

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the session identity boundary and the remaining directory-scoped surfaces:

- `activeDirectory` / route directory changes should not remount the session timeline.
- `messagesReady=false` should be treated as timeline refresh/render state, not action readiness.
- Composer submit/follow-up should wait for current directory model/provider readiness; stop/abort/revert should not be blocked by model/provider readiness.
- Last-good messages must only be reused for the same session, and must survive same-session cache misses while session info reloads.
- Local model selection cache, follow-up, revert, review helpers, and review artifact history should use current directory/client values after directory changes.

## Risk Notes

Moderate UI lifecycle risk: `DirectoryLayout` no longer remounts the provider subtree on valid route directory changes. This is intentional for #432, but reviewers should check for assumptions that depended on directory-driven remounts.

Follow-up queue persistence is now session-scoped/global instead of workspace-scoped so a mounted session subtree cannot keep writing queued followups into the initial directory's workspace storage. Legacy workspace-scoped follow-up queues are intentionally not migrated because their saved execution directory can be stale after worktree exit.

Local model selection remains directory-scoped in this Stage 1 patch. If a session has a saved selection in the current directory, restore from the latest user message does not overwrite it; this preserves directory-local user intent. Broader `{server, sessionID}` identity, session-scoped cache, route canonicalization, and SyncProvider current-directory unpin/replace policy are tracked in #441.

This PR intentionally does not migrate timeline identity, last-good cache, or follow-up persistence to `{serverKey, sessionID}`. That needs a coherent SessionScope migration and is tracked in #441 rather than mixed into this Stage 1 stopgap.

Manual browser reproduction of the original long-timeline `enter-worktree -> exit-worktree -> follow-up` path is still not complete. This PR should be merged only if that gap is accepted or after a reviewer runs that UI path and confirms no same-session timeline unmount, no rendered-count reset, and no scrollTop jump near 0.

## How To Verify

```text
Latest focused P1 regression tests: 37 passed, 0 failed
Command: cd packages/app && bun test --preload ./happydom.ts ./src/components/prompt-input/readiness.test.ts ./src/pages/session/use-session-timeline-data.test.ts ./src/components/prompt-input/submit.test.ts

Local/sync isolated regression tests: 10 passed, 0 failed
Command: bun --cwd packages/app test ./src/context/local.test.ts ./src/context/sync-current-child.test.ts

App typecheck: ok
Command: bun --cwd packages/app run typecheck

GitHub CI for head ee84e798a: all required checks passed, including ci, codeql, desktop-smoke, e2e-artifacts, dependency-review, commit-lint, CodeRabbit, and CodeQL.
```

Note: one combined local test invocation that mixed the local/sync context tests with other test files hit existing Bun module-mock isolation pollution. The same test files passed when run in the isolated groups above.

## Screenshots or Recordings

Not included. This PR changes lifecycle behavior for the session timeline; targeted unit coverage, diagnostics tests, typecheck, and GitHub CI were run. Manual browser reproduction of the original `exit-worktree` scroll path was not run in this turn.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger session readiness gating (action/abort) across composer and followups.
  * Improved timeline caching and "last good" message retention.
  * Persistent per-directory local session stores and safer followup drafts.

* **Bug Fixes**
  * More stable session behavior across directory switches and cache misses.
  * Safer revert/restore flows with snapshot-backed rollback and recovery.

* **Performance**
  * More resilient provider refresh and session-status hydration with better concurrency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->