### PR TITLE
fix(app): align jump-to-bottom button to W1 preview (#601)

### DIFF
--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -92,41 +92,41 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
     // does not skew the measurement.
     const dims = await jumpButton.evaluate((el) => {
       const cs = window.getComputedStyle(el)
-      return { width: cs.width, height: cs.height, cursor: cs.cursor }
+      return { width: cs.width, height: cs.height }
     })
     expect(dims.width).toBe(`${JUMP_BUTTON_SIZE_PX}px`)
     expect(dims.height).toBe(`${JUMP_BUTTON_SIZE_PX}px`)
 
-    // Cursor — preview L267 locks cursor: pointer.
-    expect(dims.cursor).toBe("pointer")
-
-    // Hover background — preview L269 layers a 4% overlay over
-    // --surface-raised. The hover class is bg-row-hover-overlay, which maps
-    // to the theme variable that flips correctly between light/dark via
-    // :root[data-color-scheme]. Light theme resolves to rgba(0, 0, 0, 0.04).
+    // Hover background — preview L269-270 layers a 4% overlay on top of
+    // --surface-raised (not replacing it). Implemented as
+    // background-image: linear-gradient(var(--row-hover-overlay), var(...))
+    // so bg-surface-raised stays as the background-color underneath.
+    // --row-hover-overlay flips with :root[data-color-scheme], so dark
+    // theme parity (asserted below) follows the app attribute, not the
+    // OS prefers-color-scheme media query.
     await jumpButton.hover()
     await expect
       .poll(
-        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundImage),
         { timeout: 2_000 },
       )
-      .toBe("rgba(0, 0, 0, 0.04)")
+      .toBe("linear-gradient(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.04))")
     await page.mouse.move(0, 0)
 
     // Dark theme parity — flip data-color-scheme (the source of truth that
     // Settings → Appearance writes) and re-hover. The overlay must follow
-    // the app attribute, not OS prefers-color-scheme, hence the white
-    // overlay even though Playwright defaults to a light OS preference.
+    // the app attribute, hence the white overlay even though Playwright
+    // defaults to a light OS preference.
     await page.evaluate(() => {
       document.documentElement.dataset.colorScheme = "dark"
     })
     await jumpButton.hover()
     await expect
       .poll(
-        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundImage),
         { timeout: 2_000 },
       )
-      .toBe("rgba(255, 255, 255, 0.04)")
+      .toBe("linear-gradient(rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04))")
     await page.evaluate(() => {
       delete document.documentElement.dataset.colorScheme
     })

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -87,9 +87,7 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
     const jumpButton = page.locator('button[aria-label="Jump to latest"]')
     await expect(jumpButton).toBeVisible()
 
