### PR TITLE
fix(windows): cache rooted path probes and UNC globs

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { dirname, join, relative, resolve as pathResolve, win32 } from "path"
-import { existsSync, realpathSync } from "fs"
+import * as fs from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
 import { Context, Effect, FileSystem, Layer, Schema } from "effect"
@@ -190,7 +190,7 @@ export namespace AppFileSystem {
     if (process.platform !== "win32") return path
     const resolved = normalizeWindowsPath(path, options)
     try {
-      return realpathSync.native(resolved)
+      return fs.realpathSync.native(resolved)
     } catch {
       return resolved
     }
@@ -202,13 +202,13 @@ export namespace AppFileSystem {
     const match = path.match(/^(.*)[\\/]\*$/)
     if (!match) return normalizePath(path, options)
     const dir = /^[A-Za-z]:$/.test(match[1]) ? match[1] + "\\" : match[1]
-    return join(normalizePath(dir, options), "*")
+    return win32.join(normalizePath(dir, options), "*")
   }
 
   export function resolve(path: string, options?: WindowsPathOptions): string {
     const resolved = process.platform === "win32" ? normalizeWindowsPath(path, options) : pathResolve(path)
     try {
-      return normalizePath(realpathSync(resolved))
+      return normalizePath(fs.realpathSync(resolved))
     } catch (error: any) {
       if (error?.code === "ENOENT") return normalizePath(resolved)
       throw error
@@ -232,7 +232,11 @@ export namespace AppFileSystem {
     base?: string
     driveRoots?: string[]
     exists?: (path: string) => boolean
+    cache?: Map<string, string>
   }
+
+  const rootedWindowsVariantCache = new Map<string, string>()
+  let rootedWindowsVariantCacheEnv = ""
 
   // Rooted but driveless paths (e.g. "/users/runner/...") arrive when callers
   // strip the drive letter before handing the path back. path.resolve would
@@ -256,16 +260,52 @@ export namespace AppFileSystem {
 
   function resolveRootedWindowsVariant(p: string, options: WindowsPathOptions): string | undefined {
     if (!isRootedDriveless(p)) return
+    const useDefaultCache = !options.driveRoots && !options.exists
+    const cacheKey = rootedWindowsVariantCacheKey(p)
+    const cache = options.cache ?? (useDefaultCache ? rootedWindowsVariantCache : undefined)
+    if (useDefaultCache) {
+      refreshRootedWindowsVariantCache()
+    }
+    if (cache) {
+      const cached = cache.get(cacheKey)
+      if (cached && (options.exists ?? fs.existsSync)(cached)) return cached
+      if (cached) cache.delete(cacheKey)
+    }
     const suffix = p.replace(/^[\\/]+/, "").replaceAll("/", "\\")
     const matches: string[] = []
+    const exists = options.exists ?? fs.existsSync
     for (const root of uniqueWindowsDriveRoots(options.driveRoots ?? windowsDriveRoots())) {
       const candidate = win32.join(root, suffix)
-      if ((options.exists ?? existsSync)(candidate)) matches.push(candidate)
+      if (exists(candidate)) matches.push(candidate)
     }
     if (matches.length > 1) {
       throw new Error(`Ambiguous Windows path ${p}; use a drive-qualified path.`)
     }
-    return matches[0]
+    const match = matches[0]
+    if (cache && match) cache.set(cacheKey, match)
+    return match
+  }
+
+  function rootedWindowsVariantCacheKey(p: string): string {
+    return win32.normalize(p).toUpperCase()
+  }
+
+  function rootedWindowsVariantCacheEnvKey(): string {
+    const cwdRoot = uppercaseDriveRoot(win32.parse(process.cwd()).root || "")
+    const systemDrive = (process.env.SystemDrive || "").toUpperCase()
+    return `${cwdRoot}|${systemDrive}`
+  }
+
+  function refreshRootedWindowsVariantCache() {
+    const next = rootedWindowsVariantCacheEnvKey()
+    if (next === rootedWindowsVariantCacheEnv) return
+    rootedWindowsVariantCacheEnv = next
+    rootedWindowsVariantCache.clear()
+  }
+
+  export function resetWindowsRootedVariantCacheForTest() {
+    rootedWindowsVariantCacheEnv = ""
+    rootedWindowsVariantCache.clear()
   }
 
   function uniqueWindowsDriveRoots(roots: string[]): string[] {

--- a/packages/core/test/filesystem/normalize-path.test.ts
+++ b/packages/core/test/filesystem/normalize-path.test.ts
@@ -38,6 +38,14 @@ test("normalizePath folds extended-length UNC paths on Windows", () => {
   })
 })
 
+test("normalizePathPattern preserves UNC glob roots on Windows", () => {
+  withWin32Platform(() => {
+    expect(AppFileSystem.normalizePathPattern("\\\\?\\UNC\\server\\share\\dir\\*")).toBe(
+      "\\\\server\\share\\dir\\*",
+    )
+  })
+})
+
 test("normalizeWindowsPath resolves non-existing rooted-driveless paths from an explicit base drive", () => {
   expect(AppFileSystem.normalizeWindowsPath("\\future\\file.txt", { base: "D:\\project\\work" })).toBe(
     "D:\\future\\file.txt",
@@ -65,6 +73,51 @@ test("normalizeWindowsPath de-duplicates caller-supplied drive roots before ambi
       exists: (candidate) => candidate.toLowerCase() === "c:\\shared\\file.txt",
     }),
   ).toBe("C:\\shared\\file.txt")
+})
+
+test("normalizeWindowsPath caches rooted-driveless matches until the cached path disappears", () => {
+  withWin32Platform(() => {
+    AppFileSystem.resetWindowsRootedVariantCacheForTest()
+    const cache = new Map<string, string>()
+    const live = new Map<string, boolean>([
+      ["C:\\shared\\file.txt", false],
+      ["D:\\shared\\file.txt", true],
+    ])
+    let probes = 0
+    const exists = (candidate: string) => {
+      probes += 1
+      return live.get(candidate) ?? false
+    }
+
+    const first = AppFileSystem.normalizeWindowsPath("\\shared\\file.txt", {
+      cache,
+      exists,
+      driveRoots: ["C:\\", "D:\\"],
+    })
+    const probesAfterFirst = probes
+    const second = AppFileSystem.normalizeWindowsPath("\\shared\\file.txt", {
+      cache,
+      exists,
+      driveRoots: ["C:\\", "D:\\"],
+    })
+
+    expect(first).toBe("D:\\shared\\file.txt")
+    expect(second).toBe("D:\\shared\\file.txt")
+    expect(probesAfterFirst).toBe(2)
+    expect(probes - probesAfterFirst).toBe(1)
+
+    live.set("D:\\shared\\file.txt", false)
+    live.set("E:\\shared\\file.txt", true)
+
+    const refreshed = AppFileSystem.normalizeWindowsPath("\\shared\\file.txt", {
+      cache,
+      exists,
+      driveRoots: ["C:\\", "D:\\", "E:\\"],
+    })
+
+    expect(refreshed).toBe("E:\\shared\\file.txt")
+    expect(probes - probesAfterFirst).toBe(5)
+  })
 })
 
 test.skipIf(process.platform !== "win32")(

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -146,10 +146,15 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   if (Instance.containsPath(resolved, scope)) return full
 
   const kind = options?.kind ?? "file"
-  const dir = kind === "directory" ? resolved : path.dirname(resolved)
+  const dir =
+    kind === "directory"
+      ? resolved
+      : process.platform === "win32"
+      ? path.win32.dirname(resolved)
+      : path.dirname(resolved)
   const glob =
     process.platform === "win32"
-      ? AppFileSystem.normalizePathPattern(path.join(dir, "*"), { base: ins.directory })
+      ? AppFileSystem.normalizePathPattern(path.win32.join(dir, "*"), { base: ins.directory })
       : path.join(dir, "*").replaceAll("\\", "/")
 
   yield* ctx.ask({

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -242,6 +242,27 @@ describe("tool.assertExternalDirectory", () => {
     })
   })
 
+  test("returns the canonical UNC target used for permission metadata", async () => {
+    await withWin32Platform(async () => {
+      const { requests, ctx } = makeCtx()
+
+      await Instance.provide({
+        directory: "D:\\project",
+        fn: async () => {
+          const target = await assertExternalDirectory(ctx, "\\\\?\\UNC\\server\\share\\outside\\file.txt")
+          expect(target).toBe("\\\\server\\share\\outside\\file.txt")
+        },
+      })
+
+      const req = requests.find((r) => r.permission === "external_directory")
+      expect(req).toBeDefined()
+      expect(req!.patterns).toEqual(["\\\\server\\share\\outside\\*"])
+      expect(req!.always).toEqual(["\\\\server\\share\\outside\\*"])
+      expect(req!.metadata.filepath).toBe("\\\\server\\share\\outside\\file.txt")
+      expect(req!.metadata.realpath).toBe("\\\\server\\share\\outside\\file.txt")
+    })
+  })
+
   test("resolves Windows junction traversal before dot-dot normalization", async () => {
     await withWin32Platform(async () => {
       const junction = "C:\\project\\tmp\\link"
@@ -277,6 +298,20 @@ describe("tool.assertExternalDirectory", () => {
       })
 
       expect(resolved).toBe(expected)
+    })
+  })
+
+  test("resolves extended UNC share paths without dropping the share root", async () => {
+    await withWin32Platform(async () => {
+      const resolved = resolveExternalPathForPermission("\\\\?\\UNC\\server\\share\\dir\\file.txt", "D:\\project", {
+        lstat: (_candidate) =>
+          ({
+            isSymbolicLink: () => false,
+          }) as ReturnType<typeof import("fs").lstatSync>,
+        realpath: (candidate) => candidate,
+      })
+
+      expect(resolved).toBe("\\\\server\\share\\dir\\file.txt")
     })
   })
 


### PR DESCRIPTION
## Summary

Cache repeated Windows rooted-but-driveless canonicalization probes and close the remaining UNC validation gap in the external-directory permission path.

Changes included:

- cache successful rooted-but-driveless Windows probe results, with cache invalidation when the cached target disappears or the default Windows root environment changes
- normalize Windows UNC glob patterns with `path.win32` so `\\server\share\...` permission scopes do not collapse to `*`
- add deterministic tests for cache reuse/invalidation, extended UNC path normalization, and UNC permission-glob generation

## Why

Issue #497 left two bounded Windows follow-ups after #493:

1. repeated rooted-but-driveless canonicalization still re-probed drive roots on every hit
2. UNC / extended UNC validation was still incomplete, especially around permission-glob generation

This PR keeps the fix inside that P3 follow-up surface. It does not reopen #427 correctness work, wildcard semantics, or broader path architecture.

## Related Issue

Closes #497.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- whether the rooted-but-driveless cache only changes repeated Windows probe behavior and stays conservative on invalidation
- whether Windows UNC and extended UNC permission paths now preserve the share root all the way through glob generation
- whether the patch stays bounded to Windows-only canonicalization / permission-path logic

## Risk Notes

- Windows-only behavior change in path canonicalization and external-directory permission glob generation
- the cache stores only successful rooted-but-driveless matches; misses and ambiguities still probe live
- no live Windows UNC host was available locally, so UNC validation is deterministic unit coverage rather than an interactive Windows smoke

## How To Verify

```text
Core Windows normalization tests: bun --cwd packages/core test test/filesystem/normalize-path.test.ts -> 9 passed, 7 skipped
Guarded-tool boundary suite: bun --cwd packages/opencode test test/tool/external-directory.test.ts test/tool/read.test.ts test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/tool/glob.test.ts test/tool/grep.test.ts test/tool/lsp.test.ts -> 135 passed
Core typecheck: bun --cwd packages/core typecheck -> exit 0
Opencode typecheck: bun --cwd packages/opencode typecheck -> exit 0
Diff check: git diff --check -> exit 0
Validation recorded in tests: packages/core/test/filesystem/normalize-path.test.ts and packages/opencode/test/tool/external-directory.test.ts
```

## Screenshots or Recordings

None. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling to preserve extended UNC roots and produce correct Windows-style glob patterns; fixed directory canonicalization to retain share roots.

* **Performance**
  * Added/refined caching for Windows path resolution to reduce redundant filesystem probes and refresh correctly when drive context changes.

* **Tests**
  * Expanded Windows-only tests covering UNC/extended paths and caching/refresh behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/582)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->