### PR TITLE
feat(ui): motion primitives — keyframes, hover overlays, reduced-motion (slice 03, issue #440)

### DIFF
--- a/packages/ui/src/styles/animations.css
+++ b/packages/ui/src/styles/animations.css
@@ -1,6 +1,11 @@
 :root {
   --animate-pulse: pulse-opacity 2s ease-in-out infinite;
   --animate-pulse-scale: pulse-scale 1.2s ease-in-out infinite;
+
+  /* PawWork motion primitives · STANDARDS L22 */
+  --animate-pw-spin:    pw-spin 700ms linear infinite;
+  --animate-pw-rail:    pw-rail 1400ms linear infinite;
+  --animate-pw-shimmer: pw-shimmer 1200ms linear infinite;
 }
 
 @keyframes pulse-opacity {
@@ -42,6 +47,26 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* ────────── PawWork motion keyframes · STANDARDS L22 ────────── */
+
+/* Circular geometry only (spinner / thinking ring); non-circular icons must not use this */
+@keyframes pw-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Running-state bottom separator rail: a highlight element sweeps left → right */
+@keyframes pw-rail {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(400%); }
+}
+
+/* Tool-name shimmer when trow is running: gradient sweep across text via background-position */
+@keyframes pw-shimmer {
+  from { background-position: 200% center; }
+  to   { background-position: -200% center; }
 }
 
 .fade-up-text {

--- a/packages/ui/src/styles/animations.css
+++ b/packages/ui/src/styles/animations.css
@@ -57,10 +57,12 @@
   to   { transform: rotate(360deg); }
 }
 
-/* Running-state bottom separator rail: a highlight element sweeps left → right */
+/* Running-state bottom separator rail: highlight starts off-screen left and exits off-screen
+ * right. translateX is relative to the element's own width; 500% ensures clean exit for
+ * elements up to ~container-width (consuming component sets actual width). */
 @keyframes pw-rail {
   from { transform: translateX(-100%); }
-  to   { transform: translateX(400%); }
+  to   { transform: translateX(500%); }
 }
 
 /* Tool-name shimmer when trow is running: gradient sweep across text via background-position */

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -134,6 +134,12 @@
   --duration-base: 120ms;
   --duration-slow: 240ms;
 
+  /* ────────── Hover overlays · STANDARDS L22 ────────── */
+  /* White/raised surface: 4% black overlay */
+  --hover-overlay:      rgba(0, 0, 0, 0.04);
+  /* Warm cream surface (sidebar, bg-cream): 6% for perceptual parity */
+  --hover-overlay-warm: rgba(0, 0, 0, 0.06);
+
   color-scheme: light;
 
   /* ──────────────────────────────────────────────────────────────────────
@@ -513,4 +519,18 @@ body {
   font: var(--type-body);
   color: var(--fg-strong);
   background: var(--bg-base);
+}
+
+/* ────────── Reduced-motion global kill-switch · STANDARDS L22 ────────── */
+/* Matches prefers-reduced-motion: reduce. Per spec: animations → 0.001ms,
+ * transitions → 80ms cap, scroll-behavior → auto. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 80ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -522,17 +522,18 @@ body {
 }
 
 /* ────────── Reduced-motion global kill-switch · STANDARDS L22 ────────── */
-/* Matches prefers-reduced-motion: reduce. Both animation and transition are
- * set to 0.001ms (effectively instant) so that components with explicit
- * transition-duration: 0ms rules are not raised to a higher value by this
- * blanket override. scroll-behavior is forced to auto. */
+/* Matches prefers-reduced-motion: reduce. Durations and delays are all set to
+ * 0.001ms (effectively instant) so staggered animations don't leave elements
+ * stuck at their start state while waiting for a delay to fire. */
 @media (prefers-reduced-motion: reduce) {
   *,
   ::before,
   ::after {
     animation-duration: 0.001ms !important;
+    animation-delay: 0ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
+    transition-delay: 0ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -522,15 +522,17 @@ body {
 }
 
 /* ────────── Reduced-motion global kill-switch · STANDARDS L22 ────────── */
-/* Matches prefers-reduced-motion: reduce. Per spec: animations → 0.001ms,
- * transitions → 80ms cap, scroll-behavior → auto. */
+/* Matches prefers-reduced-motion: reduce. Both animation and transition are
+ * set to 0.001ms (effectively instant) so that components with explicit
+ * transition-duration: 0ms rules are not raised to a higher value by this
+ * blanket override. scroll-behavior is forced to auto. */
 @media (prefers-reduced-motion: reduce) {
   *,
   ::before,
   ::after {
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 80ms !important;
+    transition-duration: 0.001ms !important;
     scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary

Slice 03 of eleven in issue #440 (PawWork UI carve-out). Scope: motion layer primitives only — no component changes, no token renames, no layout impact.

- **`packages/ui/src/styles/animations.css`**: adds three PawWork keyframe definitions (`pw-spin`, `pw-rail`, `pw-shimmer`) plus matching `--animate-pw-*` shorthand variables in `:root`.
- **`packages/ui/src/styles/theme.css`**: adds `--hover-overlay` (rgba 4%) and `--hover-overlay-warm` (rgba 6%) as regulated tokens under the Motion section, and appends a global `@media (prefers-reduced-motion: reduce)` kill-switch (animations → 0.001ms, transitions → 0.001ms, scroll-behavior → auto).

## Why

Provides the motion vocabulary that slices 04–11 consume. Without these keyframe primitives, component slices would embed literal animation values inline and drift from each other. The hover overlay tokens canonicalise the 0.04 / 0.06 pair so sidebar/cream-surface hover in slice 08 reads `var(--hover-overlay-warm)` rather than a raw rgba literal. The reduced-motion rule is a one-time global gate required by STANDARDS L22; individual component `@media` overrides added in slices 04–11 will coexist correctly since the kill-switch uses `!important`.

## Related Issue

Refs #440 (umbrella). This PR is slice 03 of eleven.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- **`pw-spin`**: rotation 0→360, 700ms linear infinite. Must only be applied to circular geometry (spinner, thinking ring) per the keyframe comment. No call sites yet — future slices wire it in.
- **`pw-rail`**: translateX −100% → +500%. Highlight sweeps across the rail container in ~1400ms. The 500% endpoint ensures clean off-screen exit for elements up to container width.
- **`pw-shimmer`**: background-position 200% → −200%, intended for `background-clip: text` gradient sweeps on tool-name text. Consumer sets the gradient on the element; this keyframe animates the position.
- **`--hover-overlay` / `--hover-overlay-warm`**: purely additive, no existing callers. Not included in `pawwork.json` (not opencode loader tokens; `hover` prefix is outside `REGULATED_PREFIXES`).
- **Reduced-motion rule**: `!important` is load-bearing here. Without it, component `transition-duration` declarations win the cascade and the kill-switch does nothing.

## Risk Notes

- No component CSS or TSX files touched. No existing call sites for the new keyframes or hover tokens in this slice.
- The `!important` on the reduced-motion rule is intentional and documented in the Review Focus above.
- `--hover-overlay` / `--hover-overlay-warm` are light-only tokens. Dark mode hover on warm surfaces (sidebar) has a different effective surface color; dark-mode callers will inline the appropriate alpha or use a dark-specific override. No dark-override is needed in this slice because there are no call sites yet.

## Changed-file boundary check

Only two files changed, both inside `packages/ui/src/styles/`:

- `animations.css` — in scope (motion primitives)
- `theme.css` — in scope (token layer)

No files in `packages/app/`, `packages/opencode/`, `packages/desktop-electron/`, or `packages/ui/src/components/` are touched.

## How To Verify

```text
parity test:
  bun --cwd packages/ui test test/theme-parity.test.ts
  131 pass, 0 fail (unchanged — new tokens not in pawwork.json scope)

colors consistency test:
  bun --cwd packages/ui test test/colors-generation.test.ts
  4 pass, 0 fail

undefined-token scan:
  bun --cwd packages/ui test test/undefined-tokens.test.ts
  2 pass, 0 fail

git diff --stat HEAD~1:
  packages/ui/src/styles/animations.css | 25 +++++++++++++++++++++++++
  packages/ui/src/styles/theme.css      | 20 ++++++++++++++++++++
  2 files changed, 45 insertions(+)
```

## Screenshots or Recordings

No visible changes in this slice. Keyframes are defined but have no call sites yet; hover overlay tokens and reduced-motion rule have no runtime effect until component slices consume them.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added new animation effects for spin, rail, and shimmer interactions with customizable motion properties.
  * Introduced hover overlay design tokens for standardized surface styling and visual consistency.
  * Enhanced accessibility support with respect for reduced-motion preferences, automatically adjusting animation and transition durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
