### PR TITLE
fix(opencode): sync provider model hotfixes

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -438,6 +438,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
   return {
     provider: {
       id: "openai",
+      postConfig: true,
       async models(provider, ctx) {
         if (ctx.auth?.type !== "oauth") return provider.models
 

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -100,7 +100,7 @@ export function extractAccountId(tokens: TokenResponse): string | undefined {
 }
 
 export function shouldKeepCodexOAuthModel(modelId: string, apiId: string): boolean {
-  if (modelId.includes("codex")) return true
+  if (apiId.includes("codex")) return true
   if (CODEX_OAUTH_ALLOWED_MODELS.has(apiId)) return true
   const match = apiId.match(/^gpt-(\d+)\.(\d+)/)
   if (!match) return false

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -22,6 +22,7 @@ const CODEX_OAUTH_ALLOWED_MODELS = new Set([
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
   "gpt-5.4",
   "gpt-5.4-mini",
 ])
@@ -435,34 +436,40 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 
 export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
   return {
+    provider: {
+      id: "openai",
+      async models(provider, ctx) {
+        if (ctx.auth?.type !== "oauth") return provider.models
+
+        return Object.fromEntries(
+          Object.entries(provider.models)
+            .filter(([modelId, model]) => shouldKeepCodexOAuthModel(modelId, model.api.id))
+            .map(([modelId, model]) => [
+              modelId,
+              {
+                ...model,
+                cost: {
+                  input: 0,
+                  output: 0,
+                  cache: { read: 0, write: 0 },
+                },
+                limit: hasCodexOAuthGpt55Limit(model.api.id)
+                  ? ({
+                      context: 400_000,
+                      input: 272_000,
+                      output: 128_000,
+                    } satisfies typeof model.limit & { input: number })
+                  : model.limit,
+              },
+            ]),
+        )
+      },
+    },
     auth: {
       provider: "openai",
-      async loader(getAuth, provider) {
+      async loader(getAuth) {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
-
-        for (const [modelId, model] of Object.entries(provider.models)) {
-          if (shouldKeepCodexOAuthModel(modelId, model.api.id)) continue
-          delete provider.models[modelId]
-        }
-
-        // Zero out costs for Codex (included with ChatGPT subscription)
-        for (const model of Object.values(provider.models)) {
-          model.cost = {
-            input: 0,
-            output: 0,
-            cache: { read: 0, write: 0 },
-          }
-
-          if (hasCodexOAuthGpt55Limit(model.api.id)) {
-            const limit: typeof model.limit & { input: number } = {
-              context: 400_000,
-              input: 272_000,
-              output: 128_000,
-            }
-            model.limit = limit
-          }
-        }
 
         return {
           apiKey: OAUTH_DUMMY_KEY,

--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -54,7 +54,7 @@ export namespace CopilotModels {
 
     const isMsgApi = remote.supported_endpoints?.includes("/v1/messages")
 
-    return {
+    const model: Model = {
       id: key,
       providerID: "github-copilot",
       api: {
@@ -103,8 +103,50 @@ export namespace CopilotModels {
       release_date:
         prev?.release_date ??
         (remote.version.startsWith(`${remote.id}-`) ? remote.version.slice(remote.id.length + 1) : remote.version),
-      variants: prev?.variants ?? {},
     }
+
+    const efforts = remote.capabilities.supports.reasoning_effort
+    const variants: NonNullable<Model["variants"]> = {}
+    if (!isMsgApi && efforts?.length) {
+      efforts.forEach((effort) => {
+        variants[effort] = {
+          reasoningEffort: effort,
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+        }
+      })
+    } else {
+      if (efforts?.length && remote.capabilities.supports.adaptive_thinking) {
+        efforts.forEach((effort) => {
+          variants[effort] = {
+            thinking: {
+              type: "adaptive",
+              ...(model.api.id.includes("opus-4.7") ? { display: "summarized" } : {}),
+            },
+            effort,
+          }
+        })
+      } else if (remote.capabilities.supports.max_thinking_budget) {
+        const max = remote.capabilities.supports.max_thinking_budget
+        variants.max = {
+          thinking: {
+            type: "enabled",
+            budgetTokens: max - 1,
+          },
+        }
+        variants.high = {
+          thinking: {
+            type: "enabled",
+            budgetTokens: Math.floor(max / 2),
+          },
+        }
+      }
+    }
+    if (Object.keys(variants).length > 0) {
+      model.variants = variants
+    }
+
+    return model
   }
 
   export async function get(

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -153,6 +153,14 @@ function useLanguageModel(sdk: any) {
   return sdk.responses === undefined && sdk.chat === undefined
 }
 
+function selectAzureLanguageModel(sdk: any, modelID: string, useChat: boolean) {
+  if (useChat && sdk.chat) return sdk.chat(modelID)
+  if (sdk.responses) return sdk.responses(modelID)
+  if (sdk.messages) return sdk.messages(modelID)
+  if (sdk.chat) return sdk.chat(modelID)
+  return sdk.languageModel(modelID)
+}
+
 function custom(dep: CustomDep): Record<string, CustomLoader> {
   return {
     anthropic: () =>
@@ -223,12 +231,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-          if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
-          }
+          return selectAzureLanguageModel(sdk, modelID, Boolean(options?.["useCompletionUrls"]))
         },
         options: {},
         vars(_options) {
@@ -243,12 +246,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-          if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
-          }
+          return selectAzureLanguageModel(sdk, modelID, Boolean(options?.["useCompletionUrls"]))
         },
         options: {
           baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,
@@ -1147,6 +1145,33 @@ const layer: Layer.Layer<
           return true
         }
 
+        for (const hook of plugins) {
+          const p = hook.provider
+          const models = p?.models
+          if (!p || !models) continue
+
+          const providerID = ProviderID.make(p.id)
+          if (!isProviderAllowed(providerID)) continue
+
+          const provider = database[providerID]
+          if (!provider) continue
+          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
+
+          provider.models = yield* Effect.promise(async () => {
+            const next = await models(provider, { auth: pluginAuth })
+            return Object.fromEntries(
+              Object.entries(next).map(([id, model]) => [
+                id,
+                {
+                  ...model,
+                  id: ModelID.make(id),
+                  providerID,
+                },
+              ]),
+            )
+          })
+        }
+
         // extend database from config
         for (const [providerID, provider] of configProviders) {
           const existing = database[providerID]
@@ -1161,6 +1186,13 @@ const layer: Layer.Layer<
 
           for (const [modelID, model] of Object.entries(provider.models ?? {})) {
             const existingModel = parsed.models[model.id ?? modelID]
+            const apiID = model.id ?? existingModel?.api.id ?? modelID
+            const apiNpm =
+              model.provider?.npm ??
+              provider.npm ??
+              existingModel?.api.npm ??
+              modelsDev.providers[providerID]?.npm ??
+              "@ai-sdk/openai-compatible"
             const name = iife(() => {
               if (model.name) return model.name
               if (model.id && model.id !== modelID) return modelID
@@ -1169,13 +1201,8 @@ const layer: Layer.Layer<
             const parsedModel: Model = {
               id: ModelID.make(modelID),
               api: {
-                id: model.id ?? existingModel?.api.id ?? modelID,
-                npm:
-                  model.provider?.npm ??
-                  provider.npm ??
-                  existingModel?.api.npm ??
-                  modelsDev.providers[providerID]?.npm ??
-                  "@ai-sdk/openai-compatible",
+                id: apiID,
+                npm: apiNpm,
                 url:
                   model.provider?.api ??
                   provider?.api ??
@@ -1208,7 +1235,14 @@ const layer: Layer.Layer<
                     model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
                   pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
                 },
-                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? false,
+                interleaved:
+                  model.interleaved ??
+                  existingModel?.capabilities.interleaved ??
+                  (!existingModel &&
+                  apiNpm === "@ai-sdk/openai-compatible" &&
+                  /(^|[/:])deepseek(?:[-_/]|$)/.test(apiID.toLowerCase())
+                    ? { field: "reasoning_content" }
+                    : false),
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
@@ -1331,33 +1365,6 @@ const layer: Layer.Layer<
           })
         }
 
-        for (const hook of plugins) {
-          const p = hook.provider
-          const models = p?.models
-          if (!p || !models) continue
-
-          const providerID = ProviderID.make(p.id)
-          if (disabled.has(providerID)) continue
-
-          const provider = providers[providerID]
-          if (!provider) continue
-          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
-
-          provider.models = yield* Effect.promise(async () => {
-            const next = await models(provider, { auth: pluginAuth })
-            return Object.fromEntries(
-              Object.entries(next).map(([id, model]) => [
-                id,
-                {
-                  ...model,
-                  id: ModelID.make(id),
-                  providerID,
-                },
-              ]),
-            )
-          })
-        }
-
         for (const [id, provider] of Object.entries(providers)) {
           const providerID = ProviderID.make(id)
           if (!isProviderAllowed(providerID)) {
@@ -1382,7 +1389,9 @@ const layer: Layer.Layer<
             )
               delete provider.models[modelID]
 
-            model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
+            if (!model.variants || Object.keys(model.variants).length === 0) {
+              model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
+            }
 
             const configVariants = configProvider?.models?.[modelID]?.variants
             if (configVariants && model.variants) {
@@ -1499,10 +1508,13 @@ const layer: Layer.Layer<
           if (combined) opts.signal = combined
 
           // Strip openai itemId metadata following what codex does
-          if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {
+          if (
+            (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") &&
+            opts.body &&
+            opts.method === "POST"
+          ) {
             const body = JSON.parse(opts.body as string)
-            const isAzure = model.providerID.includes("azure")
-            const keepIds = isAzure && body.store === true
+            const keepIds = body.store === true
             if (!keepIds && Array.isArray(body.input)) {
               for (const item of body.input) {
                 if ("id" in item) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1173,7 +1173,7 @@ const layer: Layer.Layer<
 
         const appliedProviderModelHooks = new Set<string>()
         const applyProviderModelHooks = Effect.fn("Provider.applyProviderModelHooks")(function* (input?: {
-          rerunOAuth?: boolean
+          postConfig?: boolean
         }) {
           for (const [index, hook] of plugins.entries()) {
             const p = hook.provider
@@ -1189,7 +1189,7 @@ const layer: Layer.Layer<
             const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
             if (
               appliedProviderModelHooks.has(hookKey) &&
-              !(input?.rerunOAuth && pluginAuth?.type === "oauth" && configModelProviderIDs.has(providerID))
+              !(input?.postConfig && p.postConfig && pluginAuth?.type === "oauth" && configModelProviderIDs.has(providerID))
             ) {
               continue
             }
@@ -1314,7 +1314,7 @@ const layer: Layer.Layer<
           database[providerID] = parsed
         }
 
-        yield* applyProviderModelHooks({ rerunOAuth: true })
+        yield* applyProviderModelHooks({ postConfig: true })
 
         // load env
         const envs = yield* env.all()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1171,23 +1171,24 @@ const layer: Layer.Layer<
           return true
         }
 
-        const appliedProviderModelHooks = new Set<ProviderID>()
+        const appliedProviderModelHooks = new Set<string>()
         const applyProviderModelHooks = Effect.fn("Provider.applyProviderModelHooks")(function* (input?: {
           rerunOAuth?: boolean
         }) {
-          for (const hook of plugins) {
+          for (const [index, hook] of plugins.entries()) {
             const p = hook.provider
             const models = p?.models
             if (!p || !models) continue
 
             const providerID = ProviderID.make(p.id)
+            const hookKey = `${index}:${providerID}`
             if (!isProviderAllowed(providerID)) continue
 
             const provider = database[providerID]
             if (!provider) continue
             const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
             if (
-              appliedProviderModelHooks.has(providerID) &&
+              appliedProviderModelHooks.has(hookKey) &&
               !(input?.rerunOAuth && pluginAuth?.type === "oauth" && configModelProviderIDs.has(providerID))
             ) {
               continue
@@ -1206,7 +1207,7 @@ const layer: Layer.Layer<
                 ]),
               )
             })
-            appliedProviderModelHooks.add(providerID)
+            appliedProviderModelHooks.add(hookKey)
           }
         })
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1146,19 +1146,23 @@ const layer: Layer.Layer<
         }
 
         const appliedProviderModelHooks = new Set<ProviderID>()
-        const applyProviderModelHooks = Effect.fn("Provider.applyProviderModelHooks")(function* () {
+        const applyProviderModelHooks = Effect.fn("Provider.applyProviderModelHooks")(function* (input?: {
+          rerunOAuth?: boolean
+        }) {
           for (const hook of plugins) {
             const p = hook.provider
             const models = p?.models
             if (!p || !models) continue
 
             const providerID = ProviderID.make(p.id)
-            if (appliedProviderModelHooks.has(providerID)) continue
             if (!isProviderAllowed(providerID)) continue
 
             const provider = database[providerID]
             if (!provider) continue
             const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
+            if (appliedProviderModelHooks.has(providerID) && !(input?.rerunOAuth && pluginAuth?.type === "oauth")) {
+              continue
+            }
 
             provider.models = yield* Effect.promise(async () => {
               const next = await models(provider, { auth: pluginAuth })
@@ -1280,7 +1284,7 @@ const layer: Layer.Layer<
           database[providerID] = parsed
         }
 
-        yield* applyProviderModelHooks()
+        yield* applyProviderModelHooks({ rerunOAuth: true })
 
         // load env
         const envs = yield* env.all()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -95,6 +95,29 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   })
 }
 
+export function stripOpenAIResponseInputIDs(body: unknown) {
+  if (typeof body !== "string") return
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return
+  }
+
+  if (!isRecord(parsed)) return
+  if (parsed.store === true) return
+  if (!Array.isArray(parsed.input)) return
+
+  for (const item of parsed.input) {
+    if (isRecord(item) && "id" in item) {
+      delete item.id
+    }
+  }
+
+  return JSON.stringify(parsed)
+}
+
 type BundledSDK = {
   languageModel(modelId: string): LanguageModelV3
   chatModel?(modelId: string): LanguageModelV3
@@ -1529,19 +1552,10 @@ const layer: Layer.Layer<
           // Strip openai itemId metadata following what codex does
           if (
             (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") &&
-            opts.body &&
+            typeof opts.body === "string" &&
             opts.method === "POST"
           ) {
-            const body = JSON.parse(opts.body as string)
-            const keepIds = body.store === true
-            if (!keepIds && Array.isArray(body.input)) {
-              for (const item of body.input) {
-                if ("id" in item) {
-                  delete item.id
-                }
-              }
-              opts.body = JSON.stringify(body)
-            }
+            opts.body = stripOpenAIResponseInputIDs(opts.body) ?? opts.body
           }
 
           if (model.api.npm.includes("@ai-sdk/openai-compatible") && opts.body && opts.method === "POST") {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1136,6 +1136,9 @@ const layer: Layer.Layer<
 
         // now read config providers - includes any modifications from plugin config() hook
         const configProviders = Object.entries(cfg.provider ?? {})
+        const configModelProviderIDs = new Set(
+          configProviders.filter(([, provider]) => provider.models).map(([providerID]) => ProviderID.make(providerID)),
+        )
         const disabled = new Set(cfg.disabled_providers ?? [])
         const enabled = cfg.enabled_providers ? new Set(cfg.enabled_providers) : null
 
@@ -1160,7 +1163,10 @@ const layer: Layer.Layer<
             const provider = database[providerID]
             if (!provider) continue
             const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
-            if (appliedProviderModelHooks.has(providerID) && !(input?.rerunOAuth && pluginAuth?.type === "oauth")) {
+            if (
+              appliedProviderModelHooks.has(providerID) &&
+              !(input?.rerunOAuth && pluginAuth?.type === "oauth" && configModelProviderIDs.has(providerID))
+            ) {
               continue
             }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1145,32 +1145,39 @@ const layer: Layer.Layer<
           return true
         }
 
-        for (const hook of plugins) {
-          const p = hook.provider
-          const models = p?.models
-          if (!p || !models) continue
+        const appliedProviderModelHooks = new Set<ProviderID>()
+        const applyProviderModelHooks = Effect.fn("Provider.applyProviderModelHooks")(function* () {
+          for (const hook of plugins) {
+            const p = hook.provider
+            const models = p?.models
+            if (!p || !models) continue
 
-          const providerID = ProviderID.make(p.id)
-          if (!isProviderAllowed(providerID)) continue
+            const providerID = ProviderID.make(p.id)
+            if (appliedProviderModelHooks.has(providerID)) continue
+            if (!isProviderAllowed(providerID)) continue
 
-          const provider = database[providerID]
-          if (!provider) continue
-          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
+            const provider = database[providerID]
+            if (!provider) continue
+            const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
 
-          provider.models = yield* Effect.promise(async () => {
-            const next = await models(provider, { auth: pluginAuth })
-            return Object.fromEntries(
-              Object.entries(next).map(([id, model]) => [
-                id,
-                {
-                  ...model,
-                  id: ModelID.make(id),
-                  providerID,
-                },
-              ]),
-            )
-          })
-        }
+            provider.models = yield* Effect.promise(async () => {
+              const next = await models(provider, { auth: pluginAuth })
+              return Object.fromEntries(
+                Object.entries(next).map(([id, model]) => [
+                  id,
+                  {
+                    ...model,
+                    id: ModelID.make(id),
+                    providerID,
+                  },
+                ]),
+              )
+            })
+            appliedProviderModelHooks.add(providerID)
+          }
+        })
+
+        yield* applyProviderModelHooks()
 
         // extend database from config
         for (const [providerID, provider] of configProviders) {
@@ -1272,6 +1279,8 @@ const layer: Layer.Layer<
           }
           database[providerID] = parsed
         }
+
+        yield* applyProviderModelHooks()
 
         // load env
         const envs = yield* env.all()

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -63,6 +63,15 @@ function sdkKey(npm: string): string | undefined {
   return undefined
 }
 
+function providerOptionsKey(model: Provider.Model): string {
+  const usesDotSplitOptions =
+    model.providerID.includes(".") &&
+    (model.api.npm === "@ai-sdk/openai-compatible" ||
+      model.api.npm === "@ai-sdk/openai" ||
+      model.api.npm === "@ai-sdk/anthropic")
+  return usesDotSplitOptions ? model.providerID.split(".")[0]! : (sdkKey(model.api.npm) ?? model.providerID)
+}
+
 function isDeepSeekModelID(id: string) {
   return /(^|[/:])deepseek(?:[-_/]|$)/.test(id.toLowerCase())
 }
@@ -416,7 +425,7 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
   }
 
   // Remap providerOptions keys from stored providerID to expected SDK key
-  const key = sdkKey(model.api.npm)
+  const key = providerOptionsKey(model)
   if (key && key !== model.providerID) {
     const remap = (opts: Record<string, any> | undefined) => {
       if (!opts) return opts
@@ -1142,12 +1151,7 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   if (model.api.npm === "@ai-sdk/azure") {
     return { openai: options, azure: options }
   }
-  const usesDotSplitOptions =
-    model.providerID.includes(".") &&
-    (model.api.npm === "@ai-sdk/openai-compatible" ||
-      model.api.npm === "@ai-sdk/openai" ||
-      model.api.npm === "@ai-sdk/anthropic")
-  const key = usesDotSplitOptions ? model.providerID.split(".")[0]! : (sdkKey(model.api.npm) ?? model.providerID)
+  const key = providerOptionsKey(model)
   return { [key]: options }
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -719,7 +719,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       if (adaptiveEfforts) {
         let efforts = [...adaptiveEfforts]
         if (model.providerID === "github-copilot") {
-          if (model.api.id.includes("opus-4.7")) efforts = ["medium"]
+          if (model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")) efforts = ["medium"]
           efforts = efforts.filter((effort) => effort !== "max" && effort !== "xhigh")
         }
         return Object.fromEntries(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1141,9 +1141,10 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
     return { openai: options, azure: options }
   }
   const usesDotSplitOptions =
-    model.api.npm === "@ai-sdk/openai-compatible" ||
-    model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/anthropic"
+    model.providerID.includes(".") &&
+    (model.api.npm === "@ai-sdk/openai-compatible" ||
+      model.api.npm === "@ai-sdk/openai" ||
+      model.api.npm === "@ai-sdk/anthropic")
   const key = usesDotSplitOptions ? model.providerID.split(".")[0]! : (sdkKey(model.api.npm) ?? model.providerID)
   return { [key]: options }
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -668,7 +668,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       return Object.fromEntries(openaiCompatibleEfforts.map((effort) => [effort, { reasoningEffort: effort }]))
     }
 
-    case "@ai-sdk/azure":
+    case "@ai-sdk/azure": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       const azureEfforts = ["low", "medium", "high"]
@@ -685,7 +685,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           },
         ]),
       )
-    case "@ai-sdk/openai":
+    }
+    case "@ai-sdk/openai": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
       const openaiEfforts = openaiReasoningEfforts(model.api.id, model.release_date)
       if (!openaiEfforts) return {}
@@ -699,6 +700,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           },
         ]),
       )
+    }
 
     case "@ai-sdk/anthropic":
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -57,12 +57,14 @@ function sdkKey(npm: string): string | undefined {
       return "gateway"
     case "@openrouter/ai-sdk-provider":
       return "openrouter"
+    case "ai-gateway-provider":
+      return "openaiCompatible"
   }
   return undefined
 }
 
 function isDeepSeekModelID(id: string) {
-  return /(^|[/:])deepseek(?:[-/]|$)/.test(id.toLowerCase())
+  return /(^|[/:])deepseek(?:[-_/]|$)/.test(id.toLowerCase())
 }
 
 function isLegacyDeepSeekVariantID(id: string) {
@@ -482,6 +484,23 @@ export function topK(model: Provider.Model) {
 
 const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_NONE_EFFORT_RELEASE_DATE = "2025-11-13"
+const OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"
+const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
+
+function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | null {
+  const id = apiId.toLowerCase()
+  if (id === "gpt-5-pro" || id === "openai/gpt-5-pro") return null
+  if (id.includes("codex")) {
+    if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+    return [...WIDELY_SUPPORTED_EFFORTS]
+  }
+  const efforts = [...WIDELY_SUPPORTED_EFFORTS]
+  if (GPT5_FAMILY_RE.test(id)) efforts.unshift("minimal")
+  if (releaseDate >= OPENAI_NONE_EFFORT_RELEASE_DATE) efforts.unshift("none")
+  if (releaseDate >= OPENAI_XHIGH_EFFORT_RELEASE_DATE) efforts.push("xhigh")
+  return efforts
+}
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
   if (["opus-4-7", "opus-4.7"].some((v) => apiId.includes(v))) {
@@ -595,6 +614,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       }
       return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
 
+    case "ai-gateway-provider": {
+      if (model.api.id.startsWith("openai/")) {
+        const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
+        if (!efforts) return {}
+        return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
+      }
+      return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+    }
+
     case "@ai-sdk/github-copilot":
       if (model.id.includes("gemini")) {
         // currently github copilot only returns thinking
@@ -659,24 +687,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       )
     case "@ai-sdk/openai":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
-      if (id === "gpt-5-pro") return {}
-      const openaiEfforts = iife(() => {
-        if (id.includes("codex")) {
-          if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-          return WIDELY_SUPPORTED_EFFORTS
-        }
-        const arr = [...WIDELY_SUPPORTED_EFFORTS]
-        if (id.includes("gpt-5-") || id === "gpt-5") {
-          arr.unshift("minimal")
-        }
-        if (model.release_date >= "2025-11-13") {
-          arr.unshift("none")
-        }
-        if (model.release_date >= "2025-12-04") {
-          arr.push("xhigh")
-        }
-        return arr
-      })
+      const openaiEfforts = openaiReasoningEfforts(model.api.id, model.release_date)
+      if (!openaiEfforts) return {}
       return Object.fromEntries(
         openaiEfforts.map((effort) => [
           effort,
@@ -693,15 +705,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/google-vertex/anthropic":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
 
-      if (model.providerID === "github-copilot") {
-        if (model.api.id.includes("opus-4.7")) {
-          return Object.fromEntries(["medium"].map((effort) => [effort, { reasoningEffort: effort }]))
-        }
-      }
-
       if (adaptiveEfforts) {
+        let efforts = [...adaptiveEfforts]
+        if (model.providerID === "github-copilot") {
+          if (model.api.id.includes("opus-4.7")) efforts = ["medium"]
+          efforts = efforts.filter((effort) => effort !== "max" && effort !== "xhigh")
+        }
         return Object.fromEntries(
-          adaptiveEfforts.map((effort) => [
+          efforts.map((effort) => [
             effort,
             {
               thinking: {
@@ -818,9 +829,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
       // https://docs.mistral.ai/capabilities/reasoning/adjustable
       if (!model.capabilities.reasoning) return {}
-      // Only Mistral Small 4 supports reasoning (mistral-small-2603, mistral-small-latest)
+      // Mistral Small 4 and Medium 3.5 support reasoning.
       const mistralId = model.api.id.toLowerCase()
-      if (!mistralId.includes("mistral-small-2603") && !mistralId.includes("mistral-small-latest")) return {}
+      if (
+        !mistralId.includes("mistral-small-2603") &&
+        !mistralId.includes("mistral-small-latest") &&
+        !mistralId.includes("mistral-medium-3.5") &&
+        !mistralId.includes("mistral-medium-2604")
+      )
+        return {}
       return {
         high: { reasoningEffort: "high" },
       }
@@ -925,7 +942,7 @@ export function options(input: {
   }
 
   if (input.model.api.npm === "@ai-sdk/azure") {
-    result["store"] = true
+    result["store"] = false
     result["promptCacheKey"] = input.sessionID
   }
 
@@ -1117,13 +1134,17 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
     return result
   }
 
-  const key = sdkKey(model.api.npm) ?? model.providerID
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.
   if (model.api.npm === "@ai-sdk/azure") {
     return { openai: options, azure: options }
   }
+  const usesDotSplitOptions =
+    model.api.npm === "@ai-sdk/openai-compatible" ||
+    model.api.npm === "@ai-sdk/openai" ||
+    model.api.npm === "@ai-sdk/anthropic"
+  const key = usesDotSplitOptions ? model.providerID.split(".")[0]! : (sdkKey(model.api.npm) ?? model.providerID)
   return { [key]: options }
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -672,7 +672,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       const azureEfforts = ["low", "medium", "high"]
-      if (id.includes("gpt-5-") || id === "gpt-5") {
+      if (GPT5_FAMILY_RE.test(id)) {
         azureEfforts.unshift("minimal")
       }
       return Object.fromEntries(

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -874,10 +874,19 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             })
         }
         if (part.type === "reasoning") {
+          if (differentModel) {
+            if (part.text.trim().length > 0) {
+              assistantMessage.parts.push({
+                type: "text",
+                text: part.text,
+              })
+            }
+            continue
+          }
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,
-            ...(differentModel ? {} : { providerMetadata: part.metadata }),
+            providerMetadata: part.metadata,
           })
         }
       }

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -128,6 +128,7 @@ describe("plugin.codex", () => {
   describe("shouldKeepCodexOAuthModel", () => {
     test("keeps explicit OAuth models and codex model ids", () => {
       expect(shouldKeepCodexOAuthModel("gpt-5.4", "gpt-5.4")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("gpt-5.3-codex-spark", "gpt-5.3-codex-spark")).toBe(true)
       expect(shouldKeepCodexOAuthModel("some-codex-model", "custom-model")).toBe(true)
     })
 
@@ -160,7 +161,7 @@ describe("plugin.codex", () => {
   })
 
   describe("CodexAuthPlugin", () => {
-    test("overrides GPT-5.5 limits for OAuth Codex plans", async () => {
+    test("filters and normalizes OAuth Codex models through provider model hook", async () => {
       const provider = {
         models: {
           "gpt-5.5": {
@@ -174,6 +175,32 @@ describe("plugin.codex", () => {
             limit: {
               context: 1_050_000,
               input: 922_000,
+              output: 128_000,
+            },
+          },
+          "gpt-5.3-codex-spark": {
+            id: "gpt-5.3-codex-spark",
+            api: { id: "gpt-5.3-codex-spark" },
+            cost: {
+              input: 2,
+              output: 8,
+              cache: { read: 1, write: 2 },
+            },
+            limit: {
+              context: 1_000_000,
+              output: 128_000,
+            },
+          },
+          "gpt-5.3": {
+            id: "gpt-5.3",
+            api: { id: "gpt-5.3" },
+            cost: {
+              input: 2,
+              output: 8,
+              cache: { read: 1, write: 2 },
+            },
+            limit: {
+              context: 1_000_000,
               output: 128_000,
             },
           },
@@ -196,23 +223,23 @@ describe("plugin.codex", () => {
         },
       } as never)
 
-      await hooks.auth!.loader!(
-        async () =>
-          ({
-            type: "oauth",
-            access: "access",
-            refresh: "refresh",
-            expires: Date.now() + 60_000,
-          }) as never,
-        provider as never,
-      )
+      const models = await hooks.provider!.models!(provider as never, {
+        auth: {
+          type: "oauth",
+          access: "access",
+          refresh: "refresh",
+          expires: Date.now() + 60_000,
+        } as never,
+      })
 
-      expect(provider.models["gpt-5.5"].limit).toEqual({
+      expect(models["gpt-5.3"]).toBeUndefined()
+      expect(models["gpt-5.3-codex-spark"]).toBeDefined()
+      expect(models["gpt-5.5"].limit).toEqual({
         context: 400_000,
         input: 272_000,
         output: 128_000,
       })
-      expect(provider.models["gpt-5.5"].cost).toEqual({
+      expect(models["gpt-5.5"].cost).toEqual({
         input: 0,
         output: 0,
         cache: { read: 0, write: 0 },

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -126,10 +126,11 @@ describe("plugin.codex", () => {
   })
 
   describe("shouldKeepCodexOAuthModel", () => {
-    test("keeps explicit OAuth models and codex model ids", () => {
+    test("keeps explicit OAuth models and codex API ids", () => {
       expect(shouldKeepCodexOAuthModel("gpt-5.4", "gpt-5.4")).toBe(true)
       expect(shouldKeepCodexOAuthModel("gpt-5.3-codex-spark", "gpt-5.3-codex-spark")).toBe(true)
-      expect(shouldKeepCodexOAuthModel("some-codex-model", "custom-model")).toBe(true)
+      expect(shouldKeepCodexOAuthModel("some-codex-model", "custom-model")).toBe(false)
+      expect(shouldKeepCodexOAuthModel("custom-alias", "some-codex-model")).toBe(true)
     })
 
     test("keeps future GPT minor versions using semantic comparison", () => {

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -117,6 +117,161 @@ test("preserves temperature support from existing provider models", async () => 
   expect(models["brand-new"].capabilities.temperature).toBe(true)
 })
 
+test("clears existing variants so refreshed models calculate provider-specific variants", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "claude-opus-4.7",
+              name: "Claude Opus 4.7",
+              version: "claude-opus-4.7-2026-04-16",
+              supported_endpoints: ["/v1/messages"],
+              capabilities: {
+                family: "claude-opus",
+                limits: {
+                  max_context_window_tokens: 144000,
+                  max_output_tokens: 64000,
+                  max_prompt_tokens: 128000,
+                },
+                supports: {
+                  adaptive_thinking: true,
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get(
+    "https://api.githubcopilot.com",
+    {},
+    {
+      "claude-opus-4.7": {
+        id: "claude-opus-4.7",
+        providerID: "github-copilot",
+        api: {
+          id: "claude-opus-4.7",
+          url: "https://api.githubcopilot.com",
+          npm: "@ai-sdk/github-copilot",
+        },
+        name: "Claude Opus 4.7",
+        family: "claude-opus",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: true,
+          toolcall: true,
+          input: {
+            text: true,
+            audio: false,
+            image: true,
+            video: false,
+            pdf: false,
+          },
+          output: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          interleaved: false,
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context: 144000,
+          input: 128000,
+          output: 64000,
+        },
+        options: {},
+        headers: {},
+        release_date: "2026-04-16",
+        variants: {
+          low: {
+            reasoningEffort: "low",
+          },
+        },
+        status: "active",
+      },
+    },
+  )
+
+  expect(models["claude-opus-4.7"].api.npm).toBe("@ai-sdk/anthropic")
+  expect(models["claude-opus-4.7"].variants).toBeUndefined()
+})
+
+test("builds variants from Copilot API reasoning_effort metadata", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "gpt-5.3-codex",
+              name: "GPT-5.3 Codex",
+              version: "gpt-5.3-codex-2026-02-01",
+              capabilities: {
+                family: "gpt-5.3",
+                limits: {
+                  max_context_window_tokens: 256000,
+                  max_output_tokens: 64000,
+                  max_prompt_tokens: 192000,
+                },
+                supports: {
+                  reasoning_effort: ["low", "medium", "high", "xhigh"],
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get("https://api.githubcopilot.com")
+  expect(models["gpt-5.3-codex"].variants).toEqual({
+    low: {
+      reasoningEffort: "low",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    },
+    medium: {
+      reasoningEffort: "medium",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    },
+    high: {
+      reasoningEffort: "high",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    },
+    xhigh: {
+      reasoningEffort: "xhigh",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    },
+  })
+})
+
 test("remaps fallback oauth model urls to the enterprise host", async () => {
   globalThis.fetch = mock(() => Promise.reject(new Error("timeout"))) as unknown as typeof fetch
 

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { JSONValue } from "ai"
+import { generateText } from "ai"
+import { createAiGateway } from "ai-gateway-provider"
+import { createUnified } from "ai-gateway-provider/providers/unified"
+import { ProviderTransform } from "@/provider/transform"
+import type * as Provider from "@/provider/provider"
+import { ModelID, ProviderID } from "@/provider/schema"
+
+type Captured = { url: string; outerBody: unknown }
+type ProviderOptions = Record<string, Record<string, JSONValue>>
+
+const realFetch = globalThis.fetch
+let captured: Captured | null = null
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+beforeEach(() => {
+  captured = null
+  const handle = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    if (url.startsWith("https://gateway.ai.cloudflare.com/")) {
+      const bodyText = typeof init?.body === "string" ? init.body : ""
+      captured = { url, outerBody: bodyText ? JSON.parse(bodyText) : null }
+      return new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: "openai/gpt-5.4",
+          choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    }
+    return realFetch(input, init)
+  }
+  globalThis.fetch = Object.assign(handle, { preconnect: realFetch.preconnect.bind(realFetch) })
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+const cfModel = (apiId: string, releaseDate = "2026-03-05"): Provider.Model => ({
+  id: ModelID.make(`cloudflare-ai-gateway/${apiId}`),
+  providerID: ProviderID.make("cloudflare-ai-gateway"),
+  name: apiId,
+  api: { id: apiId, url: "https://gateway.ai.cloudflare.com/v1/compat", npm: "ai-gateway-provider" },
+  capabilities: {
+    reasoning: true,
+    temperature: false,
+    attachment: true,
+    toolcall: true,
+    input: { text: true, audio: false, image: true, video: false, pdf: true },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: false,
+  },
+  cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+  limit: { context: 1_000_000, output: 128_000 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: releaseDate,
+})
+
+function extractUpstreamQuery(body: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(body) || body.length === 0) return undefined
+  const first = body[0]
+  if (!isRecord(first)) return undefined
+  const query = first.query
+  return isRecord(query) ? query : undefined
+}
+
+async function callThroughGateway(apiId: string, providerOptions: ProviderOptions) {
+  const aigateway = createAiGateway({ accountId: "test", gateway: "test", apiKey: "test" })
+  const unified = createUnified()
+  await generateText({ model: aigateway(unified(apiId)), prompt: "hi", providerOptions })
+  return extractUpstreamQuery(captured?.outerBody)
+}
+
+describe("cf-ai-gateway provider options", () => {
+  test("ProviderTransform.providerOptions output puts reasoning_effort on the wire", async () => {
+    const opts = ProviderTransform.providerOptions(cfModel("openai/gpt-5.4"), { reasoningEffort: "xhigh" })
+    expect(opts).toEqual({ openaiCompatible: { reasoningEffort: "xhigh" } })
+
+    const upstream = await callThroughGateway("openai/gpt-5.4", opts)
+    expect(upstream?.reasoning_effort).toBe("xhigh")
+  })
+
+  test("variants output for openai/gpt-5.4 lands xhigh on the wire", async () => {
+    const variants = ProviderTransform.variants(cfModel("openai/gpt-5.4"))
+    expect(variants.xhigh).toEqual({ reasoningEffort: "xhigh" })
+
+    const opts = ProviderTransform.providerOptions(cfModel("openai/gpt-5.4"), variants.xhigh)
+    const upstream = await callThroughGateway("openai/gpt-5.4", opts)
+    expect(upstream?.reasoning_effort).toBe("xhigh")
+  })
+})

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -11,14 +11,14 @@ type Captured = { url: string; outerBody: unknown }
 type ProviderOptions = Record<string, Record<string, JSONValue>>
 
 const realFetch = globalThis.fetch
-let captured: Captured | null = null
+let captured: Captured[] = []
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 beforeEach(() => {
-  captured = null
+  captured = []
   const handle = async (
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
@@ -26,7 +26,7 @@ beforeEach(() => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
     if (url.startsWith("https://gateway.ai.cloudflare.com/")) {
       const bodyText = typeof init?.body === "string" ? init.body : ""
-      captured = { url, outerBody: bodyText ? JSON.parse(bodyText) : null }
+      captured.push({ url, outerBody: bodyText ? JSON.parse(bodyText) : null })
       return new Response(
         JSON.stringify({
           id: "chatcmpl-test",
@@ -82,7 +82,7 @@ async function callThroughGateway(apiId: string, providerOptions: ProviderOption
   const aigateway = createAiGateway({ accountId: "test", gateway: "test", apiKey: "test" })
   const unified = createUnified()
   await generateText({ model: aigateway(unified(apiId)), prompt: "hi", providerOptions })
-  return extractUpstreamQuery(captured?.outerBody)
+  return captured.map((entry) => extractUpstreamQuery(entry.outerBody)).find((query) => query !== undefined)
 }
 
 describe("cf-ai-gateway provider options", () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "../fixture/fixture"
 import { Global } from "@opencode-ai/core/global"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
+import { Auth } from "../../src/auth"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
 import { localProviderImportSpec } from "../../src/provider/provider"
@@ -2871,6 +2872,59 @@ test("plugin provider model hook runs for provider added by plugin config hook",
       const model = providers[ProviderID.make("demo")].models[ModelID.make("chat")]
       expect(model.name).toBe("Hooked Chat")
       expect(model.cost).toEqual({ input: 1, output: 2, cache: { read: 3, write: 4 } })
+    },
+  })
+})
+
+test("Codex OAuth provider hook filters OpenAI models added by config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              models: {
+                "gpt-4o-local-alias": {
+                  id: "gpt-4o",
+                  name: "GPT-4o Local Alias",
+                },
+                "gpt-5.3-codex-spark-alias": {
+                  id: "gpt-5.3-codex-spark",
+                  name: "GPT-5.3 Codex Spark Alias",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      await Auth.set(
+        ProviderID.openai,
+        {
+          type: "oauth",
+          access: "access",
+          refresh: "refresh",
+          expires: Date.now() + 60_000,
+        } as never,
+      )
+    },
+    fn: async () => {
+      const providers = await list()
+      const models = providers[ProviderID.openai].models
+      expect(models[ModelID.make("gpt-4o-local-alias")]).toBeUndefined()
+      expect(models[ModelID.make("gpt-5.3-codex-spark-alias")]).toBeDefined()
+      expect(models[ModelID.make("gpt-5.3-codex-spark-alias")].cost).toEqual({
+        input: 0,
+        output: 0,
+        cache: { read: 0, write: 0 },
+      })
     },
   })
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -9,7 +9,7 @@ import { Plugin } from "../../src/plugin/index"
 import { Auth } from "../../src/auth"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
-import { localProviderImportSpec } from "../../src/provider/provider"
+import { localProviderImportSpec, stripOpenAIResponseInputIDs } from "../../src/provider/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "../../src/util/filesystem"
 import { Env } from "../../src/env"
@@ -84,6 +84,15 @@ test("OpenCode Zen and OpenCode Go providers remain discoverable in PawWork runt
     if (previous === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
     else process.env.PAWWORK_RUNTIME_NAMESPACE = previous
   }
+})
+
+test("stripOpenAIResponseInputIDs safely handles request body shapes", () => {
+  expect(stripOpenAIResponseInputIDs(new FormData())).toBeUndefined()
+  expect(stripOpenAIResponseInputIDs("{")).toBeUndefined()
+  expect(stripOpenAIResponseInputIDs(JSON.stringify({ input: [{ id: "item-1", type: "message" }, "raw"] }))).toBe(
+    JSON.stringify({ input: [{ type: "message" }, "raw"] }),
+  )
+  expect(stripOpenAIResponseInputIDs(JSON.stringify({ store: true, input: [{ id: "item-1" }] }))).toBeUndefined()
 })
 
 function paid(providers: Awaited<ReturnType<typeof list>>) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2817,6 +2817,64 @@ test("user config model overrides plugin provider model hook output", async () =
   })
 })
 
+test("plugin provider model hook runs for provider added by plugin config hook", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "config-added-provider-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.config-added-provider-hook",',
+          "  server: async () => ({",
+          "    async config(cfg) {",
+          "      cfg.provider ??= {}",
+          "      cfg.provider.demo = {",
+          '        name: "Demo Provider",',
+          '        npm: "@ai-sdk/openai-compatible",',
+          '        api: "https://example.com/v1",',
+          "        options: { apiKey: 'demo-key' },",
+          "        models: {",
+          "          chat: {",
+          '            name: "Raw Chat",',
+          "            tool_call: true,",
+          "            limit: { context: 128000, output: 4096 },",
+          "          },",
+          "        },",
+          "      }",
+          "    },",
+          "    provider: {",
+          '      id: "demo",',
+          "      async models(provider) {",
+          "        return {",
+          "          chat: {",
+          "            ...provider.models.chat,",
+          '            name: "Hooked Chat",',
+          "            cost: { input: 1, output: 2, cache: { read: 3, write: 4 } },",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("demo")].models[ModelID.make("chat")]
+      expect(model.name).toBe("Hooked Chat")
+      expect(model.cost).toEqual({ input: 1, output: 2, cache: { read: 3, write: 4 } })
+    },
+  })
+})
+
 test("plugin config enabled and disabled providers are honored", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -3020,6 +3020,10 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
                   id: "gpt-4o",
                   name: "GPT-4o Local Alias",
                 },
+                "my-codex-alias": {
+                  id: "gpt-4o",
+                  name: "My Codex Alias",
+                },
                 "gpt-5.3-codex-spark-alias": {
                   id: "gpt-5.3-codex-spark",
                   name: "GPT-5.3 Codex Spark Alias",
@@ -3050,6 +3054,7 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
         const providers = await list()
         const models = providers[ProviderID.openai].models
         expect(models[ModelID.make("gpt-4o-local-alias")]).toBeUndefined()
+        expect(models[ModelID.make("my-codex-alias")]).toBeUndefined()
         expect(models[ModelID.make("gpt-5.3-codex-spark-alias")]).toBeDefined()
         expect(models[ModelID.make("gpt-5.3-codex-spark-alias")].cost).toEqual({
           input: 0,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -63,6 +63,28 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
+async function readAuthSnapshot() {
+  try {
+    return await Filesystem.readText(path.join(Global.Path.data, "auth.json"))
+  } catch (e) {
+    if (typeof e === "object" && e !== null && "code" in e && e.code === "ENOENT") return undefined
+    throw e
+  }
+}
+
+async function restoreAuthSnapshot(snapshot: string | undefined) {
+  const authPath = path.join(Global.Path.data, "auth.json")
+  if (snapshot !== undefined) {
+    await Filesystem.write(authPath, snapshot, 0o600)
+    return
+  }
+  try {
+    await unlink(authPath)
+  } catch (e) {
+    if (!(typeof e === "object" && e !== null && "code" in e && e.code === "ENOENT")) throw e
+  }
+}
+
 test("OpenCode Zen and OpenCode Go providers remain discoverable in PawWork runtime mode", async () => {
   await using tmp = await tmpdir({ git: true })
   const previous = process.env.PAWWORK_RUNTIME_NAMESPACE
@@ -2956,6 +2978,7 @@ test("multiple provider model hooks run for the same provider", async () => {
 })
 
 test("Codex no-op hook does not block external OpenAI model hooks", async () => {
+  const authSnapshot = await readAuthSnapshot()
   await Auth.remove(ProviderID.openai)
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -3001,11 +3024,12 @@ test("Codex no-op hook does not block external OpenAI model hooks", async () => 
       },
     })
   } finally {
-    await Auth.remove(ProviderID.openai)
+    await restoreAuthSnapshot(authSnapshot)
   }
 })
 
 test("Codex OAuth provider hook filters OpenAI models added by config", async () => {
+  const authSnapshot = await readAuthSnapshot()
   await Auth.remove(ProviderID.openai)
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -3064,11 +3088,12 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
       },
     })
   } finally {
-    await Auth.remove(ProviderID.openai)
+    await restoreAuthSnapshot(authSnapshot)
   }
 })
 
 test("Codex OAuth config model override survives external OpenAI model hook", async () => {
+  const authSnapshot = await readAuthSnapshot()
   await Auth.remove(ProviderID.openai)
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -3145,11 +3170,12 @@ test("Codex OAuth config model override survives external OpenAI model hook", as
       },
     })
   } finally {
-    await Auth.remove(ProviderID.openai)
+    await restoreAuthSnapshot(authSnapshot)
   }
 })
 
 test("post-config OAuth rerun only reprocesses providers with config models", async () => {
+  const authSnapshot = await readAuthSnapshot()
   await Auth.remove(ProviderID.anthropic)
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -3222,7 +3248,7 @@ test("post-config OAuth rerun only reprocesses providers with config models", as
       },
     })
   } finally {
-    await Auth.remove(ProviderID.anthropic)
+    await restoreAuthSnapshot(authSnapshot)
   }
 })
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -334,6 +334,70 @@ test("custom provider with npm package", async () => {
   })
 })
 
+test("custom DeepSeek openai-compatible model defaults interleaved reasoning field", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-provider": {
+              name: "Custom Provider",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://api.custom.com/v1",
+              models: {
+                "DeepSeek-R1": {
+                  name: "DeepSeek R1",
+                },
+                "deepseek-details": {
+                  name: "DeepSeek Details",
+                  interleaved: { field: "reasoning_details" },
+                },
+                "custom-model": {
+                  name: "Custom Model",
+                },
+              },
+              options: {
+                apiKey: "custom-key",
+              },
+            },
+            "custom-anthropic-provider": {
+              name: "Custom Anthropic Provider",
+              npm: "@ai-sdk/anthropic",
+              api: "https://api.custom.com/v1",
+              models: {
+                "deepseek-r1": {
+                  name: "DeepSeek R1",
+                },
+              },
+              options: {
+                apiKey: "custom-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.make("custom-provider")].models["DeepSeek-R1"].capabilities.interleaved).toEqual({
+        field: "reasoning_content",
+      })
+      expect(providers[ProviderID.make("custom-provider")].models["deepseek-details"].capabilities.interleaved).toEqual(
+        { field: "reasoning_details" },
+      )
+      expect(providers[ProviderID.make("custom-provider")].models["custom-model"].capabilities.interleaved).toBe(false)
+      expect(
+        providers[ProviderID.make("custom-anthropic-provider")].models["deepseek-r1"].capabilities.interleaved,
+      ).toBe(false)
+    },
+  })
+})
+
 test("env variable takes precedence, config merges options", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -2688,6 +2752,69 @@ test("plugin config providers persist after instance dispose", async () => {
   })
   expect(second[ProviderID.make("demo")]).toBeDefined()
   expect(second[ProviderID.make("demo")].models[ModelID.make("chat")]).toBeDefined()
+})
+
+test("user config model overrides plugin provider model hook output", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "anthropic-model-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.anthropic-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "anthropic",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          'my-alias': {",
+          "            ...provider.models['claude-sonnet-4-5'],",
+          "            id: 'my-alias',",
+          "            name: 'Plugin Alias',",
+          "            api: { ...provider.models['claude-sonnet-4-5'].api, id: 'plugin-model' },",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "my-alias": {
+                  id: "claude-sonnet-4-5",
+                  name: "Config Alias",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-anthropic-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      const alias = providers[ProviderID.anthropic].models[ModelID.make("my-alias")]
+      expect(alias.name).toBe("Config Alias")
+      expect(alias.api.id).toBe("claude-sonnet-4-5")
+    },
+  })
 })
 
 test("plugin config enabled and disabled providers are honored", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -3063,6 +3063,87 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
   }
 })
 
+test("Codex OAuth config model override survives external OpenAI model hook", async () => {
+  await Auth.remove(ProviderID.openai)
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "openai-oauth-model-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.openai-oauth-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "openai",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          'gpt-5.3-codex-spark-alias': {",
+          "            ...provider.models['gpt-5.2'],",
+          "            id: 'gpt-5.3-codex-spark-alias',",
+          "            name: 'Plugin Alias',",
+          "            api: { ...provider.models['gpt-5.2'].api, id: 'plugin-model' },",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              models: {
+                "gpt-5.3-codex-spark-alias": {
+                  id: "gpt-5.3-codex-spark",
+                  name: "Config Alias",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        await Auth.set(
+          ProviderID.openai,
+          {
+            type: "oauth",
+            access: "access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          } as never,
+        )
+      },
+      fn: async () => {
+        const providers = await list()
+        const alias = providers[ProviderID.openai].models[ModelID.make("gpt-5.3-codex-spark-alias")]
+        expect(alias.name).toBe("Config Alias")
+        expect(alias.api.id).toBe("gpt-5.3-codex-spark")
+        expect(alias.cost).toEqual({
+          input: 0,
+          output: 0,
+          cache: { read: 0, write: 0 },
+        })
+      },
+    })
+  } finally {
+    await Auth.remove(ProviderID.openai)
+  }
+})
+
 test("post-config OAuth rerun only reprocesses providers with config models", async () => {
   await Auth.remove(ProviderID.anthropic)
   await using tmp = await tmpdir({

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2885,6 +2885,126 @@ test("plugin provider model hook runs for provider added by plugin config hook",
   })
 })
 
+test("multiple provider model hooks run for the same provider", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "anthropic-first-model-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.anthropic-first-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "anthropic",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          'first-alias': {",
+          "            ...provider.models['claude-sonnet-4-5'],",
+          "            id: 'first-alias',",
+          "            name: 'First Alias',",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(root, "anthropic-second-model-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.anthropic-second-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "anthropic",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          'second-alias': {",
+          "            ...provider.models['claude-sonnet-4-5'],",
+          "            id: 'second-alias',",
+          "            name: 'Second Alias',",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-anthropic-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      const models = providers[ProviderID.anthropic].models
+      expect(models[ModelID.make("first-alias")]?.name).toBe("First Alias")
+      expect(models[ModelID.make("second-alias")]?.name).toBe("Second Alias")
+    },
+  })
+})
+
+test("Codex no-op hook does not block external OpenAI model hooks", async () => {
+  await Auth.remove(ProviderID.openai)
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "openai-model-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.openai-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "openai",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          'openai-plugin-alias': {",
+          "            ...provider.models['gpt-5.2'],",
+          "            id: 'openai-plugin-alias',",
+          "            name: 'OpenAI Plugin Alias',",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        set("OPENAI_API_KEY", "test-openai-key")
+      },
+      fn: async () => {
+        const providers = await list()
+        const alias = providers[ProviderID.openai].models[ModelID.make("openai-plugin-alias")]
+        expect(alias.name).toBe("OpenAI Plugin Alias")
+      },
+    })
+  } finally {
+    await Auth.remove(ProviderID.openai)
+  }
+})
+
 test("Codex OAuth provider hook filters OpenAI models added by config", async () => {
   await Auth.remove(ProviderID.openai)
   await using tmp = await tmpdir({

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2877,6 +2877,7 @@ test("plugin provider model hook runs for provider added by plugin config hook",
 })
 
 test("Codex OAuth provider hook filters OpenAI models added by config", async () => {
+  await Auth.remove(ProviderID.openai)
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -2902,31 +2903,35 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
     },
   })
 
-  await Instance.provide({
-    directory: tmp.path,
-    init: async () => {
-      await Auth.set(
-        ProviderID.openai,
-        {
-          type: "oauth",
-          access: "access",
-          refresh: "refresh",
-          expires: Date.now() + 60_000,
-        } as never,
-      )
-    },
-    fn: async () => {
-      const providers = await list()
-      const models = providers[ProviderID.openai].models
-      expect(models[ModelID.make("gpt-4o-local-alias")]).toBeUndefined()
-      expect(models[ModelID.make("gpt-5.3-codex-spark-alias")]).toBeDefined()
-      expect(models[ModelID.make("gpt-5.3-codex-spark-alias")].cost).toEqual({
-        input: 0,
-        output: 0,
-        cache: { read: 0, write: 0 },
-      })
-    },
-  })
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        await Auth.set(
+          ProviderID.openai,
+          {
+            type: "oauth",
+            access: "access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          } as never,
+        )
+      },
+      fn: async () => {
+        const providers = await list()
+        const models = providers[ProviderID.openai].models
+        expect(models[ModelID.make("gpt-4o-local-alias")]).toBeUndefined()
+        expect(models[ModelID.make("gpt-5.3-codex-spark-alias")]).toBeDefined()
+        expect(models[ModelID.make("gpt-5.3-codex-spark-alias")].cost).toEqual({
+          input: 0,
+          output: 0,
+          cache: { read: 0, write: 0 },
+        })
+      },
+    })
+  } finally {
+    await Auth.remove(ProviderID.openai)
+  }
 })
 
 test("plugin config enabled and disabled providers are honored", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2934,6 +2934,83 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
   }
 })
 
+test("post-config OAuth rerun only reprocesses providers with config models", async () => {
+  await Auth.remove(ProviderID.anthropic)
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "anthropic-oauth-model-hook.ts"),
+        [
+          "let calls = 0",
+          "export default {",
+          '  id: "demo.anthropic-oauth-model-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "anthropic",',
+          "      async models(provider) {",
+          "        calls += 1",
+          "        return {",
+          "          ...provider.models,",
+          "          'oauth-hook-alias': {",
+          "            ...provider.models['claude-sonnet-4-5'],",
+          "            id: 'oauth-hook-alias',",
+          "            name: calls === 1 ? 'First Hook' : 'Second Hook',",
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              models: {
+                "gpt-5.3-codex-spark-alias": {
+                  id: "gpt-5.3-codex-spark",
+                  name: "GPT-5.3 Codex Spark Alias",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        set("ANTHROPIC_API_KEY", "test-anthropic-key")
+        await Auth.set(
+          ProviderID.anthropic,
+          {
+            type: "oauth",
+            access: "access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          } as never,
+        )
+      },
+      fn: async () => {
+        const providers = await list()
+        const alias = providers[ProviderID.anthropic].models[ModelID.make("oauth-hook-alias")]
+        expect(alias.name).toBe("First Hook")
+      },
+    })
+  } finally {
+    await Auth.remove(ProviderID.anthropic)
+  }
+})
+
 test("plugin config enabled and disabled providers are honored", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3839,6 +3839,27 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("Copilot opus 4.7 hyphen ids only return medium adaptive effort", () => {
+      const model = createMockModel({
+        id: "github-copilot/claude-opus-4-7",
+        providerID: "github-copilot",
+        api: {
+          id: "claude-opus-4-7",
+          url: "https://api.githubcopilot.com/v1",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium"])
+      expect(result.medium).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "medium",
+      })
+    })
+
     test("returns high and max with thinking config", () => {
       const model = createMockModel({
         id: "anthropic/claude-4",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2605,6 +2605,55 @@ describe("ProviderTransform.message - providerOptions key remapping", () => {
     expect(result[0].providerOptions?.bedrock).toEqual({ someOption: "value" })
     expect(result[0].providerOptions?.["my-bedrock"]).toBeUndefined()
   })
+
+  test("dotted Anthropic provider remaps message options through dot-split key", () => {
+    const model = createModel("claude.proxy", "@ai-sdk/anthropic")
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Hello",
+            providerOptions: {
+              "claude.proxy": { part: true },
+            },
+          },
+        ],
+        providerOptions: {
+          "claude.proxy": { someOption: "value" },
+        },
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+    const part = result[0].content[0] as any
+
+    expect(result[0].providerOptions?.claude).toEqual({ someOption: "value" })
+    expect(result[0].providerOptions?.["claude.proxy"]).toBeUndefined()
+    expect(result[0].providerOptions?.anthropic).toBeUndefined()
+    expect(part.providerOptions?.claude).toEqual({ part: true })
+    expect(part.providerOptions?.["claude.proxy"]).toBeUndefined()
+  })
+
+  test("dotted OpenAI-compatible provider remaps message options through dot-split key", () => {
+    const model = createModel("wafer.ai", "@ai-sdk/openai-compatible")
+    const msgs = [
+      {
+        role: "user",
+        content: "Hello",
+        providerOptions: {
+          "wafer.ai": { someOption: "value" },
+        },
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+
+    expect(result[0].providerOptions?.wafer).toEqual({ someOption: "value" })
+    expect(result[0].providerOptions?.["wafer.ai"]).toBeUndefined()
+    expect(result[0].providerOptions?.openaiCompatible).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.message - claude w/bedrock custom inference profile", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3588,6 +3588,20 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
+
+    test("dotted gpt-5 family ids add minimal effort", () => {
+      const model = createMockModel({
+        id: "gpt-5.4",
+        providerID: "azure",
+        api: {
+          id: "gpt-5.4",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
+    })
   })
 
   describe("@ai-sdk/openai", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -586,6 +586,29 @@ describe("ProviderTransform.providerOptions", () => {
     })
   })
 
+  test("routes Copilot Anthropic SDK provider options through anthropic", () => {
+    const model = createModel({
+      providerID: "github-copilot",
+      api: {
+        id: "claude-opus-4.7",
+        url: "https://api.githubcopilot.com/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(model, {
+        thinking: { type: "adaptive" },
+        effort: "medium",
+      }),
+    ).toEqual({
+      anthropic: {
+        thinking: { type: "adaptive" },
+        effort: "medium",
+      },
+    })
+  })
+
   test("splits dotted provider id for OpenAI provider options", () => {
     const model = createModel({
       providerID: "openai.proxy",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -101,7 +101,7 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.store).toBe(false)
   })
 
-  test("should set store=true for azure provider by default", () => {
+  test("should set store=false for azure provider by default", () => {
     const azureModel = {
       ...mockModel,
       providerID: "azure",
@@ -116,7 +116,7 @@ describe("ProviderTransform.options - setCacheKey", () => {
       sessionID,
       providerOptions: {},
     })
-    expect(result.store).toBe(true)
+    expect(result.store).toBe(false)
   })
 
   test("should disable tool streaming for google vertex anthropic provider", () => {
@@ -553,6 +553,66 @@ describe("ProviderTransform.providerOptions", () => {
 
     expect(ProviderTransform.providerOptions(model, { cachePoint: { type: "default" } })).toEqual({
       bedrock: { cachePoint: { type: "default" } },
+    })
+  })
+
+  test("splits dotted provider id for OpenAI-compatible provider options", () => {
+    const model = createModel({
+      providerID: "wafer.ai",
+      api: {
+        id: "gpt-5",
+        url: "https://api.wafer.ai",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "high" })).toEqual({
+      wafer: { reasoningEffort: "high" },
+    })
+  })
+
+  test("splits dotted provider id for Anthropic SDK provider options", () => {
+    const model = createModel({
+      providerID: "claude.proxy",
+      api: {
+        id: "claude-sonnet-4-6",
+        url: "https://api.example.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { thinking: { type: "enabled" } })).toEqual({
+      claude: { thinking: { type: "enabled" } },
+    })
+  })
+
+  test("splits dotted provider id for OpenAI provider options", () => {
+    const model = createModel({
+      providerID: "openai.proxy",
+      api: {
+        id: "gpt-5",
+        url: "https://api.example.com",
+        npm: "@ai-sdk/openai",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "high" })).toEqual({
+      openai: { reasoningEffort: "high" },
+    })
+  })
+
+  test("routes Cloudflare AI Gateway options through openaiCompatible", () => {
+    const model = createModel({
+      providerID: "cloudflare-ai-gateway",
+      api: {
+        id: "openai/gpt-5.4",
+        url: "https://gateway.ai.cloudflare.com/v1/compat",
+        npm: "ai-gateway-provider",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "high" })).toEqual({
+      openaiCompatible: { reasoningEffort: "high" },
     })
   })
 
@@ -2902,6 +2962,25 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  test("mistral medium 3.5 with reasoning returns variants", () => {
+    for (const id of ["mistral-medium-3.5", "mistral-medium-2604"]) {
+      const model = createMockModel({
+        id: `mistral/${id}`,
+        providerID: "mistral",
+        api: {
+          id,
+          url: "https://api.mistral.com",
+          npm: "@ai-sdk/mistral",
+        },
+        capabilities: { reasoning: true },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({
+        high: { reasoningEffort: "high" },
+      })
+    }
+  })
+
   test("mistral without reasoning returns empty object", () => {
     const model = createMockModel({
       id: "mistral/mistral-large",
@@ -3551,6 +3630,77 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
+
+    test("dotted gpt-5.x ids include minimal effort", () => {
+      const model = createMockModel({
+        id: "gpt-5.4",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.4",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-03-05",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-50 lookalike does not get gpt-5 family treatment", () => {
+      const model = createMockModel({
+        id: "gpt-50",
+        providerID: "openai",
+        api: {
+          id: "gpt-50",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2024-01-01",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    })
+  })
+
+  describe("ai-gateway-provider", () => {
+    const cfModel = (apiId: string, releaseDate = "2024-01-01") =>
+      createMockModel({
+        id: `cloudflare-ai-gateway/${apiId}`,
+        providerID: "cloudflare-ai-gateway",
+        api: {
+          id: apiId,
+          url: "https://gateway.ai.cloudflare.com/v1/compat",
+          npm: "ai-gateway-provider",
+        },
+        release_date: releaseDate,
+      })
+
+    test("openai gpt-5.4 includes xhigh effort", () => {
+      const result = ProviderTransform.variants(cfModel("openai/gpt-5.4", "2026-03-05"))
+      expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
+      expect(result.high).toEqual({ reasoningEffort: "high" })
+      expect(Object.keys(result)).toContain("minimal")
+    })
+
+    test("openai gpt-5.2-codex includes xhigh", () => {
+      const result = ProviderTransform.variants(cfModel("openai/gpt-5.2-codex", "2025-12-11"))
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
+    })
+
+    test("openai gpt-4o without reasoning returns empty", () => {
+      const model = cfModel("openai/gpt-4o")
+      model.capabilities.reasoning = false
+      expect(ProviderTransform.variants(model)).toEqual({})
+    })
+
+    test("non-openai upstream falls back to widely supported OAI efforts", () => {
+      expect(ProviderTransform.variants(cfModel("anthropic/claude-sonnet-4-6"))).toEqual({
+        low: { reasoningEffort: "low" },
+        medium: { reasoningEffort: "medium" },
+        high: { reasoningEffort: "high" },
+      })
     })
   })
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -451,6 +451,13 @@ describe("session.message-v2.toModelMessage", () => {
           },
           {
             ...basePart(assistantID, "a2"),
+            type: "reasoning",
+            text: "thinking",
+            metadata: { openai: { reasoning: "meta" } },
+            time: { start: 0 },
+          },
+          {
+            ...basePart(assistantID, "a3"),
             type: "tool",
             callID: "call-1",
             tool: "bash",
@@ -477,6 +484,7 @@ describe("session.message-v2.toModelMessage", () => {
         role: "assistant",
         content: [
           { type: "text", text: "done" },
+          { type: "text", text: "thinking" },
           {
             type: "tool-call",
             toolCallId: "call-1",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -224,6 +224,10 @@ export type ProviderHookContext = {
 
 export type ProviderHook = {
   id: string
+  /**
+   * Re-run this provider model hook after config models are merged.
+   * Currently only applies to OAuth providers whose config declares models.
+   */
   postConfig?: boolean
   models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -224,6 +224,7 @@ export type ProviderHookContext = {
 
 export type ProviderHook = {
   id: string
+  postConfig?: boolean
   models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
 }
 


### PR DESCRIPTION
## Summary

- Port the narrow provider transform/model hotfix slice from the #477 upstream sync tracker.
- Fix provider option routing, reasoning variants, Cloudflare AI Gateway options, Codex OAuth model filtering, Copilot variant refresh, and custom DeepSeek interleaved defaults.
- Normalize different-model Bedrock reasoning replay so reasoning text is replayed as assistant text without forwarding provider metadata.

## Why

#477 tracks PawWork's upstream opencode sync after `17701628bd`. This PR implements the first bounded provider/model slice while intentionally excluding auth/client credentials, runtime/session retry and serialization fixes, desktop/app work, HttpApi/Effect/listener work, generated SDK/OpenAPI files, and dependency changes.

## Related Issue

Refs #477

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Provider option key routing for dotted provider IDs and Cloudflare AI Gateway.
- Variant generation for OpenAI, GitHub Copilot, Mistral Medium 3.5, and Cloudflare AI Gateway.
- Codex OAuth model filtering through the provider models hook instead of mutating models in the auth loader.
- The isolated `message-v2` replay change for reasoning parts when continuing a transcript with a different model.

## Risk Notes

- Provider behavior changes are intentional and covered by focused tests, but this still affects model option routing and variant metadata.
- No dependency or lockfile changes were made. The Cloudflare AI Gateway E2E uses the existing `ai-gateway-provider` dependency.
- No app, desktop, UI, server listener, SDK/generated, HttpApi, or Effect migration files were changed.

## How To Verify

```text
Install: bun install --frozen-lockfile completed before implementation in this worktree.
Patch check: git cherry -v origin/dev aa3c99a3c0a609ea4dd485355627e3161251584a showed all 15 provider/model candidate PRs as not patch-equivalent absorbed.
Focused tests: bun --cwd packages/opencode test test/session/llm.test.ts test/provider/provider.test.ts test/provider/transform.test.ts test/plugin/codex.test.ts test/plugin/github-copilot-models.test.ts test/session/message-v2.test.ts test/provider/cf-ai-gateway-e2e.test.ts -> 346 pass, 0 fail, 712 expect() calls.
Typecheck: bun run --cwd packages/opencode typecheck -> tsgo --noEmit completed successfully.
Diff check: git diff --check -> no output.
Boundary check: changed files are limited to packages/opencode provider/plugin/session source and tests; no app/desktop/ui/server/sdk/generated, lockfile, or package manifest changes.
Review follow-up: provider.test.ts now covers plugin config-added providers receiving provider.models hooks; transform.test.ts covers Copilot Anthropic SDK provider options routing through the anthropic namespace; provider.test.ts covers Codex OAuth filtering after config-added OpenAI models, scopes post-config OAuth hook reruns to providers whose config declares models, cleans up OAuth auth state so later OpenAI session.llm tests still hit the local responses mock, and covers safe OpenAI/Azure request-body id stripping. cf-ai-gateway-e2e.test.ts now captures all gateway requests instead of only the last intercepted request. provider.test.ts now also covers multiple provider.models hooks for the same provider and verifies the built-in Codex OpenAI no-op hook does not block external OpenAI provider model hooks. provider.ts now restricts post-config provider model hook reruns to hooks that explicitly opt in, and provider.test.ts covers Codex OAuth config aliases surviving an external OpenAI hook while still receiving Codex OAuth normalization. provider.test.ts now also filters Codex-looking aliases whose API id is not Codex OAuth-allowed, and transform.test.ts covers Azure dotted GPT-5 family ids receiving minimal effort. transform.ts now shares dotted providerOptions key logic between request-level and message-level options, with regression coverage for dotted Anthropic and OpenAI-compatible message options. provider.test.ts now snapshots and restores auth.json around auth-mutating provider hook tests. transform.test.ts now covers Copilot Anthropic Opus 4.7 hyphen IDs clamping to the supported medium adaptive effort.
```

## Screenshots or Recordings

Not applicable. This PR has no visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

Maintainer labeling requested: type fix, area provider/opencode, priority appropriate for #477 sync slice.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.3 Codex Spark support
  * Improved Azure-aware model selection and dot-split provider routing
  * Expanded reasoning-effort handling across Mistral, Anthropic, Copilot and gateway providers
  * Provider hooks can opt into post-config re-running

* **Bug Fixes**
  * Better handling of reasoning content for cross-model compatibility

* **Tests**
  * Added and expanded provider, Codex, Copilot, gateway and message-handling tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


