### PR TITLE
fix(config): tolerate Windows config fsync errors

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -411,6 +411,20 @@ export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) 
   return await fn()
 }
 
+function isWindowsSyncUnsupportedError(error: unknown) {
+  if (process.platform !== "win32") return false
+  const code = (error as NodeJS.ErrnoException).code
+  return code === "EPERM" || code === "EINVAL" || code === "ENOTSUP"
+}
+
+async function syncHandleBestEffort(handle: { sync: () => Promise<void> }) {
+  try {
+    await handle.sync()
+  } catch (error) {
+    if (!isWindowsSyncUnsupportedError(error)) throw error
+  }
+}
+
 export async function writeConfigTextAtomic(file: string, text: string, options?: { mode?: number }) {
   await fsNode.mkdir(path.dirname(file), { recursive: true })
   const existingMode = await fsNode
@@ -427,7 +441,7 @@ export async function writeConfigTextAtomic(file: string, text: string, options?
     if (mode !== undefined) await fsNode.chmod(tmp, mode)
     const tmpHandle = await fsNode.open(tmp, "r")
     try {
-      await tmpHandle.sync()
+      await syncHandleBestEffort(tmpHandle)
     } finally {
       await tmpHandle.close()
     }
@@ -435,7 +449,7 @@ export async function writeConfigTextAtomic(file: string, text: string, options?
     const dirHandle = await fsNode.open(path.dirname(file), "r").catch(() => undefined)
     if (dirHandle) {
       try {
-        await dirHandle.sync()
+        await syncHandleBestEffort(dirHandle)
       } finally {
         await dirHandle.close()
       }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -413,7 +413,7 @@ export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) 
 
 function isWindowsSyncUnsupportedError(error: unknown) {
   if (process.platform !== "win32") return false
-  const code = (error as NodeJS.ErrnoException).code
+  const code = error && typeof error === "object" && "code" in error ? (error as NodeJS.ErrnoException)?.code : undefined
   return code === "EPERM" || code === "EINVAL" || code === "ENOTSUP"
 }
 
@@ -422,6 +422,7 @@ async function syncHandleBestEffort(handle: { sync: () => Promise<void> }) {
     await handle.sync()
   } catch (error) {
     if (!isWindowsSyncUnsupportedError(error)) throw error
+    log.debug("skipping unsupported Windows fsync", { code: (error as NodeJS.ErrnoException).code })
   }
 }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -159,8 +159,8 @@ test("writeConfigTextAtomic tolerates Windows fsync EPERM", async () => {
     return handle
   })
 
-  Object.defineProperty(process, "platform", { value: "win32" })
   try {
+    Object.defineProperty(process, "platform", { value: "win32" })
     await Config.writeConfigTextAtomic(file, JSON.stringify({ model: "win/model" }))
     expect(JSON.parse(await fs.readFile(file, "utf8")).model).toBe("win/model")
     expect(open).toHaveBeenCalled()

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -143,6 +143,33 @@ test("loads config with defaults when no files exist", async () => {
   })
 })
 
+test("writeConfigTextAtomic tolerates Windows fsync EPERM", async () => {
+  await using tmp = await tmpdir()
+  const file = path.join(tmp.path, "pawwork.json")
+  const originalPlatform = process.platform
+  const originalOpen = fs.open
+  const open = spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+    const handle = await originalOpen(...args)
+    spyOn(handle, "sync").mockImplementation(async () => {
+      const error = new Error("operation not permitted") as NodeJS.ErrnoException
+      error.code = "EPERM"
+      error.syscall = "fsync"
+      throw error
+    })
+    return handle
+  })
+
+  Object.defineProperty(process, "platform", { value: "win32" })
+  try {
+    await Config.writeConfigTextAtomic(file, JSON.stringify({ model: "win/model" }))
+    expect(JSON.parse(await fs.readFile(file, "utf8")).model).toBe("win/model")
+    expect(open).toHaveBeenCalled()
+  } finally {
+    open.mockRestore()
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  }
+})
+
 test("console state keeps switchableOrgCount as a nonnegative integer", () => {
   expect(
     ConsoleState.zod.safeParse({


### PR DESCRIPTION
## Summary

Make PawWork config atomic writes tolerate Windows `fsync` errors that report unsupported sync semantics, while keeping the existing temp-file, permission, lock, and rename flow intact.

## Why

Windows advisory started failing after PR #438 because `writeConfigTextAtomic()` began syncing the temporary config file and parent directory as part of the PawWork Home write path. On GitHub Windows runners, `FileHandle.sync()` can fail with `EPERM: operation not permitted, fsync`, which caused global config updates, plugin installs, and PawWork Home seeding tests to fail before the final rename.

The fix keeps strict sync behavior on non-Windows platforms and only treats Windows sync unsupported errors as best-effort. Write, chmod, rename, parsing, and lock errors still fail normally.

## Related Issue

Follow-up to #438. Related to #328 because the failure is in the PawWork Home config write path introduced there.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check whether the Windows-only sync fallback is scoped narrowly enough: it should only ignore sync unsupported errors from file/directory handle sync, not hide write or rename failures.

## Risk Notes

Windows config durability falls back to atomic rename without explicit `fsync`, matching the safer behavior used by nearby atomic-write helpers in the repo. The main risk is platform-specific behavior, so Windows advisory should be rerun before treating this as fully verified on Windows.

## How To Verify

```text
Regression RED: bun --cwd packages/opencode test test/config/config.test.ts --timeout 30000 failed before the fix with EPERM fsync in the new test
Regression GREEN: bun --cwd packages/opencode test test/config/config.test.ts --timeout 30000, 102 passed, 0 failed
Focused tests: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/plugin/install.test.ts --timeout 30000, 84 passed, 0 failed
Typecheck: bun run --cwd packages/opencode typecheck, exit 0
Diff check: git diff --check, exit 0
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows compatibility for configuration file operations. Config saves now gracefully handle certain file system errors, ensuring settings are reliably saved even when encountering permission restrictions or unsupported operations on Windows systems.

* **Tests**
  * Added test coverage validating configuration saves on Windows with file system error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->