### PR TITLE
fix(app): restore prompt input bottom radius

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -549,7 +549,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           removeLabel={language.t("prompt.attachment.remove")}
         />
         <div
-          class="relative"
+          class="relative overflow-hidden rounded-b-[var(--radius-lg)]"
           onMouseDown={(e) => {
             const target = e.target
             if (!(target instanceof HTMLElement)) return

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -8,7 +8,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke home hero prompt starts a session",
   "packages/app/e2e/app/home.spec.ts:@smoke home renders the hero composer and starter cards",
   "packages/app/e2e/app/home.spec.ts:@smoke project home status panel can open the server picker dialog",
-  "packages/app/e2e/app/home.spec.ts:@smoke root route renders seeded home entrypoints",
+  "packages/app/e2e/app/home.spec.ts:@smoke root route renders the no-project empty state",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/session.spec.ts:@smoke session composer matches home structure without docktray or agent control",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",


### PR DESCRIPTION
## Summary

Fix home prompt input bottom radius being clipped (task #17 regression). Adds `overflow-hidden rounded-b-[var(--radius-lg)]` to the inner chrome wrapper of PromptInput so the bottom corners are clipped again.

Also syncs the opencode `@smoke` inventory with the home spec retitle merged in #540, which was leaving CI red on `dev`.

## Why

PR cf7126bec (#524) changed the outer DockCard to `overflow-visible!` to restore popover visibility, which caused the inner gradient/background of the prompt input to no longer be clipped by the outer rounded corner, making the bottom edge appear flat. This PR adds overflow + bottom radius on the inner wrapper only, leaving the outer DockCard untouched so #524 popover visibility is preserved.

PR #540 retitled the root-route home smoke test after this branch was created, but the opencode smoke inventory on `dev` still referenced the old title. This PR syncs that expected title so the merge-state CI can pass.

## Related Issue

task #17 / regression introduced in commit cf7126bec; CI blocker introduced by PR #540 smoke-title retitle.

## Human Review Status

Opus second-pass: pass
GPT-X engineering final review: pass (geometry check verified `overflow:hidden` and `bottom-radius:14px` via focused locator)
Human final merge decision: pending

## Review Focus

- Whether the inner wrapper class change introduces unintended side effects
- prompt-slash-open E2E still passes (#524 popover not regressed)
- opencode smoke inventory matches `dev`'s home spec title after the #540 merge

## Risk Notes

Low risk. The inner overflow-hidden does not affect popover rendering, which is governed by the outer DockCard `overflow-visible!`. The opencode change is a one-line test inventory sync for an already-merged smoke-title change.

## How To Verify

```text
prompt-slash-open E2E: 3 passed
Typecheck: passed
Diff check: no whitespace errors
Geometry check: GPT-X verified overflow:hidden and bottom radius 14px with focused locator
Smoke inventory: packages/opencode @smoke inventory matches dev's home.spec.ts after merge
Screenshot: uploaded in Slock thread #PawWork:fa978555 attachment d6a37675
```

## Screenshots or Recordings

Screenshot uploaded in Slock thread `#PawWork:fa978555` as attachment `d6a37675` for visual confirmation.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
