### PR TITLE
feat: add LLM trace diagnostics to session exports

### DIFF
--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -24,6 +24,7 @@ import { ConfigVariable } from "../config/variable"
 import { isRecord } from "@/util/record"
 import { Glob } from "@/util/glob"
 import { safeToolFailureMetadata } from "./tool-failure"
+import { LLMTrace } from "./llm-trace"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -151,6 +152,8 @@ export namespace Export {
           attemptedInput?: unknown
         }
       }
+      llm_trace_schema_version?: typeof LLMTrace.SCHEMA_VERSION
+      llm_traces?: LLMTrace.Summary[]
     }
     session: Tree
   }
@@ -174,6 +177,8 @@ export namespace Export {
         attemptedInput?: unknown
       }
     }
+    llm_trace_schema_version?: typeof LLMTrace.SCHEMA_VERSION
+    llm_traces?: LLMTrace.Summary[]
   } {
     let lastAt = -Infinity
     let last:
@@ -232,7 +237,30 @@ export namespace Export {
       for (const child of t.children ?? []) walk(child)
     }
     walk(node)
-    return last ? { loop: { last } } : {}
+    const llm_traces = collectLLMTraces(node)
+    return {
+      ...(last ? { loop: { last } } : {}),
+      ...(llm_traces.length
+        ? { llm_trace_schema_version: LLMTrace.SCHEMA_VERSION, llm_traces }
+        : {}),
+    }
+  }
+
+  function collectLLMTraces(node: Tree) {
+    const traces: LLMTrace.Summary[] = []
+    const walk = (t: Tree) => {
+      for (const message of t.messages ?? []) {
+        if (message.info.role !== "assistant") continue
+        const trace = message.info.diagnostics?.llm_trace
+        if (trace) traces.push(trace)
+      }
+      for (const child of t.children ?? []) walk(child)
+    }
+    walk(node)
+    return traces.sort((a, b) => {
+      if (a.session_id !== b.session_id) return a.session_id.localeCompare(b.session_id)
+      return a.message_id.localeCompare(b.message_id)
+    })
   }
 
   const climbToRoot = Effect.fn("Export.climbToRoot")(function* (svc: Session.Interface, id: SessionID) {

--- a/packages/opencode/src/session/llm-trace/index.ts
+++ b/packages/opencode/src/session/llm-trace/index.ts
@@ -1,0 +1,26 @@
+import {
+  createRecorder as createTraceRecorder,
+  requestSummary as summarizeRequest,
+  storedPartCounts as countStoredParts,
+} from "./recorder"
+import { SCHEMA_VERSION as VERSION } from "./types"
+import * as Types from "./types"
+
+export namespace LLMTrace {
+  export const SCHEMA_VERSION = VERSION
+  export const Summary = Types.Summary
+  export const createRecorder = createTraceRecorder
+  export const requestSummary = summarizeRequest
+  export const storedPartCounts = countStoredParts
+
+  export type RequestSummary = Types.RequestSummary
+  export type StreamEvents = Types.StreamEvents
+  export type StoredParts = Types.StoredParts
+  export type Tokens = Types.Tokens
+  export type Flags = Types.Flags
+  export type Summary = Types.Summary
+  export type RequestSummaryInput = Types.RequestSummaryInput
+  export type RecorderInput = Types.RecorderInput
+  export type FinalizeInput = Types.FinalizeInput
+  export type Recorder = Types.Recorder
+}

--- a/packages/opencode/src/session/llm-trace/recorder.ts
+++ b/packages/opencode/src/session/llm-trace/recorder.ts
@@ -1,0 +1,162 @@
+import type { MessageV2 } from "../message-v2"
+import type {
+  FinalizeInput,
+  Flags,
+  Recorder,
+  RecorderInput,
+  RequestSummary,
+  RequestSummaryInput,
+  StoredParts,
+  StreamEvents,
+  Tokens,
+} from "./types"
+import { SCHEMA_VERSION } from "./types"
+
+export function requestSummary(input: RequestSummaryInput): RequestSummary {
+  const options = safeOptions(input.options)
+  return {
+    streaming: true,
+    tool_count: input.toolCount,
+    tool_choice: input.toolChoice,
+    small: input.small,
+    reasoning_capability: input.reasoningCapability,
+    interleaved_field: input.interleavedField,
+    ...(options ? { options } : {}),
+  }
+}
+
+export function createRecorder(input: RecorderInput): Recorder {
+  const events = emptyStreamEvents()
+  let request: RequestSummary | undefined
+  let finishReason: string | undefined
+  let tokens: MessageV2.Assistant["tokens"] | undefined
+
+  return {
+    request(summary) {
+      request = summary
+    },
+    observeEvent(event) {
+      countEvent(events, event.type)
+    },
+    finish(reason, nextTokens) {
+      finishReason = reason
+      tokens = nextTokens
+    },
+    finalize(final: FinalizeInput) {
+      const finalFinishReason = final.finishReason ?? finishReason
+      const finalTokens = final.tokens ?? tokens
+      const stored = storedPartCounts(final.storedParts)
+      const flags: Flags = {
+        empty_completion: isEmptyCompletion(finalFinishReason, stored),
+        ...(final.streamError ? { stream_error: true } : {}),
+        ...(final.aborted ? { aborted: true } : {}),
+      }
+      return {
+        schema_version: SCHEMA_VERSION,
+        trace_id: input.traceID,
+        session_id: input.sessionID,
+        message_id: input.messageID,
+        parent_message_id: input.parentMessageID,
+        provider: input.providerID,
+        model: input.modelID,
+        agent: input.agent,
+        variant: input.variant,
+        request: final.request ?? request,
+        stream_events: {
+          ...events,
+          ...(finalFinishReason ? { finish_reason: finalFinishReason } : {}),
+        },
+        stored_parts: stored,
+        ...(finalTokens ? { tokens: tokenSummary(finalTokens) } : {}),
+        flags,
+        created_at: input.createdAt,
+        completed_at: final.completedAt,
+      }
+    },
+  }
+}
+
+export function storedPartCounts(parts: MessageV2.Part[]): StoredParts {
+  const counts: StoredParts = {
+    text: 0,
+    reasoning: 0,
+    tool: 0,
+    step_start: 0,
+    step_finish: 0,
+    patch: 0,
+    file: 0,
+    other: 0,
+  }
+  for (const part of parts) countPart(counts, part.type)
+  return counts
+}
+
+function countPart(counts: StoredParts, type: MessageV2.Part["type"]) {
+  if (type === "step-start") counts.step_start++
+  else if (type === "step-finish") counts.step_finish++
+  else if (type === "text") counts.text++
+  else if (type === "reasoning") counts.reasoning++
+  else if (type === "tool") counts.tool++
+  else if (type === "patch") counts.patch++
+  else if (type === "file") counts.file++
+  else counts.other++
+}
+
+function safeOptions(options: Record<string, unknown> | undefined): RequestSummary["options"] | undefined {
+  if (!options) return undefined
+  const result: NonNullable<RequestSummary["options"]> = {}
+  const temperature = number(options.temperature)
+  const topP = number(options.topP)
+  const topK = number(options.topK)
+  const maxOutputTokens = number(options.maxOutputTokens)
+  if (temperature !== undefined) result.temperature = temperature
+  if (topP !== undefined) result.top_p = topP
+  if (topK !== undefined) result.top_k = topK
+  if (maxOutputTokens !== undefined) result.max_output_tokens = maxOutputTokens
+  return Object.keys(result).length ? result : undefined
+}
+
+function number(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function emptyStreamEvents(): StreamEvents {
+  return {
+    start: 0,
+    start_step: 0,
+    finish_step: 0,
+    finish: 0,
+    text_start: 0,
+    text_delta: 0,
+    text_end: 0,
+    reasoning_start: 0,
+    reasoning_delta: 0,
+    reasoning_end: 0,
+    tool_input_start: 0,
+    tool_input_delta: 0,
+    tool_input_end: 0,
+    tool_call: 0,
+    tool_result: 0,
+    tool_error: 0,
+    error: 0,
+  }
+}
+
+function countEvent(events: StreamEvents, type: string) {
+  const key = type.replaceAll("-", "_") as keyof StreamEvents
+  if (key in events && typeof events[key] === "number") events[key]++
+}
+
+function tokenSummary(tokens: MessageV2.Assistant["tokens"]): Tokens {
+  return {
+    input: tokens.input,
+    output: tokens.output,
+    reasoning: tokens.reasoning,
+    cache_read: tokens.cache.read,
+    cache_write: tokens.cache.write,
+  }
+}
+
+function isEmptyCompletion(finishReason: string | undefined, stored: StoredParts) {
+  return finishReason === "stop" && stored.text === 0 && stored.reasoning === 0 && stored.tool === 0 && stored.file === 0
+}

--- a/packages/opencode/src/session/llm-trace/types.ts
+++ b/packages/opencode/src/session/llm-trace/types.ts
@@ -1,0 +1,132 @@
+import type { MessageV2 } from "../message-v2"
+import { MessageID, SessionID } from "../schema"
+import z from "zod"
+
+export const SCHEMA_VERSION = 1
+
+export const RequestSummary = z.object({
+  streaming: z.literal(true),
+  tool_count: z.number().int().nonnegative(),
+  tool_choice: z.enum(["auto", "required", "none"]).optional(),
+  small: z.boolean(),
+  reasoning_capability: z.boolean(),
+  interleaved_field: z.string().optional(),
+  options: z
+    .object({
+      temperature: z.number().optional(),
+      top_p: z.number().optional(),
+      top_k: z.number().optional(),
+      max_output_tokens: z.number().optional(),
+    })
+    .optional(),
+})
+export type RequestSummary = z.infer<typeof RequestSummary>
+
+export const StreamEvents = z.object({
+  start: z.number().int().nonnegative(),
+  start_step: z.number().int().nonnegative(),
+  finish_step: z.number().int().nonnegative(),
+  finish: z.number().int().nonnegative(),
+  text_start: z.number().int().nonnegative(),
+  text_delta: z.number().int().nonnegative(),
+  text_end: z.number().int().nonnegative(),
+  reasoning_start: z.number().int().nonnegative(),
+  reasoning_delta: z.number().int().nonnegative(),
+  reasoning_end: z.number().int().nonnegative(),
+  tool_input_start: z.number().int().nonnegative(),
+  tool_input_delta: z.number().int().nonnegative(),
+  tool_input_end: z.number().int().nonnegative(),
+  tool_call: z.number().int().nonnegative(),
+  tool_result: z.number().int().nonnegative(),
+  tool_error: z.number().int().nonnegative(),
+  error: z.number().int().nonnegative(),
+  finish_reason: z.string().optional(),
+})
+export type StreamEvents = z.infer<typeof StreamEvents>
+
+export const StoredParts = z.object({
+  text: z.number().int().nonnegative(),
+  reasoning: z.number().int().nonnegative(),
+  tool: z.number().int().nonnegative(),
+  step_start: z.number().int().nonnegative(),
+  step_finish: z.number().int().nonnegative(),
+  patch: z.number().int().nonnegative(),
+  file: z.number().int().nonnegative(),
+  other: z.number().int().nonnegative(),
+})
+export type StoredParts = z.infer<typeof StoredParts>
+
+export const Tokens = z.object({
+  input: z.number().int().nonnegative(),
+  output: z.number().int().nonnegative(),
+  reasoning: z.number().int().nonnegative(),
+  cache_read: z.number().int().nonnegative(),
+  cache_write: z.number().int().nonnegative(),
+})
+export type Tokens = z.infer<typeof Tokens>
+
+export const Flags = z.object({
+  empty_completion: z.boolean(),
+  stream_error: z.boolean().optional(),
+  aborted: z.boolean().optional(),
+})
+export type Flags = z.infer<typeof Flags>
+
+export const Summary = z.object({
+  schema_version: z.literal(SCHEMA_VERSION),
+  trace_id: MessageID.zod,
+  session_id: SessionID.zod,
+  message_id: MessageID.zod,
+  parent_message_id: MessageID.zod.optional(),
+  provider: z.string(),
+  model: z.string(),
+  agent: z.string(),
+  variant: z.string().optional(),
+  request: RequestSummary.optional(),
+  stream_events: StreamEvents,
+  stored_parts: StoredParts,
+  tokens: Tokens.optional(),
+  flags: Flags,
+  created_at: z.number(),
+  completed_at: z.number().optional(),
+})
+export type Summary = z.infer<typeof Summary>
+
+export type RequestSummaryInput = {
+  streaming: true
+  toolCount: number
+  toolChoice?: "auto" | "required" | "none"
+  small: boolean
+  reasoningCapability: boolean
+  interleavedField?: string
+  options?: Record<string, unknown>
+}
+
+export type RecorderInput = {
+  traceID: MessageID
+  sessionID: SessionID
+  messageID: MessageID
+  parentMessageID?: MessageID
+  providerID: string
+  modelID: string
+  agent: string
+  variant?: string
+  createdAt: number
+}
+
+export type FinalizeInput = {
+  completedAt?: number
+  finishReason?: string
+  request?: RequestSummary
+  storedParts: MessageV2.Part[]
+  tokens?: MessageV2.Assistant["tokens"]
+  streamError?: boolean
+  aborted?: boolean
+}
+
+export type Recorder = {
+  request(summary: RequestSummary): void
+  observeEvent(event: { type: string } & Record<string, unknown>): void
+  finish(reason: string | undefined, tokens?: MessageV2.Assistant["tokens"]): void
+  finalize(input: FinalizeInput): Summary
+}

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -22,6 +22,7 @@ import { Auth } from "@/auth"
 import { Installation } from "@/installation"
 import { EffectBridge } from "@/effect"
 import * as Option from "effect/Option"
+import { LLMTrace } from "./llm-trace"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
@@ -42,6 +43,7 @@ export type StreamInput = {
   retries?: number
   streamTimeoutMs?: number
   toolChoice?: "auto" | "required" | "none"
+  trace?: Pick<LLMTrace.Recorder, "request">
 }
 
 export type StreamRequest = StreamInput & {
@@ -194,6 +196,7 @@ const live: Layer.Layer<
       )
 
       const tools = resolveTools(input)
+      const activeToolNames = Object.keys(tools).filter((x) => x !== "invalid")
 
       // LiteLLM and some Anthropic proxies require the tools parameter to be present
       // when message history contains tool calls, even if no tools are being used.
@@ -316,6 +319,26 @@ const live: Layer.Layer<
 
       const tracer = undefined
 
+      input.trace?.request(
+        LLMTrace.requestSummary({
+          streaming: true,
+          toolCount: activeToolNames.length,
+          toolChoice: input.toolChoice,
+          small: input.small ?? false,
+          reasoningCapability: input.model.capabilities.reasoning,
+          interleavedField:
+            input.model.capabilities.interleaved && typeof input.model.capabilities.interleaved === "object"
+              ? input.model.capabilities.interleaved.field
+              : undefined,
+          options: {
+            temperature: params.temperature,
+            topP: params.topP,
+            topK: params.topK,
+            maxOutputTokens: params.maxOutputTokens,
+          },
+        }),
+      )
+
       return streamText({
         onError(error) {
           l.error("stream error", {
@@ -347,7 +370,7 @@ const live: Layer.Layer<
         topP: params.topP,
         topK: params.topK,
         providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-        activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+        activeTools: activeToolNames,
         tools,
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -196,7 +196,7 @@ const live: Layer.Layer<
       )
 
       const tools = resolveTools(input)
-      const activeToolNames = Object.keys(tools).filter((x) => x !== "invalid")
+      const traceToolCount = Object.keys(tools).filter((x) => x !== "invalid").length
 
       // LiteLLM and some Anthropic proxies require the tools parameter to be present
       // when message history contains tool calls, even if no tools are being used.
@@ -318,11 +318,12 @@ const live: Layer.Layer<
       }
 
       const tracer = undefined
+      const activeToolNames = Object.keys(tools).filter((x) => x !== "invalid")
 
       input.trace?.request(
         LLMTrace.requestSummary({
           streaming: true,
-          toolCount: activeToolNames.length,
+          toolCount: traceToolCount,
           toolChoice: input.toolChoice,
           small: input.small ?? false,
           reasoningCapability: input.model.capabilities.reasoning,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -18,6 +18,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
 import { EffectLogger } from "@/effect"
 import { isMedia } from "@/util/media"
+import { LLMTrace } from "./llm-trace"
 export { isMedia } from "@/util/media"
 
 function truncateToolOutput(text: string, maxChars?: number) {
@@ -506,6 +507,11 @@ export const Assistant = Base.extend({
   structured: z.any().optional(),
   variant: z.string().optional(),
   finish: z.string().optional(),
+  diagnostics: z
+    .object({
+      llm_trace: LLMTrace.Summary.optional(),
+    })
+    .optional(),
 }).meta({
   ref: "AssistantMessage",
 })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -22,6 +22,7 @@ import { errorMessage } from "@/util/error"
 import { Log } from "@opencode-ai/core/util/log"
 import { isRecord } from "@/util/record"
 import { TurnChange } from "./turn-change"
+import { LLMTrace } from "./llm-trace"
 
 const log = Log.create({ service: "session.processor" })
 const TOOL_CLEANUP_TIMEOUT_MS = 1_000
@@ -125,6 +126,8 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
+  trace: LLMTrace.Recorder
+  streamError: boolean
 }
 
 type StreamEvent = Event
@@ -176,6 +179,18 @@ export const layer: Layer.Layer<
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        trace: LLMTrace.createRecorder({
+          traceID: input.assistantMessage.id,
+          sessionID: input.sessionID,
+          messageID: input.assistantMessage.id,
+          parentMessageID: input.assistantMessage.parentID,
+          providerID: input.model.providerID,
+          modelID: input.model.id,
+          agent: input.assistantMessage.agent,
+          variant: input.assistantMessage.variant,
+          createdAt: input.assistantMessage.time.created,
+        }),
+        streamError: false,
       }
       let aborted = false
       const slog = log.clone().tag("sessionID", input.sessionID).tag("messageID", input.assistantMessage.id)
@@ -574,6 +589,7 @@ export const layer: Layer.Layer<
       })
 
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
+        ctx.trace.observeEvent(value)
         switch (value.type) {
           case "start":
             yield* status.set(ctx.sessionID, { type: "busy" })
@@ -720,6 +736,7 @@ export const layer: Layer.Layer<
               usage: value.usage,
               metadata: value.providerMetadata,
             })
+            ctx.trace.finish(value.finishReason, usage.tokens)
             ctx.assistantMessage.finish = value.finishReason
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
@@ -887,12 +904,24 @@ export const layer: Layer.Layer<
         }
         ctx.toolcalls = {}
         ctx.assistantMessage.time.completed = Date.now()
+        ctx.assistantMessage.diagnostics = {
+          ...(ctx.assistantMessage.diagnostics ?? {}),
+          llm_trace: ctx.trace.finalize({
+            completedAt: ctx.assistantMessage.time.completed,
+            finishReason: ctx.assistantMessage.finish,
+            storedParts: MessageV2.parts(ctx.assistantMessage.id),
+            tokens: ctx.assistantMessage.tokens,
+            streamError: ctx.streamError,
+            aborted,
+          }),
+        }
         yield* session.updateMessage(ctx.assistantMessage)
         yield* turnChange.finalize({ sessionID: ctx.sessionID, messageID: ctx.assistantMessage.id })
       })
 
       const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown) {
         slog.error("process", { error: errorMessage(e), stack: e instanceof Error ? e.stack : undefined })
+        ctx.streamError = true
         const error = parse(e)
         if (MessageV2.ContextOverflowError.isInstance(error)) {
           ctx.needsCompaction = true
@@ -916,7 +945,7 @@ export const layer: Layer.Layer<
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
-            const stream = llm.stream(streamInput)
+            const stream = llm.stream({ ...streamInput, trace: ctx.trace })
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -12,6 +12,7 @@ import { Global } from "../../src/global"
 import { tmpdir } from "../fixture/fixture"
 import { Config } from "../../src/config"
 import { TOOL_FAILURE_HINTS } from "../../src/session/tool-failure"
+import { LLMTrace } from "../../src/session/llm-trace"
 
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
@@ -555,6 +556,122 @@ describe("Export.session", () => {
           if (!entry.resolved) {
             expect(entry.unresolved_reason).toBeTruthy()
           }
+        } finally {
+          await SessionNs.remove(root.id)
+        }
+      },
+    })
+  })
+
+  test("exports assistant llm traces from covered session messages", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "llm trace export" })
+        try {
+          const userID = MessageID.ascending()
+          const assistantID = MessageID.ascending()
+          const trace: LLMTrace.Summary = {
+            schema_version: 1,
+            trace_id: assistantID,
+            session_id: root.id,
+            message_id: assistantID,
+            parent_message_id: userID,
+            provider: "test",
+            model: "test-model",
+            agent: "build",
+            request: {
+              streaming: true,
+              tool_count: 0,
+              small: false,
+              reasoning_capability: true,
+            },
+            stream_events: {
+              start: 1,
+              start_step: 1,
+              finish_step: 1,
+              finish: 1,
+              text_start: 1,
+              text_delta: 2,
+              text_end: 1,
+              reasoning_start: 0,
+              reasoning_delta: 0,
+              reasoning_end: 0,
+              tool_input_start: 0,
+              tool_input_delta: 0,
+              tool_input_end: 0,
+              tool_call: 0,
+              tool_result: 0,
+              tool_error: 0,
+              error: 0,
+              finish_reason: "stop",
+            },
+            stored_parts: {
+              text: 1,
+              reasoning: 0,
+              tool: 0,
+              step_start: 1,
+              step_finish: 1,
+              patch: 0,
+              file: 0,
+              other: 0,
+            },
+            tokens: {
+              input: 3,
+              output: 5,
+              reasoning: 0,
+              cache_read: 0,
+              cache_write: 0,
+            },
+            flags: { empty_completion: false },
+            created_at: 1,
+            completed_at: 2,
+          }
+
+          await SessionNs.updateMessage({
+            id: userID,
+            sessionID: root.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+          } as MessageV2.User)
+          await SessionNs.updateMessage({
+            id: assistantID,
+            role: "assistant",
+            sessionID: root.id,
+            mode: "build",
+            agent: "build",
+            path: { cwd: projectRoot, root: projectRoot },
+            cost: 0,
+            tokens: { input: 3, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: "test-model",
+            providerID: "test",
+            parentID: userID,
+            time: { created: Date.now(), completed: Date.now() },
+            finish: "stop",
+            diagnostics: { llm_trace: trace },
+          } as MessageV2.Assistant)
+
+          const result = await AppRuntime.runPromise(Export.session(root.id))
+          expect(result.diagnostics.llm_trace_schema_version).toBe(1)
+          expect(result.diagnostics.llm_traces).toEqual([trace])
+        } finally {
+          await SessionNs.remove(root.id)
+        }
+      },
+    })
+  })
+
+  test("omits llm_traces when no exported assistant message has trace diagnostics", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "no llm trace" })
+        try {
+          const result = await AppRuntime.runPromise(Export.session(root.id))
+          expect(result.diagnostics.llm_traces).toBeUndefined()
+          expect(result.diagnostics.llm_trace_schema_version).toBeUndefined()
         } finally {
           await SessionNs.remove(root.id)
         }

