### PR TITLE
fix: honor weak upward timeline scroll intent

### DIFF
--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -147,6 +147,27 @@ async function resetTimelineToTop(page: Page) {
   expect(found, "session timeline viewport should exist").toBe(true)
 }
 
+async function wheelTimelineBy(page: Page, deltaY: number) {
+  const box = await page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return null
+      const rect = viewport.getBoundingClientRect()
+      return {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      }
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+  expect(box, "session timeline viewport should exist").not.toBeNull()
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + Math.min(box!.height / 2, box!.height - 4))
+  await page.mouse.wheel(0, deltaY)
+}
+
 async function markTimelinePointerGesture(page: Page) {
   const found = await page.evaluate(
     ({ scrollViewportSelector, turnListSelector }) => {
@@ -341,6 +362,59 @@ test("captures renderer diagnostics while guarding send scroll position", async 
     expect(
       events.some((event) => event.name === "session.scroll.sample" && event.data?.user_scrolled === false),
     ).toBe(true)
+  })
+})
+
+test("honors weak upward wheel after submit instead of restoring latest", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await installRendererDiagnosticsCapture(page)
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e weak wheel reading ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 18 })
+
+    await project.gotoSession(session.id)
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(10, { timeout: 30_000 })
+    await scrollTimelineToBottom(page)
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(40)
+
+    const promptText = `weak wheel guard ${Date.now()}`
+    await sendVisiblePrompt({ page, text: promptText })
+    await expect(page.locator(sessionMessageItemSelector).last()).toContainText(promptText, { timeout: 30_000 })
+
+    const wheelCheckpoint = (await readRendererDiagnostics(page)).length
+    for (let i = 0; i < 8; i++) {
+      await wheelTimelineBy(page, -48)
+    }
+
+    await expect
+      .poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom, { timeout: 10_000 })
+      .toBeGreaterThan(160)
+
+    const events = (await readRendererDiagnostics(page)).slice(wheelCheckpoint)
+    expect(
+      events.some(
+        (event) =>
+          event.name === "session.timeline.scroll_controller" &&
+          event.data?.intent_type === "wheel_scroll" &&
+          event.data?.reason === "user_upward_navigation" &&
+          event.data?.mode_after === "reading_history",
+      ),
+    ).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.name === "session.timeline.scroll_controller" &&
+          event.data?.accepted === false &&
+          event.data?.reason === "submit_restore_latest_after_top_reset",
+      ),
+    ).toBe(false)
+
+    await page.getByRole("button", { name: "Jump to latest" }).click()
+    await expect.poll(async () => (await expectTimelineMetrics(page)).distanceFromBottom).toBeLessThan(80)
   })
 })
 

--- a/packages/app/src/pages/session/session-timeline-scroll-controller.test.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-controller.test.ts
@@ -229,11 +229,11 @@ describe("session timeline scroll controller", () => {
       nestedScrollable: false,
     })
 
-    expect(result.reason).toBe("strong_upward_navigation")
+    expect(result.reason).toBe("user_upward_navigation")
     expect(controller.state().mode).toBe("reading_history")
   })
 
