### PR TITLE
fix(app): keep session composer within timeline width

### DIFF
--- a/packages/app/e2e/app/session.spec.ts
+++ b/packages/app/e2e/app/session.spec.ts
@@ -101,6 +101,9 @@ test("session timeline visible content is not narrower than composer shell", asy
 
   await assertWidthContract()
 
+  await page.setViewportSize({ width: 893, height: 776 })
+  await assertWidthContract({ maxComposerColumn: 720 })
+
   await page.setViewportSize({ width: 1600, height: 1000 })
   await assertWidthContract({ maxComposerColumn: 920, minTimelineComposerDelta: 80 })
 })

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1098,7 +1098,7 @@ export function MessageTimeline(props: {
               class="flex flex-col items-start justify-start pb-4 transition-[margin]"
               classList={{
                 "w-full": true,
-                "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+                "md:max-w-[800px] md:mx-auto 2xl:max-w-[1000px]": props.centered,
                 "mt-0.5": props.centered,
                 "mt-0": !props.centered,
               }}
@@ -1139,7 +1139,7 @@ export function MessageTimeline(props: {
                       data-message-id={messageID}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
-                        "md:max-w-200 2xl:max-w-[1000px]": props.centered,
+                        "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
                       }}
                       style={{
                         "content-visibility": active() ? undefined : "auto",


### PR DESCRIPTION
## Summary

Fix the session timeline width cap so the visible conversation flow stays wider than the composer in the md viewport range.

## Why

Fixes #456.

The previous fix shipped in the release asset, but it missed the middle desktop width band. The composer used fixed pixel caps (`720px` / `920px`), while the timeline used `md:max-w-200`. With PawWork's 13px root font size, `max-w-200` resolves to `650px`, so the composer could become wider than the message flow around a 893px CSS viewport.

## Related Issue

Closes #456

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Check that the timeline width cap change is intentionally scoped to session layout and does not alter global spacing tokens.

## Risk Notes

Low. This changes only the centered session timeline max width at `md` and keeps the existing `2xl` cap unchanged. It does not touch persistence, release packaging, updater, permissions, or dependencies.

## How To Verify

```text
Focused regression before fix: failed at 893x776 with timeline 650px vs composer 720px
Session E2E: 3 passed with bun --cwd packages/app test:e2e e2e/app/session.spec.ts
Typecheck: passed with bun --cwd packages/app typecheck
Diff check: no whitespace errors with git diff --check
Electron dev visual check: user confirmed the composer now aligns with the conversation flow
```

## Screenshots or Recordings

Manual Electron dev verification was performed against the reported layout. The user confirmed the updated UI now looks normal in the thread screenshot.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