--- a/packages/opencode/test/session/llm-trace.test.ts
+++ b/packages/opencode/test/session/llm-trace.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { LLMTrace } from "../../src/session/llm-trace"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+describe("LLMTrace", () => {
+  test("keeps request summaries to a safe allowlist", () => {
+    const summary = LLMTrace.requestSummary({
+      streaming: true,
+      toolCount: 2,
+      toolChoice: "auto",
+      small: false,
+      reasoningCapability: true,
+      interleavedField: "reasoning_content",
+      options: {
+        temperature: 0.2,
+        topP: 0.9,
+        topK: 40,
+        maxOutputTokens: 8192,
+        apiKey: "secret",
+        headers: { authorization: "Bearer secret" },
+        messages: [{ role: "user", content: "private prompt" }],
+      },
+    })
+
+    expect(summary).toEqual({
+      streaming: true,
+      tool_count: 2,
+      tool_choice: "auto",
+      small: false,
+      reasoning_capability: true,
+      interleaved_field: "reasoning_content",
+      options: {
+        temperature: 0.2,
+        top_p: 0.9,
+        top_k: 40,
+        max_output_tokens: 8192,
+      },
+    })
+    expect(JSON.stringify(summary)).not.toContain("secret")
+    expect(JSON.stringify(summary)).not.toContain("private prompt")
+  })
+
+  test("counts normalized stream event types without retaining payload text", () => {
+    const recorder = LLMTrace.createRecorder({
+      traceID: MessageID.make("msg_trace"),
+      sessionID: SessionID.make("ses_trace"),
+      messageID: MessageID.make("msg_trace"),
+      parentMessageID: MessageID.make("msg_parent"),
+      providerID: "test",
+      modelID: "model",
+      agent: "build",
+      createdAt: 1,
+    })
+
+    recorder.observeEvent({ type: "text-delta", text: "private output" })
+    recorder.observeEvent({ type: "reasoning-delta", text: "private thought" })
+    recorder.observeEvent({ type: "tool-call", toolName: "bash" })
+    recorder.observeEvent({ type: "error", error: new Error("private response body") })
+
+    const summary = recorder.finalize({
+      completedAt: 2,
+      storedParts: [],
+      tokens: { input: 1, output: 2, reasoning: 3, cache: { read: 0, write: 0 } },
+      finishReason: "stop",
+    })
+
+    expect(summary.stream_events).toMatchObject({
+      text_delta: 1,
+      reasoning_delta: 1,
+      tool_call: 1,
+      error: 1,
+      finish_reason: "stop",
+    })
+    expect(summary.tokens).toEqual({ input: 1, output: 2, reasoning: 3, cache_read: 0, cache_write: 0 })
+    expect(JSON.stringify(summary)).not.toContain("private output")
+    expect(JSON.stringify(summary)).not.toContain("private thought")
+    expect(JSON.stringify(summary)).not.toContain("private response body")
+  })
+
+  test("counts final stored part types and flags empty completions", () => {
+    const recorder = LLMTrace.createRecorder({
+      traceID: MessageID.make("msg_trace"),
+      sessionID: SessionID.make("ses_trace"),
+      messageID: MessageID.make("msg_trace"),
+      providerID: "test",
+      modelID: "model",
+      agent: "build",
+      createdAt: 1,
+    })
+
+    const text: MessageV2.TextPart = {
+      id: PartID.make("prt_text"),
+      sessionID: SessionID.make("ses_trace"),
+      messageID: MessageID.make("msg_trace"),
+      type: "text",
+      text: "hello",
+    }
+    const reasoning: MessageV2.ReasoningPart = {
+      id: PartID.make("prt_reasoning"),
+      sessionID: SessionID.make("ses_trace"),
+      messageID: MessageID.make("msg_trace"),
+      type: "reasoning",
+      text: "think",
+      time: { start: 1, end: 2 },
+    }
+
+    const withParts = recorder.finalize({ completedAt: 2, finishReason: "stop", storedParts: [text, reasoning] })
+    expect(withParts.stored_parts).toMatchObject({ text: 1, reasoning: 1 })
+    expect(withParts.flags.empty_completion).toBe(false)
+
+    const empty = recorder.finalize({ completedAt: 3, finishReason: "stop", storedParts: [] })
+    expect(empty.flags.empty_completion).toBe(true)
+  })
+})

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -666,6 +666,113 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("keeps noop compatibility tool active for LiteLLM tool-call history", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "test-litellm"
+    const source = await loadFixture("alibaba", "qwen-plus")
+    const model = source.model
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                name: "Test LiteLLM",
+                env: ["TEST_LITELLM_API_KEY"],
+                npm: "@ai-sdk/openai-compatible",
+                api: `${server.url.origin}/v1`,
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-litellm-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-noop-tool")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-noop-tool"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const ctrl = new AbortController()
+        const run = llm.runPromiseExit(
+          (svc) =>
+            svc
+              .stream({
+                user,
+                sessionID,
+                model: resolved,
+                agent,
+                system: ["You are a helpful assistant."],
+                messages: [
+                  { role: "user", content: "Read a file" },
+                  {
+                    role: "assistant",
+                    content: [{ type: "tool-call", toolCallId: "call-1", toolName: "read", input: {} }],
+                  },
+                  {
+                    role: "tool",
+                    content: [
+                      {
+                        type: "tool-result",
+                        toolCallId: "call-1",
+                        toolName: "read",
+                        output: { type: "text", value: "done" },
+                      },
+                    ],
+                  },
+                ] as ModelMessage[],
+                tools: {},
+              })
+              .pipe(Stream.runDrain),
+          { signal: ctrl.signal },
+        )
+
+        const capture = await Promise.race([request, timeout(500)])
+        const tools = capture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(tools?.some((item) => item.function?.name === "_noop")).toBe(true)
+        ctrl.abort()
+        await run
+      },
+    })
+  })
+
   test("sends responses API payload for OpenAI models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -218,7 +218,7 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
       Effect.gen(function* () {
         const { processors, session, provider } = yield* boot()
 
-        yield* llm.text("hello")
+        yield* llm.text("hello", { usage: { input: 3, output: 5 } })
 
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "hi")
@@ -254,6 +254,24 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
         expect(value).toBe("continue")
         expect(calls).toBe(1)
         expect(parts.some((part) => part.type === "text" && part.text === "hello")).toBe(true)
+        const trace = handle.message.diagnostics?.llm_trace
+        expect(trace?.message_id).toBe(msg.id)
+        expect(trace?.session_id).toBe(chat.id)
+        expect(trace?.parent_message_id).toBe(parent.id)
+        expect(trace?.provider).toBe("test")
+        expect(trace?.model).toBe("test-model")
+        expect(trace?.request).toMatchObject({
+          streaming: true,
+          tool_count: 0,
+          small: false,
+          reasoning_capability: false,
+        })
+        expect(trace?.stream_events.text_delta).toBeGreaterThan(0)
+        expect(trace?.stream_events.reasoning_delta).toBe(0)
+        expect(trace?.stored_parts.text).toBeGreaterThan(0)
+        expect(trace?.stored_parts.reasoning).toBe(0)
+        expect(trace?.tokens?.output).toBeGreaterThan(0)
+        expect(trace?.flags.empty_completion).toBe(false)
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),
@@ -470,6 +488,50 @@ it.live("session.processor effect tests stop after token overflow requests compa
   ),
 )
 
