### PR TITLE
test(e2e): add permission replay fallback coverage

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test"
-import type { QuestionRequest } from "@opencode-ai/sdk/v2/client"
+import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
 import { test, expect } from "../fixtures"
 import {
   composerEvent,
@@ -150,6 +150,24 @@ async function e2eAskQuestion(
   expect(response.status).toBe(204)
 }
 
+async function e2eAskPermission(
+  project: ProjectQuestionSeed,
+  input: {
+    sessionID: string
+    permission: string
+    patterns: string[]
+    metadata?: Record<string, unknown>
+    always?: string[]
+  },
+) {
+  const response = await fetch(`${project.url}/permission/__e2e/ask?directory=${encodeURIComponent(project.directory)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  })
+  expect(response.status).toBe(204)
+}
+
 async function e2ePublishQuestionAsked(project: ProjectQuestionSeed, request: QuestionRequest) {
   const response = await fetch(
     `${project.url}/question/__e2e/publish-asked?directory=${encodeURIComponent(project.directory)}`,
@@ -189,6 +207,30 @@ async function waitForQuestionSeed(project: ProjectQuestionSeed, sessionID: stri
     )
     .toBe(true)
   if (!current) throw new Error("Question seed was not visible after polling")
+  return current
+}
+
+async function waitForPermissionSeed(
+  project: ProjectQuestionSeed,
+  input: { sessionID: string; permission: string; pattern: string },
+) {
+  let current: PermissionRequest | undefined
+  await expect
+    .poll(
+      async () => {
+        const permissions = await project.sdk.permission.list().then((response) => response.data ?? [])
+        current = permissions.find(
+          (permission) =>
+            permission.sessionID === input.sessionID &&
+            permission.permission === input.permission &&
+            permission.patterns.includes(input.pattern),
+        )
+        return !!current
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true)
+  if (!current) throw new Error("Permission seed was not visible after polling")
   return current
 }
 
@@ -616,6 +658,42 @@ test("question dock recovers after invalid replay cursor forces fallback refresh
 
         await expectQuestionBlocked(page)
         await expect(page.locator(questionDockSelector)).toHaveCount(1)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("permission dock recovers after invalid replay cursor forces fallback refresh", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock permission invalid cursor fallback",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+        await expect(page.locator(promptSelector)).toBeVisible()
+
+        const stream = globalEventStream(page)
+        const pattern = "/tmp/opencode-e2e-perm-replay-fallback"
+
+        await expect.poll(stream.cursor, { timeout: 10_000 }).toMatch(/:/)
+        await stream.stop()
+        await e2eAskPermission(project, {
+          sessionID: session.id,
+          permission: "bash",
+          patterns: [pattern],
+          metadata: { description: "Need permission for replay fallback" },
+        })
+        await waitForPermissionSeed(project, { sessionID: session.id, permission: "bash", pattern })
+
+        await expect(page.locator(permissionDockSelector)).toHaveCount(0, { timeout: 750 })
+        await stream.setCursorForTest("bad:999")
+        await expect.poll(stream.cursor, { timeout: 5_000 }).toBe("bad:999")
+        await stream.start()
+
+        await expectPermissionBlocked(page)
+        await expect(page.locator(permissionDockSelector)).toHaveCount(1)
       })
     },
     { trackSession: project.trackSession },

--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -3,11 +3,53 @@ import { describeRoute, validator, resolver } from "hono-openapi"
 import z from "zod"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
+import { SessionID } from "@/session/schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Env } from "@/env"
+import { AppRuntime } from "@/effect/app-runtime"
+import { Log } from "@opencode-ai/core/util/log"
+
+const log = Log.create({ service: "server" })
+const e2ePermissionRoutesEnabled = () =>
+  Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 export const PermissionRoutes = lazy(() =>
   new Hono()
+    .post(
+      "/__e2e/ask",
+      validator(
+        "json",
+        z.object({
+          sessionID: SessionID.zod,
+          permission: z.string().min(1),
+          patterns: z.array(z.string()).min(1),
+          metadata: z.record(z.string(), z.any()).optional(),
+          always: z.array(z.string()).optional(),
+        }),
+      ),
+      async (c) => {
+        if (!e2ePermissionRoutesEnabled()) return c.notFound()
+
+        const json = c.req.valid("json")
+        void AppRuntime.runPromise(
+          Permission.Service.use((svc) =>
+            svc.ask({
+              sessionID: json.sessionID,
+              permission: json.permission,
+              patterns: json.patterns,
+              metadata: json.metadata ?? {},
+              always: json.always ?? json.patterns,
+              ruleset: [{ permission: json.permission, pattern: "*", action: "ask" }],
+            }),
+          ),
+        ).catch((error) => {
+          log.error("e2e permission seed failed", { sessionID: json.sessionID, error })
+        })
+
+        return c.body(null, 204)
+      },
+    )
     .post(
       "/:requestID/reply",
       describeRoute({


### PR DESCRIPTION
## Summary

- add an e2e-only `permission/__e2e/ask` backend hook that seeds a real pending permission request into the current worker backend store
- add a deterministic composer-dock e2e that misses `permission.asked`, forces an invalid SSE cursor fallback, and verifies the permission dock recovers from real backend state
- keep the existing question replay coverage unchanged and re-verify it alongside the new permission path

## Why

Issue #567 called out that the current permission dock coverage is mostly route-mock based, so it does not prove replay or invalid-cursor fallback. The missing piece was an authoritative test seed that creates real pending permission state in the backend.

## Related Issue

Closes #567.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/opencode/src/server/instance/permission.ts`: the new e2e-only hook should only exist behind the existing `OPENCODE_E2E_ENABLED` gate and should seed a real pending permission request through `Permission.Service.ask`
- `packages/app/e2e/session/session-composer-dock.spec.ts`: the new test should prove replay fallback using real backend permission state, not route mocks

## Risk Notes

Low. This adds one e2e-only backend route behind the existing test gate and one focused replay/fallback test. No product UI behavior changes.

## How To Verify

```text
Focused replay e2e: bun --cwd packages/app test:e2e e2e/session/session-composer-dock.spec.ts --workers=1 -g 'question dock recovers after invalid replay cursor forces fallback refresh|permission dock recovers after invalid replay cursor forces fallback refresh' -> 2 passed
App typecheck: bun --cwd packages/app typecheck -> pass
Opencode typecheck: bun --cwd packages/opencode typecheck -> pass
Diff check: git diff --check -> clean
Hook fail-fast proof: the permission seed helper asserts HTTP 204 from /permission/__e2e/ask, so removing or disabling the hook turns this coverage into an immediate hard failure instead of a silent route-mock pass
```

## Screenshots or Recordings

Not needed. This PR adds deterministic e2e coverage for an existing dock UI and does not change visible product behavior.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test coverage for permission replay fallback behavior and permission dock state transitions.

* **Chores**
  * Added testing infrastructure to support permission seeding and validation during quality assurance workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/578)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->