### PR TITLE
fix(app): recover question state after reconnect replay gaps

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -127,6 +127,13 @@ function globalEventStream(page: Page) {
         }
         win.__opencode_e2e?.globalEventStream?.start()
       }),
+    setCursorForTest: (value: string | undefined) =>
+      page.evaluate((value) => {
+        const win = window as Window & {
+          __opencode_e2e?: { globalEventStream?: { setCursorForTest: (value: string | undefined) => void } }
+        }
+        win.__opencode_e2e?.globalEventStream?.setCursorForTest(value)
+      }, value),
   }
 }
 
@@ -617,6 +624,35 @@ test("question dock recovers after missed question.asked via SSE replay", async 
   )
 })
 
+test("question dock recovers after invalid replay cursor forces fallback refresh", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question invalid cursor fallback",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+        await expect(page.locator(promptSelector)).toBeVisible()
+
+        const stream = globalEventStream(page)
+
+        await expect.poll(stream.cursor, { timeout: 10_000 }).toMatch(/:/)
+        await stream.stop()
+        await e2eAskQuestion(project, { sessionID: session.id, questions: defaultQuestions })
+        await waitForQuestionSeed(project, session.id)
+
+        await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 750 })
+        await stream.setCursorForTest("bad:999")
+        await stream.start()
+
+        await expectQuestionBlocked(page)
+        await expect(page.locator(questionDockSelector)).toHaveCount(1)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
 test("question dock renders from backend blocker when question sync is missing", async ({ page, project }) => {
   await project.open()
   await withDockSession(
@@ -659,6 +695,30 @@ test("stale question.asked does not reopen after question reply", async ({ page,
         await expectQuestionOpen(page)
 
         await e2ePublishQuestionAsked(project, request)
+        await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 1_000 })
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("stale session.blocker.upserted does not reopen after question reply", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock stale blocker question",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        await e2eAskQuestion(project, { sessionID: session.id, questions: defaultQuestions })
+        const request = await waitForQuestionSeed(project, session.id)
+
+        await expectQuestionBlocked(page)
+        await project.sdk.question.reply({ requestID: request.id, questionReply: { answers: [["Continue"]] } })
+        await expectQuestionOpen(page)
+
+        await e2ePublishQuestionBlocker(project, request)
         await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 1_000 })
       })
     },

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -132,7 +132,9 @@ function globalEventStream(page: Page) {
         const win = window as Window & {
           __opencode_e2e?: { globalEventStream?: { setCursorForTest: (value: string | undefined) => void } }
         }
-        win.__opencode_e2e?.globalEventStream?.setCursorForTest(value)
+        const hook = win.__opencode_e2e?.globalEventStream?.setCursorForTest
+        if (!hook) throw new Error("Missing e2e global event stream cursor override hook")
+        hook(value)
       }, value),
   }
 }
@@ -643,6 +645,7 @@ test("question dock recovers after invalid replay cursor forces fallback refresh
 
         await expect(page.locator(questionDockSelector)).toHaveCount(0, { timeout: 750 })
         await stream.setCursorForTest("bad:999")
+        await expect.poll(stream.cursor, { timeout: 5_000 }).toBe("bad:999")
         await stream.start()
 
         await expectQuestionBlocked(page)

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -195,6 +195,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
           void start()
         },
         cursor: replayCursor.current,
+        setCursorForTest: replayCursor.setCursorForTest,
       }
     }
 

--- a/packages/app/src/context/global-sdk/sse-cursor.test.ts
+++ b/packages/app/src/context/global-sdk/sse-cursor.test.ts
@@ -27,4 +27,15 @@ describe("createSseCursor", () => {
     expect(headers).toBeInstanceOf(Headers)
     expect(headers?.get("Last-Event-ID")).toBe("boot:7")
   })
+
+  test("allows e2e tests to override the cursor", () => {
+    const cursor = createSseCursor()
+    cursor.update("boot:7")
+    cursor.setCursorForTest("bad:999")
+    expect(cursor.current()).toBe("bad:999")
+
+    cursor.setCursorForTest(undefined)
+    expect(cursor.current()).toBeUndefined()
+    expect(cursor.headers()).toBeUndefined()
+  })
 })

--- a/packages/app/src/context/global-sdk/sse-cursor.ts
+++ b/packages/app/src/context/global-sdk/sse-cursor.ts
@@ -5,6 +5,9 @@ export function createSseCursor() {
     current() {
       return value
     },
+    setCursorForTest(next: string | undefined) {
+      value = next || undefined
+    },
     update(id: string | undefined) {
       if (!id) return
       // SSE ids come from the server replay layer; keep this helper transport-only.

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -318,7 +318,12 @@ function createGlobalSync() {
         },
         setGlobalProject: setProjects,
       })
