### PR TITLE
fix(app): clear prompt source scope on submit success

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -30,6 +30,7 @@ const abortedSessions: string[] = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
+const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
 
 let params: { dir?: string; id?: string } = {}
 let selected = "/repo/worktree-a"
@@ -136,7 +137,9 @@ beforeAll(async () => {
   mock.module("@/context/prompt", () => ({
     usePrompt: () => ({
       current: () => promptValue,
-      reset: (_target?: { dir: string; id?: string }) => undefined,
+      reset: (target?: { dir: string; id?: string }) => {
+        promptResetCalls.push({ target })
+      },
       set: (next: Prompt, cursor?: number, target?: { dir: string; id?: string }) => {
         promptSetCalls.push({ prompt: next, cursor, target })
       },
@@ -260,6 +263,7 @@ beforeEach(() => {
   globalTodoSets.length = 0
   childTodoSets.length = 0
   promptSetCalls.length = 0
+  promptResetCalls.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
@@ -724,5 +728,36 @@ describe("prompt submit worktree selection", () => {
     })
 
     expect(commandCalls.at(-1)?.locale).toBe("zh-Hans")
+  })
+
+  test("clears prompt source scope on successful new-session submit", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "hello", start: 0, end: 5 }]
+
+    const submit = createPromptSubmit({
+      info: () => undefined,
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) =>
+        value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptResetCalls.length > 0)
+
+    // clearInput must reset the SOURCE scope (home page: dir=/repo/main, no session id)
+    // not the FINAL scope (new session route after navigate changes params.id)
+    expect(promptResetCalls.at(-1)?.target?.dir).toBe("/repo/main")
+    expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
   })
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -33,6 +33,7 @@ const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: s
 const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
 
 let params: { dir?: string; id?: string } = {}
+let navigateImpl = (_path: string): void => {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
 
@@ -89,7 +90,7 @@ beforeAll(async () => {
   const rootClient = clientFor("/repo/main")
 
   mock.module("@solidjs/router", () => ({
-    useNavigate: () => () => undefined,
+    useNavigate: () => (path: string) => navigateImpl(path),
     useParams: () => params,
   }))
 
@@ -265,6 +266,7 @@ beforeEach(() => {
   promptSetCalls.length = 0
   promptResetCalls.length = 0
   params = {}
+  navigateImpl = (_path: string): void => {}
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
@@ -733,6 +735,11 @@ describe("prompt submit worktree selection", () => {
   test("clears prompt source scope on successful new-session submit", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "hello", start: 0, end: 5 }]
+    // Simulate navigate() changing params.id to the new session id, just as SolidJS router does
+    navigateImpl = (path: string) => {
+      const match = path.match(/\/session\/([^/]+)/)
+      if (match) params.id = match[1]
+    }
 
     const submit = createPromptSubmit({
       info: () => undefined,
@@ -755,8 +762,9 @@ describe("prompt submit worktree selection", () => {
     await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
     await waitForCall(() => promptResetCalls.length > 0)
 
-    // clearInput must reset the SOURCE scope (home page: dir=/repo/main, no session id)
-    // not the FINAL scope (new session route after navigate changes params.id)
+    // After navigate(), params.id is now "session-1", but clearInput must reset the
+    // SOURCE scope (home page: dir=/repo/main, no session id) not the final session scope
+    expect(params.id).toBe("session-1") // confirm navigate ran and updated params
     expect(promptResetCalls.at(-1)?.target?.dir).toBe("/repo/main")
     expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
   })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -23,7 +23,7 @@ import { setCursorPosition } from "./editor-dom"
 import { buildHomeOverride } from "./home-override"
 import { formatServerError } from "@/utils/server-errors"
 import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
-import { promptScopeForSession } from "@/pages/session/prompt-route-scope"
+import { type PromptRouteScope, promptScopeForSession } from "@/pages/session/prompt-route-scope"
 
 type PendingPrompt = {
   abort: AbortController
@@ -355,6 +355,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     promptProbe.start()
 
     const projectDirectory = sdk.directory
+    // Capture the source scope before any await so navigate() cannot change params.id under us
+    const sourcePromptScope: PromptRouteScope = {
+      dir: params.dir ?? base64Encode(projectDirectory),
+      id: params.id,
+    }
     const shouldAutoAccept = creatingNewSession && input.autoAccept()
     const worktreeSelection = input.newSessionWorktree?.() || "main"
 
@@ -450,7 +455,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     const clearInput = () => {
-      prompt.reset()
+      prompt.reset(sourcePromptScope)
       input.setMode("normal")
       input.setPopover(null)
     }


### PR DESCRIPTION
## Summary

Capture the source prompt scope at the start of `handleSubmit` (before any `await`) and pass it to `prompt.reset()` inside `clearInput`. This ensures the home-page prompt cache is cleared on the correct route scope after new-session navigation changes `params.id`.

## Why

After a new-session submit on the home page, `navigate()` changes `params.id` from `undefined` to the new session ID. The previous `prompt.reset()` call inside `clearInput` had no scope argument, so it cleared the wrong scope (the newly-navigated session) instead of the source scope (the home page). This left the home-page prompt cached and caused it to leak into another project's input after switching projects.

## Related Issue

Closes #518

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `submit.ts`: `sourcePromptScope` declaration placement (must be before first `await`) and its use in `clearInput`
- `submit.test.ts`: new test verifies `prompt.reset` is called with source scope on new-session submit success

## Risk Notes

`clearInput` is called in 4 paths (queue, shell, command, normal submit). All now pass `sourcePromptScope`. For existing-session submits, `params` does not change during `handleSubmit` so scope is the same as before. Scope capture is purely additive; no store writes or side effects.

## How To Verify

```text
Targeted unit tests: bun --cwd packages/app test src/components/prompt-input/submit.test.ts
All existing tests pass + new test "clears prompt source scope on successful new-session submit" passes
Typecheck: bunx tsgo -b (in packages/app) — 0 errors
```

## Screenshots or Recordings

N/A — no visible UI change; this is a state/memory fix.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English