### PR TITLE
fix(config): fix Windows advisory config assumptions

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -55,7 +55,7 @@ export async function substitute(input: SubstituteInput) {
     const optional = rawName.endsWith("?")
     const varName = optional ? rawName.slice(0, -1) : rawName
     const value = process.env[varName]
-    if (value !== undefined) return value
+    if (value !== undefined) return JSON.stringify(value).slice(1, -1)
     if (optional || missing === "empty") return ""
     throw new InvalidError({
       path: source(input),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -562,6 +562,28 @@ test("handles environment variable substitution", async () => {
   }
 })
 
+test("escapes environment variable substitution for JSON strings", async () => {
+  const originalEnv = process.env["TEST_WINDOWS_PATH_VAR"]
+  process.env["TEST_WINDOWS_PATH_VAR"] = String.raw`C:\Users\runneradmin\AppData\Local\Temp\rules.md`
+
+  try {
+    await using tmp = await tmpdir()
+    const text = await ConfigVariable.substitute({
+      type: "virtual",
+      source: "test:env-windows-path",
+      dir: tmp.path,
+      text: `{"instructions":["{env:TEST_WINDOWS_PATH_VAR}"]}`,
+    })
+    expect(JSON.parse(text).instructions).toEqual([process.env["TEST_WINDOWS_PATH_VAR"]])
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env["TEST_WINDOWS_PATH_VAR"] = originalEnv
+    } else {
+      delete process.env["TEST_WINDOWS_PATH_VAR"]
+    }
+  }
+})
+
 test("rejects missing environment variable substitution by default", async () => {
   const originalEnv = process.env["TEST_MISSING_VAR"]
   delete process.env["TEST_MISSING_VAR"]

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -52,6 +52,7 @@ const originalRuntimeNamespace = process.env.PAWWORK_RUNTIME_NAMESPACE
 const originalPawWorkHome = process.env.PAWWORK_HOME
 const originalPawWorkConfigDir = process.env.PAWWORK_CONFIG_DIR
 const originalTestHome = process.env.OPENCODE_TEST_HOME
+const shouldAssertPosixFileMode = process.platform !== "win32"
 
 beforeEach(async () => {
   process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
@@ -1183,8 +1184,10 @@ home command`,
 
         await saveGlobal({ username: "secure-user" })
 
-        const mode = (await fs.stat(configPath)).mode & 0o777
-        expect(mode).toBe(0o600)
+        if (shouldAssertPosixFileMode) {
+          const mode = (await fs.stat(configPath)).mode & 0o777
+          expect(mode).toBe(0o600)
+        }
         expect(JSON.parse(await Bun.file(configPath).text()).username).toBe("secure-user")
       },
     })
@@ -1211,8 +1214,10 @@ home command`,
           await saveGlobal({ username: "secure-user" })
 
           const configPath = path.join(home.path, ".pawwork", "pawwork.json")
-          const mode = (await fs.stat(configPath)).mode & 0o777
-          expect(mode).toBe(0o600)
+          if (shouldAssertPosixFileMode) {
+            const mode = (await fs.stat(configPath)).mode & 0o777
+            expect(mode).toBe(0o600)
+          }
           expect(JSON.parse(await Bun.file(configPath).text()).username).toBe("secure-user")
         },
       })

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -10,6 +10,8 @@ import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { ConfigPaths } from "../../src/config/paths"
 import { Global } from "../../src/global"
 
+const shouldAssertPosixFileMode = process.platform !== "win32"
+
 function deps(global: string, target: string | Error): PlugDeps {
   return {
     spinner: () => ({
@@ -164,7 +166,7 @@ describe("plugin.install.task", () => {
       })(ctx(tmp.path))
 
       expect(ok).toBe(true)
-      expect((await fs.stat(configFile)).mode & 0o777).toBe(0o600)
+      if (shouldAssertPosixFileMode) expect((await fs.stat(configFile)).mode & 0o777).toBe(0o600)
       const config = await read(configFile)
       expect(config.plugin).toEqual([target])
     } finally {

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -219,6 +219,8 @@ describe("Export.session", () => {
     await using global = await tmpdir()
     const previousConfig = Global.Path.config
     const previousEnv = process.env.GLOBAL_EXPORT_RULE
+    const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+    delete process.env.PAWWORK_RUNTIME_NAMESPACE
     ;(Global.Path as { config: string }).config = global.path
     const globalRules = path.join(global.path, "rules", "global-rules.md")
     const envRules = path.join(global.path, "env-rules.md")
@@ -279,6 +281,8 @@ describe("Export.session", () => {
       ;(Global.Path as { config: string }).config = previousConfig
       if (previousEnv === undefined) delete process.env.GLOBAL_EXPORT_RULE
       else process.env.GLOBAL_EXPORT_RULE = previousEnv
+      if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
       await Config.invalidate(true)
       if (sessionID) await SessionNs.remove(sessionID)
     }

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -220,46 +220,46 @@ describe("Export.session", () => {
     const previousConfig = Global.Path.config
     const previousEnv = process.env.GLOBAL_EXPORT_RULE
     const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
-    delete process.env.PAWWORK_RUNTIME_NAMESPACE
-    ;(Global.Path as { config: string }).config = global.path
     const globalRules = path.join(global.path, "rules", "global-rules.md")
     const envRules = path.join(global.path, "env-rules.md")
     const fileRules = path.join(global.path, "file-rules.md")
-    process.env.GLOBAL_EXPORT_RULE = envRules
-    await fs.mkdir(path.join(global.path, "rules"), { recursive: true })
-    await fs.writeFile(globalRules, "global config instructions")
-    await fs.writeFile(envRules, "env config instructions")
-    await fs.writeFile(fileRules, "file config instructions")
-    await fs.writeFile(path.join(global.path, "rule-path.txt"), fileRules)
-    await fs.writeFile(
-      path.join(global.path, "opencode.json"),
-      JSON.stringify({
-        instructions: [
-          "rules/*.md",
-          "{env:GLOBAL_EXPORT_RULE}",
-          "{file:rule-path.txt}",
-          "missing/*.md",
-          "https://example.invalid/global-rules.md",
-        ],
-      }),
-    )
-    await fs.writeFile(
-      path.join(currentProject.path, "opencode.json"),
-      JSON.stringify({
-        instructions: ["https://example.invalid/current-project.md"],
-      }),
-    )
 
     let sessionID: SessionID | undefined
-    await Instance.provide({
-      directory: sessionProject.path,
-      fn: async () => {
-        const root = await SessionNs.create({ title: "missing global config provenance" })
-        sessionID = root.id
-      },
-    })
-
     try {
+      delete process.env.PAWWORK_RUNTIME_NAMESPACE
+      ;(Global.Path as { config: string }).config = global.path
+      process.env.GLOBAL_EXPORT_RULE = envRules
+      await fs.mkdir(path.join(global.path, "rules"), { recursive: true })
+      await fs.writeFile(globalRules, "global config instructions")
+      await fs.writeFile(envRules, "env config instructions")
+      await fs.writeFile(fileRules, "file config instructions")
+      await fs.writeFile(path.join(global.path, "rule-path.txt"), fileRules)
+      await fs.writeFile(
+        path.join(global.path, "opencode.json"),
+        JSON.stringify({
+          instructions: [
+            "rules/*.md",
+            "{env:GLOBAL_EXPORT_RULE}",
+            "{file:rule-path.txt}",
+            "missing/*.md",
+            "https://example.invalid/global-rules.md",
+          ],
+        }),
+      )
+      await fs.writeFile(
+        path.join(currentProject.path, "opencode.json"),
+        JSON.stringify({
+          instructions: ["https://example.invalid/current-project.md"],
+        }),
+      )
+      await Instance.provide({
+        directory: sessionProject.path,
+        fn: async () => {
+          const root = await SessionNs.create({ title: "missing global config provenance" })
+          sessionID = root.id
+        },
+      })
+
       await Config.invalidate(true)
       await fs.rm(sessionProject.path, { recursive: true, force: true })
       await Instance.provide({


### PR DESCRIPTION
## Summary

Fixes the Windows advisory failures exposed after PR #447 by making POSIX permission assertions platform-aware, isolating one export-session test from the ambient PawWork runtime, and escaping env-token substitution so Windows paths remain valid inside JSON strings.

## Why

Windows advisory was no longer blocked by `FileHandle.sync()` after PR #447, but it exposed three separate assumptions:

- Windows does not provide stable POSIX `0o600` semantics through `stat().mode & 0o777`; the runner reported `0o666` after `chmod(0o600)`.
- `Export.session` wrote `opencode.json` while inheriting `PAWWORK_RUNTIME_NAMESPACE=pawwork`, so the test was sometimes running under the wrong config filename rules.
- `ConfigVariable.substitute` inserted `{env:...}` values without JSON-string escaping. On Windows, an env value like `C:\Users\...` becomes invalid JSON when substituted inside a quoted config field.

The permission coverage remains intentionally platform-specific: POSIX still checks `0o600`; Windows keeps write/content coverage instead of asserting Unix mode bits. The env substitution fix is production code because the Windows advisory exposed a real config parsing risk, not a test-only failure.

## Related Issue

No linked issue. Follow-up from Windows advisory run #25372298853 on PR #447, plus review/advisory follow-up on this PR.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that the permission-test boundary stays narrow and that env substitution now matches the existing `{file:...}` behavior: escape string content without adding surrounding quotes.

## Risk Notes

Moderate but bounded product risk: `{env:...}` substitution now escapes JSON string content, which fixes Windows paths and quoted values. Existing simple substitutions still resolve to the same parsed values. The other changes are test-only and keep POSIX permission assertions intact.

## How To Verify

```text
Regression red check: failed before implementation with JSON Parse error: Invalid escape character U
bun --cwd packages/opencode test test/config/config.test.ts --timeout 30000 --test-name-pattern "escapes environment variable substitution"

Config substitution tests: 103 passed, 0 failed
bun --cwd packages/opencode test test/config/config.test.ts --timeout 30000

Focused export regression under PawWork runtime: 1 passed, 0 failed
PAWWORK_RUNTIME_NAMESPACE=pawwork bun --cwd packages/opencode test test/session/export.test.ts --timeout 30000 --test-name-pattern "keeps global config instruction provenance when session directory is gone"

Related files test run: 114 passed, 0 failed
bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/plugin/install.test.ts test/session/export.test.ts --timeout 30000

Typecheck: pass
bun --cwd packages/opencode typecheck

Diff check: no whitespace errors
git diff --check
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
