### PR TITLE
test(windows): stabilize advisory loop and bootstrap cases

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -254,7 +254,7 @@ describe("bootstrapDirectory", () => {
         queryClient,
       })
 
-      await waitFor(() => store.provider_ready)
+      await waitFor(() => store.session_status_state === "error")
 
       expect(store.session_status_state).toBe("error")
       expect(store.session_status_ready).toBe(false)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1270,7 +1270,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  slowIOTimeout,
 )
 
 it.live(
@@ -1554,7 +1554,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  slowIOTimeout,
 )
 
 it.live(


### PR DESCRIPTION
## Summary

- switch the two Windows-sensitive session loop tests to the existing `slowIOTimeout` budget
- fix the bootstrap status-hydration error test to wait for the state it actually asserts instead of the unrelated parallel `provider_ready` branch
- keep both fixes scoped to test code only; no product abort, retry, or bootstrap behavior changes

## Why

Two chronic Windows advisory failures were open at the same time:

- #555: two `packages/opencode` session loop tests still used a hardcoded `3000ms` timeout even though the file already had the established `slowIOTimeout` constant for Windows-sensitive cases
- #546: the `bootstrapDirectory > marks session status as error when status hydration fails` test waited on `provider_ready` before asserting `session_status_state === "error"`, but provider refresh and session-status hydration run in parallel, so Windows timing could satisfy the wait before the error branch settled

These are different failure modes, but both close cleanly in the test layer.

## Related Issue

Closes #555.
Closes #546.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/opencode/test/session/prompt-effect.test.ts`: only the two named advisory loop tests should move from `3000` to `slowIOTimeout`
- `packages/app/src/context/global-sync/bootstrap.test.ts`: the error-path test should now wait for `session_status_state === "error"`, matching the behavior it actually verifies

## Risk Notes

Low. Test-only changes. No runtime or product behavior changes.

## How To Verify

```text
Session loop advisory slice: bun --cwd packages/opencode test test/session/prompt-effect.test.ts -t 'cancel interrupts loop and resolves with an assistant message|concurrent loop callers all receive same error result' -> 2 passed
Bootstrap advisory slice: bun --cwd packages/app test src/context/global-sync/bootstrap.test.ts --preload ./happydom.ts -t 'marks session status as error when status hydration fails' -> 1 passed
Opencode typecheck: bun --cwd packages/opencode typecheck -> pass
App typecheck: bun --cwd packages/app typecheck -> pass
Diff check: git diff --check -> clean
```

## Screenshots or Recordings

Not needed. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved session error handling test reliability
  * Enhanced cross-platform test timeout handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/579)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->