### PR TITLE
fix(opencode): release loaded instances before fixture deletion

### DIFF
--- a/packages/opencode/src/project/instance-runtime.ts
+++ b/packages/opencode/src/project/instance-runtime.ts
@@ -9,6 +9,9 @@ export const reloadInstance = (input: LoadInput) =>
 export const disposeInstance = (ctx: Parameters<InstanceStore.Interface["dispose"]>[0]) =>
   AppRuntime.runPromise(InstanceStore.Service.use((store) => store.dispose(ctx)))
 
+export const disposeDirectory = (directory: string) =>
+  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeDirectory(directory)))
+
 export const disposeAllInstances = () =>
   AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeAll()))
 

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -19,6 +19,7 @@ export interface Interface {
   readonly load: (input: LoadInput) => Effect.Effect<InstanceContext, unknown>
   readonly reload: (input: LoadInput) => Effect.Effect<InstanceContext, unknown>
   readonly dispose: (ctx: InstanceContext) => Effect.Effect<void>
+  readonly disposeDirectory: (directory: string) => Effect.Effect<void>
   readonly disposeAll: () => Effect.Effect<void>
   readonly provide: <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E | unknown, R>
 }
@@ -186,6 +187,17 @@ export const layer = Layer.effect(
         yield* disposeEntry(directory, entry, ctx).pipe(Effect.asVoid)
       })
 
+    const disposeDirectory = (inputDirectory: string) =>
+      Effect.gen(function* () {
+        const directory = Filesystem.resolve(inputDirectory)
+        const entry = entries.get(directory)
+        if (!entry) return
+
+        const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
+        if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
+        yield* disposeEntry(directory, entry, exit.value).pipe(Effect.asVoid)
+      })
+
     const disposeAllOnce = Effect.gen(function* () {
       yield* Effect.forEach(
         [...entries.entries()],
@@ -222,6 +234,7 @@ export const layer = Layer.effect(
       load,
       reload,
       dispose,
+      disposeDirectory,
       disposeAll,
       provide: (input, effect) => load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx)))),
     }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -125,6 +125,12 @@ export const Instance = {
     await instanceRuntime.disposeInstance(ctx)
     directories.delete(ctx.directory)
   },
+  async disposeDirectory(inputDirectory: string) {
+    const directory = Filesystem.resolve(inputDirectory)
+    const instanceRuntime = await runtime()
+    await instanceRuntime.disposeDirectory(directory)
+    directories.delete(directory)
+  },
   async disposeAll() {
     const { disposeAllLoadedInstances } = await import("./instance-store")
     await disposeAllLoadedInstances()

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -95,6 +95,29 @@ describe("InstanceStore", () => {
     }),
   )
 
+  it.live("disposeDirectory disposes loaded entries without loading missing directories", () =>
+    Effect.gen(function* () {
+      const loaded = yield* tmpdirScoped()
+      const missing = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const disposed: string[] = []
+      const off = registerDisposer(async (directory) => {
+        disposed.push(directory)
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      yield* store.load({ directory: loaded })
+
+      bootstrapRun = Effect.sync(() => {
+        throw new Error("disposeDirectory must not bootstrap unloaded directories")
+      })
+      yield* store.disposeDirectory(missing)
+      yield* store.disposeDirectory(loaded)
+
+      expect(disposed).toEqual([loaded])
+    }),
+  )
+
   it.live("drops failed loads so the next attempt can boot again", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -22,7 +22,7 @@ async function removeLoadedSessionProjectDirectory(dir: string) {
   await fs.rm(dir, {
     recursive: true,
     force: true,
-    maxRetries: 5,
+    maxRetries: process.platform === "win32" ? 30 : 5,
     retryDelay: 100,
   })
 }

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -17,11 +17,12 @@ import { LLMTrace } from "../../src/session/llm-trace"
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
 
-async function removeSessionProjectDirectory(dir: string) {
+async function removeLoadedSessionProjectDirectory(dir: string) {
+  await Instance.disposeDirectory(dir)
   await fs.rm(dir, {
     recursive: true,
     force: true,
-    maxRetries: process.platform === "win32" ? 30 : 5,
+    maxRetries: 5,
     retryDelay: 100,
   })
 }
@@ -201,7 +202,7 @@ describe("Export.session", () => {
     })
 
     try {
-      await removeSessionProjectDirectory(sessionProject.path)
+      await removeLoadedSessionProjectDirectory(sessionProject.path)
       await Instance.provide({
         directory: currentProject.path,
         fn: async () => {
@@ -271,7 +272,7 @@ describe("Export.session", () => {
       })
 
       await Config.invalidate(true)
-      await removeSessionProjectDirectory(sessionProject.path)
+      await removeLoadedSessionProjectDirectory(sessionProject.path)
       await Instance.provide({
         directory: currentProject.path,
         fn: async () => {


### PR DESCRIPTION
## Summary

Adds a directory-scoped instance disposal path and uses it before export tests remove loaded session project fixture directories.

## Why

The post-merge Windows advisory job still failed in `unit-windows-opencode-session` with `EBUSY` while deleting a git-backed temp project directory. The failure was a lifecycle contract bug in the test/runtime boundary: the directory had been loaded into `InstanceStore`, so directory-scoped resources must be released before the fixture removes it.

## Related Issue

No issue. Follow-up to the post-merge Windows advisory failure after PR #511.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that `disposeDirectory` is a no-load disposal path and cannot bootstrap or mutate missing directories just to clean them up.

## Risk Notes

Low. This adds a production lifecycle API, but the current call site is test cleanup only. Product export behavior is unchanged. `disposeDirectory` is intentionally no-load and releases only already-loaded directories; callers must only use it once the directory is no longer needed by the active task. Windows impact is positive because loaded fixture directories are released before deletion.

## How To Verify

```text
Red test: InstanceStore suite failed before implementation because store.disposeDirectory was undefined
Instance store tests: 7 pass, 0 fail
Export tests: 32 pass, 0 fail
Combined focused tests: 39 pass, 0 fail
Typecheck: bun run --cwd packages/opencode typecheck passed
Diff check: git diff --check passed
Windows advisory: workflow_dispatch run 25605476612 passed, including unit-windows-opencode-session in 8m31s
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced directory-scoped instance disposal capability, allowing you to dispose of individual directory instances independently without affecting other loaded instances. This provides more granular control over resource management and complements existing disposal mechanisms.

* **Tests**
  * Added tests to validate directory-scoped disposal behavior and ensure the cleanup process works correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/513)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->