### PR TITLE
refactor(ui): remove product-UI middle-dot separators per DESIGN.md L537

### DIFF
--- a/packages/app/src/components/prompt-input/model-controls.tsx
+++ b/packages/app/src/components/prompt-input/model-controls.tsx
@@ -59,8 +59,8 @@ export function PromptModelControl(props: {
           </span>
           <Show when={props.model.variant.current()}>
             {(v) => (
-              <span class="shrink-0 text-fg-weak font-normal">
-                · {translateVariant(props.language.t, v())}
+              <span class="ms-1.5 shrink-0 text-fg-weaker font-normal">
+                {translateVariant(props.language.t, v())}
               </span>
             )}
           </Show>

--- a/packages/app/src/components/settings-worktree-row.tsx
+++ b/packages/app/src/components/settings-worktree-row.tsx
@@ -20,7 +20,7 @@ export function SettingsWorktreeRow(props: {
   const name = () => props.worktree.name || basename(props.worktree.directory)
   const branch = () => props.worktree.branch || ""
   const identity = () => branch() || name()
-  const rowTooltip = () => [language.t(sourceKey(props.worktree.source)), directory()].filter(Boolean).join(" — ")
+  const rowTooltip = () => [language.t(sourceKey(props.worktree.source)), directory()].filter(Boolean).join(" ")
 
   return (
     <li

--- a/packages/app/src/components/settings-worktree-row.tsx
+++ b/packages/app/src/components/settings-worktree-row.tsx
@@ -20,7 +20,7 @@ export function SettingsWorktreeRow(props: {
   const name = () => props.worktree.name || basename(props.worktree.directory)
   const branch = () => props.worktree.branch || ""
   const identity = () => branch() || name()
-  const rowTooltip = () => [language.t(sourceKey(props.worktree.source)), directory()].filter(Boolean).join(" · ")
+  const rowTooltip = () => [language.t(sourceKey(props.worktree.source)), directory()].filter(Boolean).join(" — ")
 
   return (
     <li

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -919,7 +919,7 @@ export const dict = {
   "settings.general.row.lsp.description": "Detect type errors and symbol references when editing code",
   "settings.general.webSearch.title": "Web search",
   "settings.general.webSearch.description": "Let agents look up fresh information online when needed",
-  "settings.general.webSearch.chip.free": "Free · bundled",
+  "settings.general.webSearch.chip.free": "Free (bundled)",
   "settings.general.webSearch.chip.loading": "Checking",
   "settings.general.webSearch.chip.exhausted": "Free quota used",
   "settings.general.webSearch.chip.savedQuota": "Key quota used",

--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -172,11 +172,6 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
                 {language.t("error.page.action.restart")}
               </button>
             </Show>
-            <Show when={platform.checkUpdate}>
-              <span class="text-fg-weaker" aria-hidden="true">
-                ·
-              </span>
-            </Show>
             <button
               type="button"
               class="hover:text-fg-strong transition-colors disabled:opacity-50"
@@ -255,9 +250,6 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
                 {(version) => (
                   <>
                     <span>{language.t("error.page.version", { version: version() })}</span>
-                    <span class="text-fg-weaker" aria-hidden="true">
-                      ·
-                    </span>
                   </>
                 )}
               </Show>

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -466,9 +466,6 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
         <>
           <div data-slot="question-header-title">
             <span data-slot="question-header-seq">{summary()}</span>
-            <span data-slot="question-header-separator" aria-hidden="true">
-              ·
-            </span>
             <span data-slot="question-header-mode">
               {multi() ? language.t("ui.question.multiHint") : language.t("ui.question.singleHint")}
             </span>


### PR DESCRIPTION
## Summary

Remove product-UI middle-dot separators from the five in-scope PawWork surfaces called out by issue #572.

## Why

DESIGN.md L537 was tightened to one rule: use spacing plus typographic contrast, and do not use `·` as a product-UI separator. These five call sites were still rendering `·`, including the question dock site that was added back into scope after the issue body was re-checked.

## Related Issue

Closes #572.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Verify that each of the five call sites now reads cleanly without `·`, and that the replacement pattern matches the local context:
- prompt model control uses spacing plus quieter variant color
- settings worktree tooltip reads cleanly as prose
- web search chip keeps the qualifier readable
- error page and question dock rely on gap-based separation without decorative dots

## Risk Notes

Low. This is user-visible copy/layout cleanup only. No behavior, persistence, API, or platform logic changed.

## How To Verify

```text
packages/app typecheck: pass
packages/app unit tests: 1050 passed (including settings-websearch-source.test.ts in the scoped run)
Diff check: no whitespace errors
Before/after screenshot capture: pass for 5 surfaces
Scoped grep: no `·` remains in the 5 edited source files
```

## Screenshots or Recordings

Before/after pairs were captured locally for all 5 surfaces and shared in #PawWork:81e824c0 for AstroHan visual review.

Worktree tooltip text:
```text
before: Created · /private/var/folders/tm/wc1zbpfx4mq9dbz4gl4b968m0000gn/T/opencode-e2e-project-C5qZI6/.worktrees/pawwork/playful-comet
after:  Created /private/var/folders/tm/wc1zbpfx4mq9dbz4gl4b968m0000gn/T/opencode-e2e-project-dvSque/.worktrees/pawwork/glowing-wizard
```

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed decorative separator dots across the UI for cleaner headers and details
  * Adjusted model variant label styling (color and spacing) for better readability
  * Updated Web Search chip text to "Free (bundled)"
  * Changed tooltip/source label concatenation to use a plain space
  * Streamlined error and composer header layouts for improved clarity

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/574)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->