### PR TITLE
refactor(app): preindex session turn messages

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -350,16 +350,16 @@ export function MessageTimeline(props: {
   // hide the action rather than ship a misleading export.
   const exportAvailable = createMemo(() => !!platform.exportSession && server.current?.type === "sidecar")
 
-  const rendered = createMemo(() => props.renderedUserMessages)
+  const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
   const visibleRange = createMemo(() => {
-    const messages = rendered()
-    const first = messages[0]?.id
-    const last = messages.at(-1)?.id
+    const ids = rendered()
+    const first = ids[0]
+    const last = ids.at(-1)
     return {
-      rendered_count: messages.length,
+      rendered_count: ids.length,
       visible_first_message_id: first,
       visible_last_message_id: last,
-      signature: `${messages.length}:${first ?? ""}:${last ?? ""}`,
+      signature: `${ids.length}:${first ?? ""}:${last ?? ""}`,
     }
   })
   const visibleRangeData = () => {
@@ -1106,8 +1106,8 @@ export function MessageTimeline(props: {
                 </div>
               </Show>
               <For each={rendered()}>
-                {(userMessage) => {
-                  const messageID = userMessage.id
+                {(messageID, index) => {
+                  const userMessage = createMemo(() => props.renderedUserMessages[index()])
                   const active = createMemo(() => activeMessageID() === messageID)
                   const comments = createMemo(() => messageComments(sync.data.part[messageID] ?? []), [], {
                     equals: (a, b) =>
@@ -1177,7 +1177,7 @@ export function MessageTimeline(props: {
                       <SessionTurn
                         sessionID={sessionID() ?? ""}
                         messageID={messageID}
-                        message={userMessage}
+                        message={userMessage()}
                         assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
                         messages={sessionMessages()}
                         actions={props.actions}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -350,16 +350,16 @@ export function MessageTimeline(props: {
   // hide the action rather than ship a misleading export.
   const exportAvailable = createMemo(() => !!platform.exportSession && server.current?.type === "sidecar")
 
-  const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
+  const rendered = createMemo(() => props.renderedUserMessages)
   const visibleRange = createMemo(() => {
-    const ids = rendered()
-    const first = ids[0]
-    const last = ids.at(-1)
+    const messages = rendered()
+    const first = messages[0]?.id
+    const last = messages.at(-1)?.id
     return {
-      rendered_count: ids.length,
+      rendered_count: messages.length,
       visible_first_message_id: first,
       visible_last_message_id: last,
-      signature: `${ids.length}:${first ?? ""}:${last ?? ""}`,
+      signature: `${messages.length}:${first ?? ""}:${last ?? ""}`,
     }
   })
   const visibleRangeData = () => {
@@ -373,9 +373,6 @@ export function MessageTimeline(props: {
   const sessionKey = createMemo(() => props.sessionKey)
   const sessionID = createMemo(() => props.sessionID)
   const sessionMessages = createMemo(() => props.sessionMessages)
-  const renderedUserMessageByID = createMemo(
-    () => new Map(props.renderedUserMessages.map((message) => [message.id, message] as const)),
-  )
   const turnMessagesByUserID = createMemo(() => buildTurnMessagesByUserID(sessionMessages()))
   const webSearchToastSurfaced = new Set<string>()
   const webSearchPartCursor = new Map<string, number>()
@@ -1109,9 +1106,9 @@ export function MessageTimeline(props: {
                 </div>
               </Show>
               <For each={rendered()}>
-                {(messageID) => {
+                {(userMessage) => {
+                  const messageID = userMessage.id
                   const active = createMemo(() => activeMessageID() === messageID)
-                  const userMessage = createMemo(() => renderedUserMessageByID().get(messageID))
                   const comments = createMemo(() => messageComments(sync.data.part[messageID] ?? []), [], {
                     equals: (a, b) =>
                       a.length === b.length &&
@@ -1180,7 +1177,7 @@ export function MessageTimeline(props: {
                       <SessionTurn
                         sessionID={sessionID() ?? ""}
                         messageID={messageID}
-                        message={userMessage()}
+                        message={userMessage}
                         assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
                         messages={sessionMessages()}
                         actions={props.actions}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -25,6 +25,7 @@ import {
   type TimelineScrollObservation,
 } from "@/pages/session/session-timeline-scroll-controller"
 import { taskDescription } from "@/pages/session/task-description"
+import { buildTurnMessagesByUserID, emptyAssistantMessages } from "@/pages/session/session-messages"
 import {
   turnFetchSignature,
   turnFetchTargets,
@@ -372,6 +373,10 @@ export function MessageTimeline(props: {
   const sessionKey = createMemo(() => props.sessionKey)
   const sessionID = createMemo(() => props.sessionID)
   const sessionMessages = createMemo(() => props.sessionMessages)
+  const renderedUserMessageByID = createMemo(
+    () => new Map(props.renderedUserMessages.map((message) => [message.id, message] as const)),
+  )
+  const turnMessagesByUserID = createMemo(() => buildTurnMessagesByUserID(sessionMessages()))
   const webSearchToastSurfaced = new Set<string>()
   const webSearchPartCursor = new Map<string, number>()
   const webSearchPendingParts = new Map<string, Set<string>>()
@@ -1106,6 +1111,7 @@ export function MessageTimeline(props: {
               <For each={rendered()}>
                 {(messageID) => {
                   const active = createMemo(() => activeMessageID() === messageID)
+                  const userMessage = createMemo(() => renderedUserMessageByID().get(messageID))
                   const comments = createMemo(() => messageComments(sync.data.part[messageID] ?? []), [], {
                     equals: (a, b) =>
                       a.length === b.length &&
@@ -1174,6 +1180,8 @@ export function MessageTimeline(props: {
                       <SessionTurn
                         sessionID={sessionID() ?? ""}
                         messageID={messageID}
+                        message={userMessage()}
+                        assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
                         messages={sessionMessages()}
                         actions={props.actions}
                         active={active()}

--- a/packages/app/src/pages/session/session-messages.test.ts
+++ b/packages/app/src/pages/session/session-messages.test.ts
@@ -68,9 +68,9 @@ describe("session turn message indexing", () => {
     expect(byUserID.has("missing_user")).toBe(false)
   })
 
-  test("returns stable empty assistant lists for users without assistant messages", () => {
+  test("does not allocate per-user empty assistant lists", () => {
     const byUserID = buildTurnMessagesByUserID([message("user_1", "user")])
 
-    expect(byUserID.get("user_1")).toHaveLength(0)
+    expect(byUserID.has("user_1")).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/session-messages.test.ts
+++ b/packages/app/src/pages/session/session-messages.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { readSessionMessages, readUserMessages } from "./session-messages"
+import { buildTurnMessagesByUserID, readSessionMessages, readUserMessages } from "./session-messages"
 
-const message = (id: string, role: Message["role"]): Message =>
+const message = (id: string, role: Message["role"], parentID?: string): Message =>
   ({
     id,
     sessionID: "ses_1",
     role,
+    parentID,
     time: { created: 1 },
   }) as Message
 
@@ -44,5 +45,32 @@ describe("session message readers", () => {
     const loaded = [null, {}, message("msg_1", "assistant"), message("msg_2", "user")]
 
     expect(readUserMessages(loaded).map((item) => item.id)).toEqual(["msg_2"])
+  })
+})
+
+describe("session turn message indexing", () => {
+  test("groups assistant messages by parent user while preserving current turn scan semantics", () => {
+    const loaded = [
+      message("early_assistant", "assistant", "user_1"),
+      message("user_1", "user"),
+      message("assistant_1", "assistant", "user_1"),
+      message("user_2", "user"),
+      message("assistant_2", "assistant", "user_1"),
+      message("assistant_3", "assistant", "user_2"),
+      message("orphan_assistant", "assistant"),
+      message("unknown_parent", "assistant", "missing_user"),
+    ]
+
+    const byUserID = buildTurnMessagesByUserID(loaded)
+
+    expect(byUserID.get("user_1")?.map((item) => item.id)).toEqual(["assistant_1", "assistant_2"])
+    expect(byUserID.get("user_2")?.map((item) => item.id)).toEqual(["assistant_3"])
+    expect(byUserID.has("missing_user")).toBe(false)
+  })
+
+  test("returns stable empty assistant lists for users without assistant messages", () => {
+    const byUserID = buildTurnMessagesByUserID([message("user_1", "user")])
+
+    expect(byUserID.get("user_1")).toHaveLength(0)
   })
 })

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -1,7 +1,8 @@
-import type { Message, UserMessage } from "@opencode-ai/sdk/v2/client"
+import type { AssistantMessage, Message, UserMessage } from "@opencode-ai/sdk/v2/client"
 
 export const emptyMessages = Object.freeze([]) as unknown as Message[]
 export const emptyUserMessages = Object.freeze([]) as unknown as UserMessage[]
+export const emptyAssistantMessages = Object.freeze([]) as unknown as AssistantMessage[]
 
 export function readSessionMessages(value: unknown): Message[] {
   return Array.isArray(value) ? (value as Message[]) : emptyMessages
@@ -11,8 +12,31 @@ function isUserMessage(value: unknown): value is UserMessage {
   return !!value && typeof value === "object" && "role" in value && value.role === "user"
 }
 
+function isAssistantMessage(value: unknown): value is AssistantMessage {
+  return !!value && typeof value === "object" && "role" in value && value.role === "assistant"
+}
+
 export function readUserMessages(messages: unknown): UserMessage[] {
   if (!Array.isArray(messages)) return emptyUserMessages
   const users = messages.filter(isUserMessage)
   return users.length > 0 ? users : emptyUserMessages
+}
+
+export function buildTurnMessagesByUserID(messages: readonly Message[]) {
+  const result = new Map<string, AssistantMessage[]>()
+  const seenUsers = new Set<string>()
+
+  for (const message of messages) {
+    if (isUserMessage(message)) {
+      seenUsers.add(message.id)
+      if (!result.has(message.id)) result.set(message.id, [])
+      continue
+    }
+
+    if (!isAssistantMessage(message) || !message.parentID || !seenUsers.has(message.parentID)) continue
+    const assistants = result.get(message.parentID)
+    if (assistants) assistants.push(message)
+  }
+
+  return result
 }

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -24,16 +24,14 @@ export function readUserMessages(messages: unknown): UserMessage[] {
 
 export function buildTurnMessagesByUserID(messages: readonly Message[]) {
   const result = new Map<string, AssistantMessage[]>()
-  const seenUsers = new Set<string>()
 
   for (const message of messages) {
     if (isUserMessage(message)) {
-      seenUsers.add(message.id)
       if (!result.has(message.id)) result.set(message.id, [])
       continue
     }
 
-    if (!isAssistantMessage(message) || !message.parentID || !seenUsers.has(message.parentID)) continue
+    if (!isAssistantMessage(message) || !message.parentID) continue
     const assistants = result.get(message.parentID)
     if (assistants) assistants.push(message)
   }

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -24,16 +24,21 @@ export function readUserMessages(messages: unknown): UserMessage[] {
 
 export function buildTurnMessagesByUserID(messages: readonly Message[]) {
   const result = new Map<string, AssistantMessage[]>()
+  const seenUserIDs = new Set<string>()
 
   for (const message of messages) {
     if (isUserMessage(message)) {
-      if (!result.has(message.id)) result.set(message.id, [])
+      seenUserIDs.add(message.id)
       continue
     }
 
-    if (!isAssistantMessage(message) || !message.parentID) continue
-    const assistants = result.get(message.parentID)
-    if (assistants) assistants.push(message)
+    if (!isAssistantMessage(message) || !message.parentID || !seenUserIDs.has(message.parentID)) continue
+    let assistants = result.get(message.parentID)
+    if (!assistants) {
+      assistants = []
+      result.set(message.parentID, assistants)
+    }
+    assistants.push(message)
   }
 
   return result

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -3,6 +3,7 @@ import {
   type SnapshotFileDiff,
   Message as MessageType,
   Part as PartType,
+  UserMessage,
 } from "@opencode-ai/sdk/v2/client"
 import type { SessionStatus } from "@opencode-ai/sdk/v2"
 import { useData } from "../context"
@@ -156,6 +157,8 @@ export function SessionTurn(
   props: ParentProps<{
     sessionID: string
     messageID: string
+    message?: UserMessage
+    assistantMessages?: AssistantMessage[]
     messages?: MessageType[]
     actions?: UserActions
     showReasoningSummaries?: boolean
@@ -211,6 +214,7 @@ export function SessionTurn(
   })
 
   const message = createMemo(() => {
+    if (props.message?.id === props.messageID) return props.message
     const index = messageIndex()
     if (index < 0) return undefined
 
@@ -286,6 +290,7 @@ export function SessionTurn(
 
   const assistantMessages = createMemo(
     () => {
+      if (props.assistantMessages !== undefined) return props.assistantMessages
       const msg = message()
       if (!msg) return emptyAssistant
 


### PR DESCRIPTION
## Summary

- Add `buildTurnMessagesByUserID` to preindex assistant messages by parent user turn.
- Pass precomputed `message` / `assistantMessages` into `SessionTurn` while keeping the existing fallback path.
- Keep rendered turn reuse keyed by message ID, and avoid per-user empty assistant arrays for no-reply turns.

## Why

This is an Area A prep refactor, not a proven performance win. It moves one repeated Session Timeline derivation out of each `SessionTurn` so the data flow is easier to reason about before Area A visual work.

PR0.4 low-end perf remains the gate signal. The current `session-timeline-recompute` fixture is mostly a static 36 user-turn scroll/recompute scenario, so it does not strongly prove assistant-heavy or streaming benefits from this change.

## Related Issue

Refs #601

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Assistant ownership semantics: grouped by `parentID`, allowed after later user turns, ignored before the parent user is seen.
- No-reply user turns use the shared `emptyAssistantMessages` fallback instead of dedicated empty arrays.
- `MessageTimeline` stays keyed by message ID without reintroducing an `id -> userMessage` lookup Map.
- `SessionTurn` only adds a fast path and keeps the old full-message fallback.

## Risk Notes

The main risk is changing assistant-to-user ownership. Focused tests cover parent-linked assistants, later-user crossings, unknown parents, and no-reply turns.

This PR intentionally does not change visual structure, CSS, scroll/history/hash behavior, turn-change fetch logic, or the perf harness. It should not be described as a measured performance improvement unless a PR0.4 comparison proves that.

## How To Verify

```text
Focused tests: 7 passed in session-messages.test.ts
App typecheck: passed
Turbo typecheck: 8 successful, 8 total
Diff check: no whitespace errors
Local low-end perf: session-timeline-recompute passed, 3 runs, interaction median 48 ms, worst 48 ms, long tasks 0, TBT 0 ms, jank count 0
GitHub checks: ci, codeql, desktop-smoke, e2e-artifacts, and perf-probe-baseline succeeded
GitHub PR0.4 low-end target: comparator pass; interaction median 112 -> 120, interaction worst 136 -> 120, long task max 103 -> 106, TBT 137 -> 143, frame gap p95 66.7 -> 83.4, frame gap max 183.3 -> 166.7, jank 3 -> 3
```

Commands run locally:

```text
bun test --preload ./happydom.ts ./src/pages/session/session-messages.test.ts
bun --cwd packages/app typecheck
bun turbo typecheck
git diff --check
PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_OUTPUT=/tmp/pawwork-area-a-low-end-stable-id.json bun --cwd packages/app test:e2e:local:perf
```

## Screenshots or Recordings

Not required. This PR has no intended visible UI or copy change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
