### PR TITLE
feat: add structured tool failure reasons

### DIFF
--- a/packages/opencode/src/session/diagnostics.ts
+++ b/packages/opencode/src/session/diagnostics.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import type { MessageV2 } from "./message-v2"
 import type { MessageID, SessionID } from "./schema"
+import type { ToolFailureMetadata } from "./tool-failure"
 
 export namespace SessionDiagnostics {
   const NON_SEMANTIC_KEYS = new Set(["requestid", "request_id", "traceid", "trace_id", "nonce"])
@@ -103,6 +104,7 @@ export namespace SessionDiagnostics {
   export type Metadata = {
     diagnostics?: {
       loop?: LoopMetadata
+      failure?: ToolFailureMetadata
     }
   }
 

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -23,6 +23,7 @@ import { Config } from "../config"
 import { ConfigVariable } from "../config/variable"
 import { isRecord } from "@/util/record"
 import { Glob } from "@/util/glob"
+import { safeToolFailureMetadata } from "./tool-failure"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -523,6 +524,19 @@ export namespace Export {
     return Object.keys(value).length ? { redacted: `${kind}:${id}` } : value
   }
 
+  function toolStateMetadata(kind: string, id: string, value: Record<string, unknown> | undefined) {
+    if (!value) return value
+    const redacted = dataField(kind, id, value)
+    const failure = safeToolFailureMetadata((value.diagnostics as Record<string, unknown> | undefined)?.failure)
+    if (!failure) return redacted
+    return {
+      ...(redacted ?? {}),
+      diagnostics: {
+        failure,
+      },
+    }
+  }
+
   function dataValue(kind: string, id: string, value: unknown) {
     if (value === undefined || value === null) return value
     if (typeof value === "string") return redact(kind, id, value)
@@ -651,7 +665,7 @@ export namespace Export {
                 ...part.state,
                 input: dataField("tool-input", part.id, part.state.input) ?? part.state.input,
                 title: part.state.title === undefined ? undefined : redact("tool-title", part.id, part.state.title),
-                metadata: dataField("tool-state-metadata", part.id, part.state.metadata),
+                metadata: toolStateMetadata("tool-state-metadata", part.id, part.state.metadata),
               },
             }
           case "completed":
@@ -663,7 +677,7 @@ export namespace Export {
                 input: dataField("tool-input", part.id, part.state.input) ?? part.state.input,
                 output: redact("tool-output", part.id, part.state.output),
                 title: redact("tool-title", part.id, part.state.title),
-                metadata: dataField("tool-state-metadata", part.id, part.state.metadata) ?? part.state.metadata,
+                metadata: toolStateMetadata("tool-state-metadata", part.id, part.state.metadata) ?? part.state.metadata,
                 attachments: part.state.attachments?.map(filepart),
               },
             }
@@ -675,7 +689,7 @@ export namespace Export {
                 ...part.state,
                 input: dataField("tool-input", part.id, part.state.input) ?? part.state.input,
                 error: redact("tool-error", part.id, part.state.error),
-                metadata: dataField("tool-state-metadata", part.id, part.state.metadata) ?? part.state.metadata,
+                metadata: toolStateMetadata("tool-state-metadata", part.id, part.state.metadata) ?? part.state.metadata,
               },
             }
         }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -11,6 +11,7 @@ import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import { ProviderError } from "@/provider"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
+import { formatToolFailureForModel } from "./tool-failure"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
@@ -844,7 +845,10 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 state: "output-error",
                 toolCallId: part.callID,
                 input: part.state.input,
-                errorText: part.state.error,
+                errorText: formatToolFailureForModel(
+                  part.state.error,
+                  part.state.metadata?.diagnostics?.failure,
+                ),
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
                 ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
               })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -15,6 +15,7 @@ import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
 import { SessionDiagnostics } from "./diagnostics"
+import { classifyToolFailure } from "./tool-failure"
 import type { Provider } from "@/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
