### PR TITLE
chore(bench): add native-core benchmark baselines

### DIFF
--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -40,7 +40,7 @@ type ScenarioRun =
 
 type Scenario = {
   name: string
-  layer: "production path" | "CLI floor" | "approximation"
+  layer: "production path" | "production path: parse-only" | "CLI floor" | "approximation"
   group: "file" | "git" | "patch" | "process"
   run: () => Promise<Omit<RunMetrics, "durationMs">>
 }
@@ -63,6 +63,14 @@ type RepoSummary = {
   fileCount?: number
   dirCount?: number
   gitStatus: "clean" | "dirty" | "unknown"
+}
+
+type FileSummary = {
+  available: boolean
+  files: string[]
+  dirs: string[]
+  fileCount?: number
+  dirCount?: number
 }
 
 type Environment = {
@@ -253,7 +261,7 @@ async function runGitMaybe(args: string[], cwd: string) {
 
 async function runRgFiles(cwd: string) {
   const result = await runCommand(["rg", ...rgFilesArgs], cwd)
-  if (result.code !== 0) {
+  if (result.code !== 0 && (result.stdout.length > 0 || result.stderr.length > 0)) {
     throw new SkipScenario("rg --files is unavailable or failed")
   }
   return {
@@ -290,13 +298,21 @@ function slug(value: string) {
 }
 
 function scenarioMatches(filter: string | undefined, scenario: Scenario) {
-  if (!filter || filter === "all") return true
+  if (!filter || slug(filter) === "all") return true
   const wanted = slug(filter)
   return slug(scenario.name) === wanted || slug(`${scenario.group} ${scenario.name}`) === wanted
 }
 
 function scenarioSlugList(scenarios: Scenario[]) {
-  return scenarios.map((scenario) => `  - ${slug(scenario.name)}`).join("\n")
+  return scenarios
+    .map((scenario) => {
+      const nameSlug = slug(scenario.name)
+      const groupSlug = slug(`${scenario.group} ${scenario.name}`)
+      return nameSlug === groupSlug || nameSlug.startsWith(`${scenario.group}-`)
+        ? `  - ${nameSlug}`
+        : `  - ${nameSlug} (also: ${groupSlug})`
+    })
+    .join("\n")
 }
 
 async function timed(run: () => Promise<Omit<RunMetrics, "durationMs">>): Promise<ScenarioRun> {
@@ -478,11 +494,12 @@ function parseWorktreeCount(stdout: Buffer) {
   return splitLines(stdout.toString("utf8")).filter((line) => line.startsWith("worktree ")).length
 }
 
-async function collectFileSummary(cwd: string) {
+async function collectFileSummary(cwd: string): Promise<FileSummary> {
   try {
     const rg = await runRgFiles(cwd)
     const dirs = dirListFromFiles(rg.files)
     return {
+      available: true,
       files: rg.files,
       dirs,
       fileCount: rg.files.length,
@@ -490,6 +507,7 @@ async function collectFileSummary(cwd: string) {
     }
   } catch {
     return {
+      available: false,
       files: [] as string[],
       dirs: [] as string[],
       fileCount: undefined,
@@ -530,7 +548,8 @@ async function collectEnvironment(config: BenchConfig, summary: RepoSummary): Pr
   }
 }
 
-function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): Scenario[] {
+function buildScenarios(config: BenchConfig, fileSummary: FileSummary): Scenario[] {
+  const { files, dirs } = fileSummary
   const smallPatch = makeSyntheticPatch(5)
   const largePatch = makeSyntheticPatch(500)
 
@@ -545,7 +564,8 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: result.files.length,
           outputBytes: result.stdout.length,
-          notes: "CLI floor; system PATH rg; production Ripgrep.Service may add managed binary/env/stream cleanup overhead",
+          notes:
+            "CLI floor; system PATH rg; production Ripgrep.Service may add managed binary/env/stream cleanup overhead; benchmark helper timeout/kill is not a Windows process-semantics check",
         }
       },
     },
@@ -554,7 +574,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
       layer: "approximation",
       group: "file",
       run: async () => {
-        if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
+        if (!fileSummary.available) throw new SkipScenario("rg --files unavailable during setup")
         const next = { files: [] as string[], dirs: [] as string[] }
         const seen = new Set<string>()
         for (const file of files) {
@@ -580,7 +600,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
       layer: "approximation",
       group: "file",
       run: async () => {
-        if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
+        if (!fileSummary.available) throw new SkipScenario("rg --files unavailable during setup")
         const items = [...files, ...dirs]
         let resultCount = 0
         for (const query of scenarioQueries) {
@@ -608,7 +628,8 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseStatusCount(result.stdout),
           outputBytes: result.stdout.length,
-          notes: "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper",
+          notes:
+            "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check",
         }
       },
     },
@@ -623,7 +644,8 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseNameStatusCount(result.stdout),
           outputBytes: result.stdout.length,
-          notes: "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper",
+          notes:
+            "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check",
         }
       },
     },
@@ -639,7 +661,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: stats.files,
           outputBytes: result.stdout.length,
-          notes: `CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; additions=${stats.additions}; deletions=${stats.deletions}`,
+          notes: `CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check; additions=${stats.additions}; deletions=${stats.deletions}`,
         }
       },
     },
@@ -654,13 +676,14 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseWorktreeCount(result.stdout),
           outputBytes: result.stdout.length,
-          notes: "CLI floor; parses porcelain output without Worktree service orchestration",
+          notes:
+            "CLI floor; parses porcelain output without Worktree service orchestration, registry, cleanup, reset, or Windows retry behavior",
         }
       },
     },
     {
       name: "apply_patch parse small",
-      layer: "production path",
+      layer: "production path: parse-only",
       group: "patch",
       run: async () => {
         const parsed = Patch.parsePatch(smallPatch)
@@ -674,7 +697,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
     },
     {
       name: "apply_patch parse large",
-      layer: "production path",
+      layer: "production path: parse-only",
       group: "patch",
       run: async () => {
         const parsed = Patch.parsePatch(largePatch)
@@ -700,7 +723,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
       },
     },
     {
-      name: "process timeout abort",
+      name: "process abort single-child",
       layer: "production path",
       group: "process",
       run: async () => {
@@ -728,7 +751,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
 
 function formatMarkdown(env: Environment, results: BenchResult[]) {
   const lines = [
-    `## Native-core baseline - ${new Date().toISOString().slice(0, 10)}`,
+    `## Native-core baseline - ${formatLocalDate(new Date())}`,
     "",
     "Environment:",
     `- OS: ${escapeMarkdownInline(env.os)}`,
@@ -742,7 +765,10 @@ function formatMarkdown(env: Environment, results: BenchResult[]) {
     `- Files: ${escapeMarkdownInline(env.files)}`,
     `- Dirs: ${escapeMarkdownInline(env.dirs)}`,
     `- Git status: ${escapeMarkdownInline(env.gitStatus)}`,
+    `- Command timeout: ${commandTimeoutMs}ms`,
     "- Setup note: file/repo summary collection runs before scenario timing, so first measured values are not cold-start measurements.",
+    `- Percentile note: p50/p95 use nearest-rank over repeat runs; with low iteration counts p95 may equal the slowest run.`,
+    "- Label note: choose a non-sensitive --label value because it is printed in pasteable output.",
     "",
     "| Scenario | Layer | First measured | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
     "|---|---|---:|---:|---:|---:|---:|---:|---|",
@@ -768,6 +794,16 @@ function formatMarkdown(env: Environment, results: BenchResult[]) {
     )
   }
 
+  lines.push(
+    "",
+    "Decision guard:",
+    "- `production path` rows can support implementation decisions for the measured path.",
+    "- `production path: parse-only` rows cover only parsing and do not cover verification, preview diff, file reads, BOM handling, or write behavior.",
+    "- `CLI floor` rows are lower-bound command measurements and bypass service wrappers, managed tool selection, registry/orchestration, and some cross-platform cleanup behavior.",
+    "- `approximation` rows mimic current logic over captured inputs and should not be used alone for native/no-native decisions.",
+    "- Missing from this first PR: service-path File/Git/Worktree benchmarks, apply_patch verify/preview, process-tree termination, Windows results, large synthetic fixtures, CPU/RSS/heap/event-loop metrics.",
+  )
+
   return lines.join("\n")
 }
 
@@ -787,7 +823,17 @@ function formatMetricCount(value?: number) {
 }
 
 function escapeMarkdownInline(value: string) {
-  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim()
+  return stripControl(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r?\n/g, " ")
+    .trim()
 }
 
 function escapeMarkdownTableCell(value: string) {
@@ -796,11 +842,24 @@ function escapeMarkdownTableCell(value: string) {
 
 function sanitizeError(error: unknown, cwd?: string) {
   const raw = error instanceof Error ? error.message : String(error)
-  let text = raw.replace(/\s+/g, " ").trim()
+  let text = stripControl(raw).replace(/\s+/g, " ").trim()
   if (cwd) text = text.split(cwd).join("[cwd]")
   text = text.split(os.homedir()).join("[home]")
   if (text.length > 180) text = `${text.slice(0, 177)}...`
   return text || "unknown error"
+}
+
+function stripControl(value: string) {
+  return value
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
+}
+
+function formatLocalDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
 async function main() {
@@ -824,7 +883,7 @@ async function main() {
   const fileSummary = await collectFileSummary(config.cwd)
   const repoSummary = await collectRepoSummary(config.cwd, fileSummary.fileCount, fileSummary.dirCount)
   const env = await collectEnvironment(config, repoSummary)
-  const allScenarios = buildScenarios(config, fileSummary.files, fileSummary.dirs)
+  const allScenarios = buildScenarios(config, fileSummary)
   const scenarios = allScenarios.filter((scenario) => scenarioMatches(config.scenario, scenario))
 
   if (scenarios.length === 0) {

--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -117,7 +117,7 @@ Options:
   --iterations <n>       Measured repeat runs, defaults to 7
   --warmups <n>          Warmup runs before repeat measurements, defaults to 2
   --show-path            Print the full cwd path instead of redacting it
-  --scenario <name>      Run one scenario by exact or slug name
+  --scenario <name|all>  Run one scenario by exact or slug name, or all scenarios
   --help                 Print this help
 `
 

--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -339,6 +339,15 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
 
   for (let i = 0; i < config.warmups; i++) {
     const warmup = await timed(scenario.run)
+    if (warmup.status === "skipped") {
+      return {
+        name: scenario.name,
+        layer: scenario.layer,
+        group: scenario.group,
+        status: "skipped",
+        notes: warmup.notes,
+      }
+    }
     if (warmup.status === "error") {
       return {
         name: scenario.name,

--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Buffer } from "node:buffer"
+import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -39,12 +40,14 @@ type ScenarioRun =
 
 type Scenario = {
   name: string
+  layer: "production path" | "CLI floor" | "approximation"
   group: "file" | "git" | "patch" | "process"
   run: () => Promise<Omit<RunMetrics, "durationMs">>
 }
 
 type BenchResult = {
   name: string
+  layer: Scenario["layer"]
   group: Scenario["group"]
   status: "ok" | "skipped" | "error"
   firstRunMs?: number
@@ -68,6 +71,7 @@ type Environment = {
   bun: string
   node: string
   git: string
+  ripgrep: string
   repo: string
   path: string
   files: string
@@ -81,6 +85,10 @@ class SkipScenario extends Error {
     this.name = "SkipScenario"
   }
 }
+
+const commandTimeoutMs = 30_000
+const maxIterations = 100
+const maxWarmups = 20
 
 const gitConfig = [
   "--no-optional-locks",
@@ -96,7 +104,7 @@ const gitConfig = [
   "core.quotepath=false",
 ] as const
 
-const rgFilesArgs = ["--no-config", "--files", "--hidden", "--glob=!.git/*", "."] as const
+const rgFilesArgs = ["--no-config", "--files", "--hidden", "-0", "--glob=!.git/*", "."] as const
 
 const scenarioQueries = ["session", "worktree", "git", "index", "config"] as const
 
@@ -169,21 +177,33 @@ function requiredValue(flag: string, args: string[]) {
 }
 
 function parsePositiveInteger(flag: string, value: string) {
+  if (!/^[1-9]\d*$/.test(value)) throw new Error(`${flag} must be a positive integer`)
   const n = Number.parseInt(value, 10)
-  if (!Number.isInteger(n) || n <= 0) throw new Error(`${flag} must be a positive integer`)
+  if (!Number.isSafeInteger(n)) throw new Error(`${flag} is too large`)
+  if (flag === "--iterations" && n > maxIterations) throw new Error(`${flag} must be <= ${maxIterations}`)
   return n
 }
 
 function parseNonNegativeInteger(flag: string, value: string) {
+  if (!/^(0|[1-9]\d*)$/.test(value)) throw new Error(`${flag} must be a non-negative integer`)
   const n = Number.parseInt(value, 10)
-  if (!Number.isInteger(n) || n < 0) throw new Error(`${flag} must be a non-negative integer`)
+  if (!Number.isSafeInteger(n)) throw new Error(`${flag} is too large`)
+  if (flag === "--warmups" && n > maxWarmups) throw new Error(`${flag} must be <= ${maxWarmups}`)
   return n
 }
 
 async function runCommand(cmd: string[], cwd: string): Promise<CommandResult> {
   if (cmd.length === 0) throw new Error("Command is required")
+  let proc: Bun.Subprocess<"ignore", "pipe", "pipe"> | undefined
+  let timedOut = false
+  let forceKill: Timer | undefined
+  const timeout = setTimeout(() => {
+    timedOut = true
+    proc?.kill("SIGTERM")
+    forceKill = setTimeout(() => proc?.kill("SIGKILL"), 500)
+  }, commandTimeoutMs)
   try {
-    const proc = Bun.spawn(cmd, {
+    proc = Bun.spawn(cmd, {
       cwd,
       stdin: "ignore",
       stdout: "pipe",
@@ -194,6 +214,7 @@ async function runCommand(cmd: string[], cwd: string): Promise<CommandResult> {
       new Response(proc.stdout).arrayBuffer(),
       new Response(proc.stderr).arrayBuffer(),
     ])
+    if (timedOut) throw new Error(`command timed out after ${commandTimeoutMs}ms`)
     return {
       code,
       stdout: Buffer.from(stdout),
@@ -202,7 +223,20 @@ async function runCommand(cmd: string[], cwd: string): Promise<CommandResult> {
     }
   } catch (error) {
     throw new Error(sanitizeError(error, cwd))
+  } finally {
+    clearTimeout(timeout)
+    if (forceKill) clearTimeout(forceKill)
   }
+}
+
+async function validateCwd(cwd: string) {
+  let stat
+  try {
+    stat = await fs.stat(cwd)
+  } catch {
+    throw new Error(`--cwd does not exist: ${cwd}`)
+  }
+  if (!stat.isDirectory()) throw new Error(`--cwd is not a directory: ${cwd}`)
 }
 
 async function runGit(args: string[], cwd: string) {
@@ -224,7 +258,7 @@ async function runRgFiles(cwd: string) {
   }
   return {
     ...result,
-    files: splitLines(result.stdout.toString("utf8")),
+    files: splitNul(result.stdout.toString()),
   }
 }
 
@@ -261,6 +295,10 @@ function scenarioMatches(filter: string | undefined, scenario: Scenario) {
   return slug(scenario.name) === wanted || slug(`${scenario.group} ${scenario.name}`) === wanted
 }
 
+function scenarioSlugList(scenarios: Scenario[]) {
+  return scenarios.map((scenario) => `  - ${slug(scenario.name)}`).join("\n")
+}
+
 async function timed(run: () => Promise<Omit<RunMetrics, "durationMs">>): Promise<ScenarioRun> {
   const start = performance.now()
   try {
@@ -283,6 +321,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
   if (first.status === "skipped") {
     return {
       name: scenario.name,
+      layer: scenario.layer,
       group: scenario.group,
       status: "skipped",
       notes: first.notes,
@@ -291,6 +330,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
   if (first.status === "error") {
     return {
       name: scenario.name,
+      layer: scenario.layer,
       group: scenario.group,
       status: "error",
       notes: first.error,
@@ -302,6 +342,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
     if (warmup.status === "error") {
       return {
         name: scenario.name,
+        layer: scenario.layer,
         group: scenario.group,
         status: "error",
         notes: `warmup failed: ${warmup.error}`,
@@ -315,6 +356,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
     if (run.status === "skipped") {
       return {
         name: scenario.name,
+        layer: scenario.layer,
         group: scenario.group,
         status: "skipped",
         notes: run.notes,
@@ -323,6 +365,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
     if (run.status === "error") {
       return {
         name: scenario.name,
+        layer: scenario.layer,
         group: scenario.group,
         status: "error",
         notes: run.error,
@@ -333,6 +376,7 @@ async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<B
 
   return {
     name: scenario.name,
+    layer: scenario.layer,
     group: scenario.group,
     status: "ok",
     firstRunMs: first.metrics.durationMs,
@@ -373,14 +417,33 @@ function makeSyntheticPatch(hunks: number) {
 }
 
 function parseStatusCount(stdout: Buffer) {
-  return splitNul(stdout.toString("utf8")).filter((item) => item.slice(3)).length
+  const parts = splitNul(stdout.toString())
+  let count = 0
+  for (let i = 0; i < parts.length; i++) {
+    const item = parts[i]
+    const code = item.slice(0, 2)
+    const file = item.slice(3)
+    if (!code.trim() || !file) continue
+    count++
+    if (code.includes("R") || code.includes("C")) i++
+  }
+  return count
 }
 
 function parseNameStatusCount(stdout: Buffer) {
-  const parts = splitNul(stdout.toString("utf8"))
+  const parts = splitNul(stdout.toString())
   let count = 0
-  for (let i = 0; i < parts.length; i += 2) {
-    if (parts[i] && parts[i + 1]) count++
+  for (let i = 0; i < parts.length; ) {
+    const code = parts[i++]
+    if (!code) continue
+    if (code.startsWith("R") || code.startsWith("C")) {
+      const oldPath = parts[i++]
+      const newPath = parts[i++]
+      if (oldPath && newPath) count++
+      continue
+    }
+    const file = parts[i++]
+    if (file) count++
   }
   return count
 }
@@ -439,6 +502,9 @@ async function collectEnvironment(config: BenchConfig, summary: RepoSummary): Pr
   const gitVersion = await runCommand(["git", "--version"], config.cwd)
     .then((result) => (result.code === 0 ? result.stdout.toString("utf8").trim() : "unknown"))
     .catch(() => "unknown")
+  const ripgrepVersion = await runCommand(["rg", "--version"], config.cwd)
+    .then((result) => (result.code === 0 ? splitLines(result.stdout.toString("utf8"))[0] : "unknown"))
+    .catch(() => "unknown")
   const cpu = os.cpus()[0]
   return {
     os: `${os.type()} ${os.release()} ${os.arch()}`,
@@ -446,6 +512,7 @@ async function collectEnvironment(config: BenchConfig, summary: RepoSummary): Pr
     bun: Bun.version,
     node: process.version,
     git: gitVersion || "unknown",
+    ripgrep: `${ripgrepVersion || "unknown"}; source=system PATH`,
     repo: config.label,
     path: config.showPath ? config.cwd : "redacted",
     files: formatCount(summary.fileCount),
@@ -461,6 +528,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
   return [
     {
       name: "file scan: rg --files",
+      layer: "CLI floor",
       group: "file",
       run: async () => {
         const result = await runRgFiles(config.cwd)
@@ -468,11 +536,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: result.files.length,
           outputBytes: result.stdout.length,
+          notes: "CLI floor; system PATH rg; production Ripgrep.Service may add managed binary/env/stream cleanup overhead",
         }
       },
     },
     {
       name: "file index approximation: dirs cache",
+      layer: "approximation",
       group: "file",
       run: async () => {
         if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
@@ -498,6 +568,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
     },
     {
       name: "file fuzzy search approximation",
+      layer: "approximation",
       group: "file",
       run: async () => {
         if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
@@ -516,6 +587,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
     },
     {
       name: "git status",
+      layer: "CLI floor",
       group: "git",
       run: async () => {
         const result = await runGit(
@@ -527,11 +599,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseStatusCount(result.stdout),
           outputBytes: result.stdout.length,
+          notes: "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper",
         }
       },
     },
     {
       name: "git diff name-status",
+      layer: "CLI floor",
       group: "git",
       run: async () => {
         const result = await runGit(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", "HEAD", "--", "."], config.cwd)
@@ -540,11 +614,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseNameStatusCount(result.stdout),
           outputBytes: result.stdout.length,
+          notes: "CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper",
         }
       },
     },
     {
       name: "git diff numstat",
+      layer: "CLI floor",
       group: "git",
       run: async () => {
         const result = await runGit(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", "HEAD", "--", "."], config.cwd)
@@ -554,12 +630,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: stats.files,
           outputBytes: result.stdout.length,
-          notes: `additions=${stats.additions}; deletions=${stats.deletions}`,
+          notes: `CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; additions=${stats.additions}; deletions=${stats.deletions}`,
         }
       },
     },
     {
       name: "git worktree list parse",
+      layer: "CLI floor",
       group: "git",
       run: async () => {
         const result = await runGit(["worktree", "list", "--porcelain"], config.cwd)
@@ -568,11 +645,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: result.spawnCount,
           resultCount: parseWorktreeCount(result.stdout),
           outputBytes: result.stdout.length,
+          notes: "CLI floor; parses porcelain output without Worktree service orchestration",
         }
       },
     },
     {
       name: "apply_patch parse small",
+      layer: "production path",
       group: "patch",
       run: async () => {
         const parsed = Patch.parsePatch(smallPatch)
@@ -580,12 +659,13 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: 0,
           resultCount: parsed.hunks.length,
           outputBytes: Buffer.byteLength(smallPatch),
-          notes: "synthetic patch; parse only",
+          notes: "synthetic patch; parse only; not a verify/preview/content replacement benchmark",
         }
       },
     },
     {
       name: "apply_patch parse large",
+      layer: "production path",
       group: "patch",
       run: async () => {
         const parsed = Patch.parsePatch(largePatch)
@@ -593,18 +673,18 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           spawnCount: 0,
           resultCount: parsed.hunks.length,
           outputBytes: Buffer.byteLength(largePatch),
-          notes: "synthetic patch; parse only",
+          notes: "synthetic patch; parse only; 500 update chunks in one file hunk; not a verify/preview/content replacement benchmark",
         }
       },
     },
     {
       name: "process spawn noop",
+      layer: "production path",
       group: "process",
       run: async () => {
         const result = await Process.run([process.execPath, "-e", "0"], { nothrow: true })
         return {
           spawnCount: 1,
-          resultCount: result.code,
           outputBytes: result.stdout.length + result.stderr.length,
           notes: `exitCode=${result.code}`,
         }
@@ -612,6 +692,7 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
     },
     {
       name: "process timeout abort",
+      layer: "production path",
       group: "process",
       run: async () => {
         const controller = new AbortController()
@@ -624,9 +705,8 @@ function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): S
           })
           return {
             spawnCount: 1,
-            resultCount: result.code,
             outputBytes: result.stdout.length + result.stderr.length,
-            notes: `exitCode=${result.code}`,
+            notes: `single-process abort only; no process-tree fixture in first PR; exitCode=${result.code}`,
           }
         } finally {
           clearTimeout(timer)
@@ -642,34 +722,37 @@ function formatMarkdown(env: Environment, results: BenchResult[]) {
     `## Native-core baseline - ${new Date().toISOString().slice(0, 10)}`,
     "",
     "Environment:",
-    `- OS: ${env.os}`,
-    `- CPU: ${env.cpu}`,
-    `- Bun: ${env.bun}`,
-    `- Node: ${env.node}`,
-    `- Git: ${env.git}`,
-    `- Repo: ${env.repo}`,
-    `- Path: ${env.path}`,
-    `- Files: ${env.files}`,
-    `- Dirs: ${env.dirs}`,
-    `- Git status: ${env.gitStatus}`,
+    `- OS: ${escapeMarkdownInline(env.os)}`,
+    `- CPU: ${escapeMarkdownInline(env.cpu)}`,
+    `- Bun: ${escapeMarkdownInline(env.bun)}`,
+    `- Node: ${escapeMarkdownInline(env.node)}`,
+    `- Git: ${escapeMarkdownInline(env.git)}`,
+    `- Ripgrep: ${escapeMarkdownInline(env.ripgrep)}`,
+    `- Repo: ${escapeMarkdownInline(env.repo)}`,
+    `- Path: ${escapeMarkdownInline(env.path)}`,
+    `- Files: ${escapeMarkdownInline(env.files)}`,
+    `- Dirs: ${escapeMarkdownInline(env.dirs)}`,
+    `- Git status: ${escapeMarkdownInline(env.gitStatus)}`,
+    "- Setup note: file/repo summary collection runs before scenario timing, so first measured values are not cold-start measurements.",
     "",
-    "| Scenario | First run | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
-    "|---|---:|---:|---:|---:|---:|---:|---|",
+    "| Scenario | Layer | First measured | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
+    "|---|---|---:|---:|---:|---:|---:|---:|---|",
   ]
 
   for (const result of results) {
     lines.push(
       [
         result.name,
+        result.layer,
         result.status === "ok" ? formatMs(result.firstRunMs) : result.status,
         result.status === "ok" ? formatMs(result.repeatP50Ms) : result.status,
         result.status === "ok" ? formatMs(result.repeatP95Ms) : result.status,
-        result.status === "ok" ? formatCount(result.spawnCount) : "",
-        result.status === "ok" ? formatCount(result.resultCount) : "",
-        result.status === "ok" ? formatCount(result.outputBytes) : "",
-        sanitizeCell(result.notes ?? ""),
+        result.status === "ok" ? formatMetricCount(result.spawnCount) : "",
+        result.status === "ok" ? formatMetricCount(result.resultCount) : "",
+        result.status === "ok" ? formatMetricCount(result.outputBytes) : "",
+        result.notes ?? "",
       ]
-        .map((cell) => ` ${cell} `)
+        .map((cell) => ` ${escapeMarkdownTableCell(cell)} `)
         .join("|")
         .replace(/^/, "|")
         .replace(/$/, "|"),
@@ -690,8 +773,16 @@ function formatCount(value?: number) {
   return value === undefined ? "unknown" : new Intl.NumberFormat("en-US").format(value)
 }
 
-function sanitizeCell(value: string) {
-  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim()
+function formatMetricCount(value?: number) {
+  return value === undefined ? "" : new Intl.NumberFormat("en-US").format(value)
+}
+
+function escapeMarkdownInline(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim()
+}
+
+function escapeMarkdownTableCell(value: string) {
+  return escapeMarkdownInline(value)
 }
 
 function sanitizeError(error: unknown, cwd?: string) {
@@ -714,15 +805,23 @@ async function main() {
     process.exit(1)
   }
 
+  try {
+    await validateCwd(config.cwd)
+  } catch (error) {
+    console.error(sanitizeError(error, config.cwd))
+    process.exit(1)
+  }
+
   const fileSummary = await collectFileSummary(config.cwd)
   const repoSummary = await collectRepoSummary(config.cwd, fileSummary.fileCount, fileSummary.dirCount)
   const env = await collectEnvironment(config, repoSummary)
-  const scenarios = buildScenarios(config, fileSummary.files, fileSummary.dirs).filter((scenario) =>
-    scenarioMatches(config.scenario, scenario),
-  )
+  const allScenarios = buildScenarios(config, fileSummary.files, fileSummary.dirs)
+  const scenarios = allScenarios.filter((scenario) => scenarioMatches(config.scenario, scenario))
 
   if (scenarios.length === 0) {
     console.error(`No scenario matched: ${config.scenario}`)
+    console.error("Available scenario slugs:")
+    console.error(scenarioSlugList(allScenarios))
     process.exit(1)
   }
 
@@ -733,6 +832,7 @@ async function main() {
 
   console.log(formatMarkdown(env, results))
 
+  if (results.some((result) => result.status === "error")) process.exit(1)
   if (!results.some((result) => result.status === "ok")) process.exit(1)
 }
 

--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -112,7 +112,7 @@ const gitConfig = [
   "core.quotepath=false",
 ] as const
 
-const rgFilesArgs = ["--no-config", "--files", "--hidden", "-0", "--glob=!.git/*", "."] as const
+const rgFilesArgs = ["--no-config", "--files", "--hidden", "--glob=!.git/*", "."] as const
 
 const scenarioQueries = ["session", "worktree", "git", "index", "config"] as const
 
@@ -121,7 +121,7 @@ const usage = `Usage:
 
 Options:
   --cwd <path>           Required repo or workspace path to benchmark
-  --label <name>         Output repo label, defaults to basename(cwd)
+  --label <name>         Output repo label, defaults to redacted
   --iterations <n>       Measured repeat runs, defaults to 7
   --warmups <n>          Warmup runs before repeat measurements, defaults to 2
   --show-path            Print the full cwd path instead of redacting it
@@ -139,27 +139,29 @@ function parseArgs(argv: string[]): BenchConfig {
 
   while (args.length > 0) {
     const arg = args.shift()!
-    switch (arg) {
+    const [flag, inlineValue] = arg.includes("=") ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    switch (flag) {
       case "--help":
         console.log(usage)
         process.exit(0)
       case "--cwd":
-        config.cwd = requiredValue(arg, args)
+        config.cwd = inlineValue ?? requiredValue(flag, args)
         break
       case "--label":
-        config.label = requiredValue(arg, args)
+        config.label = inlineValue ?? requiredValue(flag, args)
         break
       case "--iterations":
-        config.iterations = parsePositiveInteger(arg, requiredValue(arg, args))
+        config.iterations = parsePositiveInteger(flag, inlineValue ?? requiredValue(flag, args))
         break
       case "--warmups":
-        config.warmups = parseNonNegativeInteger(arg, requiredValue(arg, args))
+        config.warmups = parseNonNegativeInteger(flag, inlineValue ?? requiredValue(flag, args))
         break
       case "--show-path":
+        if (inlineValue !== undefined) throw new Error(`${flag} does not accept a value`)
         config.showPath = true
         break
       case "--scenario":
-        config.scenario = requiredValue(arg, args)
+        config.scenario = inlineValue ?? requiredValue(flag, args)
         break
       default:
         throw new Error(`Unknown argument: ${arg}`)
@@ -170,7 +172,7 @@ function parseArgs(argv: string[]): BenchConfig {
   const cwd = path.resolve(config.cwd)
   return {
     cwd,
-    label: config.label ?? path.basename(cwd),
+    label: config.label ?? "redacted",
     iterations: config.iterations ?? 7,
     warmups: config.warmups ?? 2,
     showPath: config.showPath ?? false,
@@ -180,7 +182,7 @@ function parseArgs(argv: string[]): BenchConfig {
 
 function requiredValue(flag: string, args: string[]) {
   const value = args.shift()
-  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`)
+  if (!value) throw new Error(`${flag} requires a value`)
   return value
 }
 
@@ -266,7 +268,7 @@ async function runRgFiles(cwd: string) {
   }
   return {
     ...result,
-    files: splitNul(result.stdout.toString()),
+    files: splitLines(result.stdout.toString()).map(cleanRipgrepPath),
   }
 }
 
@@ -276,6 +278,10 @@ function splitLines(text: string) {
 
 function splitNul(text: string) {
   return text.split("\0").filter(Boolean)
+}
+
+function cleanRipgrepPath(file: string) {
+  return path.normalize(file.replace(/^\.[\\/]/, ""))
 }
 
 function dirListFromFiles(files: string[]) {
@@ -565,7 +571,7 @@ function buildScenarios(config: BenchConfig, fileSummary: FileSummary): Scenario
           resultCount: result.files.length,
           outputBytes: result.stdout.length,
           notes:
-            "CLI floor; system PATH rg; production Ripgrep.Service may add managed binary/env/stream cleanup overhead; benchmark helper timeout/kill is not a Windows process-semantics check",
+            "CLI floor; system PATH rg with production-style files args/path cleanup; production Ripgrep.Service may add managed binary/env/stream cleanup overhead; benchmark helper timeout/kill is not a Windows process-semantics check",
         }
       },
     },
@@ -591,7 +597,7 @@ function buildScenarios(config: BenchConfig, fileSummary: FileSummary): Scenario
           spawnCount: 0,
           resultCount: next.dirs.length,
           outputBytes: 0,
-          notes: "approximation; uses rg file list captured before scenario timing",
+          notes: "approximation; uses production-style cleaned rg file list captured before scenario timing",
         }
       },
     },
@@ -610,7 +616,7 @@ function buildScenarios(config: BenchConfig, fileSummary: FileSummary): Scenario
           spawnCount: 0,
           resultCount,
           outputBytes: 0,
-          notes: "approximation; fixed queries over captured file and dir list",
+          notes: "approximation; fixed queries over captured production-style cleaned file and dir list",
         }
       },
     },
@@ -766,11 +772,11 @@ function formatMarkdown(env: Environment, results: BenchResult[]) {
     `- Dirs: ${escapeMarkdownInline(env.dirs)}`,
     `- Git status: ${escapeMarkdownInline(env.gitStatus)}`,
     `- Command timeout: ${commandTimeoutMs}ms`,
-    "- Setup note: file/repo summary collection runs before scenario timing, so first measured values are not cold-start measurements.",
+    "- Setup note: file/repo summary collection runs before scenario timing, so this is a warm-only baseline, not a cold-start measurement.",
     `- Percentile note: p50/p95 use nearest-rank over repeat runs; with low iteration counts p95 may equal the slowest run.`,
     "- Label note: choose a non-sensitive --label value because it is printed in pasteable output.",
     "",
-    "| Scenario | Layer | First measured | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
+    "| Scenario | Layer | First after setup | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
     "|---|---|---:|---:|---:|---:|---:|---:|---|",
   ]
 

--- a/packages/opencode/script/bench-native-candidates.ts
+++ b/packages/opencode/script/bench-native-candidates.ts
@@ -1,0 +1,739 @@
+#!/usr/bin/env bun
+
+import { Buffer } from "node:buffer"
+import os from "node:os"
+import path from "node:path"
+import { setTimeout as delay } from "node:timers/promises"
+import fuzzysort from "fuzzysort"
+import { Patch } from "../src/patch"
+import { Process } from "../src/util/process"
+
+type BenchConfig = {
+  cwd: string
+  label: string
+  iterations: number
+  warmups: number
+  showPath: boolean
+  scenario?: string
+}
+
+type CommandResult = {
+  code: number
+  stdout: Buffer
+  stderr: Buffer
+  spawnCount: number
+}
+
+type RunMetrics = {
+  durationMs: number
+  spawnCount?: number
+  resultCount?: number
+  outputBytes?: number
+  notes?: string
+}
+
+type ScenarioRun =
+  | { status: "ok"; metrics: RunMetrics }
+  | { status: "skipped"; notes: string }
+  | { status: "error"; error: string }
+
+type Scenario = {
+  name: string
+  group: "file" | "git" | "patch" | "process"
+  run: () => Promise<Omit<RunMetrics, "durationMs">>
+}
+
+type BenchResult = {
+  name: string
+  group: Scenario["group"]
+  status: "ok" | "skipped" | "error"
+  firstRunMs?: number
+  repeatP50Ms?: number
+  repeatP95Ms?: number
+  spawnCount?: number
+  resultCount?: number
+  outputBytes?: number
+  notes?: string
+}
+
+type RepoSummary = {
+  fileCount?: number
+  dirCount?: number
+  gitStatus: "clean" | "dirty" | "unknown"
+}
+
+type Environment = {
+  os: string
+  cpu: string
+  bun: string
+  node: string
+  git: string
+  repo: string
+  path: string
+  files: string
+  dirs: string
+  gitStatus: RepoSummary["gitStatus"]
+}
+
+class SkipScenario extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "SkipScenario"
+  }
+}
+
+const gitConfig = [
+  "--no-optional-locks",
+  "-c",
+  "core.autocrlf=false",
+  "-c",
+  "core.fsmonitor=false",
+  "-c",
+  "core.longpaths=true",
+  "-c",
+  "core.symlinks=true",
+  "-c",
+  "core.quotepath=false",
+] as const
+
+const rgFilesArgs = ["--no-config", "--files", "--hidden", "--glob=!.git/*", "."] as const
+
+const scenarioQueries = ["session", "worktree", "git", "index", "config"] as const
+
+const usage = `Usage:
+  bun --cwd packages/opencode ./script/bench-native-candidates.ts --cwd /path/to/repo [options]
+
+Options:
+  --cwd <path>           Required repo or workspace path to benchmark
+  --label <name>         Output repo label, defaults to basename(cwd)
+  --iterations <n>       Measured repeat runs, defaults to 7
+  --warmups <n>          Warmup runs before repeat measurements, defaults to 2
+  --show-path            Print the full cwd path instead of redacting it
+  --scenario <name>      Run one scenario by exact or slug name
+  --help                 Print this help
+`
+
+function parseArgs(argv: string[]): BenchConfig {
+  const args = [...argv]
+  const config: Partial<BenchConfig> = {
+    iterations: 7,
+    warmups: 2,
+    showPath: false,
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()!
+    switch (arg) {
+      case "--help":
+        console.log(usage)
+        process.exit(0)
+      case "--cwd":
+        config.cwd = requiredValue(arg, args)
+        break
+      case "--label":
+        config.label = requiredValue(arg, args)
+        break
+      case "--iterations":
+        config.iterations = parsePositiveInteger(arg, requiredValue(arg, args))
+        break
+      case "--warmups":
+        config.warmups = parseNonNegativeInteger(arg, requiredValue(arg, args))
+        break
+      case "--show-path":
+        config.showPath = true
+        break
+      case "--scenario":
+        config.scenario = requiredValue(arg, args)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!config.cwd) throw new Error("--cwd is required")
+  const cwd = path.resolve(config.cwd)
+  return {
+    cwd,
+    label: config.label ?? path.basename(cwd),
+    iterations: config.iterations ?? 7,
+    warmups: config.warmups ?? 2,
+    showPath: config.showPath ?? false,
+    scenario: config.scenario,
+  }
+}
+
+function requiredValue(flag: string, args: string[]) {
+  const value = args.shift()
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parsePositiveInteger(flag: string, value: string) {
+  const n = Number.parseInt(value, 10)
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`${flag} must be a positive integer`)
+  return n
+}
+
+function parseNonNegativeInteger(flag: string, value: string) {
+  const n = Number.parseInt(value, 10)
+  if (!Number.isInteger(n) || n < 0) throw new Error(`${flag} must be a non-negative integer`)
+  return n
+}
+
+async function runCommand(cmd: string[], cwd: string): Promise<CommandResult> {
+  if (cmd.length === 0) throw new Error("Command is required")
+  try {
+    const proc = Bun.spawn(cmd, {
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).arrayBuffer(),
+      new Response(proc.stderr).arrayBuffer(),
+    ])
+    return {
+      code,
+      stdout: Buffer.from(stdout),
+      stderr: Buffer.from(stderr),
+      spawnCount: 1,
+    }
+  } catch (error) {
+    throw new Error(sanitizeError(error, cwd))
+  }
+}
+
+async function runGit(args: string[], cwd: string) {
+  return runCommand(["git", ...gitConfig, ...args], cwd)
+}
+
+async function runGitMaybe(args: string[], cwd: string) {
+  try {
+    return await runGit(args, cwd)
+  } catch {
+    return undefined
+  }
+}
+
+async function runRgFiles(cwd: string) {
+  const result = await runCommand(["rg", ...rgFilesArgs], cwd)
+  if (result.code !== 0) {
+    throw new SkipScenario("rg --files is unavailable or failed")
+  }
+  return {
+    ...result,
+    files: splitLines(result.stdout.toString("utf8")),
+  }
+}
+
+function splitLines(text: string) {
+  return text.split(/\r?\n/).filter(Boolean)
+}
+
+function splitNul(text: string) {
+  return text.split("\0").filter(Boolean)
+}
+
+function dirListFromFiles(files: string[]) {
+  const dirs = new Set<string>()
+  for (const file of files) {
+    const parts = file.split(/[\\/]/).filter(Boolean)
+    for (let i = 1; i < parts.length; i++) {
+      dirs.add(`${parts.slice(0, i).join("/")}/`)
+    }
+  }
+  return Array.from(dirs).sort()
+}
+
+function slug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+function scenarioMatches(filter: string | undefined, scenario: Scenario) {
+  if (!filter || filter === "all") return true
+  const wanted = slug(filter)
+  return slug(scenario.name) === wanted || slug(`${scenario.group} ${scenario.name}`) === wanted
+}
+
+async function timed(run: () => Promise<Omit<RunMetrics, "durationMs">>): Promise<ScenarioRun> {
+  const start = performance.now()
+  try {
+    const metrics = await run()
+    return {
+      status: "ok",
+      metrics: {
+        ...metrics,
+        durationMs: performance.now() - start,
+      },
+    }
+  } catch (error) {
+    if (error instanceof SkipScenario) return { status: "skipped", notes: error.message }
+    return { status: "error", error: sanitizeError(error) }
+  }
+}
+
+async function benchScenario(scenario: Scenario, config: BenchConfig): Promise<BenchResult> {
+  const first = await timed(scenario.run)
+  if (first.status === "skipped") {
+    return {
+      name: scenario.name,
+      group: scenario.group,
+      status: "skipped",
+      notes: first.notes,
+    }
+  }
+  if (first.status === "error") {
+    return {
+      name: scenario.name,
+      group: scenario.group,
+      status: "error",
+      notes: first.error,
+    }
+  }
+
+  for (let i = 0; i < config.warmups; i++) {
+    const warmup = await timed(scenario.run)
+    if (warmup.status === "error") {
+      return {
+        name: scenario.name,
+        group: scenario.group,
+        status: "error",
+        notes: `warmup failed: ${warmup.error}`,
+      }
+    }
+  }
+
+  const measured: RunMetrics[] = []
+  for (let i = 0; i < config.iterations; i++) {
+    const run = await timed(scenario.run)
+    if (run.status === "skipped") {
+      return {
+        name: scenario.name,
+        group: scenario.group,
+        status: "skipped",
+        notes: run.notes,
+      }
+    }
+    if (run.status === "error") {
+      return {
+        name: scenario.name,
+        group: scenario.group,
+        status: "error",
+        notes: run.error,
+      }
+    }
+    measured.push(run.metrics)
+  }
+
+  return {
+    name: scenario.name,
+    group: scenario.group,
+    status: "ok",
+    firstRunMs: first.metrics.durationMs,
+    repeatP50Ms: percentile(
+      measured.map((run) => run.durationMs),
+      0.5,
+    ),
+    repeatP95Ms: percentile(
+      measured.map((run) => run.durationMs),
+      0.95,
+    ),
+    spawnCount: first.metrics.spawnCount,
+    resultCount: first.metrics.resultCount,
+    outputBytes: first.metrics.outputBytes,
+    notes: first.metrics.notes,
+  }
+}
+
+function percentile(values: number[], p: number) {
+  if (values.length === 0) return undefined
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.max(0, Math.ceil(sorted.length * p) - 1)
+  return sorted[idx]
+}
+
+function makeSyntheticPatch(hunks: number) {
+  const lines = ["*** Begin Patch", "*** Update File: synthetic.txt"]
+  for (let i = 0; i < hunks; i++) {
+    const line = String(i + 1).padStart(6, "0")
+    lines.push(`@@ line ${line}`)
+    lines.push(` line ${line}`)
+    lines.push(`-old value ${line}`)
+    lines.push(`+new value ${line}`)
+    lines.push(` next line ${line}`)
+  }
+  lines.push("*** End Patch")
+  return lines.join("\n")
+}
+
+function parseStatusCount(stdout: Buffer) {
+  return splitNul(stdout.toString("utf8")).filter((item) => item.slice(3)).length
+}
+
+function parseNameStatusCount(stdout: Buffer) {
+  const parts = splitNul(stdout.toString("utf8"))
+  let count = 0
+  for (let i = 0; i < parts.length; i += 2) {
+    if (parts[i] && parts[i + 1]) count++
+  }
+  return count
+}
+
+function parseNumstat(stdout: Buffer) {
+  let files = 0
+  let additions = 0
+  let deletions = 0
+  for (const item of splitNul(stdout.toString("utf8"))) {
+    const first = item.indexOf("\t")
+    const second = item.indexOf("\t", first + 1)
+    if (first === -1 || second === -1) continue
+    const adds = item.slice(0, first)
+    const dels = item.slice(first + 1, second)
+    files++
+    additions += adds === "-" ? 0 : Number.parseInt(adds || "0", 10) || 0
+    deletions += dels === "-" ? 0 : Number.parseInt(dels || "0", 10) || 0
+  }
+  return { files, additions, deletions }
+}
+
+function parseWorktreeCount(stdout: Buffer) {
+  return splitLines(stdout.toString("utf8")).filter((line) => line.startsWith("worktree ")).length
+}
+
+async function collectFileSummary(cwd: string) {
+  try {
+    const rg = await runRgFiles(cwd)
+    const dirs = dirListFromFiles(rg.files)
+    return {
+      files: rg.files,
+      dirs,
+      fileCount: rg.files.length,
+      dirCount: dirs.length,
+    }
+  } catch {
+    return {
+      files: [] as string[],
+      dirs: [] as string[],
+      fileCount: undefined,
+      dirCount: undefined,
+    }
+  }
+}
+
+async function collectRepoSummary(cwd: string, fileCount?: number, dirCount?: number): Promise<RepoSummary> {
+  const status = await runGitMaybe(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], cwd)
+  return {
+    fileCount,
+    dirCount,
+    gitStatus: status && status.code === 0 ? (parseStatusCount(status.stdout) === 0 ? "clean" : "dirty") : "unknown",
+  }
+}
+
+async function collectEnvironment(config: BenchConfig, summary: RepoSummary): Promise<Environment> {
+  const gitVersion = await runCommand(["git", "--version"], config.cwd)
+    .then((result) => (result.code === 0 ? result.stdout.toString("utf8").trim() : "unknown"))
+    .catch(() => "unknown")
+  const cpu = os.cpus()[0]
+  return {
+    os: `${os.type()} ${os.release()} ${os.arch()}`,
+    cpu: cpu ? `${cpu.model}, ${os.cpus().length} cores` : "unknown",
+    bun: Bun.version,
+    node: process.version,
+    git: gitVersion || "unknown",
+    repo: config.label,
+    path: config.showPath ? config.cwd : "redacted",
+    files: formatCount(summary.fileCount),
+    dirs: formatCount(summary.dirCount),
+    gitStatus: summary.gitStatus,
+  }
+}
+
+function buildScenarios(config: BenchConfig, files: string[], dirs: string[]): Scenario[] {
+  const smallPatch = makeSyntheticPatch(5)
+  const largePatch = makeSyntheticPatch(500)
+
+  return [
+    {
+      name: "file scan: rg --files",
+      group: "file",
+      run: async () => {
+        const result = await runRgFiles(config.cwd)
+        return {
+          spawnCount: result.spawnCount,
+          resultCount: result.files.length,
+          outputBytes: result.stdout.length,
+        }
+      },
+    },
+    {
+      name: "file index approximation: dirs cache",
+      group: "file",
+      run: async () => {
+        if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
+        const next = { files: [] as string[], dirs: [] as string[] }
+        const seen = new Set<string>()
+        for (const file of files) {
+          next.files.push(file)
+          const parts = file.split(/[\\/]/).filter(Boolean)
+          for (let i = 1; i < parts.length; i++) {
+            const dir = `${parts.slice(0, i).join("/")}/`
+            if (seen.has(dir)) continue
+            seen.add(dir)
+            next.dirs.push(dir)
+          }
+        }
+        return {
+          spawnCount: 0,
+          resultCount: next.dirs.length,
+          outputBytes: 0,
+          notes: "approximation; uses rg file list captured before scenario timing",
+        }
+      },
+    },
+    {
+      name: "file fuzzy search approximation",
+      group: "file",
+      run: async () => {
+        if (files.length === 0) throw new SkipScenario("rg --files unavailable during setup")
+        const items = [...files, ...dirs]
+        let resultCount = 0
+        for (const query of scenarioQueries) {
+          resultCount += fuzzysort.go(query, items, { limit: 100 }).length
+        }
+        return {
+          spawnCount: 0,
+          resultCount,
+          outputBytes: 0,
+          notes: "approximation; fixed queries over captured file and dir list",
+        }
+      },
+    },
+    {
+      name: "git status",
+      group: "git",
+      run: async () => {
+        const result = await runGit(
+          ["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."],
+          config.cwd,
+        )
+        if (result.code !== 0) throw new SkipScenario("git status unavailable for this cwd")
+        return {
+          spawnCount: result.spawnCount,
+          resultCount: parseStatusCount(result.stdout),
+          outputBytes: result.stdout.length,
+        }
+      },
+    },
+    {
+      name: "git diff name-status",
+      group: "git",
+      run: async () => {
+        const result = await runGit(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", "HEAD", "--", "."], config.cwd)
+        if (result.code !== 0) throw new SkipScenario("git diff name-status unavailable for this cwd")
+        return {
+          spawnCount: result.spawnCount,
+          resultCount: parseNameStatusCount(result.stdout),
+          outputBytes: result.stdout.length,
+        }
+      },
+    },
+    {
+      name: "git diff numstat",
+      group: "git",
+      run: async () => {
+        const result = await runGit(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", "HEAD", "--", "."], config.cwd)
+        if (result.code !== 0) throw new SkipScenario("git diff numstat unavailable for this cwd")
+        const stats = parseNumstat(result.stdout)
+        return {
+          spawnCount: result.spawnCount,
+          resultCount: stats.files,
+          outputBytes: result.stdout.length,
+          notes: `additions=${stats.additions}; deletions=${stats.deletions}`,
+        }
+      },
+    },
+    {
+      name: "git worktree list parse",
+      group: "git",
+      run: async () => {
+        const result = await runGit(["worktree", "list", "--porcelain"], config.cwd)
+        if (result.code !== 0) throw new SkipScenario("git worktree list unavailable for this cwd")
+        return {
+          spawnCount: result.spawnCount,
+          resultCount: parseWorktreeCount(result.stdout),
+          outputBytes: result.stdout.length,
+        }
+      },
+    },
+    {
+      name: "apply_patch parse small",
+      group: "patch",
+      run: async () => {
+        const parsed = Patch.parsePatch(smallPatch)
+        return {
+          spawnCount: 0,
+          resultCount: parsed.hunks.length,
+          outputBytes: Buffer.byteLength(smallPatch),
+          notes: "synthetic patch; parse only",
+        }
+      },
+    },
+    {
+      name: "apply_patch parse large",
+      group: "patch",
+      run: async () => {
+        const parsed = Patch.parsePatch(largePatch)
+        return {
+          spawnCount: 0,
+          resultCount: parsed.hunks.length,
+          outputBytes: Buffer.byteLength(largePatch),
+          notes: "synthetic patch; parse only",
+        }
+      },
+    },
+    {
+      name: "process spawn noop",
+      group: "process",
+      run: async () => {
+        const result = await Process.run([process.execPath, "-e", "0"], { nothrow: true })
+        return {
+          spawnCount: 1,
+          resultCount: result.code,
+          outputBytes: result.stdout.length + result.stderr.length,
+          notes: `exitCode=${result.code}`,
+        }
+      },
+    },
+    {
+      name: "process timeout abort",
+      group: "process",
+      run: async () => {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), 50)
+        try {
+          const result = await Process.run([process.execPath, "-e", "setTimeout(() => {}, 5000)"], {
+            abort: controller.signal,
+            nothrow: true,
+            timeout: 50,
+          })
+          return {
+            spawnCount: 1,
+            resultCount: result.code,
+            outputBytes: result.stdout.length + result.stderr.length,
+            notes: `exitCode=${result.code}`,
+          }
+        } finally {
+          clearTimeout(timer)
+          await delay(0)
+        }
+      },
+    },
+  ]
+}
+
+function formatMarkdown(env: Environment, results: BenchResult[]) {
+  const lines = [
+    `## Native-core baseline - ${new Date().toISOString().slice(0, 10)}`,
+    "",
+    "Environment:",
+    `- OS: ${env.os}`,
+    `- CPU: ${env.cpu}`,
+    `- Bun: ${env.bun}`,
+    `- Node: ${env.node}`,
+    `- Git: ${env.git}`,
+    `- Repo: ${env.repo}`,
+    `- Path: ${env.path}`,
+    `- Files: ${env.files}`,
+    `- Dirs: ${env.dirs}`,
+    `- Git status: ${env.gitStatus}`,
+    "",
+    "| Scenario | First run | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |",
+    "|---|---:|---:|---:|---:|---:|---:|---|",
+  ]
+
+  for (const result of results) {
+    lines.push(
+      [
+        result.name,
+        result.status === "ok" ? formatMs(result.firstRunMs) : result.status,
+        result.status === "ok" ? formatMs(result.repeatP50Ms) : result.status,
+        result.status === "ok" ? formatMs(result.repeatP95Ms) : result.status,
+        result.status === "ok" ? formatCount(result.spawnCount) : "",
+        result.status === "ok" ? formatCount(result.resultCount) : "",
+        result.status === "ok" ? formatCount(result.outputBytes) : "",
+        sanitizeCell(result.notes ?? ""),
+      ]
+        .map((cell) => ` ${cell} `)
+        .join("|")
+        .replace(/^/, "|")
+        .replace(/$/, "|"),
+    )
+  }
+
+  return lines.join("\n")
+}
+
+function formatMs(ms?: number) {
+  if (ms === undefined) return "n/a"
+  if (ms < 10) return `${ms.toFixed(2)}ms`
+  if (ms < 100) return `${ms.toFixed(1)}ms`
+  return `${Math.round(ms)}ms`
+}
+
+function formatCount(value?: number) {
+  return value === undefined ? "unknown" : new Intl.NumberFormat("en-US").format(value)
+}
+
+function sanitizeCell(value: string) {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim()
+}
+
+function sanitizeError(error: unknown, cwd?: string) {
+  const raw = error instanceof Error ? error.message : String(error)
+  let text = raw.replace(/\s+/g, " ").trim()
+  if (cwd) text = text.split(cwd).join("[cwd]")
+  text = text.split(os.homedir()).join("[home]")
+  if (text.length > 180) text = `${text.slice(0, 177)}...`
+  return text || "unknown error"
+}
+
+async function main() {
+  let config: BenchConfig
+  try {
+    config = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(sanitizeError(error))
+    console.error("")
+    console.error(usage)
+    process.exit(1)
+  }
+
+  const fileSummary = await collectFileSummary(config.cwd)
+  const repoSummary = await collectRepoSummary(config.cwd, fileSummary.fileCount, fileSummary.dirCount)
+  const env = await collectEnvironment(config, repoSummary)
+  const scenarios = buildScenarios(config, fileSummary.files, fileSummary.dirs).filter((scenario) =>
+    scenarioMatches(config.scenario, scenario),
+  )
+
+  if (scenarios.length === 0) {
+    console.error(`No scenario matched: ${config.scenario}`)
+    process.exit(1)
+  }
+
+  const results: BenchResult[] = []
+  for (const scenario of scenarios) {
+    results.push(await benchScenario(scenario, config))
+  }
+
+  console.log(formatMarkdown(env, results))
+
+  if (!results.some((result) => result.status === "ok")) process.exit(1)
+}
+
+await main()


