### PR TITLE
fix(opencode): preserve loop diagnostics in tool metadata

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -578,7 +578,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               ...match,
               state: {
                 title: val.title,
-                metadata: val.metadata,
+                metadata: SessionDiagnostics.mergeMetadata(
+                  "metadata" in match.state && match.state.metadata && typeof match.state.metadata === "object"
+                    ? match.state.metadata
+                    : undefined,
+                  val.metadata ?? {},
+                ),
                 status: "running",
                 input: args,
                 time: { start: Date.now() },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -686,6 +686,77 @@ it.live("loop gate stops repeated successful tools across model steps", () =>
   ),
 )
 
+unix("loop gate stops repeated successful bash calls after metadata updates", () =>
+  provideTmpdirServer(
+    ({ llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Loop gate bash successful stop",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "repeat bash" }],
+        })
+
+        const input = {
+          command: "printf stable",
+          description: "print stable output",
+        }
+        for (let i = 0; i < 5; i++) yield* llm.tool("bash", input)
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const allMessages = yield* MessageV2.filterCompactedEffect(session.id)
+        const allParts = allMessages.flatMap((m) => m.parts)
+        const completedBashParts = allParts.filter(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "bash" && part.state.status === "completed",
+        )
+        const blockParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.tool === "bash" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "block",
+        )
+        const stopParts = allParts.filter(
+          (part): part is ErrorToolPart =>
+            part.type === "tool" &&
+            part.tool === "bash" &&
+            part.state.status === "error" &&
+            part.state.metadata?.diagnostics?.loop?.loopAction === "stop",
+        )
+
+        expect(completedBashParts).toHaveLength(3)
+        expect(blockParts).toHaveLength(1)
+        expect(stopParts).toHaveLength(1)
+        for (const part of completedBashParts) {
+          expect(part.state.metadata?.diagnostics?.loop?.inputHash).toBeString()
+          expect(part.state.metadata?.diagnostics?.loop?.outputHash).toBeString()
+          expect(part.state.metadata?.output).toContain("stable")
+          expect(part.state.metadata?.exit).toBe(0)
+          expect(part.state.metadata?.description).toBe("print stable output")
+          expect(part.state.metadata?.truncated).toBe(false)
+        }
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.outcome).toBe("success")
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopCompletedCount).toBe(3)
+        expect(stopParts[0].state.metadata?.diagnostics?.loop?.loopOccurrenceCount).toBe(5)
+        expect(result.parts.some((part) => part.type === "text" && part.text.includes("stopped the repetition"))).toBe(
+          true,
+        )
+        expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(false)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop gate allows successful read calls for different ranges of the same file", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
## Summary

- Preserve existing harness diagnostics when tools update running tool metadata.
- Add regression coverage for repeated successful Bash calls after Bash output metadata updates.

## Why

Bash updates `state.metadata` while it streams output. That replaced the loop diagnostics attached on `tool-call`, so successful repeated Bash commands were invisible to the loop gate. In the #489 export, the same `git diff` command ran 39 times without the expected reminder, block, or stop.

This fixes the shared `Tool.Context.metadata` boundary instead of special-casing Bash, so tool-owned display metadata and harness-owned diagnostics can coexist.

## Related Issue

Closes #489

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- The metadata merge order in `SessionPrompt`: new tool metadata such as Bash output should still update, while `diagnostics.loop` and `diagnostics.failure` remain intact.
- The new regression test proves repeated successful Bash exact-input calls hit the existing 3/4/5 loop gate.
- No Bash execution, permission, timeout, truncation, or loop threshold behavior changed.

## Risk Notes

Low implementation risk, but the touched boundary is shared by tools that call `ctx.metadata()`. The focused tests cover Bash streaming metadata plus existing diagnostics, loop-gate, and Bash behavior.

## How To Verify

```text
Red test before fix: bun test test/session/prompt-effect.test.ts --test-name-pattern "loop gate stops repeated successful bash calls after metadata updates" failed with 5 completed Bash parts instead of 3.
Focused regression after fix: same command passed, 1 test, 27 expect calls.
Focused tests: bun test test/session/prompt-effect.test.ts test/session/diagnostics.test.ts test/session/loop-gate.test.ts test/tool/bash.test.ts: 129 passed, 0 failed.
Typecheck: bun run typecheck in packages/opencode passed.
Diff check: git diff --check had no output.
```

## Screenshots or Recordings

Not applicable. This is session harness behavior with no visible UI layout change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
