### PR TITLE
test(desktop): avoid all-platform install in embedded build test

### DIFF
--- a/packages/desktop-electron/src/main/embedded-server-build.test.ts
+++ b/packages/desktop-electron/src/main/embedded-server-build.test.ts
@@ -2,8 +2,11 @@ import { expect, test } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
 import { withEmbeddedServerArtifactLock } from "../../../opencode/test/shared/embedded-server-artifact-lock"
+import { tmpdir } from "../../../opencode/test/fixture/fixture"
+import { expectModelsSnapshotUnchanged, writeCurrentModelsFixture } from "../../../opencode/test/server/models-snapshot-fixture"
 
 const root = path.join(import.meta.dir, "../..")
+const opencodeRoot = path.resolve(root, "../opencode")
 const runtimeDir = path.resolve(root, "../opencode/dist/node")
 const outDir = path.join(root, "out")
 const outChunksDir = path.join(outDir, "main", "chunks")
@@ -14,13 +17,19 @@ const requiredWasmMatchers = [
   (file: string) => /^tree-sitter-powershell-.+\.wasm$/.test(file),
 ]
 
-function run(cmd: string[]) {
+function run(
+  cmd: string[],
+  options?: {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+  },
+) {
   const result = Bun.spawnSync({
     cmd,
-    cwd: root,
+    cwd: options?.cwd ?? root,
     stdout: "pipe",
     stderr: "pipe",
-    env: process.env,
+    env: { ...process.env, ...options?.env },
   })
 
   if (result.exitCode !== 0) {
@@ -36,10 +45,16 @@ function run(cmd: string[]) {
 
 test("electron-vite build copies required embedded server wasm sidecars into out/main/chunks", () => {
   return withEmbeddedServerArtifactLock(async () => {
+    await using tmp = await tmpdir()
+    const modelsFixture = writeCurrentModelsFixture(opencodeRoot, tmp.path)
+
     fs.rmSync(runtimeDir, { recursive: true, force: true })
     fs.rmSync(outDir, { recursive: true, force: true })
 
-    run([process.execPath, "./scripts/prepare-embedded-server.ts"])
+    run([process.execPath, "run", "build:embedded-server"], {
+      cwd: opencodeRoot,
+      env: { MODELS_DEV_API_JSON: modelsFixture.fixture },
+    })
     run([electronViteBin, "build"])
 
     const files = fs.readdirSync(outChunksDir)
@@ -47,5 +62,7 @@ test("electron-vite build copies required embedded server wasm sidecars into out
     for (const matches of requiredWasmMatchers) {
       expect(files.some((file) => matches(file))).toBe(true)
     }
+
+    expectModelsSnapshotUnchanged(modelsFixture)
   })
 }, 120_000)


### PR DESCRIPTION
## Summary

Narrow the desktop embedded-server build test so it only runs the work the assertion actually needs:
- build the embedded server directly from `packages/opencode`
- stop running the broader `prepare-embedded-server.ts` setup path inside this test
- pin the models snapshot during the build step so the test does not leave generated source drift behind

## Why

The test setup does unnecessary all-platform install work that can push Windows advisory runtime into timeout territory. This is a preventive optimization; recent CI runs do not show this exact timeout as the dominant failure mode.

For this specific test, we only need the embedded server runtime artifacts before `electron-vite build` copies the wasm sidecars into `out/main/chunks`. Pulling in the broader setup script adds extra work that is useful for packaging paths, but not for this assertion.

## Related Issue

None. This is a preventive Windows advisory test-setup optimization, not a user-facing bug fix or a dedicated GitHub issue.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

1. `packages/desktop-electron/src/main/embedded-server-build.test.ts`: the test now builds only the embedded server artifacts it needs, without changing packaging or prebuild scripts
2. the test still proves the same contract: `electron-vite build` copies the required wasm sidecars into `out/main/chunks`
3. the models snapshot fixture keeps the focused build from introducing generated source drift during test execution

## Risk Notes

Low risk, scoped to one desktop test only:
- no product behavior, packaging script, or release build path changed
- no timeout was increased or CI rule relaxed
- this test no longer exercises `prepare-embedded-server.ts`; the broader install path is intentionally uncovered by this specific test
- the changed test still exercises the same `electron-vite build` copy behavior after the embedded server build step

## How To Verify

```text
bun --cwd packages/desktop-electron test src/main/embedded-server-build.test.ts
Result: pass (1 test, 0 fail)

cd packages/desktop-electron && bun run typecheck
Result: pass

git diff --check
Result: clean
```

## Screenshots or Recordings

None. Test-only change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
