### PR TITLE
test: stabilize PTY output isolation

### DIFF
--- a/packages/opencode/test/pty/pty-output-isolation.test.ts
+++ b/packages/opencode/test/pty/pty-output-isolation.test.ts
@@ -4,6 +4,15 @@ import { Pty } from "../../src/pty"
 import { tmpdir } from "../fixture/fixture"
 import { setTimeout as sleep } from "node:timers/promises"
 
+const wait = async (fn: () => boolean, ms = 5000) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (fn()) return
+    await sleep(25)
+  }
+  throw new Error("timeout waiting for pty output")
+}
+
 describe("pty", () => {
   test("does not leak output when websocket objects are reused", async () => {
     await using dir = await tmpdir({ git: true })
@@ -29,21 +38,21 @@ describe("pty", () => {
           }
 
           // Connect "a" first with ws.
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
 
           // Now "reuse" the same ws object for another connection.
           ws.data = { events: { connection: "b" } }
           ws.send = (data: unknown) => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
-          Pty.connect(b.id, ws as any)
+          await Pty.connect(b.id, ws as any)
 
           // Clear connect metadata writes.
           outA.length = 0
           outB.length = 0
 
           // Output from a must never show up in b.
-          Pty.write(a.id, "AAA\n")
+          await Pty.write(a.id, "AAA\n")
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
@@ -78,7 +87,7 @@ describe("pty", () => {
           }
 
           // Connect "a" first.
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
           outA.length = 0
 
           // Simulate Bun reusing the same websocket object for another
@@ -88,7 +97,7 @@ describe("pty", () => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
 
-          Pty.write(a.id, "AAA\n")
+          await Pty.write(a.id, "AAA\n")
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
@@ -121,15 +130,15 @@ describe("pty", () => {
             },
           }
 
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
           out.length = 0
 
           // Mutating fields on ws.data should not look like a new
           // connection lifecycle when the object identity stays stable.
           ctx.connId = 2
 
-          Pty.write(a.id, "AAA\n")
-          await sleep(100)
+          await Pty.write(a.id, "AAA\n")
+          await wait(() => out.join("").includes("AAA"))
 
           expect(out.join("")).toContain("AAA")
         } finally {

--- a/packages/opencode/test/pty/pty-output-isolation.test.ts
+++ b/packages/opencode/test/pty/pty-output-isolation.test.ts
@@ -10,7 +10,8 @@ const wait = async (fn: () => boolean, ms = 5000) => {
     if (fn()) return
     await sleep(25)
   }
-  throw new Error("timeout waiting for pty output")
+  if (fn()) return
+  throw new Error(`timeout waiting ${ms}ms for pty output`)
 }
 
 describe("pty", () => {


### PR DESCRIPTION
## Summary

- Stabilizes the PTY output isolation tests by awaiting async connect/write operations.
- Replaces the positive-output fixed sleep with condition-based waiting so Windows runner timing does not decide the assertion.
- Handles the timeout edge by checking the condition once more after the wait deadline and reporting the timeout duration.

## Why

Windows advisory run 25374664379 failed only in `unit-windows-opencode-server-tools` on `pty > treats in-place socket data mutation as the same connection`. The PTY isolation logic uses socket/data object identity, but the test wrote to the PTY before awaiting subscription setup. On slower Windows runners, the positive assertion could run without observing the output.

## Related Issue

No issue. Follow-up from Windows advisory run 25374664379 after PR #449.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm this stays test-only and does not broaden PR #449 scope.
- Confirm the test now measures PTY subscriber identity behavior instead of async scheduling speed.

## Risk Notes

Low. Test-only change; no runtime PTY, WebSocket, or workflow behavior changed.

## How To Verify

```text
Focused PTY isolation: 3 pass, 0 fail
PTY directory: 8 pass, 0 fail
Opencode typecheck: exit 0
Local opencode-server-tools shard equivalent: 1170 pass, 2 skip, 0 fail
Windows advisory: manually triggered for current head, run 25376017400
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
