### PR TITLE
fix: tolerate Windows NSIS line endings

### DIFF
--- a/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
+++ b/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
@@ -43,7 +43,7 @@ describe("windows nsis desktop shortcut customization", () => {
 
   test("declares a real custom page instead of running page commands inline", () => {
     expect(script).toContain("!ifndef BUILD_UNINSTALLER")
-    expect(script).toMatch(/!ifndef BUILD_UNINSTALLER\s+Var AddDesktopShortcutCheckbox/)
+    expect(script).toMatch(/!ifndef BUILD_UNINSTALLER\r?\n[^\S\r\n]*Var AddDesktopShortcutCheckbox/)
     expect(script).toContain("PageEx custom")
     expect(script).toContain('Caption "$(PawWorkShortcutOptions)"')
     expect(script).toContain("PageCallbacks PawWorkDesktopShortcutPageCreate PawWorkDesktopShortcutPageLeave")

--- a/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
+++ b/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
@@ -43,7 +43,7 @@ describe("windows nsis desktop shortcut customization", () => {
 
   test("declares a real custom page instead of running page commands inline", () => {
     expect(script).toContain("!ifndef BUILD_UNINSTALLER")
-    expect(script).toContain("!ifndef BUILD_UNINSTALLER\n  Var AddDesktopShortcutCheckbox")
+    expect(script).toMatch(/!ifndef BUILD_UNINSTALLER\r?\n  Var AddDesktopShortcutCheckbox/)
     expect(script).toContain("PageEx custom")
     expect(script).toContain('Caption "$(PawWorkShortcutOptions)"')
     expect(script).toContain("PageCallbacks PawWorkDesktopShortcutPageCreate PawWorkDesktopShortcutPageLeave")

--- a/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
+++ b/packages/desktop-electron/electron-builder-nsis-shortcut.test.ts
@@ -43,7 +43,7 @@ describe("windows nsis desktop shortcut customization", () => {
 
   test("declares a real custom page instead of running page commands inline", () => {
     expect(script).toContain("!ifndef BUILD_UNINSTALLER")
-    expect(script).toMatch(/!ifndef BUILD_UNINSTALLER\r?\n  Var AddDesktopShortcutCheckbox/)
+    expect(script).toMatch(/!ifndef BUILD_UNINSTALLER\s+Var AddDesktopShortcutCheckbox/)
     expect(script).toContain("PageEx custom")
     expect(script).toContain('Caption "$(PawWorkShortcutOptions)"')
     expect(script).toContain("PageCallbacks PawWorkDesktopShortcutPageCreate PawWorkDesktopShortcutPageLeave")


### PR DESCRIPTION
## Summary

Allow the Windows NSIS shortcut customization test to match both LF and CRLF line endings.

## Why

The post-merge `windows-advisory` workflow started failing after #503 because Git for Windows checked out `packages/desktop-electron/resources/installer.nsh` with CRLF line endings, while the test asserted a literal LF-only substring. The installer script content was correct; the test was too line-ending-specific for the Windows runner.

## Related Issue

No dedicated issue. This fixes the repeated post-merge `windows-advisory` failure introduced by #503.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Confirm the regex preserves the original structural assertion while accepting Windows CRLF checkout behavior.

## Risk Notes

Low. This is a test-only change and does not change installer runtime behavior.

## How To Verify

```text
Focused desktop test: 9 passed, 0 failed via bun --cwd packages/desktop-electron test electron-builder-nsis-shortcut.test.ts
Line-ending proof: ok for both LF and CRLF via a Bun regex smoke check
Diff check: git diff --check passed with no whitespace errors
Final diff: 1 file changed, 1 insertion, 1 deletion
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced Windows installer test robustness to handle varying line ending formats across different systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/509)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->