### PR TITLE
feat(ui): render release notes toast with markdown and visible scroll

### DIFF
--- a/packages/app/e2e/release-notes/release-notes-toast.spec.ts
+++ b/packages/app/e2e/release-notes/release-notes-toast.spec.ts
@@ -50,6 +50,7 @@ const LOCALIZED_PAYLOAD = [
 const TOAST_SELECTOR = '[data-component="toast"][data-variant="subtle"]'
 const TOAST_TITLE_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-title"]`
 const TOAST_DESCRIPTION_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-description"]`
+const TOAST_MARKDOWN_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-markdown"]`
 const TOAST_ACTION_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-action"]`
 const TOAST_CLOSE_BUTTON_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-close-button"]`
 const TOAST_ICON_SELECTOR = `${TOAST_SELECTOR} [data-slot="toast-icon"]`
@@ -72,9 +73,9 @@ test.describe("release notes toast", () => {
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("Important refresh for this release.")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• Added subtle toast variant")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• Replaced release notes dialog")
+    // Content is now rendered as HTML in the toast-markdown slot
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("Important refresh for this release.")
+    await expect(page.locator(`${TOAST_MARKDOWN_SELECTOR} li`)).toContainText(["Added subtle toast variant", "Replaced release notes dialog"])
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     await expect(page.locator(TOAST_ICON_SELECTOR)).toBeVisible()
   })
