### PR TITLE
test(opencode): extend Windows workspace sync retry wait

### DIFF
--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -49,7 +49,7 @@ async function waitFor(fn: () => boolean, timeout = 5_000) {
   throw new Error("timed out waiting for workspace status")
 }
 
-async function waitForCounter(file: string, min: number) {
+async function waitForCounter(file: string, min: number, timeout = 5_000) {
   const read = async () => {
     const text = await Bun.file(file)
       .text()
@@ -61,15 +61,19 @@ async function waitForCounter(file: string, min: number) {
     if (!Number.isFinite(value)) throw new Error(`invalid retry counter value: ${text}`)
     return value
   }
-  const end = Date.now() + 5_000
+  const end = Date.now() + timeout
   let value = 0
   while (Date.now() < end) {
     value = await read()
     if (value > min) return value
     await wait(50)
   }
-  throw new Error(`timed out waiting for counter ${file} to exceed ${min}; last value=${value}`)
+  value = await read()
+  if (value > min) return value
+  throw new Error(`timed out after ${timeout}ms waiting for counter ${file} to exceed ${min}; last value=${value}`)
 }
+
+const workspaceSyncRetryTimeout = process.platform === "win32" ? 20_000 : 5_000
 
 async function pluginProject() {
   return tmpdir({
@@ -518,11 +522,11 @@ describe("plugin.workspace", () => {
     await Instance.disposeAll()
 
     await Workspace.get(workspace.id)
-    const first = await waitForCounter(tmp.extra.counter, 0)
+    const first = await waitForCounter(tmp.extra.counter, 0, workspaceSyncRetryTimeout)
     expect(first).toBeGreaterThan(0)
 
     await Workspace.get(workspace.id)
-    const second = await waitForCounter(tmp.extra.counter, first)
+    const second = await waitForCounter(tmp.extra.counter, first, workspaceSyncRetryTimeout)
     expect(second).toBeGreaterThan(first)
 
     const status = Workspace.status().find((item) => item.workspaceID === workspace.id)


### PR DESCRIPTION
## Summary

Extend the Windows wait budget for the workspace sync retry assertion in `workspace-adaptor.test.ts`.

## Why

#529 cleanup found that `windows-advisory` fails this test frequently on Windows runners. The assertion waits for the background workspace sync retry loop to call the persisted remote adaptor target after owner bootstrap. On Windows advisory VMs the same async path can be much slower than macOS/Linux, so the fixed 5s counter wait can expire before the retry is observed.

## Related Issue

Refs #529.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please verify the change stays limited to the Windows-only timing budget for this advisory flake. It should not skip the test or change workspace sync behavior.

## Risk Notes

Test-only change. It only increases this test helper's timeout on Windows from 5s to 20s; non-Windows keeps the existing 5s wait. No product code, schema, dependency, or runtime behavior changes.

## How To Verify

```text
Focused test before change: bun test test/plugin/workspace-adaptor.test.ts -t "cold-start Workspace.get retries sync after owner bootstrap for remote adaptors" -> passed locally on macOS, confirming the local path is healthy
Focused test after change: same command -> passed
Full file test: bun test test/plugin/workspace-adaptor.test.ts -> 7 passed
Diff check: git diff --check -> no whitespace errors
```

## Screenshots or Recordings

Not required. This is a test-only PR with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
