### PR TITLE
refactor(ui): tag, popover, inverse tooltip per pawwork ds (slice 06, issue #440)

### DIFF
--- a/packages/ui/src/components/popover.css
+++ b/packages/ui/src/components/popover.css
@@ -4,13 +4,10 @@
 
 [data-component="popover-content"] {
   z-index: 50;
-  min-width: 200px;
-  max-width: 320px;
-  border-radius: 14px;
-  background-color: var(--surface-raised);
-
+  border-radius: var(--radius-md);
+  background-color: var(--surface-base);
   background-clip: padding-box;
-  box-shadow: var(--shadow-floating);
+  box-shadow: var(--ring-base), var(--shadow-floating);
 
   transform-origin: var(--kb-popover-content-transform-origin);
 
@@ -19,17 +16,16 @@
   }
 
   &[data-closed] {
-    animation: popover-close 0.15s ease-out;
+    animation: popover-close 0.12s ease-out;
   }
 
   &[data-expanded] {
-    animation: popover-open 0.15s ease-out;
+    animation: popover-open 0.12s ease-out;
   }
 
   [data-slot="popover-header"] {
     display: flex;
-    padding: 12px;
-    padding-bottom: 0;
+    padding: 10px 12px 8px;
     justify-content: space-between;
     align-items: center;
     gap: 8px;
@@ -38,13 +34,7 @@
       flex: 1;
       color: var(--fg-strong);
       margin: 0;
-
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-base);
-      font-style: normal;
-      font-weight: var(--font-weight-medium);
-      line-height: var(--line-height-large);
-      letter-spacing: var(--letter-spacing-normal);
+      font: var(--type-h3);
     }
 
     [data-slot="popover-close-button"] {
@@ -53,26 +43,93 @@
   }
 
   [data-slot="popover-description"] {
-    padding: 0 12px;
+    padding: 0 12px 8px;
     margin: 0;
     color: var(--fg-base);
-
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-small);
-    font-style: normal;
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-large);
-    letter-spacing: var(--letter-spacing-normal);
+    font: var(--type-body);
   }
 
   [data-slot="popover-body"] {
     padding: 4px;
   }
+}
 
-  [data-slot="popover-arrow"] {
-    fill: var(--surface-raised);
+/* ── Menu item primitives (used by popover-body consumers) ── */
+
+[data-slot="popover-item"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  color: var(--fg-strong);
+  font: var(--type-body);
+  white-space: nowrap;
+  user-select: none;
+
+  &:hover,
+  &[data-force-state="hover"] {
+    background: var(--bg-cream);
+  }
+
+  &[data-active],
+  &[data-force-state="active"] {
+    background: var(--bg-cream);
+    opacity: 0.8;
+  }
+
+  &:focus-visible,
+  &[data-force-state="focus-visible"] {
+    outline: none;
+    background: var(--bg-cream);
+  }
+
+  &[data-selected],
+  &[data-force-state="selected"] {
+    background: var(--bg-cream);
+  }
+
+  &[data-disabled],
+  &[data-force-state="disabled"] {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
   }
 }
+
+[data-slot="popover-item-icon"] {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  color: var(--icon-base);
+}
+
+[data-slot="popover-item-shortcut"] {
+  margin-left: auto;
+  font: var(--type-kbd);
+  color: var(--fg-weak);
+}
+
+[data-slot="popover-separator"] {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border-weaker);
+}
+
+[data-slot="popover-item"][data-variant="danger"] {
+  color: var(--error);
+
+  &:hover,
+  &[data-force-state="hover"] {
+    background: var(--error-bg);
+  }
+}
+
+/* ── Animations ── */
 
 @keyframes popover-open {
   from {

--- a/packages/ui/src/components/popover.css
+++ b/packages/ui/src/components/popover.css
@@ -16,11 +16,11 @@
   }
 
   &[data-closed] {
-    animation: popover-close 0.12s ease-out;
+    animation: popover-close var(--duration-base) ease-out;
   }
 
   &[data-expanded] {
-    animation: popover-open 0.12s ease-out;
+    animation: popover-open var(--duration-base) ease-out;
   }
 
   [data-slot="popover-header"] {
@@ -79,7 +79,7 @@
     &:focus-visible {
       outline: none;
       border-radius: 2px;
-      box-shadow: 0 0 0 1px #ff5910, 0 0 0 3px rgba(255, 89, 16, 0.2);
+      box-shadow: var(--shadow-xs-border-focus);
     }
   }
 }