-      if (event.type === "server.connected" || event.type === "global.disposed") {
+      if (event.type === "server.connected") {
+        for (const directory of Object.keys(children.children)) {
+          queue.push(directory)
+        }
+      }
+      if (event.type === "global.disposed") {
         if (recent) return
         for (const directory of Object.keys(children.children)) {
           queue.push(directory)

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -704,6 +704,45 @@ describe("applyDirectoryEvent", () => {
     expect(store.blocker[sessionID]).toEqual([])
   })
 
+  test("question.replied before blocker.upserted prevents stale blocker from reopening", () => {
+    const blockerTerminals = createBlockerTerminalCache({ now: () => 1000 })
+    const [store, setStore] = createStore(baseState())
+    const sessionID = "ses_1"
+
+    applyDirectoryEvent({
+      event: { type: "question.replied", properties: { sessionID, requestID: "q1" } },
+      directory: "/repo",
+      store,
+      setStore,
+      push() {},
+      loadLsp() {},
+      blockerTerminals,
+    })
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.blocker.upserted",
+        properties: {
+          kind: "question",
+          status: "awaiting_user",
+          sessionID,
+          requestID: "q1",
+          request: questionRequest("q1", sessionID),
+          armedAt: 1,
+          updatedAt: 1,
+        },
+      },
+      directory: "/repo",
+      store,
+      setStore,
+      push() {},
+      loadLsp() {},
+      blockerTerminals,
+    })
+
+    expect(store.blocker[sessionID]).toBeUndefined()
+  })
+
   test("permission.replied before permission.asked prevents stale ask from reopening", () => {
     const blockerTerminals = createBlockerTerminalCache({ now: () => 1000 })
     const [store, setStore] = createStore(baseState())

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -399,6 +399,9 @@ export function applyDirectoryEvent(input: {
     }
     case "session.blocker.upserted": {
       const blocker = event.properties as State["blocker"][string][number]
+      if (blocker.kind === "question" && input.blockerTerminals?.has("question", input.directory, blocker.sessionID, blocker.requestID)) {
+        break
+      }
       const blockers = input.store.blocker[blocker.sessionID]
       if (!blockers) {
         input.setStore("blocker", blocker.sessionID, [blocker])

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -34,6 +34,7 @@ export type E2EWindow = Window & {
       stop: () => void
       start: () => void
       cursor: () => string | undefined
+      setCursorForTest: (value: string | undefined) => void
     }
   }
 }


### PR DESCRIPTION
## Summary

- refresh directory child stores on `server.connected` even inside the recent-boot window so invalid or gapped replay reconnects can recover question state
- ignore stale `session.blocker.upserted` question blockers after the matching question was already terminally answered
- add deterministic e2e coverage for invalid replay cursor fallback and stale blocker replay, with an e2e-only SSE cursor override hook

## Why

This PR fixes a real bug discovered during the remaining #405 coverage work: a stale `session.blocker.upserted` replay could reopen the question dock after the user had already replied.

While adding the invalid-cursor replay e2e, the same investigation also found a second production gap: `server.connected` respected the recent-boot suppression window, so an invalid or gapped reconnect could leave the session in a loading state without rehydrating question data.

Permission replay coverage is still deferred to #567 because the current permission e2e path does not have an authoritative pending-state seed hook.

## Related Issue

closes #405
follow-up: #567

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/app/src/context/global-sync.tsx`: `server.connected` should always queue per-directory bootstrap on reconnect, while `global.disposed` keeps the recent-boot guard.
- `packages/app/src/context/global-sync/event-reducer.ts`: stale question blockers should not be reinserted after the matching terminal cache entry exists.
- `packages/app/e2e/session/session-composer-dock.spec.ts`: invalid replay cursor fallback and stale blocker replay should stay deterministic without LLM-dependent timing.

## Risk Notes

Low to medium. The production change only affects reconnect refresh behavior and stale question-blocker replay suppression. The new cursor override is e2e-only surface exposed through `__opencode_e2e`.

Previously `server.connected` shared the `recent` gate with `global.disposed`; splitting them adds one extra refresh queue on cold-boot reconnect in exchange for replay-gap correctness. The queue is idempotent, so the trade-off is safe.

## How To Verify

```text
Focused unit tests: `bun test --preload ./happydom.ts ./src/context/global-sync/event-reducer.test.ts ./src/context/global-sdk/sse-cursor.test.ts` -> 26 passed
Typecheck: `bun run typecheck` -> pass
Focused e2e stability: `bun run test:e2e e2e/session/session-composer-dock.spec.ts --grep "question dock recovers after missed question.asked via SSE replay|question dock recovers after invalid replay cursor forces fallback refresh|stale session.blocker.upserted does not reopen after question reply"` -> 3 passed, repeated 3 runs total
Diff check: `git diff --check dev...HEAD` -> pass
```

## Screenshots or Recordings

Not included. This PR changes existing dock recovery behavior without introducing new visual surfaces; the focused e2e coverage above is the primary proof.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Question dock no longer reopens when stale blocker events occur after answering a question.

* **Tests**
  * Enhanced E2E test coverage for SSE replay cursor handling, including cursor override and blocking state validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/568)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->