### PR TITLE
fix(app): use last user message time in sidebar

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -79,6 +79,7 @@ import {
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
+  buildPawworkSidebarSessionRows,
   pawworkSessionDirectories,
   sortPawworkSidebarSessions,
 } from "./layout/pawwork-session-source"
@@ -573,12 +574,14 @@ export default function Layout(props: ParentProps) {
   )
 
   const pawworkSessions = createMemo(() => {
-    const rows = pawworkSessionWindow().sessions.map((session) => ({
-      session,
-      slug: base64Encode(session.directory),
-      projectLabel: projectLabelForSession(session),
-      created: session.time.created,
-    }))
+    const rows = buildPawworkSidebarSessionRows(pawworkSessionWindow().sessions, {
+      slugForDirectory: base64Encode,
+      projectLabelForSession,
+      messagesForSession: (session) => {
+        const [store] = globalSync.child(session.directory, { bootstrap: false })
+        return store.message[session.id]
+      },
+    })
     return sortPawworkSidebarSessions(rows.map((item) => ({ ...item, id: item.session.id }))).map(({ id: _, ...item }) => item)
   })
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -578,7 +578,7 @@ export default function Layout(props: ParentProps) {
       slugForDirectory: base64Encode,
       projectLabelForSession,
       messagesForSession: (session) => {
-        const [store] = globalSync.child(session.directory, { bootstrap: false })
+        const [store] = globalSync.child(session.directory, { bootstrap: false, pin: false })
         return store.message[session.id]
       },
     })

--- a/packages/app/src/pages/layout/pawwork-session-source.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.test.ts
@@ -164,6 +164,24 @@ describe("buildPawworkSidebarSessionRows", () => {
       },
     ])
   })
+
+  test("falls back to session creation time when messages are missing", () => {
+    const result = buildPawworkSidebarSessionRows(
+      [
+        {
+          id: "session-without-cache",
+          directory: "/repo",
+          time: { created: 300, updated: 900 },
+        },
+      ],
+      {
+        slugForDirectory: (directory) => `slug:${directory}`,
+        projectLabelForSession: () => "PawWork",
+      },
+    )
+
+    expect(result[0].created).toBe(300)
+  })
 })
 
 describe("pawworkSidebarSessionTime", () => {

--- a/packages/app/src/pages/layout/pawwork-session-source.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  buildPawworkSidebarSessionRows,
   pawworkSidebarSessionTime,
   resolvePawworkProjectLabels,
   sortPawworkSidebarSessions,
@@ -127,6 +128,41 @@ describe("sortPawworkSidebarSessions", () => {
     ])
 
     expect(result.map((item) => item.id)).toEqual(["newer-session", "old-with-new-assistant"])
+  })
+})
+
+describe("buildPawworkSidebarSessionRows", () => {
+  test("uses loaded user message time for sidebar rows", () => {
+    const result = buildPawworkSidebarSessionRows(
+      [
+        {
+          id: "session-old",
+          directory: "/repo",
+          time: { created: 100, updated: 900 },
+        },
+      ],
+      {
+        slugForDirectory: (directory) => `slug:${directory}`,
+        projectLabelForSession: () => "PawWork",
+        messagesForSession: () => [
+          { id: "msg_1", role: "assistant", time: { created: 950 } },
+          { id: "msg_2", role: "user", time: { created: 800 } },
+        ],
+      },
+    )
+
+    expect(result).toEqual([
+      {
+        session: {
+          id: "session-old",
+          directory: "/repo",
+          time: { created: 100, updated: 900 },
+        },
+        slug: "slug:/repo",
+        projectLabel: "PawWork",
+        created: 800,
+      },
+    ])
   })
 })
 

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -29,6 +29,11 @@ type MessageTimeLike = {
   }
 }
 
+type SidebarRowSessionLike = SessionTimeLike & {
+  id: string
+  directory: string
+}
+
 const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value)
 
 const shortenHome = (value: string, home?: string) => {
@@ -72,6 +77,22 @@ export function pawworkSidebarSessionTime(session: SessionTimeLike, messages?: M
   }
   const sessionCreated = session.time?.created
   return isFiniteNumber(sessionCreated) ? sessionCreated : 0
+}
+
+export function buildPawworkSidebarSessionRows<T extends SidebarRowSessionLike>(
+  sessions: T[],
+  input: {
+    slugForDirectory: (directory: string) => string
+    projectLabelForSession: (session: T) => string
+    messagesForSession?: (session: T) => MessageTimeLike[] | undefined
+  },
+) {
+  return sessions.map((session) => ({
+    session,
+    slug: input.slugForDirectory(session.directory),
+    projectLabel: input.projectLabelForSession(session),
+    created: pawworkSidebarSessionTime(session, input.messagesForSession?.(session)),
+  }))
 }
 
 export function pawworkSessionDirectories(input: {


### PR DESCRIPTION
## Summary

- Wire PawWork sidebar session rows to the existing last-user-message timestamp helper.
- Keep sidebar display time and time sorting on the same computed timestamp.
- Add focused regression coverage for the row-building path that feeds the sidebar.
- Avoid pinning child stores while reading loaded message caches for sidebar timestamps.

## Why

The PawWork sidebar row builder in `layout.tsx` was still writing `created: session.time.created`, so a session could look stale after the user sent a new message. The existing `pawworkSidebarSessionTime` helper already has the intended contract: use the latest valid loaded user message time, otherwise fall back to session creation time.

## Related Issue

Closes #470

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that the `layout.tsx` PawWork session window path now passes the per-session message cache into the shared helper without bootstrapping or pinning child stores, and that missing message caches still fall back to creation time.

## Risk Notes

Low. This changes the timestamp source for loaded sidebar rows only. No backend API, persistence schema, desktop packaging, updater, or generated-file changes are included. Sorting by time changes with the displayed timestamp, which is intended for this bug.

The global session window is still selected by the existing created-time API window; this PR intentionally fixes only timestamps for rows already in the PawWork sidebar window.

## How To Verify

```text
TDD red check: focused app unit test failed before implementation because buildPawworkSidebarSessionRows was not exported.
Focused app tests: bun --cwd packages/app test --preload ./happydom.ts ./src/pages/layout/pawwork-session-source.test.ts -> 916 pass, 0 fail
App typecheck: bun --cwd packages/app typecheck -> tsgo -b completed successfully
Workspace typecheck: bun turbo typecheck -> 8 successful, 8 total
Diff check: git diff --check -> no whitespace errors
Desktop startup check: bun run dev:desktop built main/preload/renderer and started the Electron app, but this machine already had another PawWork dev Electron instance using the shared dev profile, so I could not complete the interactive sidebar click-through in this worktree.
```

## Screenshots or Recordings

Not captured. The Electron manual path was blocked by an existing local PawWork dev instance using the shared `ai.pawwork.desktop.dev` profile. The code change is data wiring for existing sidebar UI, with no layout or copy changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English