### PR TITLE
fix: scope worktree guard to current message

### DIFF
--- a/packages/opencode/src/session/state-machine-guard.ts
+++ b/packages/opencode/src/session/state-machine-guard.ts
@@ -1,24 +1,27 @@
 import { Effect } from "effect"
 import * as Session from "./session"
 import * as SubagentRun from "./subagent-run"
-import type { SessionID } from "./schema"
+import type { MessageID, SessionID } from "./schema"
 
 /**
- * Returns true when this session has a tool part in pending or running state whose callID differs
- * from `exceptCallID`. Used by EnterWorktree / ExitWorktree to refuse a transition while another
- * tool call is unresolved (the calling tool's own callID is excluded so the tool can introspect
- * itself).
+ * Returns true when the current assistant message has a tool part in pending or running state whose
+ * callID differs from `exceptCallID`. Used by EnterWorktree / ExitWorktree to refuse a transition
+ * while another tool call in the same turn is unresolved (the calling tool's own callID is excluded
+ * so the tool can introspect itself). Historical transcript state is not live tool liveness.
  */
 export const hasInFlightToolCallsExcept = (
   sessions: Session.Service["Service"],
   sessionID: SessionID,
+  messageID: MessageID,
   exceptCallID: string,
 ) =>
   Effect.gen(function* () {
     const messages = yield* sessions.messages({ sessionID })
     for (const m of messages) {
+      if (m.info.id !== messageID) continue
       for (const part of m.parts) {
         if (part.type !== "tool") continue
+        if (part.messageID !== messageID) continue
         if (part.callID === exceptCallID) continue
         if (part.state.status === "running" || part.state.status === "pending") return true
       }

--- a/packages/opencode/src/session/state-machine-guard.ts
+++ b/packages/opencode/src/session/state-machine-guard.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import * as Session from "./session"
 import * as SubagentRun from "./subagent-run"
 import type { MessageID, SessionID } from "./schema"
@@ -16,15 +16,13 @@ export const hasInFlightToolCallsExcept = (
   exceptCallID: string,
 ) =>
   Effect.gen(function* () {
-    const messages = yield* sessions.messages({ sessionID })
-    for (const m of messages) {
-      if (m.info.id !== messageID) continue
-      for (const part of m.parts) {
-        if (part.type !== "tool") continue
-        if (part.messageID !== messageID) continue
-        if (part.callID === exceptCallID) continue
-        if (part.state.status === "running" || part.state.status === "pending") return true
-      }
+    const message = yield* sessions.findMessage(sessionID, (m) => m.info.id === messageID)
+    if (Option.isNone(message)) return false
+    for (const part of message.value.parts) {
+      if (part.type !== "tool") continue
+      if (part.messageID !== messageID) continue
+      if (part.callID === exceptCallID) continue
+      if (part.state.status === "running" || part.state.status === "pending") return true
     }
     return false
   })

--- a/packages/opencode/src/tool/enter-worktree.ts
+++ b/packages/opencode/src/tool/enter-worktree.ts
@@ -33,10 +33,10 @@ export const EnterWorktreeTool = Tool.define(
     const subagents = yield* SubagentRun.Service
     const spawner = yield* ChildProcessSpawner
 
-    const guard = (sessionID: SessionID, callID: string | undefined) =>
+    const guard = (sessionID: SessionID, messageID: Tool.Context["messageID"], callID: string | undefined) =>
       Effect.gen(function* () {
         if (callID) {
-          const inFlight = yield* hasInFlightToolCallsExcept(sessions, sessionID, callID)
+          const inFlight = yield* hasInFlightToolCallsExcept(sessions, sessionID, messageID, callID)
           if (inFlight) {
             return yield* Effect.fail(
               new Error("Cannot enter a worktree while another tool call is running in this session."),
@@ -93,7 +93,7 @@ export const EnterWorktreeTool = Tool.define(
           return yield* Effect.fail(new Error(`name max ${MAX_SLUG_LEN} chars`))
         }
 
-        yield* guard(ctx.sessionID, ctx.callID)
+        yield* guard(ctx.sessionID, ctx.messageID, ctx.callID)
 
         const project = Instance.project
         if (project.vcs !== "git") {

--- a/packages/opencode/src/tool/exit-worktree.ts
+++ b/packages/opencode/src/tool/exit-worktree.ts
@@ -17,7 +17,7 @@ export const ExitWorktreeTool = Tool.define(
     const run = (_params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
       Effect.gen(function* () {
         if (ctx.callID) {
-          const inFlight = yield* hasInFlightToolCallsExcept(sessions, ctx.sessionID, ctx.callID)
+          const inFlight = yield* hasInFlightToolCallsExcept(sessions, ctx.sessionID, ctx.messageID, ctx.callID)
           if (inFlight) {
             return yield* Effect.fail(
               new Error("Cannot exit a worktree while another tool call is running in this session."),

--- a/packages/opencode/test/session/state-machine-guard.test.ts
+++ b/packages/opencode/test/session/state-machine-guard.test.ts
@@ -2,23 +2,36 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { testEffect } from "../lib/effect"
 import type { Session } from "../../src/session"
-import type { SessionID } from "../../src/session/schema"
+import { MessageID, type SessionID } from "../../src/session/schema"
 import type { SubagentRun } from "../../src/session/subagent-run"
 import { hasInFlightToolCallsExcept, hasRunningSubagents } from "../../src/session/state-machine-guard"
 
 const sessionID = "session_test" as SessionID
+const currentMessageID = MessageID.ascending()
+const historicalMessageID = MessageID.ascending()
 const it = testEffect(Layer.empty)
 
-function sessionsWithParts(parts: unknown[]): Session.Service["Service"] {
+function sessionsWithMessages(messages: Array<{ id: string; parts: unknown[] }>): Session.Service["Service"] {
   return {
-    messages: () => Effect.succeed([{ parts }]),
+    messages: () =>
+      Effect.succeed(
+        messages.map((message) => ({
+          info: { id: message.id },
+          parts: message.parts,
+        })),
+      ),
   } as unknown as Session.Service["Service"]
+}
+
+function sessionsWithCurrentParts(parts: unknown[]): Session.Service["Service"] {
+  return sessionsWithMessages([{ id: currentMessageID, parts }])
 }
 
 function toolPart(callID: string, status: string) {
   return {
     type: "tool",
     tool: "bash",
+    messageID: currentMessageID,
     callID,
     state: { status },
   }
@@ -33,13 +46,13 @@ function subagents(active: boolean): SubagentRun.Service["Service"] {
 describe("state-machine guard", () => {
   it.live("detects pending and running tool calls except the current call", () =>
     Effect.gen(function* () {
-      const sessions = sessionsWithParts([
+      const sessions = sessionsWithCurrentParts([
         toolPart("current", "running"),
         toolPart("other-pending", "pending"),
         toolPart("other-running", "running"),
       ])
 
-      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, "current")
+      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, currentMessageID, "current")
 
       expect(blocked).toBe(true)
     }),
@@ -47,9 +60,9 @@ describe("state-machine guard", () => {
 
   it.live("detects pending tool calls except the current call", () =>
     Effect.gen(function* () {
-      const sessions = sessionsWithParts([toolPart("current", "running"), toolPart("other-pending", "pending")])
+      const sessions = sessionsWithCurrentParts([toolPart("current", "running"), toolPart("other-pending", "pending")])
 
-      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, "current")
+      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, currentMessageID, "current")
 
       expect(blocked).toBe(true)
     }),
@@ -57,9 +70,9 @@ describe("state-machine guard", () => {
 
   it.live("detects running tool calls except the current call", () =>
     Effect.gen(function* () {
-      const sessions = sessionsWithParts([toolPart("current", "running"), toolPart("other-running", "running")])
+      const sessions = sessionsWithCurrentParts([toolPart("current", "running"), toolPart("other-running", "running")])
 
-      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, "current")
+      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, currentMessageID, "current")
 
       expect(blocked).toBe(true)
     }),
@@ -67,14 +80,36 @@ describe("state-machine guard", () => {
 
   it.live("ignores the current call and finished tool calls", () =>
     Effect.gen(function* () {
-      const sessions = sessionsWithParts([
+      const sessions = sessionsWithCurrentParts([
         toolPart("current", "running"),
         toolPart("done", "completed"),
         toolPart("failed", "error"),
         { type: "text", text: "not a tool" },
       ])
 
-      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, "current")
+      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, currentMessageID, "current")
+
+      expect(blocked).toBe(false)
+    }),
+  )
+
+  it.live("ignores stale pending and running tool calls from historical messages", () =>
+    Effect.gen(function* () {
+      const sessions = sessionsWithMessages([
+        {
+          id: historicalMessageID,
+          parts: [
+            { ...toolPart("historical-pending", "pending"), messageID: historicalMessageID },
+            { ...toolPart("historical-running", "running"), messageID: historicalMessageID },
+          ],
+        },
+        {
+          id: currentMessageID,
+          parts: [toolPart("current", "running"), toolPart("done", "completed")],
+        },
+      ])
+
+      const blocked = yield* hasInFlightToolCallsExcept(sessions, sessionID, currentMessageID, "current")
 
       expect(blocked).toBe(false)
     }),

--- a/packages/opencode/test/session/state-machine-guard.test.ts
+++ b/packages/opencode/test/session/state-machine-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Option } from "effect"
 import { testEffect } from "../lib/effect"
 import type { Session } from "../../src/session"
 import { MessageID, type SessionID } from "../../src/session/schema"
@@ -12,14 +12,16 @@ const historicalMessageID = MessageID.ascending()
 const it = testEffect(Layer.empty)
 
 function sessionsWithMessages(messages: Array<{ id: string; parts: unknown[] }>): Session.Service["Service"] {
+  const items = messages.map((message) => ({
+    info: { id: message.id },
+    parts: message.parts,
+  }))
   return {
-    messages: () =>
-      Effect.succeed(
-        messages.map((message) => ({
-          info: { id: message.id },
-          parts: message.parts,
-        })),
-      ),
+    messages: () => Effect.succeed(items),
+    findMessage: (_sessionID: SessionID, predicate: (msg: (typeof items)[number]) => boolean) => {
+      const match = items.find(predicate)
+      return Effect.succeed(match ? Option.some(match) : Option.none())
+    },
   } as unknown as Session.Service["Service"]
 }
 

--- a/packages/opencode/test/tool/enter-worktree.test.ts
+++ b/packages/opencode/test/tool/enter-worktree.test.ts
@@ -3,12 +3,14 @@ import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Cause, Effect, Exit, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { Session } from "../../src/session"
-import { MessageID } from "../../src/session/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID } from "../../src/session/schema"
 import { SubagentRun } from "../../src/session/subagent-run"
 import { EnterWorktreeTool } from "../../src/tool/enter-worktree"
 import { ExitWorktreeTool } from "../../src/tool/exit-worktree"
 import type { Context } from "../../src/tool/tool"
 import { Truncate } from "../../src/tool/truncate"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -22,18 +24,74 @@ const it = testEffect(
   ),
 )
 
-function toolContext(sessionID: Session.Info["id"]): Context {
+function toolContext(
+  sessionID: Session.Info["id"],
+  input?: { messageID?: MessageID; callID?: string },
+): Context {
   return {
     sessionID,
-    messageID: MessageID.ascending(),
+    messageID: input?.messageID ?? MessageID.ascending(),
     agent: "build",
     abort: new AbortController().signal,
-    callID: "call_test",
+    callID: input?.callID ?? "call_test",
     extra: {},
     messages: [],
     metadata: () => Effect.void,
     ask: () => Effect.void,
   }
+}
+
+const model = {
+  providerID: ProviderID.openai,
+  modelID: ModelID.make("test-model"),
+}
+
+const tokens = {
+  total: 0,
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cache: { read: 0, write: 0 },
+}
+
+function addAssistantToolPart(input: {
+  sessions: Session.Service["Service"]
+  sessionID: Session.Info["id"]
+  messageID: MessageID
+  root: string
+  callID: string
+  status: "pending" | "running"
+}) {
+  return Effect.gen(function* () {
+    const message: MessageV2.Assistant = {
+      id: input.messageID,
+      role: "assistant",
+      sessionID: input.sessionID,
+      parentID: MessageID.ascending(),
+      modelID: model.modelID,
+      providerID: model.providerID,
+      mode: "build",
+      agent: "build",
+      path: { cwd: input.root, root: input.root },
+      cost: 0,
+      tokens,
+      time: { created: Date.now(), completed: Date.now() },
+      finish: "tool-calls",
+    }
+    yield* input.sessions.updateMessage(message)
+    yield* input.sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: input.messageID,
+      sessionID: input.sessionID,
+      type: "tool",
+      tool: "bash",
+      callID: input.callID,
+      state:
+        input.status === "running"
+          ? { status: "running", input: { cmd: "pwd" }, time: { start: Date.now() } }
+          : { status: "pending", input: { cmd: "pwd" }, raw: "" },
+    })
+  })
 }
 
 it.live("enter-worktree rejects relative path inputs", () =>
@@ -99,6 +157,74 @@ it.live("enter-worktree and exit-worktree update the session execution context",
         yield* enter.execute({ path: activeDirectory }, toolContext(session.id))
         const pathExit = yield* exit.execute({}, toolContext(session.id))
         expect(pathExit.metadata.previousSource).toBe("created")
+      }),
+    { git: true },
+  ),
+)
+
+it.live("exit-worktree ignores stale historical running tool parts", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "stale-historical-tool" })
+        const enterTool = yield* EnterWorktreeTool
+        const exitTool = yield* ExitWorktreeTool
+        const enter = yield* enterTool.init()
+        const exit = yield* exitTool.init()
+
+        const entered = yield* enter.execute({ name: "stale-tool" }, toolContext(session.id))
+        yield* addAssistantToolPart({
+          sessions,
+          sessionID: session.id,
+          messageID: MessageID.ascending(),
+          root: dir,
+          callID: "call_historical_running",
+          status: "running",
+        })
+
+        const result = yield* exit.execute({}, toolContext(session.id, { messageID: MessageID.ascending() }))
+
+        expect(result.title).toBe("Exited worktree")
+        expect(result.metadata.activeDirectory).toBe(dir)
+        expect(result.metadata.previousDirectory).toBe(entered.metadata.activeDirectory)
+      }),
+    { git: true },
+  ),
+)
+
+it.live("exit-worktree rejects unresolved tool parts in the current assistant message", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({ title: "current-tool-running" })
+        const enterTool = yield* EnterWorktreeTool
+        const exitTool = yield* ExitWorktreeTool
+        const enter = yield* enterTool.init()
+        const exit = yield* exitTool.init()
+
+        yield* enter.execute({ name: "current-tool" }, toolContext(session.id))
+        const currentMessageID = MessageID.ascending()
+        yield* addAssistantToolPart({
+          sessions,
+          sessionID: session.id,
+          messageID: currentMessageID,
+          root: dir,
+          callID: "call_other_running",
+          status: "running",
+        })
+
+        const result = yield* exit
+          .execute({}, toolContext(session.id, { messageID: currentMessageID, callID: "call_exit" }))
+          .pipe(Effect.exit)
+
+        expect(Exit.isFailure(result)).toBe(true)
+        if (Exit.isFailure(result)) {
+          expect(Cause.pretty(result.cause)).toContain(
+            "Cannot exit a worktree while another tool call is running in this session.",
+          )
+        }
       }),
     { git: true },
   ),


### PR DESCRIPTION
## Summary

Scope the worktree transition guard to the current assistant message instead of scanning the full historical transcript.

## Why

Fixes #418. `EnterWorktree` and `ExitWorktree` used persisted transcript `pending` / `running` tool parts as live tool liveness. A stale historical tool part could therefore permanently block exiting a worktree even when no real tool process was active.

## Related Issue

Fixes #418

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the guard boundary: historical unresolved tool parts should no longer block enter/exit, while another unresolved tool part in the same assistant message and running subagents still block transitions.

## Risk Notes

Low. No schema, migration, SDK, UI, bash exit-code, or worktree creation behavior changes. The main behavioral assumption is that cross-turn live concurrency is still enforced by the existing session run-state layer; this PR only preserves same-message parallel tool protection.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in this fresh worktree
Red test: bun --cwd packages/opencode test test/session/state-machine-guard.test.ts failed before implementation on current-message/historical-boundary assertions
Focused guard tests: bun --cwd packages/opencode test test/session/state-machine-guard.test.ts, 6 pass / 0 fail
Focused worktree tests: bun --cwd packages/opencode test test/tool/enter-worktree.test.ts, 4 pass / 0 fail
Typecheck: bun run --cwd packages/opencode typecheck, ok
Diff check: git diff --check, ok
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
