### PR TITLE
fix(app): add non-creating child-store peek for sidebar timestamps (closes #475)

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -471,6 +471,7 @@ function createGlobalSync() {
     },
     child: children.child,
     peek: children.peek,
+    peekExisting: children.peekExisting,
     retainDirectory,
     bootstrap,
     updateConfig,

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -8,7 +8,10 @@ import { ChildStoreError, type ChildStorePersistedFactory } from "./child-store-
 
 const child = () => createStore({} as State)
 
-function createManager(persist?: ChildStorePersistedFactory) {
+function createManager(
+  persist?: ChildStorePersistedFactory,
+  overrides?: Partial<Parameters<typeof createChildStoreManager>[0]>,
+) {
   const owner = createRoot((dispose) => {
     const current = getOwner()
     dispose()
@@ -27,6 +30,7 @@ function createManager(persist?: ChildStorePersistedFactory) {
       if (key === "error.childStore.persistedCacheCreateFailed") return "Failed to create persisted cache"
       return key
     },
+    ...overrides,
   })
 }
 
@@ -70,6 +74,35 @@ describe("createChildStoreManager", () => {
     const manager = createManager()
 
     expect(() => manager.child(undefined as unknown as string)).toThrow("Invalid workspace directory for child store")
+  })
+
+  test("peekExisting returns undefined without creating child caches", () => {
+    const bootstrapCalls: string[] = []
+    const manager = createManager(undefined, {
+      onBootstrap(directory) {
+        bootstrapCalls.push(directory)
+      },
+    })
+
+    expect(manager.peekExisting("/tmp/missing")).toBeUndefined()
+    expect(Object.keys(manager.children)).toHaveLength(0)
+    expect(manager.vcsCache.size).toBe(0)
+    expect(manager.metaCache.size).toBe(0)
+    expect(manager.iconCache.size).toBe(0)
+    expect(bootstrapCalls).toEqual([])
+  })
+
+  test("peekExisting returns an existing child store without changing creation semantics", () => {
+    const manager = createManager((_target, store) => [
+      store[0],
+      store[1],
+      null,
+      Object.assign(() => true, { promise: undefined }),
+    ])
+    const directory = "/tmp/project"
+    const tuple = manager.child(directory, { bootstrap: false, pin: false })
+
+    expect(manager.peekExisting(directory)).toBe(tuple)
   })
 
   test("preserves persisted setup cause and workspace target context", () => {

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -11,6 +11,7 @@ import {
   DIR_IDLE_TTL_MS,
   MAX_DIR_STORES,
   type ChildOptions,
+  type ChildStoreTuple,
   type DirState,
   type IconCache,
   type MetaCache,
@@ -29,7 +30,7 @@ export function createChildStoreManager(input: {
   onDispose: (directory: string) => void
   translate: (key: string, vars?: Record<string, string | number>) => string
 }) {
-  const children: Record<string, [Store<State>, SetStoreFunction<State>]> = {}
+  const children: Record<string, ChildStoreTuple> = {}
   const vcsCache = new Map<string, VcsCache>()
   const metaCache = new Map<string, MetaCache>()
   const iconCache = new Map<string, IconCache>()
@@ -257,6 +258,11 @@ export function createChildStoreManager(input: {
     return childStore
   }
 
+  function peekExisting(directory: string): ChildStoreTuple | undefined {
+    validateChildStoreDirectory(directory)
+    return children[directory]
+  }
+
   function projectMeta(directory: string, patch: ProjectMeta) {
     const [store, setStore] = ensureChild(directory)
     const cached = metaCache.get(directory)
@@ -288,6 +294,7 @@ export function createChildStoreManager(input: {
     ensureChild,
     child,
     peek,
+    peekExisting,
     projectMeta,
     projectIcon,
     mark,

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -93,6 +93,8 @@ export type State = {
   }
 }
 
+export type ChildStoreTuple = [Store<State>, SetStoreFunction<State>]
+
 export type VcsCache = {
   store: Store<{ value: VcsInfo | undefined }>
   setStore: SetStoreFunction<{ value: VcsInfo | undefined }>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -602,12 +602,12 @@ export default function Layout(props: ParentProps) {
       projectKeyForSession,
       projectLabelForSession,
       messagesForSession: (session) => {
-        const [store] = globalSync.child(session.directory, { bootstrap: false, pin: false })
-        return store.message[session.id]
+        const tuple = globalSync.peekExisting(session.directory)
+        return tuple?.[0].message[session.id]
       },
       partsForMessage: (session, messageID) => {
-        const [store] = globalSync.child(session.directory, { bootstrap: false, pin: false })
-        return store.part[messageID]
+        const tuple = globalSync.peekExisting(session.directory)
+        return tuple?.[0].part[messageID]
       },
     })
     const hidden = store.pawworkProjectHidden

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { describe, expect, test } from "bun:test"
 import { buildPawworkSidebarSessionRows } from "./pawwork-session-source"
 
@@ -142,5 +143,14 @@ describe("buildPawworkSidebarSessionRows", () => {
     )
 
     expect(result[0].created).toBe(300)
+  })
+
+  test("layout sidebar timestamp cache reads do not create child stores", () => {
+    const source = readFileSync(new URL("../layout.tsx", import.meta.url), "utf8")
+
+    expect(source).not.toContain("globalSync.child(session.directory, { bootstrap: false, pin: false })")
+    expect(source).toContain("const tuple = globalSync.peekExisting(session.directory)")
+    expect(source).toContain("return tuple?.[0].message[session.id]")
+    expect(source).toContain("return tuple?.[0].part[messageID]")
   })
 })


### PR DESCRIPTION
## Summary

- Add `peekExisting(directory)` as a cache-only child-store accessor.
- Switch sidebar timestamp message and part reads to `peekExisting` so missing directory caches are not materialized during sidebar row building.
- Add child-store and layout source-level tests that lock the non-creating behavior.

## Why

Sidebar timestamp reads only need cached messages and parts when a child store already exists. Calling `globalSync.child(..., { bootstrap: false, pin: false })` still creates a child store and its persisted vcs/project/icon caches just to discover absence.

## Related Issue

Closes #475.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `peekExisting` must stay read-only: validate the directory, then return `children[directory]` without calling `ensureChild`, pinning, bootstrapping, marking, or evicting.
- Existing `child()` and `peek()` semantics should remain unchanged.
- Sidebar timestamp `messagesForSession` and `partsForMessage` should both use the non-creating accessor.

## peekExisting semantics

`peekExisting(directory)` returns the existing `ChildStoreTuple` if present in `children`, otherwise `undefined`. It does not call `ensureChild`, does not pin for the current owner, does not bootstrap loading, and does not run eviction. It is intentionally a non-reactive read: if the child store does not yet exist, `peekExisting` does not subscribe to its eventual creation. Sidebar timestamp reads use this to avoid materializing per-directory caches just to discover absence.

If a future caller needs absent-to-present reactivity, that is a separate reactive-registry design and out of scope for this PR.

## Risk Notes

Low. The new accessor is only used by sidebar timestamp cache reads. Missing caches now return `undefined`, which preserves the existing row-builder fallback to session creation time. Existing `child()` and `peek()` callers keep their current ensure/create behavior.

## How To Verify

```text
Targeted app tests: 1048 passed, 0 failed
Command: bun --cwd packages/app test --preload ./happydom.ts src/context/global-sync/child-store.test.ts src/pages/layout/pawwork-sidebar-session-rows.test.ts

App typecheck: passed
Command: bun --cwd packages/app typecheck

Diff check: passed
Command: git diff --check
```

## Screenshots or Recordings

Not applicable. This is a cache access behavior change with no intended visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized data access method for existing application state, allowing more efficient queries without triggering unnecessary initialization.

* **Improvements**
  * Enhanced sidebar rendering performance by streamlining how session data is accessed and displayed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/552)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->