### PR TITLE
fix: keep question blockers pending through timeout

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -137,6 +137,18 @@ async function e2ePublishQuestionAsked(project: ProjectQuestionSeed, request: Qu
   expect(response.status).toBe(204)
 }
 
+async function e2ePublishQuestionBlocker(project: ProjectQuestionSeed, request: QuestionRequest) {
+  const response = await fetch(
+    `${project.url}/blocker/__e2e/publish-upserted?directory=${encodeURIComponent(project.directory)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ request }),
+    },
+  )
+  expect(response.status).toBe(204)
+}
+
 async function waitForQuestionSeed(project: ProjectQuestionSeed, sessionID: string) {
   let current: QuestionRequest | undefined
   await expect
@@ -476,6 +488,31 @@ test("question dock recovers after missed question.asked via SSE replay", async 
 
         await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 750 })
         await stream.start()
+
+        await expectQuestionBlocked(page)
+        await expect(page.locator(questionDockSelector)).toHaveCount(1)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("question dock renders from backend blocker when question sync is missing", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock blocker question",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        const request = {
+          id: "que_e2e_blocker",
+          sessionID: session.id,
+          questions: defaultQuestions,
+        } satisfies QuestionRequest
+
+        await e2ePublishQuestionBlocker(project, request)
 
         await expectQuestionBlocked(page)
         await expect(page.locator(questionDockSelector)).toHaveCount(1)

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -27,6 +27,7 @@ function createState(): State {
     todo: {},
     permission: {},
     question: {},
+    blocker: {},
     mcp_ready: false,
     mcp: {},
     lsp_ready: false,
@@ -142,6 +143,7 @@ describe("bootstrapDirectory", () => {
       command: { list: async () => ({ data: [] }) },
       permission: { list: async () => ({ data: [] }) },
       question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
       mcp: { status: async () => ({ data: {} }) },
       provider: {
         list: async () => {
@@ -226,6 +228,7 @@ describe("bootstrapDirectory", () => {
       command: { list: async () => ({ data: [] }) },
       permission: { list: async () => ({ data: [] }) },
       question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
       mcp: { status: async () => ({ data: {} }) },
       provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
     } as any
@@ -281,6 +284,7 @@ describe("bootstrapDirectory", () => {
       command: { list: async () => ({ data: [] }) },
       permission: { list: async () => ({ data: [] }) },
       question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
       mcp: { status: async () => ({ data: {} }) },
       provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
     } as any
@@ -336,6 +340,7 @@ describe("bootstrapDirectory", () => {
       command: { list: async () => ({ data: [] }) },
       permission: { list: async () => permission.promise },
       question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
       mcp: { status: async () => ({ data: {} }) },
       provider: { list: async () => ({ data: providers }) },
     } as any
@@ -393,6 +398,7 @@ describe("bootstrapDirectory", () => {
       command: { list: async () => ({ data: [] }) },
       permission: { list: async () => ({ data: [] }) },
       question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
       mcp: { status: async () => ({ data: {} }) },
       provider: {
         list: async () => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -147,7 +147,7 @@ function groupBlockersBySession(input: SessionBlockerEntry[]) {
     if (!item?.requestID || !item.sessionID) return acc
     const list = acc[item.sessionID]
     if (list) list.push(item)
-    if (!list) acc[item.sessionID] = [item]
+    else acc[item.sessionID] = [item]
     return acc
   }, {})
 }
@@ -411,7 +411,7 @@ export async function bootstrapDirectory(input: {
         retry(() =>
           input.sdk.blocker.list().then((x) => {
             const ids = (x.data ?? []).map((blocker) => blocker?.sessionID).filter((id): id is string => !!id)
-            const grouped = groupBlockersBySession((x.data ?? []).filter((b) => !!b?.requestID && !!b.sessionID))
+            const grouped = groupBlockersBySession(x.data ?? [])
             return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
               batch(() => {
                 for (const sessionID of Object.keys(input.store.blocker)) {
@@ -422,10 +422,7 @@ export async function bootstrapDirectory(input: {
                   input.setStore(
                     "blocker",
                     sessionID,
-                    reconcile(
-                      blockers.filter((b) => !!b?.requestID).sort((a, b) => cmp(a.requestID, b.requestID)),
-                      { key: "requestID" },
-                    ),
+                    reconcile(blockers.sort((a, b) => cmp(a.requestID, b.requestID)), { key: "requestID" }),
                   )
                 }
               }),

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -15,7 +15,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { retry } from "@opencode-ai/util/retry"
 import { batch } from "solid-js"
 import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
-import type { State, VcsCache } from "./types"
+import type { SessionBlockerEntry, State, VcsCache } from "./types"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 import { QueryClient, queryOptions } from "@tanstack/solid-query"
@@ -135,6 +135,16 @@ export async function bootstrapGlobal(input: {
 function groupBySession<T extends { id: string; sessionID: string }>(input: T[]) {
   return input.reduce<Record<string, T[]>>((acc, item) => {
     if (!item?.id || !item.sessionID) return acc
+    const list = acc[item.sessionID]
+    if (list) list.push(item)
+    if (!list) acc[item.sessionID] = [item]
+    return acc
+  }, {})
+}
+
+function groupBlockersBySession(input: SessionBlockerEntry[]) {
+  return input.reduce<Record<string, SessionBlockerEntry[]>>((acc, item) => {
+    if (!item?.requestID || !item.sessionID) return acc
     const list = acc[item.sessionID]
     if (list) list.push(item)
     if (!list) acc[item.sessionID] = [item]
@@ -390,6 +400,31 @@ export async function bootstrapDirectory(input: {
                     reconcile(
                       questions.filter((q) => !!q?.id).sort((a, b) => cmp(a.id, b.id)),
                       { key: "id" },
+                    ),
+                  )
+                }
+              }),
+            )
+          }),
+        ),
+      () =>
+        retry(() =>
+          input.sdk.blocker.list().then((x) => {
+            const ids = (x.data ?? []).map((blocker) => blocker?.sessionID).filter((id): id is string => !!id)
+            const grouped = groupBlockersBySession((x.data ?? []).filter((b) => !!b?.requestID && !!b.sessionID))
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
+              batch(() => {
+                for (const sessionID of Object.keys(input.store.blocker)) {
+                  if (grouped[sessionID]) continue
+                  input.setStore("blocker", sessionID, [])
+                }
+                for (const [sessionID, blockers] of Object.entries(grouped)) {
+                  input.setStore(
+                    "blocker",
+                    sessionID,
+                    reconcile(
+                      blockers.filter((b) => !!b?.requestID).sort((a, b) => cmp(a.requestID, b.requestID)),
+                      { key: "requestID" },
                     ),
                   )
                 }

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -191,6 +191,7 @@ export function createChildStoreManager(input: {
             todo: {},
             permission: {},
             question: {},
+            blocker: {},
             mcp_ready: false,
             mcp: {},
             lsp_ready: false,

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -588,6 +588,56 @@ describe("applyDirectoryEvent", () => {
     expect(store.blocker[sessionID]?.map((x) => x.requestID)).toEqual(["q_1", "q_3"])
   })
 
+  test("question terminal events clear matching stale question blockers", () => {
+    const sessionID = "ses_1"
+    const [store, setStore] = createStore(
+      baseState({
+        blocker: {
+          [sessionID]: [
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID,
+              requestID: "q_1",
+              request: questionRequest("q_1", sessionID),
+              armedAt: 1,
+              updatedAt: 1,
+            },
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID,
+              requestID: "q_2",
+              request: questionRequest("q_2", sessionID),
+              armedAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        },
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: { type: "question.replied", properties: { sessionID, requestID: "q_1" } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.blocker[sessionID]?.map((x) => x.requestID)).toEqual(["q_2"])
+
+    applyDirectoryEvent({
+      event: { type: "question.rejected", properties: { sessionID, requestID: "q_2", reason: "dismissed" } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.blocker[sessionID]).toEqual([])
+  })
+
   test("permission.replied before permission.asked prevents stale ask from reopening", () => {
     const blockerTerminals = createBlockerTerminalCache({ now: () => 1000 })
     const [store, setStore] = createStore(baseState())

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -78,6 +78,7 @@ const baseState = (input: Partial<State> = {}) =>
     todo: {},
     permission: {},
     question: {},
+    blocker: {},
     mcp: {},
     lsp: [],
     vcs: undefined,
@@ -524,6 +525,67 @@ describe("applyDirectoryEvent", () => {
     })
 
     expect(store.question.ses_1).toBeUndefined()
+  })
+
+  test("tracks question blocker lifecycle", () => {
+    const sessionID = "ses_1"
+    const [store, setStore] = createStore(
+      baseState({
+        blocker: {
+          [sessionID]: [
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID,
+              requestID: "q_1",
+              request: questionRequest("q_1", sessionID),
+              armedAt: 1,
+              updatedAt: 1,
+            },
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID,
+              requestID: "q_3",
+              request: questionRequest("q_3", sessionID),
+              armedAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        },
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.blocker.upserted",
+        properties: {
+          kind: "question",
+          status: "awaiting_user",
+          sessionID,
+          requestID: "q_2",
+          request: questionRequest("q_2", sessionID),
+          armedAt: 1,
+          updatedAt: 1,
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.blocker[sessionID]?.map((x) => x.requestID)).toEqual(["q_1", "q_2", "q_3"])
+
+    applyDirectoryEvent({
+      event: { type: "session.blocker.removed", properties: { kind: "question", sessionID, requestID: "q_2", reason: "replied" } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.blocker[sessionID]?.map((x) => x.requestID)).toEqual(["q_1", "q_3"])
   })
 
   test("permission.replied before permission.asked prevents stale ask from reopening", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -71,6 +71,7 @@ export function cleanupDroppedSessionCaches(
     ...Object.keys(store.todo),
     ...Object.keys(store.permission),
     ...Object.keys(store.question),
+    ...Object.keys(store.blocker),
     ...Object.keys(store.session_status),
     ...Object.values(store.part)
       .map((parts) => parts?.find((part) => !!part?.sessionID)?.sessionID)
@@ -347,6 +348,42 @@ export function applyDirectoryEvent(input: {
       if (!result.found) break
       input.setStore(
         "question",
+        props.sessionID,
+        produce((draft) => {
+          draft.splice(result.index, 1)
+        }),
+      )
+      break
+    }
+    case "session.blocker.upserted": {
+      const blocker = event.properties as State["blocker"][string][number]
+      const blockers = input.store.blocker[blocker.sessionID]
+      if (!blockers) {
+        input.setStore("blocker", blocker.sessionID, [blocker])
+        break
+      }
+      const result = Binary.search(blockers, blocker.requestID, (b) => b.requestID)
+      if (result.found) {
+        input.setStore("blocker", blocker.sessionID, result.index, reconcile(blocker))
+        break
+      }
+      input.setStore(
+        "blocker",
+        blocker.sessionID,
+        produce((draft) => {
+          draft.splice(result.index, 0, blocker)
+        }),
+      )
+      break
+    }
+    case "session.blocker.removed": {
+      const props = event.properties as { sessionID: string; requestID: string }
+      const blockers = input.store.blocker[props.sessionID]
+      if (!blockers) break
+      const result = Binary.search(blockers, props.requestID, (b) => b.requestID)
+      if (!result.found) break
+      input.setStore(
+        "blocker",
         props.sessionID,
         produce((draft) => {
           draft.splice(result.index, 1)

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -342,6 +342,19 @@ export function applyDirectoryEvent(input: {
     case "question.rejected": {
       const props = event.properties as { sessionID: string; requestID: string }
       input.blockerTerminals?.mark("question", input.directory, props.sessionID, props.requestID)
+      const blockers = input.store.blocker[props.sessionID]
+      if (blockers) {
+        const blocker = Binary.search(blockers, props.requestID, (b) => b.requestID)
+        if (blocker.found) {
+          input.setStore(
+            "blocker",
+            props.sessionID,
+            produce((draft) => {
+              draft.splice(blocker.index, 1)
+            }),
+          )
+        }
+      }
       const questions = input.store.question[props.sessionID]
       if (!questions) break
       const result = Binary.search(questions, props.requestID, (q) => q.id)

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -39,6 +39,7 @@ describe("app session cache", () => {
       part: Record<string, Part[] | undefined>
       permission: Record<string, PermissionRequest[] | undefined>
       question: Record<string, QuestionRequest[] | undefined>
+      blocker: Record<string, never[] | undefined>
     } = {
       session_status: { ses_1: { type: "busy" } as SessionStatus },
       session_diff: { ses_1: [] },
@@ -47,6 +48,7 @@ describe("app session cache", () => {
       part: { msg_1: [part("prt_1", "ses_1", "msg_1")] },
       permission: { ses_1: [] as PermissionRequest[] },
       question: { ses_1: [] as QuestionRequest[] },
+      blocker: { ses_1: [] },
     }
 
     dropSessionCaches(store, ["ses_1"])
@@ -70,6 +72,7 @@ describe("app session cache", () => {
       part: Record<string, Part[] | undefined>
       permission: Record<string, PermissionRequest[] | undefined>
       question: Record<string, QuestionRequest[] | undefined>
+      blocker: Record<string, never[] | undefined>
     } = {
       session_status: {},
       session_diff: {},
@@ -78,6 +81,7 @@ describe("app session cache", () => {
       part: { [m.id]: [part("prt_1", "ses_1", m.id)] },
       permission: {},
       question: {},
+      blocker: {},
     }
 
     dropSessionCaches(store, ["ses_1"])

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -7,6 +7,7 @@ import type {
   SnapshotFileDiff,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
+import type { SessionBlockerEntry } from "./types"
 
 export const SESSION_CACHE_LIMIT = 40
 
@@ -18,6 +19,7 @@ type SessionCache = {
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
   question: Record<string, QuestionRequest[] | undefined>
+  blocker: Record<string, SessionBlockerEntry[] | undefined>
 }
 
 export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<string>) {
@@ -37,6 +39,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
     delete store.session_status[sessionID]
     delete store.permission[sessionID]
     delete store.question[sessionID]
+    delete store.blocker[sessionID]
   }
 }
 

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -32,6 +32,17 @@ export type ProjectMeta = {
 
 export type SessionStatusState = "loading" | "ready" | "error"
 
+export type SessionBlockerEntry = {
+  kind: "question"
+  status: "awaiting_user"
+  sessionID: string
+  requestID: string
+  request: QuestionRequest
+  tool?: QuestionRequest["tool"]
+  armedAt: number
+  updatedAt: number
+}
+
 export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
@@ -61,6 +72,9 @@ export type State = {
   }
   question: {
     [sessionID: string]: QuestionRequest[]
+  }
+  blocker: {
+    [sessionID: string]: SessionBlockerEntry[]
   }
   mcp_ready: boolean
   mcp: {

--- a/packages/app/src/pages/session/blockers/request-tree.test.ts
+++ b/packages/app/src/pages/session/blockers/request-tree.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { PermissionRequest, QuestionRequest, Session } from "@opencode-ai/sdk/v2/client"
-import { sessionPermissionRequest, sessionQuestionRequest } from "./request-tree"
+import type { SessionBlockerEntry } from "@/context/global-sync/types"
+import { sessionPermissionRequest, sessionQuestionBlockerRequest, sessionQuestionRequest } from "./request-tree"
 
 const session = (input: { id: string; parentID?: string }) =>
   ({
@@ -20,6 +21,17 @@ const question = (id: string, sessionID: string) =>
     sessionID,
     questions: [],
   }) as QuestionRequest
+
+const questionBlocker = (id: string, sessionID: string) =>
+  ({
+    kind: "question",
+    status: "awaiting_user",
+    sessionID,
+    requestID: id,
+    request: question(id, sessionID),
+    armedAt: 1,
+    updatedAt: 1,
+  }) as SessionBlockerEntry
 
 describe("sessionPermissionRequest", () => {
   test("prefers the current session permission", () => {
@@ -101,5 +113,16 @@ describe("sessionQuestionRequest", () => {
     }
 
     expect(sessionQuestionRequest(sessions, questions, "root")?.id).toBe("q-grand")
+  })
+})
+
+describe("sessionQuestionBlockerRequest", () => {
+  test("returns the question request embedded in the current tree blocker", () => {
+    const sessions = [session({ id: "root" }), session({ id: "child", parentID: "root" })]
+    const blockers = {
+      child: [questionBlocker("q-child", "child")],
+    }
+
+    expect(sessionQuestionBlockerRequest(sessions, blockers, "root")?.id).toBe("q-child")
   })
 })

--- a/packages/app/src/pages/session/blockers/request-tree.ts
+++ b/packages/app/src/pages/session/blockers/request-tree.ts
@@ -1,4 +1,5 @@
 import type { PermissionRequest, QuestionRequest, Session } from "@opencode-ai/sdk/v2/client"
+import type { SessionBlockerEntry } from "@/context/global-sync/types"
 
 function sessionTreeRequest<T>(
   session: Session[],
@@ -49,4 +50,13 @@ export function sessionQuestionRequest(
   include?: (item: QuestionRequest) => boolean,
 ) {
   return sessionTreeRequest(session, request, sessionID, include)
+}
+
+export function sessionQuestionBlockerRequest(
+  session: Session[],
+  request: Record<string, SessionBlockerEntry[] | undefined>,
+  sessionID?: string,
+) {
+  return sessionTreeRequest(session, request, sessionID, (item) => item.kind === "question" && item.status === "awaiting_user")
+    ?.request
 }

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -12,7 +12,7 @@ import { questionRecoveryReverify } from "./question-recovery-reverify"
 import { resolveQuestionRecoverySnapshot } from "./question-recovery-snapshot"
 import { createQuestionRefetchRunner } from "./question-refetch-runner"
 import { refetchPendingQuestionsForSession } from "./question-reconcile"
-import { sessionPermissionRequest, sessionQuestionRequest } from "./request-tree"
+import { sessionPermissionRequest, sessionQuestionBlockerRequest, sessionQuestionRequest } from "./request-tree"
 
 export function createSessionBlockers(input: {
   sessionID: () => string | undefined
@@ -29,7 +29,10 @@ export function createSessionBlockers(input: {
   })
 
   const questionRequest = createMemo(() => {
-    return sessionQuestionRequest(sync.data.session, sync.data.question, activeSessionID())
+    return (
+      sessionQuestionBlockerRequest(sync.data.session, sync.data.blocker, activeSessionID()) ??
+      sessionQuestionRequest(sync.data.session, sync.data.question, activeSessionID())
+    )
   })
 
   const questionFallbackSessionID = createMemo(() => {

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -20,6 +20,7 @@ import { Agent } from "@/agent/agent"
 import { Skill } from "@/skill"
 import { Discovery } from "@/skill/discovery"
 import { Question } from "@/question"
+import { SessionBlocker } from "@/session/blocker"
 import { Permission } from "@/permission"
 import { Todo } from "@/session/todo"
 import { Session } from "@/session"
@@ -71,6 +72,7 @@ export const AppLayer = Layer.mergeAll(
   Agent.defaultLayer,
   Skill.defaultLayer,
   Discovery.defaultLayer,
+  SessionBlocker.defaultLayer,
   Question.defaultLayer,
   Permission.defaultLayer,
   Todo.defaultLayer,

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -7,6 +7,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 import { QuestionID } from "./schema"
+import { SessionBlocker } from "@/session/blocker"
 
 export namespace Question {
   const log = Log.create({ service: "question" })
@@ -133,6 +134,12 @@ export namespace Question {
   class Rejected extends Schema.Class<Rejected>("QuestionRejected")({
     sessionID: SessionID,
     requestID: QuestionID,
+    reason: Schema.Union([
+      Schema.Literal("cancelled"),
+      Schema.Literal("dismissed"),
+      Schema.Literal("shutdown"),
+      Schema.Literal("rejected"),
+    ]),
   }) {
     static readonly zod = zod(this)
   }
@@ -151,9 +158,17 @@ export namespace Question {
   // without each having to inspect the cancelled flag. See #419.
   export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("QuestionRejectedError", {
     cancelled: Schema.optional(Schema.Boolean),
+    reason: Schema.optional(
+      Schema.Union([
+        Schema.Literal("cancelled"),
+        Schema.Literal("dismissed"),
+        Schema.Literal("shutdown"),
+        Schema.Literal("rejected"),
+      ]),
+    ),
   }) {
     override get message() {
-      return this.cancelled
+      return this.cancelled || this.reason === "cancelled" || this.reason === "shutdown"
         ? "Question cancelled before the user answered it."
         : "The user dismissed this question"
     }
@@ -191,6 +206,7 @@ export namespace Question {
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
+      const blockers = yield* SessionBlocker.Service
       const state = yield* InstanceState.make<State>(
         Effect.fn("Question.state")(function* () {
           const state = {
@@ -200,7 +216,13 @@ export namespace Question {
           yield* Effect.addFinalizer(() =>
             Effect.gen(function* () {
               for (const item of state.pending.values()) {
-                yield* Deferred.fail(item.deferred, new RejectedError({ cancelled: true }))
+                yield* blockers.removeQuestion({ requestID: item.info.id, reason: "shutdown" })
+                yield* bus.publish(Event.Rejected, {
+                  sessionID: item.info.sessionID,
+                  requestID: item.info.id,
+                  reason: "shutdown",
+                })
+                yield* Deferred.fail(item.deferred, new RejectedError({ cancelled: true, reason: "shutdown" }))
               }
               state.pending.clear()
             }),
@@ -252,6 +274,7 @@ export namespace Question {
         // checks against the original prompt.
         const info = structuredClone(decoded)
         pending.set(id, { info, deferred })
+        yield* blockers.upsertQuestion(info)
         // Publish a fresh clone so subscribers can't reach back through the
         // event payload to mutate the pending entry either.
         yield* bus.publish(Event.Asked, structuredClone(info))
@@ -277,8 +300,9 @@ export namespace Question {
           Effect.runFork(
             Effect.provide(
               Effect.gen(function* () {
-                yield* bus.publish(Event.Rejected, { sessionID, requestID: id })
-                yield* Deferred.fail(entry.deferred, new RejectedError({ cancelled: true }))
+                yield* blockers.removeQuestion({ requestID: id, reason: "cancelled" })
+                yield* bus.publish(Event.Rejected, { sessionID, requestID: id, reason: "cancelled" })
+                yield* Deferred.fail(entry.deferred, new RejectedError({ cancelled: true, reason: "cancelled" }))
               }).pipe(
                 Effect.catchCause((cause) =>
                   Effect.sync(() =>
@@ -310,7 +334,8 @@ export namespace Question {
               if (!pending.has(id)) return
               pending.delete(id)
               log.info("rejected", { requestID: id, reason: "interrupted" })
-              yield* bus.publish(Event.Rejected, { sessionID, requestID: id })
+              yield* blockers.removeQuestion({ requestID: id, reason: "shutdown" })
+              yield* bus.publish(Event.Rejected, { sessionID, requestID: id, reason: "shutdown" })
             }),
           ),
           Effect.ensuring(
@@ -345,7 +370,13 @@ export namespace Question {
             got: input.answers.length,
           })
           pending.delete(input.requestID)
-          yield* Deferred.fail(existing.deferred, new RejectedError())
+          yield* blockers.removeQuestion({ requestID: input.requestID, reason: "rejected" })
+          yield* bus.publish(Event.Rejected, {
+            sessionID: existing.info.sessionID,
+            requestID: existing.info.id,
+            reason: "rejected",
+          })
+          yield* Deferred.fail(existing.deferred, new RejectedError({ reason: "rejected" }))
           return
         }
         // Trim every answer string so " " / "\t" can't masquerade as a real
@@ -376,7 +407,13 @@ export namespace Question {
               answer,
             })
             pending.delete(input.requestID)
-            yield* Deferred.fail(existing.deferred, new RejectedError())
+            yield* blockers.removeQuestion({ requestID: input.requestID, reason: "rejected" })
+            yield* bus.publish(Event.Rejected, {
+              sessionID: existing.info.sessionID,
+              requestID: existing.info.id,
+              reason: "rejected",
+            })
+            yield* Deferred.fail(existing.deferred, new RejectedError({ reason: "rejected" }))
             return
           }
           const validLabels = new Set(q.options.map((o) => o.label))
@@ -392,7 +429,13 @@ export namespace Question {
                   validLabels: [...validLabels],
                 })
                 pending.delete(input.requestID)
-                yield* Deferred.fail(existing.deferred, new RejectedError())
+                yield* blockers.removeQuestion({ requestID: input.requestID, reason: "rejected" })
+                yield* bus.publish(Event.Rejected, {
+                  sessionID: existing.info.sessionID,
+                  requestID: existing.info.id,
+                  reason: "rejected",
+                })
+                yield* Deferred.fail(existing.deferred, new RejectedError({ reason: "rejected" }))
                 return
               }
             }
@@ -400,6 +443,7 @@ export namespace Question {
         }
 
         pending.delete(input.requestID)
+        yield* blockers.removeQuestion({ requestID: input.requestID, reason: "replied" })
         log.info("replied", { requestID: input.requestID, answers: trimmedAnswers })
         yield* bus.publish(Event.Replied, {
           sessionID: existing.info.sessionID,
@@ -418,11 +462,13 @@ export namespace Question {
         }
         pending.delete(requestID)
         log.info("rejected", { requestID })
+        yield* blockers.removeQuestion({ requestID, reason: "dismissed" })
         yield* bus.publish(Event.Rejected, {
           sessionID: existing.info.sessionID,
           requestID: existing.info.id,
+          reason: "dismissed",
         })
-        yield* Deferred.fail(existing.deferred, new RejectedError())
+        yield* Deferred.fail(existing.deferred, new RejectedError({ reason: "dismissed" }))
       })
 
       const list = Effect.fn("Question.list")(function* () {
@@ -436,5 +482,5 @@ export namespace Question {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+  export const defaultLayer = layer.pipe(Layer.provide(SessionBlocker.defaultLayer), Layer.provide(Bus.layer))
 }

--- a/packages/opencode/src/server/event-replay.ts
+++ b/packages/opencode/src/server/event-replay.ts
@@ -40,6 +40,8 @@ const REPLAYABLE_EVENT_TYPES = new Set([
   "question.asked",
   "question.replied",
   "question.rejected",
+  "session.blocker.upserted",
+  "session.blocker.removed",
   "permission.asked",
   "permission.replied",
   "session.created",

--- a/packages/opencode/src/server/instance/blocker.ts
+++ b/packages/opencode/src/server/instance/blocker.ts
@@ -1,0 +1,46 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import z from "zod"
+import { AppRuntime } from "@/effect/app-runtime"
+import { SessionBlocker } from "@/session/blocker"
+import { lazy } from "../../util/lazy"
+import { Env } from "@/env"
+
+const e2eBlockerRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+
+export const BlockerRoutes = lazy(() =>
+  new Hono()
+    .post(
+      "/__e2e/publish-upserted",
+      async (c) => {
+        if (!e2eBlockerRoutesEnabled()) return c.notFound()
+        const json = await c.req.json()
+        await AppRuntime.runPromise(
+          SessionBlocker.Service.use((svc) => svc.upsertQuestion(SessionBlocker.QuestionRequest.parse(json.request))),
+        )
+        return c.body(null, 204)
+      },
+    )
+    .get(
+      "/",
+      describeRoute({
+        summary: "List active session blockers",
+        description: "Get active session blockers across all sessions.",
+        operationId: "blocker.list",
+        responses: {
+          200: {
+            description: "List of active session blockers",
+            content: {
+              "application/json": {
+                schema: resolver(z.array(SessionBlocker.Entry)),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const blockers = await AppRuntime.runPromise(SessionBlocker.Service.use((svc) => svc.list()))
+        return c.json(blockers)
+      },
+    ),
+)

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -15,6 +15,7 @@ import { LSP } from "../../lsp"
 import { Command } from "../../command"
 import { QuestionRoutes } from "./question"
 import { PermissionRoutes } from "./permission"
+import { BlockerRoutes } from "./blocker"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
 import { PtyRoutes } from "./pty"
@@ -37,6 +38,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
     .route("/session", SessionRoutes())
     .route("/permission", PermissionRoutes())
     .route("/question", QuestionRoutes())
+    .route("/blocker", BlockerRoutes())
     .route("/provider", ProviderRoutes())
     .route("/", FileRoutes())
     .route("/", EventRoutes())

--- a/packages/opencode/src/session/blocker.ts
+++ b/packages/opencode/src/session/blocker.ts
@@ -1,0 +1,143 @@
+import { Effect, Layer, Context } from "effect"
+import z from "zod"
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { InstanceState } from "@/effect/instance-state"
+import { SessionID, MessageID } from "./schema"
+import { QuestionID } from "@/question/schema"
+
+export namespace SessionBlocker {
+  export const TerminalReason = z.enum(["replied", "cancelled", "dismissed", "shutdown", "rejected"])
+  export type TerminalReason = z.infer<typeof TerminalReason>
+
+  export const QuestionRequest = z.object({
+    id: QuestionID.zod,
+    sessionID: SessionID.zod,
+    questions: z.array(
+      z.object({
+        question: z.string(),
+        header: z.string(),
+        options: z.array(
+          z.object({
+            label: z.string(),
+            description: z.string(),
+          }),
+        ),
+        multiple: z.boolean().optional(),
+        custom: z.boolean().optional(),
+      }),
+    ),
+    tool: z
+      .object({
+        messageID: MessageID.zod,
+        callID: z.string(),
+      })
+      .optional(),
+  })
+  export type QuestionRequest = z.infer<typeof QuestionRequest>
+
+  export const Entry = z.object({
+    kind: z.literal("question"),
+    status: z.literal("awaiting_user"),
+    sessionID: SessionID.zod,
+    requestID: QuestionID.zod,
+    request: QuestionRequest,
+    tool: QuestionRequest.shape.tool,
+    armedAt: z.number(),
+    updatedAt: z.number(),
+  })
+  export type Entry = z.infer<typeof Entry>
+
+  export const Removed = z.object({
+    kind: z.literal("question"),
+    sessionID: SessionID.zod,
+    requestID: QuestionID.zod,
+    reason: TerminalReason,
+  })
+
+  export const Event = {
+    Upserted: BusEvent.define("session.blocker.upserted", Entry),
+    Removed: BusEvent.define("session.blocker.removed", Removed),
+  }
+
+  const questionByDirectory = new Map<string, Map<QuestionID, Entry>>()
+
+  function questionState(directory: string) {
+    let state = questionByDirectory.get(directory)
+    if (!state) {
+      state = new Map<QuestionID, Entry>()
+      questionByDirectory.set(directory, state)
+    }
+    return state
+  }
+
+  export interface Interface {
+    readonly upsertQuestion: (request: QuestionRequest) => Effect.Effect<void>
+    readonly removeQuestion: (input: {
+      requestID: QuestionID
+      reason: TerminalReason
+    }) => Effect.Effect<void>
+    readonly list: () => Effect.Effect<ReadonlyArray<Entry>>
+    readonly hasAwaitingQuestion: (sessionID: SessionID) => Effect.Effect<boolean>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/SessionBlocker") {}
+
+  export const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+
+      const upsertQuestion = Effect.fn("SessionBlocker.upsertQuestion")(function* (request: QuestionRequest) {
+        const pending = questionState(yield* InstanceState.directory)
+        const now = Date.now()
+        const existing = pending.get(request.id)
+        const entry: Entry = {
+          kind: "question",
+          status: "awaiting_user",
+          sessionID: request.sessionID,
+          requestID: request.id,
+          request: structuredClone(request),
+          tool: request.tool ? structuredClone(request.tool) : undefined,
+          armedAt: existing?.armedAt ?? now,
+          updatedAt: now,
+        }
+        pending.set(request.id, entry)
+        yield* bus.publish(Event.Upserted, structuredClone(entry))
+      })
+
+      const removeQuestion = Effect.fn("SessionBlocker.removeQuestion")(function* (input: {
+        requestID: QuestionID
+        reason: TerminalReason
+      }) {
+        const pending = questionState(yield* InstanceState.directory)
+        const existing = pending.get(input.requestID)
+        if (!existing) return
+        pending.delete(input.requestID)
+        yield* bus.publish(Event.Removed, {
+          kind: "question",
+          sessionID: existing.sessionID,
+          requestID: existing.requestID,
+          reason: input.reason,
+        })
+      })
+
+      const list = Effect.fn("SessionBlocker.list")(function* () {
+        const pending = questionState(yield* InstanceState.directory)
+        return Array.from(pending.values(), (entry) => structuredClone(entry))
+      })
+
+      const hasAwaitingQuestion = Effect.fn("SessionBlocker.hasAwaitingQuestion")(function* (sessionID: SessionID) {
+        const pending = questionState(yield* InstanceState.directory)
+        for (const entry of pending.values()) {
+          if (entry.sessionID === sessionID && entry.status === "awaiting_user") return true
+        }
+        return false
+      })
+
+      return Service.of({ upsertQuestion, removeQuestion, list, hasAwaitingQuestion })
+    }),
+  )
+
+  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+}

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -23,6 +23,7 @@ import { Installation } from "@/installation"
 import { EffectBridge } from "@/effect"
 import * as Option from "effect/Option"
 import { LLMTrace } from "./llm-trace"
+import { SessionBlocker } from "./blocker"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
@@ -61,7 +62,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/LL
 const live: Layer.Layer<
   Service,
   never,
-  Auth.Service | Config.Service | Provider.Service | Plugin.Service | Permission.Service
+  Auth.Service | Config.Service | Provider.Service | Plugin.Service | Permission.Service | SessionBlocker.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -70,6 +71,7 @@ const live: Layer.Layer<
     const provider = yield* Provider.Service
     const plugin = yield* Plugin.Service
     const perm = yield* Permission.Service
+    const blockers = yield* SessionBlocker.Service
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {
       const l = log
@@ -430,18 +432,42 @@ const live: Layer.Layer<
               typeof timeoutMsInput === "number" && Number.isFinite(timeoutMsInput) && timeoutMsInput > 0
                 ? timeoutMsInput
                 : SILENT_STREAM_TIMEOUT_MS
+            const ctx = yield* Effect.context<never>()
             const request = yield* Effect.acquireRelease(
               Effect.sync(() => {
                 const ctrl = new AbortController()
-                let timeout = setTimeout(() => ctrl.abort(), timeoutMs)
+                let disposed = false
+                let sequence = 0
+                let timeout: Timer | undefined
+                const arm = () => {
+                  const current = ++sequence
+                  timeout = setTimeout(() => {
+                    Effect.runPromise(
+                      Effect.provide(blockers.hasAwaitingQuestion(SessionID.make(input.sessionID)), ctx),
+                    )
+                      .then((blocked) => {
+                        if (disposed || current !== sequence) return
+                        if (blocked) {
+                          arm()
+                          return
+                        }
+                        ctrl.abort()
+                      })
+                      .catch(() => {
+                        if (!disposed && current === sequence) ctrl.abort()
+                      })
+                  }, timeoutMs)
+                }
+                arm()
                 return {
                   ctrl,
                   resetTimeout() {
-                    clearTimeout(timeout)
-                    timeout = setTimeout(() => ctrl.abort(), timeoutMs)
+                    if (timeout) clearTimeout(timeout)
+                    arm()
                   },
                   cleanup() {
-                    clearTimeout(timeout)
+                    disposed = true
+                    if (timeout) clearTimeout(timeout)
                     ctrl.abort()
                   },
                 }
@@ -455,7 +481,6 @@ const live: Layer.Layer<
             // the next provider event, not the total model runtime.
             return Stream.fromAsyncIterable(result.fullStream, (e) => (e instanceof Error ? e : new Error(String(e)))).pipe(
               Stream.tap(() => Effect.sync(() => request.resetTimeout())),
-              Stream.timeout(Duration.millis(timeoutMs)),
             )
           }),
         ),
@@ -467,12 +492,13 @@ const live: Layer.Layer<
 
 export const layer = live.pipe(Layer.provide(Permission.defaultLayer))
 
-export const defaultLayer = Layer.suspend(() =>
+export const defaultLayer: Layer.Layer<Service, never, never> = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Config.defaultLayer),
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
+    Layer.provide(SessionBlocker.defaultLayer),
   ),
 )
 

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, test, expect } from "bun:test"
 import { Question } from "../../src/question"
+import { SessionBlocker } from "../../src/session/blocker"
 import { Bus } from "../../src/bus"
 import { Instance } from "../../src/project/instance"
 import { QuestionID } from "../../src/question/schema"
 import { tmpdir } from "../fixture/fixture"
-import { SessionID } from "../../src/session/schema"
+import { MessageID, SessionID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
 
 const ask = (
@@ -18,6 +19,8 @@ const reply = (input: { requestID: QuestionID; answers: Question.Answer[] }) =>
   AppRuntime.runPromise(Question.Service.use((svc) => svc.reply(input)))
 
 const reject = (id: QuestionID) => AppRuntime.runPromise(Question.Service.use((svc) => svc.reject(id)))
+
+const listBlockers = () => AppRuntime.runPromise(SessionBlocker.Service.use((svc) => svc.list()))
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -99,6 +102,45 @@ test("ask - adds to pending list", async () => {
   })
 })
 
+test("ask - records an awaiting question blocker", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const promise = ask({
+        sessionID: SessionID.make("ses_blocker"),
+        questions: [
+          {
+            question: "Pick one",
+            header: "Pick",
+            options: [
+              { label: "A", description: "first" },
+              { label: "B", description: "second" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make("msg_blocker"), callID: "call_blocker" },
+      })
+
+      const pending = await list()
+      const blockers = await listBlockers()
+
+      expect(blockers).toHaveLength(1)
+      expect(blockers[0]).toMatchObject({
+        kind: "question",
+        status: "awaiting_user",
+        sessionID: SessionID.make("ses_blocker"),
+        requestID: pending[0]!.id,
+        tool: { messageID: MessageID.make("msg_blocker"), callID: "call_blocker" },
+      })
+      expect(blockers[0]!.request.id).toBe(pending[0]!.id)
+
+      await rejectAll()
+      await promise.catch(() => {})
+    },
+  })
+})
+
 // reply tests
 
 test("reply - resolves the pending ask with answers", async () => {
@@ -166,6 +208,36 @@ test("reply - removes from pending list", async () => {
 
       const after = await list()
       expect(after.length).toBe(0)
+    },
+  })
+})
+
+test("reply - clears the question blocker", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const promise = ask({
+        sessionID: SessionID.make("ses_blocker_reply"),
+        questions: [
+          {
+            question: "Pick one",
+            header: "Pick",
+            options: [
+              { label: "A", description: "first" },
+              { label: "B", description: "second" },
+            ],
+          },
+        ],
+      })
+
+      const pending = await list()
+      expect(await listBlockers()).toHaveLength(1)
+
+      await reply({ requestID: pending[0]!.id, answers: [["A"]] })
+      await promise
+
+      expect(await listBlockers()).toHaveLength(0)
     },
   })
 })
@@ -624,6 +696,49 @@ test("reject - leaves cancelled flag false (user dismiss, not session cancel)", 
       expect(result).toBeInstanceOf(Question.RejectedError)
       expect((result as Question.RejectedError).cancelled).toBeFalsy()
       expect((result as Question.RejectedError).message).toBe("The user dismissed this question")
+    },
+  })
+})
+
+test("reject - publishes question.rejected with dismissed reason and clears blocker", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const events: Array<{ sessionID: SessionID; requestID: QuestionID; reason?: string }> = []
+      const unsub = Bus.subscribe(Question.Event.Rejected, (evt) => {
+        events.push(evt.properties)
+      })
+
+      const promise = ask({
+        sessionID: SessionID.make("ses_reason"),
+        questions: [
+          {
+            question: "Dismiss me?",
+            header: "Dismiss",
+            options: [
+              { label: "Yes", description: "Yes" },
+              { label: "No", description: "No" },
+            ],
+          },
+        ],
+      })
+
+      const pending = await list()
+      expect(await listBlockers()).toHaveLength(1)
+
+      await reject(pending[0]!.id)
+      await promise.catch(() => {})
+
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({
+        sessionID: SessionID.make("ses_reason"),
+        requestID: pending[0]!.id,
+        reason: "dismissed",
+      })
+      expect(await listBlockers()).toHaveLength(0)
+
+      unsub()
     },
   })
 })

--- a/packages/opencode/test/server/event-replay.test.ts
+++ b/packages/opencode/test/server/event-replay.test.ts
@@ -38,6 +38,8 @@ describe("isReplayableGlobalEvent", () => {
     expect(isReplayableGlobalEvent(event("question.asked"))).toBe(true)
     expect(isReplayableGlobalEvent(event("question.replied"))).toBe(true)
     expect(isReplayableGlobalEvent(event("question.rejected"))).toBe(true)
+    expect(isReplayableGlobalEvent(event("session.blocker.upserted"))).toBe(true)
+    expect(isReplayableGlobalEvent(event("session.blocker.removed"))).toBe(true)
     expect(isReplayableGlobalEvent(event("permission.asked"))).toBe(true)
     expect(isReplayableGlobalEvent(event("permission.replied"))).toBe(true)
     expect(isReplayableGlobalEvent(event("session.created"))).toBe(true)
@@ -122,6 +124,22 @@ describe("EventReplayStore", () => {
     expect(opened.invalidCursor).toBe(false)
     expect(opened.gap).toBe(false)
     expect(opened.replay.map((record) => record.id)).toEqual(["boot:2", "boot:3"])
+  })
+
+  test("replays blocker upsert and remove events after cursor", () => {
+    const store = new EventReplayStore({ bootID: "boot", now: () => 1000 })
+    store.append(event("session.created"))
+    store.append(event("session.blocker.upserted"))
+    store.append(event("session.blocker.removed"))
+
+    const opened = store.snapshot("boot:1")
+
+    expect(opened.invalidCursor).toBe(false)
+    expect(opened.gap).toBe(false)
+    expect(opened.replay.map((record) => record.envelope.payload.type)).toEqual([
+      "session.blocker.upserted",
+      "session.blocker.removed",
+    ])
   })
 
   test("returns no replay for invalid boot id", () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -5,6 +5,7 @@ import { Cause, Effect, Exit, Stream } from "effect"
 import z from "zod"
 import { makeRuntime } from "../../src/effect/run-service"
 import { LLM } from "../../src/session/llm"
+import { Question } from "../../src/question"
 import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider"
 import { ProviderTransform } from "../../src/provider"
@@ -152,6 +153,10 @@ function timeout(ms: number) {
   return new Promise<never>((_, reject) => {
     setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms)
   })
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
 function waitStreamingRequest(pathname: string) {
@@ -576,6 +581,119 @@ describe("session.llm.stream", () => {
         await Promise.race([pending.responseCanceled, timeout(500)])
         await Promise.race([pending.requestAborted, timeout(500)]).catch(() => undefined)
         await pending.request
+        expect(Exit.isFailure(exit)).toBe(false)
+      },
+    })
+  })
+
+  test("does not count awaiting question blockers as silent provider timeout", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+    const pending = waitSilentStreamingRequest("/chat/completions")
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-question-blocker-timeout")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-question-blocker-timeout"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const question = AppRuntime.runPromise(
+          Question.Service.use((svc) =>
+            svc.ask({
+              sessionID,
+              questions: [
+                {
+                  question: "Pick one",
+                  header: "Pick",
+                  options: [
+                    { label: "A", description: "first" },
+                    { label: "B", description: "second" },
+                  ],
+                },
+              ],
+            }),
+          ),
+        )
+
+        while ((await AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))).length === 0) {
+          await sleep(5)
+        }
+
+        const exitPromise = llm.runPromiseExit((svc) =>
+          svc
+            .stream({
+              user,
+              sessionID,
+              model: resolved,
+              agent,
+              system: ["You are a helpful assistant."],
+              messages: [{ role: "user", content: "Hello" }],
+              tools: {},
+              streamTimeoutMs: 20,
+            })
+            .pipe(Stream.runDrain),
+        )
+
+        await pending.request
+        const earlyExit = await Promise.race([
+          exitPromise.then(() => "completed" as const),
+          sleep(90).then(() => "open" as const),
+        ])
+        expect(earlyExit).toBe("open")
+
+        const earlyAbort = await Promise.race([
+          pending.requestAborted.then(() => "aborted" as const),
+          sleep(90).then(() => "open" as const),
+        ])
+        expect(earlyAbort).toBe("open")
+
+        const pendingQuestions = await AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))
+        await AppRuntime.runPromise(
+          Question.Service.use((svc) => svc.reply({ requestID: pendingQuestions[0]!.id, answers: [["A"]] })),
+        )
+        await expect(question).resolves.toEqual([["A"]])
+
+        await Promise.race([pending.requestAborted, timeout(500)])
+        const exit = await Promise.race([exitPromise, timeout(500)])
         expect(Exit.isFailure(exit)).toBe(false)
       },
     })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -23,6 +23,7 @@ import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { SessionCompaction } from "../../src/session/compaction"
+import { SessionBlocker } from "../../src/session/blocker"
 import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
@@ -175,6 +176,7 @@ function makeHttp() {
     Plugin.defaultLayer,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
+    SessionBlocker.defaultLayer,
     lsp,
     mcp,
     AppFileSystem.defaultLayer,

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -46,6 +46,7 @@ import { Settings } from "../../src/settings"
 import { SystemPrompt } from "../../src/session/system"
 import { Todo } from "../../src/session/todo"
 import { SessionCompaction } from "../../src/session/compaction"
+import { SessionBlocker } from "../../src/session/blocker"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionRunState } from "../../src/session/run-state"
@@ -123,6 +124,7 @@ function makeHttp() {
     Plugin.defaultLayer,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
+    SessionBlocker.defaultLayer,
     lsp,
     mcp,
     AppFileSystem.defaultLayer,

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -13,6 +13,7 @@ import type {
   AuthRemoveResponses,
   AuthSetErrors,
   AuthSetResponses,
+  BlockerListResponses,
   CommandListResponses,
   Config as Config3,
   ConfigGetResponses,
@@ -3093,6 +3094,38 @@ export class Question extends HeyApiClient {
   }
 }
 
+export class Blocker extends HeyApiClient {
+  /**
+   * List active session blockers
+   *
+   * Get active session blockers across all sessions.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<BlockerListResponses, unknown, ThrowOnError>({
+      url: "/blocker",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Oauth extends HeyApiClient {
   /**
    * OAuth authorize
@@ -4124,6 +4157,11 @@ export class OpencodeClient extends HeyApiClient {
   private _question?: Question
   get question(): Question {
     return (this._question ??= new Question({ client: this.client }))
+  }
+
+  private _blocker?: Blocker
+  get blocker(): Blocker {
+    return (this._blocker ??= new Blocker({ client: this.client }))
   }
 
   private _provider?: Provider

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -121,6 +121,50 @@ export type EventPermissionReplied = {
   }
 }
 
+export type EventSessionBlockerUpserted = {
+  type: "session.blocker.upserted"
+  properties: {
+    kind: "question"
+    status: "awaiting_user"
+    sessionID: string
+    requestID: string
+    request: {
+      id: string
+      sessionID: string
+      questions: Array<{
+        question: string
+        header: string
+        options: Array<{
+          label: string
+          description: string
+        }>
+        multiple?: boolean
+        custom?: boolean
+      }>
+      tool?: {
+        messageID: string
+        callID: string
+      }
+    }
+    tool?: {
+      messageID: string
+      callID: string
+    }
+    armedAt: number
+    updatedAt: number
+  }
+}
+
+export type EventSessionBlockerRemoved = {
+  type: "session.blocker.removed"
+  properties: {
+    kind: "question"
+    sessionID: string
+    requestID: string
+    reason: "replied" | "cancelled" | "dismissed" | "shutdown" | "rejected"
+  }
+}
+
 export type QuestionOption = {
   /**
    * Display text (1–5 words, max 50 chars)
@@ -191,6 +235,7 @@ export type EventQuestionReplied = {
 export type QuestionRejected = {
   sessionID: string
   requestID: string
+  reason: "cancelled" | "dismissed" | "shutdown" | "rejected"
 }
 
 export type EventQuestionRejected = {
@@ -1098,6 +1143,8 @@ export type Event =
   | EventLspServerInstallFailed
   | EventPermissionAsked
   | EventPermissionReplied
+  | EventSessionBlockerUpserted
+  | EventSessionBlockerRemoved
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
@@ -5066,6 +5113,54 @@ export type QuestionRejectResponses = {
 }
 
 export type QuestionRejectResponse = QuestionRejectResponses[keyof QuestionRejectResponses]
+
+export type BlockerListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/blocker"
+}
+
+export type BlockerListResponses = {
+  /**
+   * List of active session blockers
+   */
+  200: Array<{
+    kind: "question"
+    status: "awaiting_user"
+    sessionID: string
+    requestID: string
+    request: {
+      id: string
+      sessionID: string
+      questions: Array<{
+        question: string
+        header: string
+        options: Array<{
+          label: string
+          description: string
+        }>
+        multiple?: boolean
+        custom?: boolean
+      }>
+      tool?: {
+        messageID: string
+        callID: string
+      }
+    }
+    tool?: {
+      messageID: string
+      callID: string
+    }
+    armedAt: number
+    updatedAt: number
+  }>
+}
+
+export type BlockerListResponse = BlockerListResponses[keyof BlockerListResponses]
 
 export type ProviderListData = {
   body?: never


### PR DESCRIPTION
## Summary

Adds a question-only backend blocker ledger and uses it as the first source for restoring the session question dock.

- records pending `ask` questions as `session.blocker.*` entries
- clears question blockers on reply, dismiss, cancel, shutdown, and validation rejection
- makes LLM silent stream timeout ignore time spent waiting for user answers
- adds explicit `question.rejected.reason` values and regenerated SDK types

## Why

A pending question was previously treated like normal provider silence. With a short silent timeout, the provider abort path could remove the unanswered question and emit `question.rejected`, so the dock disappeared before the user answered. The live blocker needs to represent “waiting for user input,” not “provider is silent.”

## Related Issue

Closes #434
Refs #433

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the blocker lifecycle boundary: `ask` creates only question blockers, terminal question paths remove them with the right reason, and LLM silent timeout does not abort while an awaiting question blocker exists.

## Risk Notes

Question blockers are in-memory v0 only. This PR intentionally does not add permission blockers or persistence. Frontend still keeps the existing `sync.data.question` path as fallback, with backend blocker state preferred only when present.

## How To Verify

```text
opencode question + LLM regressions: 40 passed
opencode event replay regressions: 19 passed
app reducer regressions: 913 passed
composer dock E2E question dock grep: 2 passed
opencode typecheck: ok
app typecheck: ok
SDK generation: ok
Diff check: no whitespace errors
```

Commands run:

```text
bun --cwd packages/opencode test test/question/question.test.ts test/session/llm.test.ts --timeout 30000
bun --cwd packages/opencode test test/server/event-replay.test.ts --timeout 30000
bun --cwd packages/app test:unit src/context/global-sync/event-reducer.test.ts
bun --cwd packages/app test:e2e --grep "question dock"
bun --cwd packages/opencode typecheck
bun --cwd packages/app typecheck
bun run packages/sdk/js/script/build.ts
git diff --check
```

## Screenshots or Recordings

Not attached. Manual UI verification is not required for this PR: it does not change visual styling or copy, and the rendered dock recovery path is covered by the Playwright E2E above.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


