### PR TITLE
fix(app): separate session and execution scopes

### DIFF
--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -165,7 +165,6 @@ async function expandRenderedTimeline(page: Page, target: number) {
         if (count >= target) return count
         await viewport.hover()
         await page.mouse.wheel(0, -2400)
-        await page.waitForTimeout(100)
         return page.locator(sessionMessageItemSelector).count()
       },
       { timeout: 30_000 },
@@ -309,6 +308,7 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     await expect.poll(async () => (await expectTimelineMetrics(page)).top).toBeGreaterThan(20)
 
     const followupCheckpoint = (await readRendererDiagnostics(page)).length
+    const sentBeforeFollowup = await readPromptSent(page)
     const followupText = `worktree exit follow-up ${Date.now()}`
     await sendVisiblePrompt({ page, text: followupText })
     await expect
@@ -334,6 +334,7 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     expect(messages.length).toBeGreaterThanOrEqual(91)
 
     const sent = await readPromptSent(page)
+    expect(sent.count).toBeGreaterThan(sentBeforeFollowup.count)
     expect(sent.sessionID).toBe(session.id)
     expect(sent.directory).toBe(project.directory)
 

--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -27,6 +27,12 @@ type TimelineMetrics = {
   distanceFromBottom: number
 }
 
+function directoryCompareKey(directory: string | undefined) {
+  if (!directory) return ""
+  const value = directory.replaceAll("\\", "/").replace(/\/+$/, "") || "/"
+  return value.startsWith("/private/var/") ? value.slice("/private".length) : value
+}
+
 async function installRendererDiagnosticsCapture(page: Page) {
   await page.addInitScript(() => {
     const win = window as typeof window & {
@@ -109,6 +115,21 @@ async function scrollTimelineToBottom(page: Page) {
   expect(found, "session timeline viewport should exist").toBe(true)
 }
 
+async function scrollTimelineToOffset(page: Page, top: number) {
+  const found = await page.evaluate(
+    ({ scrollViewportSelector, turnListSelector, top }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.scrollTop = top
+      viewport.dispatchEvent(new Event("scroll", { bubbles: true }))
+      return true
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector, top },
+  )
+  expect(found, "session timeline viewport should exist").toBe(true)
+}
+
 async function resetTimelineToTop(page: Page) {
   const found = await page.evaluate(
     ({ scrollViewportSelector, turnListSelector }) => {
@@ -128,9 +149,64 @@ async function sendVisiblePrompt(input: { page: Page; text: string }) {
   const prompt = input.page.locator(promptSelector)
   await expect(prompt).toBeVisible()
   await prompt.click()
-  await input.page.keyboard.insertText(input.text)
+  await prompt.fill("")
+  await prompt.fill(input.text)
   await expect.poll(async () => (await prompt.textContent())?.replace(/\u200B/g, "").trim()).toBe(input.text)
   await input.page.keyboard.press("Enter")
+}
+
+async function expandRenderedTimeline(page: Page, target: number) {
+  const viewport = page.locator(scrollViewportSelector).first()
+  await expect(viewport).toBeVisible()
+  await expect
+    .poll(
+      async () => {
+        const count = await page.locator(sessionMessageItemSelector).count()
+        if (count >= target) return count
+        await viewport.hover()
+        await page.mouse.wheel(0, -2400)
+        await page.waitForTimeout(100)
+        return page.locator(sessionMessageItemSelector).count()
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThanOrEqual(target)
+}
+
+async function readPromptSent(page: Page) {
+  return page.evaluate(() => {
+    const win = window as typeof window & {
+      __opencode_e2e?: {
+        prompt?: {
+          sent?: {
+            started?: number
+            count?: number
+            sessionID?: string
+            directory?: string
+          }
+        }
+      }
+    }
+    const sent = win.__opencode_e2e?.prompt?.sent
+    return {
+      started: sent?.started ?? 0,
+      count: sent?.count ?? 0,
+      sessionID: sent?.sessionID,
+      directory: sent?.directory,
+    }
+  })
+}
+
+async function waitSessionActiveDirectory(input: { sdk: Sdk; sessionID: string; directory: string }) {
+  await expect
+    .poll(
+      async () => {
+        const session = await input.sdk.session.get({ sessionID: input.sessionID }).then((res) => res.data)
+        return directoryCompareKey(session?.executionContext.activeDirectory)
+      },
+      { timeout: 45_000 },
+    )
+    .toBe(directoryCompareKey(input.directory))
 }
 
 function numberData(event: CapturedDiagnosticEvent, key: string) {
@@ -192,5 +268,98 @@ test("captures renderer diagnostics while guarding send scroll position", async 
     expect(
       events.some((event) => event.name === "session.scroll.sample" && event.data?.user_scrolled === false),
     ).toBe(true)
+  })
+})
+
+test("keeps long timeline stable across worktree exit follow-up", async ({ page, project, llm }) => {
+  test.setTimeout(180_000)
+
+  await installRendererDiagnosticsCapture(page)
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e long timeline worktree ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 90 })
+
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+    await expandRenderedTimeline(page, 80)
+    await scrollTimelineToOffset(page, 240)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).top).toBeGreaterThan(20)
+
+    const created = await sdk.worktree.create({ directory: project.directory }).then((res) => res.data)
+    if (!created?.directory) throw new Error("Failed to create worktree for long timeline diagnostics")
+    const worktreeDirectory = created.directory
+    project.trackDirectory(worktreeDirectory)
+
+    await llm.tool("enter-worktree", { path: worktreeDirectory })
+    await sendVisiblePrompt({ page, text: "enter diagnostics worktree" })
+    await waitSessionActiveDirectory({ sdk, sessionID: session.id, directory: worktreeDirectory })
+    await expect
+      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
+      .toBeGreaterThanOrEqual(80)
+
+    await llm.tool("exit-worktree", {})
+    await sendVisiblePrompt({ page, text: "exit diagnostics worktree" })
+    await waitSessionActiveDirectory({ sdk, sessionID: session.id, directory: project.directory })
+    await expect
+      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
+      .toBeGreaterThanOrEqual(80)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).top).toBeGreaterThan(20)
+
+    const followupCheckpoint = (await readRendererDiagnostics(page)).length
+    const followupText = `worktree exit follow-up ${Date.now()}`
+    await sendVisiblePrompt({ page, text: followupText })
+    await expect
+      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
+      .toBeGreaterThanOrEqual(80)
+
+    await expect
+      .poll(
+        async () => {
+          const messages = await sdk.session.messages({ sessionID: session.id, limit: 200 }).then((res) => res.data ?? [])
+          return {
+            count: messages.length,
+            hasFollowup: messages.some((message) =>
+              message.parts.some((part) => part.type === "text" && part.text.includes(followupText)),
+            ),
+          }
+        },
+        { timeout: 30_000 },
+      )
+      .toEqual({ count: expect.any(Number), hasFollowup: true })
+
+    const messages = await sdk.session.messages({ sessionID: session.id, limit: 200 }).then((res) => res.data ?? [])
+    expect(messages.length).toBeGreaterThanOrEqual(91)
+
+    const sent = await readPromptSent(page)
+    expect(sent.sessionID).toBe(session.id)
+    expect(sent.directory).toBe(project.directory)
+
+    const events = await readRendererDiagnostics(page)
+    const sessionEvents = events.filter((event) => event.timeline_session_id === session.id)
+    expect(sessionEvents.filter((event) => event.name === "session.timeline.mount")).toHaveLength(1)
+    expect(sessionEvents.filter((event) => event.name === "session.timeline.unmount")).toHaveLength(0)
+    expect(sessionEvents.filter((event) => event.name === "session.identity.transition")).toHaveLength(0)
+
+    const followupEvents = events.slice(followupCheckpoint).filter((event) => event.timeline_session_id === session.id)
+    const followupVisibleCounts = followupEvents
+      .filter((event) => event.name === "session.timeline.visible")
+      .map((event) => numberData(event, "rendered_count") ?? 0)
+    if (followupVisibleCounts.length > 0) expect(Math.max(...followupVisibleCounts)).toBeGreaterThanOrEqual(80)
+
+    const followupScrollJumps = followupEvents.filter((event) => {
+      if (event.name !== "session.scroll.sample") return false
+      const top = numberData(event, "scroll_top")
+      const distance = numberData(event, "distance_from_bottom")
+      return top !== undefined && distance !== undefined && top < 20 && distance > 100
+    })
+    expect(followupScrollJumps).toEqual([])
+
+    const viewMessageCounts = events
+      .filter((event) => event.name === "session.view.state" && event.timeline_session_id === session.id)
+      .map((event) => numberData(event, "message_count") ?? 0)
+    expect(Math.max(...viewMessageCounts)).toBeGreaterThanOrEqual(91)
   })
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -24,6 +24,7 @@ const syncedDirectories: string[] = []
 const promptAsyncCalls: Array<Record<string, unknown>> = []
 const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
+let commandsReady = true
 const abortedSessions: string[] = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
@@ -166,7 +167,7 @@ beforeAll(async () => {
 
   mock.module("@/context/sync", () => ({
     useSync: () => ({
-      data: { command: commandDefinitions },
+      data: { command: commandDefinitions, get command_ready() { return commandsReady } },
       session: {
         optimistic: {
           add: (value: {
@@ -248,6 +249,7 @@ beforeEach(() => {
   promptAsyncCalls.length = 0
   commandCalls.length = 0
   commandDefinitions.length = 0
+  commandsReady = true
   abortedSessions.length = 0
   globalTodoSets.length = 0
   childTodoSets.length = 0
@@ -325,6 +327,64 @@ describe("prompt submit worktree selection", () => {
     expect(submits).toEqual([])
     expect(abortedSessions).toEqual([])
     expect(promptAsyncCalls).toEqual([])
+  })
+
+  test("blocks normal slash submit until commands hydrate", async () => {
+    params = { id: "session-existing" }
+    commandsReady = false
+    commandDefinitions.push({ name: "summarize" })
+    promptValue = [{ type: "text", content: "/summarize this", start: 0, end: 15 }]
+    const submit = createPromptSubmit({
+      sessionID: () => "session-existing",
+      isNewSession: () => false,
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(commandCalls).toEqual([])
+    expect(promptAsyncCalls).toEqual([])
+  })
+
+  test("does not block shell absolute paths on command hydration", async () => {
+    params = { id: "session-existing" }
+    commandsReady = false
+    promptValue = [{ type: "text", content: "/bin/ls", start: 0, end: 7 }]
+    const submit = createPromptSubmit({
+      sessionID: () => "session-existing",
+      isNewSession: () => false,
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "shell",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(sentShell).toEqual(["/repo/main"])
   })
 
   test("allows abort while submit readiness is blocked", async () => {
@@ -607,7 +667,7 @@ describe("prompt submit worktree selection", () => {
         child: () => [{}, () => undefined],
       } as any,
       sync: {
-        data: { command: [{ name: "summarize" }] },
+        data: { command: [{ name: "summarize" }], command_ready: true },
         session: {
           optimistic: {
             add: () => undefined,

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -25,11 +25,13 @@ const promptAsyncCalls: Array<Record<string, unknown>> = []
 const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
 let commandsReady = true
+let promptAsyncFailure: Error | undefined
 const abortedSessions: string[] = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
+const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
 
-let params: { id?: string } = {}
+let params: { dir?: string; id?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
 
@@ -64,6 +66,7 @@ const clientFor = (directory: string) => {
       prompt: async () => ({ data: undefined }),
       promptAsync: async (input: Record<string, unknown>) => {
         promptAsyncCalls.push(input)
+        if (promptAsyncFailure) throw promptAsyncFailure
         return { data: undefined }
       },
       command: async (input: Record<string, unknown>) => {
@@ -134,7 +137,9 @@ beforeAll(async () => {
     usePrompt: () => ({
       current: () => promptValue,
       reset: () => undefined,
-      set: () => undefined,
+      set: (next: Prompt, cursor?: number, target?: { dir: string; id?: string }) => {
+        promptSetCalls.push({ prompt: next, cursor, target })
+      },
       context: {
         add: () => undefined,
         remove: () => undefined,
@@ -250,9 +255,11 @@ beforeEach(() => {
   commandCalls.length = 0
   commandDefinitions.length = 0
   commandsReady = true
+  promptAsyncFailure = undefined
   abortedSessions.length = 0
   globalTodoSets.length = 0
   childTodoSets.length = 0
+  promptSetCalls.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
@@ -575,6 +582,36 @@ describe("prompt submit worktree selection", () => {
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("new worktree submit rollback targets final prompt route scope", async () => {
+    params = { dir: "/repo/main" }
+    selected = "/repo/worktree-a"
+    promptValue = [{ type: "text", content: "run tests", start: 0, end: 9 }]
+    promptAsyncFailure = new Error("send failed")
+    const submit = createPromptSubmit({
+      info: () => undefined,
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      newSessionWorktree: () => selected,
+      onNewSessionWorktreeReset: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptSetCalls.length > 0)
+
+    expect(promptSetCalls.at(-1)?.target).toEqual({ dir: "/repo/worktree-a", id: "session-1" })
   })
 
   test("sends locale with promptAsync requests", async () => {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -136,7 +136,7 @@ beforeAll(async () => {
   mock.module("@/context/prompt", () => ({
     usePrompt: () => ({
       current: () => promptValue,
-      reset: () => undefined,
+      reset: (_target?: { dir: string; id?: string }) => undefined,
       set: (next: Prompt, cursor?: number, target?: { dir: string; id?: string }) => {
         promptSetCalls.push({ prompt: next, cursor, target })
       },

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -23,6 +23,7 @@ import { setCursorPosition } from "./editor-dom"
 import { buildHomeOverride } from "./home-override"
 import { formatServerError } from "@/utils/server-errors"
 import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
+import { promptScopeForSession } from "@/pages/session/prompt-route-scope"
 
 type PendingPrompt = {
   abort: AbortController
@@ -454,8 +455,15 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       input.setPopover(null)
     }
 
+    const promptScope = promptScopeForSession({
+      routeDir: params.dir,
+      routeDirectory: projectDirectory,
+      targetDirectory: sessionDirectory,
+      sessionID: session.id,
+    })
+
     const restoreInput = () => {
-      prompt.set(currentPrompt, input.promptLength(currentPrompt))
+      prompt.set(currentPrompt, input.promptLength(currentPrompt), promptScope)
       input.setMode(mode)
       input.setPopover(null)
       requestAnimationFrame(() => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -22,6 +22,7 @@ import { buildRequestParts } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
 import { buildHomeOverride } from "./home-override"
 import { formatServerError } from "@/utils/server-errors"
+import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
 
 type PendingPrompt = {
   abort: AbortController
@@ -54,10 +55,14 @@ type FollowupSendInput = {
 
 const draftText = (prompt: Prompt) => prompt.map((part) => ("content" in part ? part.content : "")).join("")
 
+export function followupCommandText(draft: FollowupDraft) {
+  return draft.outgoingTextOverride ?? draftText(draft.prompt)
+}
+
 const draftImages = (prompt: Prompt) => prompt.filter((part): part is ImageAttachmentPart => part.type === "image")
 
 export async function sendFollowupDraft(input: FollowupSendInput) {
-  const text = input.draft.outgoingTextOverride ?? draftText(input.draft.prompt)
+  const text = followupCommandText(input.draft)
   const images = draftImages(input.draft.prompt)
   const [, setStore] = input.globalSync.child(input.draft.sessionDirectory)
 
@@ -320,7 +325,16 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       if (input.working()) abort()
       return
     }
-    if (!actionReady()) return
+    if (
+      !canSubmitPrompt({
+        mode,
+        text,
+        submitReady: actionReady(),
+        commandsReady: sync.data.command_ready,
+      })
+    ) {
+      return
+    }
 
     const currentModel = local.model.current()
     const currentAgent = local.agent.current()

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -51,10 +51,12 @@ function createVcsCache(): VcsCache {
 
 function deferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
     resolve = done
+    reject = fail
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 async function waitFor(check: () => boolean, timeoutMs = 300) {
@@ -425,6 +427,71 @@ describe("bootstrapDirectory", () => {
     await waitFor(() => store.command_ready)
 
     expect(store.command).toEqual(commands)
+  })
+
+  test("keeps command readiness false and clears commands when command list fails", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    setStore("command", [{ name: "stale" }] as State["command"])
+    setStore("command_ready", true)
+    const command = deferred<{ data: State["command"] }>()
+    let commandStarted = false
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: {
+        list: async () => {
+          commandStarted = true
+          return command.promise
+        },
+      },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => commandStarted)
+    expect(store.command_ready).toBe(false)
+
+    const originalError = console.error
+    console.error = () => undefined
+    try {
+      command.reject(new Error("command list failed"))
+      await waitFor(() => store.command.length === 0)
+    } finally {
+      console.error = originalError
+    }
+
+    expect(store.command_ready).toBe(false)
+    expect(store.command).toEqual([])
   })
 
   test("latest provider refresh writes store when an older refresh resolves later", async () => {

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -11,6 +11,7 @@ function createState(): State {
     status: "loading",
     agent: [],
     command: [],
+    command_ready: false,
     project: "",
     projectMeta: undefined,
     icon: undefined,
@@ -366,6 +367,64 @@ describe("bootstrapDirectory", () => {
     expect(store.provider).toEqual(providers)
 
     permission.resolve({ data: [] })
+  })
+
+  test("resets command readiness until command list hydrates", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    setStore("command_ready", true)
+    const command = deferred<{ data: State["command"] }>()
+    let commandStarted = false
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: {
+        list: async () => {
+          commandStarted = true
+          return command.promise
+        },
+      },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+      blocker: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => commandStarted)
+    expect(store.command_ready).toBe(false)
+
+    const commands = [{ name: "release" }] as State["command"]
+    command.resolve({ data: commands })
+    await waitFor(() => store.command_ready)
+
+    expect(store.command).toEqual(commands)
   })
 
   test("latest provider refresh writes store when an older refresh resolves later", async () => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -258,6 +258,7 @@ export async function bootstrapDirectory(input: {
   input.setStore("mcp", {})
   input.setStore("lsp_ready", false)
   input.setStore("lsp", [])
+  input.setStore("command_ready", false)
   input.setStore("session_status_state", "loading")
   input.setStore("session_status_ready", false)
   input.setStore("session_status", reconcile(statusBaseline))
@@ -354,7 +355,17 @@ export async function bootstrapDirectory(input: {
             if (next) input.vcsCache.setStore("value", next)
           }),
         ),
-      () => retry(() => input.sdk.command.list().then((x) => input.setStore("command", x.data ?? []))),
+      () =>
+        retry(() =>
+          input.sdk.command.list().then((x) => {
+            input.setStore("command", x.data ?? [])
+            input.setStore("command_ready", true)
+          }),
+        ).catch((err) => {
+          input.setStore("command", [])
+          input.setStore("command_ready", false)
+          throw err
+        }),
       () =>
         retry(() =>
           input.sdk.permission.list().then((x) => {

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -182,6 +182,7 @@ export function createChildStoreManager(input: {
             status: "loading" as const,
             agent: [],
             command: [],
+            command_ready: false,
             session: [],
             sessionTotal: 0,
             session_status: {},

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -63,6 +63,7 @@ const baseState = (input: Partial<State> = {}) =>
     status: "complete",
     agent: [],
     command: [],
+    command_ready: true,
     project: "",
     projectMeta: undefined,
     icon: undefined,

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -47,6 +47,7 @@ export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
   command: Command[]
+  command_ready: boolean
   project: string
   projectMeta: ProjectMeta | undefined
   icon: string | undefined

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -477,6 +477,7 @@ export default function Page() {
     directory: () => sdk.directory,
     client: () => sdk.client,
     sessionID: timelineSessionID,
+    sessionScope: timeline.sessionScope,
     actionReady: submitReady,
     isChildSession: timelineIsChildSession,
     busy,
@@ -568,14 +569,10 @@ export default function Page() {
               edit: followups.editingFollowup(),
               onQueue: followups.queueFollowup,
               onAbort: () => {
-                const id = timelineSessionID()
-                if (!id) return
-                followups.pause(id)
+                followups.pause()
               },
               onSend: (id) => {
-                const sessionID = timelineSessionID()
-                if (!sessionID) return
-                void followups.sendFollowup(sessionID, id, { manual: true })
+                void followups.sendFollowup(id, { manual: true })
               },
               onEdit: followups.editFollowup,
               onEditLoaded: followups.clearFollowupEdit,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -59,7 +59,7 @@ export default function Page() {
   const terminal = useTerminal()
   const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string }>()
-  const { params, sessionKey, tabs, view } = useSessionLayout()
+  const { params, tabs, view } = useSessionLayout()
 
   useSessionDesktopContext({
     context: () =>
@@ -300,7 +300,7 @@ export default function Page() {
   )
   const reviewState = createSessionReviewState({
     directory: () => sdk.directory,
-    sessionKey,
+    sessionKey: timelineSessionKey,
     sessionID: timelineSessionID,
     sync,
     sdk,
@@ -363,7 +363,7 @@ export default function Page() {
     reviewState,
     routeSessionID: () => params.id,
     sdk,
-    sessionKey,
+    sessionKey: timelineSessionKey,
     sync,
     timelineDiffs,
     turnDiffs,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -14,6 +14,7 @@ import { usePrompt } from "@/context/prompt"
 import { createSessionPerformanceDiagnostics, emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import { useSDK } from "@/context/sdk"
 import { useSettings } from "@/context/settings"
+import { useServer } from "@/context/server"
 import { useShellSurface } from "@/context/shell-surface"
 import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
@@ -53,6 +54,7 @@ export default function Page() {
   const language = useLanguage()
   const sdk = useSDK()
   const settings = useSettings()
+  const server = useServer()
   const shellSurface = useShellSurface()
   const prompt = usePrompt()
   const comments = useComments()
@@ -91,6 +93,7 @@ export default function Page() {
   const centered = createMemo(() => isDesktop())
 
   const timeline = createSessionTimelineData({
+    serverKey: () => server.key,
     directory: () => params.dir ?? "",
     routeSessionID: () => params.id,
     sync,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -403,6 +403,9 @@ export default function Page() {
   const resumeScroll = timelineInteraction.resumeScroll
   const scheduleScrollState = timelineInteraction.scheduleScrollState
   const scrollDock = timelineInteraction.scrollDock
+  const resumeScrollIfFollowing = () => {
+    if (scrollDock.scroll.bottom) resumeScroll()
+  }
   const setScrollRef = timelineInteraction.setScrollRef
 
   useSessionKeyboardFocus({
@@ -569,9 +572,9 @@ export default function Page() {
       onNewSessionWorktreeReset={newSessionWorktree.reset}
       onSubmit={() => {
         comments.clear()
-        resumeScroll()
+        resumeScrollIfFollowing()
       }}
-      onResponseSubmit={resumeScroll}
+      onResponseSubmit={resumeScrollIfFollowing}
       onModeChange={ctx?.onModeChange}
       selectedSkill={ctx?.selectedSkill}
       followup={

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -20,7 +20,9 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { buildDesktopContext } from "@/utils/desktop-context"
 import { createSessionComposerState } from "@/pages/session/composer"
+import { createExecutionScopeTracker, type ExecutionScope } from "@/pages/session/execution-scope"
 import { createSizing } from "@/pages/session/helpers"
+import { promptScopeForSession } from "@/pages/session/prompt-route-scope"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { SessionPageComposerRegion } from "@/pages/session/session-composer-region"
 import { SessionMainView } from "@/pages/session/session-main-view"
@@ -301,8 +303,15 @@ export default function Page() {
       ? desktopSidePanelOpen() && view().sidePanel.tab() === "review" && activeTab() === "review"
       : mobileChanges(),
   )
+  const executionScopeTracker = createExecutionScopeTracker()
+  const currentExecutionScope = (): ExecutionScope =>
+    executionScopeTracker({
+      serverKey: server.key,
+      directory: sdk.directory,
+    })
   const reviewState = createSessionReviewState({
     directory: () => sdk.directory,
+    executionScope: currentExecutionScope,
     sessionKey: timelineSessionKey,
     sessionID: timelineSessionID,
     sync,
@@ -500,15 +509,20 @@ export default function Page() {
     snapshot: () => {
       const directory = sdk.directory
       const handle = sync.retainDirectory(directory)
+      const scope = currentExecutionScope()
       return {
+        scope,
+        currentScope: currentExecutionScope,
         client: sdk.createClient({ directory, throwOnError: true }),
         store: handle.store,
         setStore: handle.setStore,
         prompt: prompt.current().slice(),
-        promptScope: {
-          dir: params.dir ?? directory,
-          id: timelineSessionID(),
-        },
+        promptScope: promptScopeForSession({
+          routeDir: params.dir,
+          routeDirectory: directory,
+          targetDirectory: directory,
+          sessionID: timelineSessionID(),
+        }),
         release: handle.release,
         directory,
       }

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from "@/context/language"
 import { usePrompt } from "@/context/prompt"
 import { useSync } from "@/context/sync"
 import { getSessionHandoff, setSessionHandoff } from "@/pages/session/handoff"
-import { useSessionKey } from "@/pages/session/session-layout"
+import { useSessionRouteKey } from "@/pages/session/session-layout"
 import { SessionPermissionContent } from "@/pages/session/composer/session-permission-dock"
 import { SessionQuestionDock } from "@/pages/session/composer/session-question-dock"
 import { SessionFollowupDock } from "@/pages/session/composer/session-followup-dock"
@@ -56,11 +56,11 @@ export function SessionComposerRegion(props: {
   const navigate = useNavigate()
   const prompt = usePrompt()
   const language = useLanguage()
-  const route = useSessionKey()
+  const route = useSessionRouteKey()
   const sync = useSync()
   const displaySessionID = createMemo(() => (props.variant === "session" ? props.displaySessionID : route.params.id))
   const displaySessionKey = createMemo(() =>
-    props.variant === "session" ? props.displaySessionKey : route.sessionKey(),
+    props.variant === "session" ? props.displaySessionKey : route.layoutRouteKey(),
   )
 
   const handoffPrompt = createMemo(() => {

--- a/packages/app/src/pages/session/execution-scope.test.ts
+++ b/packages/app/src/pages/session/execution-scope.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createExecutionScopeTracker,
+  executionScopeKey,
+  nextExecutionEpoch,
+  sameExecutionScope,
+  shouldApplyExecutionResult,
+  vcsTaskKey,
+} from "./execution-scope"
+
+describe("execution scope", () => {
+  test("keys include server directory and epoch", () => {
+    expect(executionScopeKey({ serverKey: "sidecar", directory: "/repo", epoch: 1 })).not.toBe(
+      executionScopeKey({ serverKey: "sidecar", directory: "/repo", epoch: 2 }),
+    )
+    expect(executionScopeKey({ serverKey: "sidecar", directory: "/repo", epoch: 1 })).not.toBe(
+      executionScopeKey({ serverKey: "sidecar", directory: "/repo-wt", epoch: 1 }),
+    )
+  })
+
+  test("increments epoch monotonically", () => {
+    expect(nextExecutionEpoch(0)).toBe(1)
+    expect(nextExecutionEpoch(41)).toBe(42)
+  })
+
+  test("tracker bumps epoch synchronously on server or directory change", () => {
+    const tracker = createExecutionScopeTracker()
+
+    const a1 = tracker({ serverKey: "sidecar", directory: "/repo" })
+    const sameA = tracker({ serverKey: "sidecar", directory: "/repo" })
+    const b2 = tracker({ serverKey: "sidecar", directory: "/repo-wt" })
+    const a3 = tracker({ serverKey: "sidecar", directory: "/repo" })
+    const remoteA = tracker({ serverKey: "remote", directory: "/repo" })
+
+    expect(a1).toEqual({ serverKey: "sidecar", directory: "/repo", epoch: 0 })
+    expect(sameA).toBe(a1)
+    expect(b2).toEqual({ serverKey: "sidecar", directory: "/repo-wt", epoch: 1 })
+    expect(a3).toEqual({ serverKey: "sidecar", directory: "/repo", epoch: 2 })
+    expect(remoteA).toEqual({ serverKey: "remote", directory: "/repo", epoch: 3 })
+  })
+
+  test("ignores stale result after A to B to A reuse", () => {
+    const oldA = { serverKey: "sidecar", directory: "/repo", epoch: 1 }
+    const newA = { serverKey: "sidecar", directory: "/repo", epoch: 3 }
+
+    expect(shouldApplyExecutionResult({ requested: oldA, current: newA })).toBe(false)
+    expect(shouldApplyExecutionResult({ requested: newA, current: newA })).toBe(true)
+  })
+
+  test("vcs task key includes execution scope", () => {
+    const oldA = vcsTaskKey({ serverKey: "sidecar", directory: "/repo", epoch: 1 }, "unstaged")
+    const newA = vcsTaskKey({ serverKey: "sidecar", directory: "/repo", epoch: 3 }, "unstaged")
+
+    expect(oldA).not.toBe(newA)
+  })
+
+  test("compares all fields", () => {
+    expect(
+      sameExecutionScope(
+        { serverKey: "sidecar", directory: "/repo", epoch: 1 },
+        { serverKey: "sidecar", directory: "/repo", epoch: 1 },
+      ),
+    ).toBe(true)
+    expect(
+      sameExecutionScope(
+        { serverKey: "sidecar", directory: "/repo", epoch: 1 },
+        { serverKey: "remote", directory: "/repo", epoch: 1 },
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/execution-scope.ts
+++ b/packages/app/src/pages/session/execution-scope.ts
@@ -1,0 +1,48 @@
+import type { VcsReviewMode } from "./review-change-mode"
+
+export type ExecutionScope = {
+  serverKey: string
+  directory: string
+  epoch: number
+}
+
+export function executionScopeKey(scope: ExecutionScope) {
+  return JSON.stringify([scope.serverKey, scope.directory, scope.epoch])
+}
+
+export function sameExecutionScope(a: ExecutionScope | undefined, b: ExecutionScope | undefined) {
+  if (!a || !b) return a === b
+  return a.serverKey === b.serverKey && a.directory === b.directory && a.epoch === b.epoch
+}
+
+export function nextExecutionEpoch(current: number) {
+  return current + 1
+}
+
+export function createExecutionScopeTracker() {
+  let current: ExecutionScope | undefined
+
+  return (input: { serverKey: string; directory: string }): ExecutionScope => {
+    if (!current) {
+      current = { serverKey: input.serverKey, directory: input.directory, epoch: 0 }
+      return current
+    }
+
+    if (current.serverKey === input.serverKey && current.directory === input.directory) return current
+
+    current = {
+      serverKey: input.serverKey,
+      directory: input.directory,
+      epoch: nextExecutionEpoch(current.epoch),
+    }
+    return current
+  }
+}
+
+export function shouldApplyExecutionResult(input: { requested: ExecutionScope; current: ExecutionScope | undefined }) {
+  return sameExecutionScope(input.requested, input.current)
+}
+
+export function vcsTaskKey(scope: ExecutionScope, mode: VcsReviewMode) {
+  return `${executionScopeKey(scope)}\n${mode}`
+}

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -177,7 +177,7 @@ export function FileTabContent(props: { tab: string }) {
   const language = useLanguage()
   const prompt = usePrompt()
   const fileComponent = useFileComponent()
-  const { sessionKey, tabs, view } = useSessionLayout()
+  const { layoutRouteKey, tabs, view } = useSessionLayout()
   const activeFileTab = createSessionTabs({
     tabs,
     pathFromTab: file.pathFromTab,
@@ -204,7 +204,7 @@ export function FileTabContent(props: { tab: string }) {
     const p = path()
     if (!p) return null
     if (file.ready()) return (file.selectedLines(p) as SelectedLineRange | undefined) ?? null
-    return (getSessionHandoff(sessionKey())?.files[p] as SelectedLineRange | undefined) ?? null
+    return (getSessionHandoff(layoutRouteKey())?.files[p] as SelectedLineRange | undefined) ?? null
   })
   const scrollSync = createScrollSync({
     tab: () => props.tab,

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -27,7 +27,7 @@ import { createSessionRunning } from "@/pages/session/session-running-state"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
-import { useSessionKey } from "@/pages/session/session-layout"
+import { useSessionRouteKey } from "@/pages/session/session-layout"
 import { usePlatform } from "@/context/platform"
 import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import { useServer } from "@/context/server"
@@ -285,7 +285,7 @@ export function MessageTimeline(props: {
   const dialog = useDialog()
   const language = useLanguage()
   const shellSurface = useShellSurface()
-  const { params } = useSessionKey()
+  const { params } = useSessionRouteKey()
   const platform = usePlatform()
   const server = useServer()
   onCleanup(() => {

--- a/packages/app/src/pages/session/prompt-route-scope.test.ts
+++ b/packages/app/src/pages/session/prompt-route-scope.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { promptScopeForSession } from "./prompt-route-scope"
+
+describe("prompt route scope", () => {
+  test("uses current route slug when execution target is current route directory", () => {
+    expect(
+      promptScopeForSession({
+        routeDir: "route-repo",
+        routeDirectory: "/repo",
+        targetDirectory: "/repo",
+        sessionID: "ses_1",
+      }),
+    ).toEqual({ dir: "route-repo", id: "ses_1" })
+  })
+
+  test("uses encoded target directory for new worktree session", () => {
+    expect(
+      promptScopeForSession({
+        routeDir: "route-repo",
+        routeDirectory: "/repo",
+        targetDirectory: "/repo-worktree",
+        sessionID: "ses_2",
+      }),
+    ).toEqual({ dir: base64Encode("/repo-worktree"), id: "ses_2" })
+  })
+
+  test("uses encoded target directory when route is missing", () => {
+    expect(
+      promptScopeForSession({
+        routeDir: undefined,
+        routeDirectory: undefined,
+        targetDirectory: "/repo",
+        sessionID: "ses_3",
+      }),
+    ).toEqual({ dir: base64Encode("/repo"), id: "ses_3" })
+  })
+})

--- a/packages/app/src/pages/session/prompt-route-scope.ts
+++ b/packages/app/src/pages/session/prompt-route-scope.ts
@@ -1,0 +1,19 @@
+import { base64Encode } from "@opencode-ai/util/encode"
+
+export type PromptRouteScope = {
+  dir: string
+  id?: string
+}
+
+export function promptScopeForSession(input: {
+  routeDir: string | undefined
+  routeDirectory: string | undefined
+  targetDirectory: string
+  sessionID: string | undefined
+}): PromptRouteScope {
+  const dir =
+    input.routeDir && input.routeDirectory === input.targetDirectory
+      ? input.routeDir
+      : base64Encode(input.targetDirectory)
+  return { dir, id: input.sessionID }
+}

--- a/packages/app/src/pages/session/session-action-readiness.test.ts
+++ b/packages/app/src/pages/session/session-action-readiness.test.ts
@@ -1,0 +1,122 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import {
+  canSendFollowupDraft,
+  canSubmitPrompt,
+  currentDirectoryProviderUsable,
+  currentSessionActionReady,
+  currentSessionSubmitReady,
+  sessionStatusKnown,
+} from "./session-action-readiness"
+import type { followupCommandText as FollowupCommandText, FollowupDraft } from "@/components/prompt-input/submit"
+
+let followupCommandText: typeof FollowupCommandText
+
+const slashDraft = { text: "/release now" }
+const normalDraft = { text: "continue" }
+
+const queuedDraft = (input: { prompt: FollowupDraft["prompt"]; outgoingTextOverride?: string }): FollowupDraft => ({
+  sessionID: "ses_1",
+  sessionDirectory: "/repo",
+  prompt: input.prompt,
+  context: [],
+  agent: "agent",
+  model: { providerID: "provider", modelID: "model" },
+  outgoingTextOverride: input.outgoingTextOverride,
+})
+
+describe("session action readiness", () => {
+  beforeAll(async () => {
+    mock.module("@solidjs/router", () => ({
+      useNavigate: () => () => undefined,
+      useParams: () => ({}),
+    }))
+
+    const mod = await import("@/components/prompt-input/submit")
+    followupCommandText = mod.followupCommandText
+  })
+
+  test("direct slash submit waits for command hydration", () => {
+    expect(canSubmitPrompt({ mode: "normal", text: "/release", submitReady: true, commandsReady: false })).toBe(false)
+    expect(canSubmitPrompt({ mode: "normal", text: "normal prompt", submitReady: true, commandsReady: false })).toBe(
+      true,
+    )
+    expect(canSubmitPrompt({ mode: "normal", text: "/release", submitReady: true, commandsReady: true })).toBe(true)
+  })
+
+  test("shell submit does not wait for command hydration", () => {
+    expect(canSubmitPrompt({ mode: "shell", text: "/bin/ls", submitReady: true, commandsReady: false })).toBe(true)
+    expect(canSubmitPrompt({ mode: "shell", text: "/release", submitReady: false, commandsReady: true })).toBe(false)
+  })
+
+  test("queued slash follow-up waits for command hydration", () => {
+    expect(canSendFollowupDraft({ draft: slashDraft, submitReady: true, commandsReady: false })).toBe(false)
+    expect(canSendFollowupDraft({ draft: slashDraft, submitReady: true, commandsReady: true })).toBe(true)
+    expect(canSendFollowupDraft({ draft: normalDraft, submitReady: true, commandsReady: false })).toBe(true)
+  })
+
+  test("queued slash follow-up uses the same command text as sendFollowupDraft", () => {
+    const draftWithLeadingImage = queuedDraft({
+      prompt: [
+        { type: "image", id: "img_1", filename: "screen.png", mime: "image/png", dataUrl: "data:image/png;base64,AA==" },
+        { type: "text", content: "/release now", start: 0, end: 12 },
+      ],
+    })
+    const draftWithOverride = queuedDraft({
+      prompt: [{ type: "text", content: "normal visible text", start: 0, end: 19 }],
+      outgoingTextOverride: "/release now",
+    })
+
+    expect(followupCommandText(draftWithLeadingImage)).toBe("/release now")
+    expect(followupCommandText(draftWithOverride)).toBe("/release now")
+    expect(
+      canSendFollowupDraft({
+        draft: { text: followupCommandText(draftWithLeadingImage) },
+        submitReady: true,
+        commandsReady: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("session actions wait for cache and status", () => {
+    expect(currentSessionActionReady({ sessionID: "ses_1", sessionInfo: {}, rawMessages: [], statusReady: true })).toBe(
+      true,
+    )
+    expect(
+      currentSessionActionReady({ sessionID: "ses_1", sessionInfo: undefined, rawMessages: [], statusReady: true }),
+    ).toBe(false)
+  })
+
+  test("submit waits for local model and provider usability", () => {
+    expect(
+      currentSessionSubmitReady({
+        sessionID: "ses_1",
+        sessionInfo: {},
+        rawMessages: [],
+        statusReady: true,
+        localReady: true,
+        providerUsable: true,
+      }),
+    ).toBe(true)
+    expect(
+      currentSessionSubmitReady({
+        sessionID: "ses_1",
+        sessionInfo: {},
+        rawMessages: [],
+        statusReady: true,
+        localReady: false,
+        providerUsable: true,
+      }),
+    ).toBe(false)
+  })
+
+  test("seeded providers are usable before refresh completes", () => {
+    expect(currentDirectoryProviderUsable({ providerReady: false, providerCount: 0 })).toBe(false)
+    expect(currentDirectoryProviderUsable({ providerReady: false, providerCount: 1 })).toBe(true)
+  })
+
+  test("busy or retry means status is known during loading", () => {
+    expect(sessionStatusKnown({ statusState: "loading", status: { type: "busy" } })).toBe(true)
+    expect(sessionStatusKnown({ statusState: "loading", status: { type: "idle" } })).toBe(false)
+    expect(sessionStatusKnown({ statusState: "ready", status: undefined })).toBe(true)
+  })
+})

--- a/packages/app/src/pages/session/session-action-readiness.test.ts
+++ b/packages/app/src/pages/session/session-action-readiness.test.ts
@@ -13,6 +13,7 @@ let followupCommandText: typeof FollowupCommandText
 
 const slashDraft = { text: "/release now" }
 const normalDraft = { text: "continue" }
+const leadingWhitespaceSlashDraft = { text: " /release now" }
 
 const queuedDraft = (input: { prompt: FollowupDraft["prompt"]; outgoingTextOverride?: string }): FollowupDraft => ({
   sessionID: "ses_1",
@@ -37,6 +38,7 @@ describe("session action readiness", () => {
 
   test("direct slash submit waits for command hydration", () => {
     expect(canSubmitPrompt({ mode: "normal", text: "/release", submitReady: true, commandsReady: false })).toBe(false)
+    expect(canSubmitPrompt({ mode: "normal", text: " /release", submitReady: true, commandsReady: false })).toBe(true)
     expect(canSubmitPrompt({ mode: "normal", text: "normal prompt", submitReady: true, commandsReady: false })).toBe(
       true,
     )
@@ -52,6 +54,9 @@ describe("session action readiness", () => {
     expect(canSendFollowupDraft({ draft: slashDraft, submitReady: true, commandsReady: false })).toBe(false)
     expect(canSendFollowupDraft({ draft: slashDraft, submitReady: true, commandsReady: true })).toBe(true)
     expect(canSendFollowupDraft({ draft: normalDraft, submitReady: true, commandsReady: false })).toBe(true)
+    expect(canSendFollowupDraft({ draft: leadingWhitespaceSlashDraft, submitReady: true, commandsReady: false })).toBe(
+      true,
+    )
   })
 
   test("queued slash follow-up uses the same command text as sendFollowupDraft", () => {

--- a/packages/app/src/pages/session/session-action-readiness.ts
+++ b/packages/app/src/pages/session/session-action-readiness.ts
@@ -1,0 +1,72 @@
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
+import type { SessionStatusState } from "@/context/global-sync/types"
+
+export type SubmitMode = "normal" | "shell"
+
+export function commandLikeText(text: string) {
+  return text.trimStart().startsWith("/")
+}
+
+export function canSubmitPrompt(input: {
+  mode: SubmitMode
+  text: string
+  submitReady: boolean
+  commandsReady: boolean
+}) {
+  if (!input.submitReady) return false
+  if (input.mode !== "normal") return true
+  if (!commandLikeText(input.text)) return true
+  return input.commandsReady
+}
+
+export function canSendFollowupDraft(input: { draft: { text: string }; submitReady: boolean; commandsReady: boolean }) {
+  return canSubmitPrompt({
+    mode: "normal",
+    text: input.draft.text,
+    submitReady: input.submitReady,
+    commandsReady: input.commandsReady,
+  })
+}
+
+export function currentSessionCacheReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+}) {
+  if (!input.sessionID) return true
+  return input.sessionInfo !== undefined && input.rawMessages !== undefined
+}
+
+export function currentSessionActionReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+  statusReady: boolean
+}) {
+  if (!input.sessionID) return true
+  return currentSessionCacheReady(input) && input.statusReady
+}
+
+export function currentSessionSubmitReady(input: {
+  sessionID: string | undefined
+  sessionInfo: unknown
+  rawMessages: unknown
+  statusReady: boolean
+  localReady: boolean
+  providerUsable: boolean
+}) {
+  return currentSessionActionReady(input) && input.localReady && input.providerUsable
+}
+
+export function currentWorkspaceSubmitReady(input: { localReady: boolean; providerUsable: boolean }) {
+  return input.localReady && input.providerUsable
+}
+
+export function currentDirectoryProviderUsable(input: { providerReady: boolean; providerCount: number }) {
+  return input.providerReady || input.providerCount > 0
+}
+
+export function sessionStatusKnown(input: { statusState: SessionStatusState; status: SessionStatus | undefined }) {
+  if (input.statusState === "ready" || input.statusState === "error") return true
+  return input.status?.type === "busy" || input.status?.type === "retry"
+}

--- a/packages/app/src/pages/session/session-action-readiness.ts
+++ b/packages/app/src/pages/session/session-action-readiness.ts
@@ -4,7 +4,7 @@ import type { SessionStatusState } from "@/context/global-sync/types"
 export type SubmitMode = "normal" | "shell"
 
 export function commandLikeText(text: string) {
-  return text.trimStart().startsWith("/")
+  return text.startsWith("/")
 }
 
 export function canSubmitPrompt(input: {

--- a/packages/app/src/pages/session/session-layout.test.ts
+++ b/packages/app/src/pages/session/session-layout.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
+import { sessionRouteLayoutKey } from "./session-layout"
 import { createStableLayoutMemo } from "./stable-layout-memo"
+
+describe("session route layout key", () => {
+  test("uses route directory and session id only", () => {
+    expect(sessionRouteLayoutKey({ dir: "repo-slug", id: "ses_1" })).toBe("repo-slug/ses_1")
+    expect(sessionRouteLayoutKey({ dir: "repo-slug", id: undefined })).toBe("repo-slug")
+  })
+})
 
 describe("createStableLayoutMemo", () => {
   test("reuses the last value when a disposed memo turns empty", () => {

--- a/packages/app/src/pages/session/session-layout.test.ts
+++ b/packages/app/src/pages/session/session-layout.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, test } from "bun:test"
+import { beforeAll, describe, expect, mock, test } from "bun:test"
 import { createRoot } from "solid-js"
-import { sessionRouteLayoutKey } from "./session-layout"
 import { createStableLayoutMemo } from "./stable-layout-memo"
+
+let sessionRouteLayoutKey: typeof import("./session-layout").sessionRouteLayoutKey
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useParams: () => ({}),
+  }))
+  const mod = await import("./session-layout")
+  sessionRouteLayoutKey = mod.sessionRouteLayoutKey
+})
 
 describe("session route layout key", () => {
   test("uses route directory and session id only", () => {
     expect(sessionRouteLayoutKey({ dir: "repo-slug", id: "ses_1" })).toBe("repo-slug/ses_1")
     expect(sessionRouteLayoutKey({ dir: "repo-slug", id: undefined })).toBe("repo-slug")
+    expect(sessionRouteLayoutKey({ dir: undefined, id: "ses_1" })).toBe("")
+    expect(sessionRouteLayoutKey({ dir: undefined, id: undefined })).toBe("")
   })
 })
 

--- a/packages/app/src/pages/session/session-layout.ts
+++ b/packages/app/src/pages/session/session-layout.ts
@@ -4,6 +4,7 @@ import { useLayout } from "@/context/layout"
 import { createStableLayoutMemo } from "./stable-layout-memo"
 
 export function sessionRouteLayoutKey(params: { dir: string | undefined; id: string | undefined }) {
+  if (!params.dir) return ""
   return `${params.dir}${params.id ? "/" + params.id : ""}`
 }
 

--- a/packages/app/src/pages/session/session-layout.ts
+++ b/packages/app/src/pages/session/session-layout.ts
@@ -8,7 +8,7 @@ export function sessionRouteLayoutKey(params: { dir: string | undefined; id: str
 }
 
 export const useSessionRouteKey = () => {
-  const params = useParams()
+  const params = useParams() as { dir: string | undefined; id: string | undefined }
   const layoutRouteKey = createMemo(() => sessionRouteLayoutKey(params))
   return { params, layoutRouteKey }
 }

--- a/packages/app/src/pages/session/session-layout.ts
+++ b/packages/app/src/pages/session/session-layout.ts
@@ -3,19 +3,23 @@ import { createMemo } from "solid-js"
 import { useLayout } from "@/context/layout"
 import { createStableLayoutMemo } from "./stable-layout-memo"
 
-export const useSessionKey = () => {
+export function sessionRouteLayoutKey(params: { dir: string | undefined; id: string | undefined }) {
+  return `${params.dir}${params.id ? "/" + params.id : ""}`
+}
+
+export const useSessionRouteKey = () => {
   const params = useParams()
-  const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
-  return { params, sessionKey }
+  const layoutRouteKey = createMemo(() => sessionRouteLayoutKey(params))
+  return { params, layoutRouteKey }
 }
 
 export const useSessionLayout = () => {
   const layout = useLayout()
-  const { params, sessionKey } = useSessionKey()
+  const { params, layoutRouteKey } = useSessionRouteKey()
   return {
     params,
-    sessionKey,
-    tabs: createStableLayoutMemo(() => layout.tabs(sessionKey)),
-    view: createStableLayoutMemo(() => layout.view(sessionKey)),
+    layoutRouteKey,
+    tabs: createStableLayoutMemo(() => layout.tabs(layoutRouteKey)),
+    view: createStableLayoutMemo(() => layout.view(layoutRouteKey)),
   }
 }

--- a/packages/app/src/pages/session/session-scope.test.ts
+++ b/packages/app/src/pages/session/session-scope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { makeSessionScope, sameSessionScope, sessionScopeKey } from "./session-scope"
+
+describe("session scope", () => {
+  test("keys include server and session", () => {
+    expect(sessionScopeKey({ serverKey: "sidecar", sessionID: "ses_same" })).not.toBe(
+      sessionScopeKey({ serverKey: "https://remote.example", sessionID: "ses_same" }),
+    )
+  })
+
+  test("constructs only when both fields exist", () => {
+    expect(makeSessionScope({ serverKey: "sidecar", sessionID: "ses_1" })).toEqual({
+      serverKey: "sidecar",
+      sessionID: "ses_1",
+    })
+    expect(makeSessionScope({ serverKey: undefined, sessionID: "ses_1" })).toBeUndefined()
+    expect(makeSessionScope({ serverKey: "sidecar", sessionID: undefined })).toBeUndefined()
+  })
+
+  test("compares server and session", () => {
+    expect(
+      sameSessionScope(
+        { serverKey: "sidecar", sessionID: "ses_1" },
+        { serverKey: "sidecar", sessionID: "ses_1" },
+      ),
+    ).toBe(true)
+    expect(
+      sameSessionScope(
+        { serverKey: "sidecar", sessionID: "ses_1" },
+        { serverKey: "remote", sessionID: "ses_1" },
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/session-scope.ts
+++ b/packages/app/src/pages/session/session-scope.ts
@@ -1,0 +1,22 @@
+export type SessionScope = {
+  serverKey: string
+  sessionID: string
+}
+
+export function makeSessionScope(input: {
+  serverKey: string | undefined
+  sessionID: string | undefined
+}): SessionScope | undefined {
+  if (!input.serverKey || !input.sessionID) return undefined
+  return { serverKey: input.serverKey, sessionID: input.sessionID }
+}
+
+export function sessionScopeKey(scope: SessionScope | undefined) {
+  if (!scope) return ""
+  return JSON.stringify([scope.serverKey, scope.sessionID])
+}
+
+export function sameSessionScope(a: SessionScope | undefined, b: SessionScope | undefined) {
+  if (!a || !b) return a === b
+  return a.serverKey === b.serverKey && a.sessionID === b.sessionID
+}

--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -75,7 +75,7 @@ beforeAll(async () => {
   mock.module("@/pages/session/handoff", () => ({ setSessionHandoff: () => undefined }))
   mock.module("@/pages/session/session-layout", () => ({
     useSessionLayout: () => ({
-      sessionKey: () => "dir/demo",
+      layoutRouteKey: () => "dir/demo",
       tabs: () => ({
         all: () => [],
         open: () => undefined,

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -107,7 +107,7 @@ export function SessionSidePanel(props: {
   const language = useLanguage()
   const command = useCommand()
   const dialog = useDialog()
-  const { sessionKey, tabs, view } = useSessionLayout()
+  const { layoutRouteKey, tabs, view } = useSessionLayout()
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
@@ -241,7 +241,7 @@ export function SessionSidePanel(props: {
   createEffect(() => {
     if (!file.ready()) return
 
-    setSessionHandoff(sessionKey(), {
+    setSessionHandoff(layoutRouteKey(), {
       files: tabs()
         .all()
         .reduce<Record<string, SelectedLineRange | null>>((acc, tab) => {

--- a/packages/app/src/pages/session/session-view-controller.test.ts
+++ b/packages/app/src/pages/session/session-view-controller.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
 import { createSessionViewController, nextSessionViewState, timelineIdentity } from "./session-view-controller"
+import { sessionScopeKey } from "./session-scope"
+
+const scope = (serverKey: string, sessionID: string) => ({ serverKey, sessionID })
 
 describe("timelineIdentity", () => {
-  test("uses stable session identity without directory input", () => {
-    expect(timelineIdentity({ sessionID: "ses_target" })).toBe("ses_target")
-    expect(timelineIdentity({ sessionID: undefined })).toBe("")
+  test("uses server and session identity without directory input", () => {
+    const target = scope("sidecar", "ses_target")
+    expect(timelineIdentity({ scope: target })).toBe(sessionScopeKey(target))
+    expect(timelineIdentity({ scope: undefined })).toBe("")
   })
 })
 
@@ -14,14 +18,16 @@ describe("createSessionViewController", () => {
     createRoot((dispose) => {
       const controller = createSessionViewController({
         routeSessionID: () => "ses_source",
+        routeScope: () => scope("sidecar", "ses_source"),
         routeMessagesReady: () => true,
       })
 
       expect(controller.route.id()).toBe("ses_source")
-      expect(controller.route.key()).toBe("ses_source")
+      expect(controller.route.key()).toBe(sessionScopeKey(scope("sidecar", "ses_source")))
       expect(controller.route.ready()).toBe(true)
       expect(controller.visible.id()).toBe("ses_source")
-      expect(controller.visible.key()).toBe("ses_source")
+      expect(controller.visible.key()).toBe(sessionScopeKey(scope("sidecar", "ses_source")))
+      expect(controller.visible.scope()).toEqual(scope("sidecar", "ses_source"))
       expect(controller.visible.ready()).toBe(true)
       expect(controller.transitioning()).toBe(false)
 
@@ -33,14 +39,15 @@ describe("createSessionViewController", () => {
     createRoot((dispose) => {
       const controller = createSessionViewController({
         routeSessionID: () => "ses_target",
+        routeScope: () => scope("sidecar", "ses_target"),
         routeMessagesReady: () => false,
       })
 
       expect(controller.route.id()).toBe("ses_target")
-      expect(controller.route.key()).toBe("ses_target")
+      expect(controller.route.key()).toBe(sessionScopeKey(scope("sidecar", "ses_target")))
       expect(controller.route.ready()).toBe(false)
       expect(controller.visible.id()).toBe("ses_target")
-      expect(controller.visible.key()).toBe("ses_target")
+      expect(controller.visible.key()).toBe(sessionScopeKey(scope("sidecar", "ses_target")))
       expect(controller.visible.ready()).toBe(false)
       expect(controller.transitioning()).toBe(true)
 
@@ -53,6 +60,7 @@ describe("nextSessionViewState", () => {
   test("does not keep the previous visible session while the route session loads", () => {
     const loading = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: false,
     })
 
@@ -61,12 +69,13 @@ describe("nextSessionViewState", () => {
       routeReady: false,
       visibleSessionID: "ses_target",
       transitioning: true,
-      routeSessionKey: "ses_target",
-      visibleSessionKey: "ses_target",
+      routeSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
+      visibleSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
     })
 
     const ready = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: true,
     })
 
@@ -75,14 +84,15 @@ describe("nextSessionViewState", () => {
       routeReady: true,
       visibleSessionID: "ses_target",
       transitioning: false,
-      routeSessionKey: "ses_target",
-      visibleSessionKey: "ses_target",
+      routeSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
+      visibleSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
     })
   })
 
   test("clears visible session when leaving a concrete session route", () => {
     const next = nextSessionViewState({
       routeSessionID: undefined,
+      routeScope: undefined,
       routeMessagesReady: true,
     })
 
@@ -97,6 +107,7 @@ describe("nextSessionViewState", () => {
   test("uses session identity without a directory input", () => {
     const next = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: false,
     })
 
@@ -105,25 +116,27 @@ describe("nextSessionViewState", () => {
       routeReady: false,
       visibleSessionID: "ses_target",
       transitioning: true,
-      routeSessionKey: "ses_target",
-      visibleSessionKey: "ses_target",
+      routeSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
+      visibleSessionKey: sessionScopeKey(scope("sidecar", "ses_target")),
     })
   })
 
   test("keeps the same timeline identity and ready state across a transient directory cache miss", () => {
     const ready = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: true,
     })
 
     const next = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: false,
       previous: ready,
     })
 
-    expect(next.routeSessionKey).toBe("ses_target")
-    expect(next.visibleSessionKey).toBe("ses_target")
+    expect(next.routeSessionKey).toBe(sessionScopeKey(scope("sidecar", "ses_target")))
+    expect(next.visibleSessionKey).toBe(sessionScopeKey(scope("sidecar", "ses_target")))
     expect(next.routeReady).toBe(true)
     expect(next.transitioning).toBe(false)
   })
@@ -131,17 +144,38 @@ describe("nextSessionViewState", () => {
   test("does not keep ready state when switching to another session", () => {
     const ready = nextSessionViewState({
       routeSessionID: "ses_source",
+      routeScope: scope("sidecar", "ses_source"),
       routeMessagesReady: true,
     })
 
     const next = nextSessionViewState({
       routeSessionID: "ses_target",
+      routeScope: scope("sidecar", "ses_target"),
       routeMessagesReady: false,
       previous: ready,
     })
 
     expect(next.routeSessionID).toBe("ses_target")
     expect(next.visibleSessionID).toBe("ses_target")
+    expect(next.routeReady).toBe(false)
+    expect(next.transitioning).toBe(true)
+  })
+
+  test("does not keep ready state for same session id under another server", () => {
+    const ready = nextSessionViewState({
+      routeSessionID: "ses_same",
+      routeScope: scope("sidecar", "ses_same"),
+      routeMessagesReady: true,
+    })
+
+    const next = nextSessionViewState({
+      routeSessionID: "ses_same",
+      routeScope: scope("https://remote.example", "ses_same"),
+      routeMessagesReady: false,
+      previous: ready,
+    })
+
+    expect(next.routeSessionKey).toBe(sessionScopeKey(scope("https://remote.example", "ses_same")))
     expect(next.routeReady).toBe(false)
     expect(next.transitioning).toBe(true)
   })

--- a/packages/app/src/pages/session/session-view-controller.ts
+++ b/packages/app/src/pages/session/session-view-controller.ts
@@ -1,9 +1,11 @@
 import { createMemo, type Accessor } from "solid-js"
+import { sameSessionScope, sessionScopeKey, type SessionScope } from "./session-scope"
 
 export type TimelineIdentity = string
 
 export type SessionViewStateInput = {
   routeSessionID: string | undefined
+  routeScope: SessionScope | undefined
   routeMessagesReady: boolean
   previous?: SessionViewState
 }
@@ -11,7 +13,9 @@ export type SessionViewStateInput = {
 export type SessionViewState = {
   routeSessionID: string | undefined
   routeReady: boolean
+  routeSessionScope: SessionScope | undefined
   visibleSessionID: string | undefined
+  visibleSessionScope: SessionScope | undefined
   transitioning: boolean
   routeSessionKey: TimelineIdentity
   visibleSessionKey: TimelineIdentity
@@ -19,21 +23,22 @@ export type SessionViewState = {
 
 export type SessionViewControllerInput = {
   routeSessionID: Accessor<string | undefined>
+  routeScope: Accessor<SessionScope | undefined>
   routeMessagesReady: Accessor<boolean>
 }
 
-export function timelineIdentity(input: { sessionID: string | undefined }): TimelineIdentity {
+export function timelineIdentity(input: { scope: SessionScope | undefined }): TimelineIdentity {
   // Timeline identity follows the stable session only; execution directory is mutable.
-  return input.sessionID ?? ""
+  return sessionScopeKey(input.scope)
 }
 
 export const sessionKey = timelineIdentity
 
 export function nextSessionViewState(input: SessionViewStateInput) {
   const sameSession =
-    input.previous?.routeSessionID === input.routeSessionID &&
-    input.previous?.visibleSessionID === input.routeSessionID &&
-    !!input.routeSessionID
+    sameSessionScope(input.previous?.routeSessionScope, input.routeScope) &&
+    sameSessionScope(input.previous?.visibleSessionScope, input.routeScope) &&
+    !!input.routeScope
   // A same-session directory cache miss is a loading state, not a timeline identity change.
   const keepReady = sameSession && !!input.previous?.routeReady && !input.routeMessagesReady
   const routeReady = !input.routeSessionID || input.routeMessagesReady || keepReady
@@ -41,11 +46,13 @@ export function nextSessionViewState(input: SessionViewStateInput) {
 
   return {
     routeSessionID: input.routeSessionID,
+    routeSessionScope: input.routeScope,
     routeReady,
     visibleSessionID,
+    visibleSessionScope: input.routeScope,
     transitioning: !routeReady,
-    routeSessionKey: timelineIdentity({ sessionID: input.routeSessionID }),
-    visibleSessionKey: timelineIdentity({ sessionID: visibleSessionID }),
+    routeSessionKey: timelineIdentity({ scope: input.routeScope }),
+    visibleSessionKey: timelineIdentity({ scope: input.routeScope }),
   }
 }
 
@@ -53,6 +60,7 @@ export function createSessionViewController(input: SessionViewControllerInput) {
   const state = createMemo((current: SessionViewState | undefined): SessionViewState => {
     return nextSessionViewState({
       routeSessionID: input.routeSessionID(),
+      routeScope: input.routeScope(),
       routeMessagesReady: input.routeMessagesReady(),
       previous: current,
     })
@@ -68,6 +76,7 @@ export function createSessionViewController(input: SessionViewControllerInput) {
     },
     visible: {
       id: () => state().visibleSessionID,
+      scope: () => state().visibleSessionScope,
       key: () => state().visibleSessionKey,
       ready: visibleReady,
     },

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -190,7 +190,9 @@ describe("session followups", () => {
       locale: "en-US",
     }
 
-    expect(followupDraftMatchesScope(item, { serverKey: "sidecar", sessionID: "ses_same" })).toBe(false)
+    expect(followupDraftMatchesScope(item as { sourceScope?: never }, { serverKey: "sidecar", sessionID: "ses_same" })).toBe(
+      false,
+    )
   })
 
   test("scoped followup validates exact source scope", () => {
@@ -270,9 +272,9 @@ describe("session followups", () => {
             resumeScroll: () => undefined,
             attachmentLabel: () => "Attachment",
           })
-          return undefined
+          return null
         },
-      })
+      } as never)
       return dispose
     })
 

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -1,6 +1,11 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
 import type {
+  canSendFollowupItem as CanSendFollowupItem,
+  createSessionFollowups as CreateSessionFollowups,
   followupDraftForDirectory as DraftForDirectory,
   followupPreviewText as PreviewText,
   shouldAutoSendFollowup as ShouldAutoSend,
@@ -9,6 +14,9 @@ import type {
 let followupPreviewText: typeof PreviewText
 let shouldAutoSendFollowup: typeof ShouldAutoSend
 let followupDraftForDirectory: typeof DraftForDirectory
+let canSendFollowupItem: typeof CanSendFollowupItem
+let createSessionFollowups: typeof CreateSessionFollowups
+const sendFollowupCalls: unknown[] = []
 
 const draft = (input: Pick<FollowupDraft, "prompt" | "context">): FollowupDraft => ({
   sessionID: "ses_1",
@@ -31,14 +39,40 @@ beforeAll(async () => {
   mock.module("@/context/platform", () => ({
     usePlatform: () => ({ platform: "web" }),
   }))
+  mock.module("@/utils/persist", () => ({
+    Persist: {
+      global: () => ({}),
+    },
+    persisted: (_target: unknown, store: unknown) => store,
+  }))
+  mock.module("@/utils/id", () => ({
+    Identifier: {
+      ascending: (prefix: string) => `${prefix}_queued`,
+    },
+  }))
+  mock.module("@/components/prompt-input/submit", () => ({
+    followupCommandText: (item: FollowupDraft) =>
+      item.outgoingTextOverride ?? item.prompt.map((part) => ("content" in part ? part.content : "")).join(""),
+    sendFollowupDraft: async (input: unknown) => {
+      sendFollowupCalls.push(input)
+      return true
+    },
+  }))
 
   const mod = await import("./use-session-followups")
   followupPreviewText = mod.followupPreviewText
   shouldAutoSendFollowup = mod.shouldAutoSendFollowup
   followupDraftForDirectory = mod.followupDraftForDirectory
+  canSendFollowupItem = mod.canSendFollowupItem
+  createSessionFollowups = mod.createSessionFollowups
 })
 
 describe("session followups", () => {
+  beforeEach(() => {
+    sendFollowupCalls.length = 0
+    localStorage.clear()
+  })
+
   test("uses first non-empty text line as dock preview", () => {
     expect(
       followupPreviewText({
@@ -127,6 +161,98 @@ describe("session followups", () => {
 
     expect(shouldAutoSendFollowup(switchingDirectory)).toBe(false)
     expect(shouldAutoSendFollowup({ ...switchingDirectory, actionReady: true })).toBe(true)
+  })
+
+  test("queued slash follow-up with leading image waits for command hydration", () => {
+    const item = draft({
+      prompt: [
+        { type: "image", id: "img_1", filename: "screen.png", mime: "image/png", dataUrl: "data:image/png;base64,AA==" },
+        { type: "text", content: "/release now", start: 0, end: 12 },
+      ],
+      context: [],
+    })
+
+    expect(canSendFollowupItem({ item, actionReady: true, commandsReady: false })).toBe(false)
+    expect(canSendFollowupItem({ item, actionReady: true, commandsReady: true })).toBe(true)
+  })
+
+  test("normal queued follow-up with leading image can send while commands hydrate", () => {
+    const item = draft({
+      prompt: [
+        { type: "image", id: "img_1", filename: "screen.png", mime: "image/png", dataUrl: "data:image/png;base64,AA==" },
+        { type: "text", content: "continue", start: 0, end: 8 },
+      ],
+      context: [],
+    })
+
+    expect(canSendFollowupItem({ item, actionReady: true, commandsReady: false })).toBe(true)
+  })
+
+  test("queued send call-site waits for command hydration when slash draft has a leading image", async () => {
+    const [syncData, setSyncData] = createStore({ command: [{ name: "release" }], command_ready: false })
+    let followups!: ReturnType<typeof createSessionFollowups>
+    let disposeRoot!: VoidFunction
+
+    disposeRoot = createRoot((dispose) => {
+      const queryClient = new QueryClient()
+      QueryClientProvider({
+        client: queryClient,
+        children: () => {
+          followups = createSessionFollowups({
+            directory: () => "/repo",
+            client: () => ({}) as never,
+            sessionID: () => "ses_send",
+            actionReady: () => true,
+            isChildSession: () => false,
+            busy: () => false,
+            blocked: () => false,
+            settings: {
+              general: {
+                followup: () => "queue",
+              },
+            } as never,
+            sync: {
+              data: syncData,
+              session: { get: () => ({ id: "ses_send" }) },
+            } as never,
+            globalSync: {} as never,
+            fail: () => undefined,
+            resumeScroll: () => undefined,
+            attachmentLabel: () => "Attachment",
+          })
+          return undefined
+        },
+      })
+      return dispose
+    })
+
+    try {
+      followups.queueFollowup({
+        sessionID: "ses_send",
+        sessionDirectory: "/repo",
+        prompt: [
+          {
+            type: "image",
+            id: "img_1",
+            filename: "screen.png",
+            mime: "image/png",
+            dataUrl: "data:image/png;base64,AA==",
+          },
+          { type: "text", content: "/release now", start: 0, end: 12 },
+        ],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+      })
+      await followups.sendFollowup("ses_send", "message_queued", { manual: true })
+      expect(sendFollowupCalls).toHaveLength(0)
+
+      setSyncData("command_ready", true)
+      await followups.sendFollowup("ses_send", "message_queued", { manual: true })
+      expect(sendFollowupCalls).toHaveLength(1)
+    } finally {
+      disposeRoot()
+    }
   })
 
   test("rebases a queued followup to the current execution directory before send", () => {

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -6,8 +6,11 @@ import type { FollowupDraft } from "@/components/prompt-input/submit"
 import type {
   canSendFollowupItem as CanSendFollowupItem,
   createSessionFollowups as CreateSessionFollowups,
+  followupDraftMatchesScope as FollowupDraftMatchesScope,
   followupDraftForDirectory as DraftForDirectory,
   followupPreviewText as PreviewText,
+  followupStoreKey as FollowupStoreKey,
+  scopedFollowupDraft as ScopedFollowupDraft,
   shouldAutoSendFollowup as ShouldAutoSend,
 } from "./use-session-followups"
 
@@ -16,6 +19,9 @@ let shouldAutoSendFollowup: typeof ShouldAutoSend
 let followupDraftForDirectory: typeof DraftForDirectory
 let canSendFollowupItem: typeof CanSendFollowupItem
 let createSessionFollowups: typeof CreateSessionFollowups
+let followupStoreKey: typeof FollowupStoreKey
+let scopedFollowupDraft: typeof ScopedFollowupDraft
+let followupDraftMatchesScope: typeof FollowupDraftMatchesScope
 const sendFollowupCalls: unknown[] = []
 
 const draft = (input: Pick<FollowupDraft, "prompt" | "context">): FollowupDraft => ({
@@ -65,6 +71,9 @@ beforeAll(async () => {
   followupDraftForDirectory = mod.followupDraftForDirectory
   canSendFollowupItem = mod.canSendFollowupItem
   createSessionFollowups = mod.createSessionFollowups
+  followupStoreKey = mod.followupStoreKey
+  scopedFollowupDraft = mod.scopedFollowupDraft
+  followupDraftMatchesScope = mod.followupDraftMatchesScope
 })
 
 describe("session followups", () => {
@@ -163,6 +172,46 @@ describe("session followups", () => {
     expect(shouldAutoSendFollowup({ ...switchingDirectory, actionReady: true })).toBe(true)
   })
 
+  test("followup store key includes server and session", () => {
+    expect(followupStoreKey({ serverKey: "sidecar", sessionID: "ses_same" })).not.toBe(
+      followupStoreKey({ serverKey: "remote", sessionID: "ses_same" }),
+    )
+  })
+
+  test("unscoped v2 followup item is rejected", () => {
+    const item = {
+      id: "msg_1",
+      sessionID: "ses_same",
+      sessionDirectory: "/repo",
+      prompt: [{ type: "text" as const, content: "next", start: 0, end: 4 }],
+      context: [],
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+      locale: "en-US",
+    }
+
+    expect(followupDraftMatchesScope(item, { serverKey: "sidecar", sessionID: "ses_same" })).toBe(false)
+  })
+
+  test("scoped followup validates exact source scope", () => {
+    const item = scopedFollowupDraft(
+      {
+        id: "msg_1",
+        sessionID: "ses_same",
+        sessionDirectory: "/repo",
+        prompt: [{ type: "text" as const, content: "next", start: 0, end: 4 }],
+        context: [],
+        agent: "build",
+        model: { providerID: "anthropic", modelID: "claude" },
+        locale: "en-US",
+      },
+      { serverKey: "sidecar", sessionID: "ses_same" },
+    )
+
+    expect(followupDraftMatchesScope(item, { serverKey: "sidecar", sessionID: "ses_same" })).toBe(true)
+    expect(followupDraftMatchesScope(item, { serverKey: "remote", sessionID: "ses_same" })).toBe(false)
+  })
+
   test("queued slash follow-up with leading image waits for command hydration", () => {
     const item = draft({
       prompt: [
@@ -202,6 +251,7 @@ describe("session followups", () => {
             directory: () => "/repo",
             client: () => ({}) as never,
             sessionID: () => "ses_send",
+            sessionScope: () => ({ serverKey: "sidecar", sessionID: "ses_send" }),
             actionReady: () => true,
             isChildSession: () => false,
             busy: () => false,
@@ -244,11 +294,11 @@ describe("session followups", () => {
         agent: "agent",
         model: { providerID: "provider", modelID: "model" },
       })
-      await followups.sendFollowup("ses_send", "message_queued", { manual: true })
+      await followups.sendFollowup("message_queued", { manual: true })
       expect(sendFollowupCalls).toHaveLength(0)
 
       setSyncData("command_ready", true)
-      await followups.sendFollowup("ses_send", "message_queued", { manual: true })
+      await followups.sendFollowup("message_queued", { manual: true })
       expect(sendFollowupCalls).toHaveLength(1)
     } finally {
       disposeRoot()
@@ -270,13 +320,16 @@ describe("session followups", () => {
         commentOrigin: "review",
       },
     ] as FollowupDraft["context"]
-    const item = {
-      id: "msg_1",
-      ...draft({
-        prompt,
-        context,
-      }),
-    }
+    const item = scopedFollowupDraft(
+      {
+        id: "msg_1",
+        ...draft({
+          prompt,
+          context,
+        }),
+      },
+      { serverKey: "sidecar", sessionID: "ses_1" },
+    )
 
     const next = followupDraftForDirectory(item, "/repo")
     expect(next).toBe(item)

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -239,6 +239,15 @@ describe("session followups", () => {
     expect(canSendFollowupItem({ item, actionReady: true, commandsReady: false })).toBe(true)
   })
 
+  test("leading-whitespace slash follow-up can send while commands hydrate", () => {
+    const item = draft({
+      prompt: [{ type: "text", content: " /release now", start: 0, end: 13 }],
+      context: [],
+    })
+
+    expect(canSendFollowupItem({ item, actionReady: true, commandsReady: false })).toBe(true)
+  })
+
   test("queued send call-site waits for command hydration when slash draft has a leading image", async () => {
     const [syncData, setSyncData] = createStore({ command: [{ name: "release" }], command_ready: false })
     let followups!: ReturnType<typeof createSessionFollowups>

--- a/packages/app/src/pages/session/use-session-followups.test.ts
+++ b/packages/app/src/pages/session/use-session-followups.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
-import { createRoot } from "solid-js"
+import { createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
 import type {
@@ -23,6 +23,7 @@ let followupStoreKey: typeof FollowupStoreKey
 let scopedFollowupDraft: typeof ScopedFollowupDraft
 let followupDraftMatchesScope: typeof FollowupDraftMatchesScope
 const sendFollowupCalls: unknown[] = []
+let sendFollowupDraftImpl: (input: unknown) => Promise<boolean>
 
 const draft = (input: Pick<FollowupDraft, "prompt" | "context">): FollowupDraft => ({
   sessionID: "ses_1",
@@ -59,10 +60,7 @@ beforeAll(async () => {
   mock.module("@/components/prompt-input/submit", () => ({
     followupCommandText: (item: FollowupDraft) =>
       item.outgoingTextOverride ?? item.prompt.map((part) => ("content" in part ? part.content : "")).join(""),
-    sendFollowupDraft: async (input: unknown) => {
-      sendFollowupCalls.push(input)
-      return true
-    },
+    sendFollowupDraft: (input: unknown) => sendFollowupDraftImpl(input),
   }))
 
   const mod = await import("./use-session-followups")
@@ -76,9 +74,30 @@ beforeAll(async () => {
   followupDraftMatchesScope = mod.followupDraftMatchesScope
 })
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 300) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error("timed out waiting for condition")
+}
+
 describe("session followups", () => {
   beforeEach(() => {
     sendFollowupCalls.length = 0
+    sendFollowupDraftImpl = async (input: unknown) => {
+      sendFollowupCalls.push(input)
+      return true
+    }
     localStorage.clear()
   })
 
@@ -311,6 +330,75 @@ describe("session followups", () => {
       setSyncData("command_ready", true)
       await followups.sendFollowup("message_queued", { manual: true })
       expect(sendFollowupCalls).toHaveLength(1)
+    } finally {
+      disposeRoot()
+    }
+  })
+
+  test("blocks duplicate follow-up sends while a scoped key is pending", async () => {
+    const [syncData] = createStore({ command: [{ name: "release" }], command_ready: true })
+    const pending = deferred<boolean>()
+    sendFollowupDraftImpl = async (input: unknown) => {
+      sendFollowupCalls.push(input)
+      return pending.promise
+    }
+
+    let followups!: ReturnType<typeof createSessionFollowups>
+    let disposeRoot!: VoidFunction
+
+    disposeRoot = createRoot((dispose) => {
+      const queryClient = new QueryClient()
+      const [sessionID] = createSignal("ses_a")
+      const [sessionScope] = createSignal({ serverKey: "sidecar", sessionID: "ses_a" })
+      QueryClientProvider({
+        client: queryClient,
+        children: () => {
+          followups = createSessionFollowups({
+            directory: () => "/repo",
+            client: () => ({}) as never,
+            sessionID,
+            sessionScope,
+            actionReady: () => true,
+            isChildSession: () => false,
+            busy: () => true,
+            blocked: () => false,
+            settings: {
+              general: {
+                followup: () => "queue",
+              },
+            } as never,
+            sync: {
+              data: syncData,
+              session: { get: () => ({ id: sessionID() }) },
+            } as never,
+            globalSync: {} as never,
+            fail: () => undefined,
+            resumeScroll: () => undefined,
+            attachmentLabel: () => "Attachment",
+          })
+          return null
+        },
+      } as never)
+      return dispose
+    })
+
+    try {
+      followups.queueFollowup({
+        sessionID: "ses_a",
+        sessionDirectory: "/repo",
+        prompt: [{ type: "text", content: "continue a", start: 0, end: 10 }],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+      })
+      const sendA = followups.sendFollowup("message_queued", { manual: true })
+      await waitFor(() => sendFollowupCalls.length === 1)
+
+      await followups.sendFollowup("message_queued", { manual: true })
+      expect(sendFollowupCalls).toHaveLength(1)
+
+      pending.resolve(true)
+      await sendA
     } finally {
       disposeRoot()
     }

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -10,8 +10,9 @@ import type { useSync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
 import { Persist, persisted } from "@/utils/persist"
 import { canSendFollowupDraft } from "./session-action-readiness"
+import { sameSessionScope, sessionScopeKey, type SessionScope } from "./session-scope"
 
-export type FollowupItem = FollowupDraft & { id: string }
+export type FollowupItem = FollowupDraft & { id: string; sourceScope: SessionScope }
 export type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 export const emptyFollowups: FollowupItem[] = []
 
@@ -63,6 +64,23 @@ export function followupDraftForDirectory(item: FollowupItem, directory: string)
   return { ...item, sessionDirectory: directory }
 }
 
+export function followupStoreKey(scope: SessionScope) {
+  return sessionScopeKey(scope)
+}
+
+export function scopedFollowupDraft<T extends FollowupDraft & { id: string }>(
+  draft: T,
+  scope: SessionScope,
+): T & { sourceScope: SessionScope } {
+  return { ...draft, sourceScope: { ...scope } }
+}
+
+export function followupDraftMatchesScope(item: { sourceScope?: SessionScope }, scope: SessionScope | undefined) {
+  if (!scope) return false
+  if (!item.sourceScope) return false
+  return sameSessionScope(item.sourceScope, scope)
+}
+
 export function canSendFollowupItem(input: { item: FollowupDraft; actionReady: boolean; commandsReady: boolean }) {
   return canSendFollowupDraft({
     draft: { text: followupCommandText(input.item) },
@@ -75,6 +93,7 @@ export function createSessionFollowups(input: {
   directory: () => string
   client: () => ReturnType<typeof useSDK>["client"]
   sessionID: () => string | undefined
+  sessionScope: () => SessionScope | undefined
   actionReady: () => boolean
   isChildSession: () => boolean
   busy: () => boolean
@@ -86,12 +105,8 @@ export function createSessionFollowups(input: {
   resumeScroll: () => void
   attachmentLabel: () => string
 }) {
-  // This persisted store intentionally moved from Persist.workspace(..., "followup", ["followup.v1"]) to
-  // Persist.global("session-followup.v1"). Legacy workspace-scoped followup.v1 queues are not migrated
-  // because their saved execution directory can be stale after worktree exit. Entries remain keyed by
-  // sessionID for Stage 1; server-scoped identity belongs with the later session-scoped store migration.
   const [followup, setFollowup] = persisted(
-    Persist.global("session-followup.v1", ["followup.v1"]),
+    Persist.global("session-followup.v2", ["followup.v2"]),
     createStore<{
       items: Record<string, FollowupItem[] | undefined>
       failed: Record<string, string | undefined>
@@ -105,25 +120,37 @@ export function createSessionFollowups(input: {
     }),
   )
 
+  const activeFollowupKey = createMemo(() => {
+    const scope = input.sessionScope()
+    return scope ? followupStoreKey(scope) : undefined
+  })
+
   const queuedFollowups = createMemo(() => {
-    const id = input.sessionID()
-    if (!id) return emptyFollowups
-    return followup.items[id] ?? emptyFollowups
+    const key = activeFollowupKey()
+    if (!key) return emptyFollowups
+    return followup.items[key] ?? emptyFollowups
   })
 
   const editingFollowup = createMemo(() => {
-    const id = input.sessionID()
-    if (!id) return
-    return followup.edit[id]
+    const key = activeFollowupKey()
+    if (!key) return
+    return followup.edit[key]
   })
 
-  const followupMutation = useMutation(() => ({
-    mutationFn: async (params: { sessionID: string; id: string; manual?: boolean }) => {
-      const item = (followup.items[params.sessionID] ?? []).find((entry) => entry.id === params.id)
-      if (!item) return
+  type SendFollowupVariables = {
+    key: string
+    sessionID: string
+    id: string
+    manual?: boolean
+  }
 
-      if (params.manual) setFollowup("paused", params.sessionID, undefined)
-      setFollowup("failed", params.sessionID, undefined)
+  const followupMutation = useMutation(() => ({
+    mutationFn: async (params: SendFollowupVariables) => {
+      const item = (followup.items[params.key] ?? []).find((entry) => entry.id === params.id)
+      if (!item || item.sessionID !== params.sessionID || !followupDraftMatchesScope(item, input.sessionScope())) return
+
+      if (params.manual) setFollowup("paused", params.key, undefined)
+      setFollowup("failed", params.key, undefined)
 
       const directory = input.directory()
       const draft = followupDraftForDirectory(item, directory)
@@ -134,30 +161,30 @@ export function createSessionFollowups(input: {
         draft,
         optimisticBusy: draft.sessionDirectory === directory,
       }).catch((err) => {
-        setFollowup("failed", params.sessionID, params.id)
+        setFollowup("failed", params.key, params.id)
         input.fail(err)
         return false
       })
       if (!ok) return
 
-      setFollowup("items", params.sessionID, (items) => (items ?? []).filter((entry) => entry.id !== params.id))
+      setFollowup("items", params.key, (items) => (items ?? []).filter((entry) => entry.id !== params.id))
       if (params.manual) input.resumeScroll()
     },
   }))
 
-  const followupBusy = (sessionID: string) =>
-    followupMutation.isPending && followupMutation.variables?.sessionID === sessionID
+  const followupBusy = (key: string | undefined) =>
+    !!key && followupMutation.isPending && followupMutation.variables?.key === key
 
   const sendingFollowup = createMemo(() => {
-    const id = input.sessionID()
-    if (!id) return
-    if (!followupBusy(id)) return
+    const key = activeFollowupKey()
+    if (!followupBusy(key)) return
     return followupMutation.variables?.id
   })
 
   const queueEnabled = createMemo(() => {
     const id = input.sessionID()
-    if (!id) return false
+    const key = activeFollowupKey()
+    if (!id || !key) return false
     return (
       input.actionReady() &&
       input.settings.general.followup() === "queue" &&
@@ -168,12 +195,13 @@ export function createSessionFollowups(input: {
   })
 
   const queueFollowup = (draft: FollowupDraft) => {
-    setFollowup("items", draft.sessionID, (items) => [
-      ...(items ?? []),
-      { id: Identifier.ascending("message"), ...draft },
-    ])
-    setFollowup("failed", draft.sessionID, undefined)
-    setFollowup("paused", draft.sessionID, undefined)
+    const scope = input.sessionScope()
+    if (!scope) return
+    const key = followupStoreKey(scope)
+    const item = scopedFollowupDraft({ id: Identifier.ascending("message"), ...draft }, scope)
+    setFollowup("items", key, (items) => [...(items ?? []), item])
+    setFollowup("failed", key, undefined)
+    setFollowup("paused", key, undefined)
   }
 
   const followupDock = createMemo(() =>
@@ -183,10 +211,14 @@ export function createSessionFollowups(input: {
     })),
   )
 
-  const sendFollowup = (sessionID: string, id: string, opts?: { manual?: boolean }) => {
+  const sendFollowup = (id: string, opts?: { manual?: boolean }) => {
+    const key = activeFollowupKey()
+    const sessionID = input.sessionID()
+    if (!key || !sessionID) return Promise.resolve()
     if (input.sync.session.get(sessionID)?.parentID) return Promise.resolve()
-    const item = (followup.items[sessionID] ?? []).find((entry) => entry.id === id)
+    const item = (followup.items[key] ?? []).find((entry) => entry.id === id)
     if (!item) return Promise.resolve()
+    if (!followupDraftMatchesScope(item, input.sessionScope())) return Promise.resolve()
     if (
       !canSendFollowupItem({
         item,
@@ -196,22 +228,22 @@ export function createSessionFollowups(input: {
     ) {
       return Promise.resolve()
     }
-    if (followupBusy(sessionID)) return Promise.resolve()
+    if (followupBusy(key)) return Promise.resolve()
 
-    return followupMutation.mutateAsync({ sessionID, id, manual: opts?.manual })
+    return followupMutation.mutateAsync({ key, sessionID, id, manual: opts?.manual })
   }
 
   const editFollowup = (id: string) => {
-    const sessionID = input.sessionID()
-    if (!sessionID) return
-    if (followupBusy(sessionID)) return
+    const key = activeFollowupKey()
+    if (!key) return
+    if (followupBusy(key)) return
 
     const item = queuedFollowups().find((entry) => entry.id === id)
     if (!item) return
 
-    setFollowup("items", sessionID, (items) => (items ?? []).filter((entry) => entry.id !== id))
-    setFollowup("failed", sessionID, (value) => (value === id ? undefined : value))
-    setFollowup("edit", sessionID, {
+    setFollowup("items", key, (items) => (items ?? []).filter((entry) => entry.id !== id))
+    setFollowup("failed", key, (value) => (value === id ? undefined : value))
+    setFollowup("edit", key, {
       id: item.id,
       prompt: item.prompt,
       context: item.context,
@@ -219,13 +251,14 @@ export function createSessionFollowups(input: {
   }
 
   const clearFollowupEdit = () => {
-    const id = input.sessionID()
-    if (!id) return
-    setFollowup("edit", id, undefined)
+    const key = activeFollowupKey()
+    if (!key) return
+    setFollowup("edit", key, undefined)
   }
 
   createEffect(() => {
     const sessionID = input.sessionID()
+    const key = activeFollowupKey()
     const item = queuedFollowups()[0]
 
     if (
@@ -241,17 +274,17 @@ export function createSessionFollowups(input: {
           })
         ),
         busy: input.busy(),
-        failed: !!(sessionID && item && followup.failed[sessionID] === item.id),
-        paused: !!(sessionID && followup.paused[sessionID]),
+        failed: !!(key && item && followup.failed[key] === item.id),
+        paused: !!(key && followup.paused[key]),
         childSession: input.isChildSession(),
         blocked: input.blocked(),
-        followupBusy: !!(sessionID && followupBusy(sessionID)),
+        followupBusy: followupBusy(key),
       })
     ) {
       return
     }
 
-    void sendFollowup(sessionID!, item!.id)
+    void sendFollowup(item!.id)
   })
 
   return {
@@ -264,8 +297,10 @@ export function createSessionFollowups(input: {
     sendFollowup,
     editFollowup,
     clearFollowupEdit,
-    pause(sessionID: string) {
-      setFollowup("paused", sessionID, true)
+    pause() {
+      const key = activeFollowupKey()
+      if (!key) return
+      setFollowup("paused", key, true)
     },
   }
 }

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -1,4 +1,4 @@
-import { createEffect, createMemo } from "solid-js"
+import { createEffect, createMemo, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useMutation } from "@tanstack/solid-query"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
@@ -144,41 +144,58 @@ export function createSessionFollowups(input: {
     manual?: boolean
   }
 
+  const [pendingFollowups, setPendingFollowups] = createSignal<Record<string, string | undefined>>({})
+  const markFollowupPending = (key: string, id: string) => {
+    setPendingFollowups((current) => ({ ...current, [key]: id }))
+  }
+  const clearFollowupPending = (key: string, id: string) => {
+    setPendingFollowups((current) => {
+      if (current[key] !== id) return current
+      const next = { ...current }
+      delete next[key]
+      return next
+    })
+  }
+
   const followupMutation = useMutation(() => ({
     mutationFn: async (params: SendFollowupVariables) => {
-      const item = (followup.items[params.key] ?? []).find((entry) => entry.id === params.id)
-      if (!item || item.sessionID !== params.sessionID || !followupDraftMatchesScope(item, input.sessionScope())) return
+      markFollowupPending(params.key, params.id)
+      try {
+        const item = (followup.items[params.key] ?? []).find((entry) => entry.id === params.id)
+        if (!item || item.sessionID !== params.sessionID || !followupDraftMatchesScope(item, input.sessionScope())) return
 
-      if (params.manual) setFollowup("paused", params.key, undefined)
-      setFollowup("failed", params.key, undefined)
+        if (params.manual) setFollowup("paused", params.key, undefined)
+        setFollowup("failed", params.key, undefined)
 
-      const directory = input.directory()
-      const draft = followupDraftForDirectory(item, directory)
-      const ok = await sendFollowupDraft({
-        client: input.client(),
-        sync: input.sync,
-        globalSync: input.globalSync,
-        draft,
-        optimisticBusy: draft.sessionDirectory === directory,
-      }).catch((err) => {
-        setFollowup("failed", params.key, params.id)
-        input.fail(err)
-        return false
-      })
-      if (!ok) return
+        const directory = input.directory()
+        const draft = followupDraftForDirectory(item, directory)
+        const ok = await sendFollowupDraft({
+          client: input.client(),
+          sync: input.sync,
+          globalSync: input.globalSync,
+          draft,
+          optimisticBusy: draft.sessionDirectory === directory,
+        }).catch((err) => {
+          setFollowup("failed", params.key, params.id)
+          input.fail(err)
+          return false
+        })
+        if (!ok) return
 
-      setFollowup("items", params.key, (items) => (items ?? []).filter((entry) => entry.id !== params.id))
-      if (params.manual) input.resumeScroll()
+        setFollowup("items", params.key, (items) => (items ?? []).filter((entry) => entry.id !== params.id))
+        if (params.manual) input.resumeScroll()
+      } finally {
+        clearFollowupPending(params.key, params.id)
+      }
     },
   }))
 
-  const followupBusy = (key: string | undefined) =>
-    !!key && followupMutation.isPending && followupMutation.variables?.key === key
+  const followupBusy = (key: string | undefined) => !!key && pendingFollowups()[key] !== undefined
 
   const sendingFollowup = createMemo(() => {
     const key = activeFollowupKey()
-    if (!followupBusy(key)) return
-    return followupMutation.variables?.id
+    if (!key || !followupBusy(key)) return
+    return pendingFollowups()[key]
   })
 
   const queueEnabled = createMemo(() => {

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -2,13 +2,14 @@ import { createEffect, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useMutation } from "@tanstack/solid-query"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
-import { sendFollowupDraft } from "@/components/prompt-input/submit"
+import { followupCommandText, sendFollowupDraft } from "@/components/prompt-input/submit"
 import type { useGlobalSync } from "@/context/global-sync"
 import type { useSDK } from "@/context/sdk"
 import type { useSettings } from "@/context/settings"
 import type { useSync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
 import { Persist, persisted } from "@/utils/persist"
+import { canSendFollowupDraft } from "./session-action-readiness"
 
 export type FollowupItem = FollowupDraft & { id: string }
 export type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
@@ -60,6 +61,14 @@ export function shouldAutoSendFollowup(input: {
 export function followupDraftForDirectory(item: FollowupItem, directory: string): FollowupItem {
   if (item.sessionDirectory === directory) return item
   return { ...item, sessionDirectory: directory }
+}
+
+export function canSendFollowupItem(input: { item: FollowupDraft; actionReady: boolean; commandsReady: boolean }) {
+  return canSendFollowupDraft({
+    draft: { text: followupCommandText(input.item) },
+    submitReady: input.actionReady,
+    commandsReady: input.commandsReady,
+  })
 }
 
 export function createSessionFollowups(input: {
@@ -175,10 +184,18 @@ export function createSessionFollowups(input: {
   )
 
   const sendFollowup = (sessionID: string, id: string, opts?: { manual?: boolean }) => {
-    if (!input.actionReady()) return Promise.resolve()
     if (input.sync.session.get(sessionID)?.parentID) return Promise.resolve()
     const item = (followup.items[sessionID] ?? []).find((entry) => entry.id === id)
     if (!item) return Promise.resolve()
+    if (
+      !canSendFollowupItem({
+        item,
+        actionReady: input.actionReady(),
+        commandsReady: input.sync.data.command_ready,
+      })
+    ) {
+      return Promise.resolve()
+    }
     if (followupBusy(sessionID)) return Promise.resolve()
 
     return followupMutation.mutateAsync({ sessionID, id, manual: opts?.manual })
@@ -215,7 +232,14 @@ export function createSessionFollowups(input: {
       !shouldAutoSendFollowup({
         hasSession: !!sessionID,
         hasItem: !!item,
-        actionReady: input.actionReady(),
+        actionReady: !!(
+          item &&
+          canSendFollowupItem({
+            item,
+            actionReady: input.actionReady(),
+            commandsReady: input.sync.data.command_ready,
+          })
+        ),
         busy: input.busy(),
         failed: !!(sessionID && item && followup.failed[sessionID] === item.id),
         paused: !!(sessionID && followup.paused[sessionID]),

--- a/packages/app/src/pages/session/use-session-revert.test.ts
+++ b/packages/app/src/pages/session/use-session-revert.test.ts
@@ -1,6 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { nextRestoreTarget, revertRequestPayload, rolledRevertItems } from "./use-session-revert"
+import { nextRestoreTarget, revertRequestPayload, revertSnapshotIsCurrent, rolledRevertItems } from "./use-session-revert"
 
 const message = (id: string) => ({ id, role: "user" }) as UserMessage
 
@@ -42,5 +42,23 @@ describe("session revert", () => {
     expect("store" in payload).toBe(false)
     expect("client" in payload).toBe(false)
     expect("release" in payload).toBe(false)
+  })
+
+  test("rejects stale revert snapshots from an older execution epoch", () => {
+    const oldScope = { serverKey: "sidecar", directory: "/repo", epoch: 1 }
+    const newScope = { serverKey: "sidecar", directory: "/repo", epoch: 3 }
+
+    expect(
+      revertSnapshotIsCurrent({
+        scope: oldScope,
+        currentScope: () => newScope,
+      }),
+    ).toBe(false)
+    expect(
+      revertSnapshotIsCurrent({
+        scope: newScope,
+        currentScope: () => newScope,
+      }),
+    ).toBe(true)
   })
 })

--- a/packages/app/src/pages/session/use-session-revert.ts
+++ b/packages/app/src/pages/session/use-session-revert.ts
@@ -5,10 +5,13 @@ import type { Prompt, usePrompt } from "@/context/prompt"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
+import { shouldApplyExecutionResult, type ExecutionScope } from "./execution-scope"
 
 type SyncSetter = ReturnType<typeof useSync>["set"]
 type SyncStore = ReturnType<typeof useSync>["data"]
 type RevertSnapshot = {
+  scope: ExecutionScope
+  currentScope: () => ExecutionScope | undefined
   directory: string
   client: ReturnType<typeof useSDK>["client"]
   store: SyncStore
@@ -22,6 +25,15 @@ type RevertSnapshot = {
 }
 
 const findSession = (store: SyncStore, sessionID: string) => store.session.find((item) => item.id === sessionID)
+
+export function revertSnapshotIsCurrent(input: Pick<RevertSnapshot, "scope" | "currentScope">) {
+  return shouldApplyExecutionResult({ requested: input.scope, current: input.currentScope() })
+}
+
+const applyIfCurrent = (snapshot: RevertSnapshot, run: () => void) => {
+  if (!revertSnapshotIsCurrent(snapshot)) return
+  run()
+}
 
 export function revertRequestPayload(input: { sessionID: string; messageID: string }) {
   return {
@@ -79,12 +91,14 @@ export function createSessionRevert(input: {
           .halt(snapshot, request.sessionID)
           .then(() => snapshot.client.session.revert(revertRequestPayload(request), { throwOnError: true }))
           .then((result) => {
-            if (result.data) input.merge(snapshot.setStore, result.data)
+            if (result.data) applyIfCurrent(snapshot, () => input.merge(snapshot.setStore, result.data!))
           })
           .catch((err) => {
-            batch(() => {
-              input.roll(snapshot.setStore, request.sessionID, last)
-              input.prompt.set(prev, undefined, snapshot.promptScope)
+            applyIfCurrent(snapshot, () => {
+              batch(() => {
+                input.roll(snapshot.setStore, request.sessionID, last)
+                input.prompt.set(prev, undefined, snapshot.promptScope)
+              })
             })
             input.fail(err)
           })
@@ -128,12 +142,14 @@ export function createSessionRevert(input: {
 
         await task
           .then((result) => {
-            if (result.data) input.merge(snapshot.setStore, result.data)
+            if (result.data) applyIfCurrent(snapshot, () => input.merge(snapshot.setStore, result.data!))
           })
           .catch((err) => {
-            batch(() => {
-              input.roll(snapshot.setStore, request.sessionID, last)
-              input.prompt.set(prev, undefined, snapshot.promptScope)
+            applyIfCurrent(snapshot, () => {
+              batch(() => {
+                input.roll(snapshot.setStore, request.sessionID, last)
+                input.prompt.set(prev, undefined, snapshot.promptScope)
+              })
             })
             input.fail(err)
           })

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test"
-import { deriveReviewArtifactFiles, shouldApplyVcsDiffResult, vcsTaskKey } from "./use-session-review-state"
+import { vcsTaskKey } from "./execution-scope"
+import { deriveReviewArtifactFiles } from "./use-session-review-state"
+
+const scope = (directory = "/repo", epoch = 1) => ({ serverKey: "sidecar", directory, epoch })
 
 describe("session review state", () => {
   test("uses session artifact history when it matches the visible session", () => {
     const files = deriveReviewArtifactFiles({
-      directory: "/repo",
+      currentScope: scope("/repo", 1),
       sessionID: "ses_1",
       history: {
+        scope: scope("/repo", 1),
         sessionID: "ses_1",
         artifacts: [{ file: "report.md", kind: "added" }],
       },
@@ -19,10 +23,10 @@ describe("session review state", () => {
 
   test("falls back while artifact history belongs to a previous execution directory", () => {
     const files = deriveReviewArtifactFiles({
-      directory: "/repo-root",
+      currentScope: scope("/repo-root", 2),
       sessionID: "ses_1",
       history: {
-        directory: "/repo-worktree",
+        scope: scope("/repo-worktree", 1),
         sessionID: "ses_1",
         artifacts: [{ file: "stale.md", kind: "added" }],
       },
@@ -32,11 +36,26 @@ describe("session review state", () => {
     expect(files.map((file) => file.path)).toEqual(["/repo-root/fallback.md"])
   })
 
+  test("falls back while artifact history belongs to an older execution epoch of the same directory", () => {
+    const files = deriveReviewArtifactFiles({
+      currentScope: scope("/repo", 3),
+      sessionID: "ses_1",
+      history: {
+        scope: scope("/repo", 1),
+        sessionID: "ses_1",
+        artifacts: [{ file: "stale.md", kind: "added" }],
+      },
+      turnDiffs: [{ file: "fallback.md", status: "added" }],
+    })
+
+    expect(files.map((file) => file.path)).toEqual(["/repo/fallback.md"])
+  })
+
   test("falls back to added and modified turn diffs", () => {
     const files = deriveReviewArtifactFiles({
-      directory: "/repo",
+      currentScope: scope("/repo", 1),
       sessionID: "ses_1",
-      history: { sessionID: "ses_2", artifacts: [{ file: "stale.md", kind: "added" }] },
+      history: { scope: scope("/repo", 1), sessionID: "ses_2", artifacts: [{ file: "stale.md", kind: "added" }] },
       turnDiffs: [
         { file: "created.md", status: "added" },
         { file: "updated.md", status: "modified" },
@@ -49,9 +68,9 @@ describe("session review state", () => {
 
   test("treats missing turn diffs as no files while a session is loading", () => {
     const files = deriveReviewArtifactFiles({
-      directory: "/repo",
+      currentScope: scope("/repo", 1),
       sessionID: "ses_1",
-      history: { sessionID: "ses_2", artifacts: [{ file: "stale.md", kind: "added" }] },
+      history: { scope: scope("/repo", 1), sessionID: "ses_2", artifacts: [{ file: "stale.md", kind: "added" }] },
       turnDiffs: undefined,
     })
 
@@ -61,36 +80,16 @@ describe("session review state", () => {
   test("does not throw before turn diffs arrive for the selected session", () => {
     expect(() =>
       deriveReviewArtifactFiles({
-        directory: "/repo",
+        currentScope: scope("/repo", 1),
         sessionID: "ses_1",
-        history: { sessionID: "ses_1", artifacts: [] },
+        history: { scope: scope("/repo", 1), sessionID: "ses_1", artifacts: [] },
         turnDiffs: undefined,
       }),
     ).not.toThrow()
   })
 
-  test("rejects stale VCS diff results from a previous execution directory", () => {
-    expect(
-      shouldApplyVcsDiffResult({
-        requestedDirectory: "/repo-worktree",
-        currentDirectory: "/repo-root",
-        requestedRun: 1,
-        currentRun: 1,
-      }),
-    ).toBe(false)
-
-    expect(
-      shouldApplyVcsDiffResult({
-        requestedDirectory: "/repo-root",
-        currentDirectory: "/repo-root",
-        requestedRun: 1,
-        currentRun: 1,
-      }),
-    ).toBe(true)
-  })
-
-  test("keys pending VCS diff tasks by directory and mode", () => {
-    expect(vcsTaskKey("/repo-worktree", "unstaged")).not.toBe(vcsTaskKey("/repo-root", "unstaged"))
-    expect(vcsTaskKey("/repo-root", "unstaged")).not.toBe(vcsTaskKey("/repo-root", "staged"))
+  test("keys pending VCS diff tasks by execution scope and mode", () => {
+    expect(vcsTaskKey(scope("/repo", 1), "unstaged")).not.toBe(vcsTaskKey(scope("/repo", 3), "unstaged"))
+    expect(vcsTaskKey(scope("/repo", 3), "unstaged")).not.toBe(vcsTaskKey(scope("/repo", 3), "staged"))
   })
 })

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -14,28 +14,29 @@ import {
   type VcsReviewMode,
 } from "@/pages/session/review-change-mode"
 import { diffs as list } from "@/utils/diffs"
+import { sameExecutionScope, shouldApplyExecutionResult, vcsTaskKey, type ExecutionScope } from "./execution-scope"
 
 type SessionReviewDiff = SnapshotFileDiff | VcsFileDiff
 
 export function deriveReviewArtifactFiles(input: {
-  directory: string
+  currentScope: ExecutionScope
   sessionID: string | undefined
-  history: { directory?: string; sessionID: string; artifacts: SessionArtifactFile[] } | undefined
+  history: { scope: ExecutionScope; sessionID: string; artifacts: SessionArtifactFile[] } | undefined
   turnDiffs?: Array<{ file: string; status?: string }>
 }) {
   const history = input.history
   if (
     history &&
     history.sessionID === input.sessionID &&
-    (history.directory === undefined || history.directory === input.directory) &&
+    shouldApplyExecutionResult({ requested: history.scope, current: input.currentScope }) &&
     history.artifacts.length > 0
   ) {
-    return deriveArtifactFiles(input.directory, history.artifacts)
+    return deriveArtifactFiles(input.currentScope.directory, history.artifacts)
   }
 
   const turnDiffs = input.turnDiffs ?? []
   return deriveArtifactFiles(
-    input.directory,
+    input.currentScope.directory,
     turnDiffs.flatMap((diff) => {
       if (diff.status !== "added" && diff.status !== "modified") return []
       return [{ file: diff.file, kind: diff.status as "added" | "modified" }]
@@ -43,21 +44,9 @@ export function deriveReviewArtifactFiles(input: {
   )
 }
 
-export function shouldApplyVcsDiffResult(input: {
-  requestedDirectory: string
-  currentDirectory: string
-  requestedRun: number
-  currentRun: number | undefined
-}) {
-  return input.requestedDirectory === input.currentDirectory && input.requestedRun === input.currentRun
-}
-
-export function vcsTaskKey(directory: string, mode: VcsReviewMode) {
-  return `${directory}\n${mode}`
-}
-
 export function createSessionReviewState(input: {
   directory: () => string
+  executionScope: () => ExecutionScope
   sessionKey: () => string
   sessionID: () => string | undefined
   sync: ReturnType<typeof useSync>
@@ -69,6 +58,7 @@ export function createSessionReviewState(input: {
   const [vcs, setVcs] = createStore<{
     diff: Record<VcsReviewMode, SessionReviewDiff[]>
     ready: Record<VcsReviewMode, boolean>
+    scope: Record<VcsReviewMode, ExecutionScope | undefined>
   }>({
     diff: {
       unstaged: [],
@@ -80,76 +70,73 @@ export function createSessionReviewState(input: {
       staged: false,
       branch: false,
     },
+    scope: {
+      unstaged: undefined,
+      staged: undefined,
+      branch: undefined,
+    },
   })
 
   const vcsTask = new Map<string, Promise<void>>()
   const vcsRun = new Map<string, number>()
 
-  const bumpVcs = (directory: string, mode: VcsReviewMode) => {
-    const key = vcsTaskKey(directory, mode)
+  const bumpVcs = (scope: ExecutionScope, mode: VcsReviewMode) => {
+    const key = vcsTaskKey(scope, mode)
     const next = (vcsRun.get(key) ?? 0) + 1
     vcsRun.set(key, next)
     return next
   }
 
   const resetVcs = (mode?: VcsReviewMode) => {
-    const directory = input.directory()
+    const scope = input.executionScope()
     const modes = mode ? [mode] : (["unstaged", "staged", "branch"] as const)
     modes.forEach((item) => {
-      const key = vcsTaskKey(directory, item)
-      bumpVcs(directory, item)
+      const key = vcsTaskKey(scope, item)
+      bumpVcs(scope, item)
       vcsTask.delete(key)
       setVcs("diff", item, [])
       setVcs("ready", item, false)
+      setVcs("scope", item, undefined)
     })
   }
 
   const loadVcs = (mode: VcsReviewMode, force = false) => {
     if (input.sync.project?.vcs !== "git") return Promise.resolve()
-    if (!force && vcs.ready[mode]) return Promise.resolve()
-    const directory = input.directory()
-    const key = vcsTaskKey(directory, mode)
+    const requestedScope = input.executionScope()
+    if (!force && vcs.ready[mode] && sameExecutionScope(vcs.scope[mode], requestedScope)) return Promise.resolve()
+    const key = vcsTaskKey(requestedScope, mode)
 
     if (force) {
-      if (vcsTask.has(key)) bumpVcs(directory, mode)
+      if (vcsTask.has(key)) bumpVcs(requestedScope, mode)
       vcsTask.delete(key)
       setVcs("ready", mode, false)
+      setVcs("scope", mode, undefined)
+    } else if (!sameExecutionScope(vcs.scope[mode], requestedScope)) {
+      setVcs("diff", mode, [])
+      setVcs("ready", mode, false)
+      setVcs("scope", mode, undefined)
     }
 
     const current = vcsTask.get(key)
     if (current) return current
-    const run = bumpVcs(directory, mode)
-    const client = input.sdk.createClient({ directory, throwOnError: true })
+    const run = bumpVcs(requestedScope, mode)
+    const client = input.sdk.createClient({ directory: requestedScope.directory, throwOnError: true })
 
     const task = client.vcs
       .diff({ mode })
       .then((result) => {
-        if (
-          !shouldApplyVcsDiffResult({
-            requestedDirectory: directory,
-            currentDirectory: input.directory(),
-            requestedRun: run,
-            currentRun: vcsRun.get(key),
-          })
-        ) {
-          return
-        }
+        if (!shouldApplyExecutionResult({ requested: requestedScope, current: input.executionScope() })) return
+        if (vcsRun.get(key) !== run) return
         setVcs("diff", mode, list(result.data))
+        setVcs("scope", mode, requestedScope)
         setVcs("ready", mode, true)
       })
       .catch((error: unknown) => {
-        if (
-          !shouldApplyVcsDiffResult({
-            requestedDirectory: directory,
-            currentDirectory: input.directory(),
-            requestedRun: run,
-            currentRun: vcsRun.get(key),
-          })
-        ) {
-          return
-        }
+        if (!shouldApplyExecutionResult({ requested: requestedScope, current: input.executionScope() })) return
+        if (vcsRun.get(key) !== run) return
         console.debug("[session-review] failed to load vcs diff", { mode, error })
         setVcs("diff", mode, [])
+        setVcs("scope", mode, requestedScope)
         setVcs("ready", mode, true)
       })
       .finally(() => {
@@ -179,26 +166,33 @@ export function createSessionReviewState(input: {
   const hasReview = createMemo(() => reviewCount() > 0)
   const reviewReady = createMemo(() => {
     const value = changes()
-    return isVcsReviewMode(value) ? vcs.ready[value] : true
+    return isVcsReviewMode(value) ? vcs.ready[value] && sameExecutionScope(vcs.scope[value], input.executionScope()) : true
   })
 
   const [artifactHistory, { refetch: refetchArtifactHistory }] = createResource(
     () => {
       const sessionID = input.sessionID()
       if (!sessionID) return
-      return { directory: input.directory(), sessionID }
+      const scope = input.executionScope()
+      return { scope, sessionID }
     },
-    async ({ directory, sessionID }) => ({
-      directory,
+    async ({ scope, sessionID }) => ({
+      scope,
       sessionID,
       artifacts: await input.sdk
-        .createClient({ directory, throwOnError: true })
+        .createClient({ directory: scope.directory, throwOnError: true })
         .session
         .artifacts({ sessionID })
         .then((res) => res.data ?? [])
         .catch(() => []),
     }),
-    { initialValue: { directory: "", sessionID: "", artifacts: [] as SessionArtifactFile[] } },
+    {
+      initialValue: {
+        scope: { serverKey: "", directory: "", epoch: -1 },
+        sessionID: "",
+        artifacts: [] as SessionArtifactFile[],
+      },
+    },
   )
   let artifactHistoryFrame: number | undefined
   let artifactHistoryPending = false
@@ -217,7 +211,7 @@ export function createSessionReviewState(input: {
   })
   const artifactFiles = createMemo(() =>
     deriveReviewArtifactFiles({
-      directory: input.directory(),
+      currentScope: input.executionScope(),
       sessionID: input.sessionID(),
       history: artifactHistory.latest,
       turnDiffs: input.turnDiffs(),

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -9,8 +9,10 @@ import {
   readTimelineMessages,
   readTimelineMessagesFromCache,
   sessionStatusKnown,
+  timelineDataIdentity,
   timelineModelSyncKey,
 } from "./use-session-timeline-data"
+import { sessionScopeKey } from "./session-scope"
 
 const userMessage = (id: string, sessionID = "ses_target"): Message =>
   ({
@@ -20,17 +22,21 @@ const userMessage = (id: string, sessionID = "ses_target"): Message =>
     time: { created: 1 },
   }) as Message
 
+const sessionScope = (sessionID = "ses_target", serverKey = "sidecar") => ({ serverKey, sessionID })
+const messages120 = Array.from({ length: 120 }, (_, index) => userMessage(`msg_${index}`))
+
 describe("readTimelineMessages", () => {
   test("keeps last-good messages for the same session when the current store briefly loses its cache", () => {
     const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const scope = sessionScope()
     const ready = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -41,14 +47,15 @@ describe("readTimelineMessages", () => {
 
   test("keeps a long session window during a same-session cache miss", () => {
     const loaded = Array.from({ length: 80 }, (_, index) => userMessage(`msg_${index}`))
+    const scope = sessionScope()
     const ready = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -59,14 +66,16 @@ describe("readTimelineMessages", () => {
 
   test("does not reuse last-good messages after switching to another session", () => {
     const loaded = [userMessage("msg_1", "ses_source")]
+    const sourceScope = sessionScope("ses_source")
+    const targetScope = sessionScope("ses_target")
     const ready = readTimelineMessages({
-      sessionID: "ses_source",
+      scope: sourceScope,
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: "ses_target",
+      scope: targetScope,
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -77,16 +86,18 @@ describe("readTimelineMessages", () => {
 
   test("does not reuse last-good messages after the same session id gets a different identity scope", () => {
     const loaded = [userMessage("msg_1")]
+    const localScope = sessionScope("ses_target", "server-a")
+    const remoteScope = sessionScope("ses_target", "server-b")
     const ready = readTimelineMessages({
-      sessionID: "ses_target",
-      dataIdentity: "server-a:ses_target",
+      scope: localScope,
+      dataIdentity: timelineDataIdentity({ scope: localScope, created: 1 }),
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: "ses_target",
-      dataIdentity: "server-b:ses_target",
+      scope: remoteScope,
+      dataIdentity: timelineDataIdentity({ scope: remoteScope, created: 1 }),
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -97,15 +108,16 @@ describe("readTimelineMessages", () => {
 
   test("keeps last-good messages when the same session cache misses before session info reloads", () => {
     const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const scope = sessionScope()
     const ready = readTimelineMessages({
-      sessionID: "ses_target",
-      dataIdentity: "ses_target:123",
+      scope,
+      dataIdentity: timelineDataIdentity({ scope, created: 123 }),
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       dataIdentity: undefined,
       raw: undefined,
       lastGood: ready.lastGood,
@@ -118,13 +130,13 @@ describe("readTimelineMessages", () => {
   test("clears last-good messages when there is no active session", () => {
     const loaded = [userMessage("msg_1", "ses_source")]
     const ready = readTimelineMessages({
-      sessionID: "ses_source",
+      scope: sessionScope("ses_source"),
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessages({
-      sessionID: undefined,
+      scope: undefined,
       raw: undefined,
       lastGood: ready.lastGood,
     })
@@ -134,14 +146,15 @@ describe("readTimelineMessages", () => {
   })
 
   test("treats an empty raw message array as authoritative loaded data", () => {
+    const scope = sessionScope()
     const ready = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: [userMessage("msg_1"), userMessage("msg_2")],
       lastGood: undefined,
     })
 
     const empty = readTimelineMessages({
-      sessionID: "ses_target",
+      scope,
       raw: [],
       lastGood: ready.lastGood,
     })
@@ -149,20 +162,62 @@ describe("readTimelineMessages", () => {
     expect(empty.messages).toEqual([])
     expect(empty.lastGood?.messages).toEqual([])
   })
+
+  test("last-good timeline cache does not cross server scopes with same session id", () => {
+    const localScope = sessionScope("ses_same", "sidecar")
+    const remoteScope = sessionScope("ses_same", "https://remote.example")
+
+    const first = readTimelineMessages({
+      scope: localScope,
+      dataIdentity: timelineDataIdentity({ scope: localScope, created: 1 }),
+      raw: messages120,
+      lastGood: undefined,
+    })
+
+    const second = readTimelineMessages({
+      scope: remoteScope,
+      dataIdentity: timelineDataIdentity({ scope: remoteScope, created: 1 }),
+      raw: undefined,
+      lastGood: first.lastGood,
+    })
+
+    expect(sessionScopeKey(localScope)).not.toBe(sessionScopeKey(remoteScope))
+    expect(second.messages).toEqual([])
+  })
+
+  test("last-good timeline cache keeps long same-scoped timeline during transient cache miss", () => {
+    const scope = sessionScope("ses_long")
+    const first = readTimelineMessages({
+      scope,
+      dataIdentity: timelineDataIdentity({ scope, created: 1 }),
+      raw: messages120,
+      lastGood: undefined,
+    })
+
+    const second = readTimelineMessages({
+      scope,
+      dataIdentity: timelineDataIdentity({ scope, created: 1 }),
+      raw: undefined,
+      lastGood: first.lastGood,
+    })
+
+    expect(second.messages.length).toBe(120)
+  })
 })
 
 describe("readTimelineMessagesFromCache", () => {
   test("keeps messages when directory switch makes session info and message cache briefly unavailable", () => {
     const loaded = [userMessage("msg_1"), userMessage("msg_2")]
+    const scope = sessionScope()
     const ready = readTimelineMessagesFromCache({
-      sessionID: "ses_target",
+      scope,
       sessionCreated: 123,
       raw: loaded,
       lastGood: undefined,
     })
 
     const missing = readTimelineMessagesFromCache({
-      sessionID: "ses_target",
+      scope,
       sessionCreated: undefined,
       raw: undefined,
       lastGood: ready.lastGood,

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -50,7 +50,9 @@ export function readTimelineMessages(input: {
 
   const dataIdentity =
     input.dataIdentity ??
-    (sameSessionScope(input.lastGood?.scope, input.scope) ? input.lastGood.dataIdentity : sessionScopeKey(input.scope))
+    (sameSessionScope(input.lastGood?.scope, input.scope) && input.lastGood
+      ? input.lastGood.dataIdentity
+      : sessionScopeKey(input.scope))
 
   if (input.raw !== undefined) {
     const messages = readSessionMessages(input.raw)

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -1,8 +1,6 @@
 import { createEffect, createMemo, on } from "solid-js"
 import type { useLocal } from "@/context/local"
 import type { useSync } from "@/context/sync"
-import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
-import type { SessionStatusState } from "@/context/global-sync/types"
 import { createSessionViewController } from "@/pages/session/session-view-controller"
 import {
   emptyMessages,
@@ -14,6 +12,23 @@ import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { diffs as list } from "@/utils/diffs"
 import { same } from "@/utils/same"
 import { makeSessionScope, sameSessionScope, sessionScopeKey, type SessionScope } from "./session-scope"
+import {
+  currentDirectoryProviderUsable,
+  currentSessionActionReady,
+  currentSessionCacheReady,
+  currentSessionSubmitReady,
+  currentWorkspaceSubmitReady,
+  sessionStatusKnown,
+} from "./session-action-readiness"
+
+export {
+  currentDirectoryProviderUsable,
+  currentSessionActionReady,
+  currentSessionCacheReady,
+  currentSessionSubmitReady,
+  currentWorkspaceSubmitReady,
+  sessionStatusKnown,
+} from "./session-action-readiness"
 
 type LastGoodMessages =
   | {
@@ -60,49 +75,6 @@ export function timelineModelSyncKey(input: {
   localReady: boolean
 }) {
   return `${input.directory}\n${input.messageID ?? ""}\n${input.localReady ? "ready" : "loading"}`
-}
-
-export function currentSessionCacheReady(input: {
-  sessionID: string | undefined
-  sessionInfo: unknown
-  rawMessages: unknown
-}) {
-  if (!input.sessionID) return true
-  return input.sessionInfo !== undefined && input.rawMessages !== undefined
-}
-
-export function currentSessionActionReady(input: {
-  sessionID: string | undefined
-  sessionInfo: unknown
-  rawMessages: unknown
-  statusReady: boolean
-}) {
-  if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.statusReady
-}
-
-export function currentSessionSubmitReady(input: {
-  sessionID: string | undefined
-  sessionInfo: unknown
-  rawMessages: unknown
-  statusReady: boolean
-  localReady: boolean
-  providerUsable: boolean
-}) {
-  return currentSessionActionReady(input) && input.localReady && input.providerUsable
-}
-
-export function currentWorkspaceSubmitReady(input: { localReady: boolean; providerUsable: boolean }) {
-  return input.localReady && input.providerUsable
-}
-
-export function currentDirectoryProviderUsable(input: { providerReady: boolean; providerCount: number }) {
-  return input.providerReady || input.providerCount > 0
-}
-
-export function sessionStatusKnown(input: { statusState: SessionStatusState; status: SessionStatus | undefined }) {
-  if (input.statusState === "ready" || input.statusState === "error") return true
-  return input.status?.type === "busy" || input.status?.type === "retry"
 }
 
 export function readTimelineMessagesFromCache(input: {

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -13,44 +13,45 @@ import {
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { diffs as list } from "@/utils/diffs"
 import { same } from "@/utils/same"
+import { makeSessionScope, sameSessionScope, sessionScopeKey, type SessionScope } from "./session-scope"
 
 type LastGoodMessages =
   | {
       dataIdentity: string
-      sessionID: string
+      scope: SessionScope
       messages: ReturnType<typeof readSessionMessages>
     }
   | undefined
 
 export function readTimelineMessages(input: {
-  sessionID: string | undefined
+  scope: SessionScope | undefined
   dataIdentity?: string
   raw: unknown
   lastGood: LastGoodMessages
 }): { messages: ReturnType<typeof readSessionMessages>; lastGood: LastGoodMessages } {
-  if (!input.sessionID) {
+  if (!input.scope) {
     return { messages: emptyMessages, lastGood: undefined }
   }
 
   const dataIdentity =
     input.dataIdentity ??
-    (input.lastGood?.sessionID === input.sessionID ? input.lastGood.dataIdentity : input.sessionID)
+    (sameSessionScope(input.lastGood?.scope, input.scope) ? input.lastGood.dataIdentity : sessionScopeKey(input.scope))
 
   if (input.raw !== undefined) {
     const messages = readSessionMessages(input.raw)
-    return { messages, lastGood: { dataIdentity, sessionID: input.sessionID, messages } }
+    return { messages, lastGood: { dataIdentity, scope: input.scope, messages } }
   }
 
-  if (input.lastGood?.dataIdentity === dataIdentity && input.lastGood.sessionID === input.sessionID) {
+  if (input.lastGood?.dataIdentity === dataIdentity && sameSessionScope(input.lastGood.scope, input.scope)) {
     return { messages: input.lastGood.messages, lastGood: input.lastGood }
   }
 
   return { messages: emptyMessages, lastGood: input.lastGood }
 }
 
-export function timelineDataIdentity(input: { sessionID: string | undefined; created: number | undefined }) {
-  if (!input.sessionID || input.created === undefined) return
-  return `${input.sessionID}:${input.created}`
+export function timelineDataIdentity(input: { scope: SessionScope | undefined; created: number | undefined }) {
+  if (!input.scope || input.created === undefined) return
+  return `${sessionScopeKey(input.scope)}\n${input.created}`
 }
 
 export function timelineModelSyncKey(input: {
@@ -105,25 +106,29 @@ export function sessionStatusKnown(input: { statusState: SessionStatusState; sta
 }
 
 export function readTimelineMessagesFromCache(input: {
-  sessionID: string | undefined
+  scope: SessionScope | undefined
   sessionCreated: number | undefined
   raw: unknown
   lastGood: LastGoodMessages
 }) {
   return readTimelineMessages({
-    sessionID: input.sessionID,
-    dataIdentity: timelineDataIdentity({ sessionID: input.sessionID, created: input.sessionCreated }),
+    scope: input.scope,
+    dataIdentity: timelineDataIdentity({ scope: input.scope, created: input.sessionCreated }),
     raw: input.raw,
     lastGood: input.lastGood,
   })
 }
 
 export function createSessionTimelineData(input: {
+  serverKey: () => string | undefined
   directory: () => string
   routeSessionID: () => string | undefined
   sync: ReturnType<typeof useSync>
   local: ReturnType<typeof useLocal>
 }) {
+  const routeScope = createMemo(() =>
+    makeSessionScope({ serverKey: input.serverKey(), sessionID: input.routeSessionID() }),
+  )
   const routeInfo = createMemo(() => {
     const id = input.routeSessionID()
     return id ? input.sync.session.get(id) : undefined
@@ -143,9 +148,11 @@ export function createSessionTimelineData(input: {
 
   const sessionView = createSessionViewController({
     routeSessionID: input.routeSessionID,
+    routeScope,
     routeMessagesReady,
   })
   const sessionID = sessionView.visible.id
+  const sessionScope = sessionView.visible.scope
   const sessionKey = sessionView.visible.key
   const transitioning = sessionView.transitioning
   const sessionInfo = createMemo(() => {
@@ -218,7 +225,7 @@ export function createSessionTimelineData(input: {
     () => {
       const id = sessionID()
       const next = readTimelineMessagesFromCache({
-        sessionID: id,
+        scope: sessionScope(),
         sessionCreated: sessionInfo()?.time.created,
         raw: id ? input.sync.data.message[id] : undefined,
         lastGood: lastGoodMessages,
@@ -308,6 +315,7 @@ export function createSessionTimelineData(input: {
     routeSessionCount,
     routeHasSessionReview,
     routeMessagesReady,
+    sessionScope,
     sessionID,
     sessionKey,
     transitioning,


### PR DESCRIPTION
## Summary

- Adds explicit `SessionScope`, `ExecutionScope`, `PromptRouteScope`, and submit/follow-up readiness helpers.
- Migrates timeline cache, follow-up persistence/action state, prompt rollback, revert, review/VCS, and artifact history to scoped ownership.
- Adds a diagnostics-backed E2E regression for the real `enter-worktree -> exit-worktree -> follow-up` path with a long rendered timeline.

## Why

#441 requires session identity and execution directory to be modeled separately. The old code mixed bare `sessionID`, route directory, and async result ownership in several places, which could reuse timeline/follow-up/review state across the wrong server or execution context and could collapse long timelines after worktree execution changes.

## Related Issue

Closes #441.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/app/src/pages/session/use-session-timeline-data.ts`: last-good timeline cache now follows durable `SessionScope`.
- `packages/app/src/pages/session/use-session-followups.ts`: v2 scoped queue plus scoped failed/paused/edit/busy/mutation state.
- `packages/app/src/components/prompt-input/submit.ts`: command hydration gates slash text without blocking shell `/bin/...`, and rollback uses captured prompt route scope.
- `packages/app/src/pages/session/use-session-review-state.ts` and `use-session-revert.ts`: stale async results are guarded by `ExecutionScope`.
- `packages/app/e2e/session/session-renderer-diagnostics.spec.ts`: long timeline regression should prove no remount, no rendered-count reset, no post-follow-up top jump, and correct post-exit send directory.

## Risk Notes

- This touches shared session wiring and persistence keys. The follow-up queue uses `session-followup.v2`; old v1 unscoped queued drafts are intentionally not auto-migrated.
- Manual Electron smoke was not run in this Codex environment. The original #432/#441 long-timeline path is covered by the focused Playwright diagnostics E2E.

## How To Verify

```text
Focused scope/unit tests: 40 passed
Typecheck: ok
Focused diagnostics E2E: 2 passed
Full app unit suite: 998 passed
Diff check: no whitespace errors
Follow-up old-key grep: no stale sessionID keying matches
```

Long-timeline E2E evidence:

```text
Path: real enter-worktree -> exit-worktree -> follow-up
Timeline mount count: 1
Timeline unmount count: 0
Post-follow-up rendered count: >= 80
Post-follow-up near-top scroll samples: none
Follow-up send directory after exit-worktree: project root
```

## Screenshots or Recordings

Not included. This PR changes session state ownership and scroll behavior; the visible regression is covered by diagnostics-backed E2E rather than a static screenshot.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command readiness gating; prompts now wait for command availability before submission
  * Introduced execution scope tracking across servers and directories for improved multi-server session management
  * Enhanced follow-up behavior with scope-aware submission control

* **Improvements**
  * Improved timeline stability across worktree transitions and directory changes
  * Better session state recovery with scope-based revert snapshots preventing stale operations
  * Refined scroll-resume behavior after composer submission

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->