### PR TITLE
test(app): add long-session input lag perf guard

### DIFF
--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -156,7 +156,7 @@ async function submitVisiblePrompt(page: Parameters<typeof snapshotPerfProbe>[0]
 }
 
 async function readPromptText(page: Parameters<typeof snapshotPerfProbe>[0]) {
-  return page.locator(promptSelector).first().evaluate((el) => (el as HTMLElement).innerText.replace(/\u200B/g, "").trim())
+  return page.locator(promptSelector).first().evaluate((el) => (el.textContent ?? "").replace(/\u200B/g, "").trim())
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -41,6 +41,12 @@ const longMarkdown = [
 const heavyBashCommand =
   'node -e \'for (let i = 0; i < 900; i++) console.log(String(i).padStart(4, "0") + " " + "heavy bash output ".repeat(8))\''
 
+const inputLagText = [
+  "Long session input lag probe.",
+  "Typing remains responsive while a realistic message history is mounted.",
+  "This fixed draft protects the composer path from timeline render regressions.",
+].join(" ")
+
 const scenarioResults: ReturnType<typeof summarizeScenarioRuns>[] = []
 
 type PerfSdk = ReturnType<typeof createSdk>
@@ -147,6 +153,10 @@ async function submitVisiblePrompt(page: Parameters<typeof snapshotPerfProbe>[0]
   await page.keyboard.type(text)
   await page.keyboard.press("Enter")
   await expect.poll(async () => (await readPromptSend(page)).started, { timeout: 10_000 }).toBeGreaterThan(previous.started)
+}
+
+async function readPromptText(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  return page.locator(promptSelector).first().evaluate((el) => (el as HTMLElement).innerText.replace(/\u200B/g, "").trim())
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {
@@ -272,6 +282,36 @@ test.describe("PR0.1 perf probe baseline", () => {
     }
 
     scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "homepage-cold", runs }))
+  })
+
+  test("long-session-input-lag emits a 3-run JSON baseline", async ({ page, project }) => {
+    skipUnlessScenario("long-session-input-lag")
+    await installPerfProbe(page)
+    await applyPerfProfile(page, PERF_PROFILE)
+    await project.open()
+
+    const runs = []
+    for (let run = 0; run < 3; run += 1) {
+      await withSession(project.sdk, `perf input lag ${Date.now()}-${run}`, async (session) => {
+        await seedTimelineRecomputeSession(project, session.id)
+        await page.goto(sessionPath(project.directory, session.id))
+        await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
+        await expect(page.locator(promptSelector).first()).toBeVisible({ timeout: 30_000 })
+        await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeGreaterThanOrEqual(8)
+
+        const prompt = page.locator(promptSelector).first()
+        await prompt.click()
+        await prompt.fill("")
+        await resetPerfProbe(page)
+        await page.keyboard.type(`${inputLagText} run ${run + 1}.`)
+        await expect.poll(() => readPromptText(page)).toBe(`${inputLagText} run ${run + 1}.`)
+        await settleFrames(page, 4)
+        runs.push(await snapshotPerfProbe(page))
+        if (run < 2) await cooldownAfterRun(page)
+      })
+    }
+
+    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "long-session-input-lag", runs }))
   })
 
   test("session-streaming-long emits a 3-run JSON baseline", async ({ page, project, llm }) => {

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -14,7 +14,7 @@ import { sessionPath, terminalToggleKey } from "../utils"
 import type { createSdk } from "../utils"
 import { installPerfProbe, resetPerfProbe, snapshotPerfProbe, summarizeScenarioRuns } from "./probe"
 import { applyPerfProfile, readPerfProfile, shouldRunScenario, type PerfScenarioName } from "./profiles"
-import { seedTimelineRecomputeSession } from "./timeline-fixture"
+import { TIMELINE_RECOMPUTE_SEED_TURN_COUNT, seedTimelineRecomputeSession } from "./timeline-fixture"
 
 const outputPath = process.env.PAWWORK_PERF_OUTPUT ?? path.join(process.cwd(), "e2e", "perf-results", "pr0.1-baseline.json")
 const perfBranch = process.env.PAWWORK_PERF_BRANCH ?? "dev"
@@ -159,6 +159,21 @@ async function readPromptText(page: Parameters<typeof snapshotPerfProbe>[0]) {
   return page.locator(promptSelector).first().evaluate((el) => (el.textContent ?? "").replace(/\u200B/g, "").trim())
 }
 
+async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfProbe>[0], expectedCount: number) {
+  const messages = page.locator(sessionMessageItemSelector)
+  if ((await messages.count()) < expectedCount) {
+    await page.locator(scrollViewportSelector).first().hover()
+    await page.mouse.wheel(0, -2400)
+    await settleFrames(page, 2)
+    await scrollTimelineTo(page, 0)
+    await settleFrames(page, 2)
+    const loadEarlier = page.getByRole("button", { name: /Load earlier messages|加载更早的消息/i }).first()
+    await expect(loadEarlier).toBeVisible({ timeout: 30_000 })
+    await loadEarlier.click()
+  }
+  await expect(messages).toHaveCount(expectedCount, { timeout: 30_000 })
+}
+
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {
   const found = await page.evaluate(
     ({ top, scrollViewportSelector, turnListSelector }) => {
@@ -297,11 +312,12 @@ test.describe("PR0.1 perf probe baseline", () => {
         await page.goto(sessionPath(project.directory, session.id))
         await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
         await expect(page.locator(promptSelector).first()).toBeVisible({ timeout: 30_000 })
-        await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeGreaterThanOrEqual(8)
+        await revealCachedSessionMessages(page, TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
 
         const prompt = page.locator(promptSelector).first()
         await prompt.click()
         await prompt.fill("")
+        await expect(page.locator(sessionMessageItemSelector)).toHaveCount(TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
         await resetPerfProbe(page)
         await page.keyboard.type(`${inputLagText} run ${run + 1}.`)
         await expect.poll(() => readPromptText(page)).toBe(`${inputLagText} run ${run + 1}.`)

--- a/packages/app/e2e/perf/profiles.ts
+++ b/packages/app/e2e/perf/profiles.ts
@@ -3,6 +3,7 @@ import type { PerfProfile } from "../../src/testing/perf-metrics"
 
 export type PerfScenarioName =
   | "homepage-cold"
+  | "long-session-input-lag"
   | "session-streaming-long"
   | "tool-call-expand"
   | "tool-default-open-heavy-bash"
@@ -12,6 +13,7 @@ export type PerfScenarioName =
 
 const defaultScenarios = new Set<PerfScenarioName>([
   "homepage-cold",
+  "long-session-input-lag",
   "session-streaming-long",
   "tool-call-expand",
   "tool-default-open-heavy-bash",

--- a/packages/app/e2e/perf/profiles.unit.ts
+++ b/packages/app/e2e/perf/profiles.unit.ts
@@ -7,3 +7,10 @@ test("default profile runs heavy default-open bash perf coverage", () => {
   expect(shouldRunScenario("default", scenario)).toBe(true)
   expect(shouldRunScenario("low-end", scenario)).toBe(false)
 })
+
+test("default profile runs long-session input lag coverage", () => {
+  const scenario = "long-session-input-lag" as PerfScenarioName
+
+  expect(shouldRunScenario("default", scenario)).toBe(true)
+  expect(shouldRunScenario("low-end", scenario)).toBe(false)
+})

--- a/packages/app/e2e/perf/timeline-fixture.ts
+++ b/packages/app/e2e/perf/timeline-fixture.ts
@@ -6,8 +6,10 @@ type TimelineProject = {
   }
 }
 
+export const TIMELINE_RECOMPUTE_SEED_TURN_COUNT = 36
+
 export async function seedTimelineRecomputeSession(project: TimelineProject, sessionID: string) {
-  for (let turn = 0; turn < 36; turn += 1) {
+  for (let turn = 0; turn < TIMELINE_RECOMPUTE_SEED_TURN_COUNT; turn += 1) {
     await project.sdk.session.promptAsync({
       sessionID,
       noReply: true,


### PR DESCRIPTION
## Summary

- Add a default-profile `long-session-input-lag` perf scenario.
- Seed a long session, focus the composer, type a fixed draft, and capture the existing PR0 perf metrics window.
- Lock the new scenario into the default profile with a unit test.

## Why

#615 calls out typing lag in long sessions as a user-visible performance symptom, and #599 now tracks the May UI rewrite launch contract. Existing PR0 coverage protects streaming, tool expansion, scroll reading, timeline recompute, terminal open, and heavy default-open bash output, but did not directly measure composer typing inside a long session.

This PR adds that guard without changing UI behavior, message rendering, scroll ownership, virtualization, or diff rendering.

## Related Issue

Related to #615 and #599.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether the scenario boundary is narrow enough: stable long-session fixture, reset after composer focus, fixed ASCII typing text, existing metrics capture, and default-profile routing only.

## Risk Notes

Low. This only changes perf test coverage. It may add a small amount of runtime to the default perf probe workflow because the new scenario runs three browser samples.

## How To Verify

```text
Dependency install: bun install --frozen-lockfile completed successfully in the new worktree
TDD red: bun --cwd packages/app test ./e2e/perf/profiles.unit.ts failed before profile wiring because long-session-input-lag was not in the default profile
Profile unit: bun --cwd packages/app test ./e2e/perf/profiles.unit.ts -> 1069 pass, 0 fail
Focused perf e2e: bun --cwd packages/app test:e2e:local:perf -- --grep "long-session-input-lag" -> 1 passed
Typecheck: bun --cwd packages/app typecheck -> exit 0
Diff check: git diff --check -> exit 0
```

## Screenshots or Recordings

Not required. This PR adds perf guard coverage only and does not change visible UI.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance testing scenario to measure input responsiveness in extended chat sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/624)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->