### PR TITLE
fix(webfetch): make HTML text extraction Node-compatible

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -158,35 +158,46 @@ export const WebFetchTool = Tool.define(
 )
 
 async function extractTextFromHTML(html: string) {
-  let text = ""
-  let skipContent = false
+  const body = html.match(/<body\b[^>]*>([\s\S]*?)<\/body\s*>/i)?.[1] ?? html
+  return decodeHTMLEntities(
+    body
+      .replace(/<!--[\s\S]*?-->/g, " ")
+      .replace(/<\s*(script|style|noscript|iframe|object|embed)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, " ")
+      .replace(/<\s*br\s*\/?>/gi, "\n")
+      .replace(/<\s*\/\s*(p|div|section|article|main|header|footer|nav|aside|li|h[1-6]|tr|table|ul|ol)\s*>/gi, "\n")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/[ \t\f\v]+/g, " ")
+      .replace(/\s*\n\s*/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+  )
+}
 
-  const rewriter = new HTMLRewriter()
-    .on("script, style, noscript, iframe, object, embed", {
-      element() {
-        skipContent = true
-      },
-      text() {
-        // Skip text content inside these elements
-      },
-    })
-    .on("*", {
-      element(element) {
-        // Reset skip flag when entering other elements
-        if (!["script", "style", "noscript", "iframe", "object", "embed"].includes(element.tagName)) {
-          skipContent = false
-        }
-      },
-      text(input) {
-        if (!skipContent) {
-          text += input.text
-        }
-      },
-    })
-    .transform(new Response(html))
+function decodeHTMLEntities(text: string) {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  }
+  return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi, (match, entity: string) => {
+    const lower = entity.toLowerCase()
+    if (lower.startsWith("#x")) {
+      const codePoint = Number.parseInt(lower.slice(2), 16)
+      return validCodePoint(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+    if (lower.startsWith("#")) {
+      const codePoint = Number.parseInt(lower.slice(1), 10)
+      return validCodePoint(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+    return named[lower] ?? match
+  })
+}
 
-  await rewriter.text()
-  return text.trim()
+function validCodePoint(value: number) {
+  return Number.isInteger(value) && value >= 0 && value <= 0x10ffff
 }
 
 function convertHTMLToMarkdown(html: string): string {

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -217,8 +217,13 @@ function scanHTMLText(html: string) {
 
     const tag = readTag(html, index)
     if (!tag) {
-      if (!skipTag) append("<")
-      index += 1
+      const end = findTagEnd(html, index + 1)
+      if (end === -1) {
+        if (!skipTag) append(html.slice(index))
+        break
+      }
+      if (!skipTag) append(html.slice(index, end + 1))
+      index = end + 1
       continue
     }
 

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -289,11 +289,38 @@ function findTagEnd(html: string, start: number) {
 }
 
 function normalizeExtractedText(text: string) {
-  return text
-    .replace(/[ \t\f\v]+/g, " ")
-    .replace(/\s*\n\s*/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim()
+  const output: string[] = []
+  let pendingSpace = false
+  let newlineCount = 0
+
+  const appendNewline = () => {
+    pendingSpace = false
+    if (newlineCount < 2) output.push("\n")
+    newlineCount++
+  }
+
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index]
+    if (char === "\r") {
+      if (text[index + 1] === "\n") index++
+      appendNewline()
+      continue
+    }
+    if (char === "\n") {
+      appendNewline()
+      continue
+    }
+    if (char === " " || char === "\t" || char === "\f" || char === "\v") {
+      pendingSpace = true
+      continue
+    }
+    if (pendingSpace && output.length > 0 && newlineCount === 0) output.push(" ")
+    output.push(char)
+    pendingSpace = false
+    newlineCount = 0
+  }
+
+  return output.join("").trim()
 }
 
 function decodeHTMLEntities(text: string) {

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -158,19 +158,137 @@ export const WebFetchTool = Tool.define(
 )
 
 async function extractTextFromHTML(html: string) {
-  const body = html.match(/<body\b[^>]*>([\s\S]*?)<\/body\s*>/i)?.[1] ?? html
-  return decodeHTMLEntities(
-    body
-      .replace(/<!--[\s\S]*?-->/g, " ")
-      .replace(/<\s*(script|style|noscript|iframe|object|embed)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, " ")
-      .replace(/<\s*br\s*\/?>/gi, "\n")
-      .replace(/<\s*\/\s*(p|div|section|article|main|header|footer|nav|aside|li|h[1-6]|tr|table|ul|ol)\s*>/gi, "\n")
-      .replace(/<[^>]*>/g, " ")
-      .replace(/[ \t\f\v]+/g, " ")
-      .replace(/\s*\n\s*/g, "\n")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim(),
-  )
+  return normalizeExtractedText(decodeHTMLEntities(scanHTMLText(html)))
+}
+
+const SKIP_TEXT_TAGS = new Set(["script", "style", "noscript", "iframe", "object", "embed"])
+const BREAK_TAGS = new Set([
+  "article",
+  "aside",
+  "body",
+  "br",
+  "div",
+  "footer",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "section",
+  "table",
+  "tr",
+  "ul",
+])
+
+function scanHTMLText(html: string) {
+  const all: string[] = []
+  const body: string[] = []
+  let sawBody = false
+  let inBody = false
+  let skipTag: string | undefined
+  let index = 0
+
+  const append = (text: string) => {
+    all.push(text)
+    if (inBody) body.push(text)
+  }
+
+  while (index < html.length) {
+    if (html[index] !== "<") {
+      const next = html.indexOf("<", index)
+      const end = next === -1 ? html.length : next
+      if (!skipTag) append(html.slice(index, end))
+      index = end
+      continue
+    }
+
+    if (html.startsWith("<!--", index)) {
+      const end = html.indexOf("-->", index + 4)
+      index = end === -1 ? html.length : end + 3
+      continue
+    }
+
+    const tag = readTag(html, index)
+    if (!tag) {
+      if (!skipTag) append("<")
+      index += 1
+      continue
+    }
+
+    if (skipTag) {
+      if (tag.closing && tag.name === skipTag) skipTag = undefined
+      index = tag.end + 1
+      continue
+    }
+
+    if (tag.name === "body") {
+      sawBody = true
+      inBody = !tag.closing
+      index = tag.end + 1
+      continue
+    }
+
+    if (!tag.closing && SKIP_TEXT_TAGS.has(tag.name)) {
+      skipTag = tag.name
+      index = tag.end + 1
+      continue
+    }
+
+    if (BREAK_TAGS.has(tag.name)) append("\n")
+    index = tag.end + 1
+  }
+
+  return (sawBody ? body : all).join("")
+}
+
+function readTag(html: string, start: number) {
+  const end = findTagEnd(html, start + 1)
+  if (end === -1) return
+
+  let index = start + 1
+  while (/\s/.test(html[index] ?? "")) index++
+  const closing = html[index] === "/"
+  if (closing) {
+    index++
+    while (/\s/.test(html[index] ?? "")) index++
+  }
+
+  const nameStart = index
+  while (/[A-Za-z0-9:-]/.test(html[index] ?? "")) index++
+  if (index === nameStart) return { closing, end, name: "" }
+  return { closing, end, name: html.slice(nameStart, index).toLowerCase() }
+}
+
+function findTagEnd(html: string, start: number) {
+  let quote: string | undefined
+  for (let index = start; index < html.length; index++) {
+    const char = html[index]
+    if (quote) {
+      if (char === quote) quote = undefined
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === ">") return index
+  }
+  return -1
+}
+
+function normalizeExtractedText(text: string) {
+  return text
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
 }
 
 function decodeHTMLEntities(text: string) {

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -63,7 +63,7 @@ describe("built node webfetch", () => {
 
         await Log.init({ level: "DEBUG", print: false })
 
-        const html = [
+        const happyHTML = [
           "<!doctype html>",
           "<html>",
           "<head>",
@@ -73,15 +73,16 @@ describe("built node webfetch", () => {
           "<body>",
           "<main>",
           "<h1>Korea visa center</h1>",
-          "<p>Bring passport &amp; application form.</p>",
+          '<p data-note="1 > 0">Bring passport &amp; application form.</p>',
           "</main>",
           "</body>",
           "</html>",
         ].join("")
+        const hostileHTML = \`<body>\${"<script>".repeat(50_000)}visible text</body>\`
 
         const server = http.createServer((req, res) => {
           res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
-          res.end(html)
+          res.end(req.url === "/hostile.html" ? hostileHTML : happyHTML)
         })
 
         await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -99,9 +100,9 @@ describe("built node webfetch", () => {
               })
               const webfetch = tools.find((tool) => tool.id === "webfetch")
               if (!webfetch) throw new Error("missing webfetch tool")
-              const result = await Effect.runPromise(
+              const run = async (pathname) => Effect.runPromise(
                 webfetch.execute(
-                  { url: \`http://127.0.0.1:\${address.port}/page.html\`, format: "text" },
+                  { url: \`http://127.0.0.1:\${address.port}\${pathname}\`, format: "text" },
                   {
                     sessionID: "ses_test",
                     messageID: "msg_test",
@@ -114,11 +115,19 @@ describe("built node webfetch", () => {
                   },
                 ),
               )
-              return result.output
+
+              const happy = await run("/page.html")
+              const hostileStart = performance.now()
+              const hostile = await run("/hostile.html")
+              return {
+                happy: happy.output,
+                hostile: hostile.output,
+                hostileElapsed: performance.now() - hostileStart,
+              }
             },
           })
 
-          console.log(JSON.stringify({ output }))
+          console.log(JSON.stringify(output))
         } finally {
           await new Promise((resolve, reject) => {
             server.close((error) => (error ? reject(error) : resolve()))
@@ -137,11 +146,18 @@ describe("built node webfetch", () => {
         },
       })
 
-      const output = JSON.parse(result.stdout.toString().trim()) as { output: string }
-      expect(output.output).toContain("Korea visa center")
-      expect(output.output).toContain("Bring passport & application form.")
-      expect(output.output).not.toContain("window.secret")
-      expect(output.output).not.toContain(".hidden")
+      const output = JSON.parse(result.stdout.toString().trim()) as {
+        happy: string
+        hostile: string
+        hostileElapsed: number
+      }
+      expect(output.happy).toContain("Korea visa center")
+      expect(output.happy).toContain("Bring passport & application form.")
+      expect(output.happy).not.toContain('0">')
+      expect(output.happy).not.toContain("window.secret")
+      expect(output.happy).not.toContain(".hidden")
+      expect(output.hostileElapsed).toBeLessThan(500)
+      expect(output.hostile).not.toContain("<script>")
     })
   }, 60_000)
 })

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -80,10 +80,19 @@ describe("built node webfetch", () => {
         ].join("")
         const hostileHTML = \`<body>\${"<script>".repeat(50_000)}visible text</body>\`
         const rawOpenHTML = \`<body>\${"<".repeat(50_000)}\`
+        const whitespaceHTML = \`<body>\${"\\r".repeat(50_000)}visible text</body>\`
 
         const server = http.createServer((req, res) => {
           res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
-          res.end(req.url === "/hostile.html" ? hostileHTML : req.url === "/raw-open.html" ? rawOpenHTML : happyHTML)
+          res.end(
+            req.url === "/hostile.html"
+              ? hostileHTML
+              : req.url === "/raw-open.html"
+                ? rawOpenHTML
+                : req.url === "/whitespace.html"
+                  ? whitespaceHTML
+                  : happyHTML,
+          )
         })
 
         await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -122,12 +131,16 @@ describe("built node webfetch", () => {
               const hostile = await run("/hostile.html")
               const rawOpenStart = performance.now()
               const rawOpen = await run("/raw-open.html")
+              const whitespaceStart = performance.now()
+              const whitespace = await run("/whitespace.html")
               return {
                 happy: happy.output,
                 hostile: hostile.output,
                 hostileElapsed: performance.now() - hostileStart,
                 rawOpen: rawOpen.output,
                 rawOpenElapsed: performance.now() - rawOpenStart,
+                whitespace: whitespace.output,
+                whitespaceElapsed: performance.now() - whitespaceStart,
               }
             },
           })
@@ -157,6 +170,8 @@ describe("built node webfetch", () => {
         hostileElapsed: number
         rawOpen: string
         rawOpenElapsed: number
+        whitespace: string
+        whitespaceElapsed: number
       }
       expect(output.happy).toContain("Korea visa center")
       expect(output.happy).toContain("Bring passport & application form.")
@@ -167,6 +182,8 @@ describe("built node webfetch", () => {
       expect(output.hostile).not.toContain("<script>")
       expect(output.rawOpenElapsed).toBeLessThan(500)
       expect(output.rawOpen).toContain("<")
+      expect(output.whitespaceElapsed).toBeLessThan(500)
+      expect(output.whitespace).toBe("visible text")
     })
   }, 60_000)
 })

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { Process } from "../../src/util/process"
+import { tmpdir } from "../fixture/fixture"
+import { withEmbeddedServerArtifactLock } from "../shared/embedded-server-artifact-lock"
+import { expectModelsSnapshotUnchanged, writeCurrentModelsFixture } from "./models-snapshot-fixture"
+
+const root = path.join(import.meta.dir, "../..")
+const distEntry = path.join(root, "dist", "node", "node.js")
+
+describe("built node webfetch", () => {
+  test("extracts text from html without relying on Bun HTMLRewriter", async () => {
+    await withEmbeddedServerArtifactLock(async () => {
+      await using tmp = await tmpdir()
+      const modelsFixture = writeCurrentModelsFixture(root, tmp.path)
+      const runtimeRoot = path.join(tmp.path, "runtime")
+      const runtimeHome = path.join(runtimeRoot, "home")
+      const isolatedEnv = {
+        ...process.env,
+        MODELS_DEV_API_JSON: modelsFixture.fixture,
+        HOME: runtimeHome,
+        USERPROFILE: runtimeHome,
+        XDG_DATA_HOME: path.join(runtimeRoot, "share"),
+        XDG_CACHE_HOME: path.join(runtimeRoot, "cache"),
+        XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+        XDG_STATE_HOME: path.join(runtimeRoot, "state"),
+        OPENCODE_TEST_HOME: runtimeHome,
+        OPENCODE_TEST_MANAGED_CONFIG_DIR: path.join(runtimeRoot, "managed"),
+        OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+        OPENCODE_DB: ":memory:",
+      }
+
+      await Promise.all(
+        [
+          isolatedEnv.HOME,
+          isolatedEnv.XDG_DATA_HOME,
+          isolatedEnv.XDG_CACHE_HOME,
+          isolatedEnv.XDG_CONFIG_HOME,
+          isolatedEnv.XDG_STATE_HOME,
+          isolatedEnv.OPENCODE_TEST_MANAGED_CONFIG_DIR,
+        ].map((dir) => fs.mkdir(dir, { recursive: true })),
+      )
+
+      await Process.run([process.execPath, "run", "build:embedded-server"], {
+        cwd: root,
+        env: isolatedEnv,
+      })
+      expectModelsSnapshotUnchanged(modelsFixture)
+
+      const script = `
+        import http from "node:http"
+        import { Effect } from "effect"
+        import { Instance, Log, ToolRegistry } from ${JSON.stringify(pathToFileURL(distEntry).href)}
+
+        if (typeof HTMLRewriter !== "undefined") {
+          throw new Error("test must run in a Node runtime without HTMLRewriter")
+        }
+
+        const directory = process.env.TEST_DIRECTORY
+        if (!directory) throw new Error("missing TEST_DIRECTORY")
+
+        await Log.init({ level: "DEBUG", print: false })
+
+        const html = [
+          "<!doctype html>",
+          "<html>",
+          "<head>",
+          "<style>.hidden { display: none }</style>",
+          "<script>window.secret = 'nope'</script>",
+          "</head>",
+          "<body>",
+          "<main>",
+          "<h1>Korea visa center</h1>",
+          "<p>Bring passport &amp; application form.</p>",
+          "</main>",
+          "</body>",
+          "</html>",
+        ].join("")
+
+        const server = http.createServer((req, res) => {
+          res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+          res.end(html)
+        })
+
+        await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+        const address = server.address()
+        if (!address || typeof address === "string") throw new Error("missing server address")
+
+        try {
+          const output = await Instance.provide({
+            directory,
+            fn: async () => {
+              const tools = await ToolRegistry.tools({
+                providerID: "openai",
+                modelID: "gpt-5",
+                agent: { name: "build", mode: "primary", permission: [], options: {} },
+              })
+              const webfetch = tools.find((tool) => tool.id === "webfetch")
+              if (!webfetch) throw new Error("missing webfetch tool")
+              const result = await Effect.runPromise(
+                webfetch.execute(
+                  { url: \`http://127.0.0.1:\${address.port}/page.html\`, format: "text" },
+                  {
+                    sessionID: "ses_test",
+                    messageID: "msg_test",
+                    callID: "tool_test",
+                    agent: "build",
+                    abort: new AbortController().signal,
+                    messages: [],
+                    metadata: () => Effect.void,
+                    ask: () => Effect.void,
+                  },
+                ),
+              )
+              return result.output
+            },
+          })
+
+          console.log(JSON.stringify({ output }))
+        } finally {
+          await new Promise((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()))
+          })
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        process.exit(0)
+      `
+
+      const result = await Process.run(["node", "--input-type=module", "-e", script], {
+        cwd: root,
+        env: {
+          ...isolatedEnv,
+          TEST_DIRECTORY: tmp.path,
+        },
+      })
+
+      const output = JSON.parse(result.stdout.toString().trim()) as { output: string }
+      expect(output.output).toContain("Korea visa center")
+      expect(output.output).toContain("Bring passport & application form.")
+      expect(output.output).not.toContain("window.secret")
+      expect(output.output).not.toContain(".hidden")
+    })
+  }, 60_000)
+})

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -79,10 +79,11 @@ describe("built node webfetch", () => {
           "</html>",
         ].join("")
         const hostileHTML = \`<body>\${"<script>".repeat(50_000)}visible text</body>\`
+        const rawOpenHTML = \`<body>\${"<".repeat(50_000)}\`
 
         const server = http.createServer((req, res) => {
           res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
-          res.end(req.url === "/hostile.html" ? hostileHTML : happyHTML)
+          res.end(req.url === "/hostile.html" ? hostileHTML : req.url === "/raw-open.html" ? rawOpenHTML : happyHTML)
         })
 
         await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -119,10 +120,14 @@ describe("built node webfetch", () => {
               const happy = await run("/page.html")
               const hostileStart = performance.now()
               const hostile = await run("/hostile.html")
+              const rawOpenStart = performance.now()
+              const rawOpen = await run("/raw-open.html")
               return {
                 happy: happy.output,
                 hostile: hostile.output,
                 hostileElapsed: performance.now() - hostileStart,
+                rawOpen: rawOpen.output,
+                rawOpenElapsed: performance.now() - rawOpenStart,
               }
             },
           })
@@ -150,6 +155,8 @@ describe("built node webfetch", () => {
         happy: string
         hostile: string
         hostileElapsed: number
+        rawOpen: string
+        rawOpenElapsed: number
       }
       expect(output.happy).toContain("Korea visa center")
       expect(output.happy).toContain("Bring passport & application form.")
@@ -158,6 +165,8 @@ describe("built node webfetch", () => {
       expect(output.happy).not.toContain(".hidden")
       expect(output.hostileElapsed).toBeLessThan(500)
       expect(output.hostile).not.toContain("<script>")
+      expect(output.rawOpenElapsed).toBeLessThan(500)
+      expect(output.rawOpen).toContain("<")
     })
   }, 60_000)
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -100,4 +100,44 @@ describe("tool.webfetch", () => {
       },
     )
   })
+
+  test("extracts text from html responses requested as text", async () => {
+    const html = [
+      "<!doctype html>",
+      "<html>",
+      "<head>",
+      "<title>ignored title</title>",
+      "<style>.hidden { display: none }</style>",
+      "<script>window.secret = 'nope'</script>",
+      "</head>",
+      "<body>",
+      "<main>",
+      "<h1>Korea visa center</h1>",
+      "<p>Bring passport &amp; application form.</p>",
+      "</main>",
+      "</body>",
+      "</html>",
+    ].join("")
+
+    await withFetch(
+      () =>
+        new Response(html, {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      async (url) => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const result = await exec({ url: new URL("/page.html", url).toString(), format: "text" })
+            expect(result.output).toContain("Korea visa center")
+            expect(result.output).toContain("Bring passport & application form.")
+            expect(result.output).not.toContain("window.secret")
+            expect(result.output).not.toContain(".hidden")
+            expect(result.attachments).toBeUndefined()
+          },
+        })
+      },
+    )
+  })
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -166,4 +166,29 @@ describe("tool.webfetch", () => {
       },
     )
   })
+
+  test("handles unterminated tag openers without long synchronous processing", async () => {
+    const html = `<body>${"<".repeat(50_000)}`
+
+    await withFetch(
+      () =>
+        new Response(html, {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      async (url) => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const start = performance.now()
+            const result = await exec({ url: new URL("/raw-open.html", url).toString(), format: "text" })
+            const elapsed = performance.now() - start
+
+            expect(elapsed).toBeLessThan(500)
+            expect(result.output).toContain("<")
+          },
+        })
+      },
+    )
+  })
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -191,4 +191,29 @@ describe("tool.webfetch", () => {
       },
     )
   })
+
+  test("handles long whitespace runs without long synchronous normalization", async () => {
+    const html = `<body>${"\r".repeat(50_000)}visible text</body>`
+
+    await withFetch(
+      () =>
+        new Response(html, {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      async (url) => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const start = performance.now()
+            const result = await exec({ url: new URL("/whitespace.html", url).toString(), format: "text" })
+            const elapsed = performance.now() - start
+
+            expect(elapsed).toBeLessThan(500)
+            expect(result.output).toBe("visible text")
+          },
+        })
+      },
+    )
+  })
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -113,7 +113,7 @@ describe("tool.webfetch", () => {
       "<body>",
       "<main>",
       "<h1>Korea visa center</h1>",
-      "<p>Bring passport &amp; application form.</p>",
+      '<p data-note="1 > 0">Bring passport &amp; application form.</p>',
       "</main>",
       "</body>",
       "</html>",
@@ -132,9 +132,35 @@ describe("tool.webfetch", () => {
             const result = await exec({ url: new URL("/page.html", url).toString(), format: "text" })
             expect(result.output).toContain("Korea visa center")
             expect(result.output).toContain("Bring passport & application form.")
+            expect(result.output).not.toContain('0">')
             expect(result.output).not.toContain("window.secret")
             expect(result.output).not.toContain(".hidden")
             expect(result.attachments).toBeUndefined()
+          },
+        })
+      },
+    )
+  })
+
+  test("handles many unclosed skip tags without long synchronous processing", async () => {
+    const html = `<body>${"<script>".repeat(50_000)}visible text</body>`
+
+    await withFetch(
+      () =>
+        new Response(html, {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      async (url) => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const start = performance.now()
+            const result = await exec({ url: new URL("/hostile.html", url).toString(), format: "text" })
+            const elapsed = performance.now() - start
+
+            expect(elapsed).toBeLessThan(500)
+            expect(result.output).not.toContain("<script>")
           },
         })
       },


### PR DESCRIPTION
## Summary

Make `webfetch({ format: "text" })` extract readable text from HTML without relying on Bun's `HTMLRewriter` global.

The extractor now uses a bounded single-pass scanner instead of regex-based block stripping, so malformed HTML with many unclosed skip tags, unterminated tag openers, or long whitespace runs cannot trigger repeated full-string rescans or regex backtracking. Regression coverage includes the source tool path and the built Node embedded-server path used by PawWork desktop.

## Why

Desktop PawWork runs the embedded opencode server from the Node-target bundle. Node does not provide Bun's `HTMLRewriter`, so HTML pages fetched as text failed with `HTMLRewriter is not defined`.

## Related Issue

Closes #466

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the single-pass HTML-to-text scanner in `packages/opencode/src/tool/webfetch.ts`, especially skip-tag handling for malformed HTML, and the built Node regression test that exercises the desktop runtime surface.

## Risk Notes

Low behavior risk. The change only affects HTML responses requested with `format: "text"`; `format: "markdown"`, `format: "html"`, text/plain responses, and image attachment handling remain on their existing branches.

The text extractor is intentionally lightweight and does not attempt browser-grade rendering or real-site anti-bot handling. It is designed to terminate deterministically on malformed HTML, including unclosed `script` / `style` blocks, raw `<` runs with no closing `>`, and long whitespace runs during text normalization.

## How To Verify

```text
webfetch source tests: 7 pass, 0 fail via bun --cwd packages/opencode test test/tool/webfetch.test.ts
built Node webfetch test: 1 pass, 0 fail via bun --cwd packages/opencode test test/server/built-node-webfetch.test.ts
opencode typecheck: ok via bun run --cwd packages/opencode typecheck
Diff check: no whitespace errors via git diff --check
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English



