### PR TITLE
chore(release): bump version to 2026.5.6

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.5.5",
+  "version": "2026.5.6",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.5",
+  "version": "2026.5.6",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bump `packages/desktop-electron/package.json` and `packages/app/package.json` from `2026.5.5` to `2026.5.6` for the v2026.5.6 release.

## Scope

- Two `package.json` version fields synced. No runtime changes.

## Release context

Cuts v2026.5.6 covering 9 PRs merged since v2026.5.5 (`#460, #461, #462, #464, #465, #468, #469, #471, #472, #476`).

Two of the merged fixes (`#464` composer width, `#472` todo dock realtime refresh) reproduced partial regressions during manual smoke; the remaining edge cases are tracked in `#479` and `#480` (P1) and will be excluded from the v2026.5.6 release notes.

## Verification

- `git diff --stat`: only the two version fields changed.
- Pre-flight smoke completed against `dev` HEAD; release-blockers triaged into `#479` / `#480`.
- After merge, the release workflow (`build.yml`) will be dispatched manually for macOS arm64 / x64 (submit + finalize) and Windows x64 (full) on the `prod` channel.