### PR TITLE
fix(app): stop auto-opening files panel

### DIFF
--- a/packages/app/e2e/session/session-artifacts.spec.ts
+++ b/packages/app/e2e/session/session-artifacts.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "../fixtures"
+import { openRightPanel } from "../actions"
 import { bodyText } from "../prompt/mock"
 
-test("first added file auto-opens the Files tab and offers open actions", async ({ page, llm, project }) => {
+test("added files stay quiet until the user opens the Files tab", async ({ page, llm, project }) => {
   const callsBefore = await llm.calls()
   await project.open()
   const session = await project.sdk.session.create({ title: "E2E artifacts" }).then((res) => {
@@ -35,10 +36,17 @@ test("first added file auto-opens the Files tab and offers open actions", async 
   })
 
   await expect.poll(() => llm.calls().then((count) => count > callsBefore), { timeout: 30000 }).toBe(true)
-  await expect(page.getByRole("tab", { name: /files/i })).toHaveAttribute("aria-selected", "true")
-  await expect(page.locator('[data-artifact-file="artifact-report.md"]')).toBeVisible()
+  const rightPanel = page.locator('[data-component="right-panel"]')
+  await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
+
+  const panel = await openRightPanel(page)
+  await panel.getByRole("button", { name: "Add tab" }).click()
+  await page.getByRole("menuitem", { name: "Files" }).click()
+
+  const shellTabList = panel.getByRole("tablist").first()
+  const filesTab = shellTabList.getByRole("tab", { name: "Files", exact: true })
+  await expect(filesTab).toHaveAttribute("aria-selected", "true")
+  await expect(page.locator('[data-artifact-file="artifact-report.md"]')).toBeVisible({ timeout: 30000 })
   await expect(page.getByRole("button", { name: /open file/i })).toBeVisible()
   await expect(page.getByRole("button", { name: /open folder/i })).toBeVisible()
-  await page.getByRole("tab", { name: /changes/i }).click()
-  await expect(page.getByRole("tab", { name: /all/i })).toBeVisible()
 })

--- a/packages/app/e2e/session/session-artifacts.spec.ts
+++ b/packages/app/e2e/session/session-artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { openRightPanel } from "../actions"
+import { openRightPanel, waitSessionIdle } from "../actions"
 import { bodyText } from "../prompt/mock"
 
 test("added files stay quiet until the user opens the Files tab", async ({ page, llm, project }) => {
@@ -36,6 +36,17 @@ test("added files stay quiet until the user opens the Files tab", async ({ page,
   })
 
   await expect.poll(() => llm.calls().then((count) => count > callsBefore), { timeout: 30000 }).toBe(true)
+  await waitSessionIdle(project.sdk, session.id)
+  await expect
+    .poll(
+      async () => {
+        const diff = await project.sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
+        return diff.some((entry) => entry.file.endsWith("artifact-report.md") && entry.status === "added")
+      },
+      { timeout: 30000 },
+    )
+    .toBe(true)
+
   const rightPanel = page.locator('[data-component="right-panel"]')
   await expect(rightPanel).toHaveAttribute("aria-hidden", "true")
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -63,8 +63,6 @@ type SessionView = {
   reviewOpen?: string[]
   openShellTabs?: RightPanelTab[]
   sidePanelTab?: RightPanelTab | "changes"
-  filesAutoOpenSeen?: boolean
-  filesAutoOpenDismissed?: boolean
   pendingMessage?: string
   pendingMessageAt?: number
 }
@@ -935,11 +933,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             },
             closeTab(tab: RightPanelTab) {
               if (tab === "status") return
-              const session = key()
-              if (tab === "files" && (s().filesAutoOpenSeen ?? false)) {
-                setStore("sessionView", session, "filesAutoOpenDismissed", true)
-              }
-              setShellTabState(session, closeShellTab(shellTabState(), tab))
+              setShellTabState(key(), closeShellTab(shellTabState(), tab))
             },
             toggleTab(tab: RightPanelTab | "changes") {
               const target = defaultSidePanelTab(tab)
@@ -954,21 +948,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             moveTab(tab: RightPanelTab, to: number) {
               if (tab === "status") return
               setShellTabState(key(), moveShellTab(shellTabState(), tab, to))
-            },
-            filesAutoOpenSeen: createMemo(() => s().filesAutoOpenSeen ?? false),
-            filesAutoOpenDismissed: createMemo(() => s().filesAutoOpenDismissed ?? false),
-            setAutoOpenState(next: { seenAdded: boolean; dismissed: boolean }) {
-              const session = key()
-              if (!store.sessionView[session]) {
-                setStore("sessionView", session, {
-                  scroll: {},
-                  filesAutoOpenSeen: next.seenAdded,
-                  filesAutoOpenDismissed: next.dismissed,
-                })
-                return
-              }
-              setStore("sessionView", session, "filesAutoOpenSeen", next.seenAdded)
-              setStore("sessionView", session, "filesAutoOpenDismissed", next.dismissed)
             },
             explorer: {
               tab: createMemo(() => store.fileTree?.tab ?? "changes"),

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -344,6 +344,7 @@ export default function Page() {
     sdk,
     wantsReview,
     turnDiffs,
+    artifactDiffs: () => (timelineDiffs().length > 0 ? timelineDiffs() : turnDiffs()),
   })
 
   const newSessionWorktree = createSessionNewWorktree({
@@ -403,8 +404,6 @@ export default function Page() {
     sdk,
     sessionKey: timelineSessionKey,
     sync,
-    timelineDiffs,
-    turnDiffs,
     view,
     wantsReview,
     openTab: tabs().open,

--- a/packages/app/src/pages/session/files-tab-state.test.ts
+++ b/packages/app/src/pages/session/files-tab-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { deriveArtifactFiles, nextFilesPanelAutoOpen } from "./files-tab-state"
+import { deriveArtifactFiles } from "./files-tab-state"
 
 describe("files tab state", () => {
   test("maps cumulative artifact history into Files-tab entries", () => {
@@ -12,19 +12,5 @@ describe("files tab state", () => {
       "/Users/yuhan/PawWork/report.docx",
       "/Users/yuhan/PawWork/notes.md",
     ])
-  })
-
-  test("auto-opens only on the first added diff and never after manual dismiss", () => {
-    expect(nextFilesPanelAutoOpen({ seenAdded: false, dismissed: false }, [{ status: "added" }] as any)).toEqual({
-      open: true,
-      seenAdded: true,
-      dismissed: false,
-    })
-
-    expect(nextFilesPanelAutoOpen({ seenAdded: true, dismissed: true }, [{ status: "added" }] as any)).toEqual({
-      open: false,
-      seenAdded: true,
-      dismissed: true,
-    })
   })
 })

--- a/packages/app/src/pages/session/files-tab-state.ts
+++ b/packages/app/src/pages/session/files-tab-state.ts
@@ -7,11 +7,6 @@ export type FilesTabEntry = SessionArtifactFile & {
   path: string
 }
 
-export type FilesPanelAutoOpenState = {
-  seenAdded: boolean
-  dismissed: boolean
-}
-
 function isAbsolutePath(path: string) {
   return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path)
 }
@@ -23,31 +18,4 @@ export function deriveArtifactFiles(baseDir: string, artifacts: SessionArtifactF
       ? artifact.file
       : `${baseDir.replace(/[\\/]+$/, "")}/${artifact.file.replace(/^[\\/]+/, "")}`,
   }))
-}
-
-export function nextFilesPanelAutoOpen(
-  state: FilesPanelAutoOpenState,
-  diffs: Array<{ status?: string | null }>,
-): FilesPanelAutoOpenState & { open: boolean } {
-  const hasAdded = diffs.some((diff) => diff.status === "added")
-  if (!hasAdded) {
-    return {
-      ...state,
-      open: false,
-    }
-  }
-
-  if (state.seenAdded || state.dismissed) {
-    return {
-      ...state,
-      seenAdded: true,
-      open: false,
-    }
-  }
-
-  return {
-    seenAdded: true,
-    dismissed: false,
-    open: true,
-  }
 }

--- a/packages/app/src/pages/session/use-session-review-panel.test.tsx
+++ b/packages/app/src/pages/session/use-session-review-panel.test.tsx
@@ -5,7 +5,9 @@ describe("createSessionReviewPanel", () => {
     const source = await Bun.file(new URL("./use-session-review-panel.tsx", import.meta.url)).text()
 
     expect(source).not.toContain("nextFilesPanelAutoOpen")
+    expect(source).not.toContain('openTab("files")')
     expect(source).not.toContain('setTab("files")')
+    expect(source).not.toContain('toggleTab("files")')
     expect(source).not.toContain("sidePanel.open()")
   })
 })

--- a/packages/app/src/pages/session/use-session-review-panel.test.tsx
+++ b/packages/app/src/pages/session/use-session-review-panel.test.tsx
@@ -1,98 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { createRoot, createSignal } from "solid-js"
-import { createSessionReviewPanel } from "./use-session-review-panel"
-
-const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe("createSessionReviewPanel", () => {
-  test("does not open the Files panel when a turn adds a file", async () => {
-    const calls: string[] = []
-    let dispose: (() => void) | undefined
+  test("does not keep the old Files panel auto-open path", async () => {
+    const source = await Bun.file(new URL("./use-session-review-panel.tsx", import.meta.url)).text()
 
-    createRoot((cleanup) => {
-      dispose = cleanup
-      const [turnDiffs, setTurnDiffs] = createSignal<Array<{ status?: string | null }>>([])
-
-      createSessionReviewPanel({
-        activeFileTab: () => undefined,
-        canReview: () => false,
-        comments: {
-          all: () => [],
-          focus: () => undefined,
-          setFocus: () => undefined,
-        } as any,
-        commentContext: {
-          add: () => undefined,
-          remove: () => undefined,
-          update: () => undefined,
-        } as any,
-        deferRender: () => true,
-        file: {
-          load: () => Promise.resolve(),
-          pathFromTab: () => undefined,
-          searchFilesAndDirectories: () => [],
-          tab: (path: string) => `file://${path}`,
-          tree: {
-            list: () => Promise.resolve(),
-            refresh: () => Promise.resolve(),
-          },
-        } as any,
-        isDesktop: () => true,
-        language: { t: (key: string) => key } as any,
-        reviewState: {
-          artifactFiles: () => [],
-          changes: () => "turn",
-          changesOptions: () => ["turn"],
-          hasReview: () => false,
-          loadVcs: () => Promise.resolve(),
-          reviewCount: () => 0,
-          reviewDiffs: () => [],
-          reviewReady: () => true,
-          setChanges: () => undefined,
-          vcsMode: () => undefined,
-        } as any,
-        routeSessionID: () => "ses_1",
-        sdk: { directory: "/repo" } as any,
-        sessionKey: () => "server:/repo:ses_1",
-        sync: {
-          data: {
-            session_diff: {},
-            session_status: {},
-          },
-          project: { vcs: "git" },
-          session: {
-            diff: () => Promise.resolve(),
-          },
-          status: "ready",
-        } as any,
-        timelineDiffs: () => [],
-        turnDiffs,
-        view: () =>
-          ({
-            setScroll: () => undefined,
-            sidePanel: {
-              explorer: {
-                setTab: () => undefined,
-                tab: () => "changes",
-              },
-              open: () => calls.push("open"),
-              opened: () => false,
-              setTab: (tab: string) => calls.push(`setTab:${tab}`),
-              tab: () => "status",
-            },
-          }) as any,
-        wantsReview: () => false,
-        openTab: () => undefined,
-        setActiveTab: () => undefined,
-      } as any)
-
-      setTurnDiffs([{ status: "added" }])
-    })
-
-    await nextTick()
-    dispose?.()
-
-    expect(calls).not.toContain("setTab:files")
-    expect(calls).not.toContain("open")
+    expect(source).not.toContain("nextFilesPanelAutoOpen")
+    expect(source).not.toContain('setTab("files")')
+    expect(source).not.toContain("sidePanel.open()")
   })
 })

--- a/packages/app/src/pages/session/use-session-review-panel.test.tsx
+++ b/packages/app/src/pages/session/use-session-review-panel.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createSessionReviewPanel } from "./use-session-review-panel"
+
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("createSessionReviewPanel", () => {
+  test("does not open the Files panel when a turn adds a file", async () => {
+    const calls: string[] = []
+    let dispose: (() => void) | undefined
+
+    createRoot((cleanup) => {
+      dispose = cleanup
+      const [turnDiffs, setTurnDiffs] = createSignal<Array<{ status?: string | null }>>([])
+
+      createSessionReviewPanel({
+        activeFileTab: () => undefined,
+        canReview: () => false,
+        comments: {
+          all: () => [],
+          focus: () => undefined,
+          setFocus: () => undefined,
+        } as any,
+        commentContext: {
+          add: () => undefined,
+          remove: () => undefined,
+          update: () => undefined,
+        } as any,
+        deferRender: () => true,
+        file: {
+          load: () => Promise.resolve(),
+          pathFromTab: () => undefined,
+          searchFilesAndDirectories: () => [],
+          tab: (path: string) => `file://${path}`,
+          tree: {
+            list: () => Promise.resolve(),
+            refresh: () => Promise.resolve(),
+          },
+        } as any,
+        isDesktop: () => true,
+        language: { t: (key: string) => key } as any,
+        reviewState: {
+          artifactFiles: () => [],
+          changes: () => "turn",
+          changesOptions: () => ["turn"],
+          hasReview: () => false,
+          loadVcs: () => Promise.resolve(),
+          reviewCount: () => 0,
+          reviewDiffs: () => [],
+          reviewReady: () => true,
+          setChanges: () => undefined,
+          vcsMode: () => undefined,
+        } as any,
+        routeSessionID: () => "ses_1",
+        sdk: { directory: "/repo" } as any,
+        sessionKey: () => "server:/repo:ses_1",
+        sync: {
+          data: {
+            session_diff: {},
+            session_status: {},
+          },
+          project: { vcs: "git" },
+          session: {
+            diff: () => Promise.resolve(),
+          },
+          status: "ready",
+        } as any,
+        timelineDiffs: () => [],
+        turnDiffs,
+        view: () =>
+          ({
+            setScroll: () => undefined,
+            sidePanel: {
+              explorer: {
+                setTab: () => undefined,
+                tab: () => "changes",
+              },
+              open: () => calls.push("open"),
+              opened: () => false,
+              setTab: (tab: string) => calls.push(`setTab:${tab}`),
+              tab: () => "status",
+            },
+          }) as any,
+        wantsReview: () => false,
+        openTab: () => undefined,
+        setActiveTab: () => undefined,
+      } as any)
+
+      setTurnDiffs([{ status: "added" }])
+    })
+
+    await nextTick()
+    dispose?.()
+
+    expect(calls).not.toContain("setTab:files")
+    expect(calls).not.toContain("open")
+  })
+})

--- a/packages/app/src/pages/session/use-session-review-panel.tsx
+++ b/packages/app/src/pages/session/use-session-review-panel.tsx
@@ -4,7 +4,6 @@ import type { useFile } from "@/context/file"
 import type { useLanguage } from "@/context/language"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
-import { nextFilesPanelAutoOpen } from "@/pages/session/files-tab-state"
 import { createOpenReviewFile } from "@/pages/session/helpers"
 import { createReviewPanelScroll } from "@/pages/session/review-panel-scroll"
 import { createReviewPanelView } from "@/pages/session/review-panel-view"
@@ -26,8 +25,6 @@ export function createSessionReviewPanel(input: {
   sdk: ReturnType<typeof useSDK>
   sessionKey: () => string
   sync: ReturnType<typeof useSync>
-  timelineDiffs: () => Array<{ status?: string | null }>
-  turnDiffs: () => Array<{ status?: string | null }>
   view: ReturnType<typeof useSessionLayout>["view"]
   wantsReview: () => boolean
   openTab: (tab: string) => void
@@ -35,25 +32,6 @@ export function createSessionReviewPanel(input: {
 }) {
   let diffFrame: number | undefined
   let diffTimer: number | undefined
-
-  createEffect(() => {
-    if (!input.routeSessionID()) return
-
-    const source = input.timelineDiffs().length > 0 ? input.timelineDiffs() : input.turnDiffs()
-    const next = nextFilesPanelAutoOpen(
-      {
-        seenAdded: input.view().sidePanel.filesAutoOpenSeen(),
-        dismissed: input.view().sidePanel.filesAutoOpenDismissed(),
-      },
-      source,
-    )
-
-    if (next.open) {
-      input.view().sidePanel.setTab("files")
-      input.view().sidePanel.open()
-    }
-    input.view().sidePanel.setAutoOpenState(next)
-  })
 
   createEffect(
     on(

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -53,6 +53,7 @@ export function createSessionReviewState(input: {
   sdk: ReturnType<typeof useSDK>
   wantsReview: () => boolean
   turnDiffs: () => SessionReviewDiff[]
+  artifactDiffs?: () => SessionReviewDiff[]
 }) {
   const [changes, setChanges] = createSignal<ReviewChangeMode>("turn")
   const [vcs, setVcs] = createStore<{
@@ -214,7 +215,7 @@ export function createSessionReviewState(input: {
       currentScope: input.executionScope(),
       sessionID: input.sessionID(),
       history: artifactHistory.latest,
-      turnDiffs: input.turnDiffs(),
+      turnDiffs: input.artifactDiffs?.() ?? input.turnDiffs(),
     }),
   )
 
@@ -245,7 +246,7 @@ export function createSessionReviewState(input: {
   createEffect(() => {
     const id = input.sessionID()
     if (!id) return
-    input.turnDiffs()
+    input.artifactDiffs?.() ?? input.turnDiffs()
     queueArtifactHistoryRefetch()
   })
 


### PR DESCRIPTION
## Summary

Stop opening the right utility panel automatically when a session writes a file. Users can still open the Files tab manually and see generated/modified files there.

## Why

The previous behavior was disruptive: the UI changed layout on first file output without a user action. The original behavior came from commit `03a09e83b5` (`feat: redesign right panel with Files + Changes tabs`), which explicitly added auto-expansion on first file output.

## Related Issue

No linked issue. Requested directly by maintainer in local workflow.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether the Files tab remains discoverable and still shows artifact files when opened manually, without reintroducing any automatic right-panel open path.

## Risk Notes

Low product risk. This removes a user-visible automatic layout change and stale per-session auto-open state. Existing persisted `filesAutoOpenSeen` / `filesAutoOpenDismissed` keys may remain in old local storage blobs but are no longer read.

## How To Verify

```text
Diff check: git diff --check passed
Typecheck: bun --cwd packages/app typecheck passed
Full app unit CI parity: bun --cwd packages/app test:ci passed
Focused unit tests: 9 passed across use-session-review-panel, use-session-review-state, files-tab-state
Layout unit tests: 40 passed across layout, shell-tabs, close-session-tab
Focused E2E: bun --cwd packages/app test:e2e e2e/session/session-artifacts.spec.ts passed, confirming file output reaches idle plus added-file diff before the right panel is asserted closed and Files is opened manually
Electron smoke: bun run dev:desktop started the desktop shell; verified the home screen loads and the right utility panel is closed by default
```

## Screenshots or Recordings

Not attached. This is a behavior change with no visual styling change; the visible workflow is covered by the focused Playwright E2E and Electron smoke check above.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users must now explicitly open the Files tab to view newly added artifacts; the panel no longer auto-opens.

* **Tests**
  * Updated end-to-end and unit tests to verify Files tab behavior requires explicit user interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/613)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