### PR DESCRIPTION
## Summary

Added a local-only native-core candidate benchmark script for #443:

- `packages/opencode/script/bench-native-candidates.ts`

The script prints privacy-safe Markdown baseline output for:

- file scan, file index approximation, and fuzzy search approximation
- Git status, diff name-status, diff numstat, and worktree list parsing
- `apply_patch` parse-only small and large synthetic patches
- process spawn noop and single-child abort basics

No Rust/native code, native package, JSON output, CI hook, package metadata change, or production behavior change is introduced.

## Why

#443 asks for evidence before deciding whether any bottom-of-stack workflow is worth a native/Rust spike. This PR adds the smallest manual benchmark harness needed to collect baseline numbers from the current TypeScript / Bun / Node / CLI paths.

The output labels each scenario as `production path`, `production path: parse-only`, `CLI floor`, or `approximation`. Only full production-path measurements should be treated as native/no-native decision evidence without further validation.

## Related Issue

Part of #443.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether the benchmark stays local-only and privacy-safe, whether the measured scenarios match the first Phase 0 scope, and whether the decision guard makes the current limitations clear enough for follow-up decisions.

## Risk Notes

Low. This is a manual script only. It does not run in CI, does not change runtime behavior, does not upload telemetry, and does not print file names, file contents, raw diffs, raw grep matches, prompt text, session messages, provider URLs, tokens, or API keys.

