### PR TITLE
fix: add todo.updated to SSE replay whitelist for dock reactivity

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -1070,6 +1070,34 @@ test("todo dock appears from real todowrite tool parts", async ({ page, llm, pro
   )
 })
 
+test("todo dock recovers after missed todowrite via SSE replay", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock todowrite replay",
+    async (session) => {
+      const dock = await todoDock(page, session.id)
+      await project.gotoSession(session.id)
+
+      const stream = globalEventStream(page)
+      await expect.poll(stream.cursor, { timeout: 10_000 }).toMatch(/:/)
+      await stream.stop()
+
+      await llm.tool("todowrite", {
+        todos: [{ content: "missed live todo", status: "in_progress", priority: "high" }],
+      })
+      await llm.text("todo started while stream was stopped")
+      await project.prompt("Create a todo while the event stream is paused.")
+
+      await expect(page.locator('[data-component="session-todo-dock"]')).toHaveCount(0, { timeout: 750 })
+      await stream.start()
+
+      await dock.expectCollapsed(["in_progress"])
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
 test("todo dock stays hidden when landing on an already completed session", async ({ page, project }) => {
   await project.open()
   await withDockSession(

--- a/packages/opencode/src/server/event-replay.ts
+++ b/packages/opencode/src/server/event-replay.ts
@@ -48,6 +48,7 @@ const REPLAYABLE_EVENT_TYPES = new Set([
   "session.updated",
   "session.deleted",
   "session.status",
+  "todo.updated",
   "server.instance.disposed",
 ])
 

--- a/packages/opencode/test/server/event-replay.test.ts
+++ b/packages/opencode/test/server/event-replay.test.ts
@@ -46,6 +46,7 @@ describe("isReplayableGlobalEvent", () => {
     expect(isReplayableGlobalEvent(event("session.updated"))).toBe(true)
     expect(isReplayableGlobalEvent(event("session.deleted"))).toBe(true)
     expect(isReplayableGlobalEvent(event("session.status"))).toBe(true)
+    expect(isReplayableGlobalEvent(event("todo.updated"))).toBe(true)
     expect(isReplayableGlobalEvent(event("server.instance.disposed"))).toBe(true)
   })
 
@@ -53,7 +54,6 @@ describe("isReplayableGlobalEvent", () => {
     expect(isReplayableGlobalEvent(event("message.part.delta"))).toBe(false)
     expect(isReplayableGlobalEvent(event("message.part.updated"))).toBe(false)
     expect(isReplayableGlobalEvent(event("message.updated"))).toBe(false)
-    expect(isReplayableGlobalEvent(event("todo.updated"))).toBe(false)
     expect(isReplayableGlobalEvent(event("lsp.updated"))).toBe(false)
     expect(isReplayableGlobalEvent(event("vcs.branch.updated"))).toBe(false)
   })


### PR DESCRIPTION
## Summary

Add `"todo.updated"` to the global SSE replay event whitelist so that missed `todo.updated` events are replayed on reconnect, keeping the composer todo dock immediately reactive.

## Why

When the SSE stream is briefly interrupted (or the event fires during a race window), `todo.updated` events were lost because they were not in `REPLAYABLE_EVENT_TYPES`. The frontend's todo dock depends on `globalSync.data.session_todo`, which is written by the `todo.updated` handler. Without replay, the dock stayed hidden until the user switched sessions (triggering a full API reload of messages/parts/todos).

Issue #463 reports exactly this: the todo dock does not appear until switching sessions.

## Related Issue

Closes #463

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

The change is one line in the whitelist (`event-replay.ts`). Reviewers should confirm that `todo.updated` is indeed low-volume enough for replay (it only fires on explicit TodoWrite tool calls, not on every message part delta) and that this does not risk bloating the replay store.

## Risk Notes

None. `todo.updated` is a low-frequency event (one per TodoWrite invocation). The replay store already keeps records by session and prunes by count/age.

## How To Verify

```text
opencode unit: event-replay.test.ts — 19 passed / 0 failed
opencode unit: global-event-replay.test.ts — 8 passed / 0 failed
app unit: todo dock machine / source / model / event reducer — 46 passed / 0 failed
app e2e: all 13 todo dock tests passed, including new "todo dock recovers after missed todowrite via SSE replay"
```

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English