### PR TITLE
fix: keep long sessions pinned after submit

### DIFF
--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -109,6 +109,21 @@ async function scrollTimelineToBottom(page: Page) {
   expect(found, "session timeline viewport should exist").toBe(true)
 }
 
+async function resetTimelineToTop(page: Page) {
+  const found = await page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.scrollTop = 0
+      viewport.dispatchEvent(new Event("scroll", { bubbles: true }))
+      return true
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+  expect(found, "session timeline viewport should exist").toBe(true)
+}
+
 async function sendVisiblePrompt(input: { page: Page; text: string }) {
   const prompt = input.page.locator(promptSelector)
   await expect(prompt).toBeVisible()
@@ -143,21 +158,24 @@ test("captures renderer diagnostics while guarding send scroll position", async 
       .locator(sessionMessageItemSelector)
       .last()
       .evaluate((item) => (item instanceof HTMLElement ? item.dataset.messageId : null))
-    const metricsBefore = await expectTimelineMetrics(page)
-    const beforeCount = await page.locator(sessionMessageItemSelector).count()
-
-    await sendVisiblePrompt({ page, text: `diagnostics guard ${Date.now()}` })
-    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(beforeCount + 1, { timeout: 30_000 })
+    const promptText = `diagnostics guard ${Date.now()}`
+    await sendVisiblePrompt({ page, text: promptText })
+    await expect(page.locator(sessionMessageItemSelector).last()).toContainText(promptText, { timeout: 30_000 })
+    await resetTimelineToTop(page)
     await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(80)
 
     const metricsAfter = await expectTimelineMetrics(page)
-    const scrollAnchorAfter = await page
-      .locator(sessionMessageItemSelector)
-      .nth(beforeCount - 1)
-      .evaluate((item) => (item instanceof HTMLElement ? item.dataset.messageId : null))
+    const scrollAnchorAfter = await page.locator(sessionTurnListSelector).evaluate((list, id) => {
+      if (!(list instanceof HTMLElement) || !id) return null
+      return Array.from(list.querySelectorAll("[data-message-id]")).some(
+        (item) => item instanceof HTMLElement && item.dataset.messageId === id,
+      )
+        ? id
+        : null
+    }, scrollAnchorBefore)
     expect(scrollAnchorBefore).not.toBeNull()
     expect(scrollAnchorAfter).toBe(scrollAnchorBefore)
-    expect(Math.abs(metricsAfter.top - metricsBefore.top)).toBeLessThan(200)
+    expect(metricsAfter.distanceFromBottom).toBeLessThan(80)
 
     const events = await readRendererDiagnostics(page)
     expect(events.some((event) => event.name === "session.action.submit")).toBe(true)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -627,7 +627,7 @@ export default function Page() {
       setScrollRef={setScrollRef}
       scheduleScrollState={scheduleScrollState}
       autoScroll={autoScroll}
-      markScrollGesture={activeMessage.markScrollGesture}
+      markScrollGesture={timelineInteraction.markScrollGesture}
       hasScrollGesture={activeMessage.hasScrollGesture}
       markUserScroll={activeMessage.markUserScroll}
       historyWindow={historyWindow}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -398,13 +398,13 @@ export default function Page() {
     dialogActive: () => !!dialog.active,
     inputRef: () => inputRef,
     isChildSession: timelineIsChildSession,
-    markScrollGesture: activeMessage.markScrollGesture,
+    markScrollGesture: timelineInteraction.markScrollGesture,
     terminalActive: terminal.active,
     terminalOpened: () => view().terminal.opened(),
   })
 
   useSessionCommands({
-    navigateMessageByOffset: activeMessage.navigateMessageByOffset,
+    navigateMessageByOffset: timelineInteraction.navigateMessageByOffset,
     setActiveMessage: activeMessage.setActiveMessage,
     focusInput,
     review: reviewTab,

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -29,4 +29,18 @@ describe("useSessionHashScroll", () => {
     expect(source).toContain("onMessageHashCleared")
     expect(source).toContain("historyWindow.clearHashTarget()")
   })
+
+  test("timeline cancels bottom follow before hash or active-message navigation", async () => {
+    const hashSource = await Bun.file(new URL("./use-session-hash-scroll.ts", import.meta.url)).text()
+    const timelineSource = await Bun.file(new URL("./use-session-timeline-interaction.ts", import.meta.url)).text()
+    const sessionSource = await Bun.file(new URL("../session.tsx", import.meta.url)).text()
+
+    expect(hashSource).toContain("onMessageNavigation")
+    expect(hashSource).toContain("input.onMessageNavigation?.()")
+    expect(timelineSource).toContain("onMessageNavigation: scrollDock.cancelBottomFollowLock")
+    expect(timelineSource).toContain("const navigateMessageByOffset")
+    expect(timelineSource).toContain("scrollDock.cancelBottomFollowLock()")
+    expect(sessionSource).toContain("markScrollGesture: timelineInteraction.markScrollGesture")
+    expect(sessionSource).toContain("navigateMessageByOffset: timelineInteraction.navigateMessageByOffset")
+  })
 })

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -22,6 +22,7 @@ export const useSessionHashScroll = (input: {
   anchor: (id: string) => string
   scheduleScrollState: (el: HTMLDivElement) => void
   consumePendingMessage: (key: string) => string | undefined
+  onMessageNavigation?: () => void
   onMessageHashCleared?: () => void
 }) => {
   const visibleUserMessages = createMemo(() => input.visibleUserMessages())
@@ -90,6 +91,7 @@ export const useSessionHashScroll = (input: {
 
   const scrollToMessage = (message: UserMessage, behavior: ScrollBehavior = "smooth") => {
     cancel()
+    input.onMessageNavigation?.()
     if (input.currentMessageId() !== message.id) input.setActiveMessage(message)
 
     const index = messageIndex().get(message.id) ?? -1
@@ -122,6 +124,7 @@ export const useSessionHashScroll = (input: {
 
     const messageId = messageIdFromHash(hash)
     if (messageId) {
+      input.onMessageNavigation?.()
       input.autoScroll.pause()
       const msg = messageById().get(messageId)
       if (msg) {
@@ -133,6 +136,7 @@ export const useSessionHashScroll = (input: {
 
     const target = document.getElementById(hash)
     if (target) {
+      input.onMessageNavigation?.()
       input.autoScroll.pause()
       scrollToElement(target, behavior)
       return

--- a/packages/app/src/pages/session/use-session-scroll-dock.test.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.test.ts
@@ -364,4 +364,33 @@ describe("session scroll dock", () => {
       dispose()
     })
   })
+
+  test("does not restore or clear hash when the lock belongs to another session", () => {
+    createRoot((dispose) => {
+      const scroller = makeScroller({
+        clientHeight: 400,
+        scrollHeight: 1000,
+        scrollTop: 600,
+      })
+      let clearedHash = 0
+      const scrollDock = createSessionScrollDock({
+        clearMessageHash: () => {
+          clearedHash += 1
+        },
+        clearActiveMessage: () => undefined,
+        fill: () => undefined,
+      })
+
+      scrollDock.setScrollRef(scroller.el)
+      scrollDock.resumeScroll("session-a")
+      scroller.el.scrollTop = 0
+
+      expect(scrollDock.restoreBottomIfLocked("session-b")).toBe(false)
+      expect(scroller.top).toBe(0)
+      expect(clearedHash).toBe(1)
+      expect(scrollDock.bottomFollowLocked("session-a")).toBe(false)
+
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/pages/session/use-session-scroll-dock.test.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.test.ts
@@ -291,4 +291,77 @@ describe("session scroll dock", () => {
       })
     })
   })
+
+  test("restores a submit-time browser reset while bottom follow is locked", () => {
+    createRoot((dispose) => {
+      const scroller = makeScroller({
+        clientHeight: 400,
+        scrollHeight: 1000,
+        scrollTop: 600,
+      })
+      const scrollDock = createSessionScrollDock({
+        clearMessageHash: () => undefined,
+        clearActiveMessage: () => undefined,
+        fill: () => undefined,
+      })
+
+      scrollDock.setScrollRef(scroller.el)
+      scrollDock.resumeScroll()
+      scroller.el.scrollTop = 0
+
+      expect(scrollDock.restoreBottomIfLocked()).toBe(true)
+      expect(scroller.top).toBe(1000)
+
+      dispose()
+    })
+  })
+
+  test("repairs a locked reset before the next scroll state sample", () => {
+    createRoot((dispose) => {
+      const scroller = makeScroller({
+        clientHeight: 400,
+        scrollHeight: 1000,
+        scrollTop: 600,
+      })
+      const scrollDock = createSessionScrollDock({
+        clearMessageHash: () => undefined,
+        clearActiveMessage: () => undefined,
+        fill: () => undefined,
+      })
+
+      scrollDock.setScrollRef(scroller.el)
+      scrollDock.resumeScroll()
+      scroller.el.scrollTop = 0
+      scrollDock.scheduleScrollState(scroller.el)
+
+      expect(scroller.top).toBe(1000)
+
+      dispose()
+    })
+  })
+
+  test("does not restore after a real scroll gesture cancels the bottom follow lock", () => {
+    createRoot((dispose) => {
+      const scroller = makeScroller({
+        clientHeight: 400,
+        scrollHeight: 1000,
+        scrollTop: 600,
+      })
+      const scrollDock = createSessionScrollDock({
+        clearMessageHash: () => undefined,
+        clearActiveMessage: () => undefined,
+        fill: () => undefined,
+      })
+
+      scrollDock.setScrollRef(scroller.el)
+      scrollDock.resumeScroll()
+      scrollDock.cancelBottomFollowLock()
+      scroller.el.scrollTop = 0
+
+      expect(scrollDock.restoreBottomIfLocked()).toBe(false)
+      expect(scroller.top).toBe(0)
+
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -107,6 +107,7 @@ export function createSessionScrollDock(input: {
   let scrollStateFrame: number | undefined
   let scrollStateTarget: HTMLDivElement | undefined
   let bottomFollowLockTimer: ReturnType<typeof setTimeout> | undefined
+  let bottomFollowLockOwner: string | undefined
   const [bottomFollowLocked, setBottomFollowLocked] = createSignal(false)
 
   const cancelBottomFollowLock = () => {
@@ -115,15 +116,25 @@ export function createSessionScrollDock(input: {
       bottomFollowLockTimer = undefined
     }
     setBottomFollowLocked(false)
+    bottomFollowLockOwner = undefined
   }
 
-  const armBottomFollowLock = () => {
+  const armBottomFollowLock = (owner?: string) => {
     if (bottomFollowLockTimer !== undefined) clearTimeout(bottomFollowLockTimer)
+    bottomFollowLockOwner = owner
     setBottomFollowLocked(true)
-    bottomFollowLockTimer = setTimeout(() => {
-      bottomFollowLockTimer = undefined
-      setBottomFollowLocked(false)
-    }, 3_000)
+    bottomFollowLockTimer = setTimeout(cancelBottomFollowLock, 3_000)
+  }
+
+  const bottomFollowLockedFor = (owner?: string) => {
+    if (!bottomFollowLocked()) return false
+    return owner === undefined || bottomFollowLockOwner === undefined || owner === bottomFollowLockOwner
+  }
+
+  const followBottom = () => {
+    input.clearActiveMessage()
+    autoScroll.forceScrollToBottom()
+    input.clearMessageHash()
   }
 
   const updateScrollState = (el: HTMLDivElement) => {
@@ -145,9 +156,7 @@ export function createSessionScrollDock(input: {
         scrollTop: el.scrollTop,
       })
       if (next.overflow && !next.bottom) {
-        input.clearActiveMessage()
-        autoScroll.forceScrollToBottom()
-        input.clearMessageHash()
+        followBottom()
       }
     }
 
@@ -163,11 +172,12 @@ export function createSessionScrollDock(input: {
     })
   }
 
-  const restoreBottomIfLocked = () => {
-    if (!bottomFollowLocked()) return false
-    input.clearActiveMessage()
-    autoScroll.forceScrollToBottom()
-    input.clearMessageHash()
+  const restoreBottomIfLocked = (owner?: string) => {
+    if (!bottomFollowLockedFor(owner)) {
+      if (bottomFollowLocked() && owner !== undefined) cancelBottomFollowLock()
+      return false
+    }
+    followBottom()
     if (scroller) scheduleScrollState(scroller)
     return true
   }
@@ -241,9 +251,9 @@ export function createSessionScrollDock(input: {
     promptDockObserver.observe(el)
   }
 
-  const resumeScroll = () => {
-    armBottomFollowLock()
-    restoreBottomIfLocked()
+  const resumeScroll = (owner?: string) => {
+    armBottomFollowLock(owner)
+    restoreBottomIfLocked(owner)
   }
 
   createEffect(
@@ -281,6 +291,6 @@ export function createSessionScrollDock(input: {
     armBottomFollowLock,
     restoreBottomIfLocked,
     cancelBottomFollowLock,
-    bottomFollowLocked,
+    bottomFollowLocked: bottomFollowLockedFor,
   }
 }

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -8,6 +8,8 @@ export type SessionScrollState = {
   jump: boolean
 }
 
+const BOTTOM_FOLLOW_LOCK_MS = 3_000
+
 export function calculateSessionScrollState(input: {
   clientHeight: number
   scrollHeight: number
@@ -123,7 +125,7 @@ export function createSessionScrollDock(input: {
     if (bottomFollowLockTimer !== undefined) clearTimeout(bottomFollowLockTimer)
     bottomFollowLockOwner = owner
     setBottomFollowLocked(true)
-    bottomFollowLockTimer = setTimeout(cancelBottomFollowLock, 3_000)
+    bottomFollowLockTimer = setTimeout(cancelBottomFollowLock, BOTTOM_FOLLOW_LOCK_MS)
   }
 
   const bottomFollowLockedFor = (owner?: string) => {
@@ -172,6 +174,8 @@ export function createSessionScrollDock(input: {
     })
   }
 
+  // A non-matching owner means the active lock belongs to an older session path.
+  // Cancel it before it can call followBottom or schedule another scroll sample.
   const restoreBottomIfLocked = (owner?: string) => {
     if (!bottomFollowLockedFor(owner)) {
       if (bottomFollowLocked() && owner !== undefined) cancelBottomFollowLock()

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -1,5 +1,5 @@
 import { createAutoScroll } from "@opencode-ai/ui/hooks"
-import { createEffect, on, onCleanup } from "solid-js"
+import { createEffect, createSignal, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 
 export type SessionScrollState = {
@@ -106,6 +106,25 @@ export function createSessionScrollDock(input: {
   let dockHeight = 0
   let scrollStateFrame: number | undefined
   let scrollStateTarget: HTMLDivElement | undefined
+  let bottomFollowLockTimer: ReturnType<typeof setTimeout> | undefined
+  const [bottomFollowLocked, setBottomFollowLocked] = createSignal(false)
+
+  const cancelBottomFollowLock = () => {
+    if (bottomFollowLockTimer !== undefined) {
+      clearTimeout(bottomFollowLockTimer)
+      bottomFollowLockTimer = undefined
+    }
+    setBottomFollowLocked(false)
+  }
+
+  const armBottomFollowLock = () => {
+    if (bottomFollowLockTimer !== undefined) clearTimeout(bottomFollowLockTimer)
+    setBottomFollowLocked(true)
+    bottomFollowLockTimer = setTimeout(() => {
+      bottomFollowLockTimer = undefined
+      setBottomFollowLocked(false)
+    }, 3_000)
+  }
 
   const updateScrollState = (el: HTMLDivElement) => {
     const next = calculateSessionScrollState({
@@ -119,6 +138,19 @@ export function createSessionScrollDock(input: {
   }
 
   const scheduleScrollState = (el: HTMLDivElement) => {
+    if (bottomFollowLocked()) {
+      const next = calculateSessionScrollState({
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+        scrollTop: el.scrollTop,
+      })
+      if (next.overflow && !next.bottom) {
+        input.clearActiveMessage()
+        autoScroll.forceScrollToBottom()
+        input.clearMessageHash()
+      }
+    }
+
     scrollStateTarget = el
     if (scrollStateFrame !== undefined) return
 
@@ -131,12 +163,22 @@ export function createSessionScrollDock(input: {
     })
   }
 
+  const restoreBottomIfLocked = () => {
+    if (!bottomFollowLocked()) return false
+    input.clearActiveMessage()
+    autoScroll.forceScrollToBottom()
+    input.clearMessageHash()
+    if (scroller) scheduleScrollState(scroller)
+    return true
+  }
+
   const setScrollRef = (el: HTMLDivElement | undefined) => {
     scroller = el
     autoScroll.scrollRef(el)
     if (!el) return
     scheduleScrollState(el)
     input.fill()
+    restoreBottomIfLocked()
   }
 
   const setContentRef = (el: HTMLDivElement | undefined) => {
@@ -149,6 +191,7 @@ export function createSessionScrollDock(input: {
     contentObserver = new ResizeObserver(() => {
       if (scroller) scheduleScrollState(scroller)
       input.fill()
+      restoreBottomIfLocked()
     })
     contentObserver.observe(el)
   }
@@ -199,17 +242,18 @@ export function createSessionScrollDock(input: {
   }
 
   const resumeScroll = () => {
-    input.clearActiveMessage()
-    autoScroll.forceScrollToBottom()
-    input.clearMessageHash()
-    if (scroller) scheduleScrollState(scroller)
+    armBottomFollowLock()
+    restoreBottomIfLocked()
   }
 
   createEffect(
     on(
       autoScroll.userScrolled,
       (scrolled) => {
-        if (scrolled) return
+        if (scrolled) {
+          cancelBottomFollowLock()
+          return
+        }
         input.clearActiveMessage()
         input.clearMessageHash()
       },
@@ -221,6 +265,7 @@ export function createSessionScrollDock(input: {
     contentObserver?.disconnect()
     promptDockObserver?.disconnect()
     if (scrollStateFrame !== undefined) cancelAnimationFrame(scrollStateFrame)
+    if (bottomFollowLockTimer !== undefined) clearTimeout(bottomFollowLockTimer)
     document.documentElement.style.removeProperty("--composer-dock-height")
   })
 
@@ -233,5 +278,9 @@ export function createSessionScrollDock(input: {
     setPromptDockRef,
     scheduleScrollState,
     resumeScroll,
+    armBottomFollowLock,
+    restoreBottomIfLocked,
+    cancelBottomFollowLock,
+    bottomFollowLocked,
   }
 }

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -1,4 +1,5 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
+import { createEffect, on } from "solid-js"
 import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import { createSessionActiveMessage } from "@/pages/session/use-session-active-message"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
@@ -44,6 +45,7 @@ export function createSessionTimelineInteraction(input: {
   })
   const autoScroll = scrollDock.autoScroll
   const resumeScroll = scrollDock.resumeScroll
+  const userScrolledForHistory = () => (scrollDock.bottomFollowLocked() ? false : autoScroll.userScrolled())
 
   activeMessage = createSessionActiveMessage({
     sessionKey: input.sessionKey,
@@ -62,7 +64,7 @@ export function createSessionTimelineInteraction(input: {
     historyMore: input.historyMore,
     historyLoading: input.historyLoading,
     loadMore: input.loadMore,
-    userScrolled: autoScroll.userScrolled,
+    userScrolled: userScrolledForHistory,
     isAtBottom: () => scrollDock.scroll.bottom,
     scroller: scrollDock.scroller,
   })
@@ -83,6 +85,21 @@ export function createSessionTimelineInteraction(input: {
     userScrolled: autoScroll.userScrolled,
     scroller: scrollDock.scroller,
   })
+
+  const markScrollGesture = (target?: EventTarget | null) => {
+    scrollDock.cancelBottomFollowLock()
+    activeMessage.markScrollGesture(target)
+  }
+
+  createEffect(
+    on(
+      () => [input.sessionID(), input.visibleUserMessages().at(-1)?.id, historyWindow.turnStart()] as const,
+      () => {
+        scrollDock.restoreBottomIfLocked()
+      },
+      { defer: true },
+    ),
+  )
 
   const hashScroll = useSessionHashScroll({
     sessionKey: input.sessionKey,
@@ -117,5 +134,6 @@ export function createSessionTimelineInteraction(input: {
     scheduleScrollState: scrollDock.scheduleScrollState,
     scrollDock,
     setScrollRef: scrollDock.setScrollRef,
+    markScrollGesture,
   }
 }

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -44,8 +44,9 @@ export function createSessionTimelineInteraction(input: {
     },
   })
   const autoScroll = scrollDock.autoScroll
-  const resumeScroll = scrollDock.resumeScroll
-  const userScrolledForHistory = () => (scrollDock.bottomFollowLocked() ? false : autoScroll.userScrolled())
+  const lockOwner = () => input.sessionKey()
+  const resumeScroll = () => scrollDock.resumeScroll(lockOwner())
+  const userScrolledForHistory = () => (scrollDock.bottomFollowLocked(lockOwner()) ? false : autoScroll.userScrolled())
 
   activeMessage = createSessionActiveMessage({
     sessionKey: input.sessionKey,
@@ -91,11 +92,16 @@ export function createSessionTimelineInteraction(input: {
     activeMessage.markScrollGesture(target)
   }
 
+  const navigateMessageByOffset = (offset: number) => {
+    scrollDock.cancelBottomFollowLock()
+    activeMessage.navigateMessageByOffset(offset)
+  }
+
   createEffect(
     on(
       () => [input.sessionID(), input.visibleUserMessages().at(-1)?.id, historyWindow.turnStart()] as const,
       () => {
-        scrollDock.restoreBottomIfLocked()
+        scrollDock.restoreBottomIfLocked(lockOwner())
       },
       { defer: true },
     ),
@@ -120,6 +126,7 @@ export function createSessionTimelineInteraction(input: {
     anchor,
     scheduleScrollState: scrollDock.scheduleScrollState,
     consumePendingMessage: input.consumePendingMessage,
+    onMessageNavigation: scrollDock.cancelBottomFollowLock,
     onMessageHashCleared: () => historyWindow.clearHashTarget(),
   })
   clearMessageHash = hashScroll.clearMessageHash
@@ -135,5 +142,6 @@ export function createSessionTimelineInteraction(input: {
     scrollDock,
     setScrollRef: scrollDock.setScrollRef,
     markScrollGesture,
+    navigateMessageByOffset,
   }
 }


### PR DESCRIPTION
## Summary

Keep long session timelines pinned to the latest turn after submit by adding a session-local bottom-follow lock around the submit/resume path. The lock is now scoped to the triggering session key and is cancelled by user navigation paths that intentionally leave the latest turn.

## Why

Closes #496. In long sessions, the viewport could reset near the top shortly after a user submitted from the bottom. The issue evidence showed this happened within the same session, without a remount, history load, or scroll-height change, so the fix belongs in the session timeline scroll coordination layer.

## Related Issue

Closes #496

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the bottom-follow lock lifetime, session-key scoping, real scroll gesture cancellation, and whether keyboard/hash/message navigation correctly cancels the lock without weakening the #496 reset recovery.

## Risk Notes

Main risk is over-following if a user intentionally leaves the latest turn immediately after submit. The PR cancels the lock on real timeline scroll gestures, keyboard scroll keys, message navigation, and hash navigation, and refuses owner-mismatched restores.

## How To Verify

```text
Focused unit: 41 passed via bun test --preload ./happydom.ts ./src/pages/session/use-session-scroll-dock.test.ts ./src/pages/session/use-session-hash-scroll.test.ts ./src/pages/session/use-session-history-window.test.ts ./src/pages/session/session-auto-scroll.test.ts ./src/context/renderer-diagnostics.test.ts
E2E: 1 passed via bun --cwd packages/app test:e2e -- e2e/session/session-renderer-diagnostics.spec.ts
Typecheck: ok via bun --cwd packages/app typecheck
Electron smoke: bun run dev:desktop opened the PawWork dev app to the new-session screen without startup errors
Diff check: git diff --check passed
```

## Screenshots or Recordings

No screenshot attached. Electron smoke verified the dev desktop app opens; the long-session reset behavior is covered by the deterministic E2E that forces the timeline viewport to top after submit.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for session scroll behavior, timeline interaction, and scroll restoration scenarios.

* **Refactor**
  * Improved scroll position management with enhanced locking and restoration mechanisms.
  * Enhanced message navigation and scroll gesture handling within session interactions.
  * Updated scroll behavior wiring to better coordinate timeline and session-level interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->