### PR TITLE
fix(app): full reload risky ui hmr edits

### DIFF
--- a/packages/app/vite.hmr.js
+++ b/packages/app/vite.hmr.js
@@ -1,3 +1,6 @@
+// Current workspace UI fanout is clustered around modules like icon (39 app
+// imports), button (34), and toast (31), so 30 catches the known risky tier
+// without disabling normal HMR for smaller leaf modules.
 export const UI_HMR_FULL_RELOAD_THRESHOLD = 30
 
 function normalizePath(file) {

--- a/packages/app/vite.hmr.js
+++ b/packages/app/vite.hmr.js
@@ -1,0 +1,34 @@
+export const UI_HMR_FULL_RELOAD_THRESHOLD = 30
+
+function normalizePath(file) {
+  return file.replace(/\\/g, "/")
+}
+
+export function isUiSourceFile(file) {
+  return normalizePath(file).includes("/packages/ui/src/")
+}
+
+export function countUniqueImporters(modules) {
+  const queue = [...modules]
+  const visitedModules = new Set()
+  const importers = new Set()
+
+  while (queue.length > 0) {
+    const current = queue.pop()
+    if (!current || visitedModules.has(current)) continue
+    visitedModules.add(current)
+
+    for (const importer of current.importers ?? []) {
+      if (!importer) continue
+      importers.add(importer)
+      queue.push(importer)
+    }
+  }
+
+  return importers.size
+}
+
+export function shouldForceFullReloadForUiHmr(input) {
+  if (!isUiSourceFile(input.file)) return false
+  return countUniqueImporters(input.modules) >= (input.threshold ?? UI_HMR_FULL_RELOAD_THRESHOLD)
+}

--- a/packages/app/vite.hmr.test.ts
+++ b/packages/app/vite.hmr.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { countUniqueImporters, isUiSourceFile, shouldForceFullReloadForUiHmr } from "./vite.hmr.js"
+
+function module(importers: any[] = []) {
+  return { importers: new Set(importers) }
+}
+
+describe("vite ui hmr guard", () => {
+  test("only targets packages/ui source files", () => {
+    expect(isUiSourceFile("/repo/packages/ui/src/components/icon.tsx")).toBe(true)
+    expect(isUiSourceFile("C:\\repo\\packages\\ui\\src\\components\\icon.tsx")).toBe(true)
+    expect(isUiSourceFile("/repo/packages/app/src/app.tsx")).toBe(false)
+  })
+
+  test("counts unique importers across a transitive graph", () => {
+    const leaf = module()
+    const a = module()
+    const b = module()
+    const c = module()
+    leaf.importers = new Set([a, b])
+    a.importers = new Set([c])
+    b.importers = new Set([c])
+
+    expect(countUniqueImporters([leaf])).toBe(3)
+  })
+
+  test("forces a full reload for high-fanout ui modules", () => {
+    const leaf = module()
+    const importers = Array.from({ length: 31 }, () => module())
+    leaf.importers = new Set(importers)
+
+    expect(
+      shouldForceFullReloadForUiHmr({
+        file: "/repo/packages/ui/src/components/icon.tsx",
+        modules: [leaf],
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps normal hmr for low-fanout ui modules", () => {
+    const leaf = module()
+    leaf.importers = new Set(Array.from({ length: 4 }, () => module()))
+
+    expect(
+      shouldForceFullReloadForUiHmr({
+        file: "/repo/packages/ui/src/components/button.tsx",
+        modules: [leaf],
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs"
 import solidPlugin from "vite-plugin-solid"
 import tailwindcss from "@tailwindcss/vite"
 import { fileURLToPath } from "url"
+import { shouldForceFullReloadForUiHmr } from "./vite.hmr.js"
 
 const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.url))
 
@@ -31,6 +32,19 @@ export default [
         '<script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>',
         `<script id="oc-theme-preload-script">${readFileSync(theme, "utf8")}</script>`,
       )
+    },
+  },
+  {
+    name: "opencode-desktop:ui-hmr-guard",
+    handleHotUpdate(ctx) {
+      if (!shouldForceFullReloadForUiHmr({ file: ctx.file, modules: ctx.modules })) return
+      // TODO: remove this workaround after Solid/Vite fixes the upstream
+      // context/HMR edge cases tracked in
+      // https://github.com/solidjs/vite-plugin-solid/issues/80 and
+      // https://github.com/solidjs/vite-plugin-solid/issues/106.
+      ctx.server.config.logger.info(`[hmr] full reload after high-fanout ui edit: ${ctx.file}`)
+      ctx.server.ws.send({ type: "full-reload", path: "*" })
+      return []
     },
   },
   tailwindcss(),

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -38,8 +38,8 @@ export default [
     name: "opencode-desktop:ui-hmr-guard",
     handleHotUpdate(ctx) {
       if (!shouldForceFullReloadForUiHmr({ file: ctx.file, modules: ctx.modules })) return
-      // TODO: remove this workaround after Solid/Vite fixes the upstream
-      // context/HMR edge cases tracked in
+      // TODO: remove this workaround after Solid/Vite fixes the related
+      // upstream context/HMR edge cases discussed in
       // https://github.com/solidjs/vite-plugin-solid/issues/80 and
       // https://github.com/solidjs/vite-plugin-solid/issues/106.
       ctx.server.config.logger.info(`[hmr] full reload after high-fanout ui edit: ${ctx.file}`)


### PR DESCRIPTION
## Summary

Add a narrow Vite dev-only guard in `packages/app` so high-fanout hot updates from `packages/ui/src/*` trigger a full reload instead of letting Solid HMR keep a broken provider tree alive:
- detect workspace UI source edits that fan out across many importer modules
- force a full reload for those specific updates inside desktop dev
- cover the guard logic with focused unit tests for path matching, importer counting, and threshold behavior

## Why

The root cause is not in PawWork's providers themselves. The failure mode is an upstream Solid/Vite HMR edge case: after a large hot update to a high-fanout workspace UI module, the app can keep rendering with a stale provider graph and throw errors such as `Layout context must be used within a context provider`.

This PR does not fix that upstream HMR bug. It adds a PawWork-side workaround: when a `packages/ui/src/*` edit fans out broadly enough to hit that risky path, desktop dev stops trying to apply HMR and falls back to a full reload instead.

The linked upstream issues are related evidence, not a claim that either issue is this exact repro:
- `solidjs/vite-plugin-solid#80` shows a real provider/context breakage across a library boundary in dev
- `solidjs/vite-plugin-solid#106` shows another case where Solid/Vite HMR corruption was avoided by falling back to a full reload

## Related Issue

Closes #189.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

1. `packages/app/vite.js`: the new dev-only plugin forces a full reload instead of HMR for risky workspace UI updates
2. `packages/app/vite.hmr.js`: the guard stays narrow by checking both source path and importer fanout before switching away from HMR
3. `packages/app/vite.hmr.test.ts`: the workaround logic is covered without changing production code paths or app runtime behavior

## Risk Notes

This is a workaround, not a root fix:
- production behavior is unchanged; only desktop dev HMR behavior is touched
- some high-fanout edits under `packages/ui/src/*` will now do a full reload instead of preserving in-place HMR state
- that trade-off costs some dev speed, but it is better than leaving the app in a broken state with missing context providers
- the threshold stays narrow so ordinary low-fanout UI edits keep normal HMR
- the current threshold is 30 because the known high-fanout UI tier in `packages/app` starts around `icon` (39 imports), `button` (34), and `toast` (31); if false positives show up in day-to-day dev, this threshold should be retuned empirically
- this guard should be removed once Solid/Vite fixes the upstream context/HMR issue or after we upgrade to a version that makes this workaround unnecessary

## How To Verify

```text
cd packages/app && bun test ./vite.hmr.test.ts
Result: pass (4 tests, 0 fail)

cd packages/app && bun run typecheck
Result: pass

git diff --check
Result: clean
```

## Screenshots or Recordings

None. Dev-only HMR workaround.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hot module replacement logic to optimize reload behavior during development.

* **Tests**
  * Added comprehensive test coverage for HMR functionality.

* **Chores**
  * Updated build tooling configuration to support improved development experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/593)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->