### PR TITLE
fix(windows): tolerate unreachable UNC permission paths

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -55,7 +55,7 @@ function resolveWindowsForPermission(target: string, base: string, fs: Permissio
       if (!stat) throw Object.assign(new Error("missing"), { code: "ENOENT" })
       current = stat.isSymbolicLink() ? fs.realpath(candidate) : candidate
     } catch (error: any) {
-      if (error?.code !== "ENOENT" && error?.code !== "ENOTDIR") throw error
+      if (!isMissingPermissionPath(error, candidate)) throw error
       return AppFileSystem.normalizePath(path.win32.join(current, part, ...parts.slice(i + 1)), { base })
     }
   }
@@ -83,6 +83,13 @@ function windowsPermissionPath(target: string, base: string): string {
     if (root) return uppercaseDriveRoot(root.replace(/[\\/]+$/, "") + input)
   }
   return uppercaseDriveRoot(`${base.replace(/[\\/]+$/, "")}\\${input}`)
+}
+
+function isMissingPermissionPath(error: any, candidate: string): boolean {
+  if (error?.code === "ENOENT" || error?.code === "ENOTDIR") return true
+  // Bun on Windows reports unreachable UNC components as EUNKNOWN; for permission metadata
+  // resolution they are equivalent to a not-yet-existing path under the UNC share.
+  return error?.code === "EUNKNOWN" && error?.syscall === "lstat" && /^\\\\/.test(candidate)
 }
 
 function stripWindowsExtendedPrefix(target: string): string {

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -315,6 +315,29 @@ describe("tool.assertExternalDirectory", () => {
     })
   })
 
+  test("treats unreachable UNC components as missing paths for permission metadata", async () => {
+    await withWin32Platform(async () => {
+      const unreachable = "\\\\server\\share\\outside"
+      const resolved = resolveExternalPathForPermission("\\\\?\\UNC\\server\\share\\outside\\file.txt", "D:\\project", {
+        lstat: (candidate) => {
+          if (candidate.toLowerCase() === unreachable.toLowerCase()) {
+            throw Object.assign(new Error("unknown"), {
+              code: "EUNKNOWN",
+              path: candidate,
+              syscall: "lstat",
+            })
+          }
+          return {
+            isSymbolicLink: () => false,
+          } as ReturnType<typeof import("fs").lstatSync>
+        },
+        realpath: (candidate) => candidate,
+      })
+
+      expect(resolved).toBe("\\\\server\\share\\outside\\file.txt")
+    })
+  })
+
   if (process.platform === "win32") {
     test("normalizes Windows path variants to one glob", async () => {
       const { requests, ctx } = makeCtx()


### PR DESCRIPTION
## Summary

Tolerate unreachable Windows UNC components while resolving external-directory permission metadata.

## Why

PR #582 tightened Windows UNC normalization so UNC inputs now reach the permission resolver more consistently. That exposed a pre-existing gap in `resolveWindowsForPermission()`: Bun on Windows can report an unreachable UNC intermediate component as `EUNKNOWN` from `lstat`, while the resolver only treated `ENOENT` and `ENOTDIR` as missing-path fallback cases.

For permission metadata, an unreachable UNC component should behave like a not-yet-existing path under the UNC share. The resolver should still produce canonical permission metadata instead of throwing before the permission request can be built. This is a follow-up for the gap exposed by PR #582, not a broad revert of the Windows path canonicalization work.

## Related Issue

Refs PR #582. This does not close issue #497; it is a follow-up fix for the Windows advisory regression exposed after #582 merged.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `resolveWindowsForPermission()` now treats only UNC `lstat` `EUNKNOWN` errors as missing-path fallbacks.
- The existing `ENOENT` / `ENOTDIR` behavior is unchanged.
- The new custom-fs regression test covers the Windows-only `EUNKNOWN` path without requiring a live unreachable UNC host on macOS.
- Confirm the fallback does not broaden non-UNC path error handling.

## Risk Notes

Windows-only path/permission behavior. The change is intentionally narrow: only `lstat` `EUNKNOWN` on UNC candidates is folded into the existing missing-path fallback. macOS/Linux behavior is not touched. The Windows advisory workflow must be green before merge.

## How To Verify

```text
Focused external-directory test: bun --cwd packages/opencode test test/tool/external-directory.test.ts -> 14 pass
Targeted tool suite: bun --cwd packages/opencode test test/tool/external-directory.test.ts test/tool/read.test.ts test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/tool/glob.test.ts test/tool/grep.test.ts test/tool/lsp.test.ts -> 136 pass
Opencode typecheck: bun --cwd packages/opencode typecheck -> pass
Diff check: git diff --check -> clean
Windows advisory workflow: required merge blocker; must pass on this PR before merge
```

## Screenshots or Recordings

None. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows network path resolution to properly handle unreachable path components.

* **Tests**
  * Added test coverage for Windows extended network path resolution scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->