### PR TITLE
fix(test): align codeql workflow test SHA with 4.35.3 bump

### DIFF
--- a/packages/opencode/test/github/codeql-workflow.test.ts
+++ b/packages/opencode/test/github/codeql-workflow.test.ts
@@ -51,8 +51,8 @@ describe("codeql workflow", () => {
     expect(job?.["timeout-minutes"]).toBe(30)
     expect(steps).toHaveLength(3)
     expect(checkoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
-    expect(initStep?.uses).toBe("github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225")
-    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225")
+    expect(initStep?.uses).toBe("github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7")
+    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7")
 
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(initStep?.with).toEqual({ languages: "javascript-typescript" })


### PR DESCRIPTION
## Summary

Updates the `codeql-workflow` test expectation to match the `github/codeql-action` 4.35.3 SHA pinned by PR #531.

## Why This Change

Dependabot bumped the workflow pin in PR #531, but the matching test fixture still expected the previous 4.35.2 SHA, which leaves `dev` CI red.

## Related Issue

None.

## Human Review Status

Pending.

## Review Focus

- The test now expects the same pinned 4.35.3 SHA used in `.github/workflows/codeql.yml`.
- No files beyond the targeted test fixture changed.

## Risk Notes

- Test-only change.
- Zero runtime or production behavior change.

## How To Verify

```bash
bun --cwd packages/opencode test test/github/codeql-workflow.test.ts
```

Expected: pass.

## Screenshots

None.

## Checklist

- [x] I re-read the issue/PR context and kept the change within the approved scope.
- [x] I did not add any user-facing copy, UI behavior, or schema changes.
- [x] I verified the change with the smallest relevant command.
- [x] I checked for unrelated file churn and excluded it from the patch.
- [x] I kept the diff review-sized and reversible.
- [x] I used the existing repo patterns instead of inventing a new path.
- [x] I did not include Slock-only context in GitHub content.
- [x] I confirmed the PR title follows the repo convention.
- [x] I confirmed the PR body is English.
- [x] I confirmed the change is safe to squash merge.
- [x] I left follow-up work out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for CodeQL workflow step references to use current baseline versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/584)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->