### PR TITLE
fix(app): persist pinned sessions across restarts

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -17,7 +17,7 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { useLayout, LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
-import { Persist, persisted } from "@/utils/persist"
+import { persisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
@@ -92,6 +92,7 @@ import {
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { PawworkTitlebar } from "./layout/pawwork-titlebar"
+import { createDefaultLayoutPageState, createLayoutPagePersistTarget } from "./layout/layout-page-store"
 import { SettingsPage, type SettingsPageTab } from "@/components/settings-page"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
 import { sessionTitle } from "@/utils/session-title"
@@ -99,18 +100,8 @@ import { sizingStopEvents } from "@/pages/session/helpers"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
-    Persist.global("layout.page", ["layout.page.v1"]),
-    createStore({
-      activeProject: undefined as string | undefined,
-      activeWorkspace: undefined as string | undefined,
-      workspaceOrder: {} as Record<string, string[]>,
-      workspaceName: {} as Record<string, string>,
-      workspaceBranchName: {} as Record<string, Record<string, string>>,
-      workspaceExpanded: {} as Record<string, boolean>,
-      gettingStartedDismissed: false,
-      pawworkPinnedSessions: [] as string[],
-      pawworkSortMode: "time" as "time" | "project",
-    }),
+    createLayoutPagePersistTarget(),
+    createStore(createDefaultLayoutPageState()),
   )
 
   const pageReady = createMemo(() => ready())

--- a/packages/app/src/pages/layout/layout-page-store.test.ts
+++ b/packages/app/src/pages/layout/layout-page-store.test.ts
@@ -1,5 +1,60 @@
 import { describe, expect, test } from "bun:test"
-import { createLayoutPagePersistTarget, migrateLayoutPageState } from "./layout-page-store"
+import type { AsyncStorage } from "@solid-primitives/storage"
+import { PersistTesting } from "@/utils/persist"
+import { createDefaultLayoutPageState, createLayoutPagePersistTarget, migrateLayoutPageState } from "./layout-page-store"
+
+class ElectronPathStorage implements AsyncStorage {
+  constructor(readonly data: Record<string, unknown> = {}) {}
+
+  private path(key: string) {
+    return key.split(".")
+  }
+
+  private read(key: string) {
+    let current: unknown = this.data
+    for (const part of this.path(key)) {
+      if (!current || typeof current !== "object" || Array.isArray(current)) return undefined
+      current = (current as Record<string, unknown>)[part]
+    }
+    return current
+  }
+
+  private write(key: string, value: unknown) {
+    const parts = this.path(key)
+    let current = this.data
+    for (const part of parts.slice(0, -1)) {
+      const next = current[part]
+      if (!next || typeof next !== "object" || Array.isArray(next)) {
+        current[part] = {}
+      }
+      current = current[part] as Record<string, unknown>
+    }
+    current[parts[parts.length - 1]] = value
+  }
+
+  getItem(key: string) {
+    const value = this.read(key)
+    if (value === undefined || value === null) return Promise.resolve(null)
+    return Promise.resolve(typeof value === "string" ? value : JSON.stringify(value))
+  }
+
+  setItem(key: string, value: string) {
+    this.write(key, value)
+    return Promise.resolve()
+  }
+
+  removeItem(key: string) {
+    const parts = this.path(key)
+    let current = this.data
+    for (const part of parts.slice(0, -1)) {
+      const next = current[part]
+      if (!next || typeof next !== "object" || Array.isArray(next)) return Promise.resolve()
+      current = next as Record<string, unknown>
+    }
+    delete current[parts[parts.length - 1]]
+    return Promise.resolve()
+  }
+}
 
 describe("layout page state migration", () => {
   test("restores pinned sessions from old desktop layout page path", () => {
@@ -71,5 +126,72 @@ describe("layout page persistence target", () => {
     expect(target.key).toBe("layout-page")
     expect(target.currentLegacy).toEqual(["layout.page", "layout"])
     expect(target.legacy).toEqual(["layout.page.v1"])
+  })
+})
+
+describe("layout page desktop persistence migration", () => {
+  async function readFromDesktopStore(current: ElectronPathStorage, legacyStore = new ElectronPathStorage()) {
+    const target = createLayoutPagePersistTarget()
+    const raw = await PersistTesting.readPersistedAsync({
+      current,
+      legacyStore,
+      key: target.key,
+      defaults: createDefaultLayoutPageState(),
+      currentLegacy: target.currentLegacy ?? [],
+      legacy: target.legacy ?? [],
+      migrate: target.migrate,
+    })
+    return JSON.parse(raw ?? "{}") as ReturnType<typeof createDefaultLayoutPageState>
+  }
+
+  test("restores from electron-store nested layout.page", async () => {
+    const current = new ElectronPathStorage({
+      layout: {
+        page: JSON.stringify({
+          pawworkPinnedSessions: ["ses_desktop"],
+          pawworkSortMode: "project",
+        }),
+      },
+    })
+
+    const restored = await readFromDesktopStore(current)
+
+    expect(restored.pawworkPinnedSessions).toEqual(["ses_desktop"])
+    expect(restored.pawworkSortMode).toBe("project")
+    expect(JSON.parse((current.data["layout-page"] as string) ?? "{}").pawworkPinnedSessions).toEqual(["ses_desktop"])
+  })
+
+  test("restores when the main layout key has already been normalized to a JSON string", async () => {
+    const current = new ElectronPathStorage({
+      layout: JSON.stringify({
+        page: JSON.stringify({
+          pawworkPinnedSessions: ["ses_layout_string"],
+        }),
+      }),
+    })
+
+    const restored = await readFromDesktopStore(current)
+
+    expect(restored.pawworkPinnedSessions).toEqual(["ses_layout_string"])
+    expect(JSON.parse((current.data["layout-page"] as string) ?? "{}").pawworkPinnedSessions).toEqual([
+      "ses_layout_string",
+    ])
+  })
+
+  test("keeps current layout-page ahead of stale desktop legacy values", async () => {
+    const current = new ElectronPathStorage({
+      "layout-page": JSON.stringify({
+        pawworkPinnedSessions: ["ses_current"],
+      }),
+      layout: {
+        page: JSON.stringify({
+          pawworkPinnedSessions: ["ses_stale"],
+        }),
+      },
+    })
+
+    const restored = await readFromDesktopStore(current)
+
+    expect(restored.pawworkPinnedSessions).toEqual(["ses_current"])
   })
 })

--- a/packages/app/src/pages/layout/layout-page-store.test.ts
+++ b/packages/app/src/pages/layout/layout-page-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { createLayoutPagePersistTarget, migrateLayoutPageState } from "./layout-page-store"
+
+describe("layout page state migration", () => {
+  test("restores pinned sessions from old desktop layout page path", () => {
+    const migrated = migrateLayoutPageState({
+      pawworkPinnedSessions: ["ses_a", "ses_a", "", 42],
+      pawworkSortMode: "project",
+    })
+
+    expect(migrated).toMatchObject({
+      pawworkPinnedSessions: ["ses_a"],
+      pawworkSortMode: "project",
+    })
+  })
+
+  test("restores pinned sessions from old layout object with nested page JSON", () => {
+    const migrated = migrateLayoutPageState({
+      sidebar: { opened: true },
+      page: JSON.stringify({
+        pawworkPinnedSessions: ["ses_nested"],
+        pawworkSortMode: "project",
+      }),
+    })
+
+    expect(migrated).toMatchObject({
+      pawworkPinnedSessions: ["ses_nested"],
+      pawworkSortMode: "project",
+    })
+  })
+
+  test("falls back safely when old page JSON is damaged", () => {
+    const migrated = migrateLayoutPageState({
+      page: "{",
+      pawworkPinnedSessions: ["ses_current"],
+    })
+
+    expect(migrated).toMatchObject({
+      pawworkPinnedSessions: ["ses_current"],
+      pawworkSortMode: "time",
+    })
+  })
+
+  test("rejects plain main layout state as a layout-page migration source", () => {
+    expect(
+      migrateLayoutPageState({
+        sidebar: { opened: true },
+        rightPanel: { opened: false },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("rejects damaged non-object layout-page migration sources", () => {
+    expect(migrateLayoutPageState("not-json")).toBeUndefined()
+    expect(migrateLayoutPageState([])).toBeUndefined()
+  })
+
+  test("rejects nested page objects without layout-page fields", () => {
+    expect(
+      migrateLayoutPageState({
+        page: { sidebar: { opened: true } },
+      }),
+    ).toBeUndefined()
+  })
+})
+
+describe("layout page persistence target", () => {
+  test("uses an unambiguous key and reads old same-storage keys", () => {
+    const target = createLayoutPagePersistTarget()
+
+    expect(target.key).toBe("layout-page")
+    expect(target.currentLegacy).toEqual(["layout.page", "layout"])
+    expect(target.legacy).toEqual(["layout.page.v1"])
+  })
+})

--- a/packages/app/src/pages/layout/layout-page-store.ts
+++ b/packages/app/src/pages/layout/layout-page-store.ts
@@ -1,0 +1,83 @@
+import { Persist } from "@/utils/persist"
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseMaybeJSON(value: unknown) {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function pinnedSessions(value: unknown) {
+  if (!Array.isArray(value)) return [] as string[]
+  const seen = new Set<string>()
+  return value.filter((item): item is string => {
+    if (typeof item !== "string") return false
+    if (!item) return false
+    if (seen.has(item)) return false
+    seen.add(item)
+    return true
+  })
+}
+
+function hasLayoutPageFields(value: Record<string, unknown>) {
+  return "pawworkPinnedSessions" in value || "pawworkSortMode" in value
+}
+
+export function createDefaultLayoutPageState() {
+  return {
+    activeProject: undefined as string | undefined,
+    activeWorkspace: undefined as string | undefined,
+    workspaceOrder: {} as Record<string, string[]>,
+    workspaceName: {} as Record<string, string>,
+    workspaceBranchName: {} as Record<string, Record<string, string>>,
+    workspaceExpanded: {} as Record<string, boolean>,
+    gettingStartedDismissed: false,
+    pawworkPinnedSessions: [] as string[],
+    pawworkSortMode: "time" as "time" | "project",
+  }
+}
+
+export function migrateLayoutPageState(value: unknown) {
+  const decoded = parseMaybeJSON(value)
+  if (!record(decoded)) return undefined
+
+  if ("page" in decoded) {
+    const parsedPage = parseMaybeJSON(decoded.page)
+    if (!record(parsedPage)) {
+      if (!hasLayoutPageFields(decoded)) return undefined
+      return {
+        ...decoded,
+        pawworkPinnedSessions: pinnedSessions(decoded.pawworkPinnedSessions),
+        pawworkSortMode: decoded.pawworkSortMode === "project" ? "project" : "time",
+      }
+    }
+    if (!hasLayoutPageFields(parsedPage)) return undefined
+    return {
+      ...parsedPage,
+      pawworkPinnedSessions: pinnedSessions(parsedPage.pawworkPinnedSessions),
+      pawworkSortMode: parsedPage.pawworkSortMode === "project" ? "project" : "time",
+    }
+  }
+
+  if (!hasLayoutPageFields(decoded)) return undefined
+
+  return {
+    ...decoded,
+    pawworkPinnedSessions: pinnedSessions(decoded.pawworkPinnedSessions),
+    pawworkSortMode: decoded.pawworkSortMode === "project" ? "project" : "time",
+  }
+}
+
+export function createLayoutPagePersistTarget() {
+  return {
+    ...Persist.global("layout-page", ["layout.page.v1"]),
+    currentLegacy: ["layout.page", "layout"],
+    migrate: migrateLayoutPageState,
+  }
+}

--- a/packages/app/src/utils/persist.test.ts
+++ b/packages/app/src/utils/persist.test.ts
@@ -131,6 +131,70 @@ describe("persist localStorage resilience", () => {
     expect(result).toBeUndefined()
   })
 
+  test("current key wins over same-storage legacy keys", () => {
+    const current = persistTesting.localStorageWithPrefix("pawwork.global.dat")
+    const legacy = persistTesting.localStorageDirect()
+    current.removeItem("layout-page")
+    current.removeItem("layout.page")
+    current.setItem("layout-page", JSON.stringify({ pinned: ["current"] }))
+    current.setItem("layout.page", JSON.stringify({ pinned: ["old"] }))
+
+    const result = persistTesting.readPersistedSync({
+      current,
+      legacyStore: legacy,
+      key: "layout-page",
+      defaults: { pinned: [] as string[] },
+      currentLegacy: ["layout.page"],
+      legacy: [],
+    })
+
+    expect(JSON.parse(result ?? "{}")).toEqual({ pinned: ["current"] })
+  })
+
+  test("same-storage legacy keys migrate into the current key", () => {
+    const current = persistTesting.localStorageWithPrefix("pawwork.global.dat")
+    const legacy = persistTesting.localStorageDirect()
+    current.removeItem("layout-page")
+    current.removeItem("layout.page")
+    current.setItem("layout.page", JSON.stringify({ pinned: ["old"] }))
+
+    const result = persistTesting.readPersistedSync({
+      current,
+      legacyStore: legacy,
+      key: "layout-page",
+      defaults: { pinned: [] as string[] },
+      currentLegacy: ["layout.page"],
+      legacy: [],
+    })
+
+    expect(JSON.parse(result ?? "{}")).toEqual({ pinned: ["old"] })
+    expect(JSON.parse(storage.getItem("pawwork.global.dat:layout-page") ?? "{}")).toEqual({
+      pinned: ["old"],
+    })
+  })
+
+  test("invalid same-storage legacy values do not block legacy storage fallback", () => {
+    const current = persistTesting.localStorageWithPrefix("pawwork.global.dat")
+    const legacy = persistTesting.localStorageDirect()
+    current.removeItem("layout-page")
+    current.removeItem("layout")
+    current.setItem("layout", JSON.stringify({ sidebar: { opened: true } }))
+    legacy.setItem("layout.page.v1", JSON.stringify({ pinned: ["legacy"] }))
+
+    const result = persistTesting.readPersistedSync({
+      current,
+      legacyStore: legacy,
+      key: "layout-page",
+      defaults: { pinned: [] as string[] },
+      currentLegacy: ["layout"],
+      legacy: ["layout.page.v1"],
+      migrate: (value) => ("pinned" in (value as Record<string, unknown>) ? value : undefined),
+    })
+
+    expect(JSON.parse(result ?? "{}")).toEqual({ pinned: ["legacy"] })
+    expect(legacy.getItem("layout.page.v1")).toBeNull()
+  })
+
   test("workspace storage sanitizes Windows filename characters", () => {
     const result = persistTesting.workspaceStorage("C:\\Users\\foo")
 

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -16,6 +16,7 @@ type PersistTarget = {
   storage?: string
   key: string
   legacy?: string[]
+  currentLegacy?: string[]
   migrate?: (value: unknown) => unknown
 }
 
@@ -207,8 +208,56 @@ function normalize(defaults: unknown, raw: string, migrate?: (value: unknown) =>
   const parsed = parse(raw)
   if (parsed === undefined) return
   const migrated = migrate ? migrate(parsed) : parsed
+  if (migrate && migrated === undefined) return
   const merged = merge(defaults, migrated)
   return JSON.stringify(merged)
+}
+
+function readPersistedSync(input: {
+  current: SyncStorage
+  legacyStore: SyncStorage
+  key: string
+  defaults: unknown
+  legacy: string[]
+  currentLegacy: string[]
+  migrate?: (value: unknown) => unknown
+}) {
+  const raw = input.current.getItem(input.key)
+  if (raw !== null) {
+    const next = normalize(input.defaults, raw, input.migrate)
+    if (next === undefined) {
+      input.current.removeItem(input.key)
+      return null
+    }
+    if (raw !== next) input.current.setItem(input.key, next)
+    return next
+  }
+
+  for (const legacyKey of input.currentLegacy) {
+    const legacyRaw = input.current.getItem(legacyKey)
+    if (legacyRaw === null) continue
+
+    const next = normalize(input.defaults, legacyRaw, input.migrate)
+    if (next === undefined) continue
+    input.current.setItem(input.key, next)
+    return next
+  }
+
+  for (const legacyKey of input.legacy) {
+    const legacyRaw = input.legacyStore.getItem(legacyKey)
+    if (legacyRaw === null) continue
+
+    const next = normalize(input.defaults, legacyRaw, input.migrate)
+    if (next === undefined) {
+      input.legacyStore.removeItem(legacyKey)
+      continue
+    }
+    input.current.setItem(input.key, next)
+    input.legacyStore.removeItem(legacyKey)
+    return next
+  }
+
+  return null
 }
 
 function workspaceStorage(dir: string) {
@@ -308,6 +357,7 @@ export const PersistTesting = {
   localStorageDirect,
   localStorageWithPrefix,
   normalize,
+  readPersistedSync,
   workspaceStorage,
 }
 
@@ -351,6 +401,7 @@ export function persisted<T>(
 
   const defaults = snapshot(store[0])
   const legacy = config.legacy ?? []
+  const currentLegacy = config.currentLegacy ?? []
 
   const isDesktop = platform.platform === "desktop" && !!platform.storage
 
@@ -374,55 +425,24 @@ export function persisted<T>(
 
       const api: SyncStorage = {
         getItem: (key) => {
-          const raw = current.getItem(key)
-          if (raw !== null) {
-            const next = normalize(defaults, raw, config.migrate)
-            if (debugTerminal) {
-              console.error("[persisted:workspace:terminal:sync]", {
-                storage: config.storage,
-                key,
-                source: "current",
-                rawPreview: raw.slice(0, 240),
-                rawLength: raw.length,
-                normalizedPreview: next?.slice(0, 240),
-                normalizedLength: next?.length,
-              })
-            }
-            if (next === undefined) {
-              current.removeItem(key)
-              return null
-            }
-            if (raw !== next) current.setItem(key, next)
-            return next
+          const next = readPersistedSync({
+            current,
+            legacyStore,
+            key,
+            defaults,
+            legacy,
+            currentLegacy,
+            migrate: config.migrate,
+          })
+          if (debugTerminal) {
+            console.error("[persisted:workspace:terminal:sync]", {
+              storage: config.storage,
+              key,
+              normalizedPreview: next?.slice(0, 240),
+              normalizedLength: next?.length,
+            })
           }
-
-          for (const legacyKey of legacy) {
-            const legacyRaw = legacyStore.getItem(legacyKey)
-            if (legacyRaw === null) continue
-
-            const next = normalize(defaults, legacyRaw, config.migrate)
-            if (debugTerminal) {
-              console.error("[persisted:workspace:terminal:sync]", {
-                storage: config.storage,
-                key,
-                source: "legacy",
-                legacyKey,
-                rawPreview: legacyRaw.slice(0, 240),
-                rawLength: legacyRaw.length,
-                normalizedPreview: next?.slice(0, 240),
-                normalizedLength: next?.length,
-              })
-            }
-            if (next === undefined) {
-              legacyStore.removeItem(legacyKey)
-              continue
-            }
-            current.setItem(key, next)
-            legacyStore.removeItem(legacyKey)
-            return next
-          }
-
-          return null
+          return next
         },
         setItem: (key, value) => {
           current.setItem(key, value)
@@ -460,6 +480,16 @@ export function persisted<T>(
             return null
           }
           if (raw !== next) await current.setItem(key, next)
+          return next
+        }
+
+        for (const legacyKey of currentLegacy) {
+          const legacyRaw = await current.getItem(legacyKey)
+          if (legacyRaw === null) continue
+
+          const next = normalize(defaults, legacyRaw, config.migrate)
+          if (next === undefined) continue
+          await current.setItem(key, next)
           return next
         }
 

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -260,6 +260,55 @@ function readPersistedSync(input: {
   return null
 }
 
+async function readPersistedAsync(input: {
+  current: AsyncStorage
+  legacyStore?: AsyncStorage
+  key: string
+  defaults: unknown
+  legacy: string[]
+  currentLegacy: string[]
+  migrate?: (value: unknown) => unknown
+}) {
+  const raw = await input.current.getItem(input.key)
+  if (raw !== null) {
+    const next = normalize(input.defaults, raw, input.migrate)
+    if (next === undefined) {
+      await input.current.removeItem(input.key).catch(() => undefined)
+      return null
+    }
+    if (raw !== next) await input.current.setItem(input.key, next)
+    return next
+  }
+
+  for (const legacyKey of input.currentLegacy) {
+    const legacyRaw = await input.current.getItem(legacyKey)
+    if (legacyRaw === null) continue
+
+    const next = normalize(input.defaults, legacyRaw, input.migrate)
+    if (next === undefined) continue
+    await input.current.setItem(input.key, next)
+    return next
+  }
+
+  if (!input.legacyStore) return null
+
+  for (const legacyKey of input.legacy) {
+    const legacyRaw = await input.legacyStore.getItem(legacyKey)
+    if (legacyRaw === null) continue
+
+    const next = normalize(input.defaults, legacyRaw, input.migrate)
+    if (next === undefined) {
+      await input.legacyStore.removeItem(legacyKey).catch(() => undefined)
+      continue
+    }
+    await input.current.setItem(input.key, next)
+    await input.legacyStore.removeItem(legacyKey)
+    return next
+  }
+
+  return null
+}
+
 function workspaceStorage(dir: string) {
   const head = (dir.slice(0, 12) || "workspace").replace(/[^a-zA-Z0-9._-]/g, "-")
   const sum = checksum(dir) ?? "0"
@@ -357,6 +406,7 @@ export const PersistTesting = {
   localStorageDirect,
   localStorageWithPrefix,
   normalize,
+  readPersistedAsync,
   readPersistedSync,
   workspaceStorage,
 }
@@ -461,67 +511,24 @@ export function persisted<T>(
 
     const api: AsyncStorage = {
       getItem: async (key) => {
-        const raw = await current.getItem(key)
-        if (raw !== null) {
-          const next = normalize(defaults, raw, config.migrate)
-          if (debugTerminal) {
-            console.error("[persisted:workspace:terminal:async]", {
-              storage: config.storage,
-              key,
-              source: "current",
-              rawPreview: raw.slice(0, 240),
-              rawLength: raw.length,
-              normalizedPreview: next?.slice(0, 240),
-              normalizedLength: next?.length,
-            })
-          }
-          if (next === undefined) {
-            await current.removeItem(key).catch(() => undefined)
-            return null
-          }
-          if (raw !== next) await current.setItem(key, next)
-          return next
+        const next = await readPersistedAsync({
+          current,
+          legacyStore,
+          key,
+          defaults,
+          legacy,
+          currentLegacy,
+          migrate: config.migrate,
+        })
+        if (debugTerminal) {
+          console.error("[persisted:workspace:terminal:async]", {
+            storage: config.storage,
+            key,
+            normalizedPreview: next?.slice(0, 240),
+            normalizedLength: next?.length,
+          })
         }
-
-        for (const legacyKey of currentLegacy) {
-          const legacyRaw = await current.getItem(legacyKey)
-          if (legacyRaw === null) continue
-
-          const next = normalize(defaults, legacyRaw, config.migrate)
-          if (next === undefined) continue
-          await current.setItem(key, next)
-          return next
-        }
-
-        if (!legacyStore) return null
-
-        for (const legacyKey of legacy) {
-          const legacyRaw = await legacyStore.getItem(legacyKey)
-          if (legacyRaw === null) continue
-
-          const next = normalize(defaults, legacyRaw, config.migrate)
-          if (debugTerminal) {
-            console.error("[persisted:workspace:terminal:async]", {
-              storage: config.storage,
-              key,
-              source: "legacy",
-              legacyKey,
-              rawPreview: legacyRaw.slice(0, 240),
-              rawLength: legacyRaw.length,
-              normalizedPreview: next?.slice(0, 240),
-              normalizedLength: next?.length,
-            })
-          }
-          if (next === undefined) {
-            await legacyStore.removeItem(legacyKey).catch(() => undefined)
-            continue
-          }
-          await current.setItem(key, next)
-          await legacyStore.removeItem(legacyKey)
-          return next
-        }
-
-        return null
+        return next
       },
       setItem: async (key, value) => {
         await current.setItem(key, value)


### PR DESCRIPTION
## Summary

Persist PawWork sidebar pinned sessions across desktop restarts by moving layout page state to an unambiguous storage key and migrating valid legacy values.

## Why

Fixes #425. The desktop storage backend treats dotted keys as object paths, so the page-level `layout.page` store could collide with the main `layout` store and lose `pawworkPinnedSessions` after restart.

## Related Issue

Fixes #425

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the layout page storage migration path, especially current-key priority, same-storage legacy fallback, and rejection of invalid legacy sources so they do not mask valid `layout.page.v1` data.

## Risk Notes

Migration-sensitive desktop storage change. The fix avoids deleting the main `layout` store and only writes new layout page state to `layout-page`.

## How To Verify

```text
Focused tests: bun test --preload ./happydom.ts ./src/pages/layout/layout-page-store.test.ts ./src/utils/persist.test.ts -> 16 pass, 0 fail
App unit tests: bun --cwd packages/app test:unit -> 850 pass, 0 fail
Typecheck: bun --cwd packages/app typecheck -> exit 0
Diff check: git diff --check -> exit 0
Fresh code review: superpowers:requesting-code-review final pass -> no Critical, Important, or Minor findings; ready to merge
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English