### PR TITLE
fix(server, app): split abort into soft/hard modes; preserve pending question on soft (closes #553)

### DIFF
--- a/packages/app/src/components/prompt-input/keydown.ts
+++ b/packages/app/src/components/prompt-input/keydown.ts
@@ -34,7 +34,7 @@ export interface PromptKeydownDeps {
   navigateHistory: (direction: "up" | "down") => boolean
   // submit / mode / file pick
   pick: () => void
-  abort: () => void
+  abort: (source?: "stopButton" | "emptyEnter" | "ctrlG" | "escape", mode?: "soft" | "hard") => void
   handleSubmit: (event: KeyboardEvent) => void
 }
 
@@ -130,7 +130,7 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
       }
 
       if (working()) {
-        abort()
+        abort("escape", "hard")
         event.preventDefault()
         event.stopPropagation()
         return
@@ -196,7 +196,7 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
         return
       }
       if (working()) {
-        abort()
+        abort("ctrlG")
         event.preventDefault()
       }
       return

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -26,7 +26,7 @@ const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
 let commandsReady = true
 let promptAsyncFailure: Error | undefined
-const abortedSessions: string[] = []
+const abortedSessions: Array<{ sessionID: string; mode?: string }> = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
@@ -75,9 +75,9 @@ const clientFor = (directory: string) => {
         commandCalls.push(input)
         return { data: undefined }
       },
-      abort: async (input: { sessionID: string }) => {
-        abortedSessions.push(input.sessionID)
-        return { data: undefined }
+      abort: async (input: { sessionID: string; mode?: string }) => {
+        abortedSessions.push({ sessionID: input.sessionID, mode: input.mode })
+        return { data: true }
       },
     },
     worktree: {
@@ -291,7 +291,8 @@ describe("prompt submit worktree selection", () => {
       working: () => true,
       editor: () => undefined,
       queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      promptLength: (value) =>
+        value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,
@@ -302,7 +303,7 @@ describe("prompt submit worktree selection", () => {
     await submit.abort()
 
     expect(aborts).toEqual(["called"])
-    expect(abortedSessions).toEqual(["session-visible"])
+    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft" }])
     expect(globalTodoSets).toEqual([])
     expect(childTodoSets).toEqual([])
   })
@@ -430,7 +431,7 @@ describe("prompt submit worktree selection", () => {
     await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
 
     expect(aborts).toEqual(["called"])
-    expect(abortedSessions).toEqual(["session-visible"])
+    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft" }])
     expect(submits).toEqual([])
     expect(promptAsyncCalls).toEqual([])
   })
@@ -750,8 +751,7 @@ describe("prompt submit worktree selection", () => {
       working: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
-      promptLength: (value) =>
-        value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -31,6 +31,8 @@ type PendingPrompt = {
 }
 
 const pending = new Map<string, PendingPrompt>()
+type AbortMode = "soft" | "hard"
+type AbortSource = "stopButton" | "emptyEnter" | "ctrlG" | "escape"
 
 export type FollowupDraft = {
   sessionID: string
@@ -245,7 +247,26 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     return language.t("common.requestFailed")
   }
 
-  const abort = async () => {
+  const emitAbortDiagnostic = (input: {
+    sessionID: string
+    source: AbortSource
+    mode: AbortMode
+    result: "aborted" | "ignored_awaiting_question"
+  }) => {
+    void emitRendererDiagnostic({
+      name: "session.action.abort",
+      route_session_id: input.sessionID,
+      visible_session_id: input.sessionID,
+      timeline_session_id: input.sessionID,
+      data: {
+        source: input.source,
+        mode: input.mode,
+        result: input.result,
+      },
+    }).catch(() => undefined)
+  }
+
+  const abort = async (source: AbortSource = "stopButton", mode: AbortMode = "soft") => {
     if (!abortReady()) return Promise.resolve()
 
     const activeSessionID = sessionID()
@@ -258,11 +279,21 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       queued.abort.abort()
       queued.cleanup()
       pending.delete(activeSessionID)
+      emitAbortDiagnostic({ sessionID: activeSessionID, source, mode, result: "aborted" })
       return Promise.resolve()
     }
     return sdk.client.session
       .abort({
         sessionID: activeSessionID,
+        mode,
+      })
+      .then((result) => {
+        emitAbortDiagnostic({
+          sessionID: activeSessionID,
+          source,
+          mode,
+          result: result.data === false ? "ignored_awaiting_question" : "aborted",
+        })
       })
       .catch(() => {})
   }
@@ -317,13 +348,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const creatingNewSession = isNewSession()
     const homeSkill = creatingNewSession && mode === "normal" ? input.selectedSkill?.() : undefined
 
-    if (
-      text.trim().length === 0 &&
-      images.length === 0 &&
-      input.commentCount() === 0 &&
-      !homeSkill
-    ) {
-      if (input.working()) abort()
+    if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0 && !homeSkill) {
+      if (input.working()) abort(event instanceof KeyboardEvent ? "emptyEnter" : "stopButton")
       return
     }
     if (

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -122,21 +122,44 @@ export default function Page() {
   const submitReady = timeline.actionReady
   const workspaceSubmitReady = timeline.workspaceSubmitReady
   const timelineIsChildSession = timeline.isChildSession
-  const haltAbort = (sessionID: string) =>
+  const emitAbortDiagnostic = (
+    sessionID: string,
+    source: "revert" | "autoHeal",
+    result: "aborted" | "ignored_awaiting_question",
+  ) => {
+    emitDiagnostics({
+      name: "session.action.abort",
+      route_session_id: params.id,
+      visible_session_id: timelineSessionID(),
+      timeline_session_id: timelineSessionID(),
+      data: {
+        source,
+        mode: "hard",
+        result,
+      },
+    })
+  }
+  const haltAbort = (sessionID: string, source: "revert" | "autoHeal" = "autoHeal") =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? sdk.client.session.abort({ sessionID })
+      ? sdk.client.session.abort({ sessionID, mode: "hard" }).then((result) => {
+          emitAbortDiagnostic(sessionID, source, result.data === false ? "ignored_awaiting_question" : "aborted")
+          return result
+        })
       : Promise.resolve()
   const haltWithSnapshot = (
     snapshot: ReturnType<typeof sync.retainDirectory> & { client: typeof sdk.client },
     sessionID: string,
   ) =>
     isSessionRunning(snapshot.store.session_status[sessionID], snapshot.store.message[sessionID])
-      ? snapshot.client.session.abort({ sessionID })
+      ? snapshot.client.session.abort({ sessionID, mode: "hard" }).then((result) => {
+          emitAbortDiagnostic(sessionID, "revert", result.data === false ? "ignored_awaiting_question" : "aborted")
+          return result
+        })
       : Promise.resolve()
   // sessionRevert chains halt with .then(), so its existing outer .catch
   // already handles abort failures. The auto-heal clock wants to see the
   // error so it can structured-warn — pass haltAbort directly there.
-  const halt = (sessionID: string) => haltAbort(sessionID).catch(() => {})
+  const halt = (sessionID: string) => haltAbort(sessionID, "autoHeal").catch(() => {})
   const composer = createSessionComposerState({
     sessionID: timelineSessionID,
     fallbackSessionID: () => params.id,

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -21,6 +21,7 @@ import { toggleDesktopTerminal } from "@/pages/session/terminal-shell-tab"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 
 export type SessionCommandContext = {
   navigateMessageByOffset: (offset: number) => void
@@ -304,7 +305,22 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     if (!sessionID) return
 
     if (status().type !== "idle") {
-      await sdk.client.session.abort({ sessionID }).catch(() => {})
+      await sdk.client.session
+        .abort({ sessionID, mode: "hard" })
+        .then((result) => {
+          void emitRendererDiagnostic({
+            name: "session.action.abort",
+            route_session_id: sessionID,
+            visible_session_id: sessionID,
+            timeline_session_id: sessionID,
+            data: {
+              source: "undo",
+              mode: "hard",
+              result: result.data === false ? "ignored_awaiting_question" : "aborted",
+            },
+          }).catch(() => undefined)
+        })
+        .catch(() => {})
     }
 
     const revert = info()?.revert?.messageID

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -35,6 +35,7 @@ import { File } from "@/file"
 import { LSP } from "@/lsp"
 
 const log = Log.create({ service: "server" })
+const AbortMode = z.enum(["soft", "hard"])
 
 function publishTurnChangeFiles(display: TurnChangeDisplay, mode: "undo" | "redo", mutatedPaths?: string[]) {
   return Effect.gen(function* () {
@@ -442,9 +443,17 @@ export const SessionRoutes = lazy(() =>
           sessionID: SessionID.zod,
         }),
       ),
+      validator(
+        "query",
+        z.object({
+          mode: AbortMode.optional(),
+        }),
+      ),
       async (c) => {
-        await SessionPrompt.cancel(c.req.valid("param").sessionID)
-        return c.json(true)
+        const aborted = await SessionPrompt.cancel(c.req.valid("param").sessionID, {
+          mode: c.req.valid("query").mode ?? "hard",
+        })
+        return c.json(aborted)
       },
     )
     .post(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,7 @@ import { EffectLogger } from "@/effect"
 import { InstanceState } from "@/effect"
 import { AgentTool, type AgentPromptOps } from "@/tool/agent"
 import { SessionRunState } from "./run-state"
+import { SessionBlocker } from "./blocker"
 import { EffectBridge } from "@/effect"
 import { attachWith, makeRuntime } from "@/effect/run-service"
 import { Instance } from "@/project/instance"
@@ -226,7 +227,7 @@ function modelCanReadMedia(model: Provider.Model, kind: MediaInputKind) {
 }
 
 export interface Interface {
-  readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly cancel: (sessionID: SessionID, options?: { mode?: "soft" | "hard" }) => Effect.Effect<boolean>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
@@ -258,6 +259,7 @@ export const layer = Layer.effect(
     const scope = yield* Scope.Scope
     const instruction = yield* Instruction.Service
     const state = yield* SessionRunState.Service
+    const blockers = yield* SessionBlocker.Service
     const revert = yield* SessionRevert.Service
     const summary = yield* SessionSummary.Service
     const sys = yield* SystemPrompt.Service
@@ -272,7 +274,7 @@ export const layer = Layer.effect(
     const interruptedSessions = new Set<SessionID>()
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
-        cancel: (sessionID: SessionID) => cancel(sessionID),
+        cancel: (sessionID: SessionID) => cancel(sessionID).pipe(Effect.asVoid),
         resolvePromptParts: (template: string) => resolvePromptParts(template),
         prompt: (input: PromptInput) => prompt(input),
         // Self-cleaning read: each subagent dispatch reads `wasInterrupted` exactly once after
@@ -286,9 +288,18 @@ export const layer = Layer.effect(
       } satisfies AgentPromptOps
     })
 
-    const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
-      yield* elog.info("cancel", { sessionID })
+    const cancel = Effect.fn("SessionPrompt.cancel")(function* (
+      sessionID: SessionID,
+      options?: { mode?: "soft" | "hard" },
+    ) {
+      const mode = options?.mode ?? "hard"
+      yield* elog.info("cancel", { sessionID, mode })
+      if (mode === "soft" && (yield* blockers.hasAwaitingQuestion(sessionID))) {
+        yield* elog.info("cancel ignored", { sessionID, mode, reason: "awaiting_question" })
+        return false
+      }
       yield* state.cancel(sessionID)
+      return true
     })
 
     const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
@@ -2090,6 +2101,7 @@ export const defaultLayer: Layer.Layer<Service, never, never> = Layer.suspend(()
     Layer.provide(Session.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(SessionSummary.defaultLayer),
+    Layer.provide(SessionBlocker.defaultLayer),
     Layer.provide(
       Layer.mergeAll(
         Agent.defaultLayer,
@@ -2177,8 +2189,8 @@ export async function resolvePromptParts(template: string) {
   return runPromise((svc) => svc.resolvePromptParts(z.string().parse(template)))
 }
 
-export async function cancel(sessionID: SessionID) {
-  return runPromise((svc) => svc.cancel(SessionID.zod.parse(sessionID)))
+export async function cancel(sessionID: SessionID, options?: { mode?: "soft" | "hard" }) {
+  return runPromise((svc) => svc.cancel(SessionID.zod.parse(sessionID), options))
 }
 
 export const LoopInput = z.object({

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -36,14 +36,14 @@ describe("session action routes", () => {
       directory: tmp.path,
       fn: async () => {
         const session = await svc.create({})
-        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
+        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue(true)
         const app = Server.Default().app
 
         const res = await app.request(`/session/${session.id}/abort`, { method: "POST" })
 
         expect(res.status).toBe(200)
         expect(await res.json()).toBe(true)
-        expect(cancel).toHaveBeenCalledWith(session.id)
+        expect(cancel).toHaveBeenCalledWith(session.id, { mode: "hard" })
 
         await svc.remove(session.id)
       },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1263,6 +1263,89 @@ it.live(
 )
 
 it.live(
+  "soft cancel preserves a pending question and continues after reply",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const questions = yield* Question.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Question" })
+
+        yield* llm.tool("question", {
+          questions: [
+            {
+              question: "Export as Word or PDF?",
+              header: "Format",
+              options: [
+                { label: "Word", description: "docx" },
+                { label: "PDF", description: "pdf" },
+              ],
+            },
+          ],
+        })
+        yield* user(chat.id, "export")
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        const pending = yield* Effect.gen(function* () {
+          for (let attempt = 0; attempt < 100; attempt++) {
+            const list = yield* questions.list()
+            if (list.length > 0) return list[0]!
+            yield* Effect.sleep("10 millis")
+          }
+          throw new Error("timed out waiting for pending question")
+        })
+
+        const cancelled = yield* prompt.cancel(chat.id, { mode: "soft" })
+        expect(cancelled).toBe(false)
+        expect(yield* questions.list()).toHaveLength(1)
+
+        yield* questions.reply({ requestID: pending.id, answers: [["Word"]] })
+        const exit = yield* Fiber.await(fiber)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        expect(yield* questions.list()).toHaveLength(0)
+
+        const messages = yield* MessageV2.filterCompactedEffect(chat.id)
+        const assistant = messages.find((item) => item.info.role === "assistant")
+        const tool = assistant?.parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+        expect(tool?.state.status).toBe("completed")
+        if (tool?.state.status === "completed") {
+          expect(tool.state.metadata?.answers).toEqual([["Word"]])
+        }
+      }),
+      { git: true, config: providerCfg },
+    ),
+  5_000,
+)
+
+it.live(
+  "soft cancel without a pending question still interrupts the running loop",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "No question" })
+        yield* llm.hang
+        yield* user(chat.id, "hello")
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        const cancelled = yield* prompt.cancel(chat.id, { mode: "soft" })
+        expect(cancelled).toBe(true)
+
+        const exit = yield* Fiber.await(fiber)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        if (Exit.isSuccess(exit) && exit.value.info.role === "assistant") {
+          expect(exit.value.info.error?.name).toBe("MessageAbortedError")
+        }
+      }),
+      { git: true, config: providerCfg },
+    ),
+  3_000,
+)
+
+it.live(
   "cancel finalizes subtask tool state",
   () =>
     provideTmpdirInstance(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1931,6 +1931,7 @@ export class Session2 extends HeyApiClient {
     parameters: {
       sessionID: string
       directory?: string
+      mode?: "soft" | "hard"
       workspace?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -1942,6 +1943,7 @@ export class Session2 extends HeyApiClient {
           args: [
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
+            { in: "query", key: "mode" },
             { in: "query", key: "workspace" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3742,6 +3742,7 @@ export type SessionAbortData = {
   }
   query?: {
     directory?: string
+    mode?: "soft" | "hard"
     workspace?: string
   }
   url: "/session/{sessionID}/abort"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2983,6 +2983,17 @@
             }
           },
           {
+            "in": "query",
+            "name": "mode",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "soft",
+                "hard"
+              ]
+            }
+          },
+          {
             "in": "path",
             "name": "sessionID",
             "schema": {


### PR DESCRIPTION
## Summary

Closes #553.

This splits session aborts into two modes:

- `soft`: stop generation only. If the session is already waiting on a pending question, the server ignores the abort and keeps the question answerable.
- `hard`: cancel the turn. This preserves the old behavior for undo, revert, and question recovery auto-heal.

Client mapping:

- Stop button, empty prompt Enter, Ctrl-G: `soft`
- Escape, undo, revert, auto-heal restart: `hard`

The abort route still defaults to `hard` so older clients keep the previous behavior.

## Root Cause

A user stop signal and a newly emitted question could race. The old abort path treated every stop as a full turn cancel, so a pending question could be cancelled after it was emitted but before the client had time to render it.

## Implementation

- Added `mode=soft|hard` to `session.abort`.
- Server-side soft abort checks `SessionBlocker.hasAwaitingQuestion(sessionID)` and returns `false` without cancelling if a question is pending.
- Hard abort keeps the existing cancel path.
- Added renderer diagnostics `session.action.abort` with `source`, `mode`, and `result`.
- Added coverage for preserving a pending question and continuing after a reply.

## Verification

```text
bun --cwd packages/opencode test
2705 pass
9 skip
1 todo
0 fail
Ran 2715 tests across 207 files. [192.36s]
```

```text
bun --cwd packages/app test --preload ./happydom.ts
1048 pass
0 fail
Ran 1048 tests across 156 files. [938.00ms]
```

```text
bun --cwd packages/opencode typecheck
$ tsgo --noEmit
```

```text
bun --cwd packages/app typecheck
$ tsgo -b
```

```text
bun --cwd packages/opencode test test/server/session-actions.test.ts test/session/prompt-effect.test.ts --timeout 10000
51 pass
0 fail
Ran 51 tests across 2 files. [23.60s]
```

```text
bun --cwd packages/app test src/components/prompt-input/submit.test.ts --preload ./happydom.ts
1048 pass
0 fail
Ran 1048 tests across 157 files. [899.00ms]
```

```text
git diff --check
# pass
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced soft and hard abort modes for canceling in-progress sessions with improved control over termination behavior

* **API Changes**
  * Extended session abort endpoint to support optional abort mode parameter (`soft` or `hard`)

* **Improvements**
  * Enhanced session abort diagnostics with detailed source and outcome tracking
  * Refined session cancellation handling during concurrent operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/556)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->