### PR TITLE
test: fix release notes e2e setup

### DIFF
--- a/packages/app/e2e/release-notes/release-notes-toast.spec.ts
+++ b/packages/app/e2e/release-notes/release-notes-toast.spec.ts
@@ -20,18 +20,18 @@ const SINGLE_RELEASE_PAYLOAD = [
 
 const MULTI_VERSION_PAYLOAD = [
   {
-    tag_name: "v2026.5.7",
+    tag_name: "v2026.5.11",
     body: "## App Update Notice\n\n- Newest highlight A\n- Newest highlight B\n",
   },
   {
-    tag_name: "v2026.5.6",
+    tag_name: "v2026.5.10",
     body: "## App Update Notice\n\n- Older highlight C\n",
   },
 ]
 
 const LOCALIZED_PAYLOAD = [
   {
-    tag_name: "v2026.5.7",
+    tag_name: "v2026.5.11",
     body: [
       "## App Update Notice",
       "",
@@ -244,11 +244,11 @@ test.describe("release notes toast", () => {
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.7")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     const description = page.locator(TOAST_DESCRIPTION_SELECTOR)
     await expect(description).toContainText("• Newest highlight A")
     await expect(description).toContainText("• Newest highlight B")
-    await expect(description).toContainText("v2026.5.6")
+    await expect(description).toContainText("v2026.5.10")
     await expect(description).toContainText("• Older highlight C")
   })
 
@@ -259,23 +259,23 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.7",
+            tag_name: "v2026.5.11",
             body: "## App Update Notice\n\n- English fallback bullet\n",
           },
         ]),
       })
     })
 
-    await page.addInitScript((highlightsKey) => {
+    await page.addInitScript(([highlightsKey, languageKey]) => {
       localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.6" }))
-      localStorage.setItem(LANGUAGE_KEY, JSON.stringify({ locale: "zh" }))
-    }, HIGHLIGHTS_KEY)
+      localStorage.setItem(languageKey, JSON.stringify({ locale: "zh" }))
+    }, [HIGHLIGHTS_KEY, LANGUAGE_KEY])
 
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
     // Title and action must follow the parsed body's locale (en) — never mix with zh UI locale.
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.7")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• English fallback bullet")
   })
@@ -289,15 +289,15 @@ test.describe("release notes toast", () => {
       })
     })
 
-    await page.addInitScript((highlightsKey) => {
+    await page.addInitScript(([highlightsKey, languageKey]) => {
       localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.6" }))
-      localStorage.setItem(LANGUAGE_KEY, JSON.stringify({ locale: "zh" }))
-    }, HIGHLIGHTS_KEY)
+      localStorage.setItem(languageKey, JSON.stringify({ locale: "zh" }))
+    }, [HIGHLIGHTS_KEY, LANGUAGE_KEY])
 
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("已更新到 v2026.5.7")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("已更新到 v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("查看完整发布说明 →")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• 中文要点 A")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• 中文要点 B")
@@ -313,12 +313,12 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.7",
+            tag_name: "v2026.5.11",
             // newest release: zh-only notice, no English App Update Notice
             body: ["## 中文版本", "", "### 主要更新", "", "- 仅中文要点"].join("\n"),
           },
           {
-            tag_name: "v2026.5.6",
+            tag_name: "v2026.5.10",
             // older skipped release: en-only notice, no 中文版本
             body: "## App Update Notice\n\n- older en-only bullet\n",
           },
@@ -326,25 +326,25 @@ test.describe("release notes toast", () => {
       })
     })
 
-    await page.addInitScript((highlightsKey) => {
-      localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.5" }))
-      localStorage.setItem(LANGUAGE_KEY, JSON.stringify({ locale: "zh" }))
-    }, HIGHLIGHTS_KEY)
+    await page.addInitScript(([highlightsKey, languageKey]) => {
+      localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.9" }))
+      localStorage.setItem(languageKey, JSON.stringify({ locale: "zh" }))
+    }, [HIGHLIGHTS_KEY, LANGUAGE_KEY])
 
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    // First-pass zh resolves to mixed (v2026.5.7 zh + v2026.5.6 en fallback),
+    // First-pass zh resolves to mixed (v2026.5.11 zh + v2026.5.10 en fallback),
     // so we re-resolve the whole window in English. The English window does
