### PR TITLE
fix(app): hide child sessions from sidebar root window

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -89,6 +89,7 @@ import {
   nextPawworkSessionWindowLimit,
   type PawworkWindowSession,
   PAWWORK_SESSION_WINDOW_INITIAL,
+  pawworkSessionWindowActiveRoot,
   sortPawworkSessionWindowSessions,
 } from "./layout/pawwork-session-window"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
@@ -639,12 +640,20 @@ export default function Layout(props: ParentProps) {
             return session ? mergePawworkWindowSessionMetadata(session, existing.get(activeID)) : undefined
           })()
         : undefined
+      const activeParentID = active?.parentID
+      const activeParent = activeParentID
+        ? await (async () => {
+            const session = loaded.get(activeParentID) ?? (await loadSessionByID(activeParentID))
+            return session ? mergePawworkWindowSessionMetadata(session, existing.get(activeParentID)) : undefined
+          })()
+        : undefined
+      const activeRoot = pawworkSessionWindowActiveRoot(active, activeParent)
 
       if (rev !== pawworkSessionWindowRev) return
       batch(() => {
         setPawworkSessionWindowState("normal", reconcile(sortPawworkSessionWindowSessions(normal), { key: "id" }))
         setPawworkSessionWindowState("pinned", reconcile(pinned, { key: "id" }))
-        setPawworkSessionWindowState("active", active)
+        setPawworkSessionWindowState("active", activeRoot)
         setPawworkSessionWindowState("hasMore", !!response.response.headers.get("x-next-cursor"))
         setPawworkSessionWindowState("loading", false)
       })

--- a/packages/app/src/pages/layout/pawwork-session-window.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.test.ts
@@ -6,16 +6,22 @@ import {
   type PawworkWindowSession,
   buildPawworkSessionWindow,
   nextPawworkSessionWindowLimit,
+  pawworkSessionWindowActiveRoot,
   sortPawworkSessionWindowSessions,
 } from "./pawwork-session-window"
 
