### PR TITLE
test(opencode): avoid Windows Node exit teardown in built harnesses

### DIFF
--- a/packages/opencode/test/server/built-node-skill-bootstrap.test.ts
+++ b/packages/opencode/test/server/built-node-skill-bootstrap.test.ts
@@ -94,19 +94,11 @@ describe("built node server skill bootstrap", () => {
         req.end()
       })
 
-      const readEndpoint = async (pathname) => {
-        const response = await request(pathname)
-        return {
-          status: response.status,
-          body: response.body,
-        }
-      }
-
       let exitCode = 0
       try {
         const result = {
-          agent: await readEndpoint("/agent"),
-          command: await readEndpoint("/command"),
+          agent: await request("/agent"),
+          command: await request("/command"),
         }
         console.log(JSON.stringify(result))
         if (result.agent.status !== 200 || result.command.status !== 200) {

--- a/packages/opencode/test/server/built-node-skill-bootstrap.test.ts
+++ b/packages/opencode/test/server/built-node-skill-bootstrap.test.ts
@@ -50,6 +50,7 @@ describe("built node server skill bootstrap", () => {
       expectModelsSnapshotUnchanged(modelsFixture)
 
       const script = `
+      import { request as httpRequest } from "node:http"
       import { Server, Log } from ${JSON.stringify(pathToFileURL(distEntry).href)}
 
       const password = process.env.OPENCODE_SERVER_PASSWORD
@@ -61,25 +62,51 @@ describe("built node server skill bootstrap", () => {
       const listener = await Server.listen({ port: 0, hostname: "127.0.0.1" })
       const auth = "Basic " + Buffer.from(\`opencode:\${password}\`).toString("base64")
 
-      const request = async (pathname) => {
+      // This test exits the child process explicitly. On Windows Node 24, fetch
+      // can abort during process.exit() handle teardown and hide the bootstrap result.
+      const request = (pathname) => new Promise((resolve, reject) => {
         const url = new URL(pathname, listener.url)
         url.searchParams.set("directory", directory)
-        const response = await fetch(url, {
-          headers: {
-            authorization: auth,
+
+        const req = httpRequest(
+          url,
+          {
+            agent: false,
+            headers: {
+              authorization: auth,
+              connection: "close",
+            },
           },
-        })
+          (response) => {
+            const chunks = []
+            response.on("data", (chunk) => chunks.push(chunk))
+            response.on("error", reject)
+            response.on("end", () => {
+              resolve({
+                status: response.statusCode ?? 0,
+                body: Buffer.concat(chunks).toString("utf8"),
+              })
+            })
+          },
+        )
+
+        req.on("error", reject)
+        req.end()
+      })
+
+      const readEndpoint = async (pathname) => {
+        const response = await request(pathname)
         return {
           status: response.status,
-          body: await response.text(),
+          body: response.body,
         }
       }
 
       let exitCode = 0
       try {
         const result = {
-          agent: await request("/agent"),
-          command: await request("/command"),
+          agent: await readEndpoint("/agent"),
+          command: await readEndpoint("/command"),
         }
         console.log(JSON.stringify(result))
         if (result.agent.status !== 200 || result.command.status !== 200) {

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -51,7 +51,9 @@ describe("built node webfetch", () => {
 
       const script = `
         import http from "node:http"
+        import https from "node:https"
         import { Effect } from "effect"
+        import { FetchHttpClient } from "effect/unstable/http"
         import { Instance, Log, ToolRegistry } from ${JSON.stringify(pathToFileURL(distEntry).href)}
 
         if (typeof HTMLRewriter !== "undefined") {
@@ -81,6 +83,49 @@ describe("built node webfetch", () => {
         const hostileHTML = \`<body>\${"<script>".repeat(50_000)}visible text</body>\`
         const rawOpenHTML = \`<body>\${"<".repeat(50_000)}\`
         const whitespaceHTML = \`<body>\${"\\r".repeat(50_000)}visible text</body>\`
+
+        // The test validates the built Node WebFetch parser path. Avoid Node
+        // 24 Windows global fetch teardown, which can abort during process.exit().
+        const nodeFetch = (input, init = {}) => new Promise((resolve, reject) => {
+          const url = new URL(input instanceof Request ? input.url : input)
+          const client = url.protocol === "https:" ? https : http
+          const headers = { ...(input instanceof Request ? Object.fromEntries(input.headers) : {}), ...(init.headers ?? {}) }
+          const req = client.request(
+            url,
+            {
+              method: init.method ?? (input instanceof Request ? input.method : "GET"),
+              headers: { ...headers, connection: "close" },
+              agent: false,
+              signal: init.signal,
+            },
+            (res) => {
+              const chunks = []
+              res.on("data", (chunk) => chunks.push(chunk))
+              res.on("error", reject)
+              res.on("end", () => {
+                const responseHeaders = new Headers()
+                for (const [key, value] of Object.entries(res.headers)) {
+                  if (Array.isArray(value)) {
+                    for (const item of value) responseHeaders.append(key, item)
+                  } else if (value !== undefined) {
+                    responseHeaders.set(key, value)
+                  }
+                }
+                resolve(
+                  new Response(Buffer.concat(chunks), {
+                    status: res.statusCode ?? 200,
+                    statusText: res.statusMessage,
+                    headers: responseHeaders,
+                  }),
+                )
+              })
+            },
+          )
+
+          req.on("error", reject)
+          if (init.signal?.aborted) req.destroy(init.signal.reason)
+          req.end(init.body)
+        })
 
         const sockets = new Set()
         const server = http.createServer((req, res) => {
@@ -128,7 +173,7 @@ describe("built node webfetch", () => {
                     metadata: () => Effect.void,
                     ask: () => Effect.void,
                   },
-                ),
+                ).pipe(Effect.provideService(FetchHttpClient.Fetch, nodeFetch)),
               )
 
               const happy = await run("/page.html")

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -89,7 +89,16 @@ describe("built node webfetch", () => {
         const nodeFetch = (input, init = {}) => new Promise((resolve, reject) => {
           const url = new URL(input instanceof Request ? input.url : input)
           const client = url.protocol === "https:" ? https : http
-          const headers = { ...(input instanceof Request ? Object.fromEntries(input.headers) : {}), ...(init.headers ?? {}) }
+          const normalizeHeaders = (headers) => {
+            if (!headers) return {}
+            if (headers instanceof Headers || Array.isArray(headers)) return Object.fromEntries(headers)
+            if (typeof headers[Symbol.iterator] === "function") return Object.fromEntries(headers)
+            return headers
+          }
+          const headers = {
+            ...(input instanceof Request ? Object.fromEntries(input.headers) : {}),
+            ...normalizeHeaders(init.headers),
+          }
           const req = client.request(
             url,
             {

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -82,8 +82,9 @@ describe("built node webfetch", () => {
         const rawOpenHTML = \`<body>\${"<".repeat(50_000)}\`
         const whitespaceHTML = \`<body>\${"\\r".repeat(50_000)}visible text</body>\`
 
+        const sockets = new Set()
         const server = http.createServer((req, res) => {
-          res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+          res.writeHead(200, { "content-type": "text/html; charset=utf-8", connection: "close" })
           res.end(
             req.url === "/hostile.html"
               ? hostileHTML
@@ -92,7 +93,11 @@ describe("built node webfetch", () => {
                 : req.url === "/whitespace.html"
                   ? whitespaceHTML
                   : happyHTML,
-          )
+            )
+        })
+        server.on("connection", (socket) => {
+          sockets.add(socket)
+          socket.on("close", () => sockets.delete(socket))
         })
 
         await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -147,8 +152,11 @@ describe("built node webfetch", () => {
 
           console.log(JSON.stringify(output))
         } finally {
+          await Instance.disposeAll()
           await new Promise((resolve, reject) => {
             server.close((error) => (error ? reject(error) : resolve()))
+            server.closeAllConnections?.()
+            for (const socket of sockets) socket.destroy()
           })
         }
 


### PR DESCRIPTION
## Summary

Updates the built Node test harnesses that were still tripping Windows Node 24 teardown assertions after #494:

- `built-node-skill-bootstrap` requests `/agent` and `/command` with `node:http` instead of Node global `fetch`, while preserving the same built artifact bootstrap and endpoint assertions.
- `built-node-webfetch` still exercises the built WebFetch tool and parser path, but closes the test-local HTTP server connections explicitly before child shutdown.
- `built-node-webfetch` injects a test-local `node:http`/`node:https` implementation for Effect's `FetchHttpClient.Fetch` reference, so the test does not trip the Windows Node 24 global fetch teardown abort after the WebFetch assertions have already succeeded.

## Why

Follow-up to #494 and #492.

After #494 merged, `dev` still failed the advisory Windows run:

- Workflow: `windows-advisory`, run `25496202877`
- Job: `unit-windows-opencode-server-tools`, job `74816526956`
- Failing test: `test/server/built-node-skill-bootstrap.test.ts`
- Observed result: child stdout showed the endpoint requests succeeded, but the child exited with code 9 after `process.exit(exitCode)`
- Windows stderr: `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76`

The first PR version fixed that bootstrap harness. A manual Windows advisory run on PR head `580534b` then proved the bootstrap test passed, but exposed the same teardown class in `built-node-webfetch`:

- Workflow: `windows-advisory`, run `25498482049`
- Job: `unit-windows-opencode-server-tools`, job `74824553484`
- `built-node-skill-bootstrap`: passed
- `built-node-webfetch`: produced the expected JSON output, then failed at `process.exit(0)` with the same `src\\win\\async.c` assertion

Closing the test-local HTTP server sockets was necessary but not sufficient. A second manual Windows advisory run on `bdac89a` still failed `built-node-webfetch` with correct stdout and the same Node 24 global fetch teardown assertion. The final fix keeps the built WebFetch tool coverage but removes Node global `fetch` from this harness.

I also tested replacing `process.exit()` with `process.exitCode`. It avoids the explicit exit, but locally leaves the built Node child alive until the test times out, so it is not a usable fix for either harness.

## Related Issue

Fixes #492

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the harness boundary. This PR intentionally avoids changing product server shutdown behavior again. It keeps the built artifact coverage intact and only makes the test child processes stop tripping the Windows Node 24 exit bug after their assertions have already succeeded.

## Risk Notes

Low product risk because this changes only tests. The main risk is test fidelity:

- `built-node-skill-bootstrap` no longer uses Node global `fetch`; that is intentional because this test is about built server bootstrap and endpoint availability, not WebFetch.
- `built-node-webfetch` still uses the built WebFetch tool and parser path; the only transport substitution is the test-local `FetchHttpClient.Fetch` implementation to avoid the Windows Node 24 global fetch teardown bug.
- `built-node-webfetch` still verifies the hostile HTML, raw `<`, whitespace, and extracted text assertions against the built artifact.

## How To Verify

```text
Focused bootstrap test after review cleanup: 1 passed
Command: bun --cwd packages/opencode test test/server/built-node-skill-bootstrap.test.ts --timeout 60000

Focused webfetch test: 1 passed
Command: bun --cwd packages/opencode test test/server/built-node-webfetch.test.ts --timeout 60000

Related built Node / adapter tests: 3 passed
Command: bun --cwd packages/opencode test test/server/built-node-skill-bootstrap.test.ts test/server/built-node-webfetch.test.ts test/server/adapter-node-shutdown.test.ts --timeout 60000

Server-tools shard local equivalent: 98 passed
Command: bun --cwd packages/opencode test --timeout 30000 test/server

Typecheck: ok
Command: bun --cwd packages/opencode typecheck

PR checks on 86d3559: all passed
Result: ci, codeql, desktop-smoke, e2e-artifacts, dependency-review, commit-lint, pr-title-lint, CodeRabbit all successful

Windows advisory manual run on 86d3559: #492 target shard passed
Run: 25501384611
Job: unit-windows-opencode-server-tools / 74835020276
Result: success

Windows advisory manual run on 86d3559: full matrix still has an unrelated setup failure
Run: 25501384611
Job: unit-windows-app / 74835020009
Result: failed in oven-sh/setup-bun before bun install or unit tests. No app unit test result was produced. Other Windows advisory jobs, including unit-windows-opencode-session and unit-windows-opencode-server-tools, passed.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
