### PR TITLE
fix(app): align session composer with timeline width

### DIFF
--- a/packages/app/e2e/app/session.spec.ts
+++ b/packages/app/e2e/app/session.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "../fixtures"
-import { promptSelector, sessionComposerDockSelector } from "../selectors"
+import {
+  promptSelector,
+  sessionComposerColumnSelector,
+  sessionComposerDockSelector,
+  sessionTimelineColumnSelector,
+} from "../selectors"
 import { withSession } from "../actions"
 
 test("can open an existing session and type into the prompt", async ({ page, sdk, gotoSession }) => {
@@ -47,22 +52,52 @@ test("@smoke session composer matches home structure without docktray or agent c
   })
 })
 
-test("session composer insets from message column at 2xl viewport", async ({ page, sdk, gotoSession }) => {
-  // At >=1536px the message timeline is capped at max-w-[1000px] and the composer is
-  // capped at md:max-w-[720px] 2xl:max-w-[920px]. This test guards the 2xl breakpoint
-  // so a regression to the old 'composer matches message column exactly' behavior
-  // (i.e. composer also grows to 1000px and sits flush with messages) fails.
-  await page.setViewportSize({ width: 1600, height: 1000 })
+function centerX(box: { x: number; width: number }) {
+  return box.x + box.width / 2
+}
 
-  const title = `e2e 2xl composer ${Date.now()}`
-  await withSession(sdk, title, async (session) => {
-    await gotoSession(session.id)
+test("session timeline visible content is not narrower than composer shell", async ({ page, project, assistant }) => {
+  await page.setViewportSize({ width: 744, height: 900 })
+  await project.open()
+  await assistant.reply(
+    [
+      "This is a deterministic assistant response for measuring the session reading column.",
+      "It needs enough text to render a full-width assistant content block instead of a tiny line.",
+      "The visible conversation flow should not be narrower than the visible composer input shell.",
+    ].join("\n\n"),
+  )
+  await project.prompt("Measure the session layout width relationship.")
 
-    const composer = page.locator(sessionComposerDockSelector)
-    await expect(composer).toBeVisible()
+  const timeline = page.locator(sessionTimelineColumnSelector)
+  const composerColumn = page.locator(sessionComposerColumnSelector)
+  const messageContent = page.locator('[data-slot="session-turn-assistant-content"]').last()
+  const composerShell = page.locator(`${sessionComposerDockSelector} [data-dock-surface="shell"]`).first()
 
-    const composerBox = await composer.boundingBox()
+  await expect(timeline).toBeVisible()
+  await expect(composerColumn).toBeVisible()
+  await expect(messageContent).toBeVisible()
+  await expect(composerShell).toBeVisible()
+
+  const assertWidthContract = async (input?: { maxComposerColumn?: number }) => {
+    const timelineBox = await timeline.boundingBox()
+    const composerColumnBox = await composerColumn.boundingBox()
+    const messageBox = await messageContent.boundingBox()
+    const composerBox = await composerShell.boundingBox()
+    expect(timelineBox).not.toBeNull()
+    expect(composerColumnBox).not.toBeNull()
+    expect(messageBox).not.toBeNull()
     expect(composerBox).not.toBeNull()
-    expect(composerBox!.width).toBeLessThanOrEqual(920)
-  })
+
+    expect(Math.abs(centerX(timelineBox!) - centerX(composerColumnBox!))).toBeLessThanOrEqual(2)
+    expect(timelineBox!.width + 1).toBeGreaterThanOrEqual(composerColumnBox!.width)
+    expect(messageBox!.width + 1).toBeGreaterThanOrEqual(composerBox!.width)
+    if (input?.maxComposerColumn !== undefined) {
+      expect(composerColumnBox!.width).toBeLessThanOrEqual(input.maxComposerColumn)
+    }
+  }
+
+  await assertWidthContract()
+
+  await page.setViewportSize({ width: 1600, height: 1000 })
+  await assertWidthContract({ maxComposerColumn: 920 })
 })

--- a/packages/app/e2e/app/session.spec.ts
+++ b/packages/app/e2e/app/session.spec.ts
@@ -78,7 +78,7 @@ test("session timeline visible content is not narrower than composer shell", asy
   await expect(messageContent).toBeVisible()
   await expect(composerShell).toBeVisible()
 
-  const assertWidthContract = async (input?: { maxComposerColumn?: number }) => {
+  const assertWidthContract = async (input?: { maxComposerColumn?: number; minTimelineComposerDelta?: number }) => {
     const timelineBox = await timeline.boundingBox()
     const composerColumnBox = await composerColumn.boundingBox()
     const messageBox = await messageContent.boundingBox()
@@ -94,10 +94,13 @@ test("session timeline visible content is not narrower than composer shell", asy
     if (input?.maxComposerColumn !== undefined) {
       expect(composerColumnBox!.width).toBeLessThanOrEqual(input.maxComposerColumn)
     }
+    if (input?.minTimelineComposerDelta !== undefined) {
+      expect(timelineBox!.width - composerColumnBox!.width).toBeGreaterThanOrEqual(input.minTimelineComposerDelta)
+    }
   }
 
   await assertWidthContract()
 
   await page.setViewportSize({ width: 1600, height: 1000 })
-  await assertWidthContract({ maxComposerColumn: 920 })
+  await assertWidthContract({ maxComposerColumn: 920, minTimelineComposerDelta: 80 })
 })

--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -3,6 +3,8 @@ const desktopTerminalSelector = '#right-panel[aria-hidden="false"] #terminal-pan
 const mobileTerminalSelector = '#terminal-panel[aria-hidden="false"] [data-component="terminal"]'
 export const terminalSelector = `${desktopTerminalSelector}, ${mobileTerminalSelector}`
 export const sessionComposerDockSelector = '[data-component="session-prompt-dock"]'
+export const sessionComposerColumnSelector = '[data-component="session-composer-column"]'
+export const sessionTimelineColumnSelector = '[data-component="session-timeline-column"]'
 export const sessionTurnListSelector = '[data-slot="session-turn-list"]'
 export const sessionMessageItemSelector = "[data-message-id]"
 export const scrollViewportSelector = '[data-component="scroll-viewport"]'

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -166,8 +166,9 @@ export function SessionComposerRegion(props: {
       }}
     >
       <div
+        data-component="session-composer-column"
         classList={{
-          "w-full px-3 pointer-events-auto": true,
+          "w-full px-4 md:px-3 pointer-events-auto": true,
           "md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]": props.centered && !home(),
           "mx-auto max-w-[1200px]": home(),
         }}

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -168,7 +168,9 @@ export function SessionComposerRegion(props: {
       <div
         data-component="session-composer-column"
         classList={{
-          "w-full px-4 md:px-3 pointer-events-auto": true,
+          "w-full pointer-events-auto": true,
+          "px-4 md:px-3": !home(),
+          "px-3": home(),
           "md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]": props.centered && !home(),
           "mx-auto max-w-[1200px]": home(),
         }}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1093,6 +1093,7 @@ export function MessageTimeline(props: {
           >
             <div
               role="log"
+              data-component="session-timeline-column"
               data-slot="session-turn-list"
               class="flex flex-col items-start justify-start pb-4 transition-[margin]"
               classList={{


### PR DESCRIPTION
## Summary

- Align the session composer column with the timeline on narrow desktop/tablet-width sessions by matching the composer wrapper inset to the message container inset below `md`.
- Add stable selectors for the visible session timeline/composer columns.
- Replace the old 2xl composer width test that measured the full-width outer dock with a regression test that measures the real timeline column, composer column, assistant content, and visible composer shell.

## Why

Closes #455.

After `v2026.5.5`, the visible session flow could appear narrower than the bottom composer/input bar. The root boundary issue was that the old E2E selector targeted `[data-component="session-prompt-dock"]`, which is intentionally full width, instead of the visible composer column/shell.

The red test reproduced the user-facing mismatch at a 744px viewport: assistant content width + 1 was `717`, while the visible composer shell was `722.5`.

## Related Issue

Closes #455

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the fix stays at the session layout boundary and does not mix in #440 token/font work.
- Confirm the E2E test measures visible DOM nodes, not the outer full-width dock.
- Confirm the existing #217 intent is preserved: at 2xl, the composer column is still capped at 920px rather than expanding to the 1000px timeline cap.

## Risk Notes

Low. This changes only the session composer wrapper inset below `md` and adds non-visual selectors. No data, API, persistence, desktop IPC, or token changes.

## How To Verify

```text
Red check: bun --cwd packages/app test:e2e e2e/app/session.spec.ts -g "session timeline visible content" failed before the fix with Expected >= 722.5, Received 717
Focused regression: bun --cwd packages/app test:e2e e2e/app/session.spec.ts -g "session timeline visible content" -> 1 passed
Session E2E file: bun --cwd packages/app test:e2e e2e/app/session.spec.ts -> 3 passed
Typecheck: bun --cwd packages/app typecheck -> exit 0
Diff check: git diff --check -> no whitespace errors
```

## Screenshots or Recordings

Not attached. The visible layout change is covered by the bounding-box E2E at 744px and 1600px viewports, including the visible composer shell and assistant content width relationship.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced layout testing for session composer and timeline components, with improved assertions for width and position constraints across different viewport sizes.

* **Refactor**
  * Adjusted responsive padding in the session composer region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->