-const session = (id: string, created: number, directory = "/repo", activityAt?: number) =>
+const session = (
+  id: string,
+  created: number,
+  options: { directory?: string; parentID?: string; activityAt?: number } = {},
+) =>
   ({
     id,
-    directory,
+    directory: options.directory ?? "/repo",
+    parentID: options.parentID,
     title: id,
     time: { created, updated: created },
-    activityAt,
+    activityAt: options.activityAt,
   }) as PawworkWindowSession
 
 describe("nextPawworkSessionWindowLimit", () => {
@@ -32,7 +38,11 @@ describe("nextPawworkSessionWindowLimit", () => {
 describe("buildPawworkSessionWindow", () => {
   test("sorts the normal window by activity time before applying the limit", () => {
     const result = buildPawworkSessionWindow({
-      normal: [session("old-active", 1, "/repo", 5), session("new-inactive", 3, "/repo", 3), session("middle", 2, "/repo", 4)],
+      normal: [
+        session("old-active", 1, { activityAt: 5 }),
+        session("new-inactive", 3, { activityAt: 3 }),
+        session("middle", 2, { activityAt: 4 }),
+      ],
       pinned: [],
       active: undefined,
       limit: 30,
@@ -85,6 +95,52 @@ describe("buildPawworkSessionWindow", () => {
     ].sort())
   })
 
+  test("does not include an active child session as a top-level sidebar row", () => {
+    const root = session("root", 100)
+    const child = session("child", 200, { parentID: root.id })
+
+    const result = buildPawworkSessionWindow({
+      normal: [root],
+      pinned: [],
+      active: child,
+      limit: 30,
+      hasMore: false,
+    })
+
+    expect(result.sessions.map((item) => item.id)).toEqual(["root"])
+  })
+
+  test("does not include a pinned child session as a top-level sidebar row", () => {
+    const root = session("root", 100)
+    const pinnedChild = session("pinned_child", 200, { parentID: root.id })
+
+    const result = buildPawworkSessionWindow({
+      normal: [root],
+      pinned: [pinnedChild],
+      active: undefined,
+      limit: 30,
+      hasMore: false,
+    })
+
+    expect(result.sessions.map((item) => item.id)).toEqual(["root"])
+  })
+
+  test("does not include a normal child session as a top-level sidebar row", () => {
+    const root = session("root", 100)
+    const child = session("normal_child", 200, { parentID: root.id })
+
+    const result = buildPawworkSessionWindow({
+      normal: [root, child],
+      pinned: [],
+      active: undefined,
+      limit: 30,
+      hasMore: false,
+    })
+
+    expect(result.normalIDs).toEqual(["root"])
+    expect(result.sessions.map((item) => item.id)).toEqual(["root"])
+  })
+
   test("shows search prompt instead of show more at the cap", () => {
     const normal = Array.from({ length: 90 }, (_, index) => session(`ses_${index}`, 10_000 - index))
 
@@ -101,12 +157,28 @@ describe("buildPawworkSessionWindow", () => {
   })
 })
 
+describe("pawworkSessionWindowActiveRoot", () => {
+  test("uses the child parent as the sidebar root fallback", () => {
+    const root = session("root", 100)
+    const child = session("child", 200, { parentID: root.id })
+
+    expect(pawworkSessionWindowActiveRoot(child, root)?.id).toBe("root")
+  })
+
+  test("does not use a mismatched parent as the sidebar root fallback", () => {
+    const other = session("other", 100)
+    const child = session("child", 200, { parentID: "root" })
+
+    expect(pawworkSessionWindowActiveRoot(child, other)).toBeUndefined()
+  })
+})
+
 describe("sortPawworkSessionWindowSessions", () => {
   test("uses activity time before creation time", () => {
     expect(
       sortPawworkSessionWindowSessions([
-        session("newer-created", 3, "/repo", 3),
-        session("older-with-user-activity", 1, "/repo", 5),
+        session("newer-created", 3, { activityAt: 3 }),
+        session("older-with-user-activity", 1, { activityAt: 5 }),
       ]).map((item) => item.id),
     ).toEqual(["older-with-user-activity", "newer-created"])
   })

--- a/packages/app/src/pages/layout/pawwork-session-window.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.test.ts
@@ -141,6 +141,23 @@ describe("buildPawworkSessionWindow", () => {
     expect(result.sessions.map((item) => item.id)).toEqual(["root"])
   })
 
+  test("keeps the active child parent root visible when it is outside the normal window", () => {
+    const root = session("old_root", 1)
+    const child = session("child", 200, { parentID: root.id })
+    const activeRoot = pawworkSessionWindowActiveRoot(child, root)
+
+    const result = buildPawworkSessionWindow({
+      normal: [],
+      pinned: [],
+      active: activeRoot,
+      limit: 30,
+      hasMore: true,
+    })
+
+    expect(result.normalIDs).toEqual([])
+    expect(result.sessions.map((item) => item.id)).toEqual(["old_root"])
+  })
+
   test("shows search prompt instead of show more at the cap", () => {
     const normal = Array.from({ length: 90 }, (_, index) => session(`ses_${index}`, 10_000 - index))
 

--- a/packages/app/src/pages/layout/pawwork-session-window.ts
+++ b/packages/app/src/pages/layout/pawwork-session-window.ts
@@ -36,6 +36,15 @@ export function sortPawworkSessionWindowSessions(sessions: PawworkWindowSession[
   return sessions.filter((item) => !!item?.id && !item.time?.archived).slice().sort(byActivityDesc)
 }
 
+const rootSessions = (sessions: PawworkWindowSession[]) => sessions.filter((item) => !!item?.id && !item.parentID)
+
+export function pawworkSessionWindowActiveRoot(active?: PawworkWindowSession, parent?: PawworkWindowSession) {
+  if (!active?.id || active.time?.archived) return
+  if (!active.parentID) return active
+  if (parent?.id !== active.parentID || parent.time?.archived) return
+  return parent
+}
+
 export function buildPawworkSessionWindow(input: {
   normal: PawworkWindowSession[]
   pinned: PawworkWindowSession[]
@@ -48,11 +57,15 @@ export function buildPawworkSessionWindow(input: {
     ...input.pinned.map((item) => item.id),
     ...(input.active?.id ? [input.active.id] : []),
   ])
-  const normal = sortPawworkSessionWindowSessions(input.normal)
+  const normal = sortPawworkSessionWindowSessions(rootSessions(input.normal))
     .filter((item) => !reservedIDs.has(item.id))
     .slice(0, limit)
   const normalIDs = normal.map((item) => item.id)
-  const sessions = mergeSessionsByID(normal, input.pinned, input.active ? [input.active] : [])
+  const sessions = mergeSessionsByID(
+    normal,
+    rootSessions(input.pinned),
+    input.active && !input.active.parentID ? [input.active] : [],
+  )
   const capReached = limit >= PAWWORK_SESSION_WINDOW_MAX && input.hasMore
 
   return {


### PR DESCRIPTION
## Summary

Filter child/subagent sessions out of the PawWork sidebar root session window. Current child sessions still appear under their parent session through the existing `showChild` path.

## Why

When the active session is a subagent child session, `buildPawworkSessionWindow` was merging that active child into the top-level sidebar rows. The parent row also renders the current child below it, so the same subagent session title appeared twice.

## Related Issue

No GitHub issue yet. Reported from v2026.5.5 sidebar behavior.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Check that root sessions still stay visible when pinned or active, while child sessions from normal, pinned, or active inputs do not become top-level sidebar rows.

## Risk Notes

Low. This changes only the sidebar window helper. It does not change session storage, subagent creation, titles, routing, or the child-row rendering path.

## How To Verify

```text
Focused layout tests: 45 passed
Command: bun test --preload ./happydom.ts src/pages/layout/helpers.test.ts src/pages/layout/pawwork-session-nav.test.ts src/pages/layout/pawwork-session-window.test.ts
App typecheck: passed
Command: bun run typecheck
Diff check: no whitespace errors
Command: git diff --check
```

## Screenshots or Recordings

Not captured. The changed behavior is covered at the sidebar window data-helper level; Electron manual verification was not run.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English