-  test("weak upward wheel intent does not leave latest", () => {
+  test("weak upward wheel intent leaves latest", () => {
     const { controller } = makeController()
 
     const result = controller.intent({
@@ -244,8 +244,72 @@ describe("session timeline scroll controller", () => {
       nestedScrollable: false,
     })
 
+    expect(result.reason).toBe("user_upward_navigation")
+    expect(result.recovery).toEqual({ type: "none" })
+    expect(controller.state().mode).toBe("reading_history")
+    expect(controller.state().latestProtected).toBe(false)
+  })
+
+  test("nested weak upward wheel intent does not leave latest", () => {
+    const { controller } = makeController()
+
+    const result = controller.intent({
+      type: "wheel_scroll",
+      source: "timeline",
+      direction: "up",
+      strength: "weak",
+      nestedScrollable: true,
+    })
+
     expect(result.reason).toBe("weak_scroll_observed")
+    expect(result.recovery).toEqual({ type: "none" })
     expect(controller.state().mode).toBe("following_latest")
+  })
+
+  test("weak upward touch intent leaves latest", () => {
+    const { controller } = makeController()
+
+    const result = controller.intent({
+      type: "touch_scroll",
+      source: "timeline",
+      direction: "up",
+      strength: "weak",
+      nestedScrollable: false,
+    })
+
+    expect(result.reason).toBe("user_upward_navigation")
+    expect(result.recovery).toEqual({ type: "none" })
+    expect(controller.state().mode).toBe("reading_history")
+    expect(controller.state().latestProtected).toBe(false)
+  })
+
+  test("weak upward wheel after submit prevents top-reset restore latest", () => {
+    const { controller } = makeController()
+
+    controller.intent({
+      type: "submit",
+      originMode: "following_latest",
+    })
+    const intentResult = controller.intent({
+      type: "wheel_scroll",
+      source: "timeline",
+      direction: "up",
+      strength: "weak",
+      nestedScrollable: false,
+    })
+    const scrollResult = controller.observe({
+      type: "scroll_sample",
+      metrics: topMetrics,
+      safePosition: readingAnchor,
+    })
+
+    expect(intentResult.reason).toBe("user_upward_navigation")
+    expect(scrollResult.accepted).toBe(true)
+    expect(scrollResult.recovery).toEqual({ type: "none" })
+    expect(scrollResult.reason).toBe("reading_anchor_preserved")
+    expect(controller.state().mode).toBe("reading_history")
+    expect(controller.state().latestProtected).toBe(false)
+    expect(controller.state().lastSafePosition).toEqual(readingAnchor)
   })
 
   test("explicit bottom navigation rejoins latest from reading", () => {

--- a/packages/app/src/pages/session/session-timeline-scroll-controller.test.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-controller.test.ts
@@ -136,6 +136,32 @@ describe("session timeline scroll controller", () => {
     expect(controller.state().lastSafePosition).toEqual(readingAnchor)
   })
 
+  test("accepts ArrowUp navigation to history instead of restoring latest", () => {
+    const { controller } = makeController()
+
+    controller.intent({
+      type: "submit",
+      originMode: "following_latest",
+    })
+    const intentResult = controller.intent({
+      type: "keyboard_scroll",
+      key: "ArrowUp",
+      source: "scroll_view",
+    })
+    const scrollResult = controller.observe({
+      type: "scroll_sample",
+      metrics: topMetrics,
+      safePosition: readingAnchor,
+    })
+
+    expect(intentResult.reason).toBe("explicit_top_navigation")
+    expect(scrollResult.accepted).toBe(true)
+    expect(scrollResult.recovery).toEqual({ type: "none" })
+    expect(controller.state().mode).toBe("reading_history")
+    expect(controller.state().latestProtected).toBe(false)
+    expect(controller.state().lastSafePosition).toEqual(readingAnchor)
+  })
+
   test("scrollbar drag after submit leaves latest protection before scroll samples", () => {
     const { controller } = makeController()
 

--- a/packages/app/src/pages/session/session-timeline-scroll-controller.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-controller.ts
@@ -38,7 +38,6 @@ export type TimelineScrollReason =
   | "explicit_bottom_navigation"
   | "follow_latest_preserved"
   | "user_upward_navigation"
-  | "strong_upward_navigation"
   | "strong_downward_navigation"
   | "weak_scroll_observed"
   | "scrollbar_drag_started"
@@ -284,7 +283,7 @@ export function createTimelineScrollControllerDiagnostic(input: {
 }
 
 function isExplicitTopIntent(intent: TimelineScrollIntent) {
-  if (intent.type === "keyboard_scroll") return intent.key === "Home" || intent.key === "PageUp"
+  if (intent.type === "keyboard_scroll") return intent.key === "ArrowUp" || intent.key === "Home" || intent.key === "PageUp"
   if (intent.type === "wheel_scroll" || intent.type === "touch_scroll") {
     return intent.direction === "up" && !intent.nestedScrollable
   }

--- a/packages/app/src/pages/session/session-timeline-scroll-controller.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-controller.ts
@@ -37,6 +37,7 @@ export type TimelineScrollReason =
   | "explicit_top_navigation"
   | "explicit_bottom_navigation"
   | "follow_latest_preserved"
+  | "user_upward_navigation"
   | "strong_upward_navigation"
   | "strong_downward_navigation"
   | "weak_scroll_observed"
@@ -285,7 +286,7 @@ export function createTimelineScrollControllerDiagnostic(input: {
 function isExplicitTopIntent(intent: TimelineScrollIntent) {
   if (intent.type === "keyboard_scroll") return intent.key === "Home" || intent.key === "PageUp"
   if (intent.type === "wheel_scroll" || intent.type === "touch_scroll") {
-    return intent.direction === "up" && intent.strength === "strong" && !intent.nestedScrollable
+    return intent.direction === "up" && !intent.nestedScrollable
   }
   if (intent.type === "scrollbar_drag_end") return !intent.metrics.nearBottom
   return false
@@ -414,7 +415,7 @@ export function createSessionTimelineScrollController(
       if (isExplicitTopIntent(intent)) {
         state.mode = "reading_history"
         state.latestProtected = false
-        const reason = intent.type === "keyboard_scroll" ? "explicit_top_navigation" : "strong_upward_navigation"
+        const reason = intent.type === "keyboard_scroll" ? "explicit_top_navigation" : "user_upward_navigation"
         return result({
           before,
           intent,

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -195,6 +195,7 @@ export function createSessionTimelineInteraction(input: {
       if (current.sessionOwner !== owner.sessionOwner || current.viewportOwner !== owner.viewportOwner) return
 
       if (recovery.type === "restore_latest") {
+        if (current.mode !== "following_latest") return
         historyWindow.resumeLatestWindow()
         resumeScroll()
         return


### PR DESCRIPTION
## Summary

- Treat non-nested upward wheel/touch intent as user history-reading intent regardless of weak/strong gesture classification.
- Add `user_upward_navigation` diagnostics so weak upward reading no longer logs as `weak_scroll_observed` or `strong_upward_navigation`.
- Guard scheduled `restore_latest` recovery so a stale RAF cannot pull the viewport back after the controller has moved out of `following_latest`.
- Add controller unit coverage and a focused E2E for small wheel deltas after submit.

## Why

#595 RCA showed real upward wheel input staying in `following_latest` because it was classified as weak. The later near-top sample then hit `submit_restore_latest_after_top_reset`, and the recovery path restored latest/bottom.

This is the Phase 1 fix only: it addresses the current wheel/touch RCA path without doing the full three-owner consolidation.

## Related Issue

Related to #595. This PR does not close the full consolidation issue because `createAutoScroll` and `bottomFollowLock` are still deferred Phase 2 work.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Whether upward wheel/touch should leave latest for all non-nested gestures.
- Whether the stale `restore_latest` mode guard is the right minimal protection.
- Whether leaving the legacy scroll owners in place is acceptable for this Phase 1 boundary.

## Risk Notes

- Diagnostic reason changed for upward wheel/touch from `strong_upward_navigation` / `weak_scroll_observed` to `user_upward_navigation`.
- This intentionally does not remove `bottomFollowLock` or `createAutoScroll`; those remain #595 Phase 2 scope.
- Existing `keeps long timeline stable across worktree exit follow-up` E2E still fails in this worktree after a single-test rerun at the pre-existing long-session render-count checkpoint: expected at least 80 rendered messages after entering a worktree, received 10. The new weak-wheel E2E and the earlier diagnostics/scrollbar cases passed.

## How To Verify

```text
Install deps: bun install --frozen-lockfile -> ok
TDD red check: controller focused test failed before implementation on user_upward_navigation / weak upward assertions -> expected red
Focused controller test: bun test --preload ./happydom.ts ./src/pages/session/session-timeline-scroll-controller.test.ts -> 23 pass, 0 fail
Typecheck: bun run typecheck -> exit 0
Focused E2E: bun run test:e2e:local -- e2e/session/session-renderer-diagnostics.spec.ts -g "honors weak upward wheel after submit" -> 1 passed
Diagnostics E2E file: bun run test:e2e:local -- e2e/session/session-renderer-diagnostics.spec.ts -> 3 passed, 1 failed in existing worktree-exit long-session case
Existing failing E2E rerun: bun run test:e2e:local -- e2e/session/session-renderer-diagnostics.spec.ts -g "keeps long timeline stable across worktree exit follow-up" -> same failure, expected >= 80 rendered messages, received 10
Diff check: git diff --check -> ok
```

## Screenshots or Recordings

Not applicable. This is a scroll behavior/controller fix with E2E coverage, not a visual styling change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline scroll handling so weak upward gestures after submitting no longer force an unwanted "jump to latest"; the timeline better preserves reading position and only restores latest when appropriate.

* **Tests**
  * Added and updated end-to-end and unit tests covering upward scroll gestures, intent classification, and recovery/restore behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/630)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->