### PR TITLE
fix(app): restore prompt popover visibility

### DIFF
--- a/packages/app/e2e/prompt/prompt-slash-open.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-open.spec.ts
@@ -1,15 +1,54 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { Locator } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
+
+async function expectOnTop(locator: Locator) {
+  await expect(locator).toBeVisible()
+  await expect
+    .poll(async () => {
+      return locator.evaluate((el) => {
+        const rect = el.getBoundingClientRect()
+        const target = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+        return !!target && (target === el || el.contains(target))
+      })
+    })
+    .toBe(true)
+}
+
+async function expectViewportGap(locator: Locator) {
+  await expect
+    .poll(async () => {
+      return locator.evaluate((el) => el.getBoundingClientRect().top)
+    })
+    .toBeGreaterThanOrEqual(8)
+}
+
+async function expectHoverPaint(locator: Locator) {
+  await locator.hover()
+  await expect
+    .poll(async () => {
+      return locator.evaluate((el) => getComputedStyle(el).backgroundColor)
+    })
+    .not.toBe("rgba(0, 0, 0, 0)")
+}
 
 test("/open opens file picker dialog", async ({ page, gotoSession }) => {
   await gotoSession()
 
   await page.locator(promptSelector).click()
-  await page.keyboard.type("/open")
+  await page.keyboard.type("/")
+
+  const popover = page.locator('[data-component="prompt-slash-popover"]')
+  await expectOnTop(popover)
+  await expectViewportGap(popover)
+
+  await page.keyboard.type("open")
 
   const command = page.locator('[data-slash-id="file.open"]')
-  await expect(command).toBeVisible()
-  await command.hover()
+  await expectOnTop(command)
+  await expectHoverPaint(command)
 
   await page.keyboard.press("Enter")
 
@@ -19,4 +58,41 @@ test("/open opens file picker dialog", async ({ page, gotoSession }) => {
 
   await page.keyboard.press("Escape")
   await expect(dialog).toHaveCount(0)
+})
+
+test("home composer shows slash commands after a bare slash", async ({ page, project }) => {
+  await project.open()
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.type("/")
+
+  const popover = page.locator('[data-component="prompt-slash-popover"]')
+  await expectOnTop(popover)
+  await expectViewportGap(popover)
+  const command = page.locator('[data-slash-id="file.open"]')
+  await expectOnTop(command)
+  await expectHoverPaint(command)
+})
+
+test("@mention file suggestions stay visible above the composer", async ({ page, project }) => {
+  await project.open({
+    setup: async (directory) => {
+      await mkdir(join(directory, "src"), { recursive: true })
+      await writeFile(join(directory, "src", "mention-target.md"), "hello")
+    },
+  })
+
+  await page.locator(promptSelector).click()
+  const sep = process.platform === "win32" ? "\\" : "/"
+  const file = ["src", "mention-target.md"].join(sep)
+  const filePattern = /src[\\/]+\s*mention-target\.md/
+
+  await page.keyboard.type(`@${file}`)
+
+  const popover = page.locator('[data-component="prompt-at-popover"]')
+  await expectOnTop(popover)
+
+  const suggestion = page.getByRole("button", { name: filePattern }).first()
+  await expectOnTop(suggestion)
+  await expectHoverPaint(suggestion)
 })

--- a/packages/app/src/components/prompt-input/slash-popover.tsx
+++ b/packages/app/src/components/prompt-input/slash-popover.tsx
@@ -38,8 +38,8 @@ export const PromptPopover: Component<PromptPopoverProps> = (props) => {
         ref={(el) => {
           if (props.popover === "slash") props.setSlashPopoverRef(el)
         }}
-        class="absolute inset-x-0 -top-2 -translate-y-full origin-bottom-left max-h-80 min-h-10
-                 overflow-auto no-scrollbar flex flex-col p-2 rounded-[12px]
+        class="absolute inset-x-0 -top-2 -translate-y-full z-50 origin-bottom-left max-h-80 min-h-10
+                 pointer-events-auto overflow-auto no-scrollbar flex flex-col p-2 rounded-[12px]
                  bg-surface-raised shadow-[var(--shadow-lg-border-base)]"
         onMouseDown={(e) => e.preventDefault()}
       >
@@ -60,7 +60,7 @@ export const PromptPopover: Component<PromptPopoverProps> = (props) => {
                   return (
                     <button
                       class="w-full flex items-center gap-x-2 rounded-md px-2 py-0.5"
-                      classList={{ "bg-surface-raised": props.atActive === key }}
+                      classList={{ "[background:var(--row-hover-overlay)]": props.atActive === key }}
                       onClick={() => props.onAtSelect(item)}
                       onMouseEnter={() => props.setAtActive(key)}
                     >
@@ -88,7 +88,7 @@ export const PromptPopover: Component<PromptPopoverProps> = (props) => {
                     data-slash-id={cmd.id}
                     classList={{
                       "w-full flex items-center justify-between gap-4 rounded-md px-2 py-1": true,
-                      "bg-surface-raised": props.slashActive === cmd.id,
+                      "[background:var(--row-hover-overlay)]": props.slashActive === cmd.id,
                     }}
                     onClick={() => props.onSlashSelect(cmd)}
                     onMouseEnter={() => props.setSlashActive(cmd.id)}

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -179,93 +179,92 @@ export function SessionComposerRegion(props: {
               </DockCard>
             }
           >
-            <DockCard>
-              <Show when={dockMounted()}>
-                <SessionTodoDock
-                  sessionID={displaySessionID()}
-                  todos={props.state.todos()}
-                  collapseLabel={language.t("session.todo.collapse")}
-                  expandLabel={language.t("session.todo.expand")}
-                  dockProgress={dockProgress()}
-                />
-              </Show>
-              <Show when={rolled()} keyed>
-                {(revert) => (
-                  <SessionRevertDock
-                    items={revert.items}
-                    restoring={revert.restoring}
-                    disabled={revert.disabled}
-                    onRestore={revert.onRestore}
+            <div class="relative z-30">
+              <DockCard class="overflow-visible!">
+                <Show when={dockMounted()}>
+                  <SessionTodoDock
+                    sessionID={displaySessionID()}
+                    todos={props.state.todos()}
+                    collapseLabel={language.t("session.todo.collapse")}
+                    expandLabel={language.t("session.todo.expand")}
+                    dockProgress={dockProgress()}
                   />
-                )}
-              </Show>
-              <Show when={props.followup?.items.length}>
-                <SessionFollowupDock
-                  items={props.followup!.items}
-                  sending={props.followup!.sending}
-                  onSend={props.followup!.onSend}
-                  onEdit={props.followup!.onEdit}
-                />
-              </Show>
-              <Show
-                when={props.state.permissionRequest()}
-                keyed
-                fallback={
-                  <Show
-                    when={child()}
-                    fallback={
-                      <Show when={!props.state.blocked()}>
-                        <PromptInput
-                          ref={props.inputRef}
-                          homeMode={home()}
-                          sessionID={displaySessionID()}
-                          sessionIDControlled={!home()}
-                          newSessionWorktree={props.newSessionWorktree}
-                          onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
-                          edit={props.followup?.edit}
-                          onEditLoaded={props.followup?.onEditLoaded}
-                          shouldQueue={props.followup?.queue}
-                          onQueue={props.followup?.onQueue}
-                          onAbort={props.followup?.onAbort}
-                          onSubmit={props.onSubmit}
-                          onModeChange={props.onModeChange}
-                          actionReady={() => props.actionReady ?? true}
-                          abortReady={() => props.abortReady ?? props.actionReady ?? true}
-                          selectedSkill={props.selectedSkill}
-                        />
-                      </Show>
-                    }
-                  >
-                    <DockSegment
-                      ref={props.inputRef as (el: HTMLDivElement) => void}
-                      class="w-full p-3 text-16-regular text-fg-weak"
+                </Show>
+                <Show when={rolled()} keyed>
+                  {(revert) => (
+                    <SessionRevertDock
+                      items={revert.items}
+                      restoring={revert.restoring}
+                      disabled={revert.disabled}
+                      onRestore={revert.onRestore}
+                    />
+                  )}
+                </Show>
+                <Show when={props.followup?.items.length}>
+                  <SessionFollowupDock
+                    items={props.followup!.items}
+                    sending={props.followup!.sending}
+                    onSend={props.followup!.onSend}
+                    onEdit={props.followup!.onEdit}
+                  />
+                </Show>
+                <Show
+                  when={props.state.permissionRequest()}
+                  keyed
+                  fallback={
+                    <Show
+                      when={child()}
+                      fallback={
+                        <Show when={!props.state.blocked()}>
+                          <PromptInput
+                            ref={props.inputRef}
+                            homeMode={home()}
+                            sessionID={displaySessionID()}
+                            sessionIDControlled={!home()}
+                            newSessionWorktree={props.newSessionWorktree}
+                            onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
+                            edit={props.followup?.edit}
+                            onEditLoaded={props.followup?.onEditLoaded}
+                            shouldQueue={props.followup?.queue}
+                            onQueue={props.followup?.onQueue}
+                            onAbort={props.followup?.onAbort}
+                            onSubmit={props.onSubmit}
+                            onModeChange={props.onModeChange}
+                            actionReady={() => props.actionReady ?? true}
+                            abortReady={() => props.abortReady ?? props.actionReady ?? true}
+                            selectedSkill={props.selectedSkill}
+                          />
+                        </Show>
+                      }
                     >
-                      <span>{language.t("session.child.promptDisabled")} </span>
-                      <Show when={parentID()}>
-                        <button
-                          type="button"
-                          class="text-fg-base transition-colors hover:text-fg-strong"
-                          onClick={openParent}
-                        >
-                          {language.t("session.child.backToParent")}
-                        </button>
-                      </Show>
-                    </DockSegment>
-                  </Show>
-                }
-              >
-                {(request) => (
-                  <SessionPermissionContent
-                    request={request}
-                    responding={props.state.permissionResponding()}
-                    onDecide={(response) => {
-                      props.onResponseSubmit()
-                      props.state.decide(response)
-                    }}
-                  />
-                )}
-              </Show>
-            </DockCard>
+                      <DockSegment ref={props.inputRef} class="w-full p-3 text-16-regular text-fg-weak">
+                        <span>{language.t("session.child.promptDisabled")} </span>
+                        <Show when={parentID()}>
+                          <button
+                            type="button"
+                            class="text-fg-base transition-colors hover:text-fg-strong"
+                            onClick={openParent}
+                          >
+                            {language.t("session.child.backToParent")}
+                          </button>
+                        </Show>
+                      </DockSegment>
+                    </Show>
+                  }
+                >
+                  {(request) => (
+                    <SessionPermissionContent
+                      request={request}
+                      responding={props.state.permissionResponding()}
+                      onDecide={(response) => {
+                        props.onResponseSubmit()
+                        props.state.decide(response)
+                      }}
+                    />
+                  )}
+                </Show>
+              </DockCard>
+            </div>
           </Show>
         </Show>
       </div>


### PR DESCRIPTION
## Summary

- Allow the prompt composer card to show `/` and `@` popovers outside its clipped card bounds.
- Keep `PromptPopover` owned and anchored by `PromptInput`; this is not a new general overlay primitive.
- Restore visible hover state for slash and @mention rows, and expand regression coverage for visibility, top spacing, topmost hit-testing, and hover paint.

## Why

#508 wrapped the composer in `DockCard`, whose root uses `overflow: hidden` for joined-card clipping. `PromptPopover` still rendered inline as an upward `absolute` child, so typing `/` or `@` could update popover state while the suggestion body was clipped outside the card.

This fix keeps the original prompt popover positioning model and applies a local overflow opt-out only to the prompt composer `DockCard`. Other `DockCard` instances keep their clipping contract. The fix deliberately does not introduce a body-level portal, fixed-position overlay system, or Kobalte migration; those would be broader design work for a later slice.

## Related Issue

Closes #524

## Human Review Status

Pending. AstroHan manually verified the current Electron build: home `/`, home `@`, session `/`, session `@`, and multi-segment composer states are functionally normal. Remaining feedback about @mention/file popover visual design is a separate DESIGN.md alignment follow-up, not part of this hotfix.

## Review Focus

- `DockCard` overflow is only opted out on the prompt composer card, not globally.
- `PromptPopover` remains anchored inside `PromptInput` with the original `max-h-80 -top-2 -translate-y-full` visual constraints.
- Slash and @mention rows should have a visible hover/active background distinct from the popover surface.
- The focused E2E should catch clipped, top-edge, covered, and transparent-hover regressions.

## Risk Notes

Visible UI change in the prompt composer popover layer. The main risk is prompt-card joined-segment clipping because this card locally opts out of `DockCard` overflow. The change is scoped to the prompt composer wrapper and does not change the shared `DockCard` primitive.

No dependency, data, permission, migration, packaging, updater, signing, shell, credential, deletion, generated-content, or local-file behavior changes.

## How To Verify

```text
Typecheck: bun --cwd packages/app typecheck -> ok
Focused E2E: bun --cwd packages/app test:e2e -- e2e/prompt/prompt-slash-open.spec.ts -> 3 passed
Diff check: git diff --check -> ok
Manual Electron: AstroHan verified home /, home @, session /, session @, and multi-segment composer states -> normal
```

The focused E2E covers session `/open`, bare `/` in the home composer, and `@mention` suggestions. It asserts visible popovers/items, topmost hit-testing via `elementFromPoint`, top viewport gap, and non-transparent hover paint.

## Screenshots or Recordings

Manual Electron check was done against the corrected i524 worktree dev environment. Earlier false negatives came from `node_modules` symlinks resolving `@opencode-ai/app` back to the main checkout; this was corrected locally before final manual verification.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
