### PR TITLE
fix: keep question dock submit anchored

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -115,7 +115,7 @@ function globalEventStream(page: Page) {
 
 async function e2eAskQuestion(
   project: ProjectQuestionSeed,
-  input: { sessionID: string; questions: typeof defaultQuestions },
+  input: { sessionID: string; questions: QuestionRequest["questions"] },
 ) {
   const response = await fetch(`${project.url}/question/__e2e/ask?directory=${encodeURIComponent(project.directory)}`, {
     method: "POST",
@@ -229,6 +229,26 @@ async function scrollTimelineToBottom(page: Page) {
       })
     })
     .toBeLessThanOrEqual(40)
+}
+
+async function expectQuestionOptionVisible(page: Page, optionIndex: number) {
+  await expect
+    .poll(async () => {
+      return page.evaluate((index) => {
+        const list = document.querySelector('[data-slot="question-options"]')
+        const target = list?.querySelectorAll('[data-slot="question-option"]').item(index)
+        if (!(list instanceof HTMLElement) || !(target instanceof HTMLElement)) return null
+        const active = document.activeElement
+        const optionRect = target.getBoundingClientRect()
+        const listRect = list.getBoundingClientRect()
+        return {
+          focused: active === target || !!target.contains(active),
+          topVisible: optionRect.top >= listRect.top,
+          bottomVisible: optionRect.bottom <= listRect.bottom,
+        }
+      }, optionIndex)
+    })
+    .toMatchObject({ focused: true, topVisible: true, bottomVisible: true })
 }
 
 async function todoDock(page: any, sessionID: string) {
@@ -1505,6 +1525,60 @@ test("submit to question dock keeps latest turn visible", async ({ page, llm, pr
         expect(metrics!.distanceFromBottom).toBeLessThanOrEqual(80)
         expect(metrics!.dockTop).toBeLessThanOrEqual(metrics!.viewportBottom)
         expect(metrics!.lastBottom).toBeLessThanOrEqual(metrics!.dockTop + 8)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("overflow question dock keeps keyboard focus visible without moving timeline", async ({ page, project, assistant }) => {
+  const title = `e2e question overflow dock ${Date.now()}`
+  const overflowQuestions = [
+    {
+      header: "Need input",
+      question:
+        "Pick one option after reading this longer prompt. The content is intentionally long enough to make the compact question dock reserve less room for the option list in a short viewport.",
+      custom: false,
+      options: Array.from({ length: 4 }, (_, index) => ({
+        label: `Option ${index + 1}`,
+        description: `Long option ${index + 1} description that fills the row.`,
+      })),
+    },
+  ]
+  const longReply = [
+    "Question dock overflow regression seed:",
+    "",
+    "```",
+    ...Array.from({ length: 150 }, (_, index) => `visible-history-line-${index + 1}`),
+    "```",
+    "",
+    "End of visible history.",
+  ].join("\n")
+
+  await page.setViewportSize({ width: 1280, height: 420 })
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    title,
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+        await assistant.reply(longReply)
+        await project.prompt("Write long visible history for the question overflow regression.")
+        await scrollTimelineToBottom(page)
+
+        await e2eAskQuestion(project, { sessionID: session.id, questions: overflowQuestions })
+        await waitForQuestionSeed(project, session.id)
+        await expectQuestionBlocked(page)
+
+        await page.keyboard.press("End")
+        await expectQuestionOptionVisible(page, overflowQuestions[0].options.length - 1)
+        const distanceAfterEnd = await page.evaluate(() => {
+          const viewport = document.querySelector('[data-component="scroll-viewport"]')
+          if (!(viewport instanceof HTMLElement)) return Number.POSITIVE_INFINITY
+          return viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop
+        })
+        expect(distanceAfterEnd).toBeLessThanOrEqual(80)
       })
     },
     { trackSession: project.trackSession },

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -204,6 +204,33 @@ async function expectPermissionOpen(page: any) {
   await expect(page.locator(promptSelector)).toBeVisible()
 }
 
+async function submitVisiblePrompt(page: Page, text: string) {
+  const prompt = page.locator(promptSelector).first()
+  await expect(prompt).toBeVisible()
+  await prompt.click()
+  await page.keyboard.type(text)
+  await expect.poll(async () => (await prompt.textContent())?.replace(/\u200B/g, "").trim()).toBe(text)
+  await page.keyboard.press("Enter")
+}
+
+async function scrollTimelineToBottom(page: Page) {
+  await page.evaluate(() => {
+    const viewport = document.querySelector('[data-component="scroll-viewport"]')
+    if (!(viewport instanceof HTMLElement)) throw new Error("Missing scroll viewport")
+    viewport.scrollTop = viewport.scrollHeight
+    viewport.dispatchEvent(new Event("scroll", { bubbles: true }))
+  })
+  await expect
+    .poll(async () => {
+      return page.evaluate(() => {
+        const viewport = document.querySelector('[data-component="scroll-viewport"]')
+        if (!(viewport instanceof HTMLElement)) return Number.POSITIVE_INFINITY
+        return viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop
+      })
+    })
+    .toBeLessThanOrEqual(40)
+}
+
 async function todoDock(page: any, sessionID: string) {
   await page.addInitScript(() => {
     const win = window as ComposerWindow
@@ -1420,6 +1447,65 @@ test("e2e composer dock keeps latest turn visible when dock height changes", asy
 
       await mkdir(".artifacts/session-scroll-dock", { recursive: true })
       await page.screenshot({ path: ".artifacts/session-scroll-dock/latest-visible.png" })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("submit to question dock keeps latest turn visible", async ({ page, llm, project, assistant }) => {
+  const title = `e2e question scroll dock ${Date.now()}`
+  const longReply = [
+    "Question dock scroll regression seed:",
+    "",
+    "```",
+    ...Array.from({ length: 150 }, (_, index) => `visible-history-line-${index + 1}`),
+    "```",
+    "",
+    "End of visible history.",
+  ].join("\n")
+  const questionPrompt = [
+    "Call exactly one question tool.",
+    `Use this JSON input: ${JSON.stringify({ questions: defaultQuestions })}`,
+    "Do not output plain text.",
+  ].join(" ")
+
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    title,
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+        await assistant.reply(longReply)
+        await project.prompt("Write long visible history for the question scroll regression.")
+        await scrollTimelineToBottom(page)
+
+        await llm.toolMatch(inputMatch({ questions: defaultQuestions }), "question", { questions: defaultQuestions })
+        await submitVisiblePrompt(page, questionPrompt)
+        await expectQuestionBlocked(page)
+
+        const metrics = await page.evaluate((dockSelector) => {
+          const viewport = document.querySelector('[data-component="scroll-viewport"]')
+          const dock = document.querySelector(dockSelector)
+          const last = [...document.querySelectorAll("[data-message-id]")].at(-1)
+          if (!(viewport instanceof HTMLElement) || !(dock instanceof HTMLElement) || !(last instanceof HTMLElement)) {
+            return null
+          }
+          return {
+            scrollTop: viewport.scrollTop,
+            distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+            dockTop: dock.getBoundingClientRect().top,
+            viewportBottom: viewport.getBoundingClientRect().bottom,
+            lastBottom: last.getBoundingClientRect().bottom,
+          }
+        }, questionDockSelector)
+
+        expect(metrics).not.toBeNull()
+        expect(metrics!.scrollTop).toBeGreaterThan(100)
+        expect(metrics!.distanceFromBottom).toBeLessThanOrEqual(80)
+        expect(metrics!.dockTop).toBeLessThanOrEqual(metrics!.viewportBottom)
+        expect(metrics!.lastBottom).toBeLessThanOrEqual(metrics!.dockTop + 8)
+      })
     },
     { trackSession: project.trackSession },
   )

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -251,6 +251,18 @@ async function expectQuestionOptionVisible(page: Page, optionIndex: number) {
     .toMatchObject({ focused: true, topVisible: true, bottomVisible: true })
 }
 
+async function expectQuestionOptionsOverflow(page: Page) {
+  await expect
+    .poll(async () => {
+      return page.evaluate(() => {
+        const list = document.querySelector('[data-slot="question-options"]')
+        if (!(list instanceof HTMLElement)) return false
+        return list.scrollHeight > list.clientHeight
+      })
+    })
+    .toBe(true)
+}
+
 async function todoDock(page: any, sessionID: string) {
   await page.addInitScript(() => {
     const win = window as ComposerWindow
@@ -1570,6 +1582,7 @@ test("overflow question dock keeps keyboard focus visible without moving timelin
         await e2eAskQuestion(project, { sessionID: session.id, questions: overflowQuestions })
         await waitForQuestionSeed(project, session.id)
         await expectQuestionBlocked(page)
+        await expectQuestionOptionsOverflow(page)
 
         await page.keyboard.press("End")
         await expectQuestionOptionVisible(page, overflowQuestions[0].options.length - 1)

--- a/packages/app/src/context/renderer-diagnostics.test.ts
+++ b/packages/app/src/context/renderer-diagnostics.test.ts
@@ -158,6 +158,60 @@ describe("renderer diagnostics", () => {
     ])
   })
 
+  test("detects submit scroll jumps that browser focus marked as user scrolled", () => {
+    const detect = createRendererIncidentDetector()
+    detect({
+      name: "session.action.submit",
+      route_session_id: "session-1",
+      visible_session_id: "session-1",
+      timeline_session_id: "session-1",
+      trace_id: "message-1",
+      monotonic_ms: 1000,
+      data: { action: "submit" },
+    })
+    expect(
+      detect({
+        name: "session.scroll.sample",
+        route_session_id: "session-1",
+        visible_session_id: "session-1",
+        timeline_session_id: "session-1",
+        monotonic_ms: 1200,
+        data: {
+          scroll_top: 14327,
+          distance_from_bottom: 0,
+          client_height: 905,
+          user_scrolled: false,
+        },
+      }),
+    ).toEqual([])
+
+    expect(
+      detect({
+        name: "session.scroll.sample",
+        route_session_id: "session-1",
+        visible_session_id: "session-1",
+        timeline_session_id: "session-1",
+        monotonic_ms: 2000,
+        data: {
+          scroll_top: 5,
+          distance_from_bottom: 14322,
+          client_height: 905,
+          user_scrolled: true,
+        },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        name: "incident.session_scroll_jump_to_top",
+        trace_id: "message-1",
+        data: expect.objectContaining({
+          scroll_top: 5,
+          distance_from_bottom: 14322,
+          user_scrolled: true,
+        }),
+      }),
+    ])
+  })
+
   test("detects timeline remounts and recovered visible message clears", () => {
     const detect = createRendererIncidentDetector()
 

--- a/packages/app/src/context/renderer-diagnostics.ts
+++ b/packages/app/src/context/renderer-diagnostics.ts
@@ -59,14 +59,28 @@ function nearBottomThreshold(clientHeight: number) {
   return Math.min(200, Math.max(80, clientHeight * 0.3))
 }
 
-export function detectSessionScrollJumpToTop(event: RendererDiagnosticInput): RendererDiagnosticInput | undefined {
+function nearTopThreshold(clientHeight: number) {
+  return Math.min(12, Math.max(4, clientHeight * 0.01))
+}
+
+export function detectSessionScrollJumpToTop(
+  event: RendererDiagnosticInput,
+  options?: { allowUserScrolled?: boolean; scrollTopThreshold?: number },
+): RendererDiagnosticInput | undefined {
   if (event.name !== "session.scroll.sample") return
   const scrollTop = numericData(event, "scroll_top")
   const distanceFromBottom = numericData(event, "distance_from_bottom")
   const clientHeight = numericData(event, "client_height")
   const userScrolled = booleanData(event, "user_scrolled")
   if (scrollTop === undefined || distanceFromBottom === undefined || clientHeight === undefined) return
-  if (scrollTop > 4 || distanceFromBottom < nearBottomThreshold(clientHeight) || userScrolled) return
+  const scrollTopThreshold = options?.scrollTopThreshold ?? 4
+  if (
+    scrollTop > scrollTopThreshold ||
+    distanceFromBottom < nearBottomThreshold(clientHeight) ||
+    (userScrolled && !options?.allowUserScrolled)
+  ) {
+    return
+  }
   return {
     name: "incident.session_scroll_jump_to_top",
     level: "warn",
@@ -102,7 +116,6 @@ export function createRendererIncidentDetector() {
     }
 
     if (sessionKey && event.name === "session.scroll.sample") {
-      const scrollIncident = detectSessionScrollJumpToTop(event)
       const distanceFromBottom = numericData(event, "distance_from_bottom")
       const clientHeight = numericData(event, "client_height")
       const nearBottom =
@@ -112,7 +125,13 @@ export function createRendererIncidentDetector() {
       const previous = lastScroll.get(sessionKey)
       const submit = recentSubmits.get(sessionKey)
       const monotonic = event.monotonic_ms ?? performance.now()
-      if (scrollIncident && previous?.nearBottom && submit && monotonic - submit.monotonicMs <= 2_000) {
+      const submittedFromBottom = !!(previous?.nearBottom && submit && monotonic - submit.monotonicMs <= 2_000)
+      const scrollIncident = detectSessionScrollJumpToTop(event, {
+        allowUserScrolled: submittedFromBottom,
+        scrollTopThreshold:
+          submittedFromBottom && clientHeight !== undefined ? nearTopThreshold(clientHeight) : undefined,
+      })
+      if (scrollIncident && submittedFromBottom) {
         incidents.push({
           ...scrollIncident,
           trace_id: scrollIncident.trace_id ?? submit.traceID,

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -13,6 +13,10 @@ type DraftAnswer = QuestionAnswer | undefined
 
 const cache = new Map<string, { tab: number; answers: DraftAnswer[]; custom: string[]; customOn: boolean[] }>()
 
+function focusWithoutScrolling(el: HTMLElement | undefined) {
+  el?.focus({ preventScroll: true })
+}
+
 /**
  * After skipping a question (setting its answer to []), decide the next action.
  * Returns either the tab to navigate to, or a submit signal when all questions are settled.
@@ -160,7 +164,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     focusFrame = requestAnimationFrame(() => {
       focusFrame = undefined
       const el = next === options().length ? customRef : optsRef[next]
-      el?.focus()
+      focusWithoutScrolling(el)
     })
   }
 
@@ -379,7 +383,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const focusCustom = (el: HTMLTextAreaElement) => {
     setTimeout(() => {
-      el.focus()
+      focusWithoutScrolling(el)
       resizeInput(el)
     }, 0)
   }

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -13,8 +13,23 @@ type DraftAnswer = QuestionAnswer | undefined
 
 const cache = new Map<string, { tab: number; answers: DraftAnswer[]; custom: string[]; customOn: boolean[] }>()
 
-function focusWithoutScrolling(el: HTMLElement | undefined) {
-  el?.focus({ preventScroll: true })
+function keepVisibleInQuestionOptions(el: HTMLElement) {
+  const scroller = el.closest('[data-slot="question-options"]')
+  if (!(scroller instanceof HTMLElement)) return
+
+  const optionRect = el.getBoundingClientRect()
+  const scrollerRect = scroller.getBoundingClientRect()
+  if (optionRect.top < scrollerRect.top) {
+    scroller.scrollTop -= scrollerRect.top - optionRect.top
+  } else if (optionRect.bottom > scrollerRect.bottom) {
+    scroller.scrollTop += optionRect.bottom - scrollerRect.bottom
+  }
+}
+
+function focusWithoutScrollingTimeline(el: HTMLElement | undefined) {
+  if (!el) return
+  el.focus({ preventScroll: true })
+  keepVisibleInQuestionOptions(el)
 }
 
 /**
@@ -164,7 +179,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     focusFrame = requestAnimationFrame(() => {
       focusFrame = undefined
       const el = next === options().length ? customRef : optsRef[next]
-      focusWithoutScrolling(el)
+      focusWithoutScrollingTimeline(el)
     })
   }
 
@@ -383,7 +398,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const focusCustom = (el: HTMLTextAreaElement) => {
     setTimeout(() => {
-      focusWithoutScrolling(el)
+      focusWithoutScrollingTimeline(el)
       resizeInput(el)
     }, 0)
   }


### PR DESCRIPTION
## Summary

- Prevent question dock programmatic focus from scrolling the session timeline away from the latest turn.
- Add a deterministic submit-to-question-dock E2E guard that keeps the timeline near bottom.
- Extend renderer diagnostics so the #467 scroll-jump shape is reported even when browser focus marks the sample as user-scrolled.

## Why

Long sessions could jump from the latest turn to near the top after the user submitted a message and the assistant entered a pending `question` tool state. The user then lost the question dock position and had to manually scroll back down to answer.

Root cause boundary: this is a frontend session scroll/focus contract issue. The fix stays in the question dock focus behavior, session renderer diagnostics, and focused regression coverage. It does not touch backend question tools, blocker ledger, SSE replay, persistence, or protocol/schema layers.

## Related Issue

Closes #467

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the question dock focus change uses `preventScroll` without breaking keyboard focus or option navigation.
- Confirm diagnostics only broadens detection for recent-submit + previous-near-bottom + near-top samples, not ordinary user-initiated scrolling.
- Confirm the E2E covers the real visible submit path for the final prompt instead of seeding the question dock directly.

## Risk Notes

Low frontend risk. `preventScroll` changes only programmatic focus inside `SessionQuestionDock`; keyboard focus is still assigned and covered by the existing keyboard E2E. Diagnostics detection remains gated by recent submit and previous near-bottom state to avoid broad false positives.

## How To Verify

```text
Focused unit tests: 914 passed
Command: bun --cwd packages/app test:unit src/pages/session/use-session-scroll-dock.test.ts src/pages/session/composer/session-question-dock.test.ts src/context/renderer-diagnostics.test.ts

Focused E2E: 2 passed
Command: bun --cwd packages/app test:e2e --grep "submit to question dock keeps latest turn visible|blocked question flow supports keyboard shortcuts"

Typecheck: passed
Command: bun --cwd packages/app typecheck

Diff check: passed
Command: git diff --check
```

## Screenshots or Recordings

Not included. This bug is hard to reproduce manually in the desktop shell, so the behavior is locked with a deterministic Playwright path: long visible history, real visible prompt submit, pending question dock, timeline remains near bottom. Existing and new E2E also verify keyboard focus still works.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