-    // not contain v2026.5.7 (no App Update Notice there), but the title and
+    // not contain v2026.5.11 (no App Update Notice there), but the title and
     // link must still anchor on the app's current version, not summaries[0].
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.7")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
-    // Description's first segment must carry the v2026.5.6 tag, otherwise
+    // Description's first segment must carry the v2026.5.10 tag, otherwise
     // the older release's bullet would read as if it described the current
-    // version (the title says v2026.5.7 but summaries[0] here is v2026.5.6
-    // because the English fallback dropped v2026.5.7).
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("v2026.5.6")
+    // version (the title says v2026.5.11 but summaries[0] here is v2026.5.10
+    // because the English fallback dropped v2026.5.11).
+    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("v2026.5.10")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• older en-only bullet")
   })
 
@@ -358,7 +358,7 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.7",
+            tag_name: "v2026.5.11",
             body: [
               "## App Update Notice",
               "",
@@ -372,17 +372,17 @@ test.describe("release notes toast", () => {
             ].join("\n"),
           },
           {
-            tag_name: "v2026.5.6",
+            tag_name: "v2026.5.10",
             body: "## App Update Notice\n\n- older en only\n",
           },
         ]),
       })
     })
 
-    await page.addInitScript((highlightsKey) => {
-      localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.5" }))
-      localStorage.setItem(LANGUAGE_KEY, JSON.stringify({ locale: "zh" }))
-    }, HIGHLIGHTS_KEY)
+    await page.addInitScript(([highlightsKey, languageKey]) => {
+      localStorage.setItem(highlightsKey, JSON.stringify({ version: "2026.5.9" }))
+      localStorage.setItem(languageKey, JSON.stringify({ locale: "zh" }))
+    }, [HIGHLIGHTS_KEY, LANGUAGE_KEY])
 
     await gotoSession()
 
@@ -390,7 +390,7 @@ test.describe("release notes toast", () => {
     // The newest release has a zh section but the older skipped release does
     // not. Spec #486 forbids mixing languages, so the entire toast — title,
     // action, and every segment — must be English.
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.7")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• newest en bullet")
     await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• older en only")


### PR DESCRIPTION
## Summary

- Passed the language storage key into the browser `addInitScript` context in release-notes E2E tests.
- Updated the release-notes E2E fixture versions so the mocked GitHub releases include the app's current version, `v2026.5.11`.
- Kept the change scoped to release-notes E2E setup data only.

## Why

#529 tracks release-gate test debt from v2026.5.11. The release-notes zh tests referenced `LANGUAGE_KEY` from inside the browser context without passing it through Playwright's init-script argument, which raised `ReferenceError: LANGUAGE_KEY is not defined`.

After that setup bug is fixed, the same release-notes spec also needs current-version fixture data: the app now runs as `2026.5.11`, and `loadReleaseHighlights` intentionally returns no toast when the mocked release payload does not contain the current version.

## Related Issue

Refs #529. This handles only the release-notes setup slice of the E2E debt list.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the PR only changes `release-notes-toast.spec.ts` fixture/setup code.
- Confirm `LANGUAGE_KEY` is passed into every browser init script that writes zh locale state.
- Confirm the fixture version changes match the current app version without changing product behavior.

## Risk Notes

Low. This is E2E test setup cleanup only. No runtime code, product behavior, copy, dependencies, or lockfiles are changed.

## How To Verify

```text
Red repro before fix: targeted zh release-notes E2E failed with ReferenceError: LANGUAGE_KEY is not defined, then no toast once the setup bug was removed but stale current-version fixtures remained.
Release-notes E2E: 10 passed, 0 failed
Diff check: no whitespace errors
```

Commands run:

```bash
bun --cwd packages/app test:e2e e2e/release-notes/release-notes-toast.spec.ts --grep 'uses zh title and action when zh release section is present' --workers=1
bun --cwd packages/app test:e2e e2e/release-notes/release-notes-toast.spec.ts --workers=1
git diff --check
```

## Screenshots or Recordings

None. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