@@ -556,7 +557,10 @@ export const layer: Layer.Layer<
             input: match.part.state.input,
             error: errorMessage(error),
             metadata: SessionDiagnostics.mergeMetadata(toolStateMetadata(match.part), {
-              diagnostics,
+              diagnostics: {
+                ...(diagnostics ?? {}),
+                failure: classifyToolFailure({ tool: match.part.tool, error }),
+              },
               ...(questionInterrupted ? { interrupted: true } : {}),
             }),
             time: { start: match.part.state.time.start, end: Date.now() },

--- a/packages/opencode/src/session/tool-failure.ts
+++ b/packages/opencode/src/session/tool-failure.ts
@@ -30,8 +30,8 @@ export type ToolFailureMetadata = {
 
 const KIND_SET = new Set<ToolFailureKind>(TOOL_FAILURE_KINDS)
 
-function object(value: unknown): Record<string, any> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, any>) : undefined
+function object(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
 }
 
 function stringField(value: unknown, key: string) {
@@ -71,6 +71,10 @@ function canonical(errorKind: ToolFailureKind): ToolFailureMetadata {
     errorKind,
     recoveryHint: TOOL_FAILURE_HINTS[errorKind],
   }
+}
+
+function isToolFailureKind(value: unknown): value is ToolFailureKind {
+  return typeof value === "string" && KIND_SET.has(value as ToolFailureKind)
 }
 
 export function classifyToolFailure(input: { tool: string; error: unknown }): ToolFailureMetadata {
@@ -162,8 +166,8 @@ export function classifyToolFailure(input: { tool: string; error: unknown }): To
 
 export function safeToolFailureMetadata(value: unknown): ToolFailureMetadata | undefined {
   const failure = object(value)
-  const errorKind = failure?.errorKind
-  if (!KIND_SET.has(errorKind)) return undefined
+  const errorKind = typeof failure?.errorKind === "string" ? failure.errorKind : undefined
+  if (!isToolFailureKind(errorKind)) return undefined
   return canonical(errorKind)
 }
 

--- a/packages/opencode/src/session/tool-failure.ts
+++ b/packages/opencode/src/session/tool-failure.ts
@@ -1,0 +1,174 @@
+import { Permission } from "@/permission"
+import { Question } from "@/question"
+
+export const TOOL_FAILURE_KINDS = [
+  "invalid_arguments",
+  "permission_denied",
+  "environment",
+  "provider",
+  "timeout",
+  "user_aborted",
+  "unknown",
+] as const
+
+export type ToolFailureKind = (typeof TOOL_FAILURE_KINDS)[number]
+
+export const TOOL_FAILURE_HINTS: Record<ToolFailureKind, string> = {
+  invalid_arguments: "Fix the tool arguments to match the schema before retrying.",
+  permission_denied: "Do not retry the same blocked call; ask the user or choose an allowed safer action.",
+  environment: "Check the path, working directory, command availability, or local setup before retrying.",
+  provider: "Treat this as an external provider or API failure; retry later or report the provider issue.",
+  timeout: "Narrow the operation or increase the timeout only when appropriate.",
+  user_aborted: "Stop this action; do not continue canceled work unless the user asks.",
+  unknown: "Identify the failure layer before retrying.",
+}
+
+export type ToolFailureMetadata = {
+  errorKind: ToolFailureKind
+  recoveryHint: string
+}
+
+const KIND_SET = new Set<ToolFailureKind>(TOOL_FAILURE_KINDS)
+
+function object(value: unknown): Record<string, any> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, any>) : undefined
+}
+
+function stringField(value: unknown, key: string) {
+  const obj = object(value)
+  const field = obj?.[key]
+  return typeof field === "string" ? field : undefined
+}
+
+function numberField(value: unknown, key: string) {
+  const obj = object(value)
+  const field = obj?.[key]
+  return typeof field === "number" ? field : undefined
+}
+
+function booleanField(value: unknown, key: string) {
+  const obj = object(value)
+  const field = obj?.[key]
+  return typeof field === "boolean" ? field : undefined
+}
+
+function text(error: unknown) {
+  const parts = [
+    stringField(error, "name"),
+    stringField(error, "_tag"),
+    stringField(error, "code"),
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error),
+  ].filter(Boolean)
+  return parts.join(" ").toLowerCase()
+}
+
+function hasAny(value: string, patterns: readonly string[]) {
+  return patterns.some((pattern) => value.includes(pattern))
+}
+
+function canonical(errorKind: ToolFailureKind): ToolFailureMetadata {
+  return {
+    errorKind,
+    recoveryHint: TOOL_FAILURE_HINTS[errorKind],
+  }
+}
+
+export function classifyToolFailure(input: { tool: string; error: unknown }): ToolFailureMetadata {
+  const error = input.error
+  const code = stringField(error, "code")?.toUpperCase()
+  const name = stringField(error, "name")
+  const tag = stringField(error, "_tag")
+  const value = text(error)
+
+  if (
+    error instanceof Permission.RejectedError ||
+    error instanceof Permission.CorrectedError ||
+    error instanceof Permission.DeniedError ||
+    code === "EACCES" ||
+    code === "EPERM"
+  ) {
+    return canonical("permission_denied")
+  }
+
+  if (
+    hasAny(value, [
+      "invalid arguments",
+      "invalid argument",
+      "malformed tool input",
+      "expected schema",
+      "satisfies the expected schema",
+      "schema decode",
+      "invalid timeout",
+      "invalid value",
+    ])
+  ) {
+    return canonical("invalid_arguments")
+  }
+
+  if (
+    error instanceof Question.RejectedError ||
+    name === "AbortError" ||
+    code === "ABORT_ERR" ||
+    hasAny(value, ["user aborted", "user cancelled", "user canceled", "cancelled before", "canceled before"])
+  ) {
+    return canonical("user_aborted")
+  }
+
+  if (name === "TimeoutError" || code === "ETIMEDOUT" || hasAny(value, ["timed out", "timeout", "exceeded timeout"])) {
+    return canonical("timeout")
+  }
+
+  if (
+    code === "ENOENT" ||
+    code === "ENOTDIR" ||
+    hasAny(value, [
+      "no such file or directory",
+      "file not found",
+      "directory not found",
+      "command not found",
+      "working directory",
+      "missing cwd",
+      "missing path",
+      "path does not exist",
+      "not a directory",
+    ])
+  ) {
+    return canonical("environment")
+  }
+
+  if (
+    tag === "APICallError" ||
+    name === "APICallError" ||
+    numberField(error, "statusCode") !== undefined ||
+    booleanField(error, "isRetryable") !== undefined ||
+    hasAny(value, [
+      "api key",
+      "api call",
+      "api error",
+      "provider",
+      "rate limit",
+      "quota",
+      "unauthorized",
+      "authentication",
+      "service unavailable",
+      "overloaded",
+    ])
+  ) {
+    return canonical("provider")
+  }
+
+  return canonical("unknown")
+}
+
+export function safeToolFailureMetadata(value: unknown): ToolFailureMetadata | undefined {
+  const failure = object(value)
+  const errorKind = failure?.errorKind
+  if (!KIND_SET.has(errorKind)) return undefined
+  return canonical(errorKind)
+}
+
+export function formatToolFailureForModel(errorText: string, failure?: ToolFailureMetadata) {
+  const safeFailure = safeToolFailureMetadata(failure)
+  if (!safeFailure) return errorText
+  return `${errorText}\n\nTool failure reason: ${safeFailure.errorKind}. Recovery hint: ${safeFailure.recoveryHint}`
+}

