### PR TITLE
fix(session): stabilize tool ordering and normalize shell output carriage returns

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -233,6 +233,7 @@ const live: Layer.Layer<
           execute: async () => ({ output: "", title: "", metadata: {} }),
         })
       }
+      const sortedTools = Object.fromEntries(Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b)))
 
       // Wire up toolExecutor for DWS workflow models so that tool calls
       // from the workflow service are executed via opencode's tool system
@@ -246,7 +247,7 @@ const live: Layer.Layer<
         workflowModel.sessionID = input.sessionID
         workflowModel.systemPrompt = system.join("\n")
         workflowModel.toolExecutor = async (toolName, argsJson, _requestID) => {
-          const t = tools[toolName]
+          const t = sortedTools[toolName]
           if (!t || !t.execute) {
             return { result: "", error: `Unknown tool: ${toolName}` }
           }
@@ -268,7 +269,7 @@ const live: Layer.Layer<
         }
 
         const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
-        workflowModel.sessionPreapprovedTools = Object.keys(tools).filter((name) => {
+        workflowModel.sessionPreapprovedTools = Object.keys(sortedTools).filter((name) => {
           const match = ruleset.findLast((rule) => Wildcard.match(name, rule.permission))
           return !match || match.action !== "ask"
         })
@@ -352,7 +353,7 @@ const live: Layer.Layer<
         },
         async experimental_repairToolCall(failed) {
           const lower = failed.toolCall.toolName.toLowerCase()
-          if (lower !== failed.toolCall.toolName && tools[lower]) {
+          if (lower !== failed.toolCall.toolName && sortedTools[lower]) {
             l.info("repairing tool call", {
               tool: failed.toolCall.toolName,
               repaired: lower,
@@ -375,8 +376,8 @@ const live: Layer.Layer<
         topP: params.topP,
         topK: params.topK,
         providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-        activeTools: activeToolNames,
-        tools,
+        activeTools: Object.keys(sortedTools).filter((x) => x !== "invalid"),
+        tools: sortedTools,
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,
         abortSignal: input.abort,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1145,6 +1145,84 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("sends tools in deterministic alphabetical order", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-tool-order")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-tool-order"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            zebra: tool({ description: "zebra", inputSchema: z.object({}), execute: async () => ({ output: "" }) }),
+            alpha: tool({ description: "alpha", inputSchema: z.object({}), execute: async () => ({ output: "" }) }),
+            middle: tool({ description: "middle", inputSchema: z.object({}), execute: async () => ({ output: "" }) }),
+          },
+        })
+
+        const capture = await request
+        const tools = capture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(tools?.map((item) => item.function?.name)).toEqual(["alpha", "middle", "zebra"])
+      },
+    })
+  })
+
   test("sends responses API payload for OpenAI models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -13,7 +13,6 @@ import {
   type JSX,
 } from "solid-js"
 import { createStore } from "solid-js/store"
-import stripAnsi from "strip-ansi"
 import { Dynamic } from "solid-js/web"
 import {
   AssistantMessage,
@@ -55,6 +54,7 @@ import { patchFiles } from "./apply-patch-file"
 import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
+import { normalizeShellOutput } from "../util/shell-output"
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -1925,7 +1925,7 @@ ToolRegistry.register({
     const sawPending = pending()
     const text = createMemo(() => {
       const cmd = props.input.command ?? props.metadata.command ?? ""
-      const out = stripAnsi(props.output || props.metadata.output || "")
+      const out = normalizeShellOutput(props.output || props.metadata.output || "")
       return `$ ${cmd}${out ? "\n\n" + out : ""}`
     })
     const [copied, setCopied] = createSignal(false)

--- a/packages/ui/src/util/shell-output.ts
+++ b/packages/ui/src/util/shell-output.ts
@@ -1,0 +1,5 @@
+import stripAnsi from "strip-ansi"
+
+export function normalizeShellOutput(output: string) {
+  return stripAnsi(output).replace(/\r\n?/g, "\n")
+}

--- a/packages/ui/test/components/message-part-rename.test.ts
+++ b/packages/ui/test/components/message-part-rename.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { ToolPart } from "@opencode-ai/sdk/v2"
 import { buildToolInfo, enterWorktreeSubtitle, exitWorktreeSubtitle } from "../../src/components/tool-info"
 import type { UiI18n } from "../../src/context/i18n"
+import { normalizeShellOutput } from "../../src/util/shell-output"
 
 const baseFields = {
   id: "part-1",
@@ -54,5 +55,11 @@ describe("worktree tool subtitles", () => {
     expect(exitWorktreeSubtitle({ activeDirectory: "/repo/pawwork", previousSlug: "feature-a" }, templateI18n)).toBe(
       'ui.tool.worktree.exit.fromWorktree:{"previous":"feature-a","project":"pawwork"}',
     )
+  })
+})
+
+describe("shell output normalization", () => {
+  test("strips ansi and normalizes carriage returns to newlines", () => {
+    expect(normalizeShellOutput("\u001b[32mline1\r\nline2\rline3\u001b[0m")).toBe("line1\nline2\nline3")
   })
 })


### PR DESCRIPTION
## Summary

Pull in two narrow upstream stability fixes as one batch:
- stabilize session tool ordering before sending tool definitions to the model and workflow adapter
- normalize shell output carriage returns before rendering and copying bash output in the UI

## Why

PawWork still differed from upstream in two small but user-visible stability paths:
- tool definitions were passed through in object insertion order, which can vary and produce non-deterministic ordering in session requests
- shell output could preserve raw `\r` / `\r\n` line endings, which made terminal output rendering and copy text inconsistent across environments

These two fixes are independent in code surface but cohesive as a small upstream stability batch.

## Related Issue

Refs #512 (tracker only; this PR should not close it).
Refs anomalyco/opencode#26370, anomalyco/opencode#26426.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

1. `packages/opencode/src/session/llm.ts`: deterministic tool ordering is applied consistently across workflow tool lookup, preapproved tool names, repaired tool calls, and streamed tool definitions
2. `packages/ui/src/components/message-part.tsx`: bash output normalization only changes carriage-return handling, not other rendering behavior
3. focused proofs: one session request-order test and one UI shell-output normalization test

## Risk Notes

Low to moderate risk, scoped to session/tool routing and shell-output presentation only:
- the session change affects tool ordering but not tool availability or permission rules
- the UI change only normalizes `\r` / `\r\n` to `\n` after ANSI stripping for bash output
- no schema, persistence, or platform packaging behavior changed

## How To Verify

```text
bun --cwd packages/opencode test test/session/llm.test.ts -t 'sends tools in deterministic alphabetical order'
Result: pass

bun --cwd packages/ui test test/components/message-part-rename.test.ts -t 'strips ansi and normalizes carriage returns to newlines'
Result: pass

bun --cwd packages/opencode typecheck
Result: pass

bun --cwd packages/ui typecheck
Result: pass

git diff --check
Result: clean
```

## Screenshots or Recordings

None. No visible layout or interaction changes beyond shell line-ending normalization.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell command output now properly removes ANSI escape codes and normalizes line endings for consistent display across platforms.
  * Tool execution now follows deterministic alphabetical ordering.

* **Tests**
  * Added test coverage for shell output normalization and tool ordering behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/587)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->