+it.live("session.processor effect tests flag empty completions", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(reply().stop())
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "empty")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "empty" }],
+          tools: {},
+        })
+
+        expect(value).toBe("continue")
+        expect(MessageV2.parts(msg.id).some((part) => part.type === "text" || part.type === "reasoning")).toBe(false)
+        expect(handle.message.diagnostics?.llm_trace?.flags.empty_completion).toBe(true)
+        expect(handle.message.diagnostics?.llm_trace?.stream_events.finish_step).toBe(1)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests capture reasoning from http mock", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
@@ -513,6 +575,8 @@ it.live("session.processor effect tests capture reasoning from http mock", () =>
         expect(yield* llm.calls).toBe(1)
         expect(reasoning?.text).toBe("think")
         expect(text?.text).toBe("done")
+        expect(handle.message.diagnostics?.llm_trace?.stream_events.reasoning_delta).toBeGreaterThan(0)
+        expect(handle.message.diagnostics?.llm_trace?.stored_parts.reasoning).toBe(1)
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -667,6 +667,7 @@ it.live("session.processor effect tests do not retry unknown json errors", () =>
         expect(value).toBe("stop")
         expect(yield* llm.calls).toBe(1)
         expect(handle.message.error?.name).toBe("APIError")
+        expect(handle.message.diagnostics?.llm_trace?.flags.stream_error).toBe(true)
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),
@@ -1023,6 +1024,7 @@ it.live("session.processor effect tests record aborted errors and idle state", (
         expect(stored.info.role).toBe("assistant")
         if (stored.info.role === "assistant") {
           expect(stored.info.error?.name).toBe("MessageAbortedError")
+          expect(stored.info.diagnostics?.llm_trace?.flags.aborted).toBe(true)
         }
         expect(state).toMatchObject({ type: "idle" })
         expect(errs).toContain("MessageAbortedError")

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -79,6 +79,8 @@ import type {
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
+  PostQuestionE2eAskResponses,
+  PostQuestionE2ePublishAskedResponses,
   ProjectCurrentResponses,
   ProjectInitGitResponses,
   ProjectListResponses,
@@ -101,12 +103,14 @@ import type {
   PtyRemoveResponses,
   PtyUpdateErrors,
   PtyUpdateResponses,
+  QuestionInfo,
   QuestionListResponses,
   QuestionRejectErrors,
   QuestionRejectResponses,
   QuestionReply,
   QuestionReplyErrors,
   QuestionReplyResponses,
+  QuestionRequest,
   SessionAbortErrors,
   SessionAbortResponses,
   SessionArtifactsResponses,
@@ -149,6 +153,18 @@ import type {
   SessionSummarizeResponses,
   SessionTodoErrors,
   SessionTodoResponses,
+  SessionTurnChangeErrors,
+  SessionTurnChangeRedoErrors,
+  SessionTurnChangeRedoResponses,
+  SessionTurnChangeResponses,
+  SessionTurnChangesAggregateErrors,
+  SessionTurnChangesAggregateRedoErrors,
+  SessionTurnChangesAggregateRedoResponses,
+  SessionTurnChangesAggregateResponses,
+  SessionTurnChangesAggregateUndoErrors,
+  SessionTurnChangesAggregateUndoResponses,
+  SessionTurnChangeUndoErrors,
+  SessionTurnChangeUndoResponses,
   SessionUnrevertErrors,
   SessionUnrevertResponses,
   SessionUnshareErrors,
@@ -2060,6 +2076,236 @@ export class Session2 extends HeyApiClient {
   }
 
   /**
+   * Get assistant turn changes
+   *
+   * Get files explicitly changed by PawWork file-writing tools during one assistant turn.
+   */
+  public turnChange<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionTurnChangeResponses, SessionTurnChangeErrors, ThrowOnError>({
+      url: "/session/{sessionID}/turn-change/{messageID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Undo assistant turn file changes
+   */
+  public turnChangeUndo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangeUndoResponses,
+      SessionTurnChangeUndoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn-change/{messageID}/undo",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Redo assistant turn file changes
+   */
+  public turnChangeRedo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangeRedoResponses,
+      SessionTurnChangeRedoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn-change/{messageID}/redo",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get aggregated turn changes
+   *
+   * Aggregate file changes across all assistants in one user turn.
+   */
+  public turnChangesAggregate<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      SessionTurnChangesAggregateResponses,
+      SessionTurnChangesAggregateErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Undo all assistant changes in a turn
+   */
+  public turnChangesAggregateUndo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+      force?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "force" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangesAggregateUndoResponses,
+      SessionTurnChangesAggregateUndoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes/undo",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Redo all assistant changes in a turn
+   */
+  public turnChangesAggregateRedo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+      force?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "force" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangesAggregateRedoResponses,
+      SessionTurnChangesAggregateRedoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes/redo",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * Get session artifacts
    *
    * Get the cumulative files created or updated across a session.
@@ -3556,8 +3802,8 @@ export class Path extends HeyApiClient {
   public get<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
-      ensureConfig?: boolean
       workspace?: string
+      ensureConfig?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3567,8 +3813,8 @@ export class Path extends HeyApiClient {
         {
           args: [
             { in: "query", key: "directory" },
-            { in: "query", key: "ensureConfig" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "ensureConfig" },
           ],
         },
       ],
@@ -3747,6 +3993,72 @@ export class OpencodeClient extends HeyApiClient {
   constructor(args?: { client?: Client; key?: string }) {
     super(args)
     OpencodeClient.__registry.set(this, args?.key)
+  }
+
+  public postQuestionE2eAsk<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      sessionID?: string
+      questions?: Array<QuestionInfo>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "questions" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PostQuestionE2eAskResponses, unknown, ThrowOnError>({
+      url: "/question/__e2e/ask",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  public postQuestionE2ePublishAsked<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      request?: QuestionRequest
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "request" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PostQuestionE2ePublishAskedResponses, unknown, ThrowOnError>({
+      url: "/question/__e2e/publish-asked",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
   }
 
   private _global?: Global

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -92,17 +92,6 @@ export type EventLspServerInstallFailed = {
   }
 }
 
-export type EventMessagePartDelta = {
-  type: "message.part.delta"
-  properties: {
-    sessionID: string
-    messageID: string
-    partID: string
-    field: string
-    delta: string
-  }
-}
-
 export type PermissionRequest = {
   id: string
   sessionID: string
@@ -129,6 +118,94 @@ export type EventPermissionReplied = {
     sessionID: string
     requestID: string
     reply: "once" | "always" | "reject"
+  }
+}
+
+export type QuestionOption = {
+  /**
+   * Display text (1–5 words, max 50 chars)
+   */
+  label: string
+  /**
+   * One-line explanation of choice (max 50 chars)
+   */
+  description: string
+}
+
+export type QuestionInfo = {
+  /**
+   * Short question (max 200 chars). Stream longer framing as normal output first.
+   */
+  question: string
+  /**
+   * Very short label (max 30 chars)
+   */
+  header: string
+  /**
+   * Available choices (2–4)
+   */
+  options: Array<QuestionOption>
+  /**
+   * Allow selecting multiple choices
+   */
+  multiple?: boolean
+  /**
+   * Allow typing a custom answer (default: true)
+   */
+  custom?: boolean
+}
+
+export type QuestionTool = {
+  messageID: string
+  callID: string
+}
+
+export type QuestionRequest = {
+  id: string
+  sessionID: string
+  /**
+   * Questions to ask
+   */
+  questions: Array<QuestionInfo>
+  tool?: QuestionTool
+}
+
+export type EventQuestionAsked = {
+  type: "question.asked"
+  properties: QuestionRequest
+}
+
+export type QuestionAnswer = Array<string>
+
+export type QuestionReplied = {
+  sessionID: string
+  requestID: string
+  answers: Array<QuestionAnswer>
+}
+
+export type EventQuestionReplied = {
+  type: "question.replied"
+  properties: QuestionReplied
+}
+
+export type QuestionRejected = {
+  sessionID: string
+  requestID: string
+}
+
+export type EventQuestionRejected = {
+  type: "question.rejected"
+  properties: QuestionRejected
+}
+
+export type EventMessagePartDelta = {
+  type: "message.part.delta"
+  properties: {
+    sessionID: string
+    messageID: string
+    partID: string
+    field: string
+    delta: string
   }
 }
 
@@ -269,83 +346,6 @@ export type EventCommandExecuted = {
     arguments: string
     messageID: string
   }
-}
-
-export type QuestionOption = {
-  /**
-   * Display text (1–5 words, max 50 chars)
-   */
-  label: string
-  /**
-   * One-line explanation of choice (max 50 chars)
-   */
-  description: string
-}
-
-export type QuestionInfo = {
-  /**
-   * Short question (max 200 chars). Stream longer framing as normal output first.
-   */
-  question: string
-  /**
-   * Very short label (max 30 chars)
-   */
-  header: string
-  /**
-   * Available choices (2–4)
-   */
-  options: Array<QuestionOption>
-  /**
-   * Allow selecting multiple choices
-   */
-  multiple?: boolean
-  /**
-   * Allow typing a custom answer (default: true)
-   */
-  custom?: boolean
-}
-
-export type QuestionTool = {
-  messageID: string
-  callID: string
-}
-
-export type QuestionRequest = {
-  id: string
-  sessionID: string
-  /**
-   * Questions to ask
-   */
-  questions: Array<QuestionInfo>
-  tool?: QuestionTool
-}
-
-export type EventQuestionAsked = {
-  type: "question.asked"
-  properties: QuestionRequest
-}
-
-export type QuestionAnswer = Array<string>
-
-export type QuestionReplied = {
-  sessionID: string
-  requestID: string
-  answers: Array<QuestionAnswer>
-}
-
-export type EventQuestionReplied = {
-  type: "question.replied"
-  properties: QuestionReplied
-}
-
-export type QuestionRejected = {
-  sessionID: string
-  requestID: string
-}
-
-export type EventQuestionRejected = {
-  type: "question.rejected"
-  properties: QuestionRejected
 }
 
 export type Todo = {
@@ -569,6 +569,77 @@ export type AssistantMessage = {
   structured?: unknown
   variant?: string
   finish?: string
+  diagnostics?: {
+    llm_trace?: {
+      schema_version: 1
+      trace_id: string
+      session_id: string
+      message_id: string
+      parent_message_id?: string
+      provider: string
+      model: string
+      agent: string
+      variant?: string
+      request?: {
+        streaming: true
+        tool_count: number
+        tool_choice?: "auto" | "required" | "none"
+        small: boolean
+        reasoning_capability: boolean
+        interleaved_field?: string
+        options?: {
+          temperature?: number
+          top_p?: number
+          top_k?: number
+          max_output_tokens?: number
+        }
+      }
+      stream_events: {
+        start: number
+        start_step: number
+        finish_step: number
+        finish: number
+        text_start: number
+        text_delta: number
+        text_end: number
+        reasoning_start: number
+        reasoning_delta: number
+        reasoning_end: number
+        tool_input_start: number
+        tool_input_delta: number
+        tool_input_end: number
+        tool_call: number
+        tool_result: number
+        tool_error: number
+        error: number
+        finish_reason?: string
+      }
+      stored_parts: {
+        text: number
+        reasoning: number
+        tool: number
+        step_start: number
+        step_finish: number
+        patch: number
+        file: number
+        other: number
+      }
+      tokens?: {
+        input: number
+        output: number
+        reasoning: number
+        cache_read: number
+        cache_write: number
+      }
+      flags: {
+        empty_completion: boolean
+        stream_error?: boolean
+        aborted?: boolean
+      }
+      created_at: number
+      completed_at?: number
+    }
+  }
 }
 
 export type Message = UserMessage | AssistantMessage
@@ -1025,9 +1096,12 @@ export type Event =
   | EventLspClientDiagnostics
   | EventLspUpdated
   | EventLspServerInstallFailed
-  | EventMessagePartDelta
   | EventPermissionAsked
   | EventPermissionReplied
+  | EventQuestionAsked
+  | EventQuestionReplied
+  | EventQuestionRejected
+  | EventMessagePartDelta
   | EventSessionDiff
   | EventSessionError
   | EventFileEdited
@@ -1036,9 +1110,6 @@ export type Event =
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
-  | EventQuestionAsked
-  | EventQuestionReplied
-  | EventQuestionRejected
   | EventTodoUpdated
   | EventSessionStatus
   | EventSessionIdle
@@ -3766,6 +3837,496 @@ export type SessionDiffResponses = {
 
 export type SessionDiffResponse = SessionDiffResponses[keyof SessionDiffResponses]
 
+export type SessionTurnChangeData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}"
+}
+
+export type SessionTurnChangeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangeError = SessionTurnChangeErrors[keyof SessionTurnChangeErrors]
+
+export type SessionTurnChangeResponses = {
+  /**
+   * Turn changes
+   */
+  200: {
+    sessionID: string
+    turnID: string
+    messageID: string
+    undoAvailable: boolean
+    redoAvailable: boolean
+    truncated?: boolean
+    omittedCount?: number
+    files: Array<{
+      path: string
+      openPath?: string
+      status: "added" | "modified" | "deleted"
+      additions?: number
+      deletions?: number
+      patch?: string
+      sensitive?: boolean
+      binary?: boolean
+      large?: boolean
+      restoreAvailable?: boolean
+      expandable: boolean
+    }>
+  } | null
+}
+
+export type SessionTurnChangeResponse = SessionTurnChangeResponses[keyof SessionTurnChangeResponses]
+
+export type SessionTurnChangeUndoData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}/undo"
+}
+
+export type SessionTurnChangeUndoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangeUndoError = SessionTurnChangeUndoErrors[keyof SessionTurnChangeUndoErrors]
+
+export type SessionTurnChangeUndoResponses = {
+  /**
+   * Undo result
+   */
+  200:
+    | {
+        status: "applied"
+        display: {
+          sessionID: string
+          turnID: string
+          messageID: string
+          undoAvailable: boolean
+          redoAvailable: boolean
+          truncated?: boolean
+          omittedCount?: number
+          files: Array<{
+            path: string
+            openPath?: string
+            status: "added" | "modified" | "deleted"
+            additions?: number
+            deletions?: number
+            patch?: string
+            sensitive?: boolean
+            binary?: boolean
+            large?: boolean
+            restoreAvailable?: boolean
+            expandable: boolean
+          }>
+        }
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+        mutatedPaths?: Array<string>
+      }
+    | {
+        status: "blocked"
+        reason:
+          | "conflict"
+          | "restore_missing"
+          | "permission_denied"
+          | "unsupported_size"
+          | "write_failed"
+          | "rollback_failed"
+        files: Array<{
+          path: string
+          reason: string
+          omittedCount?: number
+        }>
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+      }
+}
+
+export type SessionTurnChangeUndoResponse = SessionTurnChangeUndoResponses[keyof SessionTurnChangeUndoResponses]
+
+export type SessionTurnChangeRedoData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}/redo"
+}
+
+export type SessionTurnChangeRedoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangeRedoError = SessionTurnChangeRedoErrors[keyof SessionTurnChangeRedoErrors]
+
+export type SessionTurnChangeRedoResponses = {
+  /**
+   * Redo result
+   */
+  200:
+    | {
+        status: "applied"
+        display: {
+          sessionID: string
+          turnID: string
+          messageID: string
+          undoAvailable: boolean
+          redoAvailable: boolean
+          truncated?: boolean
+          omittedCount?: number
+          files: Array<{
+            path: string
+            openPath?: string
+            status: "added" | "modified" | "deleted"
+            additions?: number
+            deletions?: number
+            patch?: string
+            sensitive?: boolean
+            binary?: boolean
+            large?: boolean
+            restoreAvailable?: boolean
+            expandable: boolean
+          }>
+        }
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+        mutatedPaths?: Array<string>
+      }
+    | {
+        status: "blocked"
+        reason:
+          | "conflict"
+          | "restore_missing"
+          | "permission_denied"
+          | "unsupported_size"
+          | "write_failed"
+          | "rollback_failed"
+        files: Array<{
+          path: string
+          reason: string
+          omittedCount?: number
+        }>
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+      }
+}
+
+export type SessionTurnChangeRedoResponse = SessionTurnChangeRedoResponses[keyof SessionTurnChangeRedoResponses]
+
+export type SessionTurnChangesAggregateData = {
+  body?: never
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes"
+}
+
+export type SessionTurnChangesAggregateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangesAggregateError =
+  SessionTurnChangesAggregateErrors[keyof SessionTurnChangesAggregateErrors]
+
+export type SessionTurnChangesAggregateResponses = {
+  /**
+   * Aggregated turn changes
+   */
+  200: {
+    sessionID: string
+    turnID: string
+    messageID: string
+    undoAvailable: boolean
+    redoAvailable: boolean
+    truncated?: boolean
+    omittedCount?: number
+    files: Array<{
+      path: string
+      openPath?: string
+      status: "added" | "modified" | "deleted"
+      additions?: number
+      deletions?: number
+      patch?: string
+      sensitive?: boolean
+      binary?: boolean
+      large?: boolean
+      restoreAvailable?: boolean
+      expandable: boolean
+    }>
+  } | null
+}
+
+export type SessionTurnChangesAggregateResponse =
+  SessionTurnChangesAggregateResponses[keyof SessionTurnChangesAggregateResponses]
+
+export type SessionTurnChangesAggregateUndoData = {
+  body?: {
+    force?: boolean
+  }
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes/undo"
+}
+
+export type SessionTurnChangesAggregateUndoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangesAggregateUndoError =
+  SessionTurnChangesAggregateUndoErrors[keyof SessionTurnChangesAggregateUndoErrors]
+
+export type SessionTurnChangesAggregateUndoResponses = {
+  /**
+   * Undo result
+   */
+  200:
+    | {
+        status: "applied"
+        display: {
+          sessionID: string
+          turnID: string
+          messageID: string
+          undoAvailable: boolean
+          redoAvailable: boolean
+          truncated?: boolean
+          omittedCount?: number
+          files: Array<{
+            path: string
+            openPath?: string
+            status: "added" | "modified" | "deleted"
+            additions?: number
+            deletions?: number
+            patch?: string
+            sensitive?: boolean
+            binary?: boolean
+            large?: boolean
+            restoreAvailable?: boolean
+            expandable: boolean
+          }>
+        }
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+        mutatedPaths?: Array<string>
+      }
+    | {
+        status: "blocked"
+        reason:
+          | "conflict"
+          | "restore_missing"
+          | "permission_denied"
+          | "unsupported_size"
+          | "write_failed"
+          | "rollback_failed"
+        files: Array<{
+          path: string
+          reason: string
+          omittedCount?: number
+        }>
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+      }
+}
+
+export type SessionTurnChangesAggregateUndoResponse =
+  SessionTurnChangesAggregateUndoResponses[keyof SessionTurnChangesAggregateUndoResponses]
+
+export type SessionTurnChangesAggregateRedoData = {
+  body?: {
+    force?: boolean
+  }
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes/redo"
+}
+
+export type SessionTurnChangesAggregateRedoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangesAggregateRedoError =
+  SessionTurnChangesAggregateRedoErrors[keyof SessionTurnChangesAggregateRedoErrors]
+
+export type SessionTurnChangesAggregateRedoResponses = {
+  /**
+   * Redo result
+   */
+  200:
+    | {
+        status: "applied"
+        display: {
+          sessionID: string
+          turnID: string
+          messageID: string
+          undoAvailable: boolean
+          redoAvailable: boolean
+          truncated?: boolean
+          omittedCount?: number
+          files: Array<{
+            path: string
+            openPath?: string
+            status: "added" | "modified" | "deleted"
+            additions?: number
+            deletions?: number
+            patch?: string
+            sensitive?: boolean
+            binary?: boolean
+            large?: boolean
+            restoreAvailable?: boolean
+            expandable: boolean
+          }>
+        }
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+        mutatedPaths?: Array<string>
+      }
+    | {
+        status: "blocked"
+        reason:
+          | "conflict"
+          | "restore_missing"
+          | "permission_denied"
+          | "unsupported_size"
+          | "write_failed"
+          | "rollback_failed"
+        files: Array<{
+          path: string
+          reason: string
+          omittedCount?: number
+        }>
+        skipped?: Array<{
+          messageID: string
+          reason: "conflict" | "permission_denied"
+          files: Array<{
+            path: string
+            reason: string
+          }>
+        }>
+      }
+}
+
+export type SessionTurnChangesAggregateRedoResponse =
+  SessionTurnChangesAggregateRedoResponses[keyof SessionTurnChangesAggregateRedoResponses]
+
 export type SessionArtifactsData = {
   body?: never
   path: {
@@ -4385,6 +4946,39 @@ export type PermissionListResponses = {
 }
 
 export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
+
+export type PostQuestionE2eAskData = {
+  body?: {
+    sessionID: string
+    questions: Array<QuestionInfo>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/question/__e2e/ask"
+}
+
+export type PostQuestionE2eAskResponses = {
+  200: unknown
+}
+
+export type PostQuestionE2ePublishAskedData = {
+  body?: {
+    request: QuestionRequest
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/question/__e2e/publish-asked"
+}
+
+export type PostQuestionE2ePublishAskedResponses = {
+  200: unknown
+}
 
 export type QuestionListData = {
   body?: never
@@ -5030,8 +5624,11 @@ export type PathGetData = {
   path?: never
   query?: {
     directory?: string
-    ensureConfig?: boolean
     workspace?: string
+    /**
+     * Create the global config directory before returning it.
+     */
+    ensureConfig?: boolean
   }
   url: "/path"
 }


### PR DESCRIPTION
## Summary

Adds lightweight LLM trace summaries for assistant model runs and includes them in local session exports.

## Why

Session exports currently preserve final messages, parts, and token metadata, but they do not show whether an output anomaly happened at the request boundary, AI SDK normalized stream, PawWork processor, or persisted message. This PR adds count-only diagnostics so issue #454 can be diagnosed from the export without raw prompts, raw model output, headers, API keys, or provider chunks.

## Related Issue

Closes #454
Closes #214

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the trace contract and privacy boundary: request summary allowlist, normalized stream event counts, final stored part counts, and whether assistant-message retention is the right persistence layer.

## Risk Notes

Additive assistant message diagnostics widen the v2 SDK schema and persist one count-only trace per assistant model run. The trace intentionally omits prompts, messages, headers, API keys, raw provider chunks, raw output text, and tool bodies. Generated SDK files changed after `bun --cwd packages/sdk/js build`. No desktop, packaging, updater, signing, path, shell, or permission behavior is changed.

## How To Verify

```text
LLM trace/export tests: 35 passed, 0 failed
Processor integration tests: 15 passed, 0 failed
opencode typecheck: passed
SDK build: passed, v2 SDK generated files updated
SDK typecheck: passed
Diff check: no whitespace errors
```

Commands run:

```text
bun --cwd packages/opencode test test/session/llm-trace.test.ts test/session/export.test.ts --timeout 30000
bun --cwd packages/opencode test test/session/processor-effect.test.ts --timeout 30000
bun --cwd packages/opencode typecheck
bun --cwd packages/sdk/js build
bun --cwd packages/sdk/js typecheck
git diff --check
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Requested maintainer labeling for type, scope, and priority.