--- a/packages/opencode/src/tool/sensitive.ts
+++ b/packages/opencode/src/tool/sensitive.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { safeToolFailureMetadata } from "@/session/tool-failure"
 
 export type SensitiveStatus = "added" | "modified" | "deleted"
 
@@ -149,11 +150,13 @@ export function sanitizeSensitiveToolMetadata(metadata: unknown, input?: unknown
   if (!sensitive) return metadata
 
   const file = typeof meta.filepath === "string" ? meta.filepath : typeof meta.file === "string" ? meta.file : undefined
+  const failure = safeToolFailureMetadata(object(meta.diagnostics)?.failure)
   const next: Record<string, unknown> = {}
   if (file) next[typeof meta.filepath === "string" ? "filepath" : "file"] = file
   if (Array.isArray(meta.files)) next.files = meta.files.map(sanitizeSensitiveFileEntry)
   if (meta.filediff) next.filediff = sanitizeSensitiveFileEntry(meta.filediff)
-  if (meta.diagnostics !== undefined) next.diagnostics = {}
+  if (failure) next.diagnostics = { failure }
+  else if (meta.diagnostics !== undefined) next.diagnostics = {}
   if (meta.bomDiscarded === true) next.bomDiscarded = true
   next.status = statusFromType(meta.type, meta.status)
   next.sensitive = true

--- a/packages/opencode/test/session/diagnostics.test.ts
+++ b/packages/opencode/test/session/diagnostics.test.ts
@@ -3,6 +3,7 @@ import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionDiagnostics } from "../../src/session/diagnostics"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { TOOL_FAILURE_HINTS } from "../../src/session/tool-failure"
 
 const sessionID = SessionID.make("ses_diagnostics")
 const parentID = MessageID.make("msg_user")
