### PR TITLE
fix(windows): canonicalize permission path variants

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -258,7 +258,7 @@ export namespace AppFileSystem {
     if (!isRootedDriveless(p)) return
     const suffix = p.replace(/^[\\/]+/, "").replaceAll("/", "\\")
     const matches: string[] = []
-    for (const root of options.driveRoots ?? windowsDriveRoots()) {
+    for (const root of uniqueWindowsDriveRoots(options.driveRoots ?? windowsDriveRoots())) {
       const candidate = win32.join(root, suffix)
       if ((options.exists ?? existsSync)(candidate)) matches.push(candidate)
     }
@@ -266,6 +266,19 @@ export namespace AppFileSystem {
       throw new Error(`Ambiguous Windows path ${p}; use a drive-qualified path.`)
     }
     return matches[0]
+  }
+
+  function uniqueWindowsDriveRoots(roots: string[]): string[] {
+    const result: string[] = []
+    const seen = new Set<string>()
+    for (const root of roots) {
+      const normalized = uppercaseDriveRoot(win32.normalize(root))
+      const key = normalized.toUpperCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      result.push(normalized)
+    }
+    return result
   }
 
   function isRootedDriveless(p: string): boolean {

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -217,6 +217,10 @@ export namespace AppFileSystem {
 
   export function windowsPath(path: string): string {
     if (process.platform !== "win32") return path
+    return normalizeWindowsShellInput(path)
+  }
+
+  function normalizeWindowsShellInput(path: string): string {
     return path
       .replace(/^\/([a-zA-Z]):(?:[\\/]|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
       .replace(/^\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
@@ -237,19 +241,11 @@ export namespace AppFileSystem {
   // existing file; if none match, bind future targets to the explicit base
   // drive when one is available.
   export function normalizeWindowsPath(path: string, options: WindowsPathOptions = {}): string {
-    const p = stripExtendedLengthPrefix(windowsPathInput(path))
+    const p = stripExtendedLengthPrefix(normalizeWindowsShellInput(path))
     const existing = resolveRootedWindowsVariant(p, options)
     if (existing) return uppercaseDriveRoot(win32.normalize(existing))
     if (isRootedDriveless(p) && options.base) return uppercaseDriveRoot(win32.resolve(options.base, p))
     return uppercaseDriveRoot(win32.normalize(win32.resolve(p)))
-  }
-
-  function windowsPathInput(path: string): string {
-    return path
-      .replace(/^\/([a-zA-Z]):(?:[\\/]|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-      .replace(/^\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-      .replace(/^\/cygdrive\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
-      .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
   }
 
   function stripExtendedLengthPrefix(path: string): string {

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -186,9 +186,9 @@ export namespace AppFileSystem {
     return lookup(path) || "application/octet-stream"
   }
 
-  export function normalizePath(path: string): string {
+  export function normalizePath(path: string, options?: WindowsPathOptions): string {
     if (process.platform !== "win32") return path
-    const resolved = normalizeWindowsAbsolutePath(windowsPath(path))
+    const resolved = normalizeWindowsPath(path, options)
     try {
       return realpathSync.native(resolved)
     } catch {
@@ -196,18 +196,17 @@ export namespace AppFileSystem {
     }
   }
 
-  export function normalizePathPattern(path: string): string {
+  export function normalizePathPattern(path: string, options?: WindowsPathOptions): string {
     if (process.platform !== "win32") return path
     if (path === "*") return path
     const match = path.match(/^(.*)[\\/]\*$/)
-    if (!match) return normalizePath(path)
+    if (!match) return normalizePath(path, options)
     const dir = /^[A-Za-z]:$/.test(match[1]) ? match[1] + "\\" : match[1]
-    return join(normalizePath(dir), "*")
+    return join(normalizePath(dir, options), "*")
   }
 
-  export function resolve(path: string): string {
-    const resolved =
-      process.platform === "win32" ? normalizeWindowsAbsolutePath(windowsPath(path)) : pathResolve(path)
+  export function resolve(path: string, options?: WindowsPathOptions): string {
+    const resolved = process.platform === "win32" ? normalizeWindowsPath(path, options) : pathResolve(path)
     try {
       return normalizePath(realpathSync(resolved))
     } catch (error: any) {
@@ -225,28 +224,60 @@ export namespace AppFileSystem {
       .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
   }
 
+  export type WindowsPathOptions = {
+    base?: string
+    driveRoots?: string[]
+    exists?: (path: string) => boolean
+  }
+
   // Rooted but driveless paths (e.g. "/users/runner/...") arrive when callers
   // strip the drive letter before handing the path back. path.resolve would
   // bind such a path to the cwd's drive, which silently mismatches when the
-  // file actually lives on a different drive. Probe each known drive root for
-  // an existing file and fall back to win32.resolve only when none match.
-  //
-  // Important: this only repairs *existing* rooted-driveless paths. Targets
-  // that have not been created yet (e.g. write destinations) still fall back
-  // to the cwd-drive answer that win32.resolve produces. Callers that need
-  // a stable drive for a future path should pre-resolve via the project root.
-  function normalizeWindowsAbsolutePath(p: string): string {
-    const existing = resolveRootedWindowsVariant(p)
-    return win32.normalize(existing ?? win32.resolve(p))
+  // file actually lives on a different drive. Probe known drive roots for an
+  // existing file; if none match, bind future targets to the explicit base
+  // drive when one is available.
+  export function normalizeWindowsPath(path: string, options: WindowsPathOptions = {}): string {
+    const p = stripExtendedLengthPrefix(windowsPathInput(path))
+    const existing = resolveRootedWindowsVariant(p, options)
+    if (existing) return uppercaseDriveRoot(win32.normalize(existing))
+    if (isRootedDriveless(p) && options.base) return uppercaseDriveRoot(win32.resolve(options.base, p))
+    return uppercaseDriveRoot(win32.normalize(win32.resolve(p)))
   }
 
-  function resolveRootedWindowsVariant(p: string): string | undefined {
-    if (!/^[\\/](?![\\/])/.test(p)) return
+  function windowsPathInput(path: string): string {
+    return path
+      .replace(/^\/([a-zA-Z]):(?:[\\/]|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
+      .replace(/^\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
+      .replace(/^\/cygdrive\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
+      .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
+  }
+
+  function stripExtendedLengthPrefix(path: string): string {
+    if (/^\\\\\?\\UNC\\/i.test(path)) return path.replace(/^\\\\\?\\UNC\\/i, "\\\\")
+    if (/^\\\\\?\\[A-Za-z]:\\/i.test(path)) return path.slice(4)
+    return path
+  }
+
+  function resolveRootedWindowsVariant(p: string, options: WindowsPathOptions): string | undefined {
+    if (!isRootedDriveless(p)) return
     const suffix = p.replace(/^[\\/]+/, "").replaceAll("/", "\\")
-    for (const root of windowsDriveRoots()) {
+    const matches: string[] = []
+    for (const root of options.driveRoots ?? windowsDriveRoots()) {
       const candidate = win32.join(root, suffix)
-      if (existsSync(candidate)) return candidate
+      if ((options.exists ?? existsSync)(candidate)) matches.push(candidate)
     }
+    if (matches.length > 1) {
+      throw new Error(`Ambiguous Windows path ${p}; use a drive-qualified path.`)
+    }
+    return matches[0]
+  }
+
+  function isRootedDriveless(p: string): boolean {
+    return /^[\\/](?![\\/])/.test(p)
+  }
+
+  function uppercaseDriveRoot(path: string): string {
+    return path.replace(/^([a-z]):/, (_, drive) => `${drive.toUpperCase()}:`)
   }
 
   function windowsDriveRoots(): string[] {

--- a/packages/core/test/filesystem/normalize-path.test.ts
+++ b/packages/core/test/filesystem/normalize-path.test.ts
@@ -14,6 +14,50 @@ test("normalizePath is identity on non-Windows", () => {
   expect(AppFileSystem.normalizePath(p)).toBe(p)
 })
 
+function withWin32Platform(fn: () => void) {
+  const original = process.platform
+  Object.defineProperty(process, "platform", { value: "win32" })
+  try {
+    fn()
+  } finally {
+    Object.defineProperty(process, "platform", { value: original })
+  }
+}
+
+test("normalizePath folds extended-length drive paths on Windows", () => {
+  withWin32Platform(() => {
+    expect(AppFileSystem.normalizePath("\\\\?\\D:\\Users\\Ada\\file.txt")).toBe("D:\\Users\\Ada\\file.txt")
+  })
+})
+
+test("normalizePath folds extended-length UNC paths on Windows", () => {
+  withWin32Platform(() => {
+    expect(AppFileSystem.normalizePath("\\\\?\\UNC\\server\\share\\dir\\file.txt")).toBe(
+      "\\\\server\\share\\dir\\file.txt",
+    )
+  })
+})
+
+test("normalizeWindowsPath resolves non-existing rooted-driveless paths from an explicit base drive", () => {
+  expect(AppFileSystem.normalizeWindowsPath("\\future\\file.txt", { base: "D:\\project\\work" })).toBe(
+    "D:\\future\\file.txt",
+  )
+})
+
+test("normalizeWindowsPath uppercases drive letters for non-existing drive-qualified paths", () => {
+  expect(AppFileSystem.normalizeWindowsPath("d:\\future\\file.txt")).toBe("D:\\future\\file.txt")
+})
+
+test("normalizeWindowsPath rejects ambiguous rooted-driveless existing paths", () => {
+  expect(() =>
+    AppFileSystem.normalizeWindowsPath("\\shared\\file.txt", {
+      driveRoots: ["C:\\", "D:\\"],
+      exists: (candidate) =>
+        candidate.toLowerCase() === "c:\\shared\\file.txt" || candidate.toLowerCase() === "d:\\shared\\file.txt",
+    }),
+  ).toThrow("Ambiguous Windows path")
+})
+
 test.skipIf(process.platform !== "win32")(
   "normalizePath probes drive roots for rooted-but-driveless paths to existing files",
   () => {

--- a/packages/core/test/filesystem/normalize-path.test.ts
+++ b/packages/core/test/filesystem/normalize-path.test.ts
@@ -15,12 +15,12 @@ test("normalizePath is identity on non-Windows", () => {
 })
 
 function withWin32Platform(fn: () => void) {
-  const original = process.platform
-  Object.defineProperty(process, "platform", { value: "win32" })
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform")
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true })
   try {
     fn()
   } finally {
-    Object.defineProperty(process, "platform", { value: original })
+    if (descriptor) Object.defineProperty(process, "platform", descriptor)
   }
 }
 
@@ -56,6 +56,15 @@ test("normalizeWindowsPath rejects ambiguous rooted-driveless existing paths", (
         candidate.toLowerCase() === "c:\\shared\\file.txt" || candidate.toLowerCase() === "d:\\shared\\file.txt",
     }),
   ).toThrow("Ambiguous Windows path")
+})
+
+test("normalizeWindowsPath de-duplicates caller-supplied drive roots before ambiguity checks", () => {
+  expect(
+    AppFileSystem.normalizeWindowsPath("\\shared\\file.txt", {
+      driveRoots: ["C:\\", "c:\\"],
+      exists: (candidate) => candidate.toLowerCase() === "c:\\shared\\file.txt",
+    }),
+  ).toBe("C:\\shared\\file.txt")
 })
 
 test.skipIf(process.platform !== "win32")(

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -99,8 +99,8 @@ export const ApplyPatchTool = Tool.define(
       let totalDiff = ""
 
       for (const hunk of hunks) {
-        const filePath = path.resolve(Instance.directory, hunk.path)
-        yield* assertExternalDirectoryEffect(ctx, filePath)
+        const rawFilePath = path.resolve(Instance.directory, hunk.path)
+        const filePath = (yield* assertExternalDirectoryEffect(ctx, rawFilePath)) ?? rawFilePath
 
         switch (hunk.type) {
           case "add": {
@@ -172,8 +172,10 @@ export const ApplyPatchTool = Tool.define(
               if (change.removed) deletions += change.count || 0
             }
 
-            const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
-            yield* assertExternalDirectoryEffect(ctx, movePath)
+            const rawMovePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
+            const movePath = rawMovePath
+              ? ((yield* assertExternalDirectoryEffect(ctx, rawMovePath)) ?? rawMovePath)
+              : undefined
             const moveBefore = movePath
               ? yield* Bom.readFile(afs, movePath).pipe(Effect.catchIf(notFound, () => Effect.succeed(undefined)))
               : undefined

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -79,10 +79,10 @@ export const EditTool = Tool.define(
             throw new Error("No changes to apply: oldString and newString are identical.")
           }
 
-          const filePath = path.isAbsolute(params.filePath)
+          const rawFilePath = path.isAbsolute(params.filePath)
             ? params.filePath
             : path.join(Instance.directory, params.filePath)
-          yield* assertExternalDirectoryEffect(ctx, filePath)
+          const filePath = (yield* assertExternalDirectoryEffect(ctx, rawFilePath)) ?? rawFilePath
           const relativeFilePath = path.relative(Instance.worktree, filePath)
 
           let diff = ""

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -20,17 +20,16 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
 ) {
   if (!target) return
 
-  if (options?.bypass) return
-
   const ins = yield* InstanceState.context
-  const full = process.platform === "win32" ? AppFileSystem.normalizePath(target) : target
-  if (Instance.containsPath(full, ins)) return
+  const full = process.platform === "win32" ? AppFileSystem.normalizePath(target, { base: ins.directory }) : target
+  if (options?.bypass) return full
+  if (Instance.containsPath(full, ins)) return full
 
   const kind = options?.kind ?? "file"
   const dir = kind === "directory" ? full : path.dirname(full)
   const glob =
     process.platform === "win32"
-      ? AppFileSystem.normalizePathPattern(path.join(dir, "*"))
+      ? AppFileSystem.normalizePathPattern(path.join(dir, "*"), { base: ins.directory })
       : path.join(dir, "*").replaceAll("\\", "/")
 
   yield* ctx.ask({
@@ -42,6 +41,7 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
       parentDir: dir,
     },
   })
+  return full
 })
 
 export async function assertExternalDirectory(ctx: Tool.Context, target?: string, options?: Options) {

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -39,11 +39,12 @@ export const GlobTool = Tool.define(
 
           let search = params.path ?? ins.directory
           search = path.isAbsolute(search) ? search : path.resolve(ins.directory, search)
+          if (process.platform === "win32") search = AppFileSystem.normalizePath(search, { base: ins.directory })
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
           if (info?.type === "File") {
             throw new Error(`glob path must be a directory: ${search}`)
           }
-          yield* assertExternalDirectoryEffect(ctx, search, { kind: "directory" })
+          search = (yield* assertExternalDirectoryEffect(ctx, search, { kind: "directory" })) ?? search
 
           const limit = 100
           let truncated = false

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -52,18 +52,19 @@ export const GrepTool = Tool.define(
           })
 
           const ins = yield* InstanceState.context
-          const search = AppFileSystem.resolve(
+          let search = AppFileSystem.resolve(
             path.isAbsolute(params.path ?? ins.directory)
               ? (params.path ?? ins.directory)
               : path.join(ins.directory, params.path ?? "."),
             { base: ins.directory },
           )
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
+          search =
+            (yield* assertExternalDirectoryEffect(ctx, search, {
+              kind: info?.type === "Directory" ? "directory" : "file",
+            })) ?? search
           const cwd = info?.type === "Directory" ? search : path.dirname(search)
           const file = info?.type === "Directory" ? undefined : [path.relative(cwd, search)]
-          yield* assertExternalDirectoryEffect(ctx, search, {
-            kind: info?.type === "Directory" ? "directory" : "file",
-          })
 
           const result = yield* rg.search({
             cwd,

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -56,6 +56,7 @@ export const GrepTool = Tool.define(
             path.isAbsolute(params.path ?? ins.directory)
               ? (params.path ?? ins.directory)
               : path.join(ins.directory, params.path ?? "."),
+            { base: ins.directory },
           )
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
           const cwd = info?.type === "Directory" ? search : path.dirname(search)

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -44,8 +44,8 @@ export const LspTool = Tool.define(
       parameters: Parameters,
       execute: (args: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
-          yield* assertExternalDirectoryEffect(ctx, file)
+          const rawFile = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
+          const file = (yield* assertExternalDirectoryEffect(ctx, rawFile)) ?? rawFile
           const meta =
             args.operation === "workspaceSymbol"
               ? { operation: args.operation }

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -167,7 +167,7 @@ export const ReadTool = Tool.define(
         filepath = path.resolve(Instance.directory, filepath)
       }
       if (process.platform === "win32") {
-        filepath = AppFileSystem.normalizePath(filepath)
+        filepath = AppFileSystem.normalizePath(filepath, { base: Instance.directory })
       }
       const title = path.relative(Instance.worktree, filepath)
 
@@ -178,10 +178,11 @@ export const ReadTool = Tool.define(
         ),
       )
 
-      yield* assertExternalDirectoryEffect(ctx, filepath, {
-        bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
-        kind: stat?.type === "Directory" ? "directory" : "file",
-      })
+      filepath =
+        (yield* assertExternalDirectoryEffect(ctx, filepath, {
+          bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
+          kind: stat?.type === "Directory" ? "directory" : "file",
+        })) ?? filepath
 
       yield* ctx.ask({
         permission: "read",

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -40,10 +40,10 @@ export const WriteTool = Tool.define(
       parameters: Parameters,
       execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const filepath = path.isAbsolute(params.filePath)
+          const rawFilepath = path.isAbsolute(params.filePath)
             ? params.filePath
             : path.join(Instance.directory, params.filePath)
-          yield* assertExternalDirectoryEffect(ctx, filepath)
+          const filepath = (yield* assertExternalDirectoryEffect(ctx, rawFilepath)) ?? rawFilepath
 
           const exists = yield* fs.existsSafe(filepath)
           const source = exists ? yield* Bom.readFile(fs, filepath) : { bom: false, text: "" }

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -22,6 +22,14 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
 const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
 
+function withWin32Platform(fn: () => Promise<void>) {
+  const original = process.platform
+  Object.defineProperty(process, "platform", { value: "win32" })
+  return fn().finally(() => {
+    Object.defineProperty(process, "platform", { value: original })
+  })
+}
+
 function makeCtx() {
   const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
   const ctx: Tool.Context = {
@@ -112,6 +120,24 @@ describe("tool.assertExternalDirectory", () => {
     })
 
     expect(requests.length).toBe(0)
+  })
+
+  test("returns the canonical Windows target used for permission metadata", async () => {
+    await withWin32Platform(async () => {
+      const { requests, ctx } = makeCtx()
+
+      await Instance.provide({
+        directory: "D:\\project",
+        fn: async () => {
+          const target = await assertExternalDirectory(ctx, "\\\\?\\D:\\outside\\file.txt")
+          expect(target).toBe("D:\\outside\\file.txt")
+        },
+      })
+
+      const req = requests.find((r) => r.permission === "external_directory")
+      expect(req).toBeDefined()
+      expect(req!.metadata.filepath).toBe("D:\\outside\\file.txt")
+    })
   })
 
   if (process.platform === "win32") {

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -23,10 +23,10 @@ const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
 
 function withWin32Platform(fn: () => Promise<void>) {
-  const original = process.platform
-  Object.defineProperty(process, "platform", { value: "win32" })
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform")
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true })
   return fn().finally(() => {
-    Object.defineProperty(process, "platform", { value: original })
+    if (descriptor) Object.defineProperty(process, "platform", descriptor)
   })
 }
 


### PR DESCRIPTION
## Summary

Canonicalizes the remaining Windows permission path variants for #427 correctness and makes guarded tools use the same canonical path for permission checks and actual filesystem/LSP/ripgrep operations.

Changes included:

- Add a Windows canonicalizer path that folds extended-length drive paths, extended UNC paths, rooted-but-driveless future targets with an explicit base drive, and ambiguous rooted-but-driveless existing paths.
- Return the canonical target from `assertExternalDirectoryEffect`.
- Use that canonical target across `read`, `write`, `edit`, `apply_patch`, `glob`, `grep`, and `lsp` boundaries.

## Why

#431 fixed the existing rooted-but-driveless case, but #427 still had correctness gaps where Windows path variants could produce different permission patterns or let the permission path diverge from the actual tool path. That means a user could approve one spelling with `always` and still be prompted again, or approve coverage for a path that is not the one the tool later uses.

This PR fixes the correctness portion at the path contract and tool boundary. It intentionally does not implement drive-root probe caching.

## Related Issue

Addresses the correctness portion of #427.

Does not close #427 unless the remaining drive-root probe caching follow-up is split into a separate issue.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Windows canonicalizer behavior for `\\?\D:\...`, `\\?\UNC\server\share\...`, non-existing rooted-but-driveless targets, and ambiguous multi-drive matches.
- Whether each guarded tool now uses the canonical path consistently after `assertExternalDirectoryEffect` returns.
- The intentional scope boundary: correctness only, no drive-root probe caching or cache invalidation in this PR.

## Risk Notes

- Windows-only behavior change for path normalization and external-directory permission paths.
- Ambiguous rooted-but-driveless existing paths now fail with a clear error instead of silently picking the first drive root.
- Real network UNC share behavior still needs Windows environment validation; deterministic unit tests cover prefix folding and path-contract behavior without requiring a live share.
- Drive-root probe caching remains out of scope.

## How To Verify

```text
Core filesystem tests: bun --cwd packages/core test test/filesystem/normalize-path.test.ts -> 6 pass / 7 skip / 0 fail
Tool boundary tests: bun --cwd packages/opencode test test/tool/external-directory.test.ts test/tool/read.test.ts test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/tool/glob.test.ts test/tool/grep.test.ts test/tool/lsp.test.ts -> 127 pass / 0 fail
Core typecheck: (cd packages/core && bun run typecheck) -> exit 0
Opencode typecheck: (cd packages/opencode && bun run typecheck) -> exit 0
Diff check: git diff --check -> exit 0
```

## Screenshots or Recordings

None. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cross-platform file path handling with enhanced Windows path normalization.
  * Refactored file operation tools (read, write, edit, search, patch) to better validate and resolve file paths across platforms.
  * Enhanced external directory validation with improved path resolution.

* **Tests**
  * Added comprehensive cross-platform path normalization test coverage, including extended-length and UNC path support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->