--- a/packages/ui/src/components/popover.css
+++ b/packages/ui/src/components/popover.css
@@ -54,6 +54,36 @@
   }
 }
 
+/* ── Embedded search slot (model picker / branch picker pattern) ── */
+
+[data-slot="popover-search"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-weaker);
+
+  input,
+  [data-slot="popover-search-input"] {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--fg-strong);
+    font: var(--type-body);
+
+    &::placeholder {
+      color: var(--fg-weak);
+    }
+
+    &:focus-visible {
+      outline: none;
+      border-radius: 2px;
+      box-shadow: 0 0 0 1px #ff5910, 0 0 0 3px rgba(255, 89, 16, 0.2);
+    }
+  }
+}
+
 /* ── Menu item primitives (used by popover-body consumers) ── */
 
 [data-slot="popover-item"] {

--- a/packages/ui/src/components/popover.stories.tsx
+++ b/packages/ui/src/components/popover.stories.tsx
@@ -127,6 +127,35 @@ export const MenuMatrix = {
   ),
 }
 
+/**
+ * Embedded search slot — no border, no radius, 1px --border-weaker bottom divider.
+ * autofocus triggers static :focus-visible ring screenshot.
+ */
+export const WithSearch = {
+  render: () => (
+    <div
+      style={{
+        background: "var(--surface-base)",
+        "border-radius": "var(--radius-md)",
+        "box-shadow": "var(--ring-base), var(--shadow-floating)",
+        "min-width": "184px",
+      }}
+    >
+      <div data-slot="popover-search">
+        <input
+          data-slot="popover-search-input"
+          placeholder="Search…"
+          autofocus
+        />
+      </div>
+      <div style={{ padding: "4px" }}>
+        <div data-slot="popover-item">Result one</div>
+        <div data-slot="popover-item">Result two</div>
+      </div>
+    </div>
+  ),
+}
+
 export const WithDanger = {
   render: () => (
     <mod.Popover trigger="Open" defaultOpen portal={false}>

--- a/packages/ui/src/components/popover.stories.tsx
+++ b/packages/ui/src/components/popover.stories.tsx
@@ -1,30 +1,12 @@
 // @ts-nocheck
+/**
+ * Hover / active / focus-visible states are captured statically via
+ * data-force-state="hover|active|focus-visible|selected|disabled" +
+ * matching CSS rules in popover.css.
+ */
 import { createSignal } from "solid-js"
 import * as mod from "./popover"
 import { create } from "../storybook/scaffold"
-
-const docs = `### Overview
-Composable popover with optional title, description, and close button.
-
-Use for small contextual details; avoid long forms.
-
-### API
-- \`trigger\` and \`children\` define the anchor and content.
-- Optional: \`title\`, \`description\`, \`portal\`, \`open\`, \`defaultOpen\`.
-
-### Variants and states
-- Supports controlled and uncontrolled open state.
-
-### Behavior
-- Closes on outside click or Escape by default.
-
-### Accessibility
-- TODO: confirm focus management from Kobalte.
-
-### Theming/tokens
-- Uses \`data-component="popover-content"\` and related slots.
-
-`
 
 const story = create({
   title: "UI/Popover",
@@ -43,24 +25,9 @@ export default {
   id: "components-popover",
   component: story.meta.component,
   tags: ["autodocs"],
-  parameters: {
-    docs: {
-      description: {
-        component: docs,
-      },
-    },
-  },
 }
 
 export const Basic = story.Basic
-
-export const NoHeader = {
-  args: {
-    title: undefined,
-    description: undefined,
-    children: "Popover body only",
-  },
-}
 
 export const Inline = {
   args: {
@@ -84,4 +51,91 @@ export const Controlled = {
       </mod.Popover>
     )
   },
+}
+
+/**
+ * All item states side-by-side (light + dark).
+ * Hover/focus/selected captured via data-force-state.
+ */
+export const MenuMatrix = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", "align-items": "flex-start" }}>
+      {/* Light */}
+      <div
+        style={{
+          background: "var(--surface-base)",
+          "border-radius": "var(--radius-md)",
+          "box-shadow": "var(--ring-base), var(--shadow-floating)",
+          padding: "4px",
+          "min-width": "184px",
+        }}
+      >
+        <div data-slot="popover-item">Default item</div>
+        <div data-slot="popover-item" data-force-state="hover">
+          Hovered item
+        </div>
+        <div data-slot="popover-item" data-force-state="active">
+          Active item
+        </div>
+        <div data-slot="popover-item" data-force-state="focus-visible">
+          Focused item
+        </div>
+        <div data-slot="popover-item" data-force-state="selected">
+          Selected item
+        </div>
+        <div data-slot="popover-item" data-force-state="disabled">
+          Disabled item
+        </div>
+        <div data-slot="popover-item">
+          <span data-slot="popover-item-icon">⌘</span>
+          With icon
+          <span data-slot="popover-item-shortcut">⌘K</span>
+        </div>
+        <div data-slot="popover-separator" />
+        <div data-slot="popover-item" data-variant="danger">
+          Delete
+        </div>
+      </div>
+
+      {/* Dark */}
+      <div
+        data-color-scheme="dark"
+        style={{
+          background: "var(--surface-base)",
+          "border-radius": "var(--radius-md)",
+          "box-shadow": "var(--ring-base), var(--shadow-floating)",
+          padding: "4px",
+          "min-width": "184px",
+        }}
+      >
+        <div data-slot="popover-item">Default item</div>
+        <div data-slot="popover-item" data-force-state="hover">
+          Hovered item
+        </div>
+        <div data-slot="popover-item" data-force-state="selected">
+          Selected item
+        </div>
+        <div data-slot="popover-item" data-force-state="disabled">
+          Disabled item
+        </div>
+        <div data-slot="popover-separator" />
+        <div data-slot="popover-item" data-variant="danger" data-force-state="hover">
+          Delete (hover)
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+export const WithDanger = {
+  render: () => (
+    <mod.Popover trigger="Open" defaultOpen portal={false}>
+      <div data-slot="popover-item">Rename</div>
+      <div data-slot="popover-item">Export…</div>
+      <div data-slot="popover-separator" />
+      <div data-slot="popover-item" data-variant="danger">
+        Delete
+      </div>
+    </mod.Popover>
+  ),
 }

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -136,7 +136,7 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
   )
 
   return (
-    <Kobalte gutter={4} {...rest} open={opened()} onOpenChange={onOpenChange} modal={local.modal ?? false}>
+    <Kobalte gutter={8} {...rest} open={opened()} onOpenChange={onOpenChange} modal={local.modal ?? false}>
       <Kobalte.Trigger
         ref={(el: HTMLElement) => setState("triggerRef", el)}
         as={local.triggerAs ?? "div"}

--- a/packages/ui/src/components/tag.css
+++ b/packages/ui/src/components/tag.css
@@ -4,34 +4,17 @@
   justify-content: center;
   user-select: none;
 
-  border-radius: var(--radius-xs);
-  border: 0.5px solid var(--border-weak);
+  height: 20px;
+  padding: 0 6px;
+
   background: var(--surface-raised);
   color: var(--fg-base);
+  border: 0.5px solid var(--border-weak);
+  border-radius: var(--radius-sm);
 
-  &[data-size="normal"] {
-    height: 18px;
-    padding: 0 6px;
-
-    /* text-13-medium */
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-small);
-    font-style: normal;
-    font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large); /* 166.667% */
-    letter-spacing: var(--letter-spacing-normal);
-  }
-
-  &[data-size="large"] {
-    height: 22px;
-    padding: 0 8px;
-
-    /* text-14-medium */
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-hierarchy);
-    font-style: normal;
-    font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large); /* 142.857% */
-    letter-spacing: var(--letter-spacing-normal);
-  }
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+  letter-spacing: var(--letter-spacing-normal);
 }

--- a/packages/ui/src/components/tag.stories.tsx
+++ b/packages/ui/src/components/tag.stories.tsx
@@ -2,57 +2,33 @@
 import * as mod from "./tag"
 import { create } from "../storybook/scaffold"
 
-const docs = `### Overview
-Small label tag for metadata and status chips.
+const story = create({ title: "UI/Tag", mod, args: { children: "Label" } })
 
-Use alongside headings or lists for quick metadata.
-
-### API
-- Optional: \`size\` (normal | large).
-- Accepts standard span props.
-
-### Variants and states
-- Size variants only.
-
-### Behavior
-- Inline element; size controls padding and font size via CSS.
-
-### Accessibility
-- Ensure text conveys meaning; avoid color-only distinction.
-
-### Theming/tokens
-- Uses \`data-component="tag"\` with size data attributes.
-
-`
-
-const story = create({ title: "UI/Tag", mod, args: { children: "Tag" } })
 export default {
   title: "UI/Tag",
   id: "components-tag",
   component: story.meta.component,
   tags: ["autodocs"],
-  parameters: {
-    docs: {
-      description: {
-        component: docs,
-      },
-    },
-  },
-  argTypes: {
-    size: {
-      control: "select",
-      options: ["normal", "large"],
-    },
-  },
 }
 
 export const Basic = story.Basic
 
