### PR TITLE
chore(release): bump version to 2026.5.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "2026.5.4",
+      "version": "2026.5.5",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -97,7 +97,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.4",
+      "version": "2026.5.5",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",
@@ -145,7 +145,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "2026.5.4",
+      "version": "2026.5.5",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -371,7 +371,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "2026.5.4",
+      "version": "2026.5.5",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "zod": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.5.4",
+  "version": "2026.5.5",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.4",
+  "version": "2026.5.5",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.5.4",
+  "version": "2026.5.5",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.5.4",
+  "version": "2026.5.5",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump the PawWork release packages from `2026.5.4` to `2026.5.5`.

## Why

Prepare the release after PR #449, PR #450, and PR #451 landed on `dev`.

## Related Issue

No issue. This is release preparation.

## Human Review Status

Not required. This is a mechanical release version bump.

## Review Focus

Confirm the diff only updates release package versions and lockfile workspace metadata.

## Risk Notes

No product behavior changes in this PR. Release risk is in the subsequent build, notarization, updater metadata, and asset verification steps.

## How To Verify

```text
Lockfile check: bun install --frozen-lockfile passed with no changes
Release script tests: 49 passed, 0 failed
PTY isolation tests: 3 passed, 0 failed
Web E2E smoke: 16 passed, 1 skipped
Desktop smoke: bun run smoke:ci exited 0
Diff check: git diff --check passed before commit
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
