### PR TITLE
chore(release): bump version to v2026.5.13

### DIFF
--- a/packages/app/e2e/release-notes/release-notes-toast.spec.ts
+++ b/packages/app/e2e/release-notes/release-notes-toast.spec.ts
@@ -6,7 +6,7 @@ const LANGUAGE_KEY = "pawwork.global.dat:language"
 
 const SINGLE_RELEASE_PAYLOAD = [
   {
-    tag_name: "v2026.5.12",
+    tag_name: "v2026.5.13",
     body: [
       "## App Update Notice",
       "",
@@ -20,7 +20,7 @@ const SINGLE_RELEASE_PAYLOAD = [
 
 const MULTI_VERSION_PAYLOAD = [
   {
-    tag_name: "v2026.5.12",
+    tag_name: "v2026.5.13",
     body: "## App Update Notice\n\n- Newest highlight A\n- Newest highlight B\n",
   },
   {
@@ -31,7 +31,7 @@ const MULTI_VERSION_PAYLOAD = [
 
 const LOCALIZED_PAYLOAD = [
   {
-    tag_name: "v2026.5.12",
+    tag_name: "v2026.5.13",
     body: [
       "## App Update Notice",
       "",
@@ -72,7 +72,7 @@ test.describe("release notes toast", () => {
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.13")
     // Content is now rendered as HTML in the toast-markdown slot
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("Important refresh for this release.")
     await expect(page.locator(`${TOAST_MARKDOWN_SELECTOR} li`)).toContainText(["Added subtle toast variant", "Replaced release notes dialog"])
@@ -106,7 +106,7 @@ test.describe("release notes toast", () => {
           return raw ? (JSON.parse(raw)?.version ?? null) : null
         }, HIGHLIGHTS_KEY),
       )
-      .toBe("2026.5.12")
+      .toBe("2026.5.13")
   })
 
   test("clicking the action opens the release URL and marks the current version as seen", async ({
@@ -145,7 +145,7 @@ test.describe("release notes toast", () => {
       .poll(() =>
         page.evaluate(() => (window as unknown as { __OPENED_LINKS: string[] }).__OPENED_LINKS),
       )
-      .toContain("https://github.com/Astro-Han/pawwork/releases/tag/v2026.5.12")
+      .toContain("https://github.com/Astro-Han/pawwork/releases/tag/v2026.5.13")
 
     await expect
       .poll(() =>
@@ -154,7 +154,7 @@ test.describe("release notes toast", () => {
           return raw ? (JSON.parse(raw)?.version ?? null) : null
         }, HIGHLIGHTS_KEY),
       )
-      .toBe("2026.5.12")
+      .toBe("2026.5.13")
   })
 
   test("pressing Escape marks the current version as seen", async ({ page, gotoSession }) => {
@@ -189,7 +189,7 @@ test.describe("release notes toast", () => {
           return raw ? (JSON.parse(raw)?.version ?? null) : null
         }, HIGHLIGHTS_KEY),
       )
-      .toBe("2026.5.12")
+      .toBe("2026.5.13")
   })
 
   test("releaseNotes=false suppresses the toast", async ({ page, gotoSession }) => {
@@ -225,7 +225,7 @@ test.describe("release notes toast", () => {
           return raw ? (JSON.parse(raw)?.version ?? null) : null
         }, HIGHLIGHTS_KEY),
       )
-      .toBe("2026.5.12")
+      .toBe("2026.5.13")
     await expect(page.locator(TOAST_SELECTOR)).toHaveCount(0)
   })
 
@@ -245,7 +245,7 @@ test.describe("release notes toast", () => {
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.13")
     const markdown = page.locator(TOAST_MARKDOWN_SELECTOR)
     await expect(markdown).toContainText("Newest highlight A")
     await expect(markdown).toContainText("Newest highlight B")
@@ -266,7 +266,7 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.12",
+            tag_name: "v2026.5.13",
             body: "## App Update Notice\n\n- English fallback bullet\n",
           },
         ]),
@@ -282,7 +282,7 @@ test.describe("release notes toast", () => {
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
     // Title and action must follow the parsed body's locale (en) — never mix with zh UI locale.
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.13")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("English fallback bullet")
   })
@@ -304,7 +304,7 @@ test.describe("release notes toast", () => {
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("已更新到 v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("已更新到 v2026.5.13")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("查看完整发布说明 →")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("中文要点 A")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("中文要点 B")
@@ -320,7 +320,7 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.12",
+            tag_name: "v2026.5.13",
             // newest release: zh-only notice, no English App Update Notice
             body: ["## 中文版本", "", "### 主要更新", "", "- 仅中文要点"].join("\n"),
           },
@@ -341,16 +341,16 @@ test.describe("release notes toast", () => {
     await gotoSession()
 
     await expect(page.locator(TOAST_SELECTOR)).toBeVisible({ timeout: 10_000 })
-    // First-pass zh resolves to mixed (v2026.5.12 zh + v2026.5.10 en fallback),
+    // First-pass zh resolves to mixed (v2026.5.13 zh + v2026.5.10 en fallback),
     // so we re-resolve the whole window in English. The English window does
-    // not contain v2026.5.12 (no App Update Notice there), but the title and
+    // not contain v2026.5.13 (no App Update Notice there), but the title and
     // link must still anchor on the app's current version, not summaries[0].
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.13")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     // Markdown slot's first segment must carry the v2026.5.10 tag, otherwise
     // the older release's bullet would read as if it described the current
-    // version (the title says v2026.5.12 but summaries[0] here is v2026.5.10
-    // because the English fallback dropped v2026.5.12).
+    // version (the title says v2026.5.13 but summaries[0] here is v2026.5.10
+    // because the English fallback dropped v2026.5.13).
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("v2026.5.10")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("older en-only bullet")
   })
@@ -365,7 +365,7 @@ test.describe("release notes toast", () => {
         contentType: "application/json",
         body: JSON.stringify([
           {
-            tag_name: "v2026.5.12",
+            tag_name: "v2026.5.13",
             body: [
               "## App Update Notice",
               "",
@@ -397,7 +397,7 @@ test.describe("release notes toast", () => {
     // The newest release has a zh section but the older skipped release does
     // not. Spec #486 forbids mixing languages, so the entire toast — title,
     // action, and every segment — must be English.
-    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.12")
+    await expect(page.locator(TOAST_TITLE_SELECTOR)).toHaveText("Updated to v2026.5.13")
     await expect(page.locator(TOAST_ACTION_SELECTOR)).toHaveText("Full release notes →")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("newest en bullet")
     await expect(page.locator(TOAST_MARKDOWN_SELECTOR)).toContainText("older en only")

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "2026.5.12",
+  "version": "2026.5.13",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.12",
+  "version": "2026.5.13",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "2026.5.12",
+  "version": "2026.5.13",
   "name": "opencode",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "2026.5.12",
+  "version": "2026.5.13",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump release-facing version references from `2026.5.12` to `2026.5.13` in the four package manifests and the release-notes toast e2e fixture.

## Why

`v2026.5.13` cannot be cut while release-facing version fields still say `2026.5.12`:
- `electron-builder` would emit `2026.5.12` asset names
- `verify-release.ts` would expect `2026.5.13` from the tag

## Related Issue

None. This is the minimal release-prep bump required before cutting `v2026.5.13`.

## Human Review Status

Pending. Lead pre-approved this as a trivial release chore once required checks pass.

## Review Focus

1. the four package versions now match `2026.5.13`
2. the release-notes toast fixture now anchors on `v2026.5.13`
3. the diff stays within the same five-file scope as the previous release bump

## Risk Notes

Low risk, release-critical metadata only. No runtime logic changed.

## How To Verify

```text
git diff --check
Result: clean

Compared with the previous bump commit v2026.5.11 -> v2026.5.12
Result: same five-file scope
```

## Screenshots or Recordings

None. No visible behavior change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to v2026.5.13 across all packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->