### PR TITLE
feat(opencode): observability for session export (abort provenance + title trace + release version)

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -56,6 +56,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -1,9 +1,8 @@
-import { Cause, Deferred, Effect, Exit, Fiber, Schema, Scope, SynchronizedRef } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Ref, Schema, Scope, SynchronizedRef } from "effect"
 
 export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
-  readonly interruptMeta: () => InterruptMeta | undefined
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly startShell: (work: Effect.Effect<A, E>, options?: { ready?: Deferred.Deferred<void> }) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
@@ -15,6 +14,7 @@ export class Cancelled extends Schema.TaggedErrorClass<Cancelled>()("RunnerCance
 interface RunHandle<A, E> {
   id: number
   done: Deferred.Deferred<A, E | Cancelled>
+  interruptMeta: Ref.Ref<InterruptMeta | undefined>
   fiber: Fiber.Fiber<A, E>
 }
 
@@ -22,12 +22,14 @@ interface ShellHandle<A, E> {
   id: number
   ready: Deferred.Deferred<void>
   cancelled: Deferred.Deferred<void>
+  interruptMeta: Ref.Ref<InterruptMeta | undefined>
   fiber: Fiber.Fiber<A, E>
 }
 
 interface PendingHandle<A, E> {
   id: number
   done: Deferred.Deferred<A, E | Cancelled>
+  interruptMeta: Ref.Ref<InterruptMeta | undefined>
   work: Effect.Effect<A, E>
 }
 
@@ -51,7 +53,7 @@ export const make = <A, E = never>(
   opts?: {
     onIdle?: Effect.Effect<void>
     onBusy?: Effect.Effect<void>
-    onInterrupt?: Effect.Effect<A, E>
+    onInterrupt?: (meta?: InterruptMeta) => Effect.Effect<A, E>
     busy?: () => never
   },
 ): Runner<A, E> => {
@@ -60,7 +62,6 @@ export const make = <A, E = never>(
   const busy = opts?.onBusy ?? Effect.void
   const onInterrupt = opts?.onInterrupt
   let ids = 0
-  let lastInterruptMeta: InterruptMeta | undefined
 
   const state = () => SynchronizedRef.getUnsafe(ref)
   const next = () => {
@@ -89,15 +90,33 @@ export const make = <A, E = never>(
         ] as const,
     ).pipe(Effect.flatten)
 
-  const startRun = (work: Effect.Effect<A, E>, done: Deferred.Deferred<A, E | Cancelled>) =>
+  const startRun = (
+    work: Effect.Effect<A, E>,
+    done: Deferred.Deferred<A, E | Cancelled>,
+    interruptMeta: Ref.Ref<InterruptMeta | undefined>,
+  ) =>
     Effect.gen(function* () {
       const id = next()
       const fiber = yield* work.pipe(
         Effect.onExit((exit) => finishRun(id, done, exit)),
         Effect.forkIn(scope),
       )
-      return { id, done, fiber } satisfies RunHandle<A, E>
+      return { id, done, interruptMeta, fiber } satisfies RunHandle<A, E>
     })
+
+  const resolveInterrupt = (interruptMeta: Ref.Ref<InterruptMeta | undefined>): Effect.Effect<A, E> =>
+    Effect.gen(function* () {
+      const meta = yield* Ref.get(interruptMeta)
+      if (onInterrupt) return yield* onInterrupt(meta)
+      return yield* Effect.die(new Cancelled())
+    })
+
+  const awaitRun = (run: Pick<RunHandle<A, E>, "done" | "interruptMeta"> | PendingHandle<A, E>) =>
+    Deferred.await(run.done).pipe(
+      Effect.catch((e): Effect.Effect<A, E> =>
+        e instanceof Cancelled ? resolveInterrupt(run.interruptMeta) : Effect.fail(e as E),
+      ),
+    )
 
   const finishShell = (id: number) =>
     SynchronizedRef.modifyEffect(
@@ -105,7 +124,7 @@ export const make = <A, E = never>(
       Effect.fnUntraced(function* (st) {
         if (st._tag === "Shell" && st.shell.id === id) return [idle, { _tag: "Idle" }] as const
         if (st._tag === "ShellThenRun" && st.shell.id === id) {
-          const run = yield* startRun(st.run.work, st.run.done)
+          const run = yield* startRun(st.run.work, st.run.done, st.run.interruptMeta)
           return [Effect.void, { _tag: "Running", run }] as const
         }
         return [Effect.void, st] as const
@@ -129,28 +148,25 @@ export const make = <A, E = never>(
         switch (st._tag) {
           case "Running":
           case "ShellThenRun":
-            return [Deferred.await(st.run.done), st] as const
+            return [awaitRun(st.run), st] as const
           case "Shell": {
             const run = {
               id: next(),
               done: yield* Deferred.make<A, E | Cancelled>(),
+              interruptMeta: yield* Ref.make<InterruptMeta | undefined>(undefined),
               work,
             } satisfies PendingHandle<A, E>
-            return [Deferred.await(run.done), { _tag: "ShellThenRun", shell: st.shell, run }] as const
+            return [awaitRun(run), { _tag: "ShellThenRun", shell: st.shell, run }] as const
           }
           case "Idle": {
             const done = yield* Deferred.make<A, E | Cancelled>()
-            const run = yield* startRun(work, done)
-            return [Deferred.await(done), { _tag: "Running", run }] as const
+            const interruptMeta = yield* Ref.make<InterruptMeta | undefined>(undefined)
+            const run = yield* startRun(work, done, interruptMeta)
+            return [awaitRun(run), { _tag: "Running", run }] as const
           }
         }
       }),
-    ).pipe(
-      Effect.flatten,
-      Effect.catch(
-        (e): Effect.Effect<A, E> => (e instanceof Cancelled ? (onInterrupt ?? Effect.die(e)) : Effect.fail(e as E)),
-      ),
-    )
+    ).pipe(Effect.flatten)
 
   const startShell = (work: Effect.Effect<A, E>, options?: { ready?: Deferred.Deferred<void> }) =>
     SynchronizedRef.modifyEffect(
@@ -174,7 +190,8 @@ export const make = <A, E = never>(
             Effect.tap((ready) => Deferred.succeed(ready, undefined)),
           ))
         const fiber = yield* work.pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
-        const shell = { id, ready, cancelled, fiber } satisfies ShellHandle<A, E>
+        const interruptMeta = yield* Ref.make<InterruptMeta | undefined>(undefined)
+        const shell = { id, ready, cancelled, interruptMeta, fiber } satisfies ShellHandle<A, E>
         return [
           Effect.gen(function* () {
             const exit = yield* Fiber.await(fiber)
@@ -186,8 +203,7 @@ export const make = <A, E = never>(
                 !Cause.hasFails(exit.cause) &&
                 !Cause.hasDies(exit.cause))
             ) {
-              if (onInterrupt) return yield* onInterrupt
-              return yield* Effect.die(new Cancelled())
+              return yield* resolveInterrupt(interruptMeta)
             }
             return yield* Effect.failCause(exit.cause)
           }),
@@ -197,46 +213,53 @@ export const make = <A, E = never>(
     ).pipe(Effect.flatten)
 
   const cancelWith = (meta?: InterruptMeta) =>
-    SynchronizedRef.modify(ref, (st) => {
-      lastInterruptMeta = meta
-        ? {
-            ...meta,
-            recordedAt: meta.recordedAt ?? Date.now(),
-          }
-        : {
-            recordedAt: Date.now(),
-          }
-      switch (st._tag) {
-        case "Idle":
-          return [Effect.void, st] as const
-        case "Running":
-          return [
-            Effect.gen(function* () {
-              yield* Fiber.interrupt(st.run.fiber)
-              yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
-              yield* idleIfCurrent()
-            }),
-            { _tag: "Idle" } as const,
-          ] as const
-        case "Shell":
-          return [
-            Effect.gen(function* () {
-              yield* stopShell(st.shell)
-              yield* idleIfCurrent()
-            }),
-            { _tag: "Idle" } as const,
-          ] as const
-        case "ShellThenRun":
-          return [
-            Effect.gen(function* () {
-              yield* stopShell(st.shell)
-              yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
-              yield* idleIfCurrent()
-            }),
-            { _tag: "Idle" } as const,
-          ] as const
-      }
-    }).pipe(Effect.flatten)
+    SynchronizedRef.modifyEffect(
+      ref,
+      Effect.fnUntraced(function* (st) {
+        const snapshot = meta
+          ? {
+              ...meta,
+              recordedAt: meta.recordedAt ?? Date.now(),
+            }
+          : {
+              recordedAt: Date.now(),
+            }
+        switch (st._tag) {
+          case "Idle":
+            return [Effect.void, st] as const
+          case "Running":
+            yield* Ref.set(st.run.interruptMeta, snapshot)
+            return [
+              Effect.gen(function* () {
+                yield* Fiber.interrupt(st.run.fiber)
+                yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
+                yield* idleIfCurrent()
+              }),
+              { _tag: "Idle" } as const,
+            ] as const
+          case "Shell":
+            yield* Ref.set(st.shell.interruptMeta, snapshot)
+            return [
+              Effect.gen(function* () {
+                yield* stopShell(st.shell)
+                yield* idleIfCurrent()
+              }),
+              { _tag: "Idle" } as const,
+            ] as const
+          case "ShellThenRun":
+            yield* Ref.set(st.shell.interruptMeta, snapshot)
+            yield* Ref.set(st.run.interruptMeta, snapshot)
+            return [
+              Effect.gen(function* () {
+                yield* stopShell(st.shell)
+                yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
+                yield* idleIfCurrent()
+              }),
+              { _tag: "Idle" } as const,
+            ] as const
+        }
+      }),
+    ).pipe(Effect.flatten)
 
   return {
     get state() {
@@ -244,9 +267,6 @@ export const make = <A, E = never>(
     },
     get busy() {
       return state()._tag !== "Idle"
-    },
-    interruptMeta() {
-      return lastInterruptMeta
     },
     ensureRunning,
     startShell,

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -3,9 +3,11 @@ import { Cause, Deferred, Effect, Exit, Fiber, Schema, Scope, SynchronizedRef } 
 export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
+  readonly interruptMeta: () => InterruptMeta | undefined
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly startShell: (work: Effect.Effect<A, E>, options?: { ready?: Deferred.Deferred<void> }) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
+  readonly cancelWith: (meta?: InterruptMeta) => Effect.Effect<void>
 }
 
 export class Cancelled extends Schema.TaggedErrorClass<Cancelled>()("RunnerCancelled", {}) {}
@@ -29,6 +31,15 @@ interface PendingHandle<A, E> {
   work: Effect.Effect<A, E>
 }
 
+export interface InterruptMeta {
+  source?: string
+  reason?: string
+  mode?: "soft" | "hard"
+  viaCtxAbort?: boolean
+  propagationPoint?: string
+  recordedAt?: number
+}
+
 export type State<A, E> =
   | { readonly _tag: "Idle" }
   | { readonly _tag: "Running"; readonly run: RunHandle<A, E> }
@@ -49,6 +60,7 @@ export const make = <A, E = never>(
   const busy = opts?.onBusy ?? Effect.void
   const onInterrupt = opts?.onInterrupt
   let ids = 0
+  let lastInterruptMeta: InterruptMeta | undefined
 
   const state = () => SynchronizedRef.getUnsafe(ref)
   const next = () => {
@@ -184,38 +196,47 @@ export const make = <A, E = never>(
       }),
     ).pipe(Effect.flatten)
 
-  const cancel = SynchronizedRef.modify(ref, (st) => {
-    switch (st._tag) {
-      case "Idle":
-        return [Effect.void, st] as const
-      case "Running":
-        return [
-          Effect.gen(function* () {
-            yield* Fiber.interrupt(st.run.fiber)
-            yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
-            yield* idleIfCurrent()
-          }),
-          { _tag: "Idle" } as const,
-        ] as const
-      case "Shell":
-        return [
-          Effect.gen(function* () {
-            yield* stopShell(st.shell)
-            yield* idleIfCurrent()
-          }),
-          { _tag: "Idle" } as const,
-        ] as const
-      case "ShellThenRun":
-        return [
-          Effect.gen(function* () {
-            yield* stopShell(st.shell)
-            yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
-            yield* idleIfCurrent()
-          }),
-          { _tag: "Idle" } as const,
-        ] as const
-    }
-  }).pipe(Effect.flatten)
+  const cancelWith = (meta?: InterruptMeta) =>
+    SynchronizedRef.modify(ref, (st) => {
+      lastInterruptMeta = meta
+        ? {
+            ...meta,
+            recordedAt: meta.recordedAt ?? Date.now(),
+          }
+        : {
+            recordedAt: Date.now(),
+          }
+      switch (st._tag) {
+        case "Idle":
+          return [Effect.void, st] as const
+        case "Running":
+          return [
+            Effect.gen(function* () {
+              yield* Fiber.interrupt(st.run.fiber)
+              yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
+              yield* idleIfCurrent()
+            }),
+            { _tag: "Idle" } as const,
+          ] as const
+        case "Shell":
+          return [
+            Effect.gen(function* () {
+              yield* stopShell(st.shell)
+              yield* idleIfCurrent()
+            }),
+            { _tag: "Idle" } as const,
+          ] as const
+        case "ShellThenRun":
+          return [
+            Effect.gen(function* () {
+              yield* stopShell(st.shell)
+              yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
+              yield* idleIfCurrent()
+            }),
+            { _tag: "Idle" } as const,
+          ] as const
+      }
+    }).pipe(Effect.flatten)
 
   return {
     get state() {
@@ -224,9 +245,13 @@ export const make = <A, E = never>(
     get busy() {
       return state()._tag !== "Idle"
     },
+    interruptMeta() {
+      return lastInterruptMeta
+    },
     ensureRunning,
     startShell,
-    cancel,
+    cancel: cancelWith(),
+    cancelWith,
   }
 }
 

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -963,16 +963,33 @@ export namespace Export {
 
   function sanitizeDiagnostics(diagnostics: Snapshot["diagnostics"]): Snapshot["diagnostics"] {
     const last = diagnostics.loop?.last
-    if (!last) return diagnostics
     return {
       ...diagnostics,
-      loop: {
-        ...diagnostics.loop,
-        last: {
-          ...last,
-          attemptedInput: dataValue("loop-attempted-input", last.parentID, last.attemptedInput),
-        },
-      },
+      ...(last
+        ? {
+            loop: {
+              ...diagnostics.loop,
+              last: {
+                ...last,
+                attemptedInput: dataValue("loop-attempted-input", last.parentID, last.attemptedInput),
+              },
+            },
+          }
+        : {}),
+      aborts: diagnostics.aborts?.map((abort, index) => ({
+        ...abort,
+        error_message:
+          abort.error_message === undefined
+            ? undefined
+            : redact("abort-error-message", String(index), abort.error_message),
+      })),
+      title_generations: diagnostics.title_generations?.map((trace, index) => ({
+        ...trace,
+        error_message:
+          trace.error_message === undefined
+            ? undefined
+            : redact("title-generation-error-message", String(index), trace.error_message),
+      })),
     }
   }
 

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { Global } from "@opencode-ai/core/global"
 import { Session } from "."
-import type { SessionID } from "./schema"
+import type { MessageID, SessionID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import type { Snapshot as SnapshotMod } from "../snapshot"
 import { Installation } from "../installation"
@@ -154,6 +154,31 @@ export namespace Export {
       }
       llm_trace_schema_version?: typeof LLMTrace.SCHEMA_VERSION
       llm_traces?: LLMTrace.Summary[]
+      aborts?: Array<{
+        session_id: SessionID
+        message_id: MessageID
+        parent_id?: MessageID
+        source?: string
+        reason?: string
+        mode?: "soft" | "hard"
+        propagation_point?: string
+        error_name?: string
+        error_message?: string
+        via_ctx_abort?: boolean
+        recorded_at?: number
+      }>
+      title_generations?: Array<{
+        session_id: SessionID
+        message_id: MessageID
+        parent_id?: MessageID
+        source?: string
+        started_at: number
+        completed_at?: number
+        success: boolean
+        applied?: boolean
+        error_name?: string
+        error_message?: string
+      }>
     }
     session: Tree
   }
@@ -179,6 +204,31 @@ export namespace Export {
     }
     llm_trace_schema_version?: typeof LLMTrace.SCHEMA_VERSION
     llm_traces?: LLMTrace.Summary[]
+    aborts?: Array<{
+      session_id: SessionID
+      message_id: MessageID
+      parent_id?: MessageID
+      source?: string
+      reason?: string
+      mode?: "soft" | "hard"
+      propagation_point?: string
+      error_name?: string
+      error_message?: string
+      via_ctx_abort?: boolean
+      recorded_at?: number
+    }>
+    title_generations?: Array<{
+      session_id: SessionID
+      message_id: MessageID
+      parent_id?: MessageID
+      source?: string
+      started_at: number
+      completed_at?: number
+      success: boolean
+      applied?: boolean
+      error_name?: string
+      error_message?: string
+    }>
   } {
     let lastAt = -Infinity
     let last:
@@ -238,11 +288,15 @@ export namespace Export {
     }
     walk(node)
     const llm_traces = collectLLMTraces(node)
+    const aborts = collectAbortDiagnostics(node)
+    const title_generations = collectTitleGenerations(node)
     return {
       ...(last ? { loop: { last } } : {}),
       ...(llm_traces.length
         ? { llm_trace_schema_version: LLMTrace.SCHEMA_VERSION, llm_traces }
         : {}),
+      ...(aborts.length ? { aborts } : {}),
+      ...(title_generations.length ? { title_generations } : {}),
     }
   }
 
@@ -253,6 +307,65 @@ export namespace Export {
         if (message.info.role !== "assistant") continue
         const trace = message.info.diagnostics?.llm_trace
         if (trace) traces.push(trace)
+      }
+      for (const child of t.children ?? []) walk(child)
+    }
+    walk(node)
+    return traces.sort((a, b) => {
+      if (a.session_id !== b.session_id) return a.session_id.localeCompare(b.session_id)
+      return a.message_id.localeCompare(b.message_id)
+    })
+  }
+
+  function collectAbortDiagnostics(node: Tree) {
+    const aborts: NonNullable<Snapshot["diagnostics"]["aborts"]> = []
+    const walk = (t: Tree) => {
+      for (const message of t.messages ?? []) {
+        if (message.info.role !== "assistant") continue
+        const abort = message.info.diagnostics?.abort
+        if (!abort) continue
+        aborts.push({
+          session_id: message.info.sessionID,
+          message_id: message.info.id,
+          parent_id: message.info.parentID,
+          source: abort.source,
+          reason: abort.reason,
+          mode: abort.mode,
+          propagation_point: abort.propagation_point,
+          error_name: abort.error_name,
+          error_message: abort.error_message,
+          via_ctx_abort: abort.via_ctx_abort,
+          recorded_at: abort.recorded_at,
+        })
+      }
+      for (const child of t.children ?? []) walk(child)
+    }
+    walk(node)
+    return aborts.sort((a, b) => {
+      if (a.session_id !== b.session_id) return a.session_id.localeCompare(b.session_id)
+      return a.message_id.localeCompare(b.message_id)
+    })
+  }
+
+  function collectTitleGenerations(node: Tree) {
+    const traces: NonNullable<Snapshot["diagnostics"]["title_generations"]> = []
+    const walk = (t: Tree) => {
+      for (const message of t.messages ?? []) {
+        if (message.info.role !== "assistant") continue
+        const trace = message.info.diagnostics?.title_generation
+        if (!trace) continue
+        traces.push({
+          session_id: message.info.sessionID,
+          message_id: message.info.id,
+          parent_id: message.info.parentID,
+          source: trace.source,
+          started_at: trace.started_at,
+          completed_at: trace.completed_at,
+          success: trace.success,
+          applied: trace.applied,
+          error_name: trace.error_name,
+          error_message: trace.error_message,
+        })
       }
       for (const child of t.children ?? []) walk(child)
     }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -510,6 +510,30 @@ export const Assistant = Base.extend({
   diagnostics: z
     .object({
       llm_trace: LLMTrace.Summary.optional(),
+      abort: z
+        .object({
+          source: z.string().optional(),
+          reason: z.string().optional(),
+          mode: z.enum(["soft", "hard"]).optional(),
+          propagation_point: z.string().optional(),
+          error_name: z.string().optional(),
+          error_message: z.string().optional(),
+          via_ctx_abort: z.boolean().optional(),
+          recorded_at: z.number().optional(),
+        })
+        .optional(),
+      title_generation: z
+        .object({
+          source: z.string().optional(),
+          parent_message_id: MessageID.zod.optional(),
+          started_at: z.number(),
+          completed_at: z.number().optional(),
+          success: z.boolean(),
+          applied: z.boolean().optional(),
+          error_name: z.string().optional(),
+          error_message: z.string().optional(),
+        })
+        .optional(),
     })
     .optional(),
 }).meta({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -904,7 +904,11 @@ export const layer: Layer.Layer<
         }
         ctx.toolcalls = {}
         ctx.assistantMessage.time.completed = Date.now()
+        const persistedAssistant = (yield* session.messages({ sessionID: ctx.sessionID })).find(
+          (message) => message.info.role === "assistant" && message.info.id === ctx.assistantMessage.id,
+        )
         ctx.assistantMessage.diagnostics = {
+          ...(persistedAssistant?.info.role === "assistant" ? persistedAssistant.info.diagnostics : {}),
           ...(ctx.assistantMessage.diagnostics ?? {}),
           llm_trace: ctx.trace.finalize({
             completedAt: ctx.assistantMessage.time.completed,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1989,10 +1989,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>) {
-      const onInterrupt = Effect.gen(function* () {
+      const onInterrupt = (meta?: { source?: string; reason?: string; mode?: "soft" | "hard"; viaCtxAbort?: boolean; propagationPoint?: string; recordedAt?: number }) =>
+        Effect.gen(function* () {
         interruptedSessions.add(input.sessionID)
         const assistant = yield* lastAssistant(input.sessionID)
-        const meta = yield* state.interruptMeta(input.sessionID)
         if (assistant.info.role === "assistant") {
           const error = assistant.info.error
           const errorMessage =
@@ -2028,7 +2028,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const ready = yield* Deferred.make<void>()
         return yield* state.startShell(
           input.sessionID,
-          shellCancelledAssistant(input.sessionID),
+          () => shellCancelledAssistant(input.sessionID),
           shellImpl(input, ready),
           ready,
         )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -298,7 +298,12 @@ export const layer = Layer.effect(
         yield* elog.info("cancel ignored", { sessionID, mode, reason: "awaiting_question" })
         return false
       }
-      yield* state.cancel(sessionID)
+      yield* state.cancel(sessionID, {
+        source: "session.prompt.cancel",
+        reason: mode === "soft" ? "soft_cancel" : "hard_cancel",
+        mode,
+        viaCtxAbort: false,
+      })
       return true
     })
 
@@ -355,6 +360,40 @@ export const layer = Layer.effect(
       const firstUser = context[idx]
       if (!firstUser || firstUser.info.role !== "user") return
       const firstInfo = firstUser.info
+      const startedAt = Date.now()
+
+      const recordTitleTrace = Effect.fn("SessionPrompt.recordTitleTrace")(function* (trace: {
+        completedAt?: number
+        success: boolean
+        applied?: boolean
+        errorName?: string
+        errorMessage?: string
+      }) {
+        let assistant: MessageV2.WithParts | undefined
+        for (let attempt = 0; attempt < 50; attempt++) {
+          const messages = yield* sessions.messages({ sessionID: input.session.id })
+          assistant = messages.find((message) => message.info.role === "assistant" && message.info.parentID === firstInfo.id)
+          if (assistant) break
+          yield* Effect.sleep("10 millis")
+        }
+        if (!assistant || assistant.info.role !== "assistant") return
+        yield* sessions.updateMessage({
+          ...assistant.info,
+          diagnostics: {
+            ...(assistant.info.diagnostics ?? {}),
+            title_generation: {
+              source: "ensureTitle",
+              parent_message_id: firstInfo.id,
+              started_at: startedAt,
+              completed_at: trace.completedAt,
+              success: trace.success,
+              applied: trace.applied,
+              error_name: trace.errorName,
+              error_message: trace.errorMessage,
+            },
+          },
+        })
+      })
 
       const subtasks = firstUser.parts.filter((p): p is MessageV2.SubtaskPart => p.type === "subtask")
       const onlySubtasks = subtasks.length > 0 && firstUser.parts.every((p) => p.type === "subtask")
@@ -368,7 +407,7 @@ export const layer = Layer.effect(
       const msgs = onlySubtasks
         ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\n") }]
         : yield* MessageV2.toModelMessagesEffect(context, mdl)
-      const text = yield* llm
+      const titleExit = yield* llm
         .stream({
           agent: ag,
           user: firstInfo,
@@ -384,18 +423,35 @@ export const layer = Layer.effect(
           Stream.filter((e): e is Extract<LLM.Event, { type: "text-delta" }> => e.type === "text-delta"),
           Stream.map((e) => e.text),
           Stream.mkString,
-          Effect.orDie,
+          Effect.exit,
         )
+      const completedAt = Date.now()
+      if (titleExit._tag === "Failure") {
+        const error = Cause.squash(titleExit.cause)
+        yield* elog.error("failed to generate title", { error })
+        yield* recordTitleTrace({
+          completedAt,
+          success: false,
+          errorName: error instanceof Error ? error.name : undefined,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }).pipe(Effect.catchCause(() => Effect.void))
+        return
+      }
+      const text = titleExit.value
       const cleaned = text
         .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
         .split("\n")
         .map((line) => line.trim())
         .find((line) => line.length > 0)
-      if (!cleaned) return
+      if (!cleaned) {
+        yield* recordTitleTrace({ completedAt, success: true, applied: false }).pipe(Effect.catchCause(() => Effect.void))
+        return
+      }
       const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
       yield* sessions
         .setTitle({ sessionID: input.session.id, title: t })
         .pipe(Effect.catchCause((cause) => elog.error("failed to generate title", { error: Cause.squash(cause) })))
+      yield* recordTitleTrace({ completedAt, success: true, applied: true }).pipe(Effect.catchCause(() => Effect.void))
     })
 
     const insertReminders = Effect.fn("SessionPrompt.insertReminders")(function* (input: {
@@ -1935,7 +1991,34 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     )(function* (input: z.infer<typeof LoopInput>) {
       const onInterrupt = Effect.gen(function* () {
         interruptedSessions.add(input.sessionID)
-        return yield* lastAssistant(input.sessionID)
+        const assistant = yield* lastAssistant(input.sessionID)
+        const meta = yield* state.interruptMeta(input.sessionID)
+        if (assistant.info.role === "assistant") {
+          const error = assistant.info.error
+          const errorMessage =
+            error && "data" in error && error.data && typeof error.data === "object" && "message" in error.data
+              ? String(error.data.message)
+              : undefined
+          yield* sessions.updateMessage({
+            ...assistant.info,
+            diagnostics: {
+              ...(assistant.info.diagnostics ?? {}),
+              abort: {
+                ...(assistant.info.diagnostics?.abort ?? {}),
+                source: meta?.source,
+                reason: meta?.reason,
+                mode: meta?.mode,
+                propagation_point: meta?.propagationPoint ?? "session.prompt.loop.onInterrupt",
+                error_name: error?.name,
+                error_message: errorMessage,
+                via_ctx_abort: meta?.viaCtxAbort,
+                recorded_at: meta?.recordedAt ?? Date.now(),
+              },
+            },
+          })
+          return yield* lastAssistant(input.sessionID)
+        }
+        return assistant
       })
       return yield* state.ensureRunning(input.sessionID, onInterrupt, runLoop(input.sessionID))
     })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1653,6 +1653,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       throw new Error("Impossible")
     })
 
+    const currentTurnTarget = Effect.fnUntraced(function* (sessionID: SessionID) {
+      const latestUser = yield* sessions.findMessage(sessionID, (message) => message.info.role === "user")
+      if (Option.isNone(latestUser)) return yield* lastAssistant(sessionID)
+
+      const currentAssistant = yield* sessions.findMessage(
+        sessionID,
+        (message) => message.info.role === "assistant" && message.info.parentID === latestUser.value.info.id,
+      )
+      if (Option.isSome(currentAssistant)) return currentAssistant.value
+      return latestUser.value
+    })
+
     const shellCancelledAssistant = Effect.fnUntraced(function* (sessionID: SessionID) {
       const message = yield* lastAssistant(sessionID)
       if (message.info.role !== "assistant") return message
@@ -1992,7 +2004,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const onInterrupt = (meta?: { source?: string; reason?: string; mode?: "soft" | "hard"; viaCtxAbort?: boolean; propagationPoint?: string; recordedAt?: number }) =>
         Effect.gen(function* () {
         interruptedSessions.add(input.sessionID)
-        const assistant = yield* lastAssistant(input.sessionID)
+        const assistant = yield* currentTurnTarget(input.sessionID)
         if (assistant.info.role === "assistant") {
           const error = assistant.info.error
           const errorMessage =

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -9,15 +9,14 @@ import { SessionStatus } from "./status"
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
   readonly cancel: (sessionID: SessionID, meta?: InterruptMeta) => Effect.Effect<void>
-  readonly interruptMeta: (sessionID: SessionID) => Effect.Effect<InterruptMeta | undefined>
   readonly ensureRunning: (
     sessionID: SessionID,
-    onInterrupt: Effect.Effect<MessageV2.WithParts>,
+    onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
     work: Effect.Effect<MessageV2.WithParts>,
   ) => Effect.Effect<MessageV2.WithParts>
   readonly startShell: (
     sessionID: SessionID,
-    onInterrupt: Effect.Effect<MessageV2.WithParts>,
+    onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
     work: Effect.Effect<MessageV2.WithParts>,
     ready?: Deferred.Deferred<void>,
   ) => Effect.Effect<MessageV2.WithParts>
@@ -49,7 +48,7 @@ export const layer = Layer.effect(
 
     const runner = Effect.fn("SessionRunState.runner")(function* (
       sessionID: SessionID,
-      onInterrupt: Effect.Effect<MessageV2.WithParts>,
+      onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
     ) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
@@ -85,14 +84,9 @@ export const layer = Layer.effect(
       yield* existing.cancelWith(meta)
     })
 
-    const interruptMeta = Effect.fn("SessionRunState.interruptMeta")(function* (sessionID: SessionID) {
-      const data = yield* InstanceState.get(state)
-      return data.runners.get(sessionID)?.interruptMeta()
-    })
-
     const ensureRunning = Effect.fn("SessionRunState.ensureRunning")(function* (
       sessionID: SessionID,
-      onInterrupt: Effect.Effect<MessageV2.WithParts>,
+      onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
       work: Effect.Effect<MessageV2.WithParts>,
     ) {
       return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
@@ -100,14 +94,14 @@ export const layer = Layer.effect(
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
       sessionID: SessionID,
-      onInterrupt: Effect.Effect<MessageV2.WithParts>,
+      onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
       work: Effect.Effect<MessageV2.WithParts>,
       ready?: Deferred.Deferred<void>,
     ) {
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
     })
 
-    return Service.of({ assertNotBusy, cancel, interruptMeta, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,5 +1,5 @@
 import { InstanceState } from "@/effect/instance-state"
-import { Runner } from "@/effect/runner"
+import { Runner, type InterruptMeta } from "@/effect/runner"
 import { Deferred, Effect, Layer, Scope, Context } from "effect"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
@@ -8,7 +8,8 @@ import { SessionStatus } from "./status"
 
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
-  readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly cancel: (sessionID: SessionID, meta?: InterruptMeta) => Effect.Effect<void>
+  readonly interruptMeta: (sessionID: SessionID) => Effect.Effect<InterruptMeta | undefined>
   readonly ensureRunning: (
     sessionID: SessionID,
     onInterrupt: Effect.Effect<MessageV2.WithParts>,
@@ -74,14 +75,19 @@ export const layer = Layer.effect(
       if (existing?.busy) throw new Session.BusyError(sessionID)
     })
 
-    const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
+    const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID, meta?: InterruptMeta) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
       if (!existing || !existing.busy) {
         yield* status.set(sessionID, { type: "idle" })
         return
       }
-      yield* existing.cancel
+      yield* existing.cancelWith(meta)
+    })
+
+    const interruptMeta = Effect.fn("SessionRunState.interruptMeta")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.runners.get(sessionID)?.interruptMeta()
     })
 
     const ensureRunning = Effect.fn("SessionRunState.ensureRunning")(function* (
@@ -101,7 +107,7 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, interruptMeta, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -142,7 +142,7 @@ describe("Runner", () => {
     "cancel with onInterrupt resolves callers gracefully",
     Effect.gen(function* () {
       const s = yield* Scope.Scope
-      const runner = Runner.make<string>(s, { onInterrupt: Effect.succeed("fallback") })
+      const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
@@ -158,7 +158,7 @@ describe("Runner", () => {
     "cancel with queued callers resolves all",
     Effect.gen(function* () {
       const s = yield* Scope.Scope
-      const runner = Runner.make<string>(s, { onInterrupt: Effect.succeed("fallback") })
+      const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
 
       const a = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
@@ -172,6 +172,33 @@ describe("Runner", () => {
       expect(Exit.isSuccess(exitB)).toBe(true)
       if (Exit.isSuccess(exitA)) expect(exitA.value).toBe("fallback")
       if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("fallback")
+    }),
+  )
+
+  it.live(
+    "cancel binds interrupt metadata to the interrupted run",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const release = yield* Deferred.make<void>()
+      const runner = Runner.make<string>(s, {
+        onInterrupt: (meta) => Effect.succeed(meta?.reason ?? "missing"),
+      })
+      const work = Effect.never.pipe(
+        Effect.onInterrupt(() => Deferred.await(release)),
+        Effect.as("never"),
+      )
+
+      const fiber = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancelWith({ source: "first", reason: "first" }).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+      yield* runner.cancelWith({ source: "second", reason: "second" })
+      yield* Deferred.succeed(release, undefined)
+
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) expect(exit.value).toBe("first")
     }),
   )
 
@@ -338,7 +365,7 @@ describe("Runner", () => {
     "cancel does not mask shell defects",
     Effect.gen(function* () {
       const s = yield* Scope.Scope
-      const runner = Runner.make<string>(s, { onInterrupt: Effect.succeed("interrupted") })
+      const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("interrupted") })
 
       const sh = yield* runner
         .startShell(Effect.never.pipe(Effect.ensuring(Effect.die("boom")), Effect.as("ignored")))
@@ -354,7 +381,7 @@ describe("Runner", () => {
     "cancel does not mask shell typed failures",
     Effect.gen(function* () {
       const s = yield* Scope.Scope
-      const runner = Runner.make<string, string>(s, { onInterrupt: Effect.succeed("interrupted") })
+      const runner = Runner.make<string, string>(s, { onInterrupt: () => Effect.succeed("interrupted") })
 
       const sh = yield* runner
         .startShell(Effect.never.pipe(Effect.onInterrupt(() => Effect.fail("boom")), Effect.as("ignored")))

--- a/packages/opencode/test/script/build-node.test.ts
+++ b/packages/opencode/test/script/build-node.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+
+test("build-node injects both release version and channel defines", async () => {
+  const source = await fs.readFile(path.join(import.meta.dir, "../../script/build-node.ts"), "utf8")
+
+  expect(source).toContain("OPENCODE_VERSION")
+  expect(source).toContain("OPENCODE_CHANNEL")
+  expect(source).toContain("Script.version")
+  expect(source).toContain("Script.channel")
+})

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -688,6 +688,93 @@ describe("Export.session", () => {
       },
     })
   })
+
+  test("collects abort and title generation diagnostics from assistant messages", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const root = await SessionNs.create({ title: "diag summary" })
+        const userID = MessageID.make("msg_diag_user")
+        const assistantID = MessageID.make("msg_diag_assistant")
+        try {
+          await SessionNs.updateMessage({
+            id: userID,
+            sessionID: root.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+          } as MessageV2.User)
+          await SessionNs.updateMessage({
+            id: assistantID,
+            role: "assistant",
+            sessionID: root.id,
+            mode: "build",
+            agent: "build",
+            path: { cwd: projectRoot, root: projectRoot },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: "test-model",
+            providerID: "test",
+            parentID: userID,
+            time: { created: 10, completed: 20 },
+            finish: "error",
+            diagnostics: {
+              abort: {
+                source: "session.prompt.cancel",
+                reason: "hard_cancel",
+                mode: "hard",
+                propagation_point: "session.prompt.loop.onInterrupt",
+                error_name: "MessageAbortedError",
+                error_message: "Aborted",
+                via_ctx_abort: false,
+                recorded_at: 21,
+              },
+              title_generation: {
+                source: "ensureTitle",
+                parent_message_id: userID,
+                started_at: 11,
+                completed_at: 19,
+                success: true,
+                applied: true,
+              },
+            },
+          } as MessageV2.Assistant)
+
+          const result = await AppRuntime.runPromise(Export.session(root.id))
+          expect(result.diagnostics.aborts).toEqual([
+            {
+              session_id: root.id,
+              message_id: assistantID,
+              parent_id: userID,
+              source: "session.prompt.cancel",
+              reason: "hard_cancel",
+              mode: "hard",
+              propagation_point: "session.prompt.loop.onInterrupt",
+              error_name: "MessageAbortedError",
+              error_message: "Aborted",
+              via_ctx_abort: false,
+              recorded_at: 21,
+            },
+          ])
+          expect(result.diagnostics.title_generations).toEqual([
+            {
+              session_id: root.id,
+              message_id: assistantID,
+              parent_id: userID,
+              source: "ensureTitle",
+              started_at: 11,
+              completed_at: 19,
+              success: true,
+              applied: true,
+            },
+          ])
+        } finally {
+          await SessionNs.remove(root.id)
+        }
+      },
+    })
+  })
 })
 
 describe("Export.redactPart sensitive tool metadata", () => {

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -1385,6 +1385,57 @@ describe("redactPart", () => {
     })
   })
 
+  test("sanitizeSnapshot redacts abort and title generation error messages", () => {
+    const fakeSnapshot: Export.Snapshot = {
+      schema_version: 1,
+      format: "pawwork-session-export",
+      exported_at: 0,
+      root_session_id: SessionID.make("ses_diag"),
+      runtime_context: {
+        app_version: "test",
+        runtime_namespace: "pawwork",
+        platform: "darwin",
+        os_version: "0",
+        locale: "en-US",
+        timezone: "UTC",
+        instruction_sources: [],
+        model_refs: {},
+        stats: { session_count: 0, message_count: 0, part_count: 0, omitted_attachment_count: 0 },
+      },
+      diagnostics: {
+        aborts: [
+          {
+            session_id: SessionID.make("ses_diag"),
+            message_id: MessageID.make("msg_abort"),
+            error_message: "failed to read /Users/secret/.env",
+          },
+        ],
+        title_generations: [
+          {
+            session_id: SessionID.make("ses_diag"),
+            message_id: MessageID.make("msg_title"),
+            started_at: 1,
+            success: false,
+            error_message: "provider rejected /Users/secret/.env",
+          },
+        ],
+      },
+      session: {
+        info: { id: SessionID.make("ses_diag"), title: "t", directory: "/dir" } as never,
+        had_cloud_share: false,
+        diffs: [],
+        messages: [],
+        children: [],
+      },
+    }
+
+    const sanitized = Export.sanitizeSnapshot(fakeSnapshot)
+    expect(sanitized.diagnostics.aborts?.[0]?.error_message).toBe("[redacted:abort-error-message:0]")
+    expect(sanitized.diagnostics.title_generations?.[0]?.error_message).toBe(
+      "[redacted:title-generation-error-message:0]",
+    )
+  })
+
   test("redacts data: url inside completed tool attachments", () => {
     const ctx = { count: { omitted: 0 } }
     const part: MessageV2.ToolPart = {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -391,7 +391,7 @@ it.live("loop calls LLM and returns assistant message", () =>
         title: "Pinned",
         permission: [{ permission: "*", pattern: "*", action: "allow" }],
       })
-      yield* prompt.prompt({
+      const userMsg = yield* prompt.prompt({
         sessionID: chat.id,
         agent: "build",
         noReply: true,
@@ -1338,6 +1338,14 @@ it.live(
         expect(Exit.isSuccess(exit)).toBe(true)
         if (Exit.isSuccess(exit) && exit.value.info.role === "assistant") {
           expect(exit.value.info.error?.name).toBe("MessageAbortedError")
+          expect(exit.value.info.diagnostics?.abort).toMatchObject({
+            source: "session.prompt.cancel",
+            reason: "soft_cancel",
+            mode: "soft",
+            propagation_point: "session.prompt.loop.onInterrupt",
+            error_name: "MessageAbortedError",
+            via_ctx_abort: false,
+          })
         }
       }),
       { git: true, config: providerCfg },

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -75,6 +75,8 @@ function defer<T>() {
   return { promise, resolve }
 }
 
+type Mutable<T> = { -readonly [K in keyof T]: T[K] }
+
 function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
   return withShell("/bin/sh", fx)
 }
@@ -1273,8 +1275,9 @@ it.live(
 
         const started = defer<void>()
         const release = defer<void>()
+        const mutableSessions = sessions as Mutable<typeof sessions>
         const originalUpdateMessage = sessions.updateMessage
-        sessions.updateMessage = ((info) => {
+        mutableSessions.updateMessage = (info) => {
           if (info.role === "assistant" && info.parentID === nextUser.id) {
             return Effect.gen(function* () {
               started.resolve()
@@ -1283,8 +1286,8 @@ it.live(
             })
           }
           return originalUpdateMessage(info)
-        }) as typeof sessions.updateMessage
-        yield* Effect.addFinalizer(() => Effect.sync(() => void (sessions.updateMessage = originalUpdateMessage)))
+        }
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSessions.updateMessage = originalUpdateMessage)))
 
         const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
         yield* Effect.promise(() => started.promise)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { FetchHttpClient } from "effect/unstable/http"
 import { expect } from "bun:test"
-import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { Cause, Effect, Exit, Fiber, Layer, Option } from "effect"
 import path from "path"
 import fs from "fs/promises"
 import { pathToFileURL } from "url"
@@ -1255,6 +1255,48 @@ it.live(
           if (info.role === "assistant") {
             expect(info.error?.name).toBe("MessageAbortedError")
           }
+        }
+      }),
+      { git: true, config: providerCfg },
+    ),
+  3_000,
+)
+
+it.live(
+  "cancel before current assistant scaffold does not attach abort diagnostics to the previous assistant",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const { prompt, sessions, chat } = yield* boot({ title: "Pinned" })
+        const seeded = yield* seed(chat.id)
+        const nextUser = yield* user(chat.id, "more")
+
+        const started = defer<void>()
+        const release = defer<void>()
+        const originalUpdateMessage = sessions.updateMessage
+        sessions.updateMessage = ((info) => {
+          if (info.role === "assistant" && info.parentID === nextUser.id) {
+            return Effect.gen(function* () {
+              started.resolve()
+              yield* Effect.promise(() => release.promise)
+              return yield* originalUpdateMessage(info)
+            })
+          }
+          return originalUpdateMessage(info)
+        }) as typeof sessions.updateMessage
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (sessions.updateMessage = originalUpdateMessage)))
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        yield* Effect.promise(() => started.promise)
+        yield* prompt.cancel(chat.id)
+        release.resolve()
+        const exit = yield* Fiber.await(fiber)
+        expect(Exit.isSuccess(exit)).toBe(true)
+
+        const previous = yield* sessions.findMessage(chat.id, (message) => message.info.id === seeded.assistant.id)
+        expect(Option.isSome(previous)).toBe(true)
+        if (Option.isSome(previous) && previous.value.info.role === "assistant") {
+          expect(previous.value.info.diagnostics?.abort).toBeUndefined()
         }
       }),
       { git: true, config: providerCfg },


### PR DESCRIPTION
## Summary

Add session-export observability for abort provenance and background title generation, and inject the embedded server release version into the exported runtime metadata.

## Why

We need the next exported session to answer a concrete question instead of another guess: who triggered the abort, where did it propagate, and was the first-turn background title stream active at the same time. Separately, issue #560 showed that exported sessions from release builds were still reporting `app_version: "local"`, which made user-side RCA less trustworthy.

## Related Issue

Closes #560.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

1. The cancel provenance path: `SessionPrompt.cancel` -> `SessionRunState` / `Runner` -> prompt-loop `onInterrupt` -> assistant diagnostics -> export summaries.
2. The export surface: top-level `diagnostics.aborts` and `diagnostics.title_generations`, plus assistant-level schema compatibility.
3. The embedded/node build fix: `packages/opencode/script/build-node.ts` now injects `OPENCODE_VERSION` alongside `OPENCODE_CHANNEL`.

## Risk Notes

Low to medium. This PR is diagnostics-focused and does not change `ensureTitle()` timing or cancellation behavior, but it does touch shared runner/session plumbing and the exported schema. The title-generation trace currently has export/schema coverage rather than a full end-to-end prompt harness assertion, to keep this diagnostics PR out of race-prone behavioral testing.

## How To Verify

```text
Diff check: pass
Typecheck: pass
Focused tests: 114 passed across runner, prompt-effect, export, and build-node contract tests
- bun --cwd packages/opencode test test/effect/runner.test.ts test/session/export.test.ts test/session/prompt-effect.test.ts test/script/build-node.test.ts --timeout 30000
- bun --cwd packages/opencode typecheck
- git diff --check
```

## Screenshots or Recordings

None. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now record and propagate rich interrupt metadata and annotate assistant messages with structured abort and title-generation diagnostics.
  * Build output now embeds the application version and channel constants.

* **Bug Fixes**
  * Persisted assistant diagnostics are merged when finalizing messages; exported error details are redacted during sanitization.

* **Tests**
  * Added tests for interrupt metadata propagation, diagnostics collection/redaction, and build output injection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/563)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->