### PR TITLE
fix(opencode): close node websocket server on shutdown

### DIFF
--- a/packages/opencode/src/server/adapter.node.ts
+++ b/packages/opencode/src/server/adapter.node.ts
@@ -51,9 +51,6 @@ export const adapter: Adapter = {
                 for (const socket of upgradedSockets) {
                   socket.destroy()
                 }
-                for (const client of ws.wss.clients) {
-                  client.terminate()
-                }
               }
               const webSocketClosed = new Promise<void>((resolve, reject) => {
                 ws.wss.close((err) => {

--- a/packages/opencode/src/server/adapter.node.ts
+++ b/packages/opencode/src/server/adapter.node.ts
@@ -1,6 +1,7 @@
 import { createAdaptorServer, type ServerType } from "@hono/node-server"
 import { createNodeWebSocket } from "@hono/node-ws"
 import type { Hono } from "hono"
+import type { Socket } from "node:net"
 import type { Adapter } from "./adapter"
 
 export const adapter: Adapter = {
@@ -31,6 +32,11 @@ export const adapter: Adapter = {
           })
 
         const server = opts.port === 0 ? await start(4096).catch(() => start(0)) : await start(opts.port)
+        const upgradedSockets = new Set<Socket>()
+        server.on("upgrade", (_request, socket) => {
+          upgradedSockets.add(socket)
+          socket.once("close", () => upgradedSockets.delete(socket))
+        })
         const addr = server.address()
         if (!addr || typeof addr === "string") {
           throw new Error(`Failed to resolve server address for port ${opts.port}`)
@@ -40,13 +46,26 @@ export const adapter: Adapter = {
         return {
           port: addr.port,
           stop(close?: boolean) {
-            closing ??= new Promise((resolve, reject) => {
-              server.close((err) => {
-                if (err) {
-                  reject(err)
-                  return
+            closing ??= (async () => {
+              if (close) {
+                for (const socket of upgradedSockets) {
+                  socket.destroy()
                 }
-                resolve()
+                for (const client of ws.wss.clients) {
+                  client.terminate()
+                }
+              }
+              const webSocketClosed = new Promise<void>((resolve, reject) => {
+                ws.wss.close((err) => {
+                  if (err) reject(err)
+                  else resolve()
+                })
+              })
+              const serverClosed = new Promise<void>((resolve, reject) => {
+                server.close((err) => {
+                  if (err) reject(err)
+                  else resolve()
+                })
               })
               if (close) {
                 if ("closeAllConnections" in server && typeof server.closeAllConnections === "function") {
@@ -56,7 +75,8 @@ export const adapter: Adapter = {
                   server.closeIdleConnections()
                 }
               }
-            })
+              await Promise.all([serverClosed, webSocketClosed])
+            })()
             return closing
           },
         }

--- a/packages/opencode/test/server/adapter-node-shutdown.test.ts
+++ b/packages/opencode/test/server/adapter-node-shutdown.test.ts
@@ -30,10 +30,13 @@ describe("node server adapter shutdown", () => {
 
       try {
         await opened
+        const closed = new Promise((resolve) => {
+          socket.addEventListener("close", resolve, { once: true })
+        })
         await listener.stop(true)
-        await new Promise((resolve) => setTimeout(resolve, 50))
-        if (socket.readyState === WebSocket.OPEN) {
-          throw new Error("websocket remained open after stop(true)")
+        await closed
+        if (socket.readyState !== WebSocket.CLOSED) {
+          throw new Error("websocket was not closed after stop(true)")
         }
       } finally {
         socket.close()
@@ -48,6 +51,6 @@ describe("node server adapter shutdown", () => {
     })
 
     expect(result.code).toBe(0)
-    expect(result.stderr.toString()).not.toContain("websocket remained open after stop(true)")
+    expect(result.stderr.toString()).not.toContain("websocket was not closed after stop(true)")
   }, 10_000)
 })

--- a/packages/opencode/test/server/adapter-node-shutdown.test.ts
+++ b/packages/opencode/test/server/adapter-node-shutdown.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { adapter } from "../../src/server/adapter.node"
+
+describe("node server adapter shutdown", () => {
+  test("stop(true) closes upgraded websocket clients", async () => {
+    const app = new Hono()
+    const runtime = adapter.create(app)
+
+    app.get(
+      "/ws",
+      runtime.upgradeWebSocket(() => ({
+        onOpen(_event, ws) {
+          ws.send("ready")
+        },
+      })),
+    )
+
+    const listener = await runtime.listen({ port: 0, hostname: "127.0.0.1" })
+    const socket = new WebSocket(`ws://127.0.0.1:${listener.port}/ws`)
+    const opened = new Promise<void>((resolve, reject) => {
+      socket.addEventListener("message", (event) => {
+        if (event.data === "ready") resolve()
+      })
+      socket.addEventListener("error", () => reject(new Error("websocket failed to open")), { once: true })
+    })
+
+    try {
+      await opened
+      await listener.stop(true)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(socket.readyState).not.toBe(WebSocket.OPEN)
+    } finally {
+      socket.close()
+      await listener.stop(true)
+    }
+  })
+})

--- a/packages/opencode/test/server/adapter-node-shutdown.test.ts
+++ b/packages/opencode/test/server/adapter-node-shutdown.test.ts
@@ -1,39 +1,53 @@
 import { describe, expect, test } from "bun:test"
-import { Hono } from "hono"
-import { adapter } from "../../src/server/adapter.node"
+import { Process } from "../../src/util/process"
 
 describe("node server adapter shutdown", () => {
   test("stop(true) closes upgraded websocket clients", async () => {
-    const app = new Hono()
-    const runtime = adapter.create(app)
+    const script = `
+      import { Hono } from "hono"
+      import { adapter } from "./src/server/adapter.node.ts"
 
-    app.get(
-      "/ws",
-      runtime.upgradeWebSocket(() => ({
-        onOpen(_event, ws) {
-          ws.send("ready")
-        },
-      })),
-    )
+      const app = new Hono()
+      const runtime = adapter.create(app)
 
-    const listener = await runtime.listen({ port: 0, hostname: "127.0.0.1" })
-    const socket = new WebSocket(`ws://127.0.0.1:${listener.port}/ws`)
-    const opened = new Promise<void>((resolve, reject) => {
-      socket.addEventListener("message", (event) => {
-        if (event.data === "ready") resolve()
+      app.get(
+        "/ws",
+        runtime.upgradeWebSocket(() => ({
+          onOpen(_event, ws) {
+            ws.send("ready")
+          },
+        })),
+      )
+
+      const listener = await runtime.listen({ port: 0, hostname: "127.0.0.1" })
+      const socket = new WebSocket(\`ws://127.0.0.1:\${listener.port}/ws\`)
+      const opened = new Promise((resolve, reject) => {
+        socket.addEventListener("message", (event) => {
+          if (event.data === "ready") resolve()
+        })
+        socket.addEventListener("error", () => reject(new Error("websocket failed to open")), { once: true })
       })
-      socket.addEventListener("error", () => reject(new Error("websocket failed to open")), { once: true })
+
+      try {
+        await opened
+        await listener.stop(true)
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        if (socket.readyState === WebSocket.OPEN) {
+          throw new Error("websocket remained open after stop(true)")
+        }
+      } finally {
+        socket.close()
+        await listener.stop(true)
+      }
+    `
+
+    const result = await Process.run([process.execPath, "--conditions=node", "--eval", script], {
+      cwd: import.meta.dir + "/../..",
+      nothrow: true,
+      timeout: 5_000,
     })
 
-    try {
-      await opened
-      await listener.stop(true)
-
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      expect(socket.readyState).not.toBe(WebSocket.OPEN)
-    } finally {
-      socket.close()
-      await listener.stop(true)
-    }
-  })
+    expect(result.code).toBe(0)
+    expect(result.stderr.toString()).not.toContain("websocket remained open after stop(true)")
+  }, 10_000)
 })


### PR DESCRIPTION
## Summary

- Track Node HTTP upgraded sockets in the Node server adapter.
- Make `stop(true)` force-close upgraded sockets and `@hono/node-ws` clients before waiting for HTTP and WebSocket server shutdown.
- Add a focused regression test for `stop(true)` closing upgraded WebSocket clients.

## Why

Windows advisory CI is failing #492 in `built-node-skill-bootstrap` after `/agent` and `/command` already return 200. The failure happens during child process teardown with `src\win\async.c` assertion output.

The Node adapter already injected WebSocket support, but its shutdown path only closed the HTTP server and HTTP connections. Node does not close upgraded sockets via `closeAllConnections()`, so `stop(true)` could hang or leave upgraded resources alive.

## Related Issue

Closes #492

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Whether `stop(true)` force-close semantics are correct for upgraded/WebSocket sockets.
- Whether the new test covers the shutdown gap without weakening the built Node bootstrap test.
- Whether the PR stays scoped to #492 and avoids unrelated Windows advisory changes.

## Risk Notes

`stop(true)` is now more forceful for Node WebSocket clients. That matches the existing forced shutdown intent, but reviewers should check that graceful `stop()` behavior remains acceptable.

## How To Verify

```text
Dependency install: bun install --frozen-lockfile completed in this worktree.
Regression red: adapter-node-shutdown test timed out before the adapter fix because stop(true) did not close the upgraded WebSocket.
Focused regression: bun --cwd packages/opencode test test/server/adapter-node-shutdown.test.ts --timeout 30000 -> 1 pass, 0 fail.
Built Node bootstrap: bun --cwd packages/opencode test test/server/built-node-skill-bootstrap.test.ts --timeout 60000 -> 1 pass, 0 fail.
Server suite: bun --cwd packages/opencode test test/server --timeout 30000 -> 98 pass, 0 fail.
Typecheck: bun --cwd packages/opencode typecheck -> exit 0.
Windows confirmation: pending GitHub Actions, because #492 requires Windows Node 24 behavior to be confirmed in CI.
```

## Screenshots or Recordings

Not applicable, no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English