@@ -367,6 +368,30 @@ describe("SessionDiagnostics metadata helpers", () => {
       truncated: false,
       outputPath: "/tmp/out",
       diagnostics: { loop: { inputHash: "abc", inputRepeatCount: 1 } },
+    })
+  })
+
+  test("merges failure diagnostics without losing loop diagnostics", () => {
+    const merged = SessionDiagnostics.mergeMetadata(
+      { diagnostics: { loop: { inputHash: "abc", inputRepeatCount: 1 } } },
+      {
+        diagnostics: {
+          failure: {
+            errorKind: "environment",
+            recoveryHint: TOOL_FAILURE_HINTS.environment,
+          },
+        },
+      },
+    )
+
+    expect(merged).toEqual({
+      diagnostics: {
+        loop: { inputHash: "abc", inputRepeatCount: 1 },
+        failure: {
+          errorKind: "environment",
+          recoveryHint: TOOL_FAILURE_HINTS.environment,
+        },
+      },
     })
   })
 

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -11,6 +11,7 @@ import { Export, getRuntimeNamespace, redactPart } from "../../src/session/expor
 import { Global } from "../../src/global"
 import { tmpdir } from "../fixture/fixture"
 import { Config } from "../../src/config"
+import { TOOL_FAILURE_HINTS } from "../../src/session/tool-failure"
 
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
@@ -584,6 +585,12 @@ describe("Export.redactPart sensitive tool metadata", () => {
             additions: 1,
             deletions: 1,
           },
+          diagnostics: {
+            failure: {
+              errorKind: "environment",
+              recoveryHint: "check /Users/alice/.env",
+            },
+          },
         },
         time: { start: 1, end: 2 },
       },