-    // Geometry — preview L263-271 / L1066 locks 30 × 30. Read CSS rather
-    // than boundingBox so the parent's scale transform during transition
-    // does not skew the measurement.
+    // Geometry — preview L263-271 / L1066 locks 30 × 30.
     const dims = await jumpButton.evaluate((el) => {
       const cs = window.getComputedStyle(el)
       return { width: cs.width, height: cs.height }

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -79,13 +79,17 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
       )
       .toBeGreaterThan(450)
 
-    // The button is always present in the DOM (just transformed off-screen
-    // when the timeline is at bottom). Geometry assertions read CSS rather
-    // than boundingBox so they are not affected by the scale-95 hidden state.
+    // Scroll to top so the dock surfaces the jump button (jump = true
+    // requires overflow + distance > threshold). Then assert the button is
+    // truly visible — the wrapper applies opacity-0 / scale-95 / translate
+    // in the hidden state, so toBeVisible covers all three.
+    await scrollTimelineToTop(page)
     const jumpButton = page.locator('button[aria-label="Jump to latest"]')
-    await expect(jumpButton).toBeAttached()
+    await expect(jumpButton).toBeVisible()
 
-    // Geometry — preview L263-271 / L1066 locks 30 × 30.
+    // Geometry — preview L263-271 / L1066 locks 30 × 30. Read CSS rather
+    // than boundingBox so the parent's scale transform during transition
+    // does not skew the measurement.
     const dims = await jumpButton.evaluate((el) => {
       const cs = window.getComputedStyle(el)
       return { width: cs.width, height: cs.height, cursor: cs.cursor }
@@ -96,21 +100,21 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
     // Cursor — preview L267 locks cursor: pointer.
     expect(dims.cursor).toBe("pointer")
 
-    // Hover background — preview L269 layers a 4% black overlay over
-    // --surface-raised. We force the :hover class via hover() and read
-    // computed background-image; gradient stack must appear (not `none`).
-    await jumpButton.hover({ force: true })
-    const hoverBackgroundImage = await jumpButton.evaluate(
-      (el) => window.getComputedStyle(el).backgroundImage,
-    )
-    expect(hoverBackgroundImage).toContain("linear-gradient")
+    // Hover background — preview L269 layers a 4% overlay over
+    // --surface-raised. The hover class is bg-row-hover-overlay, which maps
+    // to the theme variable that flips correctly between light/dark via
+    // :root[data-color-scheme]. Light theme resolves to rgba(0, 0, 0, 0.04).
+    await jumpButton.hover()
+    await expect
+      .poll(
+        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        { timeout: 2_000 },
+      )
+      .toBe("rgba(0, 0, 0, 0.04)")
     await page.mouse.move(0, 0)
 
-    // Click — should scroll the timeline back to the bottom. Use scrollTo
-    // first to put the timeline somewhere off the bottom, then click and
-    // expect the dock to pull it back.
-    await scrollTimelineToTop(page)
-    await jumpButton.click({ force: true })
+    // Click — should scroll the timeline back to the bottom.
+    await jumpButton.click()
     await expect
       .poll(async () => (await timelineDistanceFromBottom(page)) ?? Infinity, { timeout: 5_000 })
       .toBeLessThanOrEqual(8)

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -1,9 +1,9 @@
 import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import { cleanupSession } from "../actions"
+import { withSession } from "../actions"
 import { scrollViewportSelector, sessionTurnListSelector } from "../selectors"
 
-type Sdk = Parameters<typeof cleanupSession>[0]["sdk"]
+type Sdk = Parameters<typeof withSession>[0]
 
 const JUMP_BUTTON_SIZE_PX = 30
 
@@ -53,10 +53,7 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
   project,
 }) => {
   await project.open()
-  const session = await project.sdk.session.create({ title: "w1 jump spec" }).then((r) => r.data)
-  if (!session?.id) throw new Error("Session create did not return an id")
-
-  try {
+  await withSession(project.sdk, "w1 jump spec", async (session) => {
     await seedSessionTurns({ sdk: project.sdk, sessionID: session.id, count: 12 })
     await project.gotoSession(session.id)
     await expect(page.locator(sessionTurnListSelector)).toBeVisible()
@@ -115,9 +112,7 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
     await scrollTimelineToTop(page)
     await jumpButton.click({ force: true })
     await expect
-      .poll(async () => (await timelineDistanceFromBottom(page)) ?? -1, { timeout: 5_000 })
+      .poll(async () => (await timelineDistanceFromBottom(page)) ?? Infinity, { timeout: 5_000 })
       .toBeLessThanOrEqual(8)
-  } finally {
-    await cleanupSession({ sdk: project.sdk, sessionID: session.id })
-  }
+  })
 })

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -113,6 +113,25 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
       .toBe("rgba(0, 0, 0, 0.04)")
     await page.mouse.move(0, 0)
 
