### PR TITLE
fix(app): cache detached todo updates for fresh sessions

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -213,6 +213,17 @@ async function submitVisiblePrompt(page: Page, text: string) {
   await page.keyboard.press("Enter")
 }
 
+async function readPromptSend(page: Page) {
+  return page.evaluate(() => {
+    const win = window as ComposerWindow
+    const sent = win.__opencode_e2e?.prompt?.sent
+    return {
+      count: sent?.count ?? 0,
+      sessionID: sent?.sessionID,
+    }
+  })
+}
+
 async function scrollTimelineToBottom(page: Page) {
   await page.evaluate(() => {
     const viewport = document.querySelector('[data-component="scroll-viewport"]')
@@ -1068,6 +1079,32 @@ test("todo dock appears from real todowrite tool parts", async ({ page, llm, pro
     },
     { trackSession: project.trackSession },
   )
+})
+
+test("todo dock appears for the first todowrite in a fresh session", async ({ page, llm, project }) => {
+  await project.open()
+
+  await llm.tool("todowrite", {
+    todos: [
+      { content: "fresh first todo", status: "in_progress", priority: "high" },
+      { content: "fresh follow-up todo", status: "pending", priority: "medium" },
+    ],
+  })
+  await llm.text("fresh todo started")
+
+  const before = await readPromptSend(page)
+  await submitVisiblePrompt(page, "Create todos in a fresh session.")
+  const sent = await expect
+    .poll(async () => readPromptSend(page), { timeout: 30_000 })
+    .toMatchObject({ count: before.count + 1 })
+    .then(() => readPromptSend(page))
+  if (!sent.sessionID) throw new Error("Prompt submission did not expose a session id")
+
+  const dock = page.locator('[data-component="session-todo-dock"]')
+
+  await expect(dock).toHaveCount(1, { timeout: 30_000 })
+  await expect(dock).toContainText("fresh first todo", { timeout: 30_000 })
+  project.trackSession(sent.sessionID)
 })
 
 test("todo dock recovers after missed todowrite via SSE replay", async ({ page, llm, project }) => {

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -18,7 +18,12 @@ import { useGlobalSDK } from "./global-sdk"
 import { bootstrapDirectory, bootstrapGlobal, clearProviderRev } from "./global-sync/bootstrap"
 import { createBlockerTerminalCache } from "./global-sync/blocker-terminal-cache"
 import { createChildStoreManager } from "./global-sync/child-store"
-import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./global-sync/event-reducer"
+import {
+  applyDetachedDirectoryEvent,
+  applyDirectoryEvent,
+  applyGlobalEvent,
+  cleanupDroppedSessionCaches,
+} from "./global-sync/event-reducer"
 import { createRefreshQueue } from "./global-sync/queue"
 import { clearSessionPrefetchDirectory } from "./global-sync/session-prefetch"
 import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
@@ -323,7 +328,10 @@ function createGlobalSync() {
     }
 
     const existing = children.children[directory]
-    if (!existing) return
+    if (!existing) {
+      applyDetachedDirectoryEvent({ event, setSessionTodo })
+      return
+    }
     children.mark(directory)
     const [store, setStore] = existing
     applyDirectoryEvent({

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -174,6 +174,34 @@ describe("applyDirectoryEvent", () => {
     expect(handled).toBe(false)
   })
 
+  test("clears detached todo cache for deleted and archived sessions", () => {
+    const writes: Array<{ sessionID: string; todos: Todo[] | undefined }> = []
+    const setSessionTodo = (sessionID: string, todos: Todo[] | undefined) => {
+      writes.push({ sessionID, todos })
+    }
+
+    const deleted = applyDetachedDirectoryEvent({
+      event: { type: "session.deleted", properties: { info: rootSession({ id: "ses_deleted" }) } },
+      setSessionTodo,
+    })
+    const archived = applyDetachedDirectoryEvent({
+      event: { type: "session.updated", properties: { info: rootSession({ id: "ses_archived", archived: 2 }) } },
+      setSessionTodo,
+    })
+    const activeUpdate = applyDetachedDirectoryEvent({
+      event: { type: "session.updated", properties: { info: rootSession({ id: "ses_active" }) } },
+      setSessionTodo,
+    })
+
+    expect(deleted).toBe(true)
+    expect(archived).toBe(true)
+    expect(activeUpdate).toBe(false)
+    expect(writes).toEqual([
+      { sessionID: "ses_deleted", todos: undefined },
+      { sessionID: "ses_archived", todos: undefined },
+    ])
+  })
+
   test("inserts root sessions in sorted order and updates sessionTotal", () => {
     const [store, setStore] = createStore(
       baseState({

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import type { Message, Part, PermissionRequest, Project, QuestionRequest, Session } from "@opencode-ai/sdk/v2/client"
+import type { Message, Part, PermissionRequest, Project, QuestionRequest, Session, Todo } from "@opencode-ai/sdk/v2/client"
 import { createStore } from "solid-js/store"
 import type { State } from "./types"
 import { createBlockerTerminalCache } from "./blocker-terminal-cache"
-import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./event-reducer"
+import { applyDetachedDirectoryEvent, applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./event-reducer"
 
 const rootSession = (input: { id: string; parentID?: string; archived?: number; created?: number; updated?: number }) =>
   ({
@@ -137,6 +137,43 @@ describe("applyGlobalEvent", () => {
 })
 
 describe("applyDirectoryEvent", () => {
+  test("caches detached todo updates before a directory child store exists", () => {
+    const todos: Todo[] = [{ id: "todo_1", content: "fresh todo", status: "in_progress", priority: "high" } as Todo]
+    const writes: Array<{ sessionID: string; todos: Todo[] | undefined }> = []
+
+    const handled = applyDetachedDirectoryEvent({
+      event: { type: "todo.updated", properties: { sessionID: "ses_fresh", todos } },
+      setSessionTodo(sessionID, value) {
+        writes.push({ sessionID, todos: value })
+      },
+    })
+
+    expect(handled).toBe(true)
+    expect(writes).toEqual([{ sessionID: "ses_fresh", todos }])
+  })
+
+  test("ignores detached events that need a directory child store", () => {
+    const handled = applyDetachedDirectoryEvent({
+      event: { type: "message.updated", properties: { info: userMessage("msg_1", "ses_1") } },
+      setSessionTodo() {
+        throw new Error("should not write detached todo cache")
+      },
+    })
+
+    expect(handled).toBe(false)
+  })
+
+  test("ignores malformed detached todo updates", () => {
+    const handled = applyDetachedDirectoryEvent({
+      event: { type: "todo.updated" },
+      setSessionTodo() {
+        throw new Error("should not write detached todo cache")
+      },
+    })
+
+    expect(handled).toBe(false)
+  })
+
   test("inserts root sessions in sorted order and updates sessionTotal", () => {
     const [store, setStore] = createStore(
       baseState({

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -92,12 +92,29 @@ export function applyDetachedDirectoryEvent(input: {
   event: { type: string; properties?: unknown }
   setSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void
 }) {
-  if (input.event.type !== "todo.updated") return false
   if (!input.event.properties || typeof input.event.properties !== "object") return false
-  const props = input.event.properties as { sessionID?: string; todos?: Todo[] }
-  if (!props.sessionID || !Array.isArray(props.todos)) return false
-  input.setSessionTodo?.(props.sessionID, props.todos)
-  return true
+  switch (input.event.type) {
+    case "todo.updated": {
+      const props = input.event.properties as { sessionID?: string; todos?: Todo[] }
+      if (!props.sessionID || !Array.isArray(props.todos)) return false
+      input.setSessionTodo?.(props.sessionID, props.todos)
+      return true
+    }
+    case "session.deleted": {
+      const info = (input.event.properties as { info?: Session }).info
+      if (!info?.id) return false
+      input.setSessionTodo?.(info.id, undefined)
+      return true
+    }
+    case "session.updated": {
+      const info = (input.event.properties as { info?: Session }).info
+      if (!info?.id || !info.time?.archived) return false
+      input.setSessionTodo?.(info.id, undefined)
+      return true
+    }
+    default:
+      return false
+  }
 }
 
 export function applyDirectoryEvent(input: {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -88,6 +88,18 @@ export function cleanupDroppedSessionCaches(
   )
 }
 
+export function applyDetachedDirectoryEvent(input: {
+  event: { type: string; properties?: unknown }
+  setSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void
+}) {
+  if (input.event.type !== "todo.updated") return false
+  if (!input.event.properties || typeof input.event.properties !== "object") return false
+  const props = input.event.properties as { sessionID?: string; todos?: Todo[] }
+  if (!props.sessionID || !Array.isArray(props.todos)) return false
+  input.setSessionTodo?.(props.sessionID, props.todos)
+  return true
+}
+
 export function applyDirectoryEvent(input: {
   event: { type: string; properties?: unknown }
   store: Store<State>


### PR DESCRIPTION
## Summary

- Cache `todo.updated` events into `globalSync.data.session_todo` even when the directory child store is not mounted yet.
- Clear detached todo cache entries when detached `session.deleted` or archived `session.updated` events arrive.
- Add focused coverage for fresh-session first `todowrite` dock visibility and detached todo event handling.

## Why

Issue #480 reports that a brand-new session can receive its first todo update without the composer todo dock appearing until the user switches away and back. The backend already publishes complete `todo.updated` payloads, and #472 already fixed reconnect replay. The missing path was app-side live sync: directory-scoped events were dropped when the matching child store did not exist yet, so the dock cache never received the fresh todo snapshot.

## Related Issue

Closes #480

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the detached handling stays limited to todo cache writes and cleanup for `todo.updated`, `session.deleted`, and archived `session.updated`.
- Confirm #472 replay behavior remains protected and is not masked by API hydration or polling.

## Risk Notes

Low. This writes the existing session todo cache from complete `todo.updated` payloads before a directory child store exists, then clears that cache if the same detached path later receives session delete/archive events. It does not change replay whitelist behavior, dock rendering, todo machine state, message/permission/question handling, or add polling.

## How To Verify

```text
Fresh/replay E2E: 2 passed
  bun --cwd packages/app test:e2e session/session-composer-dock.spec.ts --grep "todo dock appears for the first todowrite in a fresh session|todo dock recovers after missed todowrite via SSE replay"

Todo app units: 50 passed
  bun test --preload ./happydom.ts src/context/global-sync/event-reducer.test.ts src/pages/session/todos/todo-dock-machine.test.ts src/pages/session/todos/todo-source.test.ts src/pages/session/todos/todo-model.test.ts

Replay unit: 19 passed
  bun test test/server/event-replay.test.ts

App typecheck: ok
  bun --cwd packages/app typecheck

Diff check: no whitespace errors
  git diff --check
```

## Screenshots or Recordings

Not attached. This PR changes data sync behavior, not visual styling or copy. The rendered dock path is covered by the targeted Playwright E2E above.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling events in detached directory contexts, including todo updates and session management.

* **Tests**
  * Added comprehensive test coverage for session todo dock behavior with detached directories.
  * Extended event handler tests to validate detached directory event workflows, caching, and session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->