### PR TITLE
fix(ui): hide synthetic stop tool part when loop action is "stop" (closes #267)

### DIFF
--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -51,6 +51,19 @@ test("partMetadata is a fresh accessor over part().state, not a setup-time snaps
   expect(source).not.toMatch(/const partMetadata\s*=\s*createMemo\(\)/)
 })
 
+test("synthetic stop tool parts are hidden through reactive metadata", () => {
+  const source = readFileSync(new URL("./message-part.tsx", import.meta.url), "utf8")
+
+  expect(source).toContain("const hideSyntheticStop = createMemo(")
+  expect(source).toMatch(/partMetadata\(\)\.diagnostics\?\.loop\?\.loopAction\s*===\s*"stop"/)
+})
+
+test("tool part wrapper suppresses both pending questions and synthetic stop tools", () => {
+  const source = readFileSync(new URL("./message-part.tsx", import.meta.url), "utf8")
+
+  expect(source).toContain("<Show when={!hideQuestion() && !hideSyntheticStop()}>")
+})
+
 // Ensure the metadata extractor itself respects the shape variations the
 // live message stream actually emits — including the case where the part
 // initially has no metadata key and gains one on the next update.

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1388,6 +1388,10 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
 
   const input = () => part().state?.input ?? emptyInput
   const partMetadata = () => toolStateMetadata(part().state)
+  // Hide synthetic stop tool parts while keeping metadata available for exported diagnostics.
+  const hideSyntheticStop = createMemo(
+    () => partMetadata().diagnostics?.loop?.loopAction === "stop",
+  )
   const taskId = createMemo(() => {
     if (part().tool !== "task" && part().tool !== "agent") return // agent-rename:legacy-render
     const value = partMetadata().sessionId
@@ -1407,7 +1411,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const render = createMemo(() => ToolRegistry.render(part().tool) ?? GenericTool)
 
   return (
-    <Show when={!hideQuestion()}>
+    <Show when={!hideQuestion() && !hideSyntheticStop()}>
       <div data-component="tool-part-wrapper">
         <Switch>
           <Match when={part().state.status === "error" && toolStateError(part().state)}>


### PR DESCRIPTION
## Summary

Hide synthetic stop tool parts from the conversation UI when their metadata carries `diagnostics.loop.loopAction === "stop"`.

## Why

Closes #267. The loop gate already renders a user-facing synthetic summary text part when it stops a loop. The paired synthetic tool part is only an internal audit carrier, so rendering it as a failed tool bubble is redundant and confusing.

## Related Issue

Closes #267

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the hide is reactive via `createMemo + <Show>`, not a top-level return.
- Confirm only the UI render layer changed; loop diagnostics metadata and export behavior are untouched.
- Confirm the tests lock both metadata-based hiding and the combined `<Show>` condition.

## Risk Notes

Low UI-rendering risk. The underlying tool part and metadata remain in session data and exports. Manual stop-scenario smoke was skipped because the deterministic UI source test and existing export audit tests cover the changed behavior without requiring a live loop-gate repro.

## Behavior

Synthetic tool parts that carry `metadata.diagnostics.loop.loopAction === "stop"` are now hidden from the conversation UI via a reactive `createMemo + <Show>` pattern, parallel to the existing `hideQuestion` hide for pending question tools.

The metadata stays on the part:
- `Export.deriveSnapshotDiagnostics` still emits `diagnostics.loop.last` with the full audit trail
- The synthetic Chinese summary text part remains the user-facing stop message
- Only the redundant failed-tool bubble is suppressed

## How To Verify

```text
bun --cwd packages/ui test src/components/message-part-stale.test.ts: 8 pass, 0 fail
bun --cwd packages/opencode test test/session/export.test.ts: 32 pass, 0 fail
bun --cwd packages/ui typecheck: passed
bun --cwd packages/app typecheck: passed
rg -n 'loopAction === "stop"' packages/ui/src: one source hit in message-part.tsx
git diff --check: passed
Manual smoke: skipped; deterministic UI source test and export audit test cover this narrow render-only change
```

## Screenshots or Recordings

Not applicable. The target state is absence of the redundant failed-tool bubble, covered by the deterministic UI render contract test.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
