### PR TITLE
test(opencode): bump prompt-effect busy/idle timeout for windows runner

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1201,7 +1201,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  5_000,
+  slowIOTimeout,
 )
 
 // Cancel semantics

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1201,7 +1201,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  5_000,
 )
 
 // Cancel semantics


### PR DESCRIPTION
## Summary

Increase the timeout for the Windows-sensitive `loop sets status to busy then idle` prompt-effect test from 3s to 5s.

## Why

The latest `dev` Windows advisory run failed in `packages/opencode/test/session/prompt-effect.test.ts` because this test timed out after 3015ms against a 3000ms budget. This file already has a precedent for Windows runner timing headroom in `a3b8e5456 test(windows): unblock 4 prompt-effect timeouts under runner load`; this PR applies the same bounded fix to the remaining busy/idle status test.

## Related Issue

task #19 / Windows advisory CI failure on `dev`

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the change is limited to the timeout constant for `loop sets status to busy then idle`.
- Confirm this does not change test behavior or product code.
- Confirm Windows advisory CI turns green.

## Risk Notes

Low risk. Test-only timeout headroom for a Windows advisory timing edge. No product behavior, runtime code, dependencies, or generated files changed.

## How To Verify

```text
Focused prompt-effect test file: 48 passed
Opencode typecheck: passed
Diff check: no whitespace errors
Diff scope: 1 file changed, 1 insertion, 1 deletion
```

## Screenshots or Recordings

Not applicable. This is a test-only timeout adjustment.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test timeout configuration to improve test stability and reduce flakiness.

**Note:** This release contains test infrastructure updates only. No user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/543)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->