### PR TITLE
test(app): normalize perf workflow line endings

### DIFF
--- a/packages/app/src/testing/perf-workflow.test.ts
+++ b/packages/app/src/testing/perf-workflow.test.ts
@@ -1,9 +1,19 @@
 import fs from "node:fs/promises"
 import { describe, expect, test } from "bun:test"
 
+const normalizeLineEndings = (text: string) => text.replace(/\r\n?/g, "\n")
+
 describe("perf workflow contract", () => {
+  test("matches workflow snippets after Windows line-ending checkout", () => {
+    const workflow = normalizeLineEndings("restore-keys: |\r\n            playwright-${{ runner.os }}-")
+
+    expect(workflow).toContain("restore-keys: |\n            playwright-${{ runner.os }}-")
+  })
+
   test("keeps default gate broad and low-end gate scoped", async () => {
-    const workflow = await fs.readFile(new URL("../../../../.github/workflows/perf-probe-baseline.yml", import.meta.url), "utf8")
+    const workflow = normalizeLineEndings(
+      await fs.readFile(new URL("../../../../.github/workflows/perf-probe-baseline.yml", import.meta.url), "utf8"),
+    )
 
     expect(workflow).toContain("fetch-depth: 0")
     expect(workflow).toContain("Detect low-end perf scope")


### PR DESCRIPTION
## Summary

Normalize line endings before asserting snippets from `.github/workflows/perf-probe-baseline.yml` in the app perf workflow contract test.

Add a focused CRLF regression case so Windows checkout behavior stays covered.

## Why

Windows advisory has been failing in `unit-windows-app` since PR #610 because `packages/app/src/testing/perf-workflow.test.ts` reads a workflow file and matches a literal `\n` snippet. On Windows checkout, the workflow content is read as `\r\n`, so the test fails even though the workflow content is correct.

This is a test portability fix, not a product runtime change.

## Related Issue

None. This fixes the current Windows advisory failure introduced by the perf workflow contract test.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `packages/app/src/testing/perf-workflow.test.ts`: line-ending normalization is scoped to workflow text read by this test.
- The CRLF regression case matches the Windows advisory failure without changing workflow behavior.

## Risk Notes

Low. Test-only change. No runtime, packaging, updater, or workflow execution behavior changed.

## How To Verify

```text
Red check: added CRLF regression case first and confirmed the old assertion failed.
Focused test: bun test --preload ./happydom.ts ./src/testing/perf-workflow.test.ts -> 2 passed, 0 failed.
App unit CI parity: bun run test:ci in packages/app -> 1067 passed, 0 failed.
Diff check: git diff --check -> clean.
```

## Screenshots or Recordings

None. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
