### PR TITLE
feat(ci): add OfficeCLI bundled-version bump workflow

### DIFF
--- a/.github/workflows/officecli-bump.yml
+++ b/.github/workflows/officecli-bump.yml
@@ -1,0 +1,231 @@
+name: officecli-bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate the bump path without opening a pull request"
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  officecli-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Load-bearing: `bun install` runs `trustedDependencies`
+      # postinstalls from the root package.json (electron, node-pty,
+      # esbuild, tree-sitter at time of writing), which call `node`
+      # explicitly. Do not drop without first patching those scripts.
+      # Source of truth: grep `trustedDependencies` in package.json. (#70)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve OfficeCLI versions
+        id: versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          release_json="$(mktemp)"
+          gh api repos/iOfficeAI/OfficeCLI/releases/latest > "$release_json"
+
+          latest_version="$(jq -r '.tag_name' "$release_json")"
+          release_url="$(jq -r '.html_url' "$release_json")"
+          current_version="$(node -p "require('./packages/desktop-electron/bundled-tools.json').officecli.version")"
+
+          {
+            echo "latest_version=$latest_version"
+            echo "release_url=$release_url"
+            echo "current_version=$current_version"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Pinned OfficeCLI: $current_version"
+          echo "Latest OfficeCLI: $latest_version"
+          echo "Upstream release: $release_url"
+
+      - name: Exit when already up to date
+        if: ${{ steps.versions.outputs.current_version == steps.versions.outputs.latest_version }}
+        run: echo "Bundled OfficeCLI is already at ${{ steps.versions.outputs.current_version }}."
+
+      - name: Bump manifest and verify all bundled assets
+        if: ${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version }}
+        id: verify
+        shell: bash
+        env:
+          LATEST_VERSION: ${{ steps.versions.outputs.latest_version }}
+        run: |
+          set -euo pipefail
+
+          node <<'NODE'
+          const fs = require("node:fs")
+          const file = "packages/desktop-electron/bundled-tools.json"
+          const manifest = JSON.parse(fs.readFileSync(file, "utf8"))
+          manifest.officecli.version = process.env.LATEST_VERSION
+          fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`)
+          NODE
+
+          verified_targets=()
+          for target in "darwin arm64" "darwin x64" "win32 x64" "win32 arm64"; do
+            read -r platform arch <<<"$target"
+            echo "Verifying OfficeCLI asset for $platform-$arch"
+            bun packages/desktop-electron/scripts/prepare-officecli.ts --platform "$platform" --arch "$arch"
+            verified_targets+=("$platform-$arch")
+          done
+
+          {
+            echo "verified_targets<<EOF"
+            printf '%s\n' "${verified_targets[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create bump pull request
+        if: ${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          LATEST_VERSION: ${{ steps.versions.outputs.latest_version }}
+          RELEASE_URL: ${{ steps.versions.outputs.release_url }}
+          VERIFIED_TARGETS: ${{ steps.verify.outputs.verified_targets }}
+        run: |
+          set -euo pipefail
+
+          dry_run=false
+          if [ "${INPUT_DRY_RUN:-}" = "true" ]; then
+            dry_run=true
+          fi
+
+          branch="ci/officecli-bump-${LATEST_VERSION}"
+          title="chore: bump bundled OfficeCLI to ${LATEST_VERSION}"
+
+          if [ "$dry_run" = false ] && [ "$GITHUB_REF_NAME" != "dev" ]; then
+            echo "Non-dry bump runs must start from dev, got $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          if existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq '.[0].url // empty')"; then
+            if [ -n "$existing_pr" ]; then
+              echo "Open bump PR already exists: $existing_pr"
+              echo "Skipping duplicate OfficeCLI bump."
+              exit 0
+            fi
+          fi
+
+          echo "Verified targets:"
+          while IFS= read -r target; do
+            [ -n "$target" ] && printf ' - %s\n' "$target"
+          done <<< "$VERIFIED_TARGETS"
+
+          if [ "$dry_run" = true ]; then
+            echo "Dry run requested; skipping branch push and PR creation."
+            {
+              echo "### OfficeCLI bump dry run"
+              echo
+              echo "- Current pinned version: \`${{ steps.versions.outputs.current_version }}\`"
+              echo "- Latest upstream version: \`${LATEST_VERSION}\`"
+              echo "- Upstream release: ${RELEASE_URL}"
+              echo "- Verified targets:"
+              while IFS= read -r target; do
+                [ -n "$target" ] && echo "  - \`${target}\`"
+              done <<< "$VERIFIED_TARGETS"
+              echo "- Result: would open \`${title}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
+          git switch -c "$branch"
+          git add packages/desktop-electron/bundled-tools.json
+          git commit -m "$title"
+          git push --set-upstream origin "$branch"
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          ## Summary
+
+          Bump the bundled OfficeCLI version in \`packages/desktop-electron/bundled-tools.json\` from \`${{ steps.versions.outputs.current_version }}\` to \`${LATEST_VERSION}\`.
+
+          ## Why
+
+          Upstream OfficeCLI published a newer release, so this workflow verified the pinned bundle against the latest release assets and opened a reviewable bump PR. The release workflow still consumes the pinned repo version only after a maintainer reviews and merges this change.
+
+          ## Related Issue
+
+          Closes #330.
+
+          ## Human Review Status
+
+          Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.
+
+          ## Review Focus
+
+          - Confirm the new pinned version matches the intended upstream release.
+          - Confirm the bundled manifest is the only repo change.
+          - Confirm the verification summary covers all four bundled desktop assets.
+
+          ## Risk Notes
+
+          - No product code or release workflow behavior changed.
+          - This PR only updates the pinned OfficeCLI version after SHA256 verification passes for the four bundled desktop assets.
+          - Asset naming or checksum drift upstream will fail this workflow red instead of opening a partial PR.
+
+          ## How To Verify
+
+          \`\`\`text
+          Upstream release: ${RELEASE_URL}
+          Verified targets:
+          $(while IFS= read -r target; do [ -n "$target" ] && printf -- "- %s\n" "$target"; done <<< "$VERIFIED_TARGETS")
+          Validation command: bun packages/desktop-electron/scripts/prepare-officecli.ts --platform <target-platform> --arch <target-arch>
+          \`\`\`
+
+          ## Screenshots or Recordings
+
+          Not needed. This is a CI automation PR with no visible UI change.
+
+          ## Checklist
+
+          - [x] Human review status is stated above as pending, approved, or not required
+          - [x] I linked the related issue, or stated why there is no issue
+          - [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
+          - [x] I described the review focus and any meaningful risks
+          - [x] I listed the relevant verification steps and the key result for each
+          - [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
+          - [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
+          - [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
+          - [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
+          - [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
+          - [x] I am targeting \`dev\`, and my PR title and commit messages use Conventional Commits in English
+          EOF
+
+          gh pr create \
+            --base dev \
+            --head "$branch" \
+            --title "$title" \
+            --label enhancement \
+            --label ci \
+            --label upstream \
+            --body-file "$body_file"

--- a/packages/opencode/test/github/officecli-bump-workflow.test.ts
+++ b/packages/opencode/test/github/officecli-bump-workflow.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseWorkflow, readWorkflow } from "./workflow-parser"
+
+const repoRoot = path.join(import.meta.dir, "../../../..")
+const workflowPath = path.join(repoRoot, ".github", "workflows", "officecli-bump.yml")
+
+describe("officecli bump workflow", () => {
+  test("keeps the expected triggers, permissions, and pinned actions", () => {
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
+    const steps = parsed.jobs?.["officecli-bump"]?.steps ?? []
+    const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
+    const setupNode = steps.find((step) => step.uses?.startsWith("actions/setup-node@"))
+    const setupBun = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+
+    expect(parsed.name).toBe("officecli-bump")
+    expect(parsed.on?.workflow_dispatch).toEqual({
+      inputs: {
+        dry_run: {
+          default: true,
+          description: "Validate the bump path without opening a pull request",
+          required: false,
+          type: "boolean",
+        },
+      },
+    })
+    expect(parsed.on?.schedule).toEqual([{ cron: "17 3 * * 1" }])
+    expect(parsed.permissions).toEqual({
+      contents: "write",
+      "pull-requests": "write",
+      issues: "write",
+    })
+
+    expect(checkout?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
+    expect(checkout?.with?.["persist-credentials"]).toBe(false)
+    expect(setupNode?.uses).toBe("actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e")
+    expect(setupNode?.with).toEqual({ "node-version": "24" })
+    expect(setupBun?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+    expect(setupBun?.with).toEqual({ "bun-version": "1.3.13" })
+
+    expect(workflow).not.toContain("persist-credentials: true")
+    expect(workflow).toContain("gh api repos/iOfficeAI/OfficeCLI/releases/latest")
+    expect(workflow).toContain("packages/desktop-electron/bundled-tools.json")
+    expect(workflow).toContain(
+      "bun packages/desktop-electron/scripts/prepare-officecli.ts --platform \"$platform\" --arch \"$arch\"",
+    )
+    expect(workflow).toContain("Dry run requested; skipping branch push and PR creation.")
+    expect(workflow).toContain("gh auth setup-git")
+    expect(workflow).toContain("--label enhancement")
+    expect(workflow).toContain("--label ci")
+    expect(workflow).toContain("--label upstream")
+    expect(workflow).toContain("Closes #330.")
+  })
+})


### PR DESCRIPTION
## Summary

Add a scheduled/manual GitHub workflow that checks `iOfficeAI/OfficeCLI` for a newer release, verifies the four bundled desktop assets with the existing `prepare-officecli` script, and opens a reviewable bump PR when the pinned version is behind.

## Why

Today the desktop release workflow only consumes the version already pinned in `packages/desktop-electron/bundled-tools.json`. That is the right safety boundary for releases, but it leaves the repo without a first-class path to notice upstream OfficeCLI releases and prepare a version bump with verification attached.

This PR adds that missing upgrade workflow without changing release behavior:

- release builds still consume the repo's pinned OfficeCLI version only
- the new workflow only checks upstream, verifies checksums/assets, and opens a human-reviewed PR
- if upstream assets or checksums drift, the workflow fails red instead of opening a partial bump PR

## Related Issue

Closes #330.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- The workflow should only update `packages/desktop-electron/bundled-tools.json` and should not touch the release workflow itself.
- The verification step should cover all four bundled desktop targets before a PR is opened.
- The `workflow_dispatch` path should support `dry_run=true` for safe manual validation without opening a PR.

## Risk Notes

- No product code, UI, or release workflow behavior changed.
- The new workflow uses the existing `prepare-officecli.ts` contract for download + SHA256 verification, so version bumps stay aligned with the current release path.
- GitHub cannot dispatch a brand-new workflow from a feature branch before that workflow exists on the default branch. I hit `404 workflow officecli-bump.yml not found on the default branch` when trying to run `gh workflow run officecli-bump.yml --ref slock/officecli-bump-workflow -f dry_run=true`. To validate the same logic pre-merge, I ran the bump path locally against the live upstream release and restored the manifest afterward.

## How To Verify

```text
actionlint .github/workflows/officecli-bump.yml
Result: pass

bun --cwd packages/opencode test test/github/officecli-bump-workflow.test.ts
Result: 1 pass

bun --cwd packages/opencode typecheck
Result: pass

Local dry-run of workflow logic against live upstream latest release
Current pinned version: v1.0.63
Latest upstream release: v1.0.88
Verified targets:
- darwin-arm64
- darwin-x64
- win32-x64
- win32-arm64
Validation command: bun packages/desktop-electron/scripts/prepare-officecli.ts --platform <target-platform> --arch <target-arch>
Result: all 4 prepare-officecli runs passed from repo root, then bundled-tools.json restored to v1.0.63
```

## Screenshots or Recordings

Not needed. This is a CI automation PR with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated OfficeCLI version detection and update flow that opens a PR when a newer release is found
  * Supports scheduled weekly checks, manual triggering, and a dry-run mode; avoids creating duplicate PRs by detecting existing bump PRs

* **Tests**
  * Added tests validating the OfficeCLI update workflow's configuration and behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/571)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->