### PR TITLE
perf(app): unmount closed right panel body

### DIFF
--- a/packages/app/e2e/session/right-panel-width.spec.ts
+++ b/packages/app/e2e/session/right-panel-width.spec.ts
@@ -2,6 +2,27 @@ import { test, expect } from "../fixtures"
 import { sessionTurnListSelector, titlebarRightSelector } from "../selectors"
 import { withSession } from "../actions"
 
+test("right panel unmounts its tab body while closed", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
+  const aside = page.getByRole("complementary", { name: "Right utility panel", includeHidden: true })
+  const tabLists = aside.locator('[role="tablist"]')
+  const initiallyOpen = (await aside.getAttribute("aria-hidden")) === "false"
+  if (initiallyOpen) await rightToggle.click()
+
+  await expect(aside).toHaveAttribute("aria-hidden", "true")
+  await expect(tabLists).toHaveCount(0)
+
+  await rightToggle.click()
+  await expect(aside).toHaveAttribute("aria-hidden", "false")
+  await expect(tabLists.first()).toBeVisible()
+
+  await rightToggle.click()
+  await expect(aside).toHaveAttribute("aria-hidden", "true")
+  await expect(tabLists).toHaveCount(0)
+})
+
 test("right panel width persists across reload", async ({ page, gotoSession }) => {
   await gotoSession()
 

--- a/packages/app/e2e/session/right-panel-width.spec.ts
+++ b/packages/app/e2e/session/right-panel-width.spec.ts
@@ -2,25 +2,35 @@ import { test, expect } from "../fixtures"
 import { sessionTurnListSelector, titlebarRightSelector } from "../selectors"
 import { withSession } from "../actions"
 
-test("right panel unmounts its tab body while closed", async ({ page, gotoSession }) => {
+test("right panel keeps its tab body through the close transition before unmounting it", async ({
+  page,
+  gotoSession,
+}) => {
   await gotoSession()
 
   const rightToggle = page.locator(`${titlebarRightSelector} button`).first()
   const aside = page.getByRole("complementary", { name: "Right utility panel", includeHidden: true })
+  const body = aside.locator('[data-component="right-panel-body"]')
   const tabLists = aside.locator('[role="tablist"]')
+  const asideWidth = () => aside.evaluate((el) => Math.round(el.getBoundingClientRect().width))
   const initiallyOpen = (await aside.getAttribute("aria-hidden")) === "false"
   if (initiallyOpen) await rightToggle.click()
 
   await expect(aside).toHaveAttribute("aria-hidden", "true")
-  await expect(tabLists).toHaveCount(0)
+  await expect(body).toHaveCount(0)
 
   await rightToggle.click()
   await expect(aside).toHaveAttribute("aria-hidden", "false")
+  await expect(body).toHaveCount(1)
   await expect(tabLists.first()).toBeVisible()
 
   await rightToggle.click()
   await expect(aside).toHaveAttribute("aria-hidden", "true")
-  await expect(tabLists).toHaveCount(0)
+  await expect(body).toHaveCount(1)
+
+  await page.waitForTimeout(300)
+  await expect(body).toHaveCount(0)
+  await expect.poll(asideWidth).toBe(0)
 })
 
 test("right panel width persists across reload", async ({ page, gotoSession }) => {

--- a/packages/app/src/pages/session/review-panel-scroll.ts
+++ b/packages/app/src/pages/session/review-panel-scroll.ts
@@ -119,6 +119,6 @@ export function createReviewPanelScroll(input: {
 
   return {
     activeDiff: () => state.activeDiff,
-    setReviewScroll: (el: HTMLDivElement) => setState("reviewScroll", el),
+    setReviewScroll: (el: HTMLDivElement | undefined) => setState("reviewScroll", el),
   }
 }

--- a/packages/app/src/pages/session/review-panel-view.tsx
+++ b/packages/app/src/pages/session/review-panel-view.tsx
@@ -17,7 +17,7 @@ export function createReviewPanelView(input: {
   file: ReturnType<typeof useFile>
   focusedFile: () => string | undefined
   language: ReturnType<typeof useLanguage>
-  onScrollRef: (el: HTMLDivElement) => void
+  onScrollRef: (el: HTMLDivElement | undefined) => void
   onViewFile: (path: string) => void
   reviewState: ReturnType<typeof createSessionReviewState>
   view: ReturnType<typeof useSessionLayout>["view"]

--- a/packages/app/src/pages/session/review-tab.test.tsx
+++ b/packages/app/src/pages/session/review-tab.test.tsx
@@ -84,4 +84,33 @@ describe("SessionReviewTab", () => {
       dispose()
     }
   })
+
+  test("clears the exposed scroll element when unmounted", () => {
+    const scrollRefs: Array<HTMLDivElement | undefined> = []
+    const dispose = createRoot((dispose) => {
+      SessionReviewTab({
+        diffs: () => [],
+        view: () =>
+          ({
+            review: {
+              open: () => [],
+              setOpen: () => undefined,
+            },
+            scroll: () => undefined,
+            setScroll: () => undefined,
+          }) as any,
+        onScrollRef: (el) => scrollRefs.push(el),
+      })
+      return dispose
+    })
+
+    const scroll = document.createElement("div")
+    capturedProps[0].scrollRef(scroll)
+
+    dispose()
+
+    expect(scrollRefs).toHaveLength(2)
+    expect(scrollRefs[0]).toBe(scroll)
+    expect(scrollRefs[1]).toBeUndefined()
+  })
 })

--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -29,7 +29,7 @@ export interface SessionReviewTabProps {
   focusedComment?: { file: string; id: string } | null
   onFocusedCommentChange?: (focus: { file: string; id: string } | null) => void
   focusedFile?: string
-  onScrollRef?: (el: HTMLDivElement) => void
+  onScrollRef?: (el: HTMLDivElement | undefined) => void
   commentMentions?: {
     items: (query: string) => string[] | Promise<string[]>
   }
@@ -124,6 +124,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
 
   onCleanup(() => {
     if (restoreFrame !== undefined) cancelAnimationFrame(restoreFrame)
+    props.onScrollRef?.(undefined)
   })
 
   return (

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -37,6 +37,8 @@ import {
 } from "@/pages/session/right-panel-tabs"
 import { useSessionLayout } from "@/pages/session/session-layout"
 
+const RIGHT_PANEL_BODY_UNMOUNT_DELAY_MS = 240
+
 /** Converts right-panel state into the CSS width applied to the shell. */
 export function formatRightPanelWidth(open: boolean, width: number): string {
   return open ? `${width}px` : "0px"
@@ -115,6 +117,14 @@ export function SessionSidePanel(props: {
   const reviewTab = createMemo(() => isDesktop())
   const sidePanelTab = createMemo(() => view().sidePanel.tab())
   const panelWidth = createMemo(() => formatRightPanelWidth(open(), layout.rightPanel.width()))
+  const [bodyMounted, setBodyMounted] = createSignal(open())
+  let bodyUnmountTimer: number | undefined
+
+  const clearBodyUnmountTimer = () => {
+    if (bodyUnmountTimer === undefined) return
+    window.clearTimeout(bodyUnmountTimer)
+    bodyUnmountTimer = undefined
+  }
 
   const normalizeTab = (tab: string) => {
     if (!tab.startsWith("file://")) return tab
@@ -197,6 +207,24 @@ export function SessionSidePanel(props: {
 
     if (view().terminal.opened()) view().terminal.close()
   })
+
+  createEffect(() => {
+    if (open()) {
+      clearBodyUnmountTimer()
+      setBodyMounted(true)
+      return
+    }
+
+    clearBodyUnmountTimer()
+    if (!bodyMounted()) return
+
+    bodyUnmountTimer = window.setTimeout(() => {
+      bodyUnmountTimer = undefined
+      setBodyMounted(false)
+    }, RIGHT_PANEL_BODY_UNMOUNT_DELAY_MS)
+  })
+
+  onCleanup(clearBodyUnmountTimer)
 
   const handleDragStart = (event: unknown) => {
     const id = getDraggableId(event)
@@ -289,7 +317,7 @@ export function SessionSidePanel(props: {
             onResize={makeRightPanelResizeHandler(props.size, layout)}
           />
         </div>
-        <Show when={open()}>
+        <Show when={bodyMounted()}>
         <div data-component="right-panel-body" class="size-full border-l border-border-weaker">
           <DragDropProvider
             onDragStart={handleDragStart}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -289,7 +289,8 @@ export function SessionSidePanel(props: {
             onResize={makeRightPanelResizeHandler(props.size, layout)}
           />
         </div>
-        <div class="size-full border-l border-border-weaker">
+        <Show when={open()}>
+        <div data-component="right-panel-body" class="size-full border-l border-border-weaker">
           <DragDropProvider
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
@@ -517,6 +518,7 @@ export function SessionSidePanel(props: {
             </Tabs>
           </DragDropProvider>
         </div>
+        </Show>
       </aside>
     </Show>
   )


### PR DESCRIPTION
## Summary

Unmount the right panel tab body while the desktop right panel is closed, while keeping the outer panel shell available for width state and open/close transitions.

Also clear the Review scroll element ref on unmount so the review scroll controller does not retain a stale DOM node after the panel body is removed.

## Why

Closes #602.

The old right panel architecture kept the tab body mounted even when the panel was visually closed. That meant hidden tabs, tab lists, and active tab content could still exist in the DOM and keep lifecycle work alive. This PR draws the first lifecycle boundary: closed right panel means no mounted panel body.

## Related Issue

Closes #602

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on the mount boundary in `SessionSidePanel` and the Review scroll ref cleanup. This PR intentionally does not change the scroll state machine, timeline virtualization, active-tab lazy mounting, or broader right-panel structure.

## Risk Notes

Low. The visual shell and width persistence stay in place, but closed-panel content now remounts when the panel opens. Review scroll refs are cleared on unmount to avoid stale DOM references.

## How To Verify

```text
Typecheck: bun run typecheck -> passed
Focused unit tests: bun --cwd packages/app test src/pages/session/review-tab.test.tsx src/pages/session/session-side-panel.test.tsx -> 1066 passed, 0 failed
Focused E2E: bun --cwd packages/app playwright test e2e/session/right-panel-width.spec.ts --project=chromium --reporter=line -> 3 passed
Diff check: git diff --check -> no whitespace errors
Electron manual check: bun run dev:desktop -> opened and closed the right panel; open shows status panel, closed state removes right-panel content from the accessibility tree
```

## Screenshots or Recordings

No screenshot attached because this PR has no intended visual delta. The behavior was checked in Electron: opening the right panel still shows the status panel, and closing it removes the panel body from the rendered/accessibility tree.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll reference handling to properly clear when review panel components unmount, preventing stale references.

* **Performance Improvements**
  * Right panel content now conditionally mounts and unmounts based on open/closed state, reducing memory usage when the panel is not in use.

* **Tests**
  * Added comprehensive test coverage for right panel toggle behavior and scroll reference lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/619)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->