### PR TITLE
test: fix prompt mention e2e workspace

### DIFF
--- a/packages/app/e2e/prompt/prompt-mention.spec.ts
+++ b/packages/app/e2e/prompt/prompt-mention.spec.ts
@@ -1,13 +1,20 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
 
-test("@mention inserts file pill token", async ({ page, gotoSession }) => {
-  await gotoSession()
+test("@mention inserts file pill token", async ({ page, project }) => {
+  await project.open({
+    setup: async (directory) => {
+      await mkdir(join(directory, "src"), { recursive: true })
+      await writeFile(join(directory, "src", "mention-target.md"), "hello")
+    },
+  })
 
   await page.locator(promptSelector).click()
   const sep = process.platform === "win32" ? "\\" : "/"
-  const file = ["packages", "app", "package.json"].join(sep)
-  const filePattern = /packages[\\/]+app[\\/]+\s*package\.json/
+  const file = ["src", "mention-target.md"].join(sep)
+  const filePattern = /src[\\/]+\s*mention-target\.md/
 
   await page.keyboard.type(`@${file}`)
 


### PR DESCRIPTION
## Summary

Update the prompt @mention E2E to create and search for a file inside the active test project.

## Why

#529 tracks release-gate E2E debt from v2026.5.11. This test was searching for `packages/app/package.json`, which only exists when the browser project happens to be the repository checkout. In the real E2E fixture, the active workspace is a generated project, so the test can show "No matching results" even when @mention works.

## Related Issue

Refs #529.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that this PR only fixes the prompt-mention workspace assumption and still verifies the full file-pill insertion path: suggestion appears, Tab inserts the file pill, and typing can continue afterward.

## Risk Notes

No product behavior changes. This touches one E2E spec only.

## How To Verify

```text
Red repro: bun --cwd packages/app test:e2e e2e/prompt/prompt-mention.spec.ts --workers=1 -> failed on stale repo-file suggestion, No matching results
Focused E2E: bun --cwd packages/app test:e2e e2e/prompt/prompt-mention.spec.ts --workers=1 -> 1 passed
Typecheck: bun --cwd packages/app typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

N/A. Test-only change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test for @mention file integration with improved fixture setup and assertion handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/537)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->