### PR TITLE
feat(config): add discoverable PawWork home

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ PawWork includes a free plan powered by OpenCode Zen, plus built-in web search w
 
 When you want more model choice or control, connect your own accounts. PawWork supports API keys, OAuth where available, OpenAI-compatible providers, and supported coding plans, including OpenAI, Claude, DeepSeek, Gemini, Kimi, GLM, and more.
 
+## Configuration
+
+PawWork keeps human-editable global configuration in `~/.pawwork` by default. Set `PAWWORK_HOME` to use another folder. The older `PAWWORK_CONFIG_DIR` variable is still accepted as a legacy alias.
+
+Runtime data is separate. Sessions, databases, cache, logs, and downloaded helper binaries continue to use the operating system's app data, cache, state, and log directories, not `~/.pawwork`.
+
 ## Download
 
 Download the latest macOS and Windows builds from [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest).

--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ PawWork includes a free plan powered by OpenCode Zen, plus built-in web search w
 
 When you want more model choice or control, connect your own accounts. PawWork supports API keys, OAuth where available, OpenAI-compatible providers, and supported coding plans, including OpenAI, Claude, DeepSeek, Gemini, Kimi, GLM, and more.
 
-## Configuration
-
-PawWork keeps human-editable global configuration in `~/.pawwork` by default. Set `PAWWORK_HOME` to use another folder. The older `PAWWORK_CONFIG_DIR` variable is still accepted as a legacy alias.
-
-Runtime data is separate. Sessions, databases, cache, logs, and downloaded helper binaries continue to use the operating system's app data, cache, state, and log directories, not `~/.pawwork`.
-
 ## Download
 
 Download the latest macOS and Windows builds from [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest).

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,12 +60,6 @@
 
 如果你需要更多模型选择或更强控制权，可以连接自己的模型账号。爪印 PawWork 支持 API 密钥，也支持可用提供商的 OAuth 登录、OpenAI 兼容提供商和可用的 Coding Plan，包括 OpenAI、Claude、DeepSeek、Gemini、Kimi、GLM 等。
 
-## 配置
-
-爪印 PawWork 默认把用户可编辑的全局配置放在 `~/.pawwork`。如果你想换位置，可以设置 `PAWWORK_HOME`。旧的 `PAWWORK_CONFIG_DIR` 仍然兼容，作为 legacy alias 使用。
-
-运行时数据会继续分开保存。会话、数据库、缓存、日志和下载的辅助工具仍然放在系统的 app data、cache、state、log 等目录，不会写进 `~/.pawwork`。
-
 ## 下载
 
 从 [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest) 下载最新的 macOS 和 Windows 版本。

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,12 @@
 
 如果你需要更多模型选择或更强控制权，可以连接自己的模型账号。爪印 PawWork 支持 API 密钥，也支持可用提供商的 OAuth 登录、OpenAI 兼容提供商和可用的 Coding Plan，包括 OpenAI、Claude、DeepSeek、Gemini、Kimi、GLM 等。
 
