### PR TITLE
fix(app): restore session timeline width cap

### DIFF
--- a/packages/app/e2e/app/session.spec.ts
+++ b/packages/app/e2e/app/session.spec.ts
@@ -101,6 +101,10 @@ test("session timeline visible content is not narrower than composer shell", asy
 
   await assertWidthContract()
 
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await expect(page.locator("#right-panel")).toHaveAttribute("aria-hidden", "true")
+  await assertWidthContract({ maxComposerColumn: 720 })
+
   await page.setViewportSize({ width: 893, height: 776 })
   await assertWidthContract({ maxComposerColumn: 720 })
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -994,7 +994,7 @@ export function MessageTimeline(props: {
               class="flex flex-col items-start justify-start pb-4 transition-[margin]"
               classList={{
                 "w-full": true,
-                "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+                "md:max-w-[800px] md:mx-auto 2xl:max-w-[1000px]": props.centered,
                 "mt-0.5": props.centered,
                 "mt-0": !props.centered,
               }}
@@ -1035,7 +1035,7 @@ export function MessageTimeline(props: {
                       data-message-id={messageID}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
-                        "md:max-w-200 2xl:max-w-[1000px]": props.centered,
+                        "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
                       }}
                       style={{
                         "content-visibility": active() ? undefined : "auto",


### PR DESCRIPTION
## Summary

Restore the session timeline medium-width cap to the explicit `800px` value from #464, and add a right-panel-hidden regression assertion at 1280px.

## Why

Fixes #479.

#464 fixed #456 by changing the session timeline from `md:max-w-200` to `md:max-w-[800px]`, because PawWork's 13px root font makes `max-w-200` resolve to about 650px. The composer remains capped at 720px in the same viewport band, so the old timeline cap makes the composer visibly wider than the message flow.

The regression was reintroduced during the #440 UI slice merge chain: #461 first changed the two timeline caps back to `md:max-w-200`, and #460 later kept that same file state while removing dead delete-session code from `message-timeline.tsx`.

## Related Issue

Closes #479

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Check that this only restores the lost timeline width cap and adds one focused right-panel-hidden coverage point. It does not change composer sizing, right-panel behavior, or broader layout tokens.

## Risk Notes

Low. This is a two-line session layout restore plus one E2E coverage point. It does not touch persistence, packaging, permissions, dependencies, or platform code.

## How To Verify

```text
Red check: with the old md:max-w-200 cap temporarily restored, the focused E2E failed at the new 1280px/right-panel-hidden checkpoint with timeline 651px vs composer 720px
Focused E2E: passed with bun --cwd packages/app test:e2e e2e/app/session.spec.ts -g "session timeline visible content is not narrower than composer shell"
Typecheck: passed with bun --cwd packages/app typecheck
Diff check: no whitespace errors with git diff --check
```

## Screenshots or Recordings

Not attached. The regression E2E now explicitly asserts `#right-panel[aria-hidden="true"]` at 1280px and verifies the timeline/composer bounding-box contract.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