@@ -245,11 +246,17 @@ test.describe("release notes toast", () => {
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
-    const description = page.locator(TOAST_DESCRIPTION_SELECTOR)
-    await expect(description).toContainText("• Newest highlight A")
-    await expect(description).toContainText("• Newest highlight B")
-    await expect(description).toContainText("v2026.5.10")
-    await expect(description).toContainText("• Older highlight C")
+    const markdown = page.locator(TOAST_MARKDOWN_SELECTOR)
+    await expect(markdown).toContainText("Newest highlight A")
+    await expect(markdown).toContainText("Newest highlight B")
+    await expect(markdown).toContainText("v2026.5.10")
+    await expect(markdown).toContainText("Older highlight C")
+    // All bullets must be rendered as <li> elements — both newest and multi-version older
+    await expect(page.locator(`${TOAST_MARKDOWN_SELECTOR} li`)).toContainText([
+      "Newest highlight A",
+      "Newest highlight B",
+      "Older highlight C",
+    ])
   })
 
   test("falls back to English when zh release section is missing", async ({ page, gotoSession }) => {
@@ -277,7 +284,7 @@ test.describe("release notes toast", () => {
     // Title and action must follow the parsed body's locale (en) — never mix with zh UI locale.
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• English fallback bullet")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("English fallback bullet")
   })
 
   test("uses zh title and action when zh release section is present", async ({ page, gotoSession }) => {
@@ -299,8 +306,8 @@ test.describe("release notes toast", () => {
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("已更新到 v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("查看完整发布说明 →")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• 中文要点 A")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• 中文要点 B")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("中文要点 A")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("中文要点 B")
   })
 
   test("title and link anchor on the app's current version even when its release lacks a notice in the resolved locale", async ({
@@ -340,12 +347,12 @@ test.describe("release notes toast", () => {
     // link must still anchor on the app's current version, not summaries[0].
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
-    // Description's first segment must carry the v2026.5.10 tag, otherwise
+    // Markdown slot's first segment must carry the v2026.5.10 tag, otherwise
     // the older release's bullet would read as if it described the current
     // version (the title says v2026.5.11 but summaries[0] here is v2026.5.10
     // because the English fallback dropped v2026.5.11).
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("v2026.5.10")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• older en-only bullet")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("v2026.5.10")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("older en-only bullet")
   })
 
   test("falls back to English across the whole window when an older skipped release has no zh section", async ({
@@ -392,8 +399,8 @@ test.describe("release notes toast", () => {
     // action, and every segment — must be English.
     await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.11")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• newest en bullet")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).toContainText("• older en only")
-    await expect(page.locator(TOAST_DESCRIPTION_SELECTOR)).not.toContainText("中文")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("newest en bullet")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("older en only")
+    await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).not.toContainText("中文")
   })
 })

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -268,21 +268,33 @@ function escapeHtml(text: string): string {
 // minimal HTML for the toast-markdown slot. Only bullet lists and paragraphs
 // are needed — the GitHub release format does not use other block elements.
 function buildToastMarkdownHtml(text: string): string {
-  const sections = text.split("\n\n")
-  return sections
-    .map((section) => {
-      const lines = section.split("\n")
-      const isList = lines.every((line) => /^[•\-*+] /.test(line.trim()) || line.trim() === "")
-      if (isList) {
-        const items = lines
-          .filter((line) => /^[•\-*+] /.test(line.trim()))
-          .map((line) => `<li>${escapeHtml(line.replace(/^[•\-*+] /, "").trim())}</li>`)
-          .join("")
-        return `<ul>${items}</ul>`
-      }
-      return `<p>${escapeHtml(section)}</p>`
-    })
-    .join("")
+  const lines = text.split("\n")
+  const result: string[] = []
+  const bulletBuffer: string[] = []
+
+  const flushBullets = () => {
+    if (bulletBuffer.length > 0) {
+      result.push(`<ul>${bulletBuffer.map((b) => `<li>${b}</li>`).join("")}</ul>`)
+      bulletBuffer.length = 0
+    }
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === "") {
+      flushBullets()
+      continue
+    }
+    if (/^[•\-*+] /.test(trimmed)) {
+      bulletBuffer.push(escapeHtml(trimmed.replace(/^[•\-*+] /, "").trim()))
+    } else {
+      flushBullets()
+      result.push(`<p>${escapeHtml(trimmed)}</p>`)
+    }
+  }
+  flushBullets()
+
+  return result.join("")
 }
 
 function buildToastDescription(summaries: ReleaseSummary[], currentTag: string) {

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -262,6 +262,7 @@ function escapeHtml(text: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
 }
 
 // Convert the plain-text description produced by buildToastDescription into

--- a/packages/app/src/context/highlights.tsx
+++ b/packages/app/src/context/highlights.tsx
@@ -256,6 +256,35 @@ export function loadReleaseHighlights(
   return summaries
 }
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+// Convert the plain-text description produced by buildToastDescription into
+// minimal HTML for the toast-markdown slot. Only bullet lists and paragraphs
+// are needed — the GitHub release format does not use other block elements.
+function buildToastMarkdownHtml(text: string): string {
+  const sections = text.split("\n\n")
+  return sections
+    .map((section) => {
+      const lines = section.split("\n")
+      const isList = lines.every((line) => /^[•\-*+] /.test(line.trim()) || line.trim() === "")
+      if (isList) {
+        const items = lines
+          .filter((line) => /^[•\-*+] /.test(line.trim()))
+          .map((line) => `<li>${escapeHtml(line.replace(/^[•\-*+] /, "").trim())}</li>`)
+          .join("")
+        return `<ul>${items}</ul>`
+      }
+      return `<p>${escapeHtml(section)}</p>`
+    })
+    .join("")
+}
+
 function buildToastDescription(summaries: ReleaseSummary[], currentTag: string) {
   // First segment omits its tag only when it matches the toast title's
   // version. When summaries[0] is an older release (e.g. zh-locale fallback
@@ -347,7 +376,7 @@ export const { use: useHighlights, provider: HighlightsProvider } = createSimple
 
             showToast({
               title: copy.title(currentTag),
-              description: buildToastDescription(summaries, currentTag),
+              markdownHtml: buildToastMarkdownHtml(buildToastDescription(summaries, currentTag)),
               icon: "bullet-list",
               variant: "subtle",
               persistent: true,

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -220,15 +220,6 @@
     p {
       margin: 4px 0;
     }
-
-    strong {
-      font-weight: var(--font-weight-medium);
-    }
-
-    h3, h4 {
-      font-weight: var(--font-weight-medium);
-      margin: 8px 0 4px;
-    }
   }
 }
 

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -89,10 +89,7 @@
     background: var(--surface-raised);
     color: var(--fg-strong);
     border-color: var(--border-weak);
-
-    [data-slot="toast-description"] {
-      white-space: pre-line;
-    }
+    /* white-space: pre-line removed — markdown slot handles formatting */
   }
 
   [data-slot="toast-icon"] {
@@ -110,16 +107,13 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 6px;
     min-height: 0;
     min-width: 0;
     overflow-x: hidden;
     overflow-y: auto;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-base) transparent;
   }
 
   [data-slot="toast-title"] {
@@ -206,6 +200,35 @@
     width: var(--kb-toast-progress-fill-width);
     background-color: var(--brand-primary);
     transition: width 250ms linear;
+  }
+
+  [data-slot="toast-markdown"] {
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-x-large);
+    color: inherit;
+
+    ul {
+      margin: 4px 0;
+      padding-left: 16px;
+      list-style: disc;
+    }
+
+    li {
+      margin: 2px 0;
+    }
+
+    p {
+      margin: 4px 0;
+    }
+
+    strong {
+      font-weight: var(--font-weight-medium);
+    }
+
+    h3, h4 {
+      font-weight: var(--font-weight-medium);
+      margin: 8px 0 4px;
+    }
   }
 }
 

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -3,6 +3,7 @@ import type { ToastRootProps, ToastCloseButtonProps, ToastTitleProps, ToastDescr
 import type { ComponentProps, JSX } from "solid-js"
 import { onCleanup, Show } from "solid-js"
 import { Portal } from "solid-js/web"
+import DOMPurify from "dompurify"
 import { useI18n } from "../context/i18n"
 import { Icon, type IconProps } from "./icon"
 import { IconButton } from "./icon-button"
@@ -108,6 +109,7 @@ export interface ToastAction {
 export interface ToastOptions {
   title?: string
   description?: string
+  markdownHtml?: string // pre-converted HTML string for markdown content; sanitized at render time
   icon?: IconProps["name"]
   variant?: ToastVariant
   duration?: number
@@ -167,6 +169,11 @@ export function showToast(options: ToastOptions | string) {
           </Show>
           <Show when={opts.description}>
             <Toast.Description>{opts.description}</Toast.Description>
+          </Show>
+          <Show when={opts.markdownHtml}>
+            {/* innerHTML is safe: content produced by escapeHtml() in highlights.tsx;
+                DOMPurify here provides a second-layer defense */}
+            <div data-slot="toast-markdown" innerHTML={DOMPurify.sanitize(opts.markdownHtml!)} />
           </Show>
           <Show when={opts.actions?.length}>
             <Toast.Actions>


### PR DESCRIPTION
## Summary

- Render release notes toast description as markdown HTML (`<ul><li>`) instead of `pre-line` plain text
- Show thin visible scrollbar when content overflows (was `scrollbar-width: none`)
- Fix `gap: 2px` to `gap: 6px` in toast content area (4pt grid compliance)
- Remove `white-space: pre-line` override; markdown slot handles formatting

## Why

Release notes toast content was cramped, not obviously scrollable, and markdown formatting was not rendered. The `subtle` variant used `white-space: pre-line` which only preserves newlines but does not render `- bullet` as actual list items. The scrollbar was hidden (`scrollbar-width: none`), making it impossible for users to discover they can scroll long content.

## Implementation

Because `markdown.tsx` requires `useMarked()` context (unavailable inside Kobalte's `toaster.show()` render root), we use an `innerHTML` approach:

- `highlights.tsx`: new `buildToastMarkdownHtml()` converts the existing `buildToastDescription()` output (bullet lines prefixed with `•`) to `<ul><li>` HTML. Content is HTML-escaped by `escapeHtml()` before insertion.
- `toast.tsx`: new `markdownHtml?: string` field in `ToastOptions`; `DOMPurify.sanitize()` applied at render time as a second-layer defense. Existing `description` path is unchanged.
- E2E selectors updated from `toast-description` to `toast-markdown` slot; bullet assertions drop the `• ` prefix since text is now in `<li>` elements.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the diff and verification evidence.

## Review Focus

- `toast.tsx`: new `markdownHtml` field and `DOMPurify.sanitize()` at render
- `toast.css`: scrollbar-width change, gap fix, new `[data-slot="toast-markdown"]` block
- `highlights.tsx`: `buildToastMarkdownHtml()` converter and call-site change
- E2E: selectors updated to match new DOM structure

## Risk Notes

- `markdownHtml` content is HTML-escaped via `escapeHtml()` before conversion; DOMPurify in toast.tsx is a second layer
- Only toasts with `markdownHtml` set are affected; existing `description` path is unchanged
- `scrollbar-width: thin` shows system scrollbar on Windows/Linux; on macOS it shows on hover — no layout impact
- `buildToastDescription` is kept as-is (all 22 unit tests pass); only the call site changes

## How To Verify

```
Typecheck packages/ui:  bunx tsgo --noEmit   — 0 errors
Typecheck packages/app: bunx tsgo -b         — 0 errors
Unit tests highlights:  bun test src/context/highlights — 22 pass, 0 fail
E2E release-notes-toast.spec.ts: verify <ul><li> rendering (needs Electron + updater simulation)
```

## Checklist

- [x] Human review status is stated above as pending
- [x] Relates to user-reported issues (cramped layout, hidden scrollbar, plain-text rendering)
- [x] No unrelated refactors or file changes beyond stated scope
- [x] Existing `buildToastDescription` and its 22 unit tests are untouched
- [x] PR targets `dev`; title and commit use Conventional Commits in English