Known scope limits:

- file scan and Git scenarios are labeled `CLI floor`, not full service-path measurements
- file index and fuzzy search scenarios are labeled `approximation`
- `apply_patch` scenarios are labeled `production path: parse-only`; they do not cover verify/preview/content replacement
- process abort is single-child abort only; process-tree termination is left for a separate follow-up
- summary collection runs before scenario timing, so this is a warm-only baseline, not a cold-start benchmark

Deferred from this PR:

- service-path `File.Service`, `Git.Service`, and `Worktree` benchmarks
- controlled worktree create/remove/reset fixtures
- `apply_patch` verify/preview fixture
- process-tree and Windows `taskkill /t` fixture
- streaming output counting for very large repos
- CPU/RSS/heap/event-loop metrics
- splitting the single file into a full benchmark framework

## How To Verify

```text
Typecheck: bun turbo typecheck -> 8 successful, 8 total
Benchmark: bun --cwd packages/opencode ./script/bench-native-candidates.ts --cwd /path/to/repo --label pawwork-monorepo --scenario all --iterations 1 --warmups 0 -> locally verified exit 0 and printed pasteable Markdown
Default privacy check: running without --label prints Repo: redacted and Path: redacted
Empty repo check: file index approximation over an empty git repo -> exit 0, Files: 0, Dirs: 0
Scenario error check: unmatched --scenario exits 1 and lists available slugs
Diff check: git diff --check -- packages/opencode/script/bench-native-candidates.ts -> no whitespace errors
```