+## 配置
+
+爪印 PawWork 默认把用户可编辑的全局配置放在 `~/.pawwork`。如果你想换位置，可以设置 `PAWWORK_HOME`。旧的 `PAWWORK_CONFIG_DIR` 仍然兼容，作为 legacy alias 使用。
+
+运行时数据会继续分开保存。会话、数据库、缓存、日志和下载的辅助工具仍然放在系统的 app data、cache、state、log 等目录，不会写进 `~/.pawwork`。
+
 ## 下载
 
 从 [GitHub Releases](https://github.com/Astro-Han/pawwork/releases/latest) 下载最新的 macOS 和 Windows 版本。

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -29,6 +29,7 @@ export const dict = {
   "command.server.switch": "Switch server",
   "command.settings.open": "Open settings",
   "command.settings.openGlobalConfigFolder": "Open global config folder",
+  "toast.settings.openGlobalConfigFolderFailed.title": "Could not open global config folder",
   "command.session.previous": "Previous session",
   "command.session.next": "Next session",
   "command.session.previous.unseen": "Previous unread session",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -28,6 +28,7 @@ export const dict = {
   "command.provider.connect": "Connect provider",
   "command.server.switch": "Switch server",
   "command.settings.open": "Open settings",
+  "command.settings.openGlobalConfigFolder": "Open global config folder",
   "command.session.previous": "Previous session",
   "command.session.next": "Next session",
   "command.session.previous.unseen": "Previous unread session",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -34,6 +34,7 @@ export const dict = {
   "command.server.switch": "切换服务器",
 
   "command.settings.open": "打开设置",
+  "command.settings.openGlobalConfigFolder": "打开全局配置文件夹",
 
   "command.session.previous": "上一个会话",
   "command.session.next": "下一个会话",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -35,6 +35,7 @@ export const dict = {
 
   "command.settings.open": "打开设置",
   "command.settings.openGlobalConfigFolder": "打开全局配置文件夹",
+  "toast.settings.openGlobalConfigFolderFailed.title": "无法打开全局配置文件夹",
 
   "command.session.previous": "上一个会话",
   "command.session.next": "下一个会话",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1218,8 +1218,25 @@ export default function Layout(props: ParentProps) {
         category: language.t("command.category.settings"),
         disabled: !platform.openPath,
         onSelect: async () => {
-          const target = await globalSDK.client.path.get({ ensureConfig: true }).then((x) => x.data?.config)
-          if (target) await platform.openPath?.(target)
+          const target = await globalSDK.client.path
+            .get({ ensureConfig: true })
+            .then((x) => x.data?.config)
+            .catch((err) => {
+              showToast({
+                title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+                description: errorMessage(err, language.t("common.requestFailed")),
+                variant: "error",
+              })
+              return undefined
+            })
+          if (!target) return
+          await platform.openPath?.(target).catch((err) => {
+            showToast({
+              title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+              description: errorMessage(err, language.t("common.requestFailed")),
+              variant: "error",
+            })
+          })
         },
       },
       {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1213,6 +1213,16 @@ export default function Layout(props: ParentProps) {
         onSelect: () => openSettings(),
       },
       {
+        id: "settings.openGlobalConfigFolder",
+        title: language.t("command.settings.openGlobalConfigFolder"),
+        category: language.t("command.category.settings"),
+        disabled: !platform.openPath,
+        onSelect: async () => {
+          const target = globalSync.data.path.config || (await globalSDK.client.path.get().then((x) => x.data?.config))
+          if (target) await platform.openPath?.(target)
+        },
+      },
+      {
         id: "session.previous",
         title: language.t("command.session.previous"),
         category: language.t("command.category.session"),

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1218,7 +1218,7 @@ export default function Layout(props: ParentProps) {
         category: language.t("command.category.settings"),
         disabled: !platform.openPath,
         onSelect: async () => {
-          const target = globalSync.data.path.config || (await globalSDK.client.path.get().then((x) => x.data?.config))
+          const target = await globalSDK.client.path.get({ ensureConfig: true }).then((x) => x.data?.config)
           if (target) await platform.openPath?.(target)
         },
       },

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -20,6 +20,7 @@ export namespace Flag {
   export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
   export declare const OPENCODE_PURE: boolean
   export declare const OPENCODE_CONFIG_DIR: string | undefined
+  export declare const PAWWORK_HOME: string | undefined
   export declare const PAWWORK_CONFIG_DIR: string | undefined
   export declare const OPENCODE_PLUGIN_META_FILE: string | undefined
   export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"]
@@ -109,6 +110,17 @@ Object.defineProperty(Flag, "OPENCODE_DISABLE_PROJECT_CONFIG", {
 Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
   get() {
     return process.env["OPENCODE_CONFIG_DIR"]
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for PAWWORK_HOME
+// This must be evaluated at access time, not module load time,
+// because tests and external tooling may set this env var at runtime
+Object.defineProperty(Flag, "PAWWORK_HOME", {
+  get() {
+    return process.env["PAWWORK_HOME"]
   },
   enumerable: true,
   configurable: false,

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -35,10 +35,8 @@ function realpathOrResolved(input: string) {
   const resolved = path.resolve(input)
   try {
     return fsNode.realpathSync.native(resolved)
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code === "ENOENT" || code === "ENOTDIR") return process.platform === "win32" ? resolved.toLowerCase() : resolved
-    throw error
+  } catch {
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved
   }
 }
 
@@ -115,7 +113,13 @@ export namespace PawWorkHome {
 
   export function existingResourceDirectories() {
     return candidates()
-      .filter(isDirectory)
+      .filter((candidate) => {
+        try {
+          return isDirectory(candidate)
+        } catch {
+          return false
+        }
+      })
       .toReversed()
   }
 

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -94,10 +94,15 @@ export namespace PawWorkHome {
       .toReversed()
   }
 
-  export async function firstNonEmptyInstructionFile() {
+  export async function firstLoadedInstructionFile() {
     for (const file of instructionFiles()) {
+      const stat = await fs.stat(file).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return undefined
+        return "exists"
+      })
+      if (!stat) continue
       const content = await fs.readFile(file, "utf8").catch(() => "")
-      if (content) return file
+      return content ? file : undefined
     }
     return undefined
   }

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -31,6 +31,12 @@ function envPath(input: string | undefined) {
   return value ? value : undefined
 }
 
+function explicitHomeCandidates() {
+  return [envPath(Flag.PAWWORK_HOME), envPath(Flag.PAWWORK_CONFIG_DIR)]
+    .filter((item): item is string => Boolean(item))
+    .map(resolveHome)
+}
+
 function realpathOrResolved(input: string) {
   const resolved = path.resolve(input)
   try {
@@ -112,11 +118,13 @@ export namespace PawWorkHome {
   }
 
   export function existingResourceDirectories() {
+    const strict = new Set([primary(), ...explicitHomeCandidates()].map(normalize))
     return candidates()
       .filter((candidate) => {
         try {
           return isDirectory(candidate)
-        } catch {
+        } catch (error) {
+          if (strict.has(normalize(candidate))) throw error
           return false
         }
       })

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -36,7 +36,7 @@ function normalize(input: string) {
   try {
     return fsNode.realpathSync.native(resolved)
   } catch {
-    return resolved
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved
   }
 }
 
@@ -76,10 +76,6 @@ export namespace PawWorkHome {
     return [path.join(dir, "pawwork.json"), path.join(dir, "pawwork.jsonc")]
   }
 
-  export function configFileCandidates() {
-    return candidates().flatMap(configFilesIn)
-  }
-
   export function configFilesToLoad() {
     for (const dir of candidates()) {
       const files = configFilesIn(dir).filter(isFile)
@@ -109,19 +105,6 @@ export namespace PawWorkHome {
         }
       })
       .toReversed()
-  }
-
-  export async function firstLoadedInstructionFile() {
-    for (const file of instructionFiles()) {
-      const stat = await fs.stat(file).catch((error: NodeJS.ErrnoException) => {
-        if (error.code === "ENOENT") return undefined
-        return "exists"
-      })
-      if (!stat) continue
-      const content = await fs.readFile(file, "utf8").catch(() => "")
-      return content ? file : undefined
-    }
-    return undefined
   }
 
   export async function ensurePrimary() {

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -128,4 +128,8 @@ export namespace PawWorkHome {
     const resolved = normalize(dir)
     return candidates().some((candidate) => normalize(candidate) === resolved)
   }
+
+  export function isPrimary(dir: string) {
+    return normalize(dir) === normalize(primary())
+  }
 }

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -5,12 +5,25 @@ import { Flag } from "./flag/flag"
 import { Global } from "./global"
 
 function resolveHome(input: string) {
-  const expanded = input === "~" ? Global.Path.home : input.startsWith("~/") ? path.join(Global.Path.home, input.slice(2)) : input
+  const expanded =
+    input === "~" || input === "~\\"
+      ? Global.Path.home
+      : input.startsWith("~/") || input.startsWith("~\\")
+        ? path.join(Global.Path.home, input.slice(2))
+        : input
   return path.resolve(expanded)
 }
 
 function unique(items: string[]) {
-  return Array.from(new Set(items))
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const item of items) {
+    const key = normalize(item)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(item)
+  }
+  return result
 }
 
 function envPath(input: string | undefined) {
@@ -48,7 +61,7 @@ export namespace PawWorkHome {
   }
 
   export function configFileCandidates() {
-    return candidates().flatMap((dir) => [path.join(dir, "pawwork.jsonc"), path.join(dir, "pawwork.json")])
+    return candidates().flatMap((dir) => [path.join(dir, "pawwork.json"), path.join(dir, "pawwork.jsonc")])
   }
 
   export async function ensurePrimary() {

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -31,20 +31,38 @@ function envPath(input: string | undefined) {
   return value ? value : undefined
 }
 
-function normalize(input: string) {
+function realpathOrResolved(input: string) {
   const resolved = path.resolve(input)
   try {
     return fsNode.realpathSync.native(resolved)
-  } catch {
-    return process.platform === "win32" ? resolved.toLowerCase() : resolved
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT" || code === "ENOTDIR") return process.platform === "win32" ? resolved.toLowerCase() : resolved
+    throw error
   }
+}
+
+function normalize(input: string) {
+  return realpathOrResolved(input)
 }
 
 function isFile(input: string) {
   try {
     return fsNode.statSync(input).isFile()
-  } catch {
-    return false
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT" || code === "ENOTDIR") return false
+    throw error
+  }
+}
+
+function isDirectory(input: string) {
+  try {
+    return fsNode.statSync(input).isDirectory()
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT" || code === "ENOTDIR") return false
+    throw error
   }
 }
 
@@ -97,13 +115,7 @@ export namespace PawWorkHome {
 
   export function existingResourceDirectories() {
     return candidates()
-      .filter((dir) => {
-        try {
-          return fsNode.statSync(dir).isDirectory()
-        } catch {
-          return false
-        }
-      })
+      .filter(isDirectory)
       .toReversed()
   }
 

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -60,8 +60,46 @@ export namespace PawWorkHome {
     return candidates().map((dir) => path.join(dir, name))
   }
 
+  export function instructionFiles() {
+    return fileCandidates("AGENTS.md")
+  }
+
+  export function configFilesIn(dir: string) {
+    return [path.join(dir, "pawwork.json"), path.join(dir, "pawwork.jsonc")]
+  }
+
   export function configFileCandidates() {
-    return candidates().flatMap((dir) => [path.join(dir, "pawwork.json"), path.join(dir, "pawwork.jsonc")])
+    return candidates().flatMap(configFilesIn)
+  }
+
+  export function configFilesToLoad() {
+    for (const dir of candidates()) {
+      const files = configFilesIn(dir).filter((file) => fsNode.existsSync(file))
+      if (files.length) return files
+    }
+    return []
+  }
+
+  export function configFileForWrite() {
+    const primaryDir = primary()
+    const [json, jsonc] = configFilesIn(primaryDir)
+    if (fsNode.existsSync(jsonc)) return jsonc
+    if (fsNode.existsSync(json)) return json
+    return json
+  }
+
+  export function existingResourceDirectories() {
+    return candidates()
+      .filter((dir) => fsNode.existsSync(dir))
+      .toReversed()
+  }
+
+  export async function firstNonEmptyInstructionFile() {
+    for (const file of instructionFiles()) {
+      const content = await fs.readFile(file, "utf8").catch(() => "")
+      if (content) return file
+    }
+    return undefined
   }
 
   export async function ensurePrimary() {

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -118,7 +118,7 @@ export namespace PawWorkHome {
   }
 
   export function existingResourceDirectories() {
-    const strict = new Set([primary(), ...explicitHomeCandidates()].map(normalize))
+    const strict = new Set(explicitHomeCandidates().map(normalize))
     return candidates()
       .filter((candidate) => {
         try {

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -90,7 +90,13 @@ export namespace PawWorkHome {
 
   export function existingResourceDirectories() {
     return candidates()
-      .filter((dir) => fsNode.existsSync(dir))
+      .filter((dir) => {
+        try {
+          return fsNode.statSync(dir).isDirectory()
+        } catch {
+          return false
+        }
+      })
       .toReversed()
   }
 

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -1,0 +1,69 @@
+import path from "path"
+import fs from "fs/promises"
+import fsNode from "fs"
+import { Flag } from "./flag/flag"
+import { Global } from "./global"
+
+function resolveHome(input: string) {
+  const expanded = input === "~" ? Global.Path.home : input.startsWith("~/") ? path.join(Global.Path.home, input.slice(2)) : input
+  return path.resolve(expanded)
+}
+
+function unique(items: string[]) {
+  return Array.from(new Set(items))
+}
+
+function envPath(input: string | undefined) {
+  const value = input?.trim()
+  return value ? value : undefined
+}
+
+function normalize(input: string) {
+  const resolved = path.resolve(input)
+  try {
+    return fsNode.realpathSync.native(resolved)
+  } catch {
+    return resolved
+  }
+}
+
+export namespace PawWorkHome {
+  export function primary() {
+    return resolveHome(envPath(Flag.PAWWORK_HOME) ?? envPath(Flag.PAWWORK_CONFIG_DIR) ?? path.join(Global.Path.home, ".pawwork"))
+  }
+
+  export function candidates() {
+    const home = envPath(Flag.PAWWORK_HOME)
+    const config = envPath(Flag.PAWWORK_CONFIG_DIR)
+    return unique([
+      ...(home ? [resolveHome(home)] : []),
+      ...(config ? [resolveHome(config)] : []),
+      resolveHome(path.join(Global.Path.home, ".pawwork")),
+      path.resolve(Global.Path.config),
+    ])
+  }
+
+  export function fileCandidates(name: string) {
+    return candidates().map((dir) => path.join(dir, name))
+  }
+
+  export function configFileCandidates() {
+    return candidates().flatMap((dir) => [path.join(dir, "pawwork.jsonc"), path.join(dir, "pawwork.json")])
+  }
+
+  export async function ensurePrimary() {
+    const dir = primary()
+    const stat = await fs.stat(dir).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined
+      throw error
+    })
+    if (stat && !stat.isDirectory()) throw new Error(`PawWork Home exists but is not a directory: ${dir}`)
+    if (!stat) await fs.mkdir(dir, { recursive: true })
+    return dir
+  }
+
+  export function isCandidate(dir: string) {
+    const resolved = normalize(dir)
+    return candidates().some((candidate) => normalize(candidate) === resolved)
+  }
+}

--- a/packages/core/src/pawwork-home.ts
+++ b/packages/core/src/pawwork-home.ts
@@ -40,6 +40,14 @@ function normalize(input: string) {
   }
 }
 
+function isFile(input: string) {
+  try {
+    return fsNode.statSync(input).isFile()
+  } catch {
+    return false
+  }
+}
+
 export namespace PawWorkHome {
   export function primary() {
     return resolveHome(envPath(Flag.PAWWORK_HOME) ?? envPath(Flag.PAWWORK_CONFIG_DIR) ?? path.join(Global.Path.home, ".pawwork"))
@@ -74,7 +82,7 @@ export namespace PawWorkHome {
 
   export function configFilesToLoad() {
     for (const dir of candidates()) {
-      const files = configFilesIn(dir).filter((file) => fsNode.existsSync(file))
+      const files = configFilesIn(dir).filter(isFile)
       if (files.length) return files
     }
     return []
@@ -83,8 +91,11 @@ export namespace PawWorkHome {
   export function configFileForWrite() {
     const primaryDir = primary()
     const [json, jsonc] = configFilesIn(primaryDir)
-    if (fsNode.existsSync(jsonc)) return jsonc
-    if (fsNode.existsSync(json)) return json
+    for (const file of [jsonc, json]) {
+      if (!fsNode.existsSync(file)) continue
+      if (!isFile(file)) throw new Error(`PawWork config path exists but is not a file: ${file}`)
+      return file
+    }
     return json
   }
 

--- a/packages/opencode/specs/pawwork-home.md
+++ b/packages/opencode/specs/pawwork-home.md
@@ -1,0 +1,58 @@
+# PawWork Home
+
+PawWork Home is the global, user-editable configuration directory for PawWork.
+It is separate from runtime app data.
+
+## Priority
+
+Global PawWork configuration is resolved in this order:
+
+1. `PAWWORK_HOME`
+2. `PAWWORK_CONFIG_DIR`
+3. `~/.pawwork`
+4. legacy platform config, `Global.Path.config`
+
+`PAWWORK_CONFIG_DIR` is a legacy compatibility alias. If both environment
+variables are set, `PAWWORK_HOME` is the primary write target.
+
+Environment paths support `~/` and `~\` expansion. Relative environment paths
+are resolved to absolute paths.
+
+## Files
+
+PawWork reads these user-editable files from the highest-priority Home that
+contains each artifact:
+
+- `AGENTS.md`
+- `pawwork.jsonc`
+- `pawwork.json`
+- `command/`
+- `agent/`
+- `skills/`
+
+For `pawwork.jsonc` and `pawwork.json`, PawWork loads the first Home containing
+either file. Within that Home, `pawwork.jsonc` wins over `pawwork.json`.
+
+New global writes go only to the primary Home. PawWork does not write new global
+configuration to the legacy platform config directory.
+
+## Migration
+
+PawWork does not automatically move legacy files. On first write, it creates the
+primary Home and seeds it from the effective legacy global config so existing
+settings are not silently dropped.
+
+Users can migrate manually by copying global files from the legacy platform
+config directory into `~/.pawwork` or the directory named by `PAWWORK_HOME`.
+
+## Runtime Data
+
+Runtime data stays in platform app-data locations:
+
+- data
+- cache
+- state
+- logs
+- bins
+
+These directories do not move into PawWork Home.

--- a/packages/opencode/specs/pawwork-home.md
+++ b/packages/opencode/specs/pawwork-home.md
@@ -20,18 +20,21 @@ are resolved to absolute paths.
 
 ## Files
 
-PawWork reads these user-editable files from the highest-priority Home that
-contains each artifact:
+PawWork reads these user-editable files from PawWork Home candidates:
 
 - `AGENTS.md`
 - `pawwork.jsonc`
 - `pawwork.json`
-- `command/`
-- `agent/`
+- `command/` and `commands/`
+- `agent/` and `agents/`
 - `skills/`
 
 For `pawwork.jsonc` and `pawwork.json`, PawWork loads the first Home containing
 either file. Within that Home, `pawwork.jsonc` wins over `pawwork.json`.
+
+Resource directories such as `command/`, `agent/`, and `skills/` are cumulative
+across existing Home candidates. Lower-priority directories are loaded first, so
+higher-priority Home entries override same-name legacy entries.
 
 New global writes go only to the primary Home. PawWork does not write new global
 configuration to the legacy platform config directory.

--- a/packages/opencode/specs/pawwork-home.md
+++ b/packages/opencode/specs/pawwork-home.md
@@ -39,6 +39,12 @@ higher-priority Home entries override same-name legacy entries.
 New global writes go only to the primary Home. PawWork does not write new global
 configuration to the legacy platform config directory.
 
+One compatibility exception remains: the deprecated legacy TOML file named
+`config` under the legacy platform config directory is migrated in place on
+read. That migration writes `pawwork.json` in the same legacy platform directory
+and removes the old TOML file. Normal PawWork global updates and new writes
+still target the primary Home.
+
 ## Migration
 
 PawWork does not automatically move legacy files. On first write, it creates the

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -3,6 +3,8 @@ import * as prompts from "@clack/prompts"
 import { AppRuntime } from "@/effect/app-runtime"
 import { UI } from "../ui"
 import { Global } from "@opencode-ai/core/global"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { Runtime } from "@opencode-ai/core/runtime"
 import { Agent } from "../../agent/agent"
 import { Provider } from "../../provider/provider"
 import path from "path"
@@ -86,7 +88,7 @@ const AgentCreateCommand = cmd({
                 {
                   label: "Global",
                   value: "global" as const,
-                  hint: Global.Path.config,
+                  hint: Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config,
                 },
               ],
             })
@@ -94,7 +96,11 @@ const AgentCreateCommand = cmd({
             scope = scopeResult
           }
           targetPath = path.join(
-            scope === "global" ? Global.Path.config : path.join(Instance.worktree, ".opencode"),
+            scope === "global"
+              ? Runtime.isPawWork()
+                ? PawWorkHome.primary()
+                : Global.Path.config
+              : path.join(Instance.worktree, ".opencode"),
             "agent",
           )
         }

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -413,24 +413,26 @@ export function resolveConfigPath(baseDir: string, global = false) {
 }
 
 async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: string) {
-  let text = "{}"
-  if (await Filesystem.exists(configPath)) {
-    text = await Filesystem.readText(configPath)
-  }
+  return Config.withConfigFileLock(configPath, async () => {
+    let text = "{}"
+    if (await Filesystem.exists(configPath)) {
+      text = await Filesystem.readText(configPath)
+    }
 
-  // Use jsonc-parser to modify while preserving comments
-  const edits = modify(text, ["mcp", name], mcpConfig, {
-    formattingOptions: { tabSize: 2, insertSpaces: true },
+    // Use jsonc-parser to modify while preserving comments
+    const edits = modify(text, ["mcp", name], mcpConfig, {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    })
+    const result = applyEdits(text, edits)
+
+    await Config.writeConfigTextAtomic(configPath, result)
+
+    return configPath
   })
-  const result = applyEdits(text, edits)
-
-  await Filesystem.write(configPath, result)
-
-  return configPath
 }
 
 async function seedGlobalConfigIfNeeded(configPath: string, globalConfigPath: string) {
-  if (!Runtime.isPawWork() || configPath !== globalConfigPath) return true
+  if (!Runtime.isPawWork() || Config.configFileLockKey(configPath) !== Config.configFileLockKey(globalConfigPath)) return true
   try {
     await Config.seedGlobalConfig()
     return true

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -433,8 +433,7 @@ async function resolveConfigPath(baseDir: string, global = false) {
     }
   }
 
-  // Default to pawwork.json if none exist.
-  return candidates[0]
+  return Runtime.isPawWork() ? path.join(baseDir, "pawwork.json") : path.join(baseDir, "opencode.json")
 }
 
 async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: string) {
@@ -531,6 +530,7 @@ export const McpAddCommand = cmd({
             command: command.split(" "),
           }
 
+          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.updateGlobal({})
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
           prompts.outro("MCP server added successfully")
@@ -609,6 +609,7 @@ export const McpAddCommand = cmd({
             }
           }
 
+          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.updateGlobal({})
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
         }

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -410,6 +410,8 @@ export const McpLogoutCommand = cmd({
 })
 
 async function resolveConfigPath(baseDir: string, global = false) {
+  if (global) return Config.globalConfigFileForWrite()
+
   // Check for existing config files. Prefer PawWork JSONC/JSON, then fall back to legacy OpenCode names.
   const candidates = [
     path.join(baseDir, "pawwork.jsonc"),
@@ -418,14 +420,12 @@ async function resolveConfigPath(baseDir: string, global = false) {
     path.join(baseDir, "opencode.json"),
   ]
 
-  if (!global) {
-    candidates.push(
-      path.join(baseDir, ".opencode", "pawwork.jsonc"),
-      path.join(baseDir, ".opencode", "pawwork.json"),
-      path.join(baseDir, ".opencode", "opencode.jsonc"),
-      path.join(baseDir, ".opencode", "opencode.json"),
-    )
-  }
+  candidates.push(
+    path.join(baseDir, ".opencode", "pawwork.jsonc"),
+    path.join(baseDir, ".opencode", "pawwork.json"),
+    path.join(baseDir, ".opencode", "opencode.jsonc"),
+    path.join(baseDir, ".opencode", "opencode.json"),
+  )
 
   for (const candidate of candidates) {
     if (await Filesystem.exists(candidate)) {
@@ -530,7 +530,7 @@ export const McpAddCommand = cmd({
             command: command.split(" "),
           }
 
-          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.updateGlobal({})
+          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.seedGlobalConfig()
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
           prompts.outro("MCP server added successfully")
@@ -609,7 +609,7 @@ export const McpAddCommand = cmd({
             }
           }
 
-          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.updateGlobal({})
+          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.seedGlobalConfig()
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
         }

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -12,6 +12,8 @@ import { Instance } from "../../project/instance"
 import { Installation } from "../../installation"
 import path from "path"
 import { Global } from "@opencode-ai/core/global"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { Runtime } from "@opencode-ai/core/runtime"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "../../util/filesystem"
 import { Bus } from "../../bus"
@@ -408,20 +410,20 @@ export const McpLogoutCommand = cmd({
 })
 
 async function resolveConfigPath(baseDir: string, global = false) {
-  // Check for existing config files. Prefer pawwork.json/jsonc, then fall back to legacy opencode names.
+  // Check for existing config files. Prefer PawWork JSONC/JSON, then fall back to legacy OpenCode names.
   const candidates = [
-    path.join(baseDir, "pawwork.json"),
     path.join(baseDir, "pawwork.jsonc"),
-    path.join(baseDir, "opencode.json"),
+    path.join(baseDir, "pawwork.json"),
     path.join(baseDir, "opencode.jsonc"),
+    path.join(baseDir, "opencode.json"),
   ]
 
   if (!global) {
     candidates.push(
-      path.join(baseDir, ".opencode", "pawwork.json"),
       path.join(baseDir, ".opencode", "pawwork.jsonc"),
-      path.join(baseDir, ".opencode", "opencode.json"),
+      path.join(baseDir, ".opencode", "pawwork.json"),
       path.join(baseDir, ".opencode", "opencode.jsonc"),
+      path.join(baseDir, ".opencode", "opencode.json"),
     )
   }
 
@@ -465,9 +467,10 @@ export const McpAddCommand = cmd({
         const project = Instance.project
 
         // Resolve config paths eagerly for hints
+        const globalDir = Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config
         const [projectConfigPath, globalConfigPath] = await Promise.all([
           resolveConfigPath(Instance.worktree),
-          resolveConfigPath(Global.Path.config, true),
+          resolveConfigPath(globalDir, true),
         ])
 
         // Determine scope

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -16,6 +16,7 @@ import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "../../util/filesystem"
+import { errorMessage } from "../../util/error"
 import { Bus } from "../../bus"
 import { AppRuntime } from "../../effect/app-runtime"
 import { Effect } from "effect"
@@ -409,31 +410,9 @@ export const McpLogoutCommand = cmd({
   },
 })
 
-async function resolveConfigPath(baseDir: string, global = false) {
+export async function resolveConfigPath(baseDir: string, global = false) {
   if (global) return Config.globalConfigFileForWrite()
-
-  // Check for existing config files. Prefer PawWork JSONC/JSON, then fall back to legacy OpenCode names.
-  const candidates = [
-    path.join(baseDir, "pawwork.jsonc"),
-    path.join(baseDir, "pawwork.json"),
-    path.join(baseDir, "opencode.jsonc"),
-    path.join(baseDir, "opencode.json"),
-  ]
-
-  candidates.push(
-    path.join(baseDir, ".opencode", "pawwork.jsonc"),
-    path.join(baseDir, ".opencode", "pawwork.json"),
-    path.join(baseDir, ".opencode", "opencode.jsonc"),
-    path.join(baseDir, ".opencode", "opencode.json"),
-  )
-
-  for (const candidate of candidates) {
-    if (await Filesystem.exists(candidate)) {
-      return candidate
-    }
-  }
-
-  return Runtime.isPawWork() ? path.join(baseDir, "pawwork.json") : path.join(baseDir, "opencode.json")
+  return Config.projectConfigFileForWrite(baseDir)
 }
 
 async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: string) {
@@ -451,6 +430,18 @@ async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: s
   await Filesystem.write(configPath, result)
 
   return configPath
+}
+
+async function seedGlobalConfigIfNeeded(configPath: string, globalConfigPath: string) {
+  if (!Runtime.isPawWork() || configPath !== globalConfigPath) return true
+  try {
+    await Config.seedGlobalConfig()
+    return true
+  } catch (err) {
+    prompts.log.error(errorMessage(err))
+    prompts.outro("MCP server was not added")
+    return false
+  }
 }
 
 export const McpAddCommand = cmd({
@@ -530,7 +521,7 @@ export const McpAddCommand = cmd({
             command: command.split(" "),
           }
 
-          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.seedGlobalConfig()
+          if (!(await seedGlobalConfigIfNeeded(configPath, globalConfigPath))) return
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
           prompts.outro("MCP server added successfully")
@@ -609,7 +600,7 @@ export const McpAddCommand = cmd({
             }
           }
 
-          if (Runtime.isPawWork() && configPath === globalConfigPath) await Config.seedGlobalConfig()
+          if (!(await seedGlobalConfigIfNeeded(configPath, globalConfigPath))) return
           await addMcpToConfig(name, mcpConfig, configPath)
           prompts.log.success(`MCP server "${name}" added to ${configPath}`)
         }

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -11,8 +11,6 @@ import { Config } from "../../config/config"
 import { Instance } from "../../project/instance"
 import { Installation } from "../../installation"
 import path from "path"
-import { Global } from "@opencode-ai/core/global"
-import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "../../util/filesystem"
@@ -410,9 +408,8 @@ export const McpLogoutCommand = cmd({
   },
 })
 
-export async function resolveConfigPath(baseDir: string, global = false) {
-  if (global) return Config.globalConfigFileForWrite()
-  return Config.projectConfigFileForWrite(baseDir)
+export function resolveConfigPath(baseDir: string, global = false) {
+  return global ? Config.globalConfigFileForWrite() : Config.projectConfigFileForWrite(baseDir)
 }
 
 async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: string) {
@@ -457,11 +454,8 @@ export const McpAddCommand = cmd({
         const project = Instance.project
 
         // Resolve config paths eagerly for hints
-        const globalDir = Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config
-        const [projectConfigPath, globalConfigPath] = await Promise.all([
-          resolveConfigPath(Instance.worktree),
-          resolveConfigPath(globalDir, true),
-        ])
+        const projectConfigPath = resolveConfigPath(Instance.worktree)
+        const globalConfigPath = resolveConfigPath(Instance.worktree, true)
 
         // Determine scope
         let configPath = globalConfigPath

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -11,6 +11,8 @@ import { Filesystem } from "../../util/filesystem"
 import { Process } from "../../util/process"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { Runtime } from "@opencode-ai/core/runtime"
 
 type Spin = {
   start: (msg: string) => void
@@ -28,7 +30,7 @@ export type PlugDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode") => string[]
+  files: (dir: string, name: "opencode" | "pawwork") => string[]
   global: string
 }
 
@@ -58,7 +60,7 @@ const defaultPlugDeps: PlugDeps = {
   },
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
-  global: Global.Path.config,
+  global: Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config,
 }
 
 function cause(err: unknown) {

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -134,7 +134,15 @@ export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps
 
     const patch = dep.spinner()
     patch.start("Updating plugin config...")
-    if (global && Runtime.isPawWork()) await dep.seedGlobalConfig?.()
+    if (global && Runtime.isPawWork()) {
+      try {
+        await dep.seedGlobalConfig?.()
+      } catch (err) {
+        patch.stop("Failed updating plugin config", 1)
+        dep.log.error(errorMessage(err))
+        return false
+      }
+    }
     const out = await patchPluginConfig(
       {
         spec: mod,

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -66,7 +66,7 @@ const defaultPlugDeps: PlugDeps = {
   resolve: (spec) => resolvePluginTarget(spec),
   readText: (file) => Filesystem.readText(file),
   write: async (file, text) => {
-    await Filesystem.write(file, text)
+    await Config.writeConfigTextAtomic(file, text)
   },
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -2,6 +2,7 @@ import { intro, log, outro, spinner } from "@clack/prompts"
 import type { Argv } from "yargs"
 
 import { ConfigPaths } from "../../config/paths"
+import { Config } from "../../config/config"
 import { Global } from "../../global"
 import { installPlugin, patchPluginConfig, readPluginManifest } from "../../plugin/install"
 import { resolvePluginTarget } from "../../plugin/shared"
@@ -32,6 +33,7 @@ export type PlugDeps = {
   exists: (file: string) => Promise<boolean>
   files: (dir: string, name: "opencode" | "pawwork") => string[]
   global: string
+  seedGlobalConfig?: () => Promise<void>
 }
 
 export type PlugInput = {
@@ -61,6 +63,9 @@ const defaultPlugDeps: PlugDeps = {
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
   global: Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config,
+  seedGlobalConfig: async () => {
+    await Config.updateGlobal({})
+  },
 }
 
 function cause(err: unknown) {
@@ -131,6 +136,7 @@ export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps
 
     const patch = dep.spinner()
     patch.start("Updating plugin config...")
+    if (global && Runtime.isPawWork()) await dep.seedGlobalConfig?.()
     const out = await patchPluginConfig(
       {
         spec: mod,

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -63,9 +63,7 @@ const defaultPlugDeps: PlugDeps = {
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
   global: Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config,
-  seedGlobalConfig: async () => {
-    await Config.updateGlobal({})
-  },
+  seedGlobalConfig: () => Config.seedGlobalConfig(),
 }
 
 function cause(err: unknown) {

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -32,7 +32,7 @@ export type PlugDeps = {
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
   files: (dir: string, name: "opencode" | "pawwork") => string[]
-  global: string
+  global: string | (() => string)
   seedGlobalConfig?: () => Promise<void>
 }
 
@@ -46,6 +46,14 @@ export type PlugCtx = {
   vcs?: string
   worktree: string
   directory: string
+}
+
+export function defaultPluginGlobalConfigDir() {
+  return Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config
+}
+
+function globalConfigDir(dep: PlugDeps) {
+  return typeof dep.global === "function" ? dep.global() : dep.global
 }
 
 const defaultPlugDeps: PlugDeps = {
@@ -62,7 +70,7 @@ const defaultPlugDeps: PlugDeps = {
   },
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
-  global: Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config,
+  global: defaultPluginGlobalConfigDir,
   seedGlobalConfig: () => Config.seedGlobalConfig(),
 }
 
@@ -152,7 +160,7 @@ export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps
         vcs: ctx.vcs,
         worktree: ctx.worktree,
         directory: ctx.directory,
-        config: dep.global,
+        config: globalConfigDir(dep),
       },
       dep,
     )

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -15,7 +15,7 @@ import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
 import { migrateDefaultAgent, stripDefaultAgent } from "./migrate-default-agent"
 import { Instance, type InstanceContext } from "../project/instance"
-import { constants, existsSync } from "fs"
+import { constants, existsSync, statSync } from "fs"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Account } from "@/account"
@@ -373,15 +373,25 @@ function globalConfigFile() {
   }
   const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
   for (const file of [...candidates].reverse()) {
-    if (existsSync(file)) return file
+    if (isRegularFileSync(file)) return file
   }
   return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
+}
+
+function isRegularFileSync(file: string) {
+  try {
+    return statSync(file).isFile()
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT" || code === "ENOTDIR") return false
+    throw error
+  }
 }
 
 function legacyTomlMigrationTarget() {
   const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
   for (const file of [...candidates].reverse()) {
-    if (existsSync(file)) return file
+    if (isRegularFileSync(file)) return file
   }
   return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
 }
@@ -437,7 +447,7 @@ export async function writeConfigTextAtomic(file: string, text: string, options?
 function globalConfigFilesToLoad() {
   if (!Runtime.isPawWork()) {
     const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
-    return candidates.filter((file) => existsSync(file))
+    return candidates.filter(isRegularFileSync)
   }
 
   return PawWorkHome.configFilesToLoad()
@@ -488,6 +498,21 @@ function patchJsonc(input: string, patch: unknown, path: string[] = []): string 
   }, input)
 }
 
+function missingConfigPatch(lowPriority: unknown, highPriority: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(lowPriority)) return
+  const out: Record<string, unknown> = {}
+  const high = isRecord(highPriority) ? highPriority : {}
+  for (const [key, lowValue] of Object.entries(lowPriority)) {
+    if (!(key in high)) {
+      out[key] = lowValue
+      continue
+    }
+    const nested = missingConfigPatch(lowValue, high[key])
+    if (nested && Object.keys(nested).length > 0) out[key] = nested
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 function writable(info: Info) {
   const { default_agent: _defaultAgent, plugin_origins: _plugin_origins, ...next } = info
   return next
@@ -514,7 +539,7 @@ function hasConfigPlaceholder(value: string) {
 
 function resolveSeedInstructionPath(value: string, sourceFile: string) {
   const rewritten = rewriteFilePlaceholders(value, sourceFile)
-  if (hasConfigPlaceholder(rewritten)) return rewritten
+  if (hasConfigPlaceholder(rewritten) && rewritten.trimStart().startsWith("{")) return rewritten
   return resolveSeedPath(rewritten, sourceFile)
 }
 
@@ -586,13 +611,24 @@ function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
   return JSON.stringify(merged, null, 2)
 }
 
-async function writeLegacyTomlMigration(target: string, legacyConfig: Info) {
+async function writeLegacyTomlMigration(target: string, legacyConfig: Info, options?: { mergeExisting?: boolean }) {
   await withConfigFileLock(target, async () => {
     const existingText = await fsNode.readFile(target, "utf8").catch((error: NodeJS.ErrnoException) => {
       if (error.code === "ENOENT") return undefined
       throw error
     })
-    if (existingText !== undefined) return
+    if (existingText !== undefined) {
+      if (!options?.mergeExisting) return
+      const existing = ConfigParse.jsonc(existingText, target)
+      if (!isRecord(existing)) return
+      const patch = missingConfigPatch(legacyConfig, existing)
+      if (!patch) return
+      const updated = target.endsWith(".jsonc")
+        ? patchJsonc(existingText, patch)
+        : JSON.stringify(mergeDeep(legacyConfig, existing), null, 2)
+      await writeConfigTextAtomic(target, updated)
+      return
+    }
     await writeConfigTextAtomic(target, JSON.stringify(legacyConfig, null, 2))
   })
 }
@@ -686,12 +722,16 @@ const rawLayer = Layer.effect(
               if (provider && model) migrated.model = `${provider}/${model}`
               const legacyConfig = mergeDeep(migrated, rest)
               if (!Runtime.isPawWork() || globalFiles.length === 0) {
-                result = mergeDeep(result, legacyConfig)
+                result = mergeDeep(legacyConfig, result)
               }
-              await writeLegacyTomlMigration(legacyTomlMigrationTarget(), legacyConfig)
+              await writeLegacyTomlMigration(legacyTomlMigrationTarget(), legacyConfig, {
+                mergeExisting: !Runtime.isPawWork(),
+              })
               await fsNode.unlink(legacy)
             })
-            .catch(() => {}),
+            .catch((error) => {
+              log.warn("legacy TOML config migration failed", { path: legacy, error: String(error) })
+            }),
         )
       }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -381,6 +381,10 @@ function globalConfigFile() {
   return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
 }
 
+export function globalConfigFileForWrite() {
+  return globalConfigFile()
+}
+
 function globalConfigFilesToLoad() {
   if (!Runtime.isPawWork()) {
     const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
@@ -948,6 +952,10 @@ export async function updateGlobal(config: Info) {
   return runPromise((svc) => svc.updateGlobal(config))
 }
 
+export async function seedGlobalConfig() {
+  await updateGlobal({})
+}
+
 export async function invalidate(wait = false) {
   return runPromise((svc) => svc.invalidate(wait))
 }
@@ -1015,6 +1023,8 @@ const ConfigGetGlobal = getGlobal
 const ConfigGetConsoleState = getConsoleState
 const ConfigUpdate = update
 const ConfigUpdateGlobal = updateGlobal
+const ConfigSeedGlobalConfig = seedGlobalConfig
+const ConfigGlobalConfigFileForWrite = globalConfigFileForWrite
 const ConfigInvalidate = invalidate
 const ConfigDirectories = directories
 const ConfigWaitForDependencies = waitForDependencies
@@ -1057,6 +1067,8 @@ export namespace Config {
   export const getConsoleState = ConfigGetConsoleState
   export const update = ConfigUpdate
   export const updateGlobal = ConfigUpdateGlobal
+  export const seedGlobalConfig = ConfigSeedGlobalConfig
+  export const globalConfigFileForWrite = ConfigGlobalConfigFileForWrite
   export const invalidate = ConfigInvalidate
   export const directories = ConfigDirectories
   export const waitForDependencies = ConfigWaitForDependencies

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -8,6 +8,7 @@ import { Global } from "@opencode-ai/core/global"
 import fsNode from "fs/promises"
 import { NamedError } from "@opencode-ai/util/error"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
@@ -67,6 +68,7 @@ function projectConfigNames() {
 }
 
 function projectConfigFilesForDirectory(dir: string) {
+  if (Runtime.isPawWork() && PawWorkHome.isCandidate(dir)) return []
   const base = path.basename(dir)
   if (base === ".pawwork") return Runtime.isPawWork() ? PAWWORK_PROJECT_CONFIG_FILES : []
   if (base === ".opencode" || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -364,11 +366,38 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@opencode/Config") {}
 
 function globalConfigFile() {
+  if (Runtime.isPawWork()) {
+    const primary = PawWorkHome.primary()
+    const jsonc = path.join(primary, "pawwork.jsonc")
+    if (existsSync(jsonc)) return jsonc
+    const json = path.join(primary, "pawwork.json")
+    if (existsSync(json)) return json
+    return json
+  }
   const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
   for (const file of [...candidates].reverse()) {
     if (existsSync(file)) return file
   }
   return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
+}
+
+function globalConfigFilesToLoad() {
+  if (!Runtime.isPawWork()) {
+    const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
+    return candidates.filter((file) => existsSync(file))
+  }
+
+  for (const dir of PawWorkHome.candidates()) {
+    const json = path.join(dir, "pawwork.json")
+    const jsonc = path.join(dir, "pawwork.jsonc")
+    const files = [json, jsonc].filter((file) => existsSync(file))
+    if (files.length) return files
+  }
+  return []
+}
+
+function globalConfigSource() {
+  return globalConfigFilesToLoad().at(-1)
 }
 
 function projectConfigFile(dir: string) {
@@ -469,8 +498,7 @@ const rawLayer = Layer.effect(
 
     const loadGlobal = Effect.fnUntraced(function* () {
       let result: Info = {}
-      for (const file of globalConfigFiles()) {
-        const filepath = path.join(Global.Path.config, file)
+      for (const filepath of globalConfigFilesToLoad()) {
         // Strip deprecated default_agent before parsing (issue #239).
         // When sanitizedText is present we use it directly to avoid a redundant
         // disk read AND to ensure runtime never sees a stale value even if the
@@ -601,7 +629,7 @@ const rawLayer = Layer.effect(
         }
 
         const global = yield* getGlobal()
-        yield* merge(Global.Path.config, global, "global")
+        yield* merge(globalConfigSource() ?? (Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config), global, "global")
 
         if (Flag.OPENCODE_CONFIG) {
           yield* merge(Flag.OPENCODE_CONFIG, yield* loadFile(Flag.OPENCODE_CONFIG))
@@ -632,10 +660,7 @@ const rawLayer = Layer.effect(
         const deps: Fiber.Fiber<void, never>[] = []
 
         for (const dir of directories) {
-          const configFiles =
-            Runtime.isPawWork() && pawworkConfigDir && dir === pawworkConfigDir
-              ? globalConfigFiles()
-              : projectConfigFilesForDirectory(dir)
+          const configFiles = Runtime.isPawWork() && PawWorkHome.isCandidate(dir) ? [] : projectConfigFilesForDirectory(dir)
 
           if (configFiles.length > 0) {
             for (const file of configFiles) {
@@ -857,7 +882,11 @@ const rawLayer = Layer.effect(
 
     const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info) {
       const file = globalConfigFile()
-      const before = (yield* readConfigFile(file)) ?? "{}"
+      yield* Effect.promise(() =>
+        Runtime.isPawWork() ? PawWorkHome.ensurePrimary() : fsNode.mkdir(path.dirname(file), { recursive: true }),
+      )
+      const existingText = yield* readConfigFile(file)
+      const before = existingText ?? JSON.stringify(writable(yield* loadGlobal()), null, 2)
 
       let next: Info
       if (!file.endsWith(".jsonc")) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -500,12 +500,36 @@ function resolveSeedPath(value: string, sourceFile: string) {
   return path.resolve(path.dirname(sourceFile), value)
 }
 
+function hasConfigPlaceholder(value: string) {
+  return /\{[A-Za-z][A-Za-z\d_-]*:/.test(value)
+}
+
+function resolveSeedInstructionPath(value: string, sourceFile: string) {
+  const rewritten = rewriteFilePlaceholders(value, sourceFile)
+  if (hasConfigPlaceholder(rewritten)) return rewritten
+  return resolveSeedPath(rewritten, sourceFile)
+}
+
 function rewriteFilePlaceholders(value: string, sourceFile: string) {
   return value.replace(/\{file:([^}]+)\}/g, (match, filePath: string) => {
     const trimmed = filePath.trim()
     if (!trimmed || isAbsoluteOrExternalPath(trimmed)) return match
     return `{file:${path.resolve(path.dirname(sourceFile), trimmed)}}`
   })
+}
+
+function rewriteFilePlaceholdersDeep(value: unknown, sourceFile: string): unknown {
+  if (typeof value === "string") return rewriteFilePlaceholders(value, sourceFile)
+  if (Array.isArray(value)) return value.map((item) => rewriteFilePlaceholdersDeep(item, sourceFile))
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, childValue]) => [
+        childKey,
+        rewriteFilePlaceholdersDeep(childValue, sourceFile),
+      ]),
+    )
+  }
+  return value
 }
 
 function rewriteSeedPluginSpec(value: unknown, sourceFile: string): unknown {
@@ -515,36 +539,32 @@ function rewriteSeedPluginSpec(value: unknown, sourceFile: string): unknown {
   }
   if (Array.isArray(value) && typeof value[0] === "string") {
     const rewritten = rewriteFilePlaceholders(value[0], sourceFile)
-    return [rewritten.startsWith(".") ? resolveSeedPath(rewritten, sourceFile) : rewritten, ...value.slice(1)]
+    return [
+      rewritten.startsWith(".") ? resolveSeedPath(rewritten, sourceFile) : rewritten,
+      ...value.slice(1).map((item) => rewriteFilePlaceholdersDeep(item, sourceFile)),
+    ]
   }
-  return rewriteSeedValue(value, sourceFile)
+  return rewriteFilePlaceholdersDeep(value, sourceFile)
 }
 
-function rewriteSeedValue(value: unknown, sourceFile: string, key?: string): unknown {
-  if (typeof value === "string") return rewriteFilePlaceholders(value, sourceFile)
-  if (Array.isArray(value)) {
-    if (key === "instructions") {
-      return value.map((item) => (typeof item === "string" ? resolveSeedPath(item, sourceFile) : item))
-    }
-    if (key === "plugin") return value.map((item) => rewriteSeedPluginSpec(item, sourceFile))
-    return value.map((item) => rewriteSeedValue(item, sourceFile))
-  }
-  if (isRecord(value)) {
-    return Object.fromEntries(
-      Object.entries(value).map(([childKey, childValue]) => [
-        childKey,
-        rewriteSeedValue(childValue, sourceFile, childKey),
-      ]),
+function rewriteSeedConfig(value: Record<string, unknown>, sourceFile: string): Record<string, unknown> {
+  const next = rewriteFilePlaceholdersDeep(value, sourceFile) as Record<string, unknown>
+  if (Array.isArray(value.instructions)) {
+    next.instructions = value.instructions.map((item) =>
+      typeof item === "string" ? resolveSeedInstructionPath(item, sourceFile) : rewriteFilePlaceholdersDeep(item, sourceFile),
     )
   }
-  return value
+  if (Array.isArray(value.plugin)) {
+    next.plugin = value.plugin.map((item) => rewriteSeedPluginSpec(item, sourceFile))
+  }
+  return next
 }
 
 function seedConfigValueFromSource(text: string, sourceFile: string) {
   const stripped = stripDefaultAgent(text).text
   const parsed = ConfigParse.jsonc(stripped, sourceFile)
   if (!isRecord(parsed)) return stripped
-  return rewriteSeedValue(parsed, sourceFile)
+  return rewriteSeedConfig(parsed, sourceFile)
 }
 
 function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
@@ -555,6 +575,19 @@ function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
   }, {})
   if (!isRecord(merged)) return "{}"
   return JSON.stringify(merged, null, 2)
+}
+
+async function writeLegacyTomlMigration(target: string, legacyConfig: Info) {
+  let next = legacyConfig
+  const existingText = await fsNode.readFile(target, "utf8").catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined
+    throw error
+  })
+  if (existingText !== undefined) {
+    const existing = ConfigParse.jsonc(existingText, target)
+    if (isRecord(existing)) next = mergeDeep(legacyConfig, existing) as Info
+  }
+  await withConfigFileLock(target, () => writeConfigTextAtomic(target, JSON.stringify(next, null, 2)))
 }
 
 export const ConfigDirectoryTypoError = NamedError.create(
@@ -605,7 +638,9 @@ const rawLayer = Layer.effect(
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
         const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
-        yield* fs.writeFileString(options.path, updated).pipe(Effect.catch(() => Effect.void))
+        yield* Effect.promise(() =>
+          withConfigFileLock(options.path, () => writeConfigTextAtomic(options.path, updated)),
+        ).pipe(Effect.catch(() => Effect.void))
       }
       return data
     })
@@ -646,9 +681,9 @@ const rawLayer = Layer.effect(
               if (!Runtime.isPawWork() || globalFiles.length === 0) {
                 result = mergeDeep(result, legacyConfig)
               }
-              await fsNode.writeFile(
+              await writeLegacyTomlMigration(
                 path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json"),
-                JSON.stringify(legacyConfig, null, 2),
+                legacyConfig,
               )
               await fsNode.unlink(legacy)
             })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -518,6 +518,24 @@ function writable(info: Info) {
   return next
 }
 
+function normalizeWritableConfig(data: unknown, source: string) {
+  const normalized = normalizeLoadedConfig(data, source)
+  const parsed = Info.zod.safeParse(normalized)
+  if (parsed.success) return writable(parsed.data)
+
+  if (!isRecord(normalized)) return writable(ConfigParse.schema(Info.zod, normalized, source))
+  const copy = { ...normalized }
+  for (const issue of parsed.error.issues) {
+    const hit = issue as { code?: string; keys?: unknown }
+    if (hit.code !== "unrecognized_keys" || !Array.isArray(hit.keys)) continue
+    for (const key of hit.keys) {
+      if (typeof key === "string") delete copy[key]
+    }
+  }
+
+  return writable(ConfigParse.schema(Info.zod, copy, source))
+}
+
 function isAbsoluteOrExternalPath(value: string) {
   return (
     path.isAbsolute(value) ||
@@ -597,8 +615,7 @@ function seedConfigValueFromSource(text: string, sourceFile: string) {
   const stripped = stripDefaultAgent(text).text
   const parsed = ConfigParse.jsonc(stripped, sourceFile)
   if (!isRecord(parsed)) return stripped
-  const normalized = ConfigParse.schema(Info.zod, normalizeLoadedConfig(parsed, sourceFile), sourceFile)
-  return rewriteSeedConfig(writable(normalized), sourceFile)
+  return rewriteSeedConfig(normalizeWritableConfig(parsed, sourceFile), sourceFile)
 }
 
 function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
@@ -720,17 +737,24 @@ const rawLayer = Layer.effect(
               const { provider, model, ...rest } = mod.default
               const migrated: Info = { "$schema": "https://opencode.ai/config.json" }
               if (provider && model) migrated.model = `${provider}/${model}`
-              const legacyConfig = mergeDeep(migrated, rest)
+              const legacyConfig = normalizeWritableConfig(mergeDeep(migrated, rest), legacy)
               if (!Runtime.isPawWork() || globalFiles.length === 0) {
                 result = mergeDeep(legacyConfig, result)
               }
-              await writeLegacyTomlMigration(legacyTomlMigrationTarget(), legacyConfig, {
+              const target = legacyTomlMigrationTarget()
+              const action = isRegularFileSync(target) ? (Runtime.isPawWork() ? "skip-existing" : "merge") : "create"
+              await writeLegacyTomlMigration(target, legacyConfig, {
                 mergeExisting: !Runtime.isPawWork(),
               })
-              await fsNode.unlink(legacy)
+              await fsNode.unlink(legacy).catch((error) => {
+                log.warn("legacy TOML config unlink failed", { path: legacy, target, action: "unlink", error: String(error) })
+                throw error
+              })
             })
             .catch((error) => {
-              log.warn("legacy TOML config migration failed", { path: legacy, error: String(error) })
+              const target = legacyTomlMigrationTarget()
+              const action = isRegularFileSync(target) ? (Runtime.isPawWork() ? "skip-existing" : "merge") : "create"
+              log.warn("legacy TOML config migration failed", { path: legacy, target, action, error: String(error) })
             }),
         )
       }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -381,6 +381,27 @@ export function globalConfigFileForWrite() {
   return globalConfigFile()
 }
 
+export function configFileLockKey(file: string) {
+  return `config-file:${Filesystem.resolve(file)}`
+}
+
+export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) {
+  await using _ = await Flock.acquire(configFileLockKey(file))
+  return await fn()
+}
+
+export async function writeConfigTextAtomic(file: string, text: string) {
+  await fsNode.mkdir(path.dirname(file), { recursive: true })
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`)
+  try {
+    await fsNode.writeFile(tmp, text)
+    await fsNode.rename(tmp, file)
+  } catch (error) {
+    await fsNode.rm(tmp, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
 function globalConfigFilesToLoad() {
   if (!Runtime.isPawWork()) {
     const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
@@ -894,22 +915,27 @@ const rawLayer = Layer.effect(
 
     const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info) {
       const file = globalConfigFile()
-      yield* Effect.promise(() =>
-        Runtime.isPawWork() ? PawWorkHome.ensurePrimary() : fsNode.mkdir(path.dirname(file), { recursive: true }),
-      )
-      const existingText = yield* readConfigFile(file)
-      const before = existingText ?? JSON.stringify(writable(yield* loadGlobal()), null, 2)
-
+      const lock = yield* Effect.promise(() => Flock.acquire(configFileLockKey(file)))
       let next: Info
-      if (!file.endsWith(".jsonc")) {
-        const existing = ConfigParse.schema(Info.zod, ConfigParse.jsonc(before, file), file)
-        const merged = mergeDeep(writable(existing), writable(config))
-        yield* fs.writeFileString(file, JSON.stringify(merged, null, 2)).pipe(Effect.orDie)
-        next = merged
-      } else {
-        const updated = patchJsonc(before, writable(config))
-        next = ConfigParse.schema(Info.zod, ConfigParse.jsonc(updated, file), file)
-        yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
+      try {
+        yield* Effect.promise(() =>
+          Runtime.isPawWork() ? PawWorkHome.ensurePrimary() : fsNode.mkdir(path.dirname(file), { recursive: true }),
+        )
+        const existingText = yield* readConfigFile(file)
+        const before = existingText ?? JSON.stringify(writable(yield* loadGlobal()), null, 2)
+
+        if (!file.endsWith(".jsonc")) {
+          const existing = ConfigParse.schema(Info.zod, ConfigParse.jsonc(before, file), file)
+          const merged = mergeDeep(writable(existing), writable(config))
+          yield* Effect.promise(() => writeConfigTextAtomic(file, JSON.stringify(merged, null, 2))).pipe(Effect.orDie)
+          next = merged
+        } else {
+          const updated = patchJsonc(before, writable(config))
+          next = ConfigParse.schema(Info.zod, ConfigParse.jsonc(updated, file), file)
+          yield* Effect.promise(() => writeConfigTextAtomic(file, updated)).pipe(Effect.orDie)
+        }
+      } finally {
+        yield* Effect.promise(() => lock.release())
       }
 
       yield* invalidate()
@@ -1034,6 +1060,9 @@ const ConfigUpdateGlobal = updateGlobal
 const ConfigSeedGlobalConfig = seedGlobalConfig
 const ConfigGlobalConfigFileForRead = globalConfigFileForRead
 const ConfigGlobalConfigFileForWrite = globalConfigFileForWrite
+const ConfigConfigFileLockKey = configFileLockKey
+const ConfigWithConfigFileLock = withConfigFileLock
+const ConfigWriteConfigTextAtomic = writeConfigTextAtomic
 const ConfigProjectConfigFileForWrite = projectConfigFileForWrite
 const ConfigInvalidate = invalidate
 const ConfigDirectories = directories
@@ -1080,6 +1109,9 @@ export namespace Config {
   export const seedGlobalConfig = ConfigSeedGlobalConfig
   export const globalConfigFileForRead = ConfigGlobalConfigFileForRead
   export const globalConfigFileForWrite = ConfigGlobalConfigFileForWrite
+  export const configFileLockKey = ConfigConfigFileLockKey
+  export const withConfigFileLock = ConfigWithConfigFileLock
+  export const writeConfigTextAtomic = ConfigWriteConfigTextAtomic
   export const projectConfigFileForWrite = ConfigProjectConfigFileForWrite
   export const invalidate = ConfigInvalidate
   export const directories = ConfigDirectories

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -407,6 +407,10 @@ function projectConfigFile(dir: string) {
   return path.join(dir, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
 }
 
+export function projectConfigFileForWrite(dir: string) {
+  return projectConfigFile(dir)
+}
+
 function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
   if (!isRecord(patch)) {
     const edits = modify(input, path, patch, {
@@ -1014,6 +1018,7 @@ const ConfigUpdate = update
 const ConfigUpdateGlobal = updateGlobal
 const ConfigSeedGlobalConfig = seedGlobalConfig
 const ConfigGlobalConfigFileForWrite = globalConfigFileForWrite
+const ConfigProjectConfigFileForWrite = projectConfigFileForWrite
 const ConfigInvalidate = invalidate
 const ConfigDirectories = directories
 const ConfigWaitForDependencies = waitForDependencies
@@ -1058,6 +1063,7 @@ export namespace Config {
   export const updateGlobal = ConfigUpdateGlobal
   export const seedGlobalConfig = ConfigSeedGlobalConfig
   export const globalConfigFileForWrite = ConfigGlobalConfigFileForWrite
+  export const projectConfigFileForWrite = ConfigProjectConfigFileForWrite
   export const invalidate = ConfigInvalidate
   export const directories = ConfigDirectories
   export const waitForDependencies = ConfigWaitForDependencies

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -367,12 +367,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Co
 
 function globalConfigFile() {
   if (Runtime.isPawWork()) {
-    const primary = PawWorkHome.primary()
-    const jsonc = path.join(primary, "pawwork.jsonc")
-    if (existsSync(jsonc)) return jsonc
-    const json = path.join(primary, "pawwork.json")
-    if (existsSync(json)) return json
-    return json
+    return PawWorkHome.configFileForWrite()
   }
   const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
   for (const file of [...candidates].reverse()) {
@@ -391,13 +386,7 @@ function globalConfigFilesToLoad() {
     return candidates.filter((file) => existsSync(file))
   }
 
-  for (const dir of PawWorkHome.candidates()) {
-    const json = path.join(dir, "pawwork.json")
-    const jsonc = path.join(dir, "pawwork.jsonc")
-    const files = [json, jsonc].filter((file) => existsSync(file))
-    if (files.length) return files
-  }
-  return []
+  return PawWorkHome.configFilesToLoad()
 }
 
 function globalConfigSource() {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -13,7 +13,7 @@ import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
-import { migrateDefaultAgent } from "./migrate-default-agent"
+import { migrateDefaultAgent, stripDefaultAgent } from "./migrate-default-agent"
 import { Instance, type InstanceContext } from "../project/instance"
 import { constants, existsSync } from "fs"
 import { GlobalBus } from "@/bus/global"
@@ -391,16 +391,20 @@ export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) 
   return await fn()
 }
 
-export async function writeConfigTextAtomic(file: string, text: string) {
+export async function writeConfigTextAtomic(file: string, text: string, options?: { mode?: number }) {
   await fsNode.mkdir(path.dirname(file), { recursive: true })
   const existingMode = await fsNode
     .stat(file)
     .then((stat) => stat.mode & 0o777)
     .catch(() => undefined)
-  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`)
+  const mode = existingMode ?? options?.mode
+  const tmp = path.join(
+    path.dirname(file),
+    `.${path.basename(file)}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`,
+  )
   try {
-    await fsNode.writeFile(tmp, text, existingMode === undefined ? undefined : { mode: existingMode })
-    if (existingMode !== undefined) await fsNode.chmod(tmp, existingMode)
+    await fsNode.writeFile(tmp, text, mode === undefined ? undefined : { mode })
+    if (mode !== undefined) await fsNode.chmod(tmp, mode)
     const tmpHandle = await fsNode.open(tmp, "r")
     try {
       await tmpHandle.sync()
@@ -481,6 +485,78 @@ function writable(info: Info) {
   return next
 }
 
+function isAbsoluteOrExternalPath(value: string) {
+  return (
+    path.isAbsolute(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith("~/") ||
+    value.startsWith("~\\") ||
+    /^[A-Za-z][A-Za-z\d+.-]*:/.test(value)
+  )
+}
+
+function resolveSeedPath(value: string, sourceFile: string) {
+  if (!value || isAbsoluteOrExternalPath(value)) return value
+  return path.resolve(path.dirname(sourceFile), value)
+}
+
+function rewriteFilePlaceholders(value: string, sourceFile: string) {
+  return value.replace(/\{file:([^}]+)\}/g, (match, filePath: string) => {
+    const trimmed = filePath.trim()
+    if (!trimmed || isAbsoluteOrExternalPath(trimmed)) return match
+    return `{file:${path.resolve(path.dirname(sourceFile), trimmed)}}`
+  })
+}
+
+function rewriteSeedPluginSpec(value: unknown, sourceFile: string): unknown {
+  if (typeof value === "string") {
+    const rewritten = rewriteFilePlaceholders(value, sourceFile)
+    return rewritten.startsWith(".") ? resolveSeedPath(rewritten, sourceFile) : rewritten
+  }
+  if (Array.isArray(value) && typeof value[0] === "string") {
+    const rewritten = rewriteFilePlaceholders(value[0], sourceFile)
+    return [rewritten.startsWith(".") ? resolveSeedPath(rewritten, sourceFile) : rewritten, ...value.slice(1)]
+  }
+  return rewriteSeedValue(value, sourceFile)
+}
+
+function rewriteSeedValue(value: unknown, sourceFile: string, key?: string): unknown {
+  if (typeof value === "string") return rewriteFilePlaceholders(value, sourceFile)
+  if (Array.isArray(value)) {
+    if (key === "instructions") {
+      return value.map((item) => (typeof item === "string" ? resolveSeedPath(item, sourceFile) : item))
+    }
+    if (key === "plugin") return value.map((item) => rewriteSeedPluginSpec(item, sourceFile))
+    return value.map((item) => rewriteSeedValue(item, sourceFile))
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, childValue]) => [
+        childKey,
+        rewriteSeedValue(childValue, sourceFile, childKey),
+      ]),
+    )
+  }
+  return value
+}
+
+function seedConfigValueFromSource(text: string, sourceFile: string) {
+  const stripped = stripDefaultAgent(text).text
+  const parsed = ConfigParse.jsonc(stripped, sourceFile)
+  if (!isRecord(parsed)) return stripped
+  return rewriteSeedValue(parsed, sourceFile)
+}
+
+function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
+  const merged = sources.reduce<unknown>((result, source) => {
+    const next = seedConfigValueFromSource(source.text, source.path)
+    if (!isRecord(result) || !isRecord(next)) return next
+    return mergeDeep(result, next)
+  }, {})
+  if (!isRecord(merged)) return "{}"
+  return JSON.stringify(merged, null, 2)
+}
+
 export const ConfigDirectoryTypoError = NamedError.create(
   "ConfigDirectoryTypoError",
   z.object({
@@ -551,14 +627,11 @@ const rawLayer = Layer.effect(
         // When sanitizedText is present we use it directly to avoid a redundant
         // disk read AND to ensure runtime never sees a stale value even if the
         // on-disk rewrite failed.
-        const migrated = allowWrite
-          ? yield* Effect.promise(() => migrateDefaultAgent(filepath))
-          : { rewritten: false, sanitizedText: undefined }
-        if (migrated.sanitizedText !== undefined) {
-          result = pipe(result, mergeDeep(yield* loadConfig(migrated.sanitizedText, { path: filepath, allowWrite })))
-        } else {
-          result = pipe(result, mergeDeep(yield* loadFile(filepath, { allowWrite })))
-        }
+        const migrated = allowWrite ? yield* Effect.promise(() => migrateDefaultAgent(filepath)) : undefined
+        const text = migrated?.sanitizedText ?? (yield* readConfigFile(filepath))
+        if (!text) continue
+        const sanitizedText = allowWrite ? text : stripDefaultAgent(text).text
+        result = pipe(result, mergeDeep(yield* loadConfig(sanitizedText, { path: filepath, allowWrite })))
       }
 
       const legacy = path.join(Global.Path.config, "config")
@@ -941,17 +1014,43 @@ const rawLayer = Layer.effect(
       try {
         if (!Runtime.isPawWork()) yield* Effect.promise(() => fsNode.mkdir(path.dirname(file), { recursive: true }))
         const existingText = yield* readConfigFile(file)
-        const before = existingText ?? JSON.stringify(writable(yield* loadGlobal()), null, 2)
+        const seedFiles = existingText === undefined ? globalConfigFilesToLoad() : []
+        const seedSource = seedFiles.at(-1)
+        const seed =
+          existingText === undefined && seedFiles.length > 0
+            ? {
+                text: seedConfigTextFromSources(
+                  yield* Effect.all(
+                    seedFiles.map((source) =>
+                      readConfigFile(source).pipe(Effect.map((text) => ({ path: source, text: text ?? "{}" }))),
+                    ),
+                  ),
+                ),
+                mode: yield* Effect.promise(() =>
+                  seedSource
+                    ? fsNode
+                        .stat(seedSource)
+                        .then((stat) => stat.mode & 0o777)
+                        .catch(() => undefined)
+                    : Promise.resolve(undefined),
+                ),
+              }
+            : undefined
+        const before = existingText ?? seed?.text ?? "{}"
+        const writeOptions =
+          existingText === undefined && Runtime.isPawWork() ? { mode: seed?.mode ?? 0o600 } : undefined
 
         if (!file.endsWith(".jsonc")) {
           const existing = ConfigParse.schema(Info.zod, ConfigParse.jsonc(before, file), file)
           const merged = mergeDeep(writable(existing), writable(config))
-          yield* Effect.promise(() => writeConfigTextAtomic(file, JSON.stringify(merged, null, 2))).pipe(Effect.orDie)
+          yield* Effect.promise(() => writeConfigTextAtomic(file, JSON.stringify(merged, null, 2), writeOptions)).pipe(
+            Effect.orDie,
+          )
           next = merged
         } else {
           const updated = patchJsonc(before, writable(config))
           next = ConfigParse.schema(Info.zod, ConfigParse.jsonc(updated, file), file)
-          yield* Effect.promise(() => writeConfigTextAtomic(file, updated)).pipe(Effect.orDie)
+          yield* Effect.promise(() => writeConfigTextAtomic(file, updated, writeOptions)).pipe(Effect.orDie)
         }
       } finally {
         yield* Effect.promise(() => lock.release())

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -79,6 +79,7 @@ function projectConfigFilesForDirectory(dir: string) {
 
 function shouldGenerateInDirectory(dir: string) {
   const base = path.basename(dir)
+  if (Runtime.isPawWork() && PawWorkHome.isCandidate(dir)) return PawWorkHome.isPrimary(dir)
   if (Runtime.isPawWork() && base === ".opencode") return false
   if (!Runtime.isPawWork() && base === ".pawwork") return false
   return true
@@ -393,14 +394,20 @@ function globalConfigSource() {
   return globalConfigFilesToLoad().at(-1)
 }
 
+export function globalConfigFileForRead() {
+  return globalConfigSource()
+}
+
 function projectConfigFile(dir: string) {
   // OpenCode still writes existing legacy `config.*` files, but new project config uses `opencode.json`.
-  // PawWork writes only PawWork project filenames; shared project loading above preserves read compatibility.
-  const candidates = (
-    Runtime.isPawWork()
-      ? ["pawwork.json", "pawwork.jsonc"]
-      : ["config.json", "config.jsonc", "opencode.json", "opencode.jsonc"]
-  ).map((file) => path.join(dir, file))
+  // PawWork reuses the highest-priority existing project config source before creating a root `pawwork.json`.
+  const candidates = Runtime.isPawWork()
+    ? [
+        ...PAWWORK_PROJECT_CONFIG_FILES.map((file) => path.join(dir, file)),
+        ...projectConfigFilesForDirectory(path.join(dir, ".opencode")).map((file) => path.join(dir, ".opencode", file)),
+        ...projectConfigFilesForDirectory(path.join(dir, ".pawwork")).map((file) => path.join(dir, ".pawwork", file)),
+      ]
+    : ["config.json", "config.jsonc", "opencode.json", "opencode.jsonc"].map((file) => path.join(dir, file))
   for (const file of [...candidates].reverse()) {
     if (existsSync(file)) return file
   }
@@ -495,7 +502,8 @@ const rawLayer = Layer.effect(
 
     const loadGlobal = Effect.fnUntraced(function* () {
       let result: Info = {}
-      for (const filepath of globalConfigFilesToLoad()) {
+      const globalFiles = globalConfigFilesToLoad()
+      for (const filepath of globalFiles) {
         // Strip deprecated default_agent before parsing (issue #239).
         // When sanitizedText is present we use it directly to avoid a redundant
         // disk read AND to ensure runtime never sees a stale value even if the
@@ -509,7 +517,7 @@ const rawLayer = Layer.effect(
       }
 
       const legacy = path.join(Global.Path.config, "config")
-      if (existsSync(legacy)) {
+      if (existsSync(legacy) && (!Runtime.isPawWork() || globalFiles.length === 0)) {
         yield* Effect.promise(() =>
           import(pathToFileURL(legacy).href, { with: { type: "toml" } })
             .then(async (mod) => {
@@ -1017,6 +1025,7 @@ const ConfigGetConsoleState = getConsoleState
 const ConfigUpdate = update
 const ConfigUpdateGlobal = updateGlobal
 const ConfigSeedGlobalConfig = seedGlobalConfig
+const ConfigGlobalConfigFileForRead = globalConfigFileForRead
 const ConfigGlobalConfigFileForWrite = globalConfigFileForWrite
 const ConfigProjectConfigFileForWrite = projectConfigFileForWrite
 const ConfigInvalidate = invalidate
@@ -1062,6 +1071,7 @@ export namespace Config {
   export const update = ConfigUpdate
   export const updateGlobal = ConfigUpdateGlobal
   export const seedGlobalConfig = ConfigSeedGlobalConfig
+  export const globalConfigFileForRead = ConfigGlobalConfigFileForRead
   export const globalConfigFileForWrite = ConfigGlobalConfigFileForWrite
   export const projectConfigFileForWrite = ConfigProjectConfigFileForWrite
   export const invalidate = ConfigInvalidate

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -144,7 +144,9 @@ export type Layout = ConfigLayout.Layout
 // exact zod directly, preserving component $refs.
 const AgentRef = Schema.Any.annotate({ [ZodOverride]: ConfigAgent.Info })
 const LogLevelRef = Schema.Any.annotate({ [ZodOverride]: Log.Level })
-const ServerRef = Schema.Any.annotate({ [ZodOverride]: ConfigServer.Server.zod }) as unknown as typeof ConfigServer.Server
+const ServerRef = Schema.Any.annotate({
+  [ZodOverride]: ConfigServer.Server.zod,
+}) as unknown as typeof ConfigServer.Server
 
 const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 const NonNegativeInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(0))
@@ -315,9 +317,9 @@ export const Info = Schema.Struct({
   .annotate({ identifier: "Config" })
   .pipe(
     withStatics((s) => ({
-      zod: (zod(s) as unknown as z.ZodObject<any>)
-        .strict()
-        .meta({ ref: "Config" }) as unknown as z.ZodType<DeepMutable<Schema.Schema.Type<typeof s>>>,
+      zod: (zod(s) as unknown as z.ZodObject<any>).strict().meta({ ref: "Config" }) as unknown as z.ZodType<
+        DeepMutable<Schema.Schema.Type<typeof s>>
+      >,
     })),
   )
 
@@ -526,14 +528,39 @@ function normalizeWritableConfig(data: unknown, source: string) {
   if (!isRecord(normalized)) return writable(ConfigParse.schema(Info.zod, normalized, source))
   const copy = { ...normalized }
   for (const issue of parsed.error.issues) {
-    const hit = issue as { code?: string; keys?: unknown }
+    const hit = issue as { code?: string; keys?: unknown; path?: unknown[] }
     if (hit.code !== "unrecognized_keys" || !Array.isArray(hit.keys)) continue
     for (const key of hit.keys) {
-      if (typeof key === "string") delete copy[key]
+      if (typeof key === "string") deleteConfigKeyAtPath(copy, hit.path ?? [], key)
     }
   }
 
   return writable(ConfigParse.schema(Info.zod, copy, source))
+}
+
+function deleteConfigKeyAtPath(root: Record<string, unknown>, parts: unknown[], key: string) {
+  let target: unknown = root
+  for (const part of parts) {
+    if (typeof part !== "string" && typeof part !== "number") return
+    if (Array.isArray(target)) {
+      if (typeof part !== "number") return
+      target = target[part]
+    } else if (isRecord(target)) target = target[part]
+    else return
+  }
+  if (Array.isArray(target)) {
+    const index = Number(key)
+    if (Number.isInteger(index)) target.splice(index, 1)
+    return
+  }
+  if (isRecord(target)) delete target[key]
+}
+
+function shouldMergeLegacyTomlIntoRuntime(globalFiles: string[]) {
+  if (!Runtime.isPawWork()) return true
+  if (globalFiles.length === 0) return true
+  const legacyDir = path.resolve(Global.Path.config)
+  return globalFiles.some((file) => path.resolve(path.dirname(file)) === legacyDir)
 }
 
 function isAbsoluteOrExternalPath(value: string) {
@@ -602,7 +629,9 @@ function rewriteSeedConfig(value: Record<string, unknown>, sourceFile: string): 
   const next = rewriteFilePlaceholdersDeep(value, sourceFile) as Record<string, unknown>
   if (Array.isArray(value.instructions)) {
     next.instructions = value.instructions.map((item) =>
-      typeof item === "string" ? resolveSeedInstructionPath(item, sourceFile) : rewriteFilePlaceholdersDeep(item, sourceFile),
+      typeof item === "string"
+        ? resolveSeedInstructionPath(item, sourceFile)
+        : rewriteFilePlaceholdersDeep(item, sourceFile),
     )
   }
   if (Array.isArray(value.plugin)) {
@@ -731,32 +760,38 @@ const rawLayer = Layer.effect(
 
       const legacy = path.join(Global.Path.config, "config")
       if (existsSync(legacy)) {
-        yield* Effect.promise(() =>
-          import(pathToFileURL(legacy).href, { with: { type: "toml" } })
-            .then(async (mod) => {
-              const { provider, model, ...rest } = mod.default
-              const migrated: Info = { "$schema": "https://opencode.ai/config.json" }
-              if (provider && model) migrated.model = `${provider}/${model}`
-              const legacyConfig = normalizeWritableConfig(mergeDeep(migrated, rest), legacy)
-              if (!Runtime.isPawWork() || globalFiles.length === 0) {
-                result = mergeDeep(legacyConfig, result)
-              }
-              const target = legacyTomlMigrationTarget()
-              const action = isRegularFileSync(target) ? (Runtime.isPawWork() ? "skip-existing" : "merge") : "create"
-              await writeLegacyTomlMigration(target, legacyConfig, {
-                mergeExisting: !Runtime.isPawWork(),
-              })
-              await fsNode.unlink(legacy).catch((error) => {
-                log.warn("legacy TOML config unlink failed", { path: legacy, target, action: "unlink", error: String(error) })
-                throw error
-              })
+        yield* Effect.promise(async () => {
+          let target = ""
+          let action = "load"
+          let unlinked = false
+          try {
+            const mod = await import(pathToFileURL(legacy).href, { with: { type: "toml" } })
+            action = "normalize"
+            const { provider, model, ...rest } = mod.default
+            const migrated: Info = { $schema: "https://opencode.ai/config.json" }
+            if (provider && model) migrated.model = `${provider}/${model}`
+            const legacyConfig = normalizeWritableConfig(mergeDeep(migrated, rest), legacy)
+            if (shouldMergeLegacyTomlIntoRuntime(globalFiles)) {
+              result = mergeDeep(legacyConfig, result)
+            }
+            target = legacyTomlMigrationTarget()
+            action = isRegularFileSync(target) ? "merge" : "create"
+            await writeLegacyTomlMigration(target, legacyConfig, {
+              mergeExisting: true,
             })
-            .catch((error) => {
-              const target = legacyTomlMigrationTarget()
-              const action = isRegularFileSync(target) ? (Runtime.isPawWork() ? "skip-existing" : "merge") : "create"
-              log.warn("legacy TOML config migration failed", { path: legacy, target, action, error: String(error) })
-            }),
-        )
+            action = "unlink"
+            await fsNode.unlink(legacy)
+            unlinked = true
+          } catch (error) {
+            log.warn("legacy TOML config migration failed", {
+              path: legacy,
+              target: target || "unavailable",
+              action,
+              unlinked,
+              error: String(error),
+            })
+          }
+        })
       }
 
       return result
@@ -858,7 +893,11 @@ const rawLayer = Layer.effect(
         }
 
         const global = yield* getGlobal()
-        yield* merge(globalConfigSource() ?? (Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config), global, "global")
+        yield* merge(
+          globalConfigSource() ?? (Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config),
+          global,
+          "global",
+        )
 
         if (Flag.OPENCODE_CONFIG) {
           yield* merge(Flag.OPENCODE_CONFIG, yield* loadFile(Flag.OPENCODE_CONFIG))
@@ -889,7 +928,8 @@ const rawLayer = Layer.effect(
         const deps: Fiber.Fiber<void, never>[] = []
 
         for (const dir of directories) {
-          const configFiles = Runtime.isPawWork() && PawWorkHome.isCandidate(dir) ? [] : projectConfigFilesForDirectory(dir)
+          const configFiles =
+            Runtime.isPawWork() && PawWorkHome.isCandidate(dir) ? [] : projectConfigFilesForDirectory(dir)
 
           if (configFiles.length > 0) {
             for (const file of configFiles) {
@@ -1255,7 +1295,10 @@ export async function installDependencies(dir: string) {
     await Filesystem.writeJson(pkg, json)
   }
   if (!ignore) {
-    await Filesystem.write(gitignore, ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"))
+    await Filesystem.write(
+      gitignore,
+      ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+    )
   }
   if (hasDep && ignore && installed.every(Boolean)) return true
   try {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -401,7 +401,21 @@ export async function writeConfigTextAtomic(file: string, text: string) {
   try {
     await fsNode.writeFile(tmp, text, existingMode === undefined ? undefined : { mode: existingMode })
     if (existingMode !== undefined) await fsNode.chmod(tmp, existingMode)
+    const tmpHandle = await fsNode.open(tmp, "r")
+    try {
+      await tmpHandle.sync()
+    } finally {
+      await tmpHandle.close()
+    }
     await fsNode.rename(tmp, file)
+    const dirHandle = await fsNode.open(path.dirname(file), "r").catch(() => undefined)
+    if (dirHandle) {
+      try {
+        await dirHandle.sync()
+      } finally {
+        await dirHandle.close()
+      }
+    }
   } catch (error) {
     await fsNode.rm(tmp, { force: true }).catch(() => undefined)
     throw error
@@ -463,7 +477,7 @@ function patchJsonc(input: string, patch: unknown, path: string[] = []): string 
 }
 
 function writable(info: Info) {
-  const { plugin_origins: _plugin_origins, ...next } = info
+  const { default_agent: _defaultAgent, plugin_origins: _plugin_origins, ...next } = info
   return next
 }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -2,6 +2,7 @@ import { Log } from "../util"
 import path from "path"
 import { pathToFileURL } from "url"
 import os from "os"
+import crypto from "crypto"
 import z from "zod"
 import { mergeDeep, pipe } from "remeda"
 import { Global } from "@opencode-ai/core/global"
@@ -392,9 +393,14 @@ export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) 
 
 export async function writeConfigTextAtomic(file: string, text: string) {
   await fsNode.mkdir(path.dirname(file), { recursive: true })
-  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`)
+  const existingMode = await fsNode
+    .stat(file)
+    .then((stat) => stat.mode & 0o777)
+    .catch(() => undefined)
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`)
   try {
-    await fsNode.writeFile(tmp, text)
+    await fsNode.writeFile(tmp, text, existingMode === undefined ? undefined : { mode: existingMode })
+    if (existingMode !== undefined) await fsNode.chmod(tmp, existingMode)
     await fsNode.rename(tmp, file)
   } catch (error) {
     await fsNode.rm(tmp, { force: true }).catch(() => undefined)
@@ -526,7 +532,7 @@ const rawLayer = Layer.effect(
       const globalFiles = globalConfigFilesToLoad()
       for (const filepath of globalFiles) {
         const dir = path.dirname(filepath)
-        const allowWrite = !Runtime.isPawWork() || PawWorkHome.isPrimary(dir) || path.resolve(dir) !== path.resolve(Global.Path.config)
+        const allowWrite = !Runtime.isPawWork() || PawWorkHome.isPrimary(dir)
         // Strip deprecated default_agent before parsing (issue #239).
         // When sanitizedText is present we use it directly to avoid a redundant
         // disk read AND to ensure runtime never sees a stale value even if the
@@ -914,13 +920,12 @@ const rawLayer = Layer.effect(
     })
 
     const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info) {
+      if (Runtime.isPawWork()) yield* Effect.promise(() => PawWorkHome.ensurePrimary())
       const file = globalConfigFile()
       const lock = yield* Effect.promise(() => Flock.acquire(configFileLockKey(file)))
       let next: Info
       try {
-        yield* Effect.promise(() =>
-          Runtime.isPawWork() ? PawWorkHome.ensurePrimary() : fsNode.mkdir(path.dirname(file), { recursive: true }),
-        )
+        if (!Runtime.isPawWork()) yield* Effect.promise(() => fsNode.mkdir(path.dirname(file), { recursive: true }))
         const existingText = yield* readConfigFile(file)
         const before = existingText ?? JSON.stringify(writable(yield* loadGlobal()), null, 2)
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -469,7 +469,7 @@ const rawLayer = Layer.effect(
 
     const loadConfig = Effect.fnUntraced(function* (
       text: string,
-      options: { path: string } | { dir: string; source: string },
+      options: ({ path: string } | { dir: string; source: string }) & { allowWrite?: boolean },
     ) {
       const source = "path" in options ? options.path : options.source
       const expanded = yield* Effect.promise(() =>
@@ -483,7 +483,7 @@ const rawLayer = Layer.effect(
       if (pluginContextPath) {
         yield* Effect.promise(() => resolveLoadedPlugins(data, pluginContextPath))
       }
-      if (!("path" in options)) return data
+      if (!("path" in options) || options.allowWrite === false) return data
 
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
@@ -493,41 +493,48 @@ const rawLayer = Layer.effect(
       return data
     })
 
-    const loadFile = Effect.fnUntraced(function* (filepath: string) {
+    const loadFile = Effect.fnUntraced(function* (filepath: string, options?: { allowWrite?: boolean }) {
       log.info("loading", { path: filepath })
       const text = yield* readConfigFile(filepath)
       if (!text) return {} as Info
-      return yield* loadConfig(text, { path: filepath })
+      return yield* loadConfig(text, { path: filepath, allowWrite: options?.allowWrite })
     })
 
     const loadGlobal = Effect.fnUntraced(function* () {
       let result: Info = {}
       const globalFiles = globalConfigFilesToLoad()
       for (const filepath of globalFiles) {
+        const dir = path.dirname(filepath)
+        const allowWrite = !Runtime.isPawWork() || PawWorkHome.isPrimary(dir) || path.resolve(dir) !== path.resolve(Global.Path.config)
         // Strip deprecated default_agent before parsing (issue #239).
         // When sanitizedText is present we use it directly to avoid a redundant
         // disk read AND to ensure runtime never sees a stale value even if the
         // on-disk rewrite failed.
-        const migrated = yield* Effect.promise(() => migrateDefaultAgent(filepath))
+        const migrated = allowWrite
+          ? yield* Effect.promise(() => migrateDefaultAgent(filepath))
+          : { rewritten: false, sanitizedText: undefined }
         if (migrated.sanitizedText !== undefined) {
-          result = pipe(result, mergeDeep(yield* loadConfig(migrated.sanitizedText, { path: filepath })))
+          result = pipe(result, mergeDeep(yield* loadConfig(migrated.sanitizedText, { path: filepath, allowWrite })))
         } else {
-          result = pipe(result, mergeDeep(yield* loadFile(filepath)))
+          result = pipe(result, mergeDeep(yield* loadFile(filepath, { allowWrite })))
         }
       }
 
       const legacy = path.join(Global.Path.config, "config")
-      if (existsSync(legacy) && (!Runtime.isPawWork() || globalFiles.length === 0)) {
+      if (existsSync(legacy)) {
         yield* Effect.promise(() =>
           import(pathToFileURL(legacy).href, { with: { type: "toml" } })
             .then(async (mod) => {
               const { provider, model, ...rest } = mod.default
-              if (provider && model) result.model = `${provider}/${model}`
-              result["$schema"] = "https://opencode.ai/config.json"
-              result = mergeDeep(result, rest)
+              const migrated: Info = { "$schema": "https://opencode.ai/config.json" }
+              if (provider && model) migrated.model = `${provider}/${model}`
+              const legacyConfig = mergeDeep(migrated, rest)
+              if (!Runtime.isPawWork() || globalFiles.length === 0) {
+                result = mergeDeep(result, legacyConfig)
+              }
               await fsNode.writeFile(
                 path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json"),
-                JSON.stringify(result, null, 2),
+                JSON.stringify(legacyConfig, null, 2),
               )
               await fsNode.unlink(legacy)
             })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -378,6 +378,14 @@ function globalConfigFile() {
   return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
 }
 
+function legacyTomlMigrationTarget() {
+  const candidates = globalConfigFiles().map((file) => path.join(Global.Path.config, file))
+  for (const file of [...candidates].reverse()) {
+    if (existsSync(file)) return file
+  }
+  return path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json")
+}
+
 export function globalConfigFileForWrite() {
   return globalConfigFile()
 }
@@ -564,7 +572,8 @@ function seedConfigValueFromSource(text: string, sourceFile: string) {
   const stripped = stripDefaultAgent(text).text
   const parsed = ConfigParse.jsonc(stripped, sourceFile)
   if (!isRecord(parsed)) return stripped
-  return rewriteSeedConfig(parsed, sourceFile)
+  const normalized = ConfigParse.schema(Info.zod, normalizeLoadedConfig(parsed, sourceFile), sourceFile)
+  return rewriteSeedConfig(writable(normalized), sourceFile)
 }
 
 function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
@@ -578,16 +587,14 @@ function seedConfigTextFromSources(sources: { path: string; text: string }[]) {
 }
 
 async function writeLegacyTomlMigration(target: string, legacyConfig: Info) {
-  let next = legacyConfig
-  const existingText = await fsNode.readFile(target, "utf8").catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT") return undefined
-    throw error
+  await withConfigFileLock(target, async () => {
+    const existingText = await fsNode.readFile(target, "utf8").catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined
+      throw error
+    })
+    if (existingText !== undefined) return
+    await writeConfigTextAtomic(target, JSON.stringify(legacyConfig, null, 2))
   })
-  if (existingText !== undefined) {
-    const existing = ConfigParse.jsonc(existingText, target)
-    if (isRecord(existing)) next = mergeDeep(legacyConfig, existing) as Info
-  }
-  await withConfigFileLock(target, () => writeConfigTextAtomic(target, JSON.stringify(next, null, 2)))
 }
 
 export const ConfigDirectoryTypoError = NamedError.create(
@@ -681,10 +688,7 @@ const rawLayer = Layer.effect(
               if (!Runtime.isPawWork() || globalFiles.length === 0) {
                 result = mergeDeep(result, legacyConfig)
               }
-              await writeLegacyTomlMigration(
-                path.join(Global.Path.config, Runtime.isPawWork() ? "pawwork.json" : "opencode.json"),
-                legacyConfig,
-              )
+              await writeLegacyTomlMigration(legacyTomlMigrationTarget(), legacyConfig)
               await fsNode.unlink(legacy)
             })
             .catch(() => {}),

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -2,7 +2,6 @@ export * as ConfigPaths from "./paths"
 
 import path from "path"
 import os from "os"
-import { existsSync } from "fs"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import { Filesystem } from "@/util"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -35,9 +34,7 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
   const afs = yield* AppFileSystem.Service
   if (Runtime.isPawWork()) {
     return unique([
-      ...PawWorkHome.candidates()
-        .filter((dir) => existsSync(dir))
-        .toReversed(),
+      ...PawWorkHome.existingResourceDirectories(),
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? yield* afs.up({
             targets: [".opencode", ".pawwork"],

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -1,7 +1,6 @@
 export * as ConfigPaths from "./paths"
 
 import path from "path"
-import os from "os"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import { Filesystem } from "@/util"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -118,7 +117,7 @@ async function substitute(text: string, input: ParseSource, missing: "error" | "
     }
 
     let filePath = token.replace(/^\{file:/, "").replace(/\}$/, "")
-    if (filePath.startsWith("~/")) filePath = path.join(os.homedir(), filePath.slice(2))
+    if (filePath.startsWith("~/")) filePath = path.join(Global.Path.home, filePath.slice(2))
 
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
     const fileContent = (

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -2,10 +2,12 @@ export * as ConfigPaths from "./paths"
 
 import path from "path"
 import os from "os"
+import { existsSync } from "fs"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import { Filesystem } from "@/util"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { unique } from "remeda"
 import { JsonError } from "./error"
 import * as Effect from "effect/Effect"
@@ -33,7 +35,9 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
   const afs = yield* AppFileSystem.Service
   if (Runtime.isPawWork()) {
     return unique([
-      Global.Path.config,
+      ...PawWorkHome.candidates()
+        .filter((dir) => existsSync(dir))
+        .toReversed(),
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? yield* afs.up({
             targets: [".opencode", ".pawwork"],
@@ -41,7 +45,6 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
             stop: worktree,
           })
         : []),
-      ...(Flag.PAWWORK_CONFIG_DIR ? [Flag.PAWWORK_CONFIG_DIR] : []),
     ])
   }
 
@@ -64,7 +67,7 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
 })
 
 /** Return the JSON and JSONC config file candidates for a named config inside a directory. */
-export function fileInDirectory(dir: string, name: string) {
+export function fileInDirectory(dir: string, name: "opencode" | "pawwork" | string) {
   return [path.join(dir, `${name}.json`), path.join(dir, `${name}.jsonc`)]
 }
 

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -63,7 +63,7 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
   ])
 })
 
-/** Return the JSON and JSONC config file candidates for a named config inside a directory. */
+/** Return config file candidates for creating a new named config. Reverse this list when selecting the active existing file. */
 export function fileInDirectory(dir: string, name: "opencode" | "pawwork" | string) {
   return [path.join(dir, `${name}.json`), path.join(dir, `${name}.jsonc`)]
 }

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -1,9 +1,9 @@
 export * as ConfigVariable from "./variable"
 
 import path from "path"
-import os from "os"
 import { createScanner } from "jsonc-parser"
 import { Filesystem } from "@/util"
+import { Global } from "@/global"
 import { InvalidError } from "./error"
 
 type ParseSource =
@@ -84,7 +84,7 @@ export async function substitute(input: SubstituteInput) {
 
     let filePath = token.replace(/^\{file:/, "").replace(/\}$/, "")
     if (filePath.startsWith("~/")) {
-      filePath = path.join(os.homedir(), filePath.slice(2))
+      filePath = path.join(Global.Path.home, filePath.slice(2))
     }
 
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -12,6 +12,8 @@ import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@/util/flock"
 import { isRecord } from "@/util/record"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { Runtime } from "@opencode-ai/core/runtime"
 
 import { parsePluginSpecifier, readPluginPackage, resolvePluginTarget } from "./shared"
 
@@ -31,7 +33,7 @@ export type PatchDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode") => string[]
+  files: (dir: string, name: "opencode" | "pawwork") => string[]
 }
 
 export type PatchInput = {
@@ -320,14 +322,14 @@ export async function readPluginManifest(target: string): Promise<ManifestResult
 }
 
 function patchDir(input: PatchInput) {
-  if (input.global) return input.config ?? Global.Path.config
+  if (input.global) return input.config ?? (Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config)
   const git = input.vcs === "git" && input.worktree !== "/"
   const root = git ? input.worktree : input.directory
   return path.join(root, ".opencode")
 }
 
 async function patchOne(dir: string, target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
-  const name = "opencode"
+  const name = Runtime.isPawWork() ? "pawwork" : "opencode"
   await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
 
   const files = dep.files(dir, name)

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -328,17 +328,22 @@ function patchDir(input: PatchInput) {
   return path.join(root, ".opencode")
 }
 
+async function selectConfigFile(files: string[], dep: PatchDeps) {
+  const fallback = files[0]
+  if (!fallback) throw new Error("No config file candidates provided")
+  for (const file of [...files].reverse()) {
+    if (!(await dep.exists(file))) continue
+    return file
+  }
+  return fallback
+}
+
 async function patchOne(dir: string, target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
   const name = Runtime.isPawWork() ? "pawwork" : "opencode"
   await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
 
   const files = dep.files(dir, name)
-  let cfg = files[0]
-  for (const file of files) {
-    if (!(await dep.exists(file))) continue
-    cfg = file
-    break
-  }
+  const cfg = await selectConfigFile(files, dep)
 
   const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
     if (err.code === "ENOENT") return "{}"

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -330,6 +330,16 @@ function patchDir(input: PatchInput) {
   return path.join(root, ".opencode")
 }
 
+function patchFiles(input: PatchInput, dir: string, dep: PatchDeps) {
+  const name = Runtime.isPawWork() ? "pawwork" : "opencode"
+  if (!input.global && Runtime.isPawWork()) {
+    const git = input.vcs === "git" && input.worktree !== "/"
+    const root = git ? input.worktree : input.directory
+    return [Config.projectConfigFileForWrite(root)]
+  }
+  return dep.files(dir, name)
+}
+
 async function selectConfigFile(files: string[], dep: PatchDeps) {
   const fallback = files[0]
   if (!fallback) throw new Error("No config file candidates provided")
@@ -340,11 +350,10 @@ async function selectConfigFile(files: string[], dep: PatchDeps) {
   return fallback
 }
 
-async function patchOne(dir: string, target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
+async function patchOne(dir: string, files: string[], target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
   const name = Runtime.isPawWork() ? "pawwork" : "opencode"
   await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
 
-  const files = dep.files(dir, name)
   let cfg = await selectConfigFile(files, dep)
 
   return await Config.withConfigFileLock(cfg, async () => {
@@ -417,9 +426,10 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {
   if (input.global && Runtime.isPawWork() && !input.config) await Config.seedGlobalConfig()
   const dir = patchDir(input)
+  const files = patchFiles(input, dir, dep)
   const items: PatchItem[] = []
   for (const target of input.targets) {
-    const hit = await patchOne(dir, target, input.spec, Boolean(input.force), dep)
+    const hit = await patchOne(dir, files, target, input.spec, Boolean(input.force), dep)
     if (!hit.ok) {
       return {
         ...hit,

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -7,6 +7,7 @@ import {
   printParseErrorCode,
 } from "jsonc-parser"
 
+import { Config } from "@/config"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
@@ -325,6 +326,7 @@ function patchDir(input: PatchInput) {
   if (input.global) return input.config ?? (Runtime.isPawWork() ? PawWorkHome.primary() : Global.Path.config)
   const git = input.vcs === "git" && input.worktree !== "/"
   const root = git ? input.worktree : input.directory
+  if (Runtime.isPawWork()) return path.dirname(Config.projectConfigFileForWrite(root))
   return path.join(root, ".opencode")
 }
 

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -415,6 +415,7 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
 }
 
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {
+  if (input.global && Runtime.isPawWork() && !input.config) await Config.seedGlobalConfig()
   const dir = patchDir(input)
   const items: PatchItem[] = []
   for (const target of input.targets) {

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -85,7 +85,7 @@ const defaultInstallDeps: InstallDeps = {
 const defaultPatchDeps: PatchDeps = {
   readText: (file) => Filesystem.readText(file),
   write: async (file, text) => {
-    await Filesystem.write(file, text)
+    await Config.writeConfigTextAtomic(file, text)
   },
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
@@ -345,42 +345,64 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
   await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
 
   const files = dep.files(dir, name)
-  const cfg = await selectConfigFile(files, dep)
+  let cfg = await selectConfigFile(files, dep)
 
-  const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === "ENOENT") return "{}"
-    return err
-  })
-  if (src instanceof Error) {
-    return {
-      ok: false,
-      code: "patch_failed",
-      kind: target.kind,
-      error: src,
+  return await Config.withConfigFileLock(cfg, async () => {
+    cfg = await selectConfigFile(files, dep)
+    const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") return "{}"
+      return err
+    })
+    if (src instanceof Error) {
+      return {
+        ok: false,
+        code: "patch_failed",
+        kind: target.kind,
+        error: src,
+      }
     }
-  }
-  const text = src.trim() ? src : "{}"
+    const text = src.trim() ? src : "{}"
 
-  const errs: JsoncParseError[] = []
-  const data = parseJsonc(text, errs, { allowTrailingComma: true })
-  if (errs.length) {
-    const err = errs[0]
-    const lines = text.substring(0, err.offset).split("\n")
-    return {
-      ok: false,
-      code: "invalid_json",
-      kind: target.kind,
-      file: cfg,
-      line: lines.length,
-      col: lines[lines.length - 1].length + 1,
-      parse: printParseErrorCode(err.error),
+    const errs: JsoncParseError[] = []
+    const data = parseJsonc(text, errs, { allowTrailingComma: true })
+    if (errs.length) {
+      const err = errs[0]
+      const lines = text.substring(0, err.offset).split("\n")
+      return {
+        ok: false,
+        code: "invalid_json",
+        kind: target.kind,
+        file: cfg,
+        line: lines.length,
+        col: lines[lines.length - 1].length + 1,
+        parse: printParseErrorCode(err.error),
+      }
     }
-  }
 
-  const list = pluginList(data)
-  const item = target.opts ? ([spec, target.opts] as const) : spec
-  const out = patchPluginList(text, list, spec, item, force)
-  if (out.mode === "noop") {
+    const list = pluginList(data)
+    const item = target.opts ? ([spec, target.opts] as const) : spec
+    const out = patchPluginList(text, list, spec, item, force)
+    if (out.mode === "noop") {
+      return {
+        ok: true,
+        item: {
+          kind: target.kind,
+          mode: out.mode,
+          file: cfg,
+        },
+      }
+    }
+
+    const write = await dep.write(cfg, out.text).catch((error: unknown) => error)
+    if (write instanceof Error) {
+      return {
+        ok: false,
+        code: "patch_failed",
+        kind: target.kind,
+        error: write,
+      }
+    }
+
     return {
       ok: true,
       item: {
@@ -389,26 +411,7 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
         file: cfg,
       },
     }
-  }
-
-  const write = await dep.write(cfg, out.text).catch((error: unknown) => error)
-  if (write instanceof Error) {
-    return {
-      ok: false,
-      code: "patch_failed",
-      kind: target.kind,
-      error: write,
-    }
-  }
-
-  return {
-    ok: true,
-    item: {
-      kind: target.kind,
-      mode: out.mode,
-      file: cfg,
-    },
-  }
+  })
 }
 
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -1,6 +1,7 @@
 import { describeRoute, resolver, validator } from "hono-openapi"
 import { Hono } from "hono"
 import type { UpgradeWebSocket } from "hono/ws"
+import fs from "fs/promises"
 import z from "zod"
 import { Format } from "../../format"
 import { Instance } from "../../project/instance"
@@ -109,6 +110,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
             ? await PawWorkHome.ensurePrimary()
             : PawWorkHome.primary()
           : Global.Path.config
+        if (ensureConfig && !Runtime.isPawWork()) await fs.mkdir(config, { recursive: true })
         return c.json({
           home: Global.Path.home,
           state: Global.Path.state,

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -8,6 +8,8 @@ import { Vcs } from "../../project/vcs"
 import { Agent } from "../../agent/agent"
 import { Skill } from "../../skill"
 import { Global } from "../../global"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { Runtime } from "@opencode-ai/core/runtime"
 import { LSP } from "../../lsp"
 import { Command } from "../../command"
 import { QuestionRoutes } from "./question"
@@ -90,10 +92,11 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
         },
       }),
       async (c) => {
+        const config = Runtime.isPawWork() ? await PawWorkHome.ensurePrimary() : Global.Path.config
         return c.json({
           home: Global.Path.home,
           state: Global.Path.state,
-          config: Global.Path.config,
+          config,
           worktree: Instance.worktree,
           directory: Instance.directory,
         })

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -68,6 +68,17 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
         summary: "Get paths",
         description: "Retrieve the current working directory and related path information for the OpenCode instance.",
         operationId: "path.get",
+        parameters: [
+          {
+            name: "ensureConfig",
+            in: "query",
+            required: false,
+            schema: {
+              type: "boolean",
+            },
+            description: "Create the global config directory before returning it.",
+          },
+        ],
         responses: {
           200: {
             description: "Path",
@@ -92,7 +103,12 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
         },
       }),
       async (c) => {
-        const config = Runtime.isPawWork() ? await PawWorkHome.ensurePrimary() : Global.Path.config
+        const ensureConfig = c.req.query("ensureConfig") === "true"
+        const config = Runtime.isPawWork()
+          ? ensureConfig
+            ? await PawWorkHome.ensurePrimary()
+            : PawWorkHome.primary()
+          : Global.Path.config
         return c.json({
           home: Global.Path.home,
           state: Global.Path.state,

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -72,9 +72,12 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
 
     const url = new URL(c.req.url)
     if (url.pathname === "/path" && url.searchParams.get("ensureConfig") === "true" && !Runtime.isPawWork()) {
-      mkdirSync(Global.Path.config, { recursive: true })
+      try {
+        mkdirSync(Global.Path.config, { recursive: true })
+      } catch {
+        // Ignore: handler will propagate the config path creation error.
+      }
     }
-
     const sessionWorkspaceID = await getSessionWorkspace(url)
     const workspaceID = sessionWorkspaceID || url.searchParams.get("workspace")
 

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -71,18 +71,19 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const directory = Filesystem.resolve(decoded)
 
     const url = new URL(c.req.url)
-    if (url.pathname === "/path" && url.searchParams.get("ensureConfig") === "true" && !Runtime.isPawWork()) {
-      try {
-        mkdirSync(Global.Path.config, { recursive: true })
-      } catch {
-        // Ignore: handler will propagate the config path creation error.
-      }
-    }
     const sessionWorkspaceID = await getSessionWorkspace(url)
     const workspaceID = sessionWorkspaceID || url.searchParams.get("workspace")
 
     // If no workspace is provided we use the project
     if (!workspaceID) {
+      if (url.pathname === "/path" && url.searchParams.get("ensureConfig") === "true" && !Runtime.isPawWork()) {
+        try {
+          mkdirSync(Global.Path.config, { recursive: true })
+        } catch {
+          // Ignore: handler will propagate the config path creation error.
+        }
+      }
+
       return Instance.provide({
         directory,
         init: InstanceBootstrap,

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -12,6 +12,8 @@ import { InstanceBootstrap } from "@/project/bootstrap"
 import { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
+import { Global } from "@/global"
+import { Runtime } from "@opencode-ai/core/runtime"
 
 type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
 
@@ -69,6 +71,9 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const directory = Filesystem.resolve(decoded)
 
     const url = new URL(c.req.url)
+    if (url.pathname === "/path" && url.searchParams.get("ensureConfig") === "true" && !Runtime.isPawWork()) {
+      mkdirSync(Global.Path.config, { recursive: true })
+    }
 
     const sessionWorkspaceID = await getSessionWorkspace(url)
     const workspaceID = sessionWorkspaceID || url.searchParams.get("workspace")

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -305,10 +305,11 @@ export namespace Export {
     } catch {
       worktree = undefined
     }
+    const globalInstruction = Runtime.isPawWork()
+      ? yield* Effect.promise(() => PawWorkHome.firstNonEmptyInstructionFile())
+      : path.join(Global.Path.config, "AGENTS.md")
     const candidates: Array<{ kind: string; file: string }> = [
-      ...(Runtime.isPawWork()
-        ? PawWorkHome.fileCandidates("AGENTS.md").map((file) => ({ kind: "global", file }))
-        : [{ kind: "global", file: path.join(Global.Path.config, "AGENTS.md") }]),
+      ...(globalInstruction ? [{ kind: "global", file: globalInstruction }] : []),
       ...(worktree ? [{ kind: "project", file: path.join(worktree, "AGENTS.md") }] : []),
       // Bundled pawwork prompt — present in the repo at packages/opencode/src/session/prompt/pawwork.txt.
       // hashFile silently returns undefined and the entry is skipped if the file is missing.

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -15,9 +15,8 @@ import { Installation } from "../installation"
 import { Provider } from "../provider/provider"
 import { ProviderID, ModelID } from "../provider/schema"
 import { Instance } from "../project/instance"
-import { Global } from "../global"
-import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { sanitizeSensitiveDiffs, sanitizeSensitiveToolPart } from "@/tool/sensitive"
+import { Instruction } from "./instruction"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -299,26 +298,23 @@ export namespace Export {
 
   const collectInstructionSources = Effect.fn("Export.instructionSources")(function* () {
     const sources: InstructionSource[] = []
-    let worktree: string | undefined
-    try {
-      worktree = Instance.worktree
-    } catch {
-      worktree = undefined
+    const instruction = yield* Instruction.Service
+    const loaded = (yield* instruction.sources()).filter((source) => source.status === "loaded")
+
+    for (const source of loaded) {
+      if (source.kind === "remote") {
+        sources.push({ kind: source.kind, url: source.path })
+        continue
+      }
+
+      const hash = yield* Effect.promise(() => hashFile(source.path))
+      if (hash) sources.push({ kind: source.kind, path: source.path, hash })
     }
-    const globalInstruction = Runtime.isPawWork()
-      ? yield* Effect.promise(() => PawWorkHome.firstLoadedInstructionFile())
-      : path.join(Global.Path.config, "AGENTS.md")
-    const candidates: Array<{ kind: string; file: string }> = [
-      ...(globalInstruction ? [{ kind: "global", file: globalInstruction }] : []),
-      ...(worktree ? [{ kind: "project", file: path.join(worktree, "AGENTS.md") }] : []),
-      // Bundled pawwork prompt — present in the repo at packages/opencode/src/session/prompt/pawwork.txt.
-      // hashFile silently returns undefined and the entry is skipped if the file is missing.
-      { kind: "bundled", file: path.join(__dirname, "prompt", "pawwork.txt") },
-    ]
-    for (const c of candidates) {
-      const hash = yield* Effect.promise(() => hashFile(c.file))
-      if (hash) sources.push({ kind: c.kind, path: c.file, hash })
-    }
+
+    const bundled = path.join(__dirname, "prompt", "pawwork.txt")
+    const bundledHash = yield* Effect.promise(() => hashFile(bundled))
+    if (bundledHash) sources.push({ kind: "bundled", path: bundled, hash: bundledHash })
+
     return sources.sort((a, b) => {
       if (a.kind !== b.kind) return a.kind.localeCompare(b.kind)
       return (a.path ?? a.url ?? "").localeCompare(b.path ?? b.url ?? "")

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -306,7 +306,7 @@ export namespace Export {
       worktree = undefined
     }
     const globalInstruction = Runtime.isPawWork()
-      ? yield* Effect.promise(() => PawWorkHome.firstNonEmptyInstructionFile())
+      ? yield* Effect.promise(() => PawWorkHome.firstLoadedInstructionFile())
       : path.join(Global.Path.config, "AGENTS.md")
     const candidates: Array<{ kind: string; file: string }> = [
       ...(globalInstruction ? [{ kind: "global", file: globalInstruction }] : []),

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -309,6 +309,7 @@ export namespace Export {
 
       const hash = yield* Effect.promise(() => hashFile(source.path))
       if (hash) sources.push({ kind: source.kind, path: source.path, hash })
+      else sources.push({ kind: source.kind, path: source.path, hash_unavailable: true })
     }
 
     const bundled = path.join(__dirname, "prompt", "pawwork.txt")

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -299,11 +299,11 @@ export namespace Export {
   const collectInstructionSources = Effect.fn("Export.instructionSources")(function* () {
     const sources: InstructionSource[] = []
     const instruction = yield* Instruction.Service
-    const loaded = (yield* instruction.sources()).filter((source) => source.status === "loaded")
+    const loaded = (yield* instruction.sources({ fetchRemote: false })).filter((source) => source.status === "loaded")
 
     for (const source of loaded) {
       if (source.kind === "remote") {
-        sources.push({ kind: source.kind, url: source.path })
+        sources.push({ kind: source.kind, url: source.path, hash_unavailable: true })
         continue
       }
 

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -299,20 +299,43 @@ export namespace Export {
   const collectInstructionSources = Effect.fn("Export.instructionSources")(function* (directory?: string) {
     const sources: InstructionSource[] = []
     const instruction = yield* Instruction.Service
-    const resolvedSources =
-      directory && path.resolve(directory) !== path.resolve(Instance.directory)
-        ? yield* Effect.promise(async () => {
-            const fromSessionDirectory = await Instance.provide({
-              directory,
-              fn: () => Effect.runPromise(instruction.sources({ fetchRemote: false })),
-            })
-            return await fromSessionDirectory
+    const sessionDirectoryUnavailable = "session directory unavailable"
+    let resolvedSources
+    if (directory && path.resolve(directory) !== path.resolve(Instance.directory)) {
+      const fromSessionDirectory = yield* Effect.promise(async () => {
+        try {
+          const stat = await fs.stat(directory)
+          if (!stat.isDirectory()) return undefined
+          return await Instance.provide({
+            directory,
+            fn: () => Effect.runPromise(instruction.sources({ fetchRemote: false })),
           })
-        : yield* instruction.sources({ fetchRemote: false })
+        } catch {
+          return undefined
+        }
+      })
+      if (fromSessionDirectory) {
+        resolvedSources = fromSessionDirectory
+      } else {
+        const fallback = yield* instruction.sources({ fetchRemote: false }).pipe(Effect.catch(() => Effect.succeed([])))
+        resolvedSources = [
+          ...fallback.filter((source) => source.status === "loaded" && source.kind === "global"),
+          {
+            status: "considered" as const,
+            path: directory,
+            kind: "project" as const,
+            reason: sessionDirectoryUnavailable,
+          },
+        ]
+      }
+    } else {
+      resolvedSources = yield* instruction.sources({ fetchRemote: false })
+    }
     const instructionSources = resolvedSources.filter(
       (source) =>
         source.status === "loaded" ||
-        (source.status === "considered" && source.kind === "remote" && source.reason === "configured but not fetched"),
+        (source.status === "considered" && source.kind === "remote" && source.reason === "configured but not fetched") ||
+        (source.status === "considered" && source.kind === "project" && source.reason === sessionDirectoryUnavailable),
     )
 
     for (const source of instructionSources) {

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -51,10 +51,7 @@ function redactDataUrl(url: string): { mime: string; size_bytes: number; sha256:
   }
 }
 
-export function redactPart(
-  part: MessageV2.Part,
-  ctx: { count: { omitted: number } },
-): MessageV2.Part {
+export function redactPart(part: MessageV2.Part, ctx: { count: { omitted: number } }): MessageV2.Part {
   part = sanitizeSensitiveToolPart(part)
   if (part.type === "file") {
     const r = redactDataUrl(part.url)
@@ -114,6 +111,7 @@ export namespace Export {
     url?: string
     hash?: string
     hash_unavailable?: true
+    reason?: string
   }
 
   export type Snapshot = {
@@ -302,6 +300,8 @@ export namespace Export {
     return { session_count, message_count, part_count, omitted_attachment_count }
   }
 
+  const globalConfigFallbackRelativeReason = "fallback relative path resolved from global config directory"
+
   const collectInstructionSources = Effect.fn("Export.instructionSources")(function* (directory?: string) {
     const sources: InstructionSource[] = []
     const instruction = yield* Instruction.Service
@@ -342,7 +342,12 @@ export namespace Export {
     const instructionSources = resolvedSources.filter(
       (source) =>
         source.status === "loaded" ||
-        (source.status === "considered" && source.kind === "remote" && source.reason === "configured but not fetched") ||
+        (source.status === "considered" &&
+          source.kind === "remote" &&
+          source.reason === "configured but not fetched") ||
+        (source.status === "considered" &&
+          source.kind === "config" &&
+          source.reason === globalConfigFallbackRelativeReason) ||
         (source.status === "considered" && source.kind === "project" && source.reason === sessionDirectoryUnavailable),
     )
 
@@ -353,7 +358,9 @@ export namespace Export {
       }
 
       const hash = yield* Effect.promise(() => hashFile(source.path))
-      if (hash) sources.push({ kind: source.kind, path: source.path, hash })
+      if (source.status === "considered") {
+        sources.push({ kind: source.kind, path: source.path, hash_unavailable: true, reason: source.reason })
+      } else if (hash) sources.push({ kind: source.kind, path: source.path, hash })
       else sources.push({ kind: source.kind, path: source.path, hash_unavailable: true })
     }
 
@@ -388,6 +395,7 @@ export namespace Export {
         sources.push({ status: "considered", path: item, kind: "remote", reason: "configured but not fetched" })
         continue
       }
+      const isFallbackRelativePath = !item.startsWith("~/") && !path.isAbsolute(item)
       const instruction = item.startsWith("~/")
         ? path.join(Global.Path.home, item.slice(2))
         : path.isAbsolute(item)
@@ -396,7 +404,17 @@ export namespace Export {
       const matches = await globalInstructionMatches(instruction, path.dirname(file))
       for (const match of matches) {
         const text = await fs.readFile(match, "utf8").catch(() => "")
-        if (text) sources.push({ status: "loaded", path: path.resolve(match), kind: "config" })
+        if (!text) continue
+        sources.push(
+          isFallbackRelativePath
+            ? {
+                status: "considered",
+                path: path.resolve(match),
+                kind: "config",
+                reason: globalConfigFallbackRelativeReason,
+              }
+            : { status: "loaded", path: path.resolve(match), kind: "config" },
+        )
       }
     }
     return sources

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -16,6 +16,7 @@ import { Provider } from "../provider/provider"
 import { ProviderID, ModelID } from "../provider/schema"
 import { Instance } from "../project/instance"
 import { Global } from "../global"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { sanitizeSensitiveDiffs, sanitizeSensitiveToolPart } from "@/tool/sensitive"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
@@ -305,7 +306,9 @@ export namespace Export {
       worktree = undefined
     }
     const candidates: Array<{ kind: string; file: string }> = [
-      { kind: "global", file: path.join(Global.Path.config, "AGENTS.md") },
+      ...(Runtime.isPawWork()
+        ? PawWorkHome.fileCandidates("AGENTS.md").map((file) => ({ kind: "global", file }))
+        : [{ kind: "global", file: path.join(Global.Path.config, "AGENTS.md") }]),
       ...(worktree ? [{ kind: "project", file: path.join(worktree, "AGENTS.md") }] : []),
       // Bundled pawwork prompt — present in the repo at packages/opencode/src/session/prompt/pawwork.txt.
       // hashFile silently returns undefined and the entry is skipped if the file is missing.

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -3,10 +3,12 @@ import path from "node:path"
 import fs from "node:fs/promises"
 import crypto from "node:crypto"
 import { fileURLToPath } from "node:url"
+import { parse as parseJsonc } from "jsonc-parser"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 import { Effect } from "effect"
 import { Runtime } from "@opencode-ai/core/runtime"
+import { Global } from "@opencode-ai/core/global"
 import { Session } from "."
 import type { SessionID } from "./schema"
 import { MessageV2 } from "./message-v2"
@@ -17,6 +19,8 @@ import { ProviderID, ModelID } from "../provider/schema"
 import { Instance } from "../project/instance"
 import { sanitizeSensitiveDiffs, sanitizeSensitiveToolPart } from "@/tool/sensitive"
 import { Instruction } from "./instruction"
+import { Config } from "../config"
+import { isRecord } from "@/util/record"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -318,8 +322,10 @@ export namespace Export {
         resolvedSources = fromSessionDirectory
       } else {
         const fallback = yield* instruction.sources({ fetchRemote: false }).pipe(Effect.catch(() => Effect.succeed([])))
+        const globalConfigSources = yield* Effect.promise(() => globalConfiguredInstructionSources())
         resolvedSources = [
           ...fallback.filter((source) => source.status === "loaded" && source.kind === "global"),
+          ...globalConfigSources,
           {
             status: "considered" as const,
             path: directory,
@@ -358,6 +364,30 @@ export namespace Export {
       return (a.path ?? a.url ?? "").localeCompare(b.path ?? b.url ?? "")
     })
   })
+
+  async function globalConfiguredInstructionSources(): Promise<Instruction.InstructionSource[]> {
+    const file = Config.globalConfigFileForRead()
+    if (!file) return []
+    const text = await fs.readFile(file, "utf8").catch(() => undefined)
+    if (!text) return []
+    const data = parseJsonc(text)
+    if (!isRecord(data) || !Array.isArray(data.instructions)) return []
+    const sources: Instruction.InstructionSource[] = []
+    for (const item of data.instructions) {
+      if (typeof item !== "string") continue
+      if (item.startsWith("https://") || item.startsWith("http://")) {
+        sources.push({ status: "considered", path: item, kind: "remote", reason: "configured but not fetched" })
+        continue
+      }
+      const resolved = item.startsWith("~/")
+        ? path.join(Global.Path.home, item.slice(2))
+        : path.isAbsolute(item)
+          ? item
+          : path.resolve(path.dirname(file), item)
+      sources.push({ status: "loaded", path: resolved, kind: "config" })
+    }
+    return sources
+  }
 
   // Exported so it can be unit-tested with synthesized Tree fixtures.
   export const collectModelRefs = Effect.fn("Export.modelRefs")(function* (tree: Tree) {

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -20,7 +20,9 @@ import { Instance } from "../project/instance"
 import { sanitizeSensitiveDiffs, sanitizeSensitiveToolPart } from "@/tool/sensitive"
 import { Instruction } from "./instruction"
 import { Config } from "../config"
+import { ConfigVariable } from "../config/variable"
 import { isRecord } from "@/util/record"
+import { Glob } from "@/util/glob"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -370,7 +372,14 @@ export namespace Export {
     if (!file) return []
     const text = await fs.readFile(file, "utf8").catch(() => undefined)
     if (!text) return []
-    const data = parseJsonc(text)
+    const substituted = await ConfigVariable.substitute({
+      text,
+      type: "path",
+      path: file,
+      missing: "empty",
+    }).catch(() => undefined)
+    if (!substituted) return []
+    const data = parseJsonc(substituted)
     if (!isRecord(data) || !Array.isArray(data.instructions)) return []
     const sources: Instruction.InstructionSource[] = []
     for (const item of data.instructions) {
@@ -379,14 +388,39 @@ export namespace Export {
         sources.push({ status: "considered", path: item, kind: "remote", reason: "configured but not fetched" })
         continue
       }
-      const resolved = item.startsWith("~/")
+      const instruction = item.startsWith("~/")
         ? path.join(Global.Path.home, item.slice(2))
         : path.isAbsolute(item)
           ? item
-          : path.resolve(path.dirname(file), item)
-      sources.push({ status: "loaded", path: resolved, kind: "config" })
+          : item
+      const matches = await globalInstructionMatches(instruction, path.dirname(file))
+      for (const match of matches) {
+        const text = await fs.readFile(match, "utf8").catch(() => "")
+        if (text) sources.push({ status: "loaded", path: path.resolve(match), kind: "config" })
+      }
     }
     return sources
+  }
+
+  async function globalInstructionMatches(instruction: string, configDir: string) {
+    try {
+      if (path.isAbsolute(instruction)) {
+        return await Glob.scan(path.basename(instruction), {
+          cwd: path.dirname(instruction),
+          absolute: true,
+          include: "file",
+          dot: true,
+        })
+      }
+      return await Glob.scan(instruction, {
+        cwd: configDir,
+        absolute: true,
+        include: "file",
+        dot: true,
+      })
+    } catch {
+      return []
+    }
   }
 
   // Exported so it can be unit-tested with synthesized Tree fixtures.

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -296,10 +296,20 @@ export namespace Export {
     return { session_count, message_count, part_count, omitted_attachment_count }
   }
 
-  const collectInstructionSources = Effect.fn("Export.instructionSources")(function* () {
+  const collectInstructionSources = Effect.fn("Export.instructionSources")(function* (directory?: string) {
     const sources: InstructionSource[] = []
     const instruction = yield* Instruction.Service
-    const instructionSources = (yield* instruction.sources({ fetchRemote: false })).filter(
+    const resolvedSources =
+      directory && path.resolve(directory) !== path.resolve(Instance.directory)
+        ? yield* Effect.promise(async () => {
+            const fromSessionDirectory = await Instance.provide({
+              directory,
+              fn: () => Effect.runPromise(instruction.sources({ fetchRemote: false })),
+            })
+            return await fromSessionDirectory
+          })
+        : yield* instruction.sources({ fetchRemote: false })
+    const instructionSources = resolvedSources.filter(
       (source) =>
         source.status === "loaded" ||
         (source.status === "considered" && source.kind === "remote" && source.reason === "configured but not fetched"),
@@ -373,7 +383,7 @@ export namespace Export {
     const root = yield* climbToRoot(svc, anyID)
     const ctx = { count: { omitted: 0 } }
     const tree = yield* exportTree(svc, root, ctx)
-    const instruction_sources = yield* collectInstructionSources()
+    const instruction_sources = yield* collectInstructionSources(root.directory)
     const model_refs = yield* collectModelRefs(tree)
     return {
       schema_version: 1 as const,

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -299,9 +299,13 @@ export namespace Export {
   const collectInstructionSources = Effect.fn("Export.instructionSources")(function* () {
     const sources: InstructionSource[] = []
     const instruction = yield* Instruction.Service
-    const loaded = (yield* instruction.sources({ fetchRemote: false })).filter((source) => source.status === "loaded")
+    const instructionSources = (yield* instruction.sources({ fetchRemote: false })).filter(
+      (source) =>
+        source.status === "loaded" ||
+        (source.status === "considered" && source.kind === "remote" && source.reason === "configured but not fetched"),
+    )
 
-    for (const source of loaded) {
+    for (const source of instructionSources) {
       if (source.kind === "remote") {
         sources.push({ kind: source.kind, url: source.path, hash_unavailable: true })
         continue

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -161,8 +161,12 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           for (const file of FILES()) {
             const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
-            if (matches.length > 0) {
-              matches.forEach((item) => paths.add(path.resolve(item)))
+            const stats = yield* Effect.forEach(matches, (item) =>
+              fs.isFile(item).pipe(Effect.map((isFile) => ({ item, isFile }))),
+            )
+            const files = stats.filter((item) => item.isFile).map((item) => item.item)
+            if (files.length > 0) {
+              files.forEach((item) => paths.add(path.resolve(item)))
               break
             }
           }
@@ -242,8 +246,12 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
           let projectLoaded = false
           for (const file of FILES()) {
             const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
-            if (matches.length === 0) continue
-            for (const match of matches) {
+            const stats = yield* Effect.forEach(matches, (item) =>
+              fs.isFile(item).pipe(Effect.map((isFile) => ({ item, isFile }))),
+            )
+            const files = stats.filter((item) => item.isFile).map((item) => item.item)
+            if (files.length === 0) continue
+            for (const match of files) {
               const resolved = path.resolve(match)
               if (loadedPaths.has(resolved)) continue
               if (!projectLoaded) {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -36,7 +36,7 @@ function FILES() {
 }
 
 function configDir() {
-  if (Runtime.isPawWork()) return Flag.PAWWORK_CONFIG_DIR ?? PawWorkHome.primary()
+  if (Runtime.isPawWork()) return PawWorkHome.primary()
   return Flag.OPENCODE_CONFIG_DIR
 }
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -169,7 +169,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         }
 
         for (const file of globalInstructionFiles()) {
-          if (yield* fs.existsSafe(file)) {
+          if (yield* fs.isFile(file)) {
             paths.add(path.resolve(file))
             break
           }
@@ -280,6 +280,10 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
               kind: "global",
               reason: "skipped because a higher-priority global instruction file was loaded",
             })
+            continue
+          }
+          if (!(yield* fs.isFile(file))) {
+            result.push({ status: "considered", path: resolved, kind: "global", reason: "not a file" })
             continue
           }
           const ok = yield* recordFileEntry(resolved, "global")

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -5,6 +5,7 @@ import { Config } from "@/config"
 import { InstanceState } from "@/effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { Global } from "../global"
 import { Instance } from "../project/instance"
@@ -39,6 +40,7 @@ function configDir() {
 }
 
 function globalInstructionFiles() {
+  if (Runtime.isPawWork()) return PawWorkHome.fileCandidates("AGENTS.md")
   const files = []
   const dir = configDir()
   if (dir) {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -76,9 +76,9 @@ function extract(messages: MessageV2.WithParts[]) {
 }
 
 export type InstructionSource =
-  | { status: "loaded"; path: string }
-  | { status: "considered"; path: string; reason: string }
-  | { status: "ignored"; path: string; reason: string }
+  | { status: "loaded"; path: string; kind: "project" | "global" | "config" | "remote" }
+  | { status: "considered"; path: string; kind: "project" | "global" | "config" | "remote"; reason: string }
+  | { status: "ignored"; path: string; kind: "ignored"; reason: string }
 
 export interface Interface {
   readonly clear: (messageID: MessageID) => Effect.Effect<void>
@@ -218,21 +218,23 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         // Mark a file as loaded only after read() returns non-empty content; system()
         // already drops empty/unreadable files so a "loaded" entry that the prompt
         // doesn't see would mislead diagnostics.
-        const recordFileEntry = Effect.fnUntraced(function* (resolved: string) {
+        const recordFileEntry = Effect.fnUntraced(function* (
+          resolved: string,
+          kind: "project" | "global" | "config",
+        ) {
           const content = yield* read(resolved)
           if (content) {
-            result.push({ status: "loaded", path: resolved })
+            result.push({ status: "loaded", path: resolved, kind })
             loadedPaths.add(resolved)
             return true as const
           }
-          result.push({ status: "considered", path: resolved, reason: "file is empty or unreadable" })
+          result.push({ status: "considered", path: resolved, kind, reason: "file is empty or unreadable" })
           return false as const
         })
 
-        // Project-level walk: emit the full priority chain, not just the winner. First
-        // file whose content reads back non-empty is loaded; later existing matches are
-        // considered with a priority-skipped reason. Absent files are not reported here
-        // because FILES holds basenames, not paths — the directory walk is the search.
+        // Project-level walk: the first basename with existing matches wins, matching
+        // systemPaths(). Empty/unreadable matches are considered but still block lower
+        // priority basenames such as CLAUDE.md and CONTEXT.md.
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           let projectLoaded = false
           for (const file of FILES()) {
@@ -242,40 +244,44 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
               const resolved = path.resolve(match)
               if (loadedPaths.has(resolved)) continue
               if (!projectLoaded) {
-                const ok = yield* recordFileEntry(resolved)
+                const ok = yield* recordFileEntry(resolved, "project")
                 if (ok) projectLoaded = true
               } else {
                 result.push({
                   status: "considered",
                   path: resolved,
+                  kind: "project",
                   reason: "skipped because a higher-priority project instruction file was loaded",
                 })
               }
             }
+            break
           }
         }
 
-        // Global instruction file chain: report the full priority chain so debug output
-        // can show why a candidate was skipped (priority) or absent.
+        // Global instruction file chain: absent candidates are reported until the first
+        // existing candidate, which blocks lower-priority fallback locations.
         let globalLoaded = false
         for (const file of globalInstructionFiles()) {
           const resolved = path.resolve(file)
           if (loadedPaths.has(resolved)) continue
           const exists = yield* fs.existsSafe(file)
           if (!exists) {
-            result.push({ status: "considered", path: resolved, reason: "absent" })
+            result.push({ status: "considered", path: resolved, kind: "global", reason: "absent" })
             continue
           }
           if (globalLoaded) {
             result.push({
               status: "considered",
               path: resolved,
+              kind: "global",
               reason: "skipped because a higher-priority global instruction file was loaded",
             })
             continue
           }
-          const ok = yield* recordFileEntry(resolved)
+          const ok = yield* recordFileEntry(resolved, "global")
           if (ok) globalLoaded = true
+          break
         }
 
         // Local file entries from config.instructions: glob-resolve them the same way
@@ -301,6 +307,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
             result.push({
               status: "considered",
               path: raw,
+              kind: "config",
               reason: "config.instructions entry resolved to no files",
             })
             continue
@@ -308,7 +315,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
           for (const match of matches) {
             const resolved = path.resolve(match)
             if (loadedPaths.has(resolved)) continue
-            yield* recordFileEntry(resolved)
+            yield* recordFileEntry(resolved, "config")
           }
         }
 
@@ -322,9 +329,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         for (const [index, url] of urls.entries()) {
           const body = bodies[index]
           if (body) {
-            result.push({ status: "loaded", path: url })
+            result.push({ status: "loaded", path: url, kind: "remote" })
           } else {
-            result.push({ status: "considered", path: url, reason: "fetch failed or returned empty body" })
+            result.push({ status: "considered", path: url, kind: "remote", reason: "fetch failed or returned empty body" })
           }
         }
 
@@ -339,7 +346,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
             : null
         if (ignoreReason && !loadedPaths.has(claudeFallback)) {
           if (yield* fs.existsSafe(claudeFallback)) {
-            result.push({ status: "ignored", path: claudeFallback, reason: ignoreReason })
+            result.push({ status: "ignored", path: claudeFallback, kind: "ignored", reason: ignoreReason })
           }
         }
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -336,7 +336,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         const bodies = fetchRemote ? yield* Effect.forEach(urls, fetch, { concurrency: 4 }) : []
         for (const [index, url] of urls.entries()) {
           const body = bodies[index]
-          if (!fetchRemote || body) {
+          if (!fetchRemote) {
+            result.push({ status: "considered", path: url, kind: "remote", reason: "configured but not fetched" })
+          } else if (body) {
             result.push({ status: "loaded", path: url, kind: "remote" })
           } else {
             result.push({ status: "considered", path: url, kind: "remote", reason: "fetch failed or returned empty body" })

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -249,6 +249,14 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
             const stats = yield* Effect.forEach(matches, (item) =>
               fs.isFile(item).pipe(Effect.map((isFile) => ({ item, isFile }))),
             )
+            for (const item of stats.filter((item) => !item.isFile)) {
+              result.push({
+                status: "considered",
+                path: path.resolve(item.item),
+                kind: "project",
+                reason: "not a file",
+              })
+            }
             const files = stats.filter((item) => item.isFile).map((item) => item.item)
             if (files.length === 0) continue
             for (const match of files) {
@@ -374,7 +382,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
       const find = Effect.fn("Instruction.find")(function* (dir: string) {
         for (const file of FILES()) {
           const filepath = path.resolve(path.join(dir, file))
-          if (yield* fs.existsSafe(filepath)) return filepath
+          if (yield* fs.isFile(filepath)) return filepath
         }
       })
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -87,7 +87,7 @@ export interface Interface {
   readonly clear: (messageID: MessageID) => Effect.Effect<void>
   readonly systemPaths: () => Effect.Effect<Set<string>, AppFileSystem.Error>
   readonly system: () => Effect.Effect<string[], AppFileSystem.Error>
-  readonly sources: () => Effect.Effect<InstructionSource[], AppFileSystem.Error>
+  readonly sources: (options?: { fetchRemote?: boolean }) => Effect.Effect<InstructionSource[], AppFileSystem.Error>
   readonly find: (dir: string) => Effect.Effect<string | undefined, AppFileSystem.Error>
   readonly resolve: (
     messages: MessageV2.WithParts[],
@@ -214,7 +214,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         ]
       })
 
-      const sources = Effect.fn("Instruction.sources")(function* () {
+      const sources = Effect.fn("Instruction.sources")(function* (options?: { fetchRemote?: boolean }) {
         const result: InstructionSource[] = []
         const loadedPaths = new Set<string>()
 
@@ -328,10 +328,11 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         const urls = (config.instructions ?? []).filter(
           (item) => item.startsWith("https://") || item.startsWith("http://"),
         )
-        const bodies = yield* Effect.forEach(urls, fetch, { concurrency: 4 })
+        const fetchRemote = options?.fetchRemote ?? true
+        const bodies = fetchRemote ? yield* Effect.forEach(urls, fetch, { concurrency: 4 }) : []
         for (const [index, url] of urls.entries()) {
           const body = bodies[index]
-          if (body) {
+          if (!fetchRemote || body) {
             result.push({ status: "loaded", path: url, kind: "remote" })
           } else {
             result.push({ status: "considered", path: url, kind: "remote", reason: "fetch failed or returned empty body" })

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -36,7 +36,8 @@ function FILES() {
 }
 
 function configDir() {
-  return Runtime.isPawWork() ? Flag.PAWWORK_CONFIG_DIR : Flag.OPENCODE_CONFIG_DIR
+  if (Runtime.isPawWork()) return Flag.PAWWORK_CONFIG_DIR ?? PawWorkHome.primary()
+  return Flag.OPENCODE_CONFIG_DIR
 }
 
 function globalInstructionFiles() {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -36,7 +36,10 @@ function FILES() {
 }
 
 function configDir() {
-  if (Runtime.isPawWork()) return PawWorkHome.primary()
+  if (Runtime.isPawWork()) {
+    const source = Config.globalConfigFileForRead()
+    return source ? path.dirname(source) : PawWorkHome.primary()
+  }
   return Flag.OPENCODE_CONFIG_DIR
 }
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -40,7 +40,7 @@ function configDir() {
 }
 
 function globalInstructionFiles() {
-  if (Runtime.isPawWork()) return PawWorkHome.fileCandidates("AGENTS.md")
+  if (Runtime.isPawWork()) return PawWorkHome.instructionFiles()
   const files = []
   const dir = configDir()
   if (dir) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -730,6 +730,37 @@ test("handles file inclusion substitution", async () => {
   })
 })
 
+test("resolves {file:~/...} against Global.Path.home", async () => {
+  await using home = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(path.join(dir, "included.txt"), "test-home-user")
+    },
+  })
+  await using project = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        username: "{file:~/included.txt}",
+      })
+    },
+  })
+  const previousHome = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = home.path
+
+  try {
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.username).toBe("test-home-user")
+      },
+    })
+  } finally {
+    if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+    else process.env.OPENCODE_TEST_HOME = previousHome
+  }
+})
+
 test("handles file inclusion with replacement tokens", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -32,6 +32,7 @@ import { withConfigDepsLock } from "../shared/config-deps-lock"
 import { writeInstalledConfigDeps } from "../shared/mock-npm-install"
 import { Npm } from "@opencode-ai/core/npm"
 import { Installation } from "../../src/installation"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 
 const emptyAccount = Layer.mock(Account.Service)({
   active: () => Effect.succeed(Option.none()),
@@ -265,8 +266,11 @@ test("loads and updates global PawWork config aliases", async () => {
   await withPawWorkRuntime(async () => {
     await using globalTmp = await tmpdir()
     await using tmp = await tmpdir()
+    await using home = await tmpdir()
     const prev = Global.Path.config
+    const previousHome = process.env.OPENCODE_TEST_HOME
     ;(Global.Path as { config: string }).config = globalTmp.path
+    process.env.OPENCODE_TEST_HOME = home.path
     await writeInstalledConfigDeps(globalTmp.path)
     await clear()
     try {
@@ -295,11 +299,15 @@ test("loads and updates global PawWork config aliases", async () => {
         },
       })
 
-      const content = await Filesystem.readJson<{ username?: string }>(path.join(globalTmp.path, "pawwork.json"))
+      const content = await Filesystem.readJson<{ username?: string }>(path.join(PawWorkHome.primary(), "pawwork.json"))
       expect(content.username).toBe("updated-pawwork")
+      const legacy = await Filesystem.readJson<{ username?: string }>(path.join(globalTmp.path, "pawwork.json"))
+      expect(legacy.username).toBe("global-pawwork")
       expect(await Filesystem.exists(path.join(globalTmp.path, "opencode.jsonc"))).toBe(false)
     } finally {
       ;(Global.Path as { config: string }).config = prev
+      if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = previousHome
       await clear()
     }
   })

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -363,6 +363,7 @@ describe("PawWork global config isolation", () => {
         fn: async () => {
           const config = await load()
           expect(config.model).toBe("legacy/model")
+          expect(config.default_agent).toBeUndefined()
           expect(await Bun.file(legacy).text()).toBe(original)
         },
       })
@@ -387,6 +388,7 @@ describe("PawWork global config isolation", () => {
       fn: async () => {
         const config = await load()
         expect(config.model).toBe("fallback/model")
+        expect(config.default_agent).toBeUndefined()
         expect(await Bun.file(configFile).text()).toBe(original)
       },
     })
@@ -453,6 +455,56 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("first global update seeds Home from legacy source without materializing secrets or rebasing relative resources", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const secretFile = path.join(platformLegacy.path, "secret.txt")
+      const instructionFile = path.join(platformLegacy.path, "rules", "AGENTS.md")
+      const pluginFile = path.join(platformLegacy.path, "plugins", "plugin.ts")
+      await Filesystem.write(secretFile, "legacy-secret")
+      await Filesystem.write(instructionFile, "legacy instructions")
+      await Filesystem.write(pluginFile, "export const Plugin = {}")
+      await Filesystem.write(
+        path.join(platformLegacy.path, "pawwork.json"),
+        JSON.stringify(
+          {
+            username: "{file:secret.txt}",
+            instructions: ["./rules/AGENTS.md"],
+            plugin: ["./plugins/plugin.ts"],
+          },
+          null,
+          2,
+        ),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await saveGlobal({ model: "updated/model" })
+          const primaryFile = path.join(home.path, ".pawwork", "pawwork.json")
+          const savedText = await Bun.file(primaryFile).text()
+          const saved = JSON.parse(savedText)
+
+          expect(savedText).not.toContain("legacy-secret")
+          expect(saved.username).toBe(`{file:${secretFile}}`)
+          expect(saved.instructions).toEqual([instructionFile])
+          expect(saved.plugin).toEqual([pluginFile])
+          expect(saved.model).toBe("updated/model")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("global config write resolver ignores OpenCode filenames in PawWork Home", async () => {
     await using home = await tmpdir()
     process.env.PAWWORK_HOME = home.path
@@ -487,7 +539,10 @@ describe("PawWork global config isolation", () => {
 
     try {
       await Filesystem.write(path.join(platformLegacy.path, "pawwork.json"), JSON.stringify({ model: "legacy/model" }))
-      await Filesystem.write(path.join(platformLegacy.path, "pawwork.jsonc"), JSON.stringify({ username: "jsonc-user" }))
+      await Filesystem.write(
+        path.join(platformLegacy.path, "pawwork.jsonc"),
+        JSON.stringify({ username: "jsonc-user" }),
+      )
 
       await Instance.provide({
         directory: project.path,
@@ -878,6 +933,37 @@ home command`,
         expect(JSON.parse(await Bun.file(configPath).text()).username).toBe("secure-user")
       },
     })
+  })
+
+  test("first global update inherits legacy config file permissions", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const legacy = path.join(platformLegacy.path, "pawwork.json")
+      await Filesystem.write(legacy, JSON.stringify({ model: "legacy/model" }))
+      await fs.chmod(legacy, 0o600)
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await saveGlobal({ username: "secure-user" })
+
+          const configPath = path.join(home.path, ".pawwork", "pawwork.json")
+          const mode = (await fs.stat(configPath)).mode & 0o777
+          expect(mode).toBe(0o600)
+          expect(JSON.parse(await Bun.file(configPath).text()).username).toBe("secure-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
   })
 
   test("global config update reports file PawWork Home before taking the write lock", async () => {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -371,6 +371,27 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("PAWWORK_CONFIG_DIR fallback config is read without schema or default_agent writeback", async () => {
+    await using primary = await tmpdir()
+    await using fallback = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    process.env.PAWWORK_HOME = primary.path
+    process.env.PAWWORK_CONFIG_DIR = fallback.path
+
+    const configFile = path.join(fallback.path, "pawwork.json")
+    const original = JSON.stringify({ model: "fallback/model", default_agent: "build" }, null, 2)
+    await Filesystem.write(configFile, original)
+
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.model).toBe("fallback/model")
+        expect(await Bun.file(configFile).text()).toBe(original)
+      },
+    })
+  })
+
   test("first global update writes primary Home without dropping legacy effective config", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()
@@ -832,6 +853,42 @@ home command`,
     } finally {
       ;(Global.Path as { config: string }).config = previousConfig
     }
+  })
+
+  test("global config update preserves existing file permissions", async () => {
+    await using project = await tmpdir({ git: true })
+    await using global = await tmpdir()
+    process.env.PAWWORK_HOME = global.path
+
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        const configPath = path.join(global.path, "pawwork.json")
+        await Filesystem.write(configPath, JSON.stringify({ model: "test/model" }))
+        await fs.chmod(configPath, 0o600)
+
+        await saveGlobal({ username: "secure-user" })
+
+        const mode = (await fs.stat(configPath)).mode & 0o777
+        expect(mode).toBe(0o600)
+        expect(JSON.parse(await Bun.file(configPath).text()).username).toBe("secure-user")
+      },
+    })
+  })
+
+  test("global config update reports file PawWork Home before taking the write lock", async () => {
+    await using project = await tmpdir({ git: true })
+    await using home = await tmpdir()
+    const fileHome = path.join(home.path, "not-a-directory")
+    process.env.PAWWORK_HOME = fileHome
+    await Filesystem.write(fileHome, "not a directory")
+
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        await expect(saveGlobal({ username: "blocked" })).rejects.toThrow(/not a directory|directory/i)
+      },
+    })
   })
 
   test("global config update writes to the active PawWork config file", async () => {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -333,6 +333,37 @@ describe("PawWork global config isolation", () => {
           const config = await load()
           expect(config.model).toBe("home/model")
           expect(config.username).toBe("home-user")
+          expect(await Bun.file(path.join(platformLegacy.path, "config")).exists()).toBeFalse()
+          const migrated = JSON.parse(await Bun.file(path.join(platformLegacy.path, "pawwork.json")).text())
+          expect(migrated.model).toBe("legacy/model")
+          expect(migrated.username).toBe("legacy-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("legacy fallback JSON config is read without schema or default_agent writeback", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = home.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const legacy = path.join(platformLegacy.path, "pawwork.json")
+      const original = JSON.stringify({ model: "legacy/model", default_agent: "build" }, null, 2)
+      await Filesystem.write(legacy, original)
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.model).toBe("legacy/model")
+          expect(await Bun.file(legacy).text()).toBe(original)
         },
       })
     } finally {
@@ -407,6 +438,16 @@ describe("PawWork global config isolation", () => {
 
     await Filesystem.write(path.join(home.path, "pawwork.jsonc"), JSON.stringify({ model: "pawwork/model" }))
     expect(Config.globalConfigFileForWrite()).toBe(path.join(home.path, "pawwork.jsonc"))
+  })
+
+  test("global config load ignores directories named pawwork config files", async () => {
+    await using home = await tmpdir()
+    process.env.PAWWORK_HOME = home.path
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    await fs.mkdir(path.join(home.path, "pawwork.jsonc"), { recursive: true })
+    expect(PawWorkHome.configFilesToLoad()).toEqual([])
+    expect(() => Config.globalConfigFileForWrite()).toThrow("PawWork config path exists but is not a file")
   })
 
   test("first global update preserves merged legacy json and jsonc config", async () => {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -435,13 +435,17 @@ describe("PawWork global config isolation", () => {
     ;(Global.Path as { config: string }).config = platformLegacy.path
 
     try {
-      await Filesystem.write(path.join(platformLegacy.path, "pawwork.json"), JSON.stringify({ username: "legacy-user" }))
+      const legacy = path.join(platformLegacy.path, "pawwork.json")
+      const original = JSON.stringify({ default_agent: "build", username: "legacy-user" })
+      await Filesystem.write(legacy, original)
       await Instance.provide({
         directory: project.path,
         fn: async () => {
           await Config.seedGlobalConfig()
           const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
           expect(saved.username).toBe("legacy-user")
+          expect(saved.default_agent).toBeUndefined()
+          expect(await Bun.file(legacy).text()).toBe(original)
         },
       })
     } finally {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -196,6 +196,73 @@ describe("default OpenCode config compatibility", () => {
     }
   })
 
+  test("OpenCode legacy TOML migration persists non-overlapping fields into active JSONC", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = global.path
+
+    try {
+      const active = path.join(global.path, "opencode.jsonc")
+      await Filesystem.write(active, '{\n  // active config\n  "username": "jsonc-user"\n}\n')
+      await Filesystem.write(
+        path.join(global.path, "config"),
+        ['provider = "toml"', 'model = "model"', 'username = "toml-user"'].join("\n"),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const first = await load()
+          expect(first.username).toBe("jsonc-user")
+          expect(first.model).toBe("toml/model")
+          expect(await Bun.file(path.join(global.path, "config")).exists()).toBeFalse()
+          expect(await Bun.file(path.join(global.path, "opencode.json")).exists()).toBeFalse()
+
+          await clear(true)
+          const second = await load()
+          expect(second.username).toBe("jsonc-user")
+          expect(second.model).toBe("toml/model")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("OpenCode legacy TOML migration skips non-file active candidates", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = global.path
+
+    try {
+      await fs.mkdir(path.join(global.path, "opencode.jsonc"), { recursive: true })
+      await Filesystem.write(path.join(global.path, "config"), ['provider = "toml"', 'model = "model"'].join("\n"))
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.model).toBe("toml/model")
+          expect(await Bun.file(path.join(global.path, "config")).exists()).toBeFalse()
+          const migrated = JSON.parse(await Bun.file(path.join(global.path, "opencode.json")).text())
+          expect(migrated.model).toBe("toml/model")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("OpenCode MCP local resolver ignores PawWork project config aliases", async () => {
     await using project = await tmpdir({ git: true })
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
@@ -631,7 +698,7 @@ describe("PawWork global config isolation", () => {
         path.join(platformLegacy.path, "pawwork.json"),
         JSON.stringify(
           {
-            instructions: ["{env:RULES}/a.md", "./rules/AGENTS.md"],
+            instructions: ["{env:RULES}/a.md", "./rules/AGENTS.md", "rules/{env:NAME}.md"],
             provider: {
               demo: {
                 options: {
@@ -654,7 +721,11 @@ describe("PawWork global config isolation", () => {
           await saveGlobal({ model: "updated/model" })
           const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
 
-          expect(saved.instructions).toEqual(["{env:RULES}/a.md", path.join(platformLegacy.path, "rules", "AGENTS.md")])
+          expect(saved.instructions).toEqual([
+            "{env:RULES}/a.md",
+            path.join(platformLegacy.path, "rules", "AGENTS.md"),
+            path.join(platformLegacy.path, "rules", "{env:NAME}.md"),
+          ])
           expect(saved.provider.demo.options.instructions).toEqual(["./provider-owned.md"])
           expect(saved.provider.demo.options.plugin).toEqual(["./provider-plugin.ts"])
           expect(saved.provider.demo.options.token).toBe(`{file:${path.join(platformLegacy.path, "secrets", "provider-token")}}`)

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -308,6 +308,38 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("Home config wins over legacy TOML config", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = home.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(
+        path.join(home.path, "pawwork.json"),
+        JSON.stringify({ model: "home/model", username: "home-user" }),
+      )
+      await Filesystem.write(
+        path.join(platformLegacy.path, "config"),
+        ['provider = "legacy"', 'model = "model"', 'username = "legacy-user"'].join("\n"),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.model).toBe("home/model")
+          expect(config.username).toBe("home-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("first global update writes primary Home without dropping legacy effective config", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()
@@ -461,6 +493,35 @@ describe("PawWork global config isolation", () => {
 
     const dirs = await listConfigDirs(project.path, project.path)
     expect(dirs).not.toContain(fileHome)
+  })
+
+  test("legacy global resource directory stays read-only for generated dependency files", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await fs.mkdir(path.join(home.path, ".pawwork"), { recursive: true })
+      await fs.mkdir(path.join(platformLegacy.path, "command"), { recursive: true })
+      await Filesystem.write(path.join(platformLegacy.path, "command", "hello.md"), "legacy command")
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.command?.hello.template).toBe("legacy command")
+          expect(await Bun.file(path.join(platformLegacy.path, ".gitignore")).exists()).toBeFalse()
+          expect(await Bun.file(path.join(platformLegacy.path, "package.json")).exists()).toBeFalse()
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
   })
 
   test("PawWork Home command overrides same-name legacy global command", async () => {
@@ -682,6 +743,24 @@ home command`,
         expect(JSON.parse(await Bun.file(path.join(project.path, "pawwork.jsonc")).text()).model).toBe(
           "updated/project",
         )
+      },
+    })
+  })
+
+  test("PawWork local write resolver reuses existing .opencode pawwork.jsonc", async () => {
+    await using project = await tmpdir({ git: true })
+    const configDir = path.join(project.path, ".opencode")
+    await fs.mkdir(configDir, { recursive: true })
+    await Filesystem.write(path.join(configDir, "pawwork.jsonc"), JSON.stringify({ model: "directory/model" }))
+
+    expect(await resolveConfigPath(project.path)).toBe(path.join(configDir, "pawwork.jsonc"))
+
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        await save({ model: "updated/model" })
+        expect(JSON.parse(await Bun.file(path.join(configDir, "pawwork.jsonc")).text()).model).toBe("updated/model")
+        expect(await Bun.file(path.join(project.path, "pawwork.json")).exists()).toBeFalse()
       },
     })
   })

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -344,6 +344,39 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("legacy TOML migration preserves existing legacy JSON config", async () => {
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = path.join(platformLegacy.path, "empty-home")
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const legacyJson = path.join(platformLegacy.path, "pawwork.json")
+      await Filesystem.write(legacyJson, JSON.stringify({ model: "json/model", username: "json-user" }, null, 2))
+      await Filesystem.write(
+        path.join(platformLegacy.path, "config"),
+        ['provider = "toml"', 'model = "model"', 'username = "toml-user"'].join("\n"),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.model).toBe("json/model")
+          expect(config.username).toBe("json-user")
+          expect(await Bun.file(path.join(platformLegacy.path, "config")).exists()).toBeFalse()
+          const migrated = JSON.parse(await Bun.file(legacyJson).text())
+          expect(migrated.model).toBe("json/model")
+          expect(migrated.username).toBe("json-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("legacy fallback JSON config is read without schema or default_agent writeback", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()
@@ -498,6 +531,60 @@ describe("PawWork global config isolation", () => {
           expect(saved.instructions).toEqual([instructionFile])
           expect(saved.plugin).toEqual([pluginFile])
           expect(saved.model).toBe("updated/model")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("first global update seeds only top-level instructions and plugin paths", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const pluginFile = path.join(platformLegacy.path, "plugins", "plugin.ts")
+      const optionSecret = path.join(platformLegacy.path, "secrets", "plugin-token")
+      await Filesystem.write(pluginFile, "export const Plugin = {}")
+      await Filesystem.write(optionSecret, "secret")
+      await Filesystem.write(
+        path.join(platformLegacy.path, "pawwork.json"),
+        JSON.stringify(
+          {
+            instructions: ["{env:RULES}/a.md", "./rules/AGENTS.md"],
+            provider: {
+              demo: {
+                options: {
+                  instructions: ["./provider-owned.md"],
+                  plugin: ["./provider-plugin.ts"],
+                  token: "{file:secrets/provider-token}",
+                },
+              },
+            },
+            plugin: [["./plugins/plugin.ts", { token: "{file:secrets/plugin-token}" }]],
+          },
+          null,
+          2,
+        ),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await saveGlobal({ model: "updated/model" })
+          const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
+
+          expect(saved.instructions).toEqual(["{env:RULES}/a.md", path.join(platformLegacy.path, "rules", "AGENTS.md")])
+          expect(saved.provider.demo.options.instructions).toEqual(["./provider-owned.md"])
+          expect(saved.provider.demo.options.plugin).toEqual(["./provider-plugin.ts"])
+          expect(saved.provider.demo.options.token).toBe(`{file:${path.join(platformLegacy.path, "secrets", "provider-token")}}`)
+          expect(saved.plugin).toEqual([[pluginFile, { token: `{file:${optionSecret}}` }]])
         },
       })
     } finally {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -323,6 +323,43 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("seedGlobalConfig writes primary Home without dropping legacy effective config", async () => {
+    await using home = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    await using platformLegacy = await tmpdir()
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(path.join(platformLegacy.path, "pawwork.json"), JSON.stringify({ username: "legacy-user" }))
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await Config.seedGlobalConfig()
+          const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
+          expect(saved.username).toBe("legacy-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("global config write resolver ignores OpenCode filenames in PawWork Home", async () => {
+    await using home = await tmpdir()
+    process.env.PAWWORK_HOME = home.path
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    await Filesystem.write(path.join(home.path, "opencode.jsonc"), JSON.stringify({ model: "leaked/model" }))
+    expect(Config.globalConfigFileForWrite()).toBe(path.join(home.path, "pawwork.json"))
+
+    await Filesystem.write(path.join(home.path, "pawwork.jsonc"), JSON.stringify({ model: "pawwork/model" }))
+    expect(Config.globalConfigFileForWrite()).toBe(path.join(home.path, "pawwork.jsonc"))
+  })
+
   test("first global update preserves merged legacy json and jsonc config", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -238,6 +238,32 @@ describe("PawWork global config isolation", () => {
     expect(PawWorkHome.candidates()[0]).toBe(path.join(home.path, ".pawwork"))
   })
 
+  test("expands Windows-style tilde in PAWWORK_HOME", async () => {
+    await using home = await tmpdir()
+    process.env.OPENCODE_TEST_HOME = home.path
+    process.env.PAWWORK_HOME = "~\\PawWorkHome"
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    expect(PawWorkHome.primary()).toBe(path.join(home.path, "PawWorkHome"))
+  })
+
+  test("resolves relative PAWWORK_HOME to an absolute path", () => {
+    process.env.PAWWORK_HOME = "relative-pawwork-home"
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    expect(PawWorkHome.primary()).toBe(path.resolve("relative-pawwork-home"))
+  })
+
+  test("deduplicates equivalent PawWork Home candidates", async () => {
+    await using home = await tmpdir()
+    process.env.OPENCODE_TEST_HOME = home.path
+    process.env.PAWWORK_HOME = "~/same"
+    process.env.PAWWORK_CONFIG_DIR = path.join(home.path, "same")
+
+    const candidates = PawWorkHome.candidates()
+    expect(candidates.filter((candidate) => candidate === path.join(home.path, "same"))).toHaveLength(1)
+  })
+
   test("global config reads PAWWORK_HOME before PAWWORK_CONFIG_DIR and legacy config", async () => {
     await using primary = await tmpdir()
     await using envLegacy = await tmpdir()

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -377,6 +377,39 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("legacy TOML migration does not create lower-priority JSON when JSONC exists", async () => {
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = path.join(platformLegacy.path, "empty-home")
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      const legacyJsonc = path.join(platformLegacy.path, "pawwork.jsonc")
+      const original = '{\n  // active legacy config\n  "username": "jsonc-user"\n}\n'
+      await Filesystem.write(legacyJsonc, original)
+      await Filesystem.write(
+        path.join(platformLegacy.path, "config"),
+        ['provider = "toml"', 'model = "model"', 'username = "toml-user"'].join("\n"),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.username).toBe("jsonc-user")
+          expect(config.model).toBeUndefined()
+          expect(await Bun.file(path.join(platformLegacy.path, "config")).exists()).toBeFalse()
+          expect(await Bun.file(path.join(platformLegacy.path, "pawwork.json")).exists()).toBeFalse()
+          expect(await Bun.file(legacyJsonc).text()).toBe(original)
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("legacy fallback JSON config is read without schema or default_agent writeback", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()
@@ -481,6 +514,47 @@ describe("PawWork global config isolation", () => {
           expect(saved.username).toBe("legacy-user")
           expect(saved.default_agent).toBeUndefined()
           expect(await Bun.file(legacy).text()).toBe(original)
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("seedGlobalConfig normalizes deprecated legacy keys before first write", async () => {
+    await using home = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    await using platformLegacy = await tmpdir()
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(
+        path.join(platformLegacy.path, "pawwork.json"),
+        JSON.stringify(
+          {
+            model: "legacy/model",
+            theme: "legacy-theme",
+            keybinds: {},
+            tui: {},
+          },
+          null,
+          2,
+        ),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await Config.seedGlobalConfig()
+          const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
+          expect(saved.model).toBe("legacy/model")
+          expect(saved.theme).toBeUndefined()
+          expect(saved.keybinds).toBeUndefined()
+          expect(saved.tui).toBeUndefined()
         },
       })
     } finally {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -15,6 +15,7 @@ import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
+import { resolveConfigPath } from "../../src/cli/cmd/mcp"
 
 const infra = CrossSpawnSpawner.defaultLayer.pipe(
   Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
@@ -190,6 +191,22 @@ describe("default OpenCode config compatibility", () => {
       })
     } finally {
       ;(Global.Path as { config: string }).config = previousConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("OpenCode MCP local resolver ignores PawWork project config aliases", async () => {
+    await using project = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+
+    try {
+      await Filesystem.write(path.join(project.path, "pawwork.json"), JSON.stringify({ model: "leaked/project" }))
+      await Filesystem.write(path.join(project.path, "opencode.json"), JSON.stringify({ model: "expected/project" }))
+
+      expect(await resolveConfigPath(project.path)).toBe(path.join(project.path, "opencode.json"))
+    } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
     }

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -207,7 +207,10 @@ describe("default OpenCode config compatibility", () => {
 
     try {
       const active = path.join(global.path, "opencode.jsonc")
-      await Filesystem.write(active, '{\n  // active config\n  "username": "jsonc-user",\n  "instructions": ["jsonc.md"]\n}\n')
+      await Filesystem.write(
+        active,
+        '{\n  // active config\n  "username": "jsonc-user",\n  "instructions": ["jsonc.md"]\n}\n',
+      )
       await Filesystem.write(
         path.join(global.path, "config"),
         [
@@ -457,7 +460,7 @@ describe("PawWork global config isolation", () => {
     }
   })
 
-  test("legacy TOML migration does not create lower-priority JSON when JSONC exists", async () => {
+  test("legacy TOML migration merges missing fields into active PawWork JSONC", async () => {
     await using platformLegacy = await tmpdir()
     await using project = await tmpdir({ git: true })
     const previousConfig = Global.Path.config
@@ -471,7 +474,9 @@ describe("PawWork global config isolation", () => {
       await Filesystem.write(legacyJsonc, original)
       await Filesystem.write(
         path.join(platformLegacy.path, "config"),
-        ['provider = "toml"', 'model = "model"', 'username = "toml-user"'].join("\n"),
+        ['provider = "toml"', 'model = "model"', 'username = "toml-user"', "[watcher]", 'unknown = "drop-me"'].join(
+          "\n",
+        ),
       )
 
       await Instance.provide({
@@ -479,10 +484,13 @@ describe("PawWork global config isolation", () => {
         fn: async () => {
           const config = await load()
           expect(config.username).toBe("jsonc-user")
-          expect(config.model).toBeUndefined()
+          expect(config.model).toBe("toml/model")
           expect(await Bun.file(path.join(platformLegacy.path, "config")).exists()).toBeFalse()
           expect(await Bun.file(path.join(platformLegacy.path, "pawwork.json")).exists()).toBeFalse()
-          expect(await Bun.file(legacyJsonc).text()).toBe(original)
+          const migrated = parseJsonc(await Bun.file(legacyJsonc).text()) as Record<string, unknown>
+          expect(migrated.username).toBe("jsonc-user")
+          expect(migrated.model).toBe("toml/model")
+          expect((migrated.watcher as Record<string, unknown> | undefined)?.unknown).toBeUndefined()
         },
       })
     } finally {
@@ -741,7 +749,9 @@ describe("PawWork global config isolation", () => {
           ])
           expect(saved.provider.demo.options.instructions).toEqual(["./provider-owned.md"])
           expect(saved.provider.demo.options.plugin).toEqual(["./provider-plugin.ts"])
-          expect(saved.provider.demo.options.token).toBe(`{file:${path.join(platformLegacy.path, "secrets", "provider-token")}}`)
+          expect(saved.provider.demo.options.token).toBe(
+            `{file:${path.join(platformLegacy.path, "secrets", "provider-token")}}`,
+          )
           expect(saved.plugin).toEqual([[pluginFile, { token: `{file:${optionSecret}}` }]])
         },
       })

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -6,9 +6,11 @@ import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Account } from "../../src/account"
 import { Auth } from "../../src/auth"
 import { Config, ConfigManaged } from "../../src/config"
+import { ConfigPlugin } from "../../src/config/plugin"
 import { ConfigPaths } from "../../src/config/paths"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
@@ -45,6 +47,9 @@ const listConfigDirs = (directory: string, worktree: string) =>
   Effect.runPromise(ConfigPaths.directories(directory, worktree).pipe(Effect.provide(AppFileSystem.defaultLayer)))
 
 const originalRuntimeNamespace = process.env.PAWWORK_RUNTIME_NAMESPACE
+const originalPawWorkHome = process.env.PAWWORK_HOME
+const originalPawWorkConfigDir = process.env.PAWWORK_CONFIG_DIR
+const originalTestHome = process.env.OPENCODE_TEST_HOME
 
 beforeEach(async () => {
   process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
@@ -56,6 +61,12 @@ afterEach(async () => {
   await clear(true)
   if (originalRuntimeNamespace === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
   else process.env.PAWWORK_RUNTIME_NAMESPACE = originalRuntimeNamespace
+  if (originalPawWorkHome === undefined) delete process.env.PAWWORK_HOME
+  else process.env.PAWWORK_HOME = originalPawWorkHome
+  if (originalPawWorkConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+  else process.env.PAWWORK_CONFIG_DIR = originalPawWorkConfigDir
+  if (originalTestHome === undefined) delete process.env.OPENCODE_TEST_HOME
+  else process.env.OPENCODE_TEST_HOME = originalTestHome
 })
 
 describe("default OpenCode config compatibility", () => {
@@ -102,13 +113,8 @@ describe("default OpenCode config compatibility", () => {
     const script = `
       process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
       process.env.XDG_CONFIG_HOME = ${JSON.stringify(root.path)}
-      const { ConfigPaths } = await import("./src/config/paths.ts")
-      const { AppFileSystem } = await import("@opencode-ai/core/filesystem")
-      const { Effect } = await import("effect")
-      const dirs = await Effect.runPromise(
-        ConfigPaths.directories(${JSON.stringify(project)}, ${JSON.stringify(project)}).pipe(Effect.provide(AppFileSystem.defaultLayer)),
-      )
-      console.log(JSON.stringify(dirs[0]))
+      const { Global } = await import("@opencode-ai/core/global")
+      console.log(JSON.stringify(Global.Path.config))
     `
     const result = Bun.spawnSync({
       cmd: [process.execPath, "--eval", script],
@@ -191,6 +197,217 @@ describe("default OpenCode config compatibility", () => {
 })
 
 describe("PawWork global config isolation", () => {
+  test("defaults primary PawWork Home to ~/.pawwork", async () => {
+    await using home = await tmpdir()
+    const previousHome = process.env.OPENCODE_TEST_HOME
+    const previousPawWorkHome = process.env.PAWWORK_HOME
+    const previousPawWorkConfig = process.env.PAWWORK_CONFIG_DIR
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    try {
+      expect(PawWorkHome.primary()).toBe(path.join(home.path, ".pawwork"))
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = previousHome
+      if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousPawWorkHome
+      if (previousPawWorkConfig === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousPawWorkConfig
+    }
+  })
+
+  test("prefers PAWWORK_HOME over PAWWORK_CONFIG_DIR", async () => {
+    await using home = await tmpdir()
+    await using legacyEnv = await tmpdir()
+    process.env.PAWWORK_HOME = path.join(home.path, "custom-home")
+    process.env.PAWWORK_CONFIG_DIR = legacyEnv.path
+
+    expect(PawWorkHome.primary()).toBe(path.join(home.path, "custom-home"))
+    expect(PawWorkHome.candidates().slice(0, 2)).toEqual([path.join(home.path, "custom-home"), legacyEnv.path])
+  })
+
+  test("treats blank PawWork Home env vars as unset", async () => {
+    await using home = await tmpdir()
+    process.env.OPENCODE_TEST_HOME = home.path
+    process.env.PAWWORK_HOME = ""
+    process.env.PAWWORK_CONFIG_DIR = "   "
+
+    expect(PawWorkHome.primary()).toBe(path.join(home.path, ".pawwork"))
+    expect(PawWorkHome.candidates()[0]).toBe(path.join(home.path, ".pawwork"))
+  })
+
+  test("global config reads PAWWORK_HOME before PAWWORK_CONFIG_DIR and legacy config", async () => {
+    await using primary = await tmpdir()
+    await using envLegacy = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = primary.path
+    process.env.PAWWORK_CONFIG_DIR = envLegacy.path
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(path.join(primary.path, "pawwork.json"), JSON.stringify({ model: "home/model" }))
+      await Filesystem.write(path.join(envLegacy.path, "pawwork.json"), JSON.stringify({ model: "env/model" }))
+      await Filesystem.write(path.join(platformLegacy.path, "pawwork.json"), JSON.stringify({ model: "legacy/model" }))
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.model).toBe("home/model")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("first global update writes primary Home without dropping legacy effective config", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(
+        path.join(platformLegacy.path, "pawwork.json"),
+        JSON.stringify({ model: "legacy/model", username: "legacy-user" }),
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await saveGlobal({ username: "updated-user" })
+          const primaryFile = path.join(home.path, ".pawwork", "pawwork.json")
+          const saved = JSON.parse(await Bun.file(primaryFile).text())
+          expect(saved.model).toBe("legacy/model")
+          expect(saved.username).toBe("updated-user")
+          expect(await Bun.file(path.join(platformLegacy.path, "pawwork.json")).text()).toContain("legacy-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("first global update preserves merged legacy json and jsonc config", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(path.join(platformLegacy.path, "pawwork.json"), JSON.stringify({ model: "legacy/model" }))
+      await Filesystem.write(path.join(platformLegacy.path, "pawwork.jsonc"), JSON.stringify({ username: "jsonc-user" }))
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          await saveGlobal({ username: "updated-user" })
+          const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
+          expect(saved.model).toBe("legacy/model")
+          expect(saved.username).toBe("updated-user")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("PawWork Home global plugin origin points at the Home config file", async () => {
+    await using home = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    process.env.PAWWORK_HOME = home.path
+
+    await Filesystem.write(
+      path.join(home.path, "pawwork.json"),
+      JSON.stringify({
+        plugin: ["./plugin.ts"],
+      }),
+    )
+
+    await Instance.provide({
+      directory: project.path,
+      fn: async () => {
+        const config = await load()
+        const origin = config.plugin_origins?.find((item) =>
+          ConfigPlugin.pluginSpecifier(item.spec).endsWith("/plugin.ts"),
+        )
+        expect(origin?.source).toBe(path.join(home.path, "pawwork.json"))
+      },
+    })
+  })
+
+  test("global resource directories load legacy before PawWork Home so Home wins conflicts", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await fs.mkdir(path.join(home.path, ".pawwork"), { recursive: true })
+      const dirs = await listConfigDirs(project.path, project.path)
+      expect(dirs.indexOf(path.join(home.path, ".pawwork"))).toBeGreaterThanOrEqual(0)
+      expect(dirs.indexOf(platformLegacy.path)).toBeGreaterThanOrEqual(0)
+      expect(dirs.indexOf(platformLegacy.path)).toBeLessThan(dirs.indexOf(path.join(home.path, ".pawwork")))
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("PawWork Home command overrides same-name legacy global command", async () => {
+    await using home = await tmpdir()
+    await using platformLegacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousConfig = Global.Path.config
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = platformLegacy.path
+
+    try {
+      await Filesystem.write(
+        path.join(platformLegacy.path, "command", "hello.md"),
+        `---
+description: Legacy command
+---
+legacy command`,
+      )
+      await Filesystem.write(
+        path.join(home.path, ".pawwork", "command", "hello.md"),
+        `---
+description: Home command
+---
+home command`,
+      )
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.command?.hello.template).toBe("home command")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("does not discover home-level .opencode config implicitly", async () => {
     await using home = await tmpdir()
     await using project = await tmpdir({ git: true })
@@ -381,6 +598,7 @@ describe("PawWork global config isolation", () => {
     await using global = await tmpdir()
     const globalDir = global.path
     const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = globalDir
     ;(Global.Path as { config: string }).config = globalDir
 
     try {
@@ -408,6 +626,7 @@ describe("PawWork global config isolation", () => {
     await using global = await tmpdir()
     const globalDir = global.path
     const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = globalDir
     ;(Global.Path as { config: string }).config = globalDir
 
     try {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import { parse as parseJsonc } from "jsonc-parser"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Account } from "../../src/account"
@@ -206,10 +207,17 @@ describe("default OpenCode config compatibility", () => {
 
     try {
       const active = path.join(global.path, "opencode.jsonc")
-      await Filesystem.write(active, '{\n  // active config\n  "username": "jsonc-user"\n}\n')
+      await Filesystem.write(active, '{\n  // active config\n  "username": "jsonc-user",\n  "instructions": ["jsonc.md"]\n}\n')
       await Filesystem.write(
         path.join(global.path, "config"),
-        ['provider = "toml"', 'model = "model"', 'username = "toml-user"'].join("\n"),
+        [
+          'provider = "toml"',
+          'model = "model"',
+          'username = "toml-user"',
+          'instructions = ["toml.md"]',
+          'theme = "legacy-theme"',
+          'unknown_field = "drop-me"',
+        ].join("\n"),
       )
 
       await Instance.provide({
@@ -218,6 +226,7 @@ describe("default OpenCode config compatibility", () => {
           const first = await load()
           expect(first.username).toBe("jsonc-user")
           expect(first.model).toBe("toml/model")
+          expect(first.instructions).toEqual(["jsonc.md"])
           expect(await Bun.file(path.join(global.path, "config")).exists()).toBeFalse()
           expect(await Bun.file(path.join(global.path, "opencode.json")).exists()).toBeFalse()
 
@@ -225,6 +234,10 @@ describe("default OpenCode config compatibility", () => {
           const second = await load()
           expect(second.username).toBe("jsonc-user")
           expect(second.model).toBe("toml/model")
+          expect(second.instructions).toEqual(["jsonc.md"])
+          const migrated = parseJsonc(await Bun.file(active).text()) as Record<string, unknown>
+          expect(migrated.theme).toBeUndefined()
+          expect(migrated.unknown_field).toBeUndefined()
         },
       })
     } finally {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -450,6 +450,19 @@ describe("PawWork global config isolation", () => {
     }
   })
 
+  test("global resource directories ignore PawWork Home candidates that are files", async () => {
+    await using home = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const fileHome = path.join(home.path, "not-a-directory")
+    process.env.PAWWORK_HOME = fileHome
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    await Filesystem.write(fileHome, "not a directory")
+
+    const dirs = await listConfigDirs(project.path, project.path)
+    expect(dirs).not.toContain(fileHome)
+  })
+
   test("PawWork Home command overrides same-name legacy global command", async () => {
     await using home = await tmpdir()
     await using platformLegacy = await tmpdir()

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "../../src/util/filesystem"
-import { createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
+import { createPlugTask, defaultPluginGlobalConfigDir, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 
@@ -261,6 +261,31 @@ describe("plugin.install.task", () => {
 
       const config = await read(path.join(pawworkConfig.path, "pawwork.json"))
       expect(config.plugin).toEqual(["acme@1.2.3"])
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousHome
+      if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    }
+  })
+
+  test("default plugin global config dir follows runtime env changes", async () => {
+    await using homeA = await tmpdir()
+    await using homeB = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.PAWWORK_HOME
+    const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    try {
+      process.env.PAWWORK_HOME = homeA.path
+      expect(defaultPluginGlobalConfigDir()).toBe(homeA.path)
+
+      process.env.PAWWORK_HOME = homeB.path
+      expect(defaultPluginGlobalConfigDir()).toBe(homeB.path)
     } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -26,7 +26,10 @@ function deps(global: string, target: string | Error): PlugDeps {
       await Filesystem.write(file, text)
     },
     exists: (file) => Filesystem.exists(file),
-    files: (dir, name) => [path.join(dir, `${name}.jsonc`), path.join(dir, `${name}.json`)],
+    files: (dir, name) =>
+      name === "pawwork"
+        ? [path.join(dir, `${name}.json`), path.join(dir, `${name}.jsonc`)]
+        : [path.join(dir, `${name}.jsonc`), path.join(dir, `${name}.json`)],
     global,
   }
 }
@@ -111,7 +114,7 @@ async function read(file: string) {
 }
 
 describe("plugin.install.task", () => {
-  test("writes PawWork global plugin config to pawwork.jsonc", async () => {
+  test("writes PawWork global plugin config to pawwork.json", async () => {
     await using tmp = await tmpdir()
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
     process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
@@ -129,9 +132,43 @@ describe("plugin.install.task", () => {
       const ok = await run(ctx(tmp.path))
       expect(ok).toBe(true)
 
-      const config = await read(path.join(tmp.path, "global", "pawwork.jsonc"))
+      const config = await read(path.join(tmp.path, "global", "pawwork.json"))
       expect(config.plugin).toEqual(["acme@1.2.3"])
       expect(await Filesystem.exists(path.join(tmp.path, "global", "opencode.jsonc"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("seeds PawWork global plugin config before patching it", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const target = await plugin(tmp.path, ["server"])
+      const dep = deps(path.join(tmp.path, "global"), target)
+      dep.seedGlobalConfig = async () => {
+        await Filesystem.write(path.join(tmp.path, "global", "pawwork.json"), JSON.stringify({ username: "legacy-user" }))
+      }
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        dep,
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      const config = await Filesystem.readJson<{
+        username?: string
+        plugin?: unknown[]
+      }>(path.join(tmp.path, "global", "pawwork.json"))
+      expect(config.username).toBe("legacy-user")
+      expect(config.plugin).toEqual(["acme@1.2.3"])
     } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -6,6 +6,7 @@ import { Filesystem } from "../../src/util/filesystem"
 import { createPlugTask, defaultPluginGlobalConfigDir, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
+import { ConfigPaths } from "../../src/config/paths"
 
 function deps(global: string, target: string | Error): PlugDeps {
   return {
@@ -27,10 +28,7 @@ function deps(global: string, target: string | Error): PlugDeps {
       await Filesystem.write(file, text)
     },
     exists: (file) => Filesystem.exists(file),
-    files: (dir, name) =>
-      name === "pawwork"
-        ? [path.join(dir, `${name}.json`), path.join(dir, `${name}.jsonc`)]
-        : [path.join(dir, `${name}.jsonc`), path.join(dir, `${name}.json`)],
+    files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
     global,
   }
 }
@@ -236,6 +234,66 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("writes PawWork global plugin config to active pawwork.jsonc when json and jsonc both exist", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const global = path.join(tmp.path, "global")
+      await Filesystem.write(path.join(global, "pawwork.json"), JSON.stringify({ plugin: ["json-only@1.0.0"] }))
+      await Filesystem.write(path.join(global, "pawwork.jsonc"), JSON.stringify({ plugin: ["jsonc-active@1.0.0"] }))
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        deps(global, target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      expect((await read(path.join(global, "pawwork.json"))).plugin).toEqual(["json-only@1.0.0"])
+      expect((await read(path.join(global, "pawwork.jsonc"))).plugin).toEqual(["jsonc-active@1.0.0", "acme@1.2.3"])
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("writes PawWork local plugin config to active pawwork.jsonc when json and jsonc both exist", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const configDir = path.join(tmp.path, ".opencode")
+      await Filesystem.write(path.join(configDir, "pawwork.json"), JSON.stringify({ plugin: ["json-only@1.0.0"] }))
+      await Filesystem.write(path.join(configDir, "pawwork.jsonc"), JSON.stringify({ plugin: ["jsonc-active@1.0.0"] }))
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+        },
+        deps(path.join(tmp.path, "global"), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      expect((await read(path.join(configDir, "pawwork.json"))).plugin).toEqual(["json-only@1.0.0"])
+      expect((await read(path.join(configDir, "pawwork.jsonc"))).plugin).toEqual([
+        "jsonc-active@1.0.0",
+        "acme@1.2.3",
+      ])
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes PawWork global plugin config to PAWWORK_CONFIG_DIR when PAWWORK_HOME is unset", async () => {
     await using tmp = await tmpdir()
     await using pawworkConfig = await tmpdir()
@@ -309,7 +367,7 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
+    const server = await read(path.join(tmp.path, ".opencode", "opencode.json"))
     expect(server.plugin).toEqual(["acme@1.2.3"])
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(false)
   })
@@ -330,7 +388,7 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
+    const server = await read(path.join(tmp.path, ".opencode", "opencode.json"))
     expect(server.plugin).toEqual([["acme@1.2.3", { custom: true, other: false }]])
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(false)
   })
@@ -442,7 +500,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
+    const server = await read(path.join(tmp.path, ".opencode", "opencode.json"))
     expect(server.plugin).toEqual(["acme@1.2.3"])
   })
 
@@ -551,7 +609,7 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    expect(await Filesystem.exists(path.join(global, "opencode.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(global, "opencode.json"))).toBe(true)
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
   })
 
@@ -571,7 +629,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctxDir(directory, worktree))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.json"))).toBe(true)
     expect(await Filesystem.exists(path.join(worktree, ".opencode", "opencode.jsonc"))).toBe(false)
   })
 
@@ -589,7 +647,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctxRoot(directory))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.json"))).toBe(true)
   })
 
   test("returns false for tui-only plugins under directory when worktree is root slash", async () => {
@@ -656,7 +714,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
+    const server = await read(path.join(tmp.path, ".opencode", "opencode.json"))
     expect(server.plugin).toEqual(["acme@1.2.3"])
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(false)
   })

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -389,6 +389,33 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("writes PawWork local plugin config to existing .opencode opencode.jsonc", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const configFile = path.join(tmp.path, ".opencode", "opencode.jsonc")
+      await Filesystem.write(configFile, JSON.stringify({ plugin: ["legacy-active@1.0.0"] }))
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+        },
+        deps(path.join(tmp.path, "global"), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      expect((await read(configFile)).plugin).toEqual(["legacy-active@1.0.0", "acme@1.2.3"])
+      expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "pawwork.json"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes PawWork global plugin config to PAWWORK_CONFIG_DIR when PAWWORK_HOME is unset", async () => {
     await using tmp = await tmpdir()
     await using pawworkConfig = await tmpdir()

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -176,6 +176,37 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("returns false when PawWork global plugin config seeding fails", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const target = await plugin(tmp.path, ["server"])
+      const dep = deps(path.join(tmp.path, "global"), target)
+      const errors: string[] = []
+      dep.log.error = (msg) => errors.push(msg)
+      dep.seedGlobalConfig = async () => {
+        throw new Error("seed failed")
+      }
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        dep,
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(false)
+      expect(errors.some((item) => item.includes("seed failed"))).toBe(true)
+      expect(await Filesystem.exists(path.join(tmp.path, "global", "pawwork.json"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes PawWork global plugin config to an existing pawwork.jsonc", async () => {
     await using tmp = await tmpdir()
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -294,6 +294,32 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("writes PawWork local plugin config to existing root pawwork.json", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      await Filesystem.write(path.join(tmp.path, "pawwork.json"), JSON.stringify({ plugin: ["root-active@1.0.0"] }))
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+        },
+        deps(path.join(tmp.path, "global"), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      expect((await read(path.join(tmp.path, "pawwork.json"))).plugin).toEqual(["root-active@1.0.0", "acme@1.2.3"])
+      expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "pawwork.json"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes PawWork global plugin config to PAWWORK_CONFIG_DIR when PAWWORK_HOME is unset", async () => {
     await using tmp = await tmpdir()
     await using pawworkConfig = await tmpdir()

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -5,6 +5,7 @@ import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "../../src/util/filesystem"
 import { createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
+import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 
 function deps(global: string, target: string | Error): PlugDeps {
   return {
@@ -172,6 +173,70 @@ describe("plugin.install.task", () => {
     } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("writes PawWork global plugin config to an existing pawwork.jsonc", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      await Filesystem.write(path.join(tmp.path, "global", "pawwork.jsonc"), "{\n  // user comment\n}\n")
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        deps(path.join(tmp.path, "global"), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      const text = await Filesystem.readText(path.join(tmp.path, "global", "pawwork.jsonc"))
+      expect(text).toContain("// user comment")
+      expect(parseJsonc(text).plugin).toEqual(["acme@1.2.3"])
+      expect(await Filesystem.exists(path.join(tmp.path, "global", "pawwork.json"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("writes PawWork global plugin config to PAWWORK_CONFIG_DIR when PAWWORK_HOME is unset", async () => {
+    await using tmp = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.PAWWORK_HOME
+    const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    delete process.env.PAWWORK_HOME
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+
+    try {
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        deps(PawWorkHome.primary(), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      const config = await read(path.join(pawworkConfig.path, "pawwork.json"))
+      expect(config.plugin).toEqual(["acme@1.2.3"])
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousHome
+      if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
     }
   })
 

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -142,6 +142,41 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("default PawWork global plugin write is atomic and preserves config mode", async () => {
+    await using tmp = await tmpdir()
+    await using global = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.PAWWORK_HOME
+    const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.PAWWORK_HOME = global.path
+    delete process.env.PAWWORK_CONFIG_DIR
+
+    try {
+      const target = await plugin(tmp.path, ["server"])
+      const configFile = path.join(global.path, "pawwork.json")
+      await Filesystem.write(configFile, JSON.stringify({ plugin: [] }))
+      await fs.chmod(configFile, 0o600)
+
+      const ok = await createPlugTask({
+        mod: target,
+        global: true,
+      })(ctx(tmp.path))
+
+      expect(ok).toBe(true)
+      expect((await fs.stat(configFile)).mode & 0o777).toBe(0o600)
+      const config = await read(configFile)
+      expect(config.plugin).toEqual([target])
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousHome
+      if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    }
+  })
+
   test("seeds PawWork global plugin config before patching it", async () => {
     await using tmp = await tmpdir()
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -4,9 +4,11 @@ import path from "path"
 import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "../../src/util/filesystem"
 import { createPlugTask, defaultPluginGlobalConfigDir, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
+import { patchPluginConfig } from "../../src/plugin/install"
 import { tmpdir } from "../fixture/fixture"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { ConfigPaths } from "../../src/config/paths"
+import { Global } from "../../src/global"
 
 function deps(global: string, target: string | Error): PlugDeps {
   return {
@@ -171,6 +173,45 @@ describe("plugin.install.task", () => {
     } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
+  test("seeds PawWork global plugin config before direct global patching", async () => {
+    await using home = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    await using legacy = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.OPENCODE_TEST_HOME
+    const previousGlobalConfig = Global.Path.config
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = home.path
+    delete process.env.PAWWORK_HOME
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = legacy.path
+
+    try {
+      await Filesystem.write(path.join(legacy.path, "pawwork.json"), JSON.stringify({ username: "legacy-user" }))
+      const out = await patchPluginConfig({
+        spec: "acme@1.2.3",
+        targets: [{ kind: "server" }],
+        global: true,
+        worktree: project.path,
+        directory: project.path,
+      })
+
+      expect(out.ok).toBe(true)
+      const config = await Filesystem.readJson<{
+        username?: string
+        plugin?: unknown[]
+      }>(path.join(home.path, ".pawwork", "pawwork.json"))
+      expect(config.username).toBe("legacy-user")
+      expect(config.plugin).toEqual(["acme@1.2.3"])
+    } finally {
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = previousHome
     }
   })
 

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -111,6 +111,33 @@ async function read(file: string) {
 }
 
 describe("plugin.install.task", () => {
+  test("writes PawWork global plugin config to pawwork.jsonc", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const target = await plugin(tmp.path, ["server"])
+      const run = createPlugTask(
+        {
+          mod: "acme@1.2.3",
+          global: true,
+        },
+        deps(path.join(tmp.path, "global"), target),
+      )
+
+      const ok = await run(ctx(tmp.path))
+      expect(ok).toBe(true)
+
+      const config = await read(path.join(tmp.path, "global", "pawwork.jsonc"))
+      expect(config.plugin).toEqual(["acme@1.2.3"])
+      expect(await Filesystem.exists(path.join(tmp.path, "global", "opencode.jsonc"))).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes only server config for packages that expose server and tui", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"])

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -263,6 +263,34 @@ describe("plugin.install.task", () => {
     }
   })
 
+  test("serializes concurrent PawWork global plugin config updates", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+
+    try {
+      const global = path.join(tmp.path, "global")
+      const target = await plugin(tmp.path, ["server"])
+      const run = (mod: string) =>
+        createPlugTask(
+          {
+            mod,
+            global: true,
+          },
+          deps(global, target),
+        )(ctx(tmp.path))
+
+      const ok = await Promise.all([run("acme-a@1.0.0"), run("acme-b@1.0.0")])
+      expect(ok).toEqual([true, true])
+      expect(new Set((await read(path.join(global, "pawwork.json"))).plugin)).toEqual(
+        new Set(["acme-a@1.0.0", "acme-b@1.0.0"]),
+      )
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    }
+  })
+
   test("writes PawWork local plugin config to active pawwork.jsonc when json and jsonc both exist", async () => {
     await using tmp = await tmpdir()
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -5,6 +5,7 @@ import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Log } from "@opencode-ai/core/util/log"
+import { Global } from "../../src/global"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
 
@@ -32,6 +33,37 @@ describe("default directory routing", () => {
       expect(fs.existsSync(expected)).toBe(true)
     } finally {
       home.mockRestore()
+    }
+  })
+
+  test("PawWork path route creates the primary global config Home", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.OPENCODE_TEST_HOME
+    const previousPawWorkHome = process.env.PAWWORK_HOME
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = tmp.path
+    delete process.env.PAWWORK_HOME
+    ;(Global.Path as { config: string }).config = path.join(tmp.path, "legacy-config")
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request("/path")
+      const body = await response.json()
+      const expected = path.join(tmp.path, ".pawwork")
+
+      expect(response.status).toBe(200)
+      expect(body.config).toBe(expected)
+      expect(fs.existsSync(expected)).toBe(true)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = previousHome
+      if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousPawWorkHome
+      ;(Global.Path as { config: string }).config = previousConfig
     }
   })
 })

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -36,7 +36,7 @@ describe("default directory routing", () => {
     }
   })
 
-  test("PawWork path route creates the primary global config Home", async () => {
+  test("PawWork path route reports the primary global config Home without creating it", async () => {
     await using tmp = await tmpdir()
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
     const previousHome = process.env.OPENCODE_TEST_HOME
@@ -50,6 +50,37 @@ describe("default directory routing", () => {
     try {
       const app = Server.Default().app
       const response = await app.request("/path")
+      const body = await response.json()
+      const expected = path.join(tmp.path, ".pawwork")
+
+      expect(response.status).toBe(200)
+      expect(body.config).toBe(expected)
+      expect(fs.existsSync(expected)).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = previousHome
+      if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousPawWorkHome
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("PawWork path route creates the primary global config Home when explicitly requested", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.OPENCODE_TEST_HOME
+    const previousPawWorkHome = process.env.PAWWORK_HOME
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = tmp.path
+    delete process.env.PAWWORK_HOME
+    ;(Global.Path as { config: string }).config = path.join(tmp.path, "legacy-config")
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request("/path?ensureConfig=true")
       const body = await response.json()
       const expected = path.join(tmp.path, ".pawwork")
 

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -38,6 +38,7 @@ describe("default directory routing", () => {
 
   test("PawWork path route reports the primary global config Home without creating it", async () => {
     await using tmp = await tmpdir()
+    const home = spyOn(os, "homedir").mockReturnValue(tmp.path)
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
     const previousHome = process.env.OPENCODE_TEST_HOME
     const previousPawWorkHome = process.env.PAWWORK_HOME
@@ -64,11 +65,13 @@ describe("default directory routing", () => {
       if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
       else process.env.PAWWORK_HOME = previousPawWorkHome
       ;(Global.Path as { config: string }).config = previousConfig
+      home.mockRestore()
     }
   })
 
   test("PawWork path route creates the primary global config Home when explicitly requested", async () => {
     await using tmp = await tmpdir()
+    const home = spyOn(os, "homedir").mockReturnValue(tmp.path)
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
     const previousHome = process.env.OPENCODE_TEST_HOME
     const previousPawWorkHome = process.env.PAWWORK_HOME
@@ -95,6 +98,7 @@ describe("default directory routing", () => {
       if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
       else process.env.PAWWORK_HOME = previousPawWorkHome
       ;(Global.Path as { config: string }).config = previousConfig
+      home.mockRestore()
     }
   })
 

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
 
 describe("default directory routing", () => {
   test("uses ~/PawWork and creates it when no directory is provided", async () => {
-    await using tmp = await tmpdir()
+    await using tmp = await tmpdir({ git: true })
     const home = spyOn(os, "homedir").mockReturnValue(tmp.path)
 
     try {
@@ -94,6 +94,28 @@ describe("default directory routing", () => {
       else process.env.OPENCODE_TEST_HOME = previousHome
       if (previousPawWorkHome === undefined) delete process.env.PAWWORK_HOME
       else process.env.PAWWORK_HOME = previousPawWorkHome
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
+  test("OpenCode path route creates the global config directory when explicitly requested", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = path.join(tmp.path, "opencode-config")
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request(`/path?ensureConfig=true&directory=${encodeURIComponent(tmp.path)}`)
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.config).toBe(path.join(tmp.path, "opencode-config"))
+      expect(fs.existsSync(path.join(tmp.path, "opencode-config"))).toBe(true)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
       ;(Global.Path as { config: string }).config = previousConfig
     }
   })

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -123,4 +123,27 @@ describe("default directory routing", () => {
       ;(Global.Path as { config: string }).config = previousConfig
     }
   })
+
+  test("OpenCode path route does not precreate global config for workspace-routed requests", async () => {
+    await using tmp = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousConfig = Global.Path.config
+    const config = path.join(tmp.path, "opencode-config")
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = config
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request(
+        `/path?ensureConfig=true&workspace=wrk_missing&directory=${encodeURIComponent(tmp.path)}`,
+      )
+
+      expect(response.status).toBe(500)
+      expect(fs.existsSync(config)).toBe(false)
+    } finally {
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
 })

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
@@ -7,6 +8,8 @@ import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { Log } from "@opencode-ai/core/util/log"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Export, getRuntimeNamespace, redactPart } from "../../src/session/export"
+import { Global } from "../../src/global"
+import { tmpdir } from "../fixture/fixture"
 
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
@@ -138,6 +141,48 @@ describe("Export.session", () => {
         }
       },
     })
+  })
+
+  test("exports only the loaded PawWork global AGENTS.md source", async () => {
+    await using primary = await tmpdir()
+    await using legacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.PAWWORK_HOME
+    const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+    const previousGlobalConfig = Global.Path.config
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.PAWWORK_HOME = primary.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = legacy.path
+
+    try {
+      await fs.writeFile(path.join(primary.path, "AGENTS.md"), "primary instructions")
+      await fs.writeFile(path.join(legacy.path, "AGENTS.md"), "legacy instructions")
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "instruction provenance" })
+          try {
+            const result = await AppRuntime.runPromise(Export.session(root.id))
+            const globalSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "global")
+            expect(globalSources).toHaveLength(1)
+            expect(globalSources[0].path).toBe(path.join(primary.path, "AGENTS.md"))
+          } finally {
+            await SessionNs.remove(root.id)
+          }
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousHome
+      if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    }
   })
 
   test("collectModelRefs marks unknown providers as unresolved with a reason", async () => {

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -320,6 +320,54 @@ describe("Export.session", () => {
     }
   })
 
+  test("exports remote config.instructions without fetching the URL", async () => {
+    await using project = await tmpdir({ git: true })
+    await using globalConfig = await tmpdir()
+    let requests = 0
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return new Response("remote config instructions")
+      },
+    })
+    const previousConfig = process.env.OPENCODE_CONFIG_CONTENT
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousGlobalConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = globalConfig.path
+    const url = `${server.url}instructions.md`
+    process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      instructions: [url],
+    })
+    await Config.invalidate(true)
+
+    try {
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "remote instruction provenance" })
+          try {
+            const result = await AppRuntime.runPromise(Export.session(root.id))
+            const source = result.runtime_context.instruction_sources.find((item) => item.kind === "remote" && item.url === url)
+            expect(source?.hash_unavailable).toBe(true)
+            expect(requests).toBe(0)
+          } finally {
+            await SessionNs.remove(root.id)
+          }
+        },
+      })
+    } finally {
+      server.stop(true)
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = previousConfig
+      await Config.invalidate(true)
+    }
+  })
+
   test("collectModelRefs marks unknown providers as unresolved with a reason", async () => {
     await Instance.provide({
       directory: projectRoot,

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -265,7 +265,7 @@ describe("Export.session", () => {
     }
   })
 
-  test("exports loaded config.instructions local file and URL sources", async () => {
+  test("exports loaded config.instructions local file source", async () => {
     await using project = await tmpdir({ git: true })
     await using globalConfig = await tmpdir()
     await using instructions = await tmpdir({
@@ -301,9 +301,7 @@ describe("Export.session", () => {
             expect(result.runtime_context.instruction_sources.some((source) => source.kind === "config" && source.path === localFile)).toBe(
               true,
             )
-            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "remote" && source.url === url)).toBe(
-              true,
-            )
+            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "remote" && source.url === url)).toBe(false)
           } finally {
             await SessionNs.remove(root.id)
           }
@@ -320,7 +318,7 @@ describe("Export.session", () => {
     }
   })
 
-  test("exports remote config.instructions without fetching the URL", async () => {
+  test("does not export remote config.instructions when export skips fetching the URL", async () => {
     await using project = await tmpdir({ git: true })
     await using globalConfig = await tmpdir()
     let requests = 0
@@ -350,7 +348,7 @@ describe("Export.session", () => {
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
             const source = result.runtime_context.instruction_sources.find((item) => item.kind === "remote" && item.url === url)
-            expect(source?.hash_unavailable).toBe(true)
+            expect(source).toBeUndefined()
             expect(requests).toBe(0)
           } finally {
             await SessionNs.remove(root.id)

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -174,6 +174,39 @@ describe("Export.session", () => {
     }
   })
 
+  test("does not fail export when the session instruction directory is gone", async () => {
+    await using sessionProject = await tmpdir({ git: true })
+    await using currentProject = await tmpdir({ git: true })
+
+    let sessionID: SessionID | undefined
+    await Instance.provide({
+      directory: sessionProject.path,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "missing export source directory" })
+        sessionID = root.id
+      },
+    })
+
+    try {
+      await fs.rm(sessionProject.path, { recursive: true, force: true })
+      await Instance.provide({
+        directory: currentProject.path,
+        fn: async () => {
+          const result = await AppRuntime.runPromise(Export.session(sessionID!))
+          const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+          expect(projectSources).toContainEqual({
+            kind: "project",
+            path: sessionProject.path,
+            hash_unavailable: true,
+          })
+          expect(result.runtime_context.instruction_sources.some((source) => source.kind === "bundled")).toBe(true)
+        },
+      })
+    } finally {
+      if (sessionID) await SessionNs.remove(sessionID)
+    }
+  })
+
   test("exports only the loaded PawWork global AGENTS.md source", async () => {
     await using primary = await tmpdir()
     await using legacy = await tmpdir()

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -10,6 +10,7 @@ import { AppRuntime } from "../../src/effect/app-runtime"
 import { Export, getRuntimeNamespace, redactPart } from "../../src/session/export"
 import { Global } from "../../src/global"
 import { tmpdir } from "../fixture/fixture"
+import { Config } from "../../src/config"
 
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
@@ -223,6 +224,99 @@ describe("Export.session", () => {
       else process.env.PAWWORK_HOME = previousHome
       if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
       else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    }
+  })
+
+  test("exports loaded project CLAUDE.md instruction source", async () => {
+    await using project = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await fs.writeFile(path.join(dir, "CLAUDE.md"), "project claude instructions")
+      },
+    })
+    await using globalConfig = await tmpdir()
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousDisableClaude = process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const previousGlobalConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    ;(Global.Path as { config: string }).config = globalConfig.path
+
+    try {
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "claude provenance" })
+          try {
+            const result = await AppRuntime.runPromise(Export.session(root.id))
+            const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+            expect(projectSources.some((source) => source.path === path.join(project.path, "CLAUDE.md"))).toBe(true)
+          } finally {
+            await SessionNs.remove(root.id)
+          }
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousDisableClaude === undefined) delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+      else process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT = previousDisableClaude
+    }
+  })
+
+  test("exports loaded config.instructions local file and URL sources", async () => {
+    await using project = await tmpdir({ git: true })
+    await using globalConfig = await tmpdir()
+    await using instructions = await tmpdir({
+      init: async (dir) => {
+        await fs.writeFile(path.join(dir, "extra.md"), "local config instructions")
+      },
+    })
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("remote config instructions")
+      },
+    })
+    const previousConfig = process.env.OPENCODE_CONFIG_CONTENT
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousGlobalConfig = Global.Path.config
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    ;(Global.Path as { config: string }).config = globalConfig.path
+    const localFile = path.join(instructions.path, "extra.md")
+    const url = `${server.url}instructions.md`
+    process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      instructions: [localFile, url],
+    })
+    await Config.invalidate(true)
+
+    try {
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "config instruction provenance" })
+          try {
+            const result = await AppRuntime.runPromise(Export.session(root.id))
+            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "config" && source.path === localFile)).toBe(
+              true,
+            )
+            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "remote" && source.url === url)).toBe(
+              true,
+            )
+          } finally {
+            await SessionNs.remove(root.id)
+          }
+        },
+      })
+    } finally {
+      server.stop(true)
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+      else process.env.OPENCODE_CONFIG_CONTENT = previousConfig
+      await Config.invalidate(true)
     }
   })
 

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -212,13 +212,27 @@ describe("Export.session", () => {
     await using currentProject = await tmpdir({ git: true })
     await using global = await tmpdir()
     const previousConfig = Global.Path.config
+    const previousEnv = process.env.GLOBAL_EXPORT_RULE
     ;(Global.Path as { config: string }).config = global.path
-    const globalRules = path.join(global.path, "global-rules.md")
+    process.env.GLOBAL_EXPORT_RULE = "env-rules.md"
+    const globalRules = path.join(global.path, "rules", "global-rules.md")
+    const envRules = path.join(global.path, "env-rules.md")
+    const fileRules = path.join(global.path, "file-rules.md")
+    await fs.mkdir(path.join(global.path, "rules"), { recursive: true })
     await fs.writeFile(globalRules, "global config instructions")
+    await fs.writeFile(envRules, "env config instructions")
+    await fs.writeFile(fileRules, "file config instructions")
+    await fs.writeFile(path.join(global.path, "rule-path.txt"), "file-rules.md")
     await fs.writeFile(
       path.join(global.path, "opencode.json"),
       JSON.stringify({
-        instructions: ["global-rules.md", "https://example.invalid/global-rules.md"],
+        instructions: [
+          "rules/*.md",
+          "{env:GLOBAL_EXPORT_RULE}",
+          "{file:rule-path.txt}",
+          "missing/*.md",
+          "https://example.invalid/global-rules.md",
+        ],
       }),
     )
     await fs.writeFile(
@@ -246,12 +260,17 @@ describe("Export.session", () => {
           const result = await AppRuntime.runPromise(Export.session(sessionID!))
           const sources = result.runtime_context.instruction_sources
           expect(sources.map((source) => source.path)).toContain(globalRules)
+          expect(sources.map((source) => source.path)).toContain(envRules)
+          expect(sources.map((source) => source.path)).toContain(fileRules)
+          expect(sources.map((source) => source.path)).not.toContain(path.join(global.path, "missing", "*.md"))
           expect(sources.map((source) => source.url)).toContain("https://example.invalid/global-rules.md")
           expect(sources.map((source) => source.url)).not.toContain("https://example.invalid/current-project.md")
         },
       })
     } finally {
       ;(Global.Path as { config: string }).config = previousConfig
+      if (previousEnv === undefined) delete process.env.GLOBAL_EXPORT_RULE
+      else process.env.GLOBAL_EXPORT_RULE = previousEnv
       await Config.invalidate(true)
       if (sessionID) await SessionNs.remove(sessionID)
     }

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -185,6 +185,47 @@ describe("Export.session", () => {
     }
   })
 
+  test("does not export lower-priority PawWork global AGENTS.md when the first existing candidate is empty", async () => {
+    await using primary = await tmpdir()
+    await using legacy = await tmpdir()
+    await using project = await tmpdir({ git: true })
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    const previousHome = process.env.PAWWORK_HOME
+    const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+    const previousGlobalConfig = Global.Path.config
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.PAWWORK_HOME = primary.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    ;(Global.Path as { config: string }).config = legacy.path
+
+    try {
+      await fs.writeFile(path.join(primary.path, "AGENTS.md"), "")
+      await fs.writeFile(path.join(legacy.path, "AGENTS.md"), "legacy instructions")
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "empty instruction provenance" })
+          try {
+            const result = await AppRuntime.runPromise(Export.session(root.id))
+            const globalSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "global")
+            expect(globalSources).toHaveLength(0)
+          } finally {
+            await SessionNs.remove(root.id)
+          }
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousGlobalConfig
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+      if (previousHome === undefined) delete process.env.PAWWORK_HOME
+      else process.env.PAWWORK_HOME = previousHome
+      if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+      else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    }
+  })
+
   test("collectModelRefs marks unknown providers as unresolved with a reason", async () => {
     await Instance.provide({
       directory: projectRoot,

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -164,7 +164,9 @@ describe("Export.session", () => {
         directory: currentProject.path,
         fn: async () => {
           const result = await AppRuntime.runPromise(Export.session(sessionID!))
-          const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+          const projectSources = result.runtime_context.instruction_sources.filter(
+            (source) => source.kind === "project",
+          )
           expect(projectSources.map((source) => source.path)).toContain(path.join(sessionProject.path, "CLAUDE.md"))
           expect(projectSources.map((source) => source.path)).not.toContain(path.join(currentProject.path, "AGENTS.md"))
         },
@@ -193,11 +195,14 @@ describe("Export.session", () => {
         directory: currentProject.path,
         fn: async () => {
           const result = await AppRuntime.runPromise(Export.session(sessionID!))
-          const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+          const projectSources = result.runtime_context.instruction_sources.filter(
+            (source) => source.kind === "project",
+          )
           expect(projectSources).toContainEqual({
             kind: "project",
             path: sessionProject.path,
             hash_unavailable: true,
+            reason: "session directory unavailable",
           })
           expect(result.runtime_context.instruction_sources.some((source) => source.kind === "bundled")).toBe(true)
         },
@@ -214,15 +219,15 @@ describe("Export.session", () => {
     const previousConfig = Global.Path.config
     const previousEnv = process.env.GLOBAL_EXPORT_RULE
     ;(Global.Path as { config: string }).config = global.path
-    process.env.GLOBAL_EXPORT_RULE = "env-rules.md"
     const globalRules = path.join(global.path, "rules", "global-rules.md")
     const envRules = path.join(global.path, "env-rules.md")
     const fileRules = path.join(global.path, "file-rules.md")
+    process.env.GLOBAL_EXPORT_RULE = envRules
     await fs.mkdir(path.join(global.path, "rules"), { recursive: true })
     await fs.writeFile(globalRules, "global config instructions")
     await fs.writeFile(envRules, "env config instructions")
     await fs.writeFile(fileRules, "file config instructions")
-    await fs.writeFile(path.join(global.path, "rule-path.txt"), "file-rules.md")
+    await fs.writeFile(path.join(global.path, "rule-path.txt"), fileRules)
     await fs.writeFile(
       path.join(global.path, "opencode.json"),
       JSON.stringify({
@@ -259,9 +264,11 @@ describe("Export.session", () => {
         fn: async () => {
           const result = await AppRuntime.runPromise(Export.session(sessionID!))
           const sources = result.runtime_context.instruction_sources
-          expect(sources.map((source) => source.path)).toContain(globalRules)
-          expect(sources.map((source) => source.path)).toContain(envRules)
-          expect(sources.map((source) => source.path)).toContain(fileRules)
+          const byPath = new Map(sources.filter((source) => source.path).map((source) => [source.path, source]))
+          expect(byPath.get(globalRules)?.reason).toContain("fallback relative path")
+          expect(byPath.get(globalRules)?.hash_unavailable).toBe(true)
+          expect(byPath.get(envRules)?.hash).toStartWith("sha256:")
+          expect(byPath.get(fileRules)?.hash).toStartWith("sha256:")
           expect(sources.map((source) => source.path)).not.toContain(path.join(global.path, "missing", "*.md"))
           expect(sources.map((source) => source.url)).toContain("https://example.invalid/global-rules.md")
           expect(sources.map((source) => source.url)).not.toContain("https://example.invalid/current-project.md")
@@ -299,7 +306,9 @@ describe("Export.session", () => {
           const root = await SessionNs.create({ title: "instruction provenance" })
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
-            const globalSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "global")
+            const globalSources = result.runtime_context.instruction_sources.filter(
+              (source) => source.kind === "global",
+            )
             expect(globalSources).toHaveLength(1)
             expect(globalSources[0].path).toBe(path.join(primary.path, "AGENTS.md"))
           } finally {
@@ -341,7 +350,9 @@ describe("Export.session", () => {
           const root = await SessionNs.create({ title: "empty instruction provenance" })
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
-            const globalSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "global")
+            const globalSources = result.runtime_context.instruction_sources.filter(
+              (source) => source.kind === "global",
+            )
             expect(globalSources).toHaveLength(0)
           } finally {
             await SessionNs.remove(root.id)
@@ -381,7 +392,9 @@ describe("Export.session", () => {
           const root = await SessionNs.create({ title: "claude provenance" })
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
-            const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+            const projectSources = result.runtime_context.instruction_sources.filter(
+              (source) => source.kind === "project",
+            )
             expect(projectSources.some((source) => source.path === path.join(project.path, "CLAUDE.md"))).toBe(true)
           } finally {
             await SessionNs.remove(root.id)
@@ -430,10 +443,14 @@ describe("Export.session", () => {
           const root = await SessionNs.create({ title: "config instruction provenance" })
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
-            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "config" && source.path === localFile)).toBe(
-              true,
+            expect(
+              result.runtime_context.instruction_sources.some(
+                (source) => source.kind === "config" && source.path === localFile,
+              ),
+            ).toBe(true)
+            const remote = result.runtime_context.instruction_sources.find(
+              (source) => source.kind === "remote" && source.url === url,
             )
-            const remote = result.runtime_context.instruction_sources.find((source) => source.kind === "remote" && source.url === url)
             expect(remote?.hash_unavailable).toBe(true)
           } finally {
             await SessionNs.remove(root.id)
@@ -480,7 +497,9 @@ describe("Export.session", () => {
           const root = await SessionNs.create({ title: "remote instruction provenance" })
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
-            const source = result.runtime_context.instruction_sources.find((item) => item.kind === "remote" && item.url === url)
+            const source = result.runtime_context.instruction_sources.find(
+              (item) => item.kind === "remote" && item.url === url,
+            )
             expect(source?.hash_unavailable).toBe(true)
             expect(requests).toBe(0)
           } finally {
@@ -977,17 +996,13 @@ describe("redactPart", () => {
       session: {
         info: { id: SessionID.make("ses_x"), title: "t", directory: "/dir" } as never,
         had_cloud_share: false,
-        diffs: [
-          { file: "/Users/secret/code.ts", patch: "@@ -1 +1 @@\n-secret\n+leak", additions: 1, deletions: 1 },
-        ],
+        diffs: [{ file: "/Users/secret/code.ts", patch: "@@ -1 +1 @@\n-secret\n+leak", additions: 1, deletions: 1 }],
         messages: [],
         children: [
           {
             info: { id: SessionID.make("ses_y"), title: "child", directory: "/dir" } as never,
             had_cloud_share: false,
-            diffs: [
-              { file: "/Users/secret/child.ts", patch: "child secret", additions: 0, deletions: 0 },
-            ],
+            diffs: [{ file: "/Users/secret/child.ts", patch: "child secret", additions: 0, deletions: 0 }],
             messages: [],
             children: [],
           },

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -144,6 +144,36 @@ describe("Export.session", () => {
     })
   })
 
+  test("resolves project instruction sources from the exported session directory", async () => {
+    await using sessionProject = await tmpdir({ git: true })
+    await using currentProject = await tmpdir({ git: true })
+    await fs.writeFile(path.join(sessionProject.path, "CLAUDE.md"), "session project instructions")
+    await fs.writeFile(path.join(currentProject.path, "AGENTS.md"), "current project instructions")
+
+    let sessionID: SessionID | undefined
+    await Instance.provide({
+      directory: sessionProject.path,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "export source directory" })
+        sessionID = root.id
+      },
+    })
+
+    try {
+      await Instance.provide({
+        directory: currentProject.path,
+        fn: async () => {
+          const result = await AppRuntime.runPromise(Export.session(sessionID!))
+          const projectSources = result.runtime_context.instruction_sources.filter((source) => source.kind === "project")
+          expect(projectSources.map((source) => source.path)).toContain(path.join(sessionProject.path, "CLAUDE.md"))
+          expect(projectSources.map((source) => source.path)).not.toContain(path.join(currentProject.path, "AGENTS.md"))
+        },
+      })
+    } finally {
+      if (sessionID) await SessionNs.remove(sessionID)
+    }
+  })
+
   test("exports only the loaded PawWork global AGENTS.md source", async () => {
     await using primary = await tmpdir()
     await using legacy = await tmpdir()

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -265,7 +265,7 @@ describe("Export.session", () => {
     }
   })
 
-  test("exports loaded config.instructions local file source", async () => {
+  test("exports loaded local and configured remote config.instructions sources", async () => {
     await using project = await tmpdir({ git: true })
     await using globalConfig = await tmpdir()
     await using instructions = await tmpdir({
@@ -301,7 +301,8 @@ describe("Export.session", () => {
             expect(result.runtime_context.instruction_sources.some((source) => source.kind === "config" && source.path === localFile)).toBe(
               true,
             )
-            expect(result.runtime_context.instruction_sources.some((source) => source.kind === "remote" && source.url === url)).toBe(false)
+            const remote = result.runtime_context.instruction_sources.find((source) => source.kind === "remote" && source.url === url)
+            expect(remote?.hash_unavailable).toBe(true)
           } finally {
             await SessionNs.remove(root.id)
           }
@@ -318,7 +319,7 @@ describe("Export.session", () => {
     }
   })
 
-  test("does not export remote config.instructions when export skips fetching the URL", async () => {
+  test("exports configured remote config.instructions without fetching the URL", async () => {
     await using project = await tmpdir({ git: true })
     await using globalConfig = await tmpdir()
     let requests = 0
@@ -348,7 +349,7 @@ describe("Export.session", () => {
           try {
             const result = await AppRuntime.runPromise(Export.session(root.id))
             const source = result.runtime_context.instruction_sources.find((item) => item.kind === "remote" && item.url === url)
-            expect(source).toBeUndefined()
+            expect(source?.hash_unavailable).toBe(true)
             expect(requests).toBe(0)
           } finally {
             await SessionNs.remove(root.id)

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -207,6 +207,56 @@ describe("Export.session", () => {
     }
   })
 
+  test("keeps global config instruction provenance when session directory is gone", async () => {
+    await using sessionProject = await tmpdir({ git: true })
+    await using currentProject = await tmpdir({ git: true })
+    await using global = await tmpdir()
+    const previousConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = global.path
+    const globalRules = path.join(global.path, "global-rules.md")
+    await fs.writeFile(globalRules, "global config instructions")
+    await fs.writeFile(
+      path.join(global.path, "opencode.json"),
+      JSON.stringify({
+        instructions: ["global-rules.md", "https://example.invalid/global-rules.md"],
+      }),
+    )
+    await fs.writeFile(
+      path.join(currentProject.path, "opencode.json"),
+      JSON.stringify({
+        instructions: ["https://example.invalid/current-project.md"],
+      }),
+    )
+
+    let sessionID: SessionID | undefined
+    await Instance.provide({
+      directory: sessionProject.path,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "missing global config provenance" })
+        sessionID = root.id
+      },
+    })
+
+    try {
+      await Config.invalidate(true)
+      await fs.rm(sessionProject.path, { recursive: true, force: true })
+      await Instance.provide({
+        directory: currentProject.path,
+        fn: async () => {
+          const result = await AppRuntime.runPromise(Export.session(sessionID!))
+          const sources = result.runtime_context.instruction_sources
+          expect(sources.map((source) => source.path)).toContain(globalRules)
+          expect(sources.map((source) => source.url)).toContain("https://example.invalid/global-rules.md")
+          expect(sources.map((source) => source.url)).not.toContain("https://example.invalid/current-project.md")
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+      await Config.invalidate(true)
+      if (sessionID) await SessionNs.remove(sessionID)
+    }
+  })
+
   test("exports only the loaded PawWork global AGENTS.md source", async () => {
     await using primary = await tmpdir()
     await using legacy = await tmpdir()

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -852,6 +852,26 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
+  test("systemPaths() skips project instruction candidates that are not files", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await fs.mkdir(path.join(tmp.path, "AGENTS.md"))
+    await fs.writeFile(path.join(tmp.path, "CLAUDE.md"), "claude instructions")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const paths = yield* svc.systemPaths()
+              expect(paths.has(path.join(tmp.path, "AGENTS.md"))).toBe(false)
+              expect(paths.has(path.join(tmp.path, "CLAUDE.md"))).toBe(true)
+            }),
+          ),
+        ),
+    })
+  })
+
   test("sources() lists loaded project AGENTS.md", async () => {
     await using fakeHome = await tmpdir()
     await using pawworkConfig = await tmpdir()

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1173,4 +1173,36 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
       ;(Global.Path as { config: string }).config = originalGlobalConfig
     }
   })
+
+  test("resolves relative instruction paths from PAWWORK_HOME when project config is disabled", async () => {
+    await using pawworkHome = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "rules", "home-extra.md"), "# PawWork Home Relative Instructions")
+        await Bun.write(path.join(dir, "pawwork.json"), JSON.stringify({ instructions: ["rules/home-extra.md"] }))
+      },
+    })
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "1"
+    process.env.PAWWORK_HOME = pawworkHome.path
+    delete process.env.PAWWORK_CONFIG_DIR
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    await Config.invalidate(true)
+
+    await Instance.provide({
+      directory: projectTmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const rules = yield* svc.system()
+              expect(rules).toContain(
+                `Instructions from: ${path.join(pawworkHome.path, "rules", "home-extra.md")}\n# PawWork Home Relative Instructions`,
+              )
+            }),
+          ),
+        ),
+    })
+  })
 })

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -424,6 +424,7 @@ describe("Instruction.systemPaths OPENCODE_CONFIG_DIR", () => {
 describe("Instruction.systemPaths PawWork runtime config dir", () => {
   const original = {
     opencodeConfigDir: process.env.OPENCODE_CONFIG_DIR,
+    pawworkHome: process.env.PAWWORK_HOME,
     pawworkConfigDir: process.env.PAWWORK_CONFIG_DIR,
     runtimeNamespace: process.env.PAWWORK_RUNTIME_NAMESPACE,
     disableProjectConfig: process.env.OPENCODE_DISABLE_PROJECT_CONFIG,
@@ -434,6 +435,8 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
   afterEach(() => {
     if (original.opencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR
     else process.env.OPENCODE_CONFIG_DIR = original.opencodeConfigDir
+    if (original.pawworkHome === undefined) delete process.env.PAWWORK_HOME
+    else process.env.PAWWORK_HOME = original.pawworkHome
     if (original.pawworkConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
     else process.env.PAWWORK_CONFIG_DIR = original.pawworkConfigDir
     if (original.runtimeNamespace === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
@@ -512,6 +515,51 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
               Effect.gen(function* () {
                 const paths = yield* svc.systemPaths()
                 expect(paths.has(path.join(profileTmp.path, "AGENTS.md"))).toBe(true)
+                expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(false)
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("prefers PAWWORK_HOME AGENTS.md over PAWWORK_CONFIG_DIR and legacy global", async () => {
+    await using homeTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# PawWork Home Instructions")
+      },
+    })
+    await using envTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# PawWork Env Instructions")
+      },
+    })
+    await using globalTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Global Instructions")
+      },
+    })
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    delete process.env.OPENCODE_CONFIG_DIR
+    process.env.PAWWORK_HOME = homeTmp.path
+    process.env.PAWWORK_CONFIG_DIR = envTmp.path
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const paths = yield* svc.systemPaths()
+                expect(paths.has(path.join(homeTmp.path, "AGENTS.md"))).toBe(true)
+                expect(paths.has(path.join(envTmp.path, "AGENTS.md"))).toBe(false)
                 expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(false)
               }),
             ),

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -672,6 +672,52 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
+  test("sources() skips non-file global instruction candidates", async () => {
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "AGENTS.md"))
+      },
+    })
+    await using globalTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Global Instructions")
+      },
+    })
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const sources = yield* svc.sources()
+                const pawworkAgents = path.resolve(path.join(pawworkConfig.path, "AGENTS.md"))
+                const globalAgents = path.resolve(path.join(globalTmp.path, "AGENTS.md"))
+                const considered = sources.find((s) => s.status === "considered" && s.path === pawworkAgents)
+                const loaded = sources.find((s) => s.status === "loaded" && s.path === globalAgents)
+                expect(considered).toBeDefined()
+                if (considered?.status === "considered") expect(considered.reason).toBe("not a file")
+                expect(loaded).toBeDefined()
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
   test("sources() stops project instruction discovery at the first existing basename", async () => {
     // When both AGENTS.md and CLAUDE.md exist in the project root, systemPaths() stops at
     // AGENTS.md. sources() follows that same boundary instead of scanning lower-priority

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1205,4 +1205,41 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
         ),
     })
   })
+
+  test("resolves relative instruction paths from PAWWORK_HOME over PAWWORK_CONFIG_DIR when project config is disabled", async () => {
+    await using pawworkHome = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "rules", "home-wins.md"), "# Home Wins")
+        await Bun.write(path.join(dir, "pawwork.json"), JSON.stringify({ instructions: ["rules/home-wins.md"] }))
+      },
+    })
+    await using pawworkConfig = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "rules", "legacy-env.md"), "# Legacy Env")
+        await Bun.write(path.join(dir, "pawwork.json"), JSON.stringify({ instructions: ["rules/legacy-env.md"] }))
+      },
+    })
+    await using projectTmp = await tmpdir()
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "1"
+    process.env.PAWWORK_HOME = pawworkHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    await Config.invalidate(true)
+
+    await Instance.provide({
+      directory: projectTmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const rules = yield* svc.system()
+              expect(rules).toContain(`Instructions from: ${path.join(pawworkHome.path, "rules", "home-wins.md")}\n# Home Wins`)
+              expect(rules.join("\n")).not.toContain("Legacy Env")
+            }),
+          ),
+        ),
+    })
+  })
 })

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { Effect } from "effect"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instruction, projectFiles } from "../../src/session/instruction"
+import { Config } from "../../src/config"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { Instance } from "../../src/project/instance"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -11,6 +12,14 @@ import { tmpdir } from "../fixture/fixture"
 
 const run = <A>(effect: Effect.Effect<A, any, Instruction.Service>) =>
   Effect.runPromise(effect.pipe(Effect.provide(Instruction.defaultLayer)))
+
+beforeEach(async () => {
+  await Config.invalidate(true)
+})
+
+afterEach(async () => {
+  await Config.invalidate(true)
+})
 
 function loaded(filepath: string): MessageV2.WithParts[] {
   const sessionID = SessionID.make("session-loaded-1")
@@ -1123,6 +1132,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     await using pawworkConfig = await tmpdir({
       init: async (dir) => {
         await Bun.write(path.join(dir, "rules", "extra.md"), "# PawWork Relative Instructions")
+        await Bun.write(path.join(dir, "pawwork.json"), JSON.stringify({ instructions: ["rules/extra.md"] }))
       },
     })
     await using opencodeConfig = await tmpdir({
@@ -1130,17 +1140,16 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
         await Bun.write(path.join(dir, "rules", "extra.md"), "# OpenCode Relative Instructions")
       },
     })
-    await using globalTmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "pawwork.json"), JSON.stringify({ instructions: ["rules/extra.md"] }))
-      },
-    })
+    await using globalTmp = await tmpdir()
     await using projectTmp = await tmpdir()
 
     process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
     process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "1"
     process.env.OPENCODE_CONFIG_DIR = opencodeConfig.path
+    delete process.env.PAWWORK_HOME
     process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    await Config.invalidate(true)
     const originalGlobalConfig = Global.Path.config
     ;(Global.Path as { config: string }).config = globalTmp.path
 

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -119,6 +119,33 @@ describe("Instruction.resolve", () => {
     })
   })
 
+  test("nearby instruction lookup skips directories named AGENTS.md", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "subdir", "AGENTS.md"), { recursive: true })
+        await Bun.write(path.join(dir, "subdir", "CLAUDE.md"), "# Subdir Claude Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const results = yield* svc.resolve(
+                [],
+                path.join(tmp.path, "subdir", "nested", "file.ts"),
+                MessageID.make("message-test-dir-agents"),
+              )
+              expect(results.length).toBe(1)
+              expect(results[0].filepath).toBe(path.join(tmp.path, "subdir", "CLAUDE.md"))
+            }),
+          ),
+        ),
+    })
+  })
+
   test("doesn't reload AGENTS.md when reading it directly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
 import { ModelID, ProviderID } from "../../src/provider/schema"
@@ -1275,6 +1276,37 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
               const rules = yield* svc.system()
               expect(rules).toContain(`Instructions from: ${path.join(pawworkHome.path, "rules", "home-wins.md")}\n# Home Wins`)
               expect(rules.join("\n")).not.toContain("Legacy Env")
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("resolves relative instruction paths from fallback PawWork config when primary has no config", async () => {
+    await using pawworkHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using projectTmp = await tmpdir()
+    await fs.mkdir(path.join(pawworkConfig.path, "rules"), { recursive: true })
+    await Bun.write(path.join(pawworkConfig.path, "rules", "fallback.md"), "# Fallback Config")
+    await Bun.write(path.join(pawworkConfig.path, "pawwork.json"), JSON.stringify({ instructions: ["rules/fallback.md"] }))
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "1"
+    process.env.PAWWORK_HOME = pawworkHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    await Config.invalidate(true)
+
+    await Instance.provide({
+      directory: projectTmp.path,
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const rules = yield* svc.system()
+              expect(rules).toContain(
+                `Instructions from: ${path.join(pawworkConfig.path, "rules", "fallback.md")}\n# Fallback Config`,
+              )
             }),
           ),
         ),

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -623,10 +623,10 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
-  test("sources() reports priority-skipped global instruction file as considered", async () => {
-    // Acceptance criterion #7 covers "considered" sources. When both PAWWORK_CONFIG_DIR
-    // and Global.Path.config have AGENTS.md, only the higher-priority one is loaded; the
-    // other should appear as considered with a priority-skipped reason.
+  test("sources() stops global instruction discovery at the first existing candidate", async () => {
+    // systemPaths() stops at the first existing global candidate even if later candidates
+    // also exist. sources() must model that same boundary so diagnostics cannot imply a
+    // lower-priority file was part of prompt construction.
     await using fakeHome = await tmpdir()
     await using pawworkConfig = await tmpdir({
       init: async (dir) => {
@@ -661,10 +661,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
                 const loaded = sources.find((s) => s.status === "loaded" && s.path === pawworkAgents)
                 const skipped = sources.find((s) => s.status === "considered" && s.path === globalAgents)
                 expect(loaded).toBeDefined()
-                expect(skipped).toBeDefined()
-                if (skipped?.status === "considered") {
-                  expect(skipped.reason).toContain("higher-priority")
-                }
+                expect(skipped).toBeUndefined()
               }),
             ),
           ),
@@ -674,10 +671,10 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     }
   })
 
-  test("sources() reports project priority chain as loaded plus considered siblings", async () => {
-    // When both AGENTS.md and CLAUDE.md exist in the project root, system() loads only
-    // AGENTS.md. sources() must surface CLAUDE.md as considered with the priority reason
-    // so debug output can explain the project fallback order from issue #230.
+  test("sources() stops project instruction discovery at the first existing basename", async () => {
+    // When both AGENTS.md and CLAUDE.md exist in the project root, systemPaths() stops at
+    // AGENTS.md. sources() follows that same boundary instead of scanning lower-priority
+    // project basenames.
     await using fakeHome = await tmpdir()
     await using pawworkConfig = await tmpdir()
     await using globalTmp = await tmpdir()
@@ -709,10 +706,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
                 const loaded = sources.find((s) => s.status === "loaded" && s.path === agents)
                 const skipped = sources.find((s) => s.status === "considered" && s.path === claude)
                 expect(loaded).toBeDefined()
-                expect(skipped).toBeDefined()
-                if (skipped?.status === "considered") {
-                  expect(skipped.reason).toContain("higher-priority project")
-                }
+                expect(skipped).toBeUndefined()
               }),
             ),
           ),
@@ -758,6 +752,50 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
                 if (considered?.status === "considered") {
                   expect(considered.reason).toMatch(/empty|unreadable/)
                 }
+              }),
+            ),
+          ),
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = originalGlobalConfig
+    }
+  })
+
+  test("sources() does not load lower-priority project file when higher-priority file exists empty", async () => {
+    await using fakeHome = await tmpdir()
+    await using pawworkConfig = await tmpdir()
+    await using globalTmp = await tmpdir()
+    await using projectTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "")
+        await Bun.write(path.join(dir, "CLAUDE.md"), "# Project CLAUDE")
+      },
+    })
+
+    process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+    process.env.OPENCODE_TEST_HOME = fakeHome.path
+    process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT
+    const originalGlobalConfig = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+
+    try {
+      await Instance.provide({
+        directory: projectTmp.path,
+        fn: () =>
+          run(
+            Instruction.Service.use((svc) =>
+              Effect.gen(function* () {
+                const rules = yield* svc.system()
+                const sources = yield* svc.sources()
+                const agents = path.resolve(path.join(projectTmp.path, "AGENTS.md"))
+                const claude = path.resolve(path.join(projectTmp.path, "CLAUDE.md"))
+
+                expect(rules.some((rule) => rule.includes("# Project CLAUDE"))).toBe(false)
+                expect(sources.find((s) => s.status === "loaded" && s.path === claude)).toBeUndefined()
+                const considered = sources.find((s) => s.status === "considered" && s.path === agents)
+                expect(considered).toBeDefined()
               }),
             ),
           ),

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3556,6 +3556,7 @@ export class Path extends HeyApiClient {
   public get<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      ensureConfig?: boolean
       workspace?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -3566,6 +3567,7 @@ export class Path extends HeyApiClient {
         {
           args: [
             { in: "query", key: "directory" },
+            { in: "query", key: "ensureConfig" },
             { in: "query", key: "workspace" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5030,6 +5030,7 @@ export type PathGetData = {
   path?: never
   query?: {
     directory?: string
+    ensureConfig?: boolean
     workspace?: string
   }
   url: "/path"


### PR DESCRIPTION
## Summary

Add a PawWork Home for human-editable global config and wire global config, instructions, resources, CLI writes, plugin writes, path reporting, and session export sources through it.

Follow-up fixes address the review feedback: `unit-opencode` regression coverage, explicit Home creation, cross-platform env path handling, legacy config seeding before global MCP/plugin writes, aligned global config write resolution, shared PawWork Home resolver helpers, MCP project config resolution, session export provenance, command-palette error reporting, CLI seeding error UX, PAWWORK_HOME relative instruction resolution, directory-only resource discovery, formal spec docs, dynamic plugin global path resolution, and OpenCode `/path?ensureConfig=true` behavior.

## Why

Fixes #328. PawWork needs a discoverable global config folder for user-edited files such as `AGENTS.md`, `pawwork.json(c)`, commands, agents, skills, and plugin/MCP config, while runtime data stays in platform app data/cache/state/log locations.

## Related Issue

Fixes #328

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on migration behavior: `PAWWORK_HOME` precedence, legacy `Global.Path.config` fallback, first-write preservation of existing legacy config, OpenCode-mode isolation, explicit versus read-only config path handling, session export `instruction_sources`, global MCP/plugin write consistency, local MCP project config write targets, and runtime-env-sensitive path resolution.

## Risk Notes

This changes PawWork global config lookup and write targets. Runtime data paths are intentionally unchanged. Legacy platform config remains a read fallback, and first writes to the new Home preserve the effective legacy config to avoid making old settings appear lost.

## Docs

The PawWork Home behavior is documented in `packages/opencode/specs/pawwork-home.md`. It is intentionally not in the root README.

## How To Verify

```text
Focused seed/provenance regression tests: 69 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/session/export.test.ts --timeout 30000

Focused plugin/instruction regression tests: 72 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install.test.ts test/plugin/install-concurrency.test.ts test/session/instruction.test.ts --timeout 30000

OpenCode package typecheck after seed/provenance follow-up: passed
Command: bun --cwd packages/opencode typecheck

Core package typecheck after PawWorkHome cleanup: passed
Command: bun --cwd packages/core typecheck

Diff check after seed/provenance follow-up: passed
Command: git diff --check

Focused config boundary review tests: 138 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/plugin/install.test.ts test/session/export.test.ts test/session/instruction.test.ts --timeout 30000

Plugin install concurrency regression tests: 3 passed, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install-concurrency.test.ts --timeout 30000

OpenCode package typecheck after config boundary follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after config boundary follow-up: passed
Command: git diff --check

Focused latest CodeRabbit edge-case regression tests: 238 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install.test.ts test/plugin/install-concurrency.test.ts test/session/instruction.test.ts test/session/export.test.ts test/config/config.test.ts test/config/pawwork-global-config.test.ts --timeout 30000

OpenCode package typecheck after latest CodeRabbit edge-case follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after latest CodeRabbit edge-case follow-up: passed
Command: git diff --check

Focused config write serialization tests: 174 passed, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install.test.ts test/plugin/install-concurrency.test.ts test/config/config.test.ts test/config/pawwork-global-config.test.ts --timeout 30000

OpenCode package typecheck after config write serialization follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after config write serialization follow-up: passed
Command: git diff --check

Focused legacy write-boundary regression tests: 96 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/plugin/install.test.ts test/session/export.test.ts --timeout 30000

OpenCode package typecheck after legacy write-boundary follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after legacy write-boundary follow-up: passed
Command: git diff --check

Focused fallback precedence regression tests: 72 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/session/instruction.test.ts --timeout 30000

Focused PawWork global config tests: 37 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts --timeout 30000

Focused instruction tests: 35 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/session/instruction.test.ts --timeout 30000

OpenCode package typecheck after fallback precedence follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after fallback precedence follow-up: passed
Command: git diff --check

Focused instruction provenance tests: 60 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/session/instruction.test.ts test/session/export.test.ts --timeout 30000

OpenCode package typecheck after instruction provenance follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after instruction provenance follow-up: passed
Command: git diff --check


Focused plugin/path review follow-up tests: 34 passed, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install.test.ts test/server/default-directory.test.ts --timeout 30000

OpenCode package typecheck after plugin/path review follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after plugin/path review follow-up: passed
Command: git diff --check


Focused CodeRabbit follow-up tests: 65 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/server/default-directory.test.ts test/plugin/install.test.ts --timeout 30000

OpenCode package typecheck after CodeRabbit follow-up: passed
Command: bun --cwd packages/opencode typecheck

Diff check after CodeRabbit follow-up: passed
Command: git diff --check


Focused runtime resolution regression tests: 64 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/session/instruction.test.ts test/plugin/install.test.ts test/server/default-directory.test.ts

OpenCode package typecheck after runtime resolution fixes: passed
Command: bun --cwd packages/opencode typecheck

Focused resource-directory regression tests: 34 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts

OpenCode package typecheck after resource-directory fix: passed
Command: bun --cwd packages/opencode typecheck

Focused latest review plus CodeRabbit regression tests: 115 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/session/export.test.ts test/plugin/install.test.ts test/session/instruction.test.ts

OpenCode package typecheck after CodeRabbit follow-up: passed
Command: bun --cwd packages/opencode typecheck

Focused latest review regression tests: 83 passed, 0 failed
Command: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/session/export.test.ts test/plugin/install.test.ts

OpenCode package typecheck after latest review fixes: passed
Command: bun --cwd packages/opencode typecheck

Focused PawWork Home, plugin write, and export provenance tests: 80 passed, 0 failed
Command: bun --cwd packages/opencode test test/plugin/install.test.ts test/session/export.test.ts test/config/pawwork-global-config.test.ts

Focused PawWork Home, instruction, plugin write, and export provenance tests: 109 passed, 1 existing todo, 0 failed
Command: bun --cwd packages/opencode test test/session/export.test.ts test/session/instruction.test.ts test/config/pawwork-global-config.test.ts test/plugin/install.test.ts

OpenCode package typecheck: passed
Command: bun --cwd packages/opencode typecheck

App package typecheck: passed
Command: bun --cwd packages/app typecheck

Previous full opencode unit suite: 2515 passed, 9 skipped, 1 todo, 0 failed
Command: bun --cwd packages/opencode test

Previous SDK typecheck: passed
Command: bun --cwd packages/sdk/js typecheck

Previous core typecheck: passed
Command: bun --cwd packages/core typecheck

Diff check: passed
Command: git diff --check
```

## Screenshots or Recordings

Not captured. The UI change is a command palette entry that explicitly asks `/path?ensureConfig=true` before opening the global config folder and now shows an error toast if Home creation or system open fails; behavior is covered by server path regression tests and app typecheck.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Open global config folder" command in settings; runtime-aware global config resolution, ensure-config option, atomic global config writes, and seeding behavior for first-write migration.

* **Localization**
  * Added English and Chinese translations for the command and its failure toast.

* **Documentation**
  * Added spec describing PawWork Home behavior and resolution priority.

* **Tests**
  * Expanded coverage for PawWork Home, config resolution, plugin install flows, server path handling, and instruction-source provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->