@@ -599,6 +606,12 @@ describe("Export.redactPart sensitive tool metadata", () => {
       input: { filePath: "/tmp/project/.env", sensitive: true },
       output: "Sensitive file updated.",
       metadata: {
+        diagnostics: {
+          failure: {
+            errorKind: "environment",
+            recoveryHint: TOOL_FAILURE_HINTS.environment,
+          },
+        },
         filediff: {
           file: "/tmp/project/.env",
           status: "modified",
@@ -1118,6 +1131,15 @@ describe("redactPart", () => {
                   status: "error",
                   input: { command: "cat /Users/secret/.env" },
                   error: "failed to read /Users/secret/.env",
+                  metadata: {
+                    commandId: "cmd-secret",
+                    diagnostics: {
+                      failure: {
+                        errorKind: "environment",
+                        recoveryHint: "check /Users/secret/.env",
+                      },
+                    },
+                  },
                   time: { start: 1, end: 2 },
                 },
               },
@@ -1134,6 +1156,15 @@ describe("redactPart", () => {
     if (tool.type !== "tool" || tool.state.status !== "error") throw new Error("expected error tool part")
     expect(tool.state.input).toEqual({ redacted: "tool-input:prt_error" })
     expect(tool.state.error).toBe("[redacted:tool-error:prt_error]")
+    expect(tool.state.metadata).toEqual({
+      redacted: "tool-state-metadata:prt_error",
+      diagnostics: {
+        failure: {
+          errorKind: "environment",
+          recoveryHint: TOOL_FAILURE_HINTS.environment,
+        },
+      },
+    })
   })
 
   test("redacts data: url inside completed tool attachments", () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -7,6 +7,7 @@ import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { Question } from "../../src/question"
 import { Permission } from "../../src/permission"
 import { fromDeniedRule } from "../../src/permission/diagnostic"
+import { TOOL_FAILURE_HINTS } from "../../src/session/tool-failure"
 import { errorMessage } from "../../src/util/error"
 
 const sessionID = SessionID.make("session")
@@ -594,7 +595,14 @@ describe("session.message-v2.toModelMessage", () => {
               input: { cmd: "ls" },
               error: "nope",
               time: { start: 0, end: 1 },
-              metadata: {},
+              metadata: {
+                diagnostics: {
+                  failure: {
+                    errorKind: "invalid_arguments",
+                    recoveryHint: TOOL_FAILURE_HINTS.invalid_arguments,
+                  },
+                },
+              },
             },
             metadata: { openai: { tool: "meta" } },
           },
@@ -627,7 +635,10 @@ describe("session.message-v2.toModelMessage", () => {
             type: "tool-result",
             toolCallId: "call-1",
             toolName: "bash",
-            output: { type: "error-text", value: "nope" },
+            output: {
+              type: "error-text",
+              value: `nope\n\nTool failure reason: invalid_arguments. Recovery hint: ${TOOL_FAILURE_HINTS.invalid_arguments}`,
+            },
             providerOptions: { openai: { tool: "meta" } },
           },
         ],

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -551,6 +551,7 @@ it.live("loop gate records same-step repeated tool errors without block or stop"
         const stopParts = errorParts.filter((p) => p.state.metadata?.diagnostics?.loop?.loopAction === "stop")
         expect(blockParts).toHaveLength(0)
         expect(stopParts).toHaveLength(0)
+        expect(errorParts[0].state.metadata?.diagnostics?.failure?.errorKind).toBe("environment")
 
         const requests = yield* llm.inputs
         // Extract user/system message text fields rather than stringifying the whole request

--- a/packages/opencode/test/session/tool-failure.test.ts
+++ b/packages/opencode/test/session/tool-failure.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { APICallError } from "ai"
+import { Permission } from "../../src/permission"
+import { Question } from "../../src/question"
+import {
+  TOOL_FAILURE_HINTS,
+  classifyToolFailure,
+  formatToolFailureForModel,
+  safeToolFailureMetadata,
+} from "../../src/session/tool-failure"
+
+describe("tool failure classification", () => {
+  test("classifies the initial failure kinds", () => {
+    const cases = [
+      {
+        name: "invalid tool arguments",
+        error: new Error("The read tool was called with invalid arguments: missing filePath."),
+        errorKind: "invalid_arguments",
+      },
+      {
+        name: "permission denied by PawWork",
+        error: new Permission.DeniedError({ ruleset: [{ permission: "bash", pattern: "rm *", action: "deny" }] }),
+        errorKind: "permission_denied",
+      },
+      {
+        name: "environment path missing",
+        error: Object.assign(new Error("ENOENT: no such file or directory, open '/tmp/missing'"), {
+          code: "ENOENT",
+        }),
+        errorKind: "environment",
+      },
+      {
+        name: "provider api failure",
+        error: new APICallError({
+          message: "Rate limit exceeded",
+          url: "https://provider.example/v1/messages",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: {},
+          isRetryable: true,
+        }),
+        errorKind: "provider",
+      },
+      {
+        name: "tool timeout",
+        error: Object.assign(new Error("Tool execution timed out after 1000ms"), { name: "TimeoutError" }),
+        errorKind: "timeout",
+      },
+      {
+        name: "user aborted question",
+        error: new Question.RejectedError({ cancelled: true }),
+        errorKind: "user_aborted",
+      },
+      {
+        name: "unknown fallback",
+        error: new Error("something unexpected happened"),
+        errorKind: "unknown",
+      },
+    ] as const
+
+    for (const item of cases) {
+      expect(classifyToolFailure({ tool: "bash", error: item.error }), item.name).toEqual({
+        errorKind: item.errorKind,
+        recoveryHint: TOOL_FAILURE_HINTS[item.errorKind],
+      })
+    }
+  })
+
+  test("formats model-facing failures with the original error and concise hint", () => {
+    const text = formatToolFailureForModel("raw failure", {
+      errorKind: "invalid_arguments",
+      recoveryHint: TOOL_FAILURE_HINTS.invalid_arguments,
+    })
+
+    expect(text).toContain("raw failure")
+    expect(text).toContain("invalid_arguments")
+    expect(text).toContain(TOOL_FAILURE_HINTS.invalid_arguments)
+  })
+
+  test("sanitizes stored failure metadata to canonical safe fields", () => {
+    expect(
+      safeToolFailureMetadata({
+        errorKind: "environment",
+        recoveryHint: "check /Users/alice/.env",
+        extra: "raw secret",
+      }),
+    ).toEqual({
+      errorKind: "environment",
+      recoveryHint: TOOL_FAILURE_HINTS.environment,
+    })
+
+    expect(safeToolFailureMetadata({ errorKind: "not_real", recoveryHint: "retry" })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Add structured tool failure diagnostics for ordinary errored tool calls.

This PR introduces a small failure classifier, persists `metadata.diagnostics.failure` on tool-error state, appends a concise model-facing recovery hint during message replay, and preserves only safe failure fields in raw/sanitized exports.

## Why

Fixes #439.

Today ordinary tool failures are mostly flattened to an error string. That makes it hard for the agent to decide whether to fix arguments, stop after a user abort, ask for permission, check local setup, or report a provider problem. This keeps the original error text but adds a stable local reason and generic recovery hint.

## Related Issue

Fixes #439.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Whether the initial failure classifier categories are conservative enough.
- Whether `metadata.diagnostics.failure` is merged without disturbing existing loop diagnostics.
- Whether export sanitization preserves only safe generic fields and continues redacting raw input/error/metadata.

## Risk Notes

- Model behavior may change for errored tool results because `output-error.errorText` now includes a short recovery hint.
- Misclassification could nudge the model toward the wrong recovery path. The fallback remains `unknown`.
- No migration is needed because the new metadata field is optional.
- No UI copy, telemetry, provider retry policy, or Bash timeout behavior is changed.

## How To Verify

```text
Targeted tests: 135 passed, 0 failed
Command: bun --cwd packages/opencode test test/session/tool-failure.test.ts test/session/message-v2.test.ts test/session/diagnostics.test.ts test/session/export.test.ts test/session/prompt-effect.test.ts

Typecheck: passed
Command: bun --cwd packages/opencode typecheck

Diff check: no whitespace errors
Command: git diff --check
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