+    // Dark theme parity — flip data-color-scheme (the source of truth that
+    // Settings → Appearance writes) and re-hover. The overlay must follow
+    // the app attribute, not OS prefers-color-scheme, hence the white
+    // overlay even though Playwright defaults to a light OS preference.
+    await page.evaluate(() => {
+      document.documentElement.dataset.colorScheme = "dark"
+    })
+    await jumpButton.hover()
+    await expect
+      .poll(
+        () => jumpButton.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        { timeout: 2_000 },
+      )
+      .toBe("rgba(255, 255, 255, 0.04)")
+    await page.evaluate(() => {
+      delete document.documentElement.dataset.colorScheme
+    })
+    await page.mouse.move(0, 0)
+
     // Click — should scroll the timeline back to the bottom.
     await jumpButton.click()
     await expect

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -81,8 +81,8 @@ test("session w1 jump-to-bottom button matches W1-locked geometry and click beha
 
     // Scroll to top so the dock surfaces the jump button (jump = true
     // requires overflow + distance > threshold). Then assert the button is
-    // truly visible — the wrapper applies opacity-0 / scale-95 / translate
-    // in the hidden state, so toBeVisible covers all three.
+    // truly visible — the wrapper applies opacity-0 / pointer-events-none
+    // in the hidden state.
     await scrollTimelineToTop(page)
     const jumpButton = page.locator('button[aria-label="Jump to latest"]')
     await expect(jumpButton).toBeVisible()

--- a/packages/app/e2e/session/session-w1-jump.spec.ts
+++ b/packages/app/e2e/session/session-w1-jump.spec.ts
@@ -1,0 +1,123 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { cleanupSession } from "../actions"
+import { scrollViewportSelector, sessionTurnListSelector } from "../selectors"
+
+type Sdk = Parameters<typeof cleanupSession>[0]["sdk"]
+
+const JUMP_BUTTON_SIZE_PX = 30
+
+async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: number }) {
+  for (let i = 0; i < input.count; i++) {
+    await input.sdk.session.promptAsync({
+      sessionID: input.sessionID,
+      noReply: true,
+      parts: [
+        {
+          type: "text",
+          text: `w1 jump seed ${i}\n${Array.from({ length: 16 }, (_, line) => `line ${line} ${"content ".repeat(8)}`).join("\n")}`,
+        },
+      ],
+    })
+  }
+}
+
+async function scrollTimelineToTop(page: Page) {
+  return page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.scrollTop = 0
+      viewport.dispatchEvent(new Event("scroll", { bubbles: true }))
+      return true
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+}
+
+async function timelineDistanceFromBottom(page: Page) {
+  return page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return null
+      return viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  ) as Promise<number | null>
+}
+
+test("session w1 jump-to-bottom button matches W1-locked geometry and click behaviour", async ({
+  page,
+  project,
+}) => {
+  await project.open()
+  const session = await project.sdk.session.create({ title: "w1 jump spec" }).then((r) => r.data)
+  if (!session?.id) throw new Error("Session create did not return an id")
+
+  try {
+    await seedSessionTurns({ sdk: project.sdk, sessionID: session.id, count: 12 })
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionTurnListSelector)).toBeVisible()
+
+    // Wait for messages to render and the timeline to grow past the jump
+    // threshold (clientHeight + 400 per use-session-scroll-dock.ts).
+    await expect
+      .poll(
+        async () => {
+          const m = await page.evaluate(
+            ({ scrollViewportSelector, turnListSelector }) => {
+              const list = document.querySelector(turnListSelector)
+              const viewport = list?.closest(scrollViewportSelector)
+              if (!(viewport instanceof HTMLElement)) return null
+              return { scrollHeight: viewport.scrollHeight, clientHeight: viewport.clientHeight }
+            },
+            { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+          )
+          if (!m) return 0
+          return m.scrollHeight - m.clientHeight
+        },
+        { timeout: 15_000 },
+      )
+      .toBeGreaterThan(450)
+
+    // The button is always present in the DOM (just transformed off-screen
+    // when the timeline is at bottom). Geometry assertions read CSS rather
+    // than boundingBox so they are not affected by the scale-95 hidden state.
+    const jumpButton = page.locator('button[aria-label="Jump to latest"]')
+    await expect(jumpButton).toBeAttached()
+
+    // Geometry — preview L263-271 / L1066 locks 30 × 30.
+    const dims = await jumpButton.evaluate((el) => {
+      const cs = window.getComputedStyle(el)
+      return { width: cs.width, height: cs.height, cursor: cs.cursor }
+    })
+    expect(dims.width).toBe(`${JUMP_BUTTON_SIZE_PX}px`)
+    expect(dims.height).toBe(`${JUMP_BUTTON_SIZE_PX}px`)
+
+    // Cursor — preview L267 locks cursor: pointer.
+    expect(dims.cursor).toBe("pointer")
+
+    // Hover background — preview L269 layers a 4% black overlay over
+    // --surface-raised. We force the :hover class via hover() and read
+    // computed background-image; gradient stack must appear (not `none`).
+    await jumpButton.hover({ force: true })
+    const hoverBackgroundImage = await jumpButton.evaluate(
+      (el) => window.getComputedStyle(el).backgroundImage,
+    )
+    expect(hoverBackgroundImage).toContain("linear-gradient")
+    await page.mouse.move(0, 0)
+
+    // Click — should scroll the timeline back to the bottom. Use scrollTo
+    // first to put the timeline somewhere off the bottom, then click and
+    // expect the dock to pull it back.
+    await scrollTimelineToTop(page)
+    await jumpButton.click({ force: true })
+    await expect
+      .poll(async () => (await timelineDistanceFromBottom(page)) ?? -1, { timeout: 5_000 })
+      .toBeLessThanOrEqual(8)
+  } finally {
+    await cleanupSession({ sdk: project.sdk, sessionID: session.id })
+  }
+})

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -947,7 +947,7 @@ export function MessageTimeline(props: {
         >
           <button
             type="button"
-            class="pointer-events-auto size-8 rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center cursor-pointer p-0 transition-colors hover:bg-surface-raised hover:border-border-weak hover:[--icon-base:var(--icon-base)]"
+            class="pointer-events-auto w-[30px] h-[30px] rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center cursor-pointer p-0 transition-colors hover:bg-[linear-gradient(rgba(0,0,0,0.04),rgba(0,0,0,0.04))] dark:hover:bg-[linear-gradient(rgba(255,255,255,0.04),rgba(255,255,255,0.04))]"
             style={{ "box-shadow": "var(--shadow-floating)" }}
             onClick={props.onResumeScroll}
             aria-label={language.t("session.messages.jumpToLatest")}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -945,9 +945,10 @@ export function MessageTimeline(props: {
               !props.scroll.overflow || !props.scroll.jump || staging.isStaging(),
           }}
         >
+          {/* 偏离: W1 preview L267 锁 cursor:pointer，用户 2026-05-15 决定改回默认。preview/DESIGN 同步留 follow-up。 */}
           <button
             type="button"
-            class="pointer-events-auto w-[30px] h-[30px] rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center cursor-pointer p-0 transition-colors hover:bg-row-hover-overlay"
+            class="pointer-events-auto w-[30px] h-[30px] rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center p-0 transition-[background-image] hover:[background-image:linear-gradient(var(--row-hover-overlay),var(--row-hover-overlay))]"
             style={{ "box-shadow": "var(--shadow-floating)" }}
             onClick={props.onResumeScroll}
             aria-label={language.t("session.messages.jumpToLatest")}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -938,10 +938,10 @@ export function MessageTimeline(props: {
     >
       <div class="relative w-full h-full min-w-0">
         <div
-          class="absolute left-1/2 -translate-x-1/2 bottom-[calc(var(--composer-dock-height,0px)+2.5rem)] z-[60] pointer-events-none transition-[opacity,transform] duration-200 ease-out"
+          class="absolute left-1/2 -translate-x-1/2 bottom-[calc(var(--composer-dock-height,0px)+2.5rem)] z-[60] pointer-events-none transition-opacity duration-200 ease-out"
           classList={{
-            "opacity-100 translate-y-0 scale-100": props.scroll.overflow && props.scroll.jump && !staging.isStaging(),
-            "opacity-0 translate-y-2 scale-95 pointer-events-none":
+            "opacity-100": props.scroll.overflow && props.scroll.jump && !staging.isStaging(),
+            "opacity-0 pointer-events-none":
               !props.scroll.overflow || !props.scroll.jump || staging.isStaging(),
           }}
         >

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -947,7 +947,7 @@ export function MessageTimeline(props: {
         >
           <button
             type="button"
-            class="pointer-events-auto w-[30px] h-[30px] rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center cursor-pointer p-0 transition-colors hover:bg-[linear-gradient(rgba(0,0,0,0.04),rgba(0,0,0,0.04))] dark:hover:bg-[linear-gradient(rgba(255,255,255,0.04),rgba(255,255,255,0.04))]"
+            class="pointer-events-auto w-[30px] h-[30px] rounded-full border border-border-weaker bg-surface-raised flex items-center justify-center cursor-pointer p-0 transition-colors hover:bg-row-hover-overlay"
             style={{ "box-shadow": "var(--shadow-floating)" }}
             onClick={props.onResumeScroll}
             aria-label={language.t("session.messages.jumpToLatest")}


### PR DESCRIPTION
## Summary

Align the floating jump-to-bottom button at `packages/app/src/pages/session/message-timeline.tsx:940-957` with the W1-locked spec from `docs/design/preview/message-flow.html` L263-271 / L1066, plus follow-up polish driven by manual review:

- **Size**: `size-8` (32 px) → `w-[30px] h-[30px]` (the locked default control height of 30).
- **Hover overlay**: now uses `hover:[background-image:linear-gradient(var(--row-hover-overlay),var(--row-hover-overlay))]`, layering a 4 % overlay **on top of** `bg-surface-raised` rather than replacing it. `--row-hover-overlay` flips through `:root[data-color-scheme]`, so dark/light parity tracks the app theme attribute, not OS `prefers-color-scheme`.
- **Cursor**: dropped `cursor-pointer`, button now keeps the default arrow. **`偏离` from preview L267** (which locks `cursor: pointer`) — product call on 2026-05-15; preview / DESIGN sync is a follow-up.
- **Fade transition**: simplified from `transition-[opacity,transform]` + `translate-y-2 scale-95` to `transition-opacity` only. Enter / exit is now a single calm opacity transition with no position drift or scale jump.

Position, background, border, shadow, and overlap behaviour with staging are unchanged.

## Why

First slice from the [#601 W1 inventory comment](https://github.com/Astro-Han/pawwork/issues/601#issuecomment-4456099179) (slice 1 / E1). The 2 px size delta and the wrong hover treatment were flagged by the crosscheck against the W1-locked preview. Two additional fixes came from in-PR review (manual Electron testing + multi-model crosscheck): the hover overlay had to layer over the raised surface rather than replace it, and the fade transition's drift / scale was hurting perceived smoothness. Both are inside the jump button's visual contract so they live in this PR rather than a follow-up.

## Related Issue

#601 (slice 1 / E1 of the W1 inventory).

## Human Review Status

Verified by the repo owner in Electron on 2026-05-15: geometry, light/dark hover overlay, cursor, and fade all confirmed visually. Final merge decision still pending — perf-probe-baseline must come back green.

## Review Focus

- **Hover overlay layering**: `hover:[background-image:linear-gradient(var(--row-hover-overlay),var(--row-hover-overlay))]` keeps `bg-surface-raised` as the background-color underneath. An earlier iteration used `hover:bg-row-hover-overlay`, which swapped the background-color and made the button look transparent on hover — confirmed and rejected during manual testing.
- **Theme source contract**: `--row-hover-overlay` is the same token used by sidebar / model-picker / slash-popover and flips via `:root[data-color-scheme]`. The project deliberately avoids `@media (prefers-color-scheme: dark)` at the app entry (`shell-frame-contract.test.ts:49` asserts this), and Tailwind v4's default `dark:` variant would have re-introduced exactly that media query. The new E2E flips `document.documentElement.dataset.colorScheme = "dark"` to lock the contract that the overlay follows the app attribute, not the OS preference.
- **Cursor deviation**: the `偏离` comment in `message-timeline.tsx:948` flags the intentional drift from preview L267. A follow-up will sync preview / DESIGN to match.
- **Fade simplification**: removing `translate-y` / `scale` collapses the enter/exit to opacity only. No accessibility tests changed because focus / keyboard paths were not exercised by the original spec either.

## Risk Notes

- **Cursor preview drift**: preview L267 locks `cursor: pointer`; current code is the default arrow. The `偏离` comment in the production code is the only marker until the preview / DESIGN sync follow-up lands.
- **Hover transition property**: `transition-[background-image]` does not animate `linear-gradient` to/from `none` — the hover overlay snaps in instantly rather than fading. This matches the preview (which only transitions `background`) and was visually confirmed; calling it out so the next reviewer doesn't expect a hover fade.
- **No platform / packaging / migration / data / dependency / permission impact.**

## How To Verify

Targeted local checks run in the worktree:

```text
bun --cwd packages/app run typecheck                                              : clean (tsgo -b, exit 0)
bun --cwd packages/app script/e2e-local.ts -- e2e/session/session-w1-jump.spec.ts : 1/1 pass, ~4.6 s
```

The spec `packages/app/e2e/session/session-w1-jump.spec.ts` locks:

- Geometry: `getComputedStyle.width === '30px'` and `height === '30px'`
- Visibility gate: `toBeVisible()` after `scrollTimelineToTop` (covers the wrapper's `opacity-0` hidden state)
- Light hover: computed `backgroundImage === "linear-gradient(rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.04))"`
- Dark hover (P2 contract): flip `document.documentElement.dataset.colorScheme = "dark"`, hover, assert `backgroundImage === "linear-gradient(rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04))"`
- Click: timeline scrolls back to bottom (`distance ≤ 8`)

CI runs the full PR0 / e2e-artifacts / smoke-macos-arm64 / typecheck / unit-* matrix. As of `7905f7664` everything else is green; `perf-probe-baseline` is the remaining gate.

### Manual desktop eyeball — completed 2026-05-15

The repo owner ran `bun run dev:desktop`, opened a long session, and confirmed:

1. Geometry 30 × 30, correct position above composer
2. Light hover: a faint warm-grey overlay appears over `--surface-raised` (not transparent)
3. Cursor stays the default arrow (no pointer)
4. Dark mode hover (Settings → 配色方案 → Dark): faint white overlay over the dark surface
5. Fade in / out is opacity-only with no displacement or scaling

## Screenshots or Recordings

Not attached. The manual verification above was done by the human reviewer; on green E2E runs no artifact is emitted.

## Checklist

- [x] Human review status is stated above
- [x] I linked the related issue (#601)
- [x] This PR has type, primary area, and priority labels (`bug`, `app`, `ui`, `P2`)
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes — verified by the repo owner in Electron on 2026-05-15 (light + dark hover, cursor, fade)
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes (none — pure CSS class + E2E edit)
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant (cursor `偏离` from preview L267 noted in code + Risk Notes; preview / DESIGN sync is a follow-up)
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved "Jump to latest" button appearance with theme-aware hover effects and consistent visual styling across light and dark modes.

* **Tests**
  * Added comprehensive end-to-end tests validating "Jump to latest" button geometry, hover states, and behavior when switching between light and dark themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/628)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->