### PR TITLE
docs: clarify label area wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -26,7 +26,7 @@ body:
       options:
         - Not sure
         - App flow or product behavior
-        - Desktop shell, packaging, updater, signing, paths, or permissions
+        - Platform shell, packaging, updater, signing, paths, or permissions
         - UI or design system
         - Model harness, prompts, tools, or session mechanics
         - CI, release, or developer tooling

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -26,7 +26,7 @@ body:
       options:
         - Not sure
         - App flow or product behavior
-        - Desktop shell, packaging, updater, signing, paths, or permissions
+        - Platform shell, packaging, updater, signing, paths, or permissions
         - UI or design system
         - Model harness, prompts, tools, or session mechanics
         - CI, release, or developer tooling

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,12 +40,12 @@ Required for visible UI changes.
 
 - [ ] Human review status is stated above as pending, approved, or not required
 - [ ] I linked the related issue, or stated why there is no issue
-- [ ] This PR has type, scope, and priority labels, or I requested maintainer labeling
+- [ ] This PR has type, primary area, and priority labels, or I requested maintainer labeling
 - [ ] I described the review focus and any meaningful risks
 - [ ] I listed the relevant verification steps and the key result for each
 - [ ] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
 - [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
-- [ ] I considered macOS and Windows impact for desktop, packaging, updater, signing, paths, shell, or permissions changes
+- [ ] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
 - [ ] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
 - [ ] I reviewed the final diff for unrelated changes and suspicious dependency changes
 - [ ] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


### PR DESCRIPTION
## Summary

Clarify issue and PR template wording for the label cleanup pass.

## Why

The repo is moving toward a cleaner label model where `app` means product behavior and `platform` means Electron, OS integration, packaging, updater, signing, paths, and permissions. The templates should use the same wording before the live label is renamed.

## Related Issue

No related issue. This is a small maintainer taxonomy cleanup.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Check that the issue forms and PR checklist now use the clearer primary-area wording without changing form structure.

## Risk Notes

None. This only changes template copy.

## How To Verify

```text
YAML parse: ok for all three issue forms
Diff check: no whitespace errors
```

## Screenshots or Recordings

Not required. No visible app UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English