-export const Sizes = {
+/**
+ * Smoke-test Tag across common background surfaces.
+ * All instances are rest-state only (no hover/focus/disabled).
+ */
+export const OnSurfaces = {
   render: () => (
-    <div style={{ display: "flex", gap: "8px", "align-items": "center" }}>
-      <mod.Tag size="normal">Normal</mod.Tag>
-      <mod.Tag size="large">Large</mod.Tag>
+    <div style={{ display: "flex", gap: "16px", "align-items": "center" }}>
+      <div style={{ background: "var(--bg-base)", padding: "8px" }}>
+        <mod.Tag>On white</mod.Tag>
+      </div>
+      <div style={{ background: "var(--bg-cream)", padding: "8px" }}>
+        <mod.Tag>On cream</mod.Tag>
+      </div>
+      <div style={{ background: "var(--surface-raised)", padding: "8px" }}>
+        <mod.Tag>On raised</mod.Tag>
+      </div>
     </div>
   ),
 }

--- a/packages/ui/src/components/tag.tsx
+++ b/packages/ui/src/components/tag.tsx
@@ -1,16 +1,13 @@
 import { type ComponentProps, splitProps } from "solid-js"
 
-export interface TagProps extends ComponentProps<"span"> {
-  size?: "normal" | "large"
-}
+export interface TagProps extends ComponentProps<"span"> {}
 
 export function Tag(props: TagProps) {
-  const [split, rest] = splitProps(props, ["size", "class", "classList", "children"])
+  const [split, rest] = splitProps(props, ["class", "classList", "children"])
   return (
     <span
       {...rest}
       data-component="tag"
-      data-size={split.size || "normal"}
       classList={{
         ...split.classList,
         [split.class ?? ""]: !!split.class,

--- a/packages/ui/src/components/tooltip.css
+++ b/packages/ui/src/components/tooltip.css
@@ -9,66 +9,50 @@
 }
 
 [data-slot="tooltip-keybind-key"] {
-  color: var(--fg-on-brand);
-  font-size: var(--font-size-small);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--line-height-large);
+  font: var(--type-kbd);
+  color: var(--bg-cream);
 }
 
 [data-component="tooltip"] {
   z-index: 1000;
   max-width: 320px;
   border-radius: var(--radius-sm);
-  background-color: var(--fg-strong);
-  color: var(--bg-cream);
   background: var(--fg-strong);
-  padding: 2px 8px;
-  border: 1px solid var(--border-weak, rgba(0, 0, 0, 0.07));
-
+  color: var(--bg-cream);
+  padding: 8px 12px;
   box-shadow: var(--shadow-floating);
   pointer-events: none !important;
-  /* transition: all 150ms ease-out; */
-  /* transform: translate3d(0, 0, 0); */
-  /* transform-origin: var(--kb-tooltip-content-transform-origin); */
 
-  /* text-13-medium */
+  /* sans 13/500/1.2 inline per DESIGN.md L190 */
   font-family: var(--font-family-sans);
   font-size: var(--font-size-small);
-  font-style: normal;
   font-weight: var(--font-weight-medium);
-  line-height: var(--line-height-large); /* 166.667% */
+  line-height: 1.2;
   letter-spacing: var(--letter-spacing-normal);
+
+  opacity: 0;
 
   &[data-expanded] {
     opacity: 1;
-    /* transform: translate3d(0, 0, 0); */
+    animation: tooltip-fadein var(--duration-base) ease-out forwards;
   }
 
   &[data-closed]:not([data-force-open="true"]) {
     opacity: 0;
+    animation: none;
   }
+}
 
-  /* &[data-placement="top"] { */
-  /*   &[data-closed] { */
-  /*     transform: translate3d(0, 4px, 0); */
-  /*   } */
-  /* } */
-  /**/
-  /* &[data-placement="bottom"] { */
-  /*   &[data-closed] { */
-  /*     transform: translate3d(0, -4px, 0); */
-  /*   } */
-  /* } */
-  /**/
-  /* &[data-placement="left"] { */
-  /*   &[data-closed] { */
-  /*     transform: translate3d(4px, 0, 0); */
-  /*   } */
-  /* } */
-  /**/
-  /* &[data-placement="right"] { */
-  /*   &[data-closed] { */
-  /*     transform: translate3d(-4px, 0, 0); */
-  /*   } */
-  /* } */
+/* Caret — filled via Kobalte PopperArrow background-color detection */
+[data-slot="tooltip-arrow"] {
+  overflow: visible;
+}
+
+@keyframes tooltip-fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/packages/ui/src/components/tooltip.stories.tsx
+++ b/packages/ui/src/components/tooltip.stories.tsx
@@ -2,29 +2,6 @@
 import * as mod from "./tooltip"
 import { create } from "../storybook/scaffold"
 
-const docs = `### Overview
-Tooltip for contextual hints and keybind callouts.
-
-Use for short hints; avoid long descriptions.
-
-### API
-- Required: \`value\` (tooltip content).
-- Optional: \`inactive\`, \`forceOpen\`, placement props from Kobalte.
-
-### Variants and states
-- Supports keybind-style tooltip via \`TooltipKeybind\`.
-
-### Behavior
-- Opens on hover/focus; can be forced open.
-
-### Accessibility
-- TODO: confirm trigger semantics and focus behavior.
-
-### Theming/tokens
-- Uses \`data-component="tooltip"\` and related slots.
-
-`
-
 const story = create({ title: "UI/Tooltip", mod, args: { value: "Tooltip", children: "Hover me" } })
 
 export default {
@@ -32,33 +9,71 @@ export default {
   id: "components-tooltip",
   component: story.meta.component,
   tags: ["autodocs"],
-  parameters: {
-    docs: {
-      description: {
-        component: docs,
-      },
-    },
-  },
 }
 
 export const Basic = story.Basic
 
 export const Keybind = {
   render: () => (
-    <mod.TooltipKeybind title="Search" keybind="Cmd+K">
+    <mod.TooltipKeybind title="Search" keybind="⌘K">
       <span style={{ "text-decoration": "underline" }}>Hover for keybind</span>
     </mod.TooltipKeybind>
   ),
 }
 
+/** Force-open shows the inverse surface: --fg-strong bg + --bg-cream text. */
 export const ForcedOpen = {
   args: {
     forceOpen: true,
+    value: "Tooltip label",
+    children: "Trigger",
   },
+}
+
+/**
+ * All four placements × light + dark.
+ * Tooltips are force-open for static screenshot coverage.
+ */
+export const Matrix = {
+  render: () => (
+    <div style={{ display: "flex", "flex-direction": "column", gap: "48px", padding: "32px" }}>
+      {/* Light */}
+      <div style={{ display: "flex", gap: "48px", "align-items": "center" }}>
+        {(["top", "bottom", "left", "right"] as const).map((placement) => (
+          <mod.Tooltip value={`${placement}`} placement={placement} forceOpen>
+            <span style={{ padding: "4px", border: "1px solid var(--border-weak)" }}>
+              {placement}
+            </span>
+          </mod.Tooltip>
+        ))}
+      </div>
+      {/* Dark */}
+      <div
+        data-color-scheme="dark"
+        style={{
+          display: "flex",
+          gap: "48px",
+          "align-items": "center",
+          background: "var(--bg-base)",
+          padding: "16px",
+        }}
+      >
+        {(["top", "bottom"] as const).map((placement) => (
+          <mod.Tooltip value={`dark ${placement}`} placement={placement} forceOpen>
+            <span style={{ padding: "4px", border: "1px solid var(--border-weak)", color: "var(--fg-strong)" }}>
+              {placement}
+            </span>
+          </mod.Tooltip>
+        ))}
+      </div>
+    </div>
+  ),
 }
 
 export const Inactive = {
   args: {
     inactive: true,
+    value: "Never shows",
+    children: "Inactive trigger",
   },
 }

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -110,6 +110,7 @@ export function Tooltip(props: TooltipProps) {
         <KobalteTooltip
           gutter={4}
           {...others}
+          openDelay={0}
           closeDelay={0}
           ignoreSafeArea={local.ignoreSafeArea ?? true}
           open={local.forceOpen || state.open}
@@ -152,8 +153,8 @@ export function Tooltip(props: TooltipProps) {
                 e.preventDefault()
               }}
             >
+              <KobalteTooltip.Arrow data-slot="tooltip-arrow" size={5} />
               {local.value}
-              {/* <KobalteTooltip.Arrow data-slot="tooltip-arrow" /> */}
             </KobalteTooltip.Content>
           </KobalteTooltip.Portal>
         </KobalteTooltip>

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -68,7 +68,9 @@ export function Tooltip(props: TooltipProps) {
   }
 
   const sync = () => {
-    const expand = !!ref?.querySelector('[aria-expanded="true"], [data-expanded]')
+    // Only [data-expanded] (Kobalte popup marker) suppresses the tooltip.
+    // Native aria-expanded (e.g. sidebar panel toggle) must not block it.
+    const expand = !!ref?.querySelector('[data-expanded]')
     setState("expand", expand)
     if (expand) {
       setState("block", true)
@@ -109,9 +111,9 @@ export function Tooltip(props: TooltipProps) {
       <Match when={true}>
         <KobalteTooltip
           gutter={4}
-          {...others}
           openDelay={0}
           closeDelay={0}
+          {...others}
           ignoreSafeArea={local.ignoreSafeArea ?? true}
           open={local.forceOpen || state.open}
           onOpenChange={(open) => {
@@ -153,7 +155,7 @@ export function Tooltip(props: TooltipProps) {
                 e.preventDefault()
               }}
             >
-              <KobalteTooltip.Arrow data-slot="tooltip-arrow" size={5} />
+              <KobalteTooltip.Arrow data-slot="tooltip-arrow" size={8} />
               {local.value}
             </KobalteTooltip.Content>
           </KobalteTooltip.Portal>


### PR DESCRIPTION
## Summary

Slice 06 of issue #440 — rewrites Tag, Popover, and Tooltip to the PawWork design system. Also fixes two pre-existing Tooltip bugs found during manual testing.

## Why

Part of the packages/ui + packages/app full visual rewrite (#440, permanent fork from upstream). Slice 06 covers the three interaction-surface primitives that appear throughout the app (model picker tags, command popovers, icon-button tooltips).

## Related Issue

Part of #440 (slice 06). Does not close #221 — the list search focus ring requires a JS-level fix (`focus({ focusVisible: false })`) that is out of scope here; tracked separately.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `tag.css`: single rest-state, no size variants, `--surface-raised` bg (dark-mode adaptive; replaces hotfix's size-variant restoration)
- `tooltip.tsx` sync(): was checking `[aria-expanded="true"]` which blocked tooltip on sidebar toggle — narrowed to `[data-expanded]` only
- `tooltip.tsx` prop order: `openDelay/closeDelay` moved before `{...others}` so callers (e.g. new-session button `openDelay={2000}`) are not silently overridden

## Risk Notes

CSS-only changes to `packages/ui` primitives; no packages/app files changed. No new dependencies. No data, permissions, or migration concerns. The `aria-expanded` fix is behaviour-restoring (tooltip was broken before, now works as expected).

## How To Verify

```
bun --cwd packages/ui run typecheck    → 0 errors
bun --cwd packages/app run typecheck   → 0 errors
grep -r 'Tag.*size=' packages/app/src  → 0 hits (no callers of removed prop)
```

Manual smoke (Electron, light + dark):
- Tag: model picker tags display correctly in both modes ✅
- Tooltip: sidebar toggle shows tooltip on hover; caret visible; inverse surface ✅
- Tooltip: right-panel toggle shows tooltip correctly ✅
- Popover: model picker opens and closes correctly ✅
- Dark mode: all three components visually consistent ✅

## Screenshots or Recordings

Manual testing confirmed via Electron. Before/after static screenshots pending — Storybook Matrix stories cover the key visual states (ForcedOpen, 4-placement Matrix, MenuMatrix, OnSurfaces).

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, scope, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English