## Benchmark output

```markdown
## Native-core baseline - 2026-05-05

Environment:
- OS: Darwin 25.3.0 arm64
- CPU: Apple M5, 10 cores
- Bun: 1.3.13
- Node: v24.3.0
- Git: git version 2.50.1 \(Apple Git-155\)
- Ripgrep: ripgrep 15.1.0; source=system PATH
- Repo: pawwork-monorepo
- Path: redacted
- Files: 3,034
- Dirs: 265
- Git status: dirty
- Command timeout: 30000ms
- Setup note: file/repo summary collection runs before scenario timing, so this is a warm-only baseline, not a cold-start measurement.
- Percentile note: p50/p95 use nearest-rank over repeat runs; with low iteration counts p95 may equal the slowest run.
- Label note: choose a non-sensitive --label value because it is printed in pasteable output.

| Scenario | Layer | First after setup | Repeat p50 | Repeat p95 | Spawn count | Result count | Output bytes | Notes |
|---|---|---:|---:|---:|---:|---:|---:|---|
| file scan: rg --files | CLI floor | 14.9ms | 12.1ms | 12.1ms | 1 | 3,034 | 157,616 | CLI floor; system PATH rg with production-style files args/path cleanup; production Ripgrep.Service may add managed binary/env/stream cleanup overhead; benchmark helper timeout/kill is not a Windows process-semantics check |
| file index approximation: dirs cache | approximation | 2.54ms | 3.12ms | 3.12ms | 0 | 265 | 0 | approximation; uses production-style cleaned rg file list captured before scenario timing |
| file fuzzy search approximation | approximation | 18.7ms | 3.95ms | 3.95ms | 0 | 429 | 0 | approximation; fixed queries over captured production-style cleaned file and dir list |
| git status | CLI floor | 37.9ms | 33.8ms | 33.8ms | 1 | 3 | 199 | CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check |
| git diff name-status | CLI floor | 22.8ms | 20.1ms | 20.1ms | 1 | 2 | 106 | CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check |
| git diff numstat | CLI floor | 29.8ms | 46.6ms | 46.6ms | 1 | 2 | 112 | CLI floor; mirrors Git args but bypasses Git.Service spawner wrapper; benchmark helper timeout/kill is not a Windows process-semantics check; additions=23; deletions=17 |
| git worktree list parse | CLI floor | 36.5ms | 18.9ms | 18.9ms | 1 | 5 | 739 | CLI floor; parses porcelain output without Worktree service orchestration, registry, cleanup, reset, or Windows retry behavior |
| apply_patch parse small | production path: parse-only | 0.41ms | 0.02ms | 0.02ms | 0 | 1 | 470 | synthetic patch; parse only; not a verify/preview/content replacement benchmark |
| apply_patch parse large | production path: parse-only | 0.80ms | 0.49ms | 0.49ms | 0 | 1 | 41,060 | synthetic patch; parse only; 500 update chunks in one file hunk; not a verify/preview/content replacement benchmark |
| process spawn noop | production path | 12.8ms | 11.9ms | 11.9ms | 1 |  | 0 | exitCode=0 |
| process abort single-child | production path | 77.8ms | 81.9ms | 81.9ms | 1 |  | 0 | single-process abort only; no process-tree fixture in first PR; exitCode=1 |

Decision guard:
- `production path` rows can support implementation decisions for the measured path.
- `production path: parse-only` rows cover only parsing and do not cover verification, preview diff, file reads, BOM handling, or write behavior.
- `CLI floor` rows are lower-bound command measurements and bypass service wrappers, managed tool selection, registry/orchestration, and some cross-platform cleanup behavior.
- `approximation` rows mimic current logic over captured inputs and should not be used alone for native/no-native decisions.
- Missing from this first PR: service-path File/Git/Worktree benchmarks, apply_patch verify/preview, process-tree termination, Windows results, large synthetic fixtures, CPU/RSS/heap/event-loop metrics.
```

## Decision rule from #443

| Result | Decision |
|---|---|
| Current path is under 50ms | Do not native-ize now. |
| 50-200ms but not frequently triggered | Prefer TypeScript cleanup, caching, or fewer calls first. |
| Over 200ms and frequently user-triggered | Consider a scoped native spike. |
| Over 500ms in common large-repo flows | Prioritize a scoped native spike. |
| Bottleneck is mostly `git` or `rg` itself | A Rust wrapper likely helps less; first reduce call count, parsing work, or cache misses. |
| Main issue is correctness or cross-platform process semantics | Native/Rust can still be considered, but the justification is reliability, not speed. |

## Screenshots or Recordings

Not applicable. This PR has no visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
