### PR TITLE
fix: sync pre-httpapi stability baseline

### DIFF
--- a/packages/desktop-electron/src/main/ipc-window-config.test.ts
+++ b/packages/desktop-electron/src/main/ipc-window-config.test.ts
@@ -24,4 +24,15 @@ describe("desktop startup IPC", () => {
     expect(source).toContain("exportRendererDiagnostics")
     expect(source).toContain("rendererDiagnosticsSlice")
   })
+
+  test("store-get returns null when persisted store reads fail", () => {
+    const start = source.indexOf('ipcMain.handle("store-get"')
+    const end = source.indexOf('ipcMain.handle("store-set"', start)
+    const handler = source.slice(start, end)
+
+    expect(handler).toContain("try {")
+    expect(handler).toContain("getStore(name)")
+    expect(handler).toContain("catch")
+    expect(handler).toContain("return null")
+  })
 })

--- a/packages/desktop-electron/src/main/ipc-window-config.test.ts
+++ b/packages/desktop-electron/src/main/ipc-window-config.test.ts
@@ -28,6 +28,8 @@ describe("desktop startup IPC", () => {
   test("store-get returns null when persisted store reads fail", () => {
     const start = source.indexOf('ipcMain.handle("store-get"')
     const end = source.indexOf('ipcMain.handle("store-set"', start)
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
     const handler = source.slice(start, end)
 
     expect(handler).toContain("try {")

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -170,10 +170,14 @@ export function registerIpcHandlers(deps: Deps) {
     return deps.setDesktopContext(context, win)
   })
   ipcMain.handle("store-get", (_event: IpcMainInvokeEvent, name: string, key: string) => {
-    const store = getStore(name)
-    const value = store.get(key)
-    if (value === undefined || value === null) return null
-    return typeof value === "string" ? value : JSON.stringify(value)
+    try {
+      const store = getStore(name)
+      const value = store.get(key)
+      if (value === undefined || value === null) return null
+      return typeof value === "string" ? value : JSON.stringify(value)
+    } catch {
+      return null
+    }
   })
   ipcMain.handle("store-set", (_event: IpcMainInvokeEvent, name: string, key: string, value: string) => {
     getStore(name).set(key, value)

--- a/packages/desktop-electron/src/main/logging.test.ts
+++ b/packages/desktop-electron/src/main/logging.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const source = readFileSync(resolve(import.meta.dir, "logging.ts"), "utf8")
+
+describe("desktop logging", () => {
+  test("disables the console transport after a broken pipe", () => {
+    expect(source).toContain("initConsoleTransport()")
+    expect(source).toContain("log.transports.console.writeFn")
+    expect(source).toContain('err.code === "EPIPE"')
+    expect(source).toContain("log.transports.console.level = false")
+  })
+})

--- a/packages/desktop-electron/src/main/logging.test.ts
+++ b/packages/desktop-electron/src/main/logging.test.ts
@@ -1,14 +1,113 @@
-import { describe, expect, test } from "bun:test"
-import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 
-const source = readFileSync(resolve(import.meta.dir, "logging.ts"), "utf8")
+let logDir = ""
+const fakeLog: {
+  transports: {
+    file: {
+      maxSize: number
+      getFile: () => { path: string }
+    }
+    console: {
+      level: string | false
+      wrapCount: number
+      writeFn: (options: unknown) => void
+    }
+  }
+} = {
+  transports: {
+    file: {
+      maxSize: 0,
+      getFile: () => ({ path: join(tmpdir(), "desktop.log") }),
+    },
+    console: {
+      level: "info",
+      wrapCount: 0,
+      writeFn: () => undefined,
+    },
+  },
+}
+
+mock.module("electron-log/main.js", () => ({
+  default: fakeLog,
+}))
+
+afterEach(() => {
+  if (logDir) rmSync(logDir, { recursive: true, force: true })
+  logDir = ""
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+function setupLog(writeFn: (options: unknown) => void) {
+  logDir = mkdtempSync(join(tmpdir(), "pawwork-logging-test-"))
+  let currentWriteFn = writeFn
+  let wrapCount = 0
+  fakeLog.transports.file = {
+    maxSize: 0,
+    getFile: () => ({ path: join(logDir, "desktop.log") }),
+  }
+  fakeLog.transports.console = {
+    level: "info",
+    get wrapCount() {
+      return wrapCount
+    },
+    get writeFn() {
+      return currentWriteFn
+    },
+    set writeFn(next) {
+      wrapCount++
+      currentWriteFn = next
+    },
+  }
+  return fakeLog.transports.console
+}
+
+function brokenPipe() {
+  return Object.assign(new Error("broken pipe"), { code: "EPIPE" })
+}
+
+function otherWriteError() {
+  return Object.assign(new Error("write failed"), { code: "ENOENT" })
+}
 
 describe("desktop logging", () => {
-  test("disables the console transport after a broken pipe", () => {
-    expect(source).toContain("initConsoleTransport()")
-    expect(source).toContain("log.transports.console.writeFn")
-    expect(source).toContain('err.code === "EPIPE"')
-    expect(source).toContain("log.transports.console.level = false")
+  test("disables the console transport after a broken pipe", async () => {
+    const consoleTransport = setupLog(() => {
+      throw brokenPipe()
+    })
+    const { initLogging } = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+
+    initLogging()
+    consoleTransport.writeFn({})
+
+    expect(consoleTransport.level).toBe(false)
+  })
+
+  test("rethrows non-broken-pipe console transport errors", async () => {
+    const err = otherWriteError()
+    const consoleTransport = setupLog(() => {
+      throw err
+    })
+    const { initLogging } = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+
+    initLogging()
+
+    expect(() => consoleTransport.writeFn({})).toThrow(err)
+    expect(consoleTransport.level).toBe("info")
+  })
+
+  test("does not wrap the console transport more than once", async () => {
+    const consoleTransport = setupLog(() => undefined)
+    const { initLogging } = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+
+    initLogging()
+    initLogging()
+
+    expect(consoleTransport.wrapCount).toBe(1)
   })
 })

--- a/packages/desktop-electron/src/main/logging.test.ts
+++ b/packages/desktop-electron/src/main/logging.test.ts
@@ -110,4 +110,15 @@ describe("desktop logging", () => {
 
     expect(consoleTransport.wrapCount).toBe(1)
   })
+
+  test("does not wrap the console transport again across fresh module imports", async () => {
+    const consoleTransport = setupLog(() => undefined)
+    const first = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+    const second = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+
+    first.initLogging()
+    second.initLogging()
+
+    expect(consoleTransport.wrapCount).toBe(1)
+  })
 })

--- a/packages/desktop-electron/src/main/logging.ts
+++ b/packages/desktop-electron/src/main/logging.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 
 const MAX_LOG_AGE_DAYS = 7
 const TAIL_LINES = 1000
+const CONSOLE_TRANSPORT_INITIALIZED = Symbol("pawwork.consoleTransportInitialized")
 
 export function initLogging() {
   log.transports.file.maxSize = 5 * 1024 * 1024
@@ -44,13 +45,19 @@ function cleanup() {
 }
 
 function initConsoleTransport() {
-  const write = log.transports.console.writeFn.bind(log.transports.console)
-  log.transports.console.writeFn = (options) => {
+  const transport = log.transports.console as typeof log.transports.console & {
+    [CONSOLE_TRANSPORT_INITIALIZED]?: boolean
+  }
+  if (transport[CONSOLE_TRANSPORT_INITIALIZED]) return
+  transport[CONSOLE_TRANSPORT_INITIALIZED] = true
+
+  const write = transport.writeFn.bind(transport)
+  transport.writeFn = (options) => {
     try {
       write(options)
     } catch (err) {
       if (!isBrokenPipe(err)) throw err
-      log.transports.console.level = false
+      transport.level = false
     }
   }
 }

--- a/packages/desktop-electron/src/main/logging.ts
+++ b/packages/desktop-electron/src/main/logging.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path"
 
 const MAX_LOG_AGE_DAYS = 7
 const TAIL_LINES = 1000
-const CONSOLE_TRANSPORT_INITIALIZED = Symbol("pawwork.consoleTransportInitialized")
+const CONSOLE_TRANSPORT_INITIALIZED = Symbol.for("pawwork.consoleTransportInitialized")
 
 export function initLogging() {
   log.transports.file.maxSize = 5 * 1024 * 1024

--- a/packages/desktop-electron/src/main/logging.ts
+++ b/packages/desktop-electron/src/main/logging.ts
@@ -7,6 +7,7 @@ const TAIL_LINES = 1000
 
 export function initLogging() {
   log.transports.file.maxSize = 5 * 1024 * 1024
+  initConsoleTransport()
   cleanup()
   return log
 }
@@ -40,4 +41,20 @@ function cleanup() {
       continue
     }
   }
+}
+
+function initConsoleTransport() {
+  const write = log.transports.console.writeFn.bind(log.transports.console)
+  log.transports.console.writeFn = (options) => {
+    try {
+      write(options)
+    } catch (err) {
+      if (!isBrokenPipe(err)) throw err
+      log.transports.console.level = false
+    }
+  }
+}
+
+function isBrokenPipe(err: unknown) {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "EPIPE"
 }

--- a/packages/desktop-electron/src/renderer/webview-zoom.test.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.test.ts
@@ -7,18 +7,14 @@ type KeydownHandler = (event: {
   preventDefault: () => void
 }) => void
 
-const originalNavigator = globalThis.navigator
-const originalWindow = globalThis.window
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator")
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
 
 afterEach(() => {
-  Object.defineProperty(globalThis, "navigator", {
-    value: originalNavigator,
-    configurable: true,
-  })
-  Object.defineProperty(globalThis, "window", {
-    value: originalWindow,
-    configurable: true,
-  })
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator)
+  else delete (globalThis as { navigator?: Navigator }).navigator
+  if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow)
+  else delete (globalThis as { window?: Window }).window
 })
 
 function deferred() {
@@ -38,6 +34,7 @@ async function loadZoomModule(options?: { userAgent?: string; setZoomFactor?: (f
   Object.defineProperty(globalThis, "navigator", {
     value: { userAgent: options?.userAgent ?? "Windows" },
     configurable: true,
+    writable: true,
   })
   Object.defineProperty(globalThis, "window", {
     value: {
@@ -47,6 +44,7 @@ async function loadZoomModule(options?: { userAgent?: string; setZoomFactor?: (f
       },
     },
     configurable: true,
+    writable: true,
   })
 
   const module = await import(`./webview-zoom?webview-zoom-test=${crypto.randomUUID()}`)

--- a/packages/desktop-electron/src/renderer/webview-zoom.test.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.test.ts
@@ -1,22 +1,119 @@
-import { describe, expect, test } from "bun:test"
-import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { afterEach, describe, expect, mock, test } from "bun:test"
 
-const source = readFileSync(resolve(import.meta.dir, "webview-zoom.ts"), "utf8")
+type KeydownHandler = (event: {
+  key: string
+  ctrlKey: boolean
+  metaKey: boolean
+  preventDefault: () => void
+}) => void
 
-describe("desktop renderer webview zoom", () => {
-  test("only consumes keydown events that actually change zoom", () => {
-    expect(source).toContain('if (event.key === "-") {')
-    expect(source).toContain('if (event.key === "=" || event.key === "+") {')
-    expect(source).toContain('if (event.key === "0") {')
-    expect(source.match(/event\.preventDefault\(\)/g)?.length).toBe(3)
-    expect(source).not.toContain("let newZoom = webviewZoom()")
+const originalNavigator = globalThis.navigator
+const originalWindow = globalThis.window
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    value: originalNavigator,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "window", {
+    value: originalWindow,
+    configurable: true,
+  })
+})
+
+function deferred() {
+  let resolve!: () => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+async function loadZoomModule(options?: { userAgent?: string; setZoomFactor?: (factor: number) => Promise<void> }) {
+  const handlers: KeydownHandler[] = []
+  const setZoomFactor = mock(options?.setZoomFactor ?? (() => Promise.resolve()))
+
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: options?.userAgent ?? "Windows" },
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      api: { setZoomFactor },
+      addEventListener: (type: string, handler: KeydownHandler) => {
+        if (type === "keydown") handlers.push(handler)
+      },
+    },
+    configurable: true,
   })
 
-  test("keeps requested zoom separate until Electron accepts the zoom change", () => {
-    expect(source).toContain("let requestedZoom = 1")
-    expect(source).toContain("requestedZoom = next")
-    expect(source).toContain("if (requestedZoom !== next) return")
-    expect(source).toContain("setWebviewZoom(next)")
+  const module = await import(`./webview-zoom?webview-zoom-test=${crypto.randomUUID()}`)
+  return {
+    handler: handlers[0]!,
+    setZoomFactor,
+    webviewZoom: module.webviewZoom,
+  }
+}
+
+function keyEvent(key: string, overrides?: Partial<Parameters<KeydownHandler>[0]>) {
+  return {
+    key,
+    ctrlKey: true,
+    metaKey: false,
+    preventDefault: mock(() => undefined),
+    ...overrides,
+  }
+}
+
+describe("desktop renderer webview zoom", () => {
+  test("only consumes keydown events that actually change zoom", async () => {
+    const { handler, setZoomFactor } = await loadZoomModule()
+    const unrelated = keyEvent("a")
+    const zoomOut = keyEvent("-")
+
+    handler(unrelated)
+    handler(zoomOut)
+
+    expect(unrelated.preventDefault).toHaveBeenCalledTimes(0)
+    expect(zoomOut.preventDefault).toHaveBeenCalledTimes(1)
+    expect(setZoomFactor).toHaveBeenCalledTimes(1)
+    expect(setZoomFactor).toHaveBeenCalledWith(0.8)
+  })
+
+  test("keeps requested zoom separate until Electron accepts the zoom change", async () => {
+    const zoom = deferred()
+    const { handler, webviewZoom } = await loadZoomModule({ setZoomFactor: () => zoom.promise })
+
+    handler(keyEvent("-"))
+
+    expect(webviewZoom()).toBe(1)
+    zoom.resolve()
+    await zoom.promise
+    await Promise.resolve()
+    expect(webviewZoom()).toBe(0.8)
+  })
+
+  test("keeps the current zoom when Electron rejects the zoom change", async () => {
+    const zoom = deferred()
+    const { handler, webviewZoom } = await loadZoomModule({ setZoomFactor: () => zoom.promise })
+
+    handler(keyEvent("-"))
+
+    zoom.reject(new Error("zoom failed"))
+    await zoom.promise.catch(() => undefined)
+    await Promise.resolve()
+    expect(webviewZoom()).toBe(1)
+  })
+
+  test("uses requested zoom for rapid repeated shortcuts", async () => {
+    const { handler, setZoomFactor } = await loadZoomModule()
+
+    handler(keyEvent("-"))
+    handler(keyEvent("-"))
+    handler(keyEvent("0"))
+
+    expect(setZoomFactor.mock.calls.map(([factor]) => factor)).toEqual([0.8, 0.6000000000000001, 1])
   })
 })

--- a/packages/desktop-electron/src/renderer/webview-zoom.test.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const source = readFileSync(resolve(import.meta.dir, "webview-zoom.ts"), "utf8")
+
+describe("desktop renderer webview zoom", () => {
+  test("only consumes keydown events that actually change zoom", () => {
+    expect(source).toContain('if (event.key === "-") {')
+    expect(source).toContain('if (event.key === "=" || event.key === "+") {')
+    expect(source).toContain('if (event.key === "0") {')
+    expect(source.match(/event\.preventDefault\(\)/g)?.length).toBe(3)
+    expect(source).not.toContain("let newZoom = webviewZoom()")
+  })
+
+  test("keeps requested zoom separate until Electron accepts the zoom change", () => {
+    expect(source).toContain("let requestedZoom = 1")
+    expect(source).toContain("requestedZoom = next")
+    expect(source).toContain("if (requestedZoom !== next) return")
+    expect(source).toContain("setWebviewZoom(next)")
+  })
+})

--- a/packages/desktop-electron/src/renderer/webview-zoom.test.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.test.ts
@@ -112,6 +112,10 @@ describe("desktop renderer webview zoom", () => {
     handler(keyEvent("-"))
     handler(keyEvent("0"))
 
-    expect(setZoomFactor.mock.calls.map(([factor]) => factor)).toEqual([0.8, 0.6000000000000001, 1])
+    const factors = setZoomFactor.mock.calls.map(([factor]) => factor)
+    expect(factors).toHaveLength(3)
+    expect(factors[0]).toBeCloseTo(0.8, 10)
+    expect(factors[1]).toBeCloseTo(0.6, 10)
+    expect(factors[2]).toBe(1)
   })
 })

--- a/packages/desktop-electron/src/renderer/webview-zoom.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.ts
@@ -12,6 +12,7 @@ const OS_NAME = (() => {
 })()
 
 const [webviewZoom, setWebviewZoom] = createSignal(1)
+let requestedZoom = 1
 
 const MAX_ZOOM_LEVEL = 10
 const MIN_ZOOM_LEVEL = 0.2
@@ -19,20 +20,36 @@ const MIN_ZOOM_LEVEL = 0.2
 const clamp = (value: number) => Math.min(Math.max(value, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL)
 
 const applyZoom = (next: number) => {
-  setWebviewZoom(next)
-  void window.api.setZoomFactor(next)
+  requestedZoom = next
+  void window.api
+    .setZoomFactor(next)
+    .then(() => {
+      if (requestedZoom !== next) return
+      setWebviewZoom(next)
+    })
+    .catch(() => {
+      if (requestedZoom !== next) return
+      requestedZoom = webviewZoom()
+    })
 }
 
 window.addEventListener("keydown", (event) => {
   if (!(OS_NAME === "macos" ? event.metaKey : event.ctrlKey)) return
 
-  let newZoom = webviewZoom()
-
-  if (event.key === "-") newZoom -= 0.2
-  if (event.key === "=" || event.key === "+") newZoom += 0.2
-  if (event.key === "0") newZoom = 1
-
-  applyZoom(clamp(newZoom))
+  if (event.key === "-") {
+    event.preventDefault()
+    applyZoom(clamp(requestedZoom - 0.2))
+    return
+  }
+  if (event.key === "=" || event.key === "+") {
+    event.preventDefault()
+    applyZoom(clamp(requestedZoom + 0.2))
+    return
+  }
+  if (event.key === "0") {
+    event.preventDefault()
+    applyZoom(1)
+  }
 })
 
 export { webviewZoom }

--- a/packages/desktop-electron/src/renderer/webview-zoom.ts
+++ b/packages/desktop-electron/src/renderer/webview-zoom.ts
@@ -49,6 +49,7 @@ window.addEventListener("keydown", (event) => {
   if (event.key === "0") {
     event.preventDefault()
     applyZoom(1)
+    return
   }
 })
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -655,7 +655,7 @@ function googleThinkingLevelEfforts(apiId: string) {
   if (id.includes("flash-image")) return ["minimal", "high"]
   if (id.includes("pro-image")) return ["high"]
   if (id.includes("flash")) return ["minimal", "low", "medium", "high"]
-  return ["low", "medium", "high"]
+  return ["low", "high"]
 }
 
 function googleThinkingBudgetMax(apiId: string) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -569,22 +569,68 @@ export function topK(model: Provider.Model) {
 
 const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_PRO_EFFORTS = ["high"]
+const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
+const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
+const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
 const OPENAI_NONE_EFFORT_RELEASE_DATE = "2025-11-13"
 const OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"
 const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
+const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
+const GPT5_PRO_RE = /(?:^|\/)gpt-5[.-]?pro(?:[.-]|$)/
+const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
 
-function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | null {
+function gpt5Version(apiId: string) {
+  return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
+}
+
+function versionedGpt5ReasoningEfforts(apiId: string) {
+  if (GPT5_VERSIONED_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_2_PLUS_EFFORTS
+  const version = gpt5Version(apiId)
+  if (version === undefined) return undefined
+  if (version === 1) return OPENAI_GPT5_1_EFFORTS
+  return OPENAI_GPT5_2_PLUS_EFFORTS
+}
+
+function gpt5CodexReasoningEfforts(apiId: string) {
+  if (!GPT5_FAMILY_RE.test(apiId) || !apiId.includes("codex")) return undefined
+  const version = gpt5Version(apiId)
+  if (version !== undefined && version >= 3) return OPENAI_GPT5_CODEX_3_PLUS_EFFORTS
+  if (apiId.includes("codex-max") || (version !== undefined && version >= 2)) return OPENAI_GPT5_CODEX_XHIGH_EFFORTS
+  return WIDELY_SUPPORTED_EFFORTS
+}
+
+function gpt5ChatReasoningEfforts(apiId: string) {
+  if (!GPT5_FAMILY_RE.test(apiId) || !apiId.includes("-chat")) return undefined
+  return gpt5Version(apiId) === undefined ? [] : OPENAI_GPT5_CHAT_EFFORTS
+}
+
+function openaiReasoningEfforts(apiId: string, releaseDate: string) {
   const id = apiId.toLowerCase()
-  if (id === "gpt-5-pro" || id === "openai/gpt-5-pro") return null
-  if (id.includes("codex")) {
-    if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-    return [...WIDELY_SUPPORTED_EFFORTS]
-  }
+  if (id.includes("deep-research")) return ["medium"]
+  const chatEfforts = gpt5ChatReasoningEfforts(id)
+  if (chatEfforts) return chatEfforts
+  if (GPT5_PRO_RE.test(id)) return OPENAI_GPT5_PRO_EFFORTS
+  const codexEfforts = gpt5CodexReasoningEfforts(id)
+  if (codexEfforts) return codexEfforts
+  const versionedEfforts = versionedGpt5ReasoningEfforts(id)
+  if (versionedEfforts) return versionedEfforts
   const efforts = [...WIDELY_SUPPORTED_EFFORTS]
   if (GPT5_FAMILY_RE.test(id)) efforts.unshift("minimal")
   if (releaseDate >= OPENAI_NONE_EFFORT_RELEASE_DATE) efforts.unshift("none")
   if (releaseDate >= OPENAI_XHIGH_EFFORT_RELEASE_DATE) efforts.push("xhigh")
   return efforts
+}
+
+function openaiCompatibleReasoningEfforts(id: string) {
+  const apiId = id.toLowerCase()
+  const chatEfforts = gpt5ChatReasoningEfforts(apiId)
+  if (chatEfforts) return chatEfforts
+  if (GPT5_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_EFFORTS
+  return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
@@ -601,6 +647,29 @@ function deepseekMajorVersion(apiId: string): number | undefined {
   const match = apiId.toLowerCase().match(/(^|[/:])deepseek-v(\d+)(?:[.\-/]|$)/)
   if (!match) return undefined
   return Number.parseInt(match[2]!, 10)
+}
+
+function googleThinkingLevelEfforts(apiId: string) {
+  const id = apiId.toLowerCase()
+  if (!id.includes("gemini-3")) return ["low", "high"]
+  if (id.includes("flash-image")) return ["minimal", "high"]
+  if (id.includes("pro-image")) return ["high"]
+  if (id.includes("flash")) return ["minimal", "low", "medium", "high"]
+  return ["low", "medium", "high"]
+}
+
+function googleThinkingBudgetMax(apiId: string) {
+  const id = apiId.toLowerCase()
+  if (id.includes("2.5") && id.includes("pro") && !id.includes("flash")) return 32_768
+  return 24_576
+}
+
+function googleSmallThinkingConfig(apiId: string) {
+  const levels = googleThinkingLevelEfforts(apiId)
+  if (apiId.toLowerCase().includes("gemini-3")) {
+    return { thinkingLevel: levels.includes("minimal") ? "minimal" : levels.includes("low") ? "low" : "high" }
+  }
+  return { thinkingBudget: googleThinkingBudgetMax(apiId) === 32_768 ? 128 : 0 }
 }
 
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
@@ -637,8 +706,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
-      if (!model.id.includes("gpt") && !model.id.includes("gemini-3") && !model.id.includes("claude")) return {}
-      return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
+      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
+      return Object.fromEntries(
+        (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
+          effort,
+          { reasoning: { effort } },
+        ]),
+      )
 
     case "@ai-sdk/gateway":
       if (model.id.includes("anthropic")) {
@@ -702,7 +776,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "ai-gateway-provider": {
       if (model.api.id.startsWith("openai/")) {
         const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
-        if (!efforts) return {}
         return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
       }
       return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
@@ -750,18 +823,22 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       if (deepseekMajor !== undefined && deepseekMajor >= 4) {
         openaiCompatibleEfforts.push("max")
       }
-      return Object.fromEntries(openaiCompatibleEfforts.map((effort) => [effort, { reasoningEffort: effort }]))
+      return Object.fromEntries(
+        (GPT5_FAMILY_RE.test(model.api.id.toLowerCase())
+          ? openaiCompatibleReasoningEfforts(model.api.id)
+          : openaiCompatibleEfforts
+        ).map((effort) => [effort, { reasoningEffort: effort }]),
+      )
     }
 
     case "@ai-sdk/azure": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
-      const azureEfforts = ["low", "medium", "high"]
-      if (GPT5_FAMILY_RE.test(id)) {
-        azureEfforts.unshift("minimal")
-      }
       return Object.fromEntries(
-        azureEfforts.map((effort) => [
+        (GPT5_FAMILY_RE.test(id) && gpt5Version(id) === undefined
+          ? ["minimal", ...WIDELY_SUPPORTED_EFFORTS]
+          : WIDELY_SUPPORTED_EFFORTS
+        ).map((effort) => [
           effort,
           {
             reasoningEffort: effort,
@@ -774,7 +851,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/openai": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
       const openaiEfforts = openaiReasoningEfforts(model.api.id, model.release_date)
-      if (!openaiEfforts) return {}
       return Object.fromEntries(
         openaiEfforts.map((effort) => [
           effort,
@@ -812,6 +888,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             },
           ]),
         )
+      }
+
+      if (["opus-4-5", "opus-4.5"].some((v) => model.api.id.includes(v))) {
+        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { effort }]))
       }
 
       return {
@@ -890,18 +970,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           max: {
             thinkingConfig: {
               includeThoughts: true,
-              thinkingBudget: 24576,
+              thinkingBudget: googleThinkingBudgetMax(id),
             },
           },
         }
       }
-      let levels = ["low", "high"]
-      if (id.includes("3.1")) {
-        levels = ["low", "medium", "high"]
-      }
 
       return Object.fromEntries(
-        levels.map((effort) => [
+        googleThinkingLevelEfforts(id).map((effort) => [
           effort,
           {
             thinkingConfig: {
@@ -1156,6 +1232,11 @@ export function smallOptions(model: Provider.Model) {
     model.api.npm === "@ai-sdk/github-copilot"
   ) {
     if (model.api.id.includes("gpt-5")) {
+      if (model.api.id.includes("-chat")) {
+        if (gpt5Version(model.api.id) === undefined) return { store: false }
+        return { store: false, reasoningEffort: "medium" }
+      }
+      if (model.api.id.includes("search-api")) return { store: false }
       if (model.api.id.includes("5.") || model.api.id.includes("5-mini")) {
         return { store: false, reasoningEffort: "low" }
       }
@@ -1165,10 +1246,7 @@ export function smallOptions(model: Provider.Model) {
   }
   if (model.providerID === "google") {
     // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget
-    if (model.api.id.includes("gemini-3")) {
-      return { thinkingConfig: { thinkingLevel: "minimal" } }
-    }
-    return { thinkingConfig: { thinkingBudget: 0 } }
+    return { thinkingConfig: googleSmallThinkingConfig(model.api.id) }
   }
   if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
     if (model.api.id.includes("google")) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -834,11 +834,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/azure": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
-      return Object.fromEntries(
-        (GPT5_FAMILY_RE.test(id) && gpt5Version(id) === undefined
+      const azureID = model.api.id.toLowerCase()
+      const chatEfforts = gpt5ChatReasoningEfforts(azureID) ?? gpt5ChatReasoningEfforts(id)
+      const azureEfforts =
+        chatEfforts ??
+        (GPT5_FAMILY_RE.test(azureID) && gpt5Version(azureID) === undefined
           ? ["minimal", ...WIDELY_SUPPORTED_EFFORTS]
-          : WIDELY_SUPPORTED_EFFORTS
-        ).map((effort) => [
+          : WIDELY_SUPPORTED_EFFORTS)
+      return Object.fromEntries(
+        azureEfforts.map((effort) => [
           effort,
           {
             reasoningEffort: effort,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -33,10 +33,10 @@ export const Default = lazy(() => create({}))
 function create(opts: { cors?: string[] }) {
   const app = new Hono()
     .onError(ErrorMiddleware)
-    .use(AuthMiddleware)
-    .use(LoggerMiddleware)
-    .use(CompressionMiddleware)
     .use(CorsMiddleware(opts))
+    .use(LoggerMiddleware)
+    .use(AuthMiddleware)
+    .use(CompressionMiddleware)
     .route("/global", GlobalRoutes())
 
   const runtime = adapter.create(app)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3308,6 +3308,36 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
 
+    test("gpt-5.4 returns only supported OpenAI reasoning efforts", () => {
+      const model = createMockModel({
+        id: "openrouter/openai/gpt-5.4",
+        providerID: "openrouter",
+        api: {
+          id: "openai/gpt-5.4",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({ reasoning: { effort: "xhigh" } })
+    })
+
+    test("gpt-5.2-chat-latest returns only medium effort", () => {
+      const model = createMockModel({
+        id: "openrouter/openai/gpt-5.2-chat-latest",
+        providerID: "openrouter",
+        api: {
+          id: "openai/gpt-5.2-chat-latest",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium"])
+      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
+    })
+
     test("gemini-3 returns OPENAI_EFFORTS with reasoning", () => {
       const model = createMockModel({
         id: "openrouter/gemini-3-5-pro",
@@ -3768,6 +3798,21 @@ describe("ProviderTransform.variants", () => {
         max: { reasoningEffort: "max" },
       })
     })
+
+    test("gpt-5.5-pro returns only supported OpenAI-compatible reasoning efforts", () => {
+      const model = createMockModel({
+        id: "custom-provider/gpt-5.5-pro",
+        providerID: "custom-provider",
+        api: {
+          id: "gpt-5.5-pro",
+          url: "https://api.custom.com",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
+    })
   })
 
   describe("@ai-sdk/azure", () => {
@@ -3818,7 +3863,7 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
 
-    test("dotted gpt-5 family ids add minimal effort", () => {
+    test("dotted gpt-5 family ids do not add unsupported minimal effort", () => {
       const model = createMockModel({
         id: "gpt-5.4",
         providerID: "azure",
@@ -3829,12 +3874,12 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
     })
   })
 
   describe("@ai-sdk/openai", () => {
-    test("gpt-5-pro returns empty object", () => {
+    test("gpt-5-pro returns high effort", () => {
       const model = createMockModel({
         id: "gpt-5-pro",
         providerID: "openai",
@@ -3845,7 +3890,12 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
+      expect(Object.keys(result)).toEqual(["high"])
+      expect(result.high).toEqual({
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
     })
 
     test("standard openai models return custom efforts with reasoningSummary", () => {
@@ -3883,22 +3933,27 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high"])
     })
 
-    test("models after 2025-12-04 include 'xhigh' effort", () => {
+    test("gpt-5 chat models expose only supported reasoning efforts", () => {
       const model = createMockModel({
-        id: "openai/gpt-5-chat",
+        id: "openai/gpt-5.2-chat-latest",
         providerID: "openai",
         api: {
-          id: "gpt-5-chat",
+          id: "gpt-5.2-chat-latest",
           url: "https://api.openai.com",
           npm: "@ai-sdk/openai",
         },
-        release_date: "2025-12-05",
+        release_date: "2025-12-11",
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["medium"])
+      expect(result.medium).toEqual({
+        reasoningEffort: "medium",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
     })
 
-    test("dotted gpt-5.x ids include minimal effort", () => {
+    test("dotted gpt-5.x ids use supported versioned efforts", () => {
       const model = createMockModel({
         id: "gpt-5.4",
         providerID: "openai",
@@ -3910,7 +3965,37 @@ describe("ProviderTransform.variants", () => {
         release_date: "2026-03-05",
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-5.3-codex includes none and xhigh", () => {
+      const model = createMockModel({
+        id: "gpt-5.3-codex",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.3-codex",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-01-22",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
+    test("deep-research models expose only medium effort", () => {
+      const model = createMockModel({
+        id: "o3-deep-research",
+        providerID: "openai",
+        api: {
+          id: "o3-deep-research",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2025-06-26",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium"])
     })
 
     test("gpt-50 lookalike does not get gpt-5 family treatment", () => {
@@ -3944,9 +4029,9 @@ describe("ProviderTransform.variants", () => {
 
     test("openai gpt-5.4 includes xhigh effort", () => {
       const result = ProviderTransform.variants(cfModel("openai/gpt-5.4", "2026-03-05"))
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
       expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
-      expect(Object.keys(result)).toContain("minimal")
     })
 
     test("openai gpt-5.2-codex includes xhigh", () => {
@@ -3971,6 +4056,21 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/anthropic", () => {
+    test("opus 4.5 returns standard effort options", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-5",
+        providerID: "anthropic",
+        api: {
+          id: "claude-opus-4.5-20251101",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.high).toEqual({ effort: "high" })
+    })
+
     test("sonnet 4.6 returns adaptive thinking options", () => {
       const model = createMockModel({
         id: "anthropic/claude-sonnet-4-6",
@@ -4157,9 +4257,43 @@ describe("ProviderTransform.variants", () => {
       expect(result.max).toEqual({
         thinkingConfig: {
           includeThoughts: true,
-          thinkingBudget: 24576,
+          thinkingBudget: 32768,
         },
       })
+    })
+
+    test("gemini-3 flash models include minimal thinking level", () => {
+      const model = createMockModel({
+        id: "google/gemini-3-flash-preview",
+        providerID: "google",
+        api: {
+          id: "gemini-3-flash-preview",
+          url: "https://generativelanguage.googleapis.com",
+          npm: "@ai-sdk/google",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
+      expect(result.minimal).toEqual({
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingLevel: "minimal",
+        },
+      })
+    })
+
+    test("gemini-3 pro image models only expose high thinking level", () => {
+      const model = createMockModel({
+        id: "google/gemini-3-pro-image-preview",
+        providerID: "google",
+        api: {
+          id: "gemini-3-pro-image-preview",
+          url: "https://generativelanguage.googleapis.com",
+          npm: "@ai-sdk/google",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["high"])
     })
 
     test("other gemini models return low and high with thinkingLevel", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4441,6 +4441,20 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("gemini-3 pro models only expose low and high thinking levels", () => {
+      const model = createMockModel({
+        id: "google/gemini-3-pro-preview",
+        providerID: "google",
+        api: {
+          id: "gemini-3-pro-preview",
+          url: "https://generativelanguage.googleapis.com",
+          npm: "@ai-sdk/google",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "high"])
+    })
+
     test("gemini-3 pro image models only expose high thinking level", () => {
       const model = createMockModel({
         id: "google/gemini-3-pro-image-preview",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3069,6 +3069,132 @@ describe("ProviderTransform.message - cache control on gateway", () => {
   })
 })
 
+describe("ProviderTransform.smallOptions", () => {
+  const createSmallModel = (overrides: Partial<any> = {}): any => ({
+    id: "test/test-model",
+    providerID: "openai",
+    api: {
+      id: "gpt-4",
+      url: "https://api.test.com",
+      npm: "@ai-sdk/openai",
+    },
+    capabilities: {
+      reasoning: true,
+    },
+    ...overrides,
+  })
+
+  test("uses medium effort for versioned gpt-5 chat models", () => {
+    const model = createSmallModel({
+      id: "openai/gpt-5.2-chat-latest",
+      api: {
+        id: "gpt-5.2-chat-latest",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    })
+
+    expect(ProviderTransform.smallOptions(model)).toEqual({ store: false, reasoningEffort: "medium" })
+  })
+
+  test("does not send reasoning effort for unversioned gpt-5 chat models", () => {
+    const model = createSmallModel({
+      id: "openai/gpt-5-chat-latest",
+      api: {
+        id: "gpt-5-chat-latest",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    })
+
+    expect(ProviderTransform.smallOptions(model)).toEqual({ store: false })
+  })
+
+  test("does not send reasoning effort for gpt-5 search api models", () => {
+    const model = createSmallModel({
+      id: "openai/gpt-5-search-api",
+      api: {
+        id: "gpt-5-search-api",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    })
+
+    expect(ProviderTransform.smallOptions(model)).toEqual({ store: false })
+  })
+
+  test("uses small thinking budgets for gemini 2.5 models", () => {
+    expect(
+      ProviderTransform.smallOptions(
+        createSmallModel({
+          id: "google/gemini-2.5-pro",
+          providerID: "google",
+          api: {
+            id: "gemini-2.5-pro",
+            url: "https://generativelanguage.googleapis.com",
+            npm: "@ai-sdk/google",
+          },
+        }),
+      ),
+    ).toEqual({ thinkingConfig: { thinkingBudget: 128 } })
+    expect(
+      ProviderTransform.smallOptions(
+        createSmallModel({
+          id: "google/gemini-2.5-flash",
+          providerID: "google",
+          api: {
+            id: "gemini-2.5-flash",
+            url: "https://generativelanguage.googleapis.com",
+            npm: "@ai-sdk/google",
+          },
+        }),
+      ),
+    ).toEqual({ thinkingConfig: { thinkingBudget: 0 } })
+  })
+
+  test("uses small thinking levels for gemini 3 models", () => {
+    expect(
+      ProviderTransform.smallOptions(
+        createSmallModel({
+          id: "google/gemini-3-flash-preview",
+          providerID: "google",
+          api: {
+            id: "gemini-3-flash-preview",
+            url: "https://generativelanguage.googleapis.com",
+            npm: "@ai-sdk/google",
+          },
+        }),
+      ),
+    ).toEqual({ thinkingConfig: { thinkingLevel: "minimal" } })
+    expect(
+      ProviderTransform.smallOptions(
+        createSmallModel({
+          id: "google/gemini-3-pro-preview",
+          providerID: "google",
+          api: {
+            id: "gemini-3-pro-preview",
+            url: "https://generativelanguage.googleapis.com",
+            npm: "@ai-sdk/google",
+          },
+        }),
+      ),
+    ).toEqual({ thinkingConfig: { thinkingLevel: "low" } })
+    expect(
+      ProviderTransform.smallOptions(
+        createSmallModel({
+          id: "google/gemini-3-pro-image-preview",
+          providerID: "google",
+          api: {
+            id: "gemini-3-pro-image-preview",
+            url: "https://generativelanguage.googleapis.com",
+            npm: "@ai-sdk/google",
+          },
+        }),
+      ),
+    ).toEqual({ thinkingConfig: { thinkingLevel: "high" } })
+  })
+})
+
 describe("ProviderTransform.variants", () => {
   const createMockModel = (overrides: Partial<any> = {}): any => ({
     id: "test/test-model",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3876,6 +3876,39 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high"])
     })
+
+    test("versioned gpt-5 chat models expose only medium effort", () => {
+      const model = createMockModel({
+        id: "gpt-5.2-chat-latest",
+        providerID: "azure",
+        api: {
+          id: "gpt-5.2-chat-latest",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium"])
+      expect(result.medium).toEqual({
+        reasoningEffort: "medium",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
+
+    test("unversioned gpt-5 chat models do not expose effort variants", () => {
+      const model = createMockModel({
+        id: "gpt-5-chat",
+        providerID: "azure",
+        api: {
+          id: "gpt-5-chat",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
   })
 
   describe("@ai-sdk/openai", () => {

--- a/packages/opencode/test/server/cors-middleware.test.ts
+++ b/packages/opencode/test/server/cors-middleware.test.ts
@@ -1,12 +1,27 @@
-import { describe, expect } from "bun:test"
+import { afterEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Server } from "../../src/server/server"
 import { Log } from "@opencode-ai/core/util/log"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { testEffect } from "../lib/effect"
 
 Log.init({ print: false })
 
 const it = testEffect(Layer.empty)
+const mutableFlag = Flag as {
+  OPENCODE_SERVER_PASSWORD?: string
+  OPENCODE_SERVER_USERNAME?: string
+}
+
+const original = {
+  OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
+  OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
+}
+
+afterEach(() => {
+  mutableFlag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
+  mutableFlag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
+})
 
 describe("CORS middleware", () => {
   it.live("allows localhost browser origins", () =>
@@ -46,6 +61,27 @@ describe("CORS middleware", () => {
         expect(response.status).toBe(200)
         expect(response.headers.get("access-control-allow-origin")).toBeNull()
       }
+    }),
+  )
+
+  it.live("adds CORS headers to unauthorized browser responses", () =>
+    Effect.gen(function* () {
+      mutableFlag.OPENCODE_SERVER_PASSWORD = "secret"
+      mutableFlag.OPENCODE_SERVER_USERNAME = "alice"
+
+      const app = Server.Default().app
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app.request("/global/health", {
+            headers: {
+              Origin: "https://app.opencode.ai",
+            },
+          }),
+        ),
+      )
+
+      expect(response.status).toBe(401)
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://app.opencode.ai")
     }),
   )
 })


### PR DESCRIPTION
## Summary

- Sync current upstream provider reasoning variants for GPT-5.x, GPT-5 Pro/chat/codex, OpenAI-compatible paths, Anthropic Opus 4.5, and Gemini thinking controls.
- Keep the Hono fallback browser-safe by applying CORS before auth failures.
- Manual-port small desktop/app behavior fixes only: webview zoom shortcut handling, persisted store read fallback, and EPIPE-safe console logging.

## Why

This is the PR 4 pre-HttpApi stability baseline for #477. It intentionally keeps the remaining upstream sync moving with one rollback surface around pre-HttpApi safety/stability, while excluding Effect foundation, effectCmd, HttpApi listener work, default listener switching, package consolidation, and v2 session/warping contracts.

## Related Issue

Refs #477.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Provider variant matrices: confirm the newly allowed reasoning efforts match the current upstream/provider contracts and do not reintroduce unsupported `minimal` values for versioned GPT-5.x models.
- Server middleware ordering: confirm moving CORS before auth preserves browser CORS headers without weakening Basic/auth_token behavior.
- Desktop manual ports: confirm these stay behavior-only and do not pull in desktop package consolidation, utility-process restructuring, updater policy, CSP expansion, or HttpApi work.

## Risk Notes

- Provider changes affect the model variant options exposed to users, so incorrect matrices could surface invalid model settings.
- Hono middleware ordering changes all legacy fallback responses, but the auth tests still cover Basic challenge behavior and auth_token handling.
- Desktop tests include behavior-level coverage for zoom and logging shell guards, plus a narrow source-contract check for IPC registration fallback; no package structure, dependency, or generated-file changes are included.
- Hono remains the default listener. This PR does not introduce or switch to Effect HttpApi.

## How To Verify

```text
Provider variants: bun test --timeout 30000 test/provider/transform.test.ts -> 200 pass, 0 fail, 382 expect() calls
Server CORS/auth: bun test --timeout 30000 test/server/cors-middleware.test.ts test/server/auth.test.ts -> 12 pass, 0 fail, 26 expect() calls
Desktop shell guards: bun test src/renderer/webview-zoom.test.ts src/main/ipc-window-config.test.ts src/main/logging.test.ts -> 11 pass, 0 fail, 29 expect() calls
opencode typecheck: bun run typecheck -> pass
Desktop Electron typecheck: bun run typecheck -> pass
Diff check: git diff --check -> no whitespace errors
Electron dev smoke: bun run dev:desktop -> built Electron main/preload and reached app starting in dev mode
```

## Screenshots or Recordings

Not required. This PR changes desktop shell behavior guards, not visible UI layout or copy.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store reads now fail gracefully (returns null) instead of erroring
  * Logging more robust: broken-pipe errors are suppressed to avoid crashes

* **New Features**
  * Added GPT-5 reasoning-effort configuration support
  * Expanded Gemini thinking-level handling

* **Improvements**
  * More reliable webview zoom state and keyboard shortcuts
  * CORS handling adjusted to ensure appropriate headers on auth-failing responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->