### PR TITLE
feat(opencode): declare-and-stat external artifact protocol in bash tool

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,8 +1,10 @@
 import { Schema } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
+import nodefs from "node:fs/promises"
 import * as Tool from "./tool"
 import path from "path"
+import crypto from "crypto"
 import DESCRIPTION from "./bash.txt"
 import { Log } from "../util"
 import { Instance, type InstanceContext } from "../project/instance"
@@ -23,11 +25,14 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { withoutInternalServerAuthEnv } from "@/util/env"
 import { Global } from "@opencode-ai/core/global"
-import { resolveExternalPathForPermission } from "./external-directory"
+import { assertExternalDirectoryEffect, resolveExternalPathForPermission } from "./external-directory"
 import { InstanceState } from "@/effect/instance-state"
+import * as Bom from "@/util/bom"
+import { TurnChange, type FileState } from "@/session/turn-change"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
+const TRACKED_OUTPUT_LIMIT = 20 * 1024 * 1024
 const PS = new Set(["powershell", "pwsh"])
 const CWD = new Set(["cd", "push-location", "set-location"])
 const FILES = new Set([
@@ -61,6 +66,12 @@ export const Parameters = Schema.Struct({
   workdir: Schema.optional(Schema.String).annotate({
     description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
   }),
+  expected_outputs: Schema.optional(
+    Schema.Array(Schema.String).annotate({
+      description:
+        "Optional absolute or workdir-relative file paths that this command is expected to create or modify. The runtime will verify these paths after execution and register any real file changes in turn-change.",
+    }),
+  ),
   description: Schema.String.annotate({
     description:
       "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
@@ -253,6 +264,25 @@ function tail(text: string, maxLines: number, maxBytes: number) {
   }
 }
 
+function textHash(content: string, bom?: boolean) {
+  return "sha256:" + crypto.createHash("sha256").update(`${bom ? "bom:1" : "bom:0"}\0${content}`).digest("hex")
+}
+
+function binaryHash(buffer: Buffer) {
+  return "sha256-bin:" + crypto.createHash("sha256").update(buffer).digest("hex")
+}
+
+function sameState(before: FileState, after: FileState) {
+  if (!before.exists && !after.exists) return true
+  return (
+    before.exists === after.exists &&
+    before.hash === after.hash &&
+    before.bom === after.bom &&
+    before.large === after.large &&
+    before.binary === after.binary
+  )
+}
+
 const parse = Effect.fn("BashTool.parse")(function* (command: string, ps: boolean) {
   const tree = yield* Effect.promise(() => parser().then((p) => (ps ? p.ps : p.bash).parse(command)))
   if (!tree) throw new Error("Failed to parse command")
@@ -333,9 +363,10 @@ export const BashTool = Tool.define(
   "bash",
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner
-    const fs = yield* AppFileSystem.Service
+    const afs = yield* AppFileSystem.Service
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
+    const turnChange = yield* TurnChange.Service
 
     const cygpath = Effect.fn("BashTool.cygpath")(function* (shell: string, text: string) {
       const lines = yield* spawner
@@ -410,7 +441,7 @@ export const BashTool = Tool.define(
             if (!resolved) continue
             const permissionPath = resolveExternalPathForPermission(resolved, cwd)
             if (Instance.containsPath(permissionPath, instance)) continue
-            const dir = (yield* fs.isDir(permissionPath)) ? permissionPath : path.dirname(permissionPath)
+            const dir = (yield* afs.isDir(permissionPath)) ? permissionPath : path.dirname(permissionPath)
             scan.dirs.add(dir)
           }
         }
@@ -442,6 +473,46 @@ export const BashTool = Tool.define(
         PATH: bundledToolsDir ? `${bundledToolsDir}${path.delimiter}${currentPath}` : currentPath,
       })
     })
+
+    const readTrackedState = Effect.fn("BashTool.readTrackedState")((file: string) =>
+      Effect.promise(async () => {
+          try {
+            const stat = await nodefs.stat(file)
+            if (stat.isDirectory()) return { exists: true, restorable: false, hash: "directory", binary: true } satisfies FileState
+            if (stat.size > TRACKED_OUTPUT_LIMIT) {
+              return {
+                exists: true,
+                restorable: false,
+                hash: `large:${stat.size}:${stat.mtimeMs}`,
+                large: true,
+              } satisfies FileState
+            }
+            const buffer = await nodefs.readFile(file)
+            if (buffer.includes(0)) {
+              return {
+                exists: true,
+                restorable: false,
+                hash: binaryHash(buffer),
+                binary: true,
+              } satisfies FileState
+            }
+            const current = Bom.split(buffer.toString("utf-8"))
+            return {
+              exists: true,
+              content: current.text,
+              bom: current.bom,
+              hash: textHash(current.text, current.bom),
+            } satisfies FileState
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "ENOENT") return { exists: false } satisfies FileState
+            return {
+              exists: true,
+              restorable: false,
+              hash: `error:${(err as NodeJS.ErrnoException).code ?? "unknown"}`,
+            } satisfies FileState
+          }
+        }).pipe(Effect.orDie),
+    )
 
     const run = Effect.fn("BashTool.run")(function* (
       input: {
@@ -653,7 +724,29 @@ export const BashTool = Tool.define(
                 }),
               )
 
-              return yield* run(
+              const trackedOutputs = yield* Effect.forEach(params.expected_outputs ?? [], (rawPath) =>
+                Effect.gen(function* () {
+                  const resolved = yield* resolveExecutionPath(rawPath, cwd, shell)
+                  const normalized = AppFileSystem.normalizePath(resolved)
+                  const filepath = (yield* assertExternalDirectoryEffect(ctx, normalized, { kind: "file" })) ?? normalized
+                  return {
+                    normalized: AppFileSystem.normalizePath(filepath),
+                    path: filepath,
+                    before: yield* readTrackedState(filepath),
+                  }
+                }),
+              ).pipe(
+                Effect.map((items) => {
+                  const deduped = new Map<string, { path: string; before: FileState }>()
+                  for (const item of items) {
+                    if (deduped.has(item.normalized)) continue
+                    deduped.set(item.normalized, { path: item.path, before: item.before })
+                  }
+                  return Array.from(deduped.values())
+                }),
+              )
+
+              const result = yield* run(
                 {
                   shell,
                   name,
@@ -665,6 +758,39 @@ export const BashTool = Tool.define(
                 },
                 ctx,
               )
+
+              if (!trackedOutputs.length) return result
+
+              const artifacts = yield* Effect.forEach(trackedOutputs, (tracked) =>
+                Effect.gen(function* () {
+                  const after = yield* readTrackedState(tracked.path)
+                  const changed = !sameState(tracked.before, after)
+                  if (changed) {
+                    yield* turnChange.recordWrite({
+                      sessionID: ctx.sessionID,
+                      messageID: ctx.messageID,
+                      path: tracked.path,
+                      before: tracked.before,
+                      after,
+                    })
+                  }
+                  return {
+                    path: tracked.path,
+                    exists: after.exists,
+                    changed,
+                    ...(after.binary ? { binary: true } : {}),
+                    ...(after.large ? { large: true } : {}),
+                  }
+                }),
+              )
+
+              return {
+                ...result,
+                metadata: {
+                  ...result.metadata,
+                  artifacts,
+                },
+              }
             }),
         }
       })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -283,6 +283,13 @@ function sameState(before: FileState, after: FileState) {
   )
 }
 
+type TrackedOutputState = {
+  state: FileState
+  comparable: boolean
+  kind: "missing" | "file" | "directory" | "error"
+  errorCode?: string
+}
+
 const parse = Effect.fn("BashTool.parse")(function* (command: string, ps: boolean) {
   const tree = yield* Effect.promise(() => parser().then((p) => (ps ? p.ps : p.bash).parse(command)))
   if (!tree) throw new Error("Failed to parse command")
@@ -478,38 +485,62 @@ export const BashTool = Tool.define(
       Effect.promise(async () => {
           try {
             const stat = await nodefs.stat(file)
-            if (stat.isDirectory()) return { exists: true, restorable: false, hash: "directory", binary: true } satisfies FileState
+            if (stat.isDirectory()) {
+              return {
+                state: { exists: true, restorable: false, hash: "directory", binary: true } satisfies FileState,
+                comparable: true,
+                kind: "directory",
+              } satisfies TrackedOutputState
+            }
             if (stat.size > TRACKED_OUTPUT_LIMIT) {
               return {
-                exists: true,
-                restorable: false,
-                hash: `large:${stat.size}:${stat.mtimeMs}`,
-                large: true,
-              } satisfies FileState
+                state: {
+                  exists: true,
+                  restorable: false,
+                  hash: `large:${stat.size}:${stat.mtimeMs}`,
+                  large: true,
+                } satisfies FileState,
+                comparable: true,
+                kind: "file",
+              } satisfies TrackedOutputState
             }
             const buffer = await nodefs.readFile(file)
             if (buffer.includes(0)) {
               return {
-                exists: true,
-                restorable: false,
-                hash: binaryHash(buffer),
-                binary: true,
-              } satisfies FileState
+                state: {
+                  exists: true,
+                  restorable: false,
+                  hash: binaryHash(buffer),
+                  binary: true,
+                } satisfies FileState,
+                comparable: true,
+                kind: "file",
+              } satisfies TrackedOutputState
             }
             const current = Bom.split(buffer.toString("utf-8"))
             return {
-              exists: true,
-              content: current.text,
-              bom: current.bom,
-              hash: textHash(current.text, current.bom),
-            } satisfies FileState
+              state: {
+                exists: true,
+                content: current.text,
+                bom: current.bom,
+                hash: textHash(current.text, current.bom),
+              } satisfies FileState,
+              comparable: true,
+              kind: "file",
+            } satisfies TrackedOutputState
           } catch (err) {
-            if ((err as NodeJS.ErrnoException).code === "ENOENT") return { exists: false } satisfies FileState
+            const code = (err as NodeJS.ErrnoException).code
+            if (code === "ENOENT") return { state: { exists: false } satisfies FileState, comparable: true, kind: "missing" } satisfies TrackedOutputState
             return {
-              exists: true,
-              restorable: false,
-              hash: `error:${(err as NodeJS.ErrnoException).code ?? "unknown"}`,
-            } satisfies FileState
+              state: {
+                exists: true,
+                restorable: false,
+                hash: `error:${code ?? "unknown"}`,
+              } satisfies FileState,
+              comparable: false,
+              kind: "error",
+              ...(code ? { errorCode: code } : {}),
+            } satisfies TrackedOutputState
           }
         }).pipe(Effect.orDie),
     )
@@ -737,7 +768,7 @@ export const BashTool = Tool.define(
                 }),
               ).pipe(
                 Effect.map((items) => {
-                  const deduped = new Map<string, { path: string; before: FileState }>()
+                  const deduped = new Map<string, { path: string; before: TrackedOutputState }>()
                   for (const item of items) {
                     if (deduped.has(item.normalized)) continue
                     deduped.set(item.normalized, { path: item.path, before: item.before })
@@ -764,22 +795,31 @@ export const BashTool = Tool.define(
               const artifacts = yield* Effect.forEach(trackedOutputs, (tracked) =>
                 Effect.gen(function* () {
                   const after = yield* readTrackedState(tracked.path)
-                  const changed = !sameState(tracked.before, after)
+                  const changed = tracked.before.comparable && after.comparable && !sameState(tracked.before.state, after.state)
                   if (changed) {
                     yield* turnChange.recordWrite({
                       sessionID: ctx.sessionID,
                       messageID: ctx.messageID,
                       path: tracked.path,
-                      before: tracked.before,
-                      after,
+                      before: tracked.before.state,
+                      after: after.state,
                     })
                   }
                   return {
                     path: tracked.path,
-                    exists: after.exists,
+                    exists: after.state.exists,
                     changed,
-                    ...(after.binary ? { binary: true } : {}),
-                    ...(after.large ? { large: true } : {}),
+                    ...(after.kind === "directory" ? { directory: true } : {}),
+                    ...(after.state.binary && after.kind !== "directory" ? { binary: true } : {}),
+                    ...(after.state.large ? { large: true } : {}),
+                    ...(!tracked.before.comparable || !after.comparable
+                      ? {
+                          comparable: false,
+                          errorCode:
+                            ("errorCode" in tracked.before ? tracked.before.errorCode : undefined) ??
+                            ("errorCode" in after ? after.errorCode : undefined),
+                        }
+                      : {}),
                   }
                 }),
               )

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -314,6 +314,103 @@ describe("tool.bash expected_outputs", () => {
       },
     })
   })
+
+  test("records declared outputs even when command exits non-zero after writing", async () => {
+    await resetDatabase()
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const turn = await createTurn()
+        const target = path.join(tmp.path, "partial.docx")
+        const script = path.join(tmp.path, "write-then-fail.cjs")
+        await fs.promises.writeFile(
+          script,
+          "require('node:fs').writeFileSync(process.argv[2], Buffer.from([80,75,3,4,0,9]))\nprocess.exit(1)\n",
+          "utf-8",
+        )
+        const command = `${PS.has(sh()) ? "& " : ""}${bin} ${quote(script.replaceAll("\\", "/"))} ${quote(target.replaceAll("\\", "/"))}`
+        const result = await Effect.runPromise(
+          bash.execute(
+            {
+              command,
+              expected_outputs: [target],
+              description: "Write then fail",
+            },
+            { ...ctx, ...turn },
+          ),
+        )
+
+        expect(result.metadata.exit).toBe(1)
+        const display = TurnChange.finalize(turn)
+        expect(display?.files[0]).toMatchObject({
+          path: "partial.docx",
+          status: "added",
+          binary: true,
+          expandable: false,
+        })
+      },
+    })
+  })
+
+  test("does not record unchanged declared paths", async () => {
+    await resetDatabase()
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.promises.writeFile(path.join(dir, "stable.txt"), "stable\n", "utf-8")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const turn = await createTurn()
+        const target = path.join(tmp.path, "stable.txt")
+        await Effect.runPromise(
+          bash.execute(
+            {
+              command: "echo noop",
+              expected_outputs: [target],
+              description: "Leave file unchanged",
+            },
+            { ...ctx, ...turn },
+          ),
+        )
+
+        expect(TurnChange.finalize(turn)).toBeUndefined()
+      },
+    })
+  })
+
+  test("preserves legacy behavior when expected_outputs is omitted", async () => {
+    await resetDatabase()
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const turn = await createTurn()
+        const target = path.join(tmp.path, "undeclared.txt")
+        const script = path.join(tmp.path, "write-plain.cjs")
+        await fs.promises.writeFile(script, "require('node:fs').writeFileSync(process.argv[2], 'hello\\n')\n", "utf-8")
+        const command = `${PS.has(sh()) ? "& " : ""}${bin} ${quote(script.replaceAll("\\", "/"))} ${quote(target.replaceAll("\\", "/"))}`
+        const result = await Effect.runPromise(
+          bash.execute(
+            {
+              command,
+              description: "Write without declaration",
+            },
+            { ...ctx, ...turn },
+          ),
+        )
+
+        expect(result.metadata.exit).toBe(0)
+        expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
+        expect(TurnChange.finalize(turn)).toBeUndefined()
+      },
+    })
+  })
 })
 
 describe("tool.bash permissions", () => {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -18,6 +18,11 @@ import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Plugin } from "../../src/plugin"
 import { Global } from "@opencode-ai/core/global"
+import { TurnChange } from "../../src/session/turn-change"
+import { Session as SessionNs } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { resetDatabase } from "../fixture/db"
 
 const runtime = ManagedRuntime.make(
   Layer.mergeAll(
@@ -26,6 +31,7 @@ const runtime = ManagedRuntime.make(
     Plugin.defaultLayer,
     Truncate.defaultLayer,
     Agent.defaultLayer,
+    TurnChange.defaultLayer,
   ),
 )
 
@@ -42,6 +48,26 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+}
+
+async function createTurn() {
+  const session = await SessionNs.create({ title: "bash external artifact" })
+  const messageID = MessageID.make(`msg_bash_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`)
+  await SessionNs.updateMessage({
+    id: messageID,
+    sessionID: session.id,
+    role: "assistant",
+    parentID: MessageID.make("msg_user"),
+    time: { created: Date.now() },
+    modelID: ModelID.make("test"),
+    providerID: ProviderID.make("test"),
+    mode: "",
+    agent: "build",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  } as unknown as MessageV2.Info)
+  return { sessionID: session.id, messageID }
 }
 
 Shell.acceptable.reset()
@@ -236,6 +262,57 @@ describe("tool.bash", () => {
       if (previousCustom === undefined) delete process.env.PAWWORK_E2E_CUSTOM_ENV
       else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
     }
+  })
+})
+
+describe("tool.bash expected_outputs", () => {
+  test("records a declared binary artifact in turn-change", async () => {
+    await resetDatabase()
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const turn = await createTurn()
+        const target = path.join(tmp.path, "report.docx")
+        const script = path.join(tmp.path, "write-docx.cjs")
+        await fs.promises.writeFile(
+          script,
+          "require('node:fs').writeFileSync(process.argv[2], Buffer.from([80,75,3,4,0,1,2,3]))\n",
+          "utf-8",
+        )
+        const command = `${PS.has(sh()) ? "& " : ""}${bin} ${quote(script.replaceAll("\\", "/"))} ${quote(target.replaceAll("\\", "/"))}`
+        const result = await Effect.runPromise(
+          bash.execute(
+            {
+              command,
+              expected_outputs: [target],
+              description: "Create binary report",
+            },
+            { ...ctx, ...turn },
+          ),
+        )
+
+        expect(result.metadata.exit).toBe(0)
+        expect(
+          (result.metadata as { artifacts?: Array<{ path: string; exists: boolean; changed: boolean; binary?: boolean }> })
+            .artifacts,
+        ).toEqual([
+          { path: target, exists: true, changed: true, binary: true },
+        ])
+
+        const display = TurnChange.finalize(turn)
+        expect(display?.files).toEqual([
+          {
+            path: "report.docx",
+            status: "added",
+            binary: true,
+            restoreAvailable: false,
+            expandable: false,
+          },
+        ])
+      },
+    })
   })
 })
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { spyOn } from "bun:test"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import fs from "node:fs"
+import nodefs from "node:fs/promises"
 import os from "os"
 import path from "path"
 import { existsSync } from "node:fs"
@@ -408,6 +410,57 @@ describe("tool.bash expected_outputs", () => {
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
         expect(TurnChange.finalize(turn)).toBeUndefined()
+      },
+    })
+  })
+
+  test("does not record false positives when the before state is indeterminate", async () => {
+    await resetDatabase()
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const target = path.join(dir, "restricted.txt")
+        await fs.promises.writeFile(target, "secret\n", "utf-8")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await initBash()
+        const turn = await createTurn()
+        const target = path.join(tmp.path, "restricted.txt")
+        const originalReadFile = nodefs.readFile
+        const readSpy = spyOn(nodefs as any, "readFile").mockImplementationOnce(async (...args: any[]) => {
+          const filepath = typeof args[0] === "string" ? args[0] : String(args[0])
+          if (filepath === target) {
+            const err = Object.assign(new Error("denied"), { code: "EACCES" })
+            throw err
+          }
+          return await (originalReadFile as any)(...args)
+        })
+        try {
+          const result = await Effect.runPromise(
+            bash.execute(
+              {
+                command: `rm ${quote(target.replaceAll("\\", "/"))}`,
+                expected_outputs: [target],
+                description: "Delete unreadable file",
+              },
+              { ...ctx, ...turn },
+            ),
+          )
+
+          expect(result.metadata.exit).toBe(0)
+          expect(
+            (
+              result.metadata as {
+                artifacts?: Array<{ path: string; exists: boolean; changed: boolean; comparable?: boolean; errorCode?: string }>
+              }
+            ).artifacts,
+          ).toEqual([{ path: target, exists: false, changed: false, comparable: false, errorCode: "EACCES" }])
+          expect(TurnChange.finalize(turn)).toBeUndefined()
+        } finally {
+          readSpy.mockRestore()
+        }
       },
     })
   })

--- a/skills/document-processing/SKILL.md
+++ b/skills/document-processing/SKILL.md
@@ -48,6 +48,7 @@ Execution rules:
 - Prefer edits that preserve the original structure over destructive conversions.
 - If a conversion risks losing formulas, layout, comments, or branding, explain the tradeoff before finalizing.
 - Save the output in the current workspace unless the user gave a different path.
+- When a third-party CLI writes a known output file through the `bash` tool, declare that absolute file path in `expected_outputs` so PawWork can register it in turn-change.
 
 ## Step 3: Verify
 

--- a/skills/document-processing/SKILL.md
+++ b/skills/document-processing/SKILL.md
@@ -48,7 +48,7 @@ Execution rules:
 - Prefer edits that preserve the original structure over destructive conversions.
 - If a conversion risks losing formulas, layout, comments, or branding, explain the tradeoff before finalizing.
 - Save the output in the current workspace unless the user gave a different path.
-- When a third-party CLI writes a known output file through the `bash` tool, declare that absolute file path in `expected_outputs` so PawWork can register it in turn-change.
+- When a third-party CLI writes a known output file through the `bash` tool, declare that file path (absolute or relative to `workdir`) in `expected_outputs` so PawWork can register it in turn-change.
 
 ## Step 3: Verify
 


### PR DESCRIPTION
## Summary

Add a declared external artifact protocol to the bash tool so assistant-declared output files are stat-verified after command execution and registered in turn-change.

## Why

PawWork's "本轮生成文件" only showed files written through write/edit/apply_patch. Files created by third-party CLIs through bash, such as officecli-generated `.docx` files, bypassed `turnChange.recordWrite()` and never appeared in the UI.

## Related Issue

No GitHub issue. This PR implements Slock task #33 from `#PawWork:2b44653e`.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/opencode/src/tool/bash.ts`: declared `expected_outputs` flow, pre/post state capture, and `recordWrite()` only on real file changes
- `packages/opencode/test/tool/bash.test.ts`: failed-but-wrote behavior, unchanged-path suppression, and no-declaration compatibility
- `skills/document-processing/SKILL.md`: the one-line guidance for third-party CLI output declaration

## Risk Notes

Low to medium. This changes bash tool schema and records declared file side effects, including binary files, into turn-change. Main things to verify are path normalization, external-directory permission behavior, and that undeclared bash commands remain unchanged.

## How To Verify

```text
Focused expected_outputs tests: 4 passed in packages/opencode/test/tool/bash.test.ts
Bash tool suite smoke: 31 passed in packages/opencode/test/tool/bash.test.ts
Typecheck: ok (`bun --cwd packages/opencode typecheck`)
Diff check: no whitespace errors (`git diff --check`)
Package lint/smoke scripts: none defined under packages/opencode; full bash.test used as tool-level smoke
```

## Screenshots or Recordings

Not applicable. No visible UI change was introduced directly; this is tool/runtime plumbing verified through turn-change tests.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-tracking for bash commands: declare expected output paths to detect and record file creation, binary/text changes, and produce per-run artifact metadata.

* **Tests**
  * Added tests validating artifact recording for added/unchanged files, behavior on non-zero exits, binary outputs, and indeterminate pre-state handling.

* **Documentation**
  * Clarified that absolute output paths should be listed in expected_outputs for third‑party CLI outputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/561)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->