### PR TITLE
test: harden session scroll perf guard

### DIFF
--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -51,9 +51,11 @@ const inputLagText = [
 const longScrollSeedTurns = 104
 const longScrollMinimumRenderedMessages = 80
 const longScrollCoverageRatio = 0.95
-const longScrollWheelDurationMs = 6_500
-const longScrollUpWheelDurationMs = 9_000
-const longScrollWheelStepPx = 720
+const longScrollMinimumProbeWindowMs = 15_000
+const longScrollMaxRouteDurationMs = 30_000
+const longScrollTargetMovingSamples = 32
+const longScrollMinimumMovingSamples = 16
+const longScrollMinimumDistinctScrollTops = 12
 
 const scenarioResults: ReturnType<typeof summarizeScenarioRuns>[] = []
 
@@ -73,6 +75,15 @@ type TimelineMetrics = {
   scrollHeight: number
   clientHeight: number
   maxScrollTop: number
+}
+
+type WheelRouteResult = {
+  events: number
+  movingSamples: number
+  distinctScrollTopSamples: number
+  distancePx: number
+  durationMs: number
+  final: TimelineMetrics
 }
 
 const chatChunk = (delta: Record<string, unknown>, input?: { finish?: string; usage?: { input: number; output: number } }) => ({
@@ -204,6 +215,13 @@ async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], t
   expect(found).toBe(true)
 }
 
+async function hoverTimelineScrollLane(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const box = await page.locator(scrollViewportSelector).first().boundingBox()
+  expect(box).toBeTruthy()
+  if (!box) return
+  await page.mouse.move(box.x + box.width / 2, box.y + Math.min(120, box.height * 0.25))
+}
+
 async function readTimelineMetrics(page: Parameters<typeof snapshotPerfProbe>[0]) {
   const metrics = await page.evaluate(
     ({ scrollViewportSelector, turnListSelector }) => {
@@ -255,7 +273,7 @@ async function seedLongScrollSession(project: PerfProject, sessionID: string, ru
 async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>[0]) {
   const messages = page.locator(sessionMessageItemSelector)
   await expect(messages.first()).toBeVisible({ timeout: 30_000 })
-  await page.locator(scrollViewportSelector).first().hover()
+  await hoverTimelineScrollLane(page)
   for (let attempt = 0; attempt < 24; attempt += 1) {
     if ((await messages.count()) >= longScrollMinimumRenderedMessages) return
     await page.mouse.wheel(0, -2400)
@@ -263,7 +281,7 @@ async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)
   }
-  await expect.poll(async () => messages.count(), { timeout: 1_000 }).toBeGreaterThanOrEqual(longScrollMinimumRenderedMessages)
+  await expect.poll(async () => messages.count().catch(() => -1), { timeout: 1_000 }).toBeGreaterThanOrEqual(longScrollMinimumRenderedMessages)
 }
 
 async function installComposerPerfDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
@@ -315,28 +333,144 @@ function longScrollTodoPulse(
   sessionID: string,
   run: number,
 ) {
-  const checkpoints = [900, 2_400, 4_200, 6_800]
+  const checkpoints = [700, 1_600, 2_800, 4_200]
   let next = 0
   return async (elapsedMs: number) => {
-    if (next >= checkpoints.length || elapsedMs < checkpoints[next]) return
-    next += 1
-    await writeComposerDriver(page, sessionID, longScrollTodoDriver(run, next))
+    while (next < checkpoints.length && elapsedMs >= checkpoints[next]) {
+      next += 1
+      await writeComposerDriver(page, sessionID, longScrollTodoDriver(run, next))
+    }
   }
 }
 
-async function driveWheelStream(
+function calculateLongScrollStepPx(maxScrollTop: number) {
+  const target = Math.ceil((maxScrollTop * longScrollCoverageRatio) / longScrollTargetMovingSamples)
+  return Math.max(160, Math.min(900, target))
+}
+
+async function trackWheelMovement(
   page: Parameters<typeof snapshotPerfProbe>[0],
-  input: { direction: 1 | -1; durationMs: number; stepPx: number; onPulse?: (elapsedMs: number) => Promise<void> },
+  input: {
+    direction: 1 | -1
+    stepPx: number
+    previous: TimelineMetrics
+    startedAt: number
+    onPulse?: (elapsedMs: number) => Promise<void>
+  },
+) {
+  await page.mouse.wheel(0, input.direction * input.stepPx)
+  await input.onPulse?.(Date.now() - input.startedAt)
+  await page.waitForTimeout(16)
+
+  const next = await readTimelineMetrics(page)
+  const delta = Math.abs(next.scrollTop - input.previous.scrollTop)
+  return { next, delta }
+}
+
+async function driveWheelToRatio(
+  page: Parameters<typeof snapshotPerfProbe>[0],
+  input: {
+    direction: 1 | -1
+    targetRatio: number
+    stepPx: number
+    startedAt: number
+    onPulse?: (elapsedMs: number) => Promise<void>
+  },
 ) {
   const started = Date.now()
   let events = 0
-  while (Date.now() - started < input.durationMs) {
-    await page.mouse.wheel(0, input.direction * input.stepPx)
+  let movingSamples = 0
+  let distancePx = 0
+  let previous = await readTimelineMetrics(page)
+  const distinct = new Set([Math.round(previous.scrollTop)])
+  await hoverTimelineScrollLane(page)
+
+  while (Date.now() - started < longScrollMaxRouteDurationMs) {
+    const { next, delta } = await trackWheelMovement(page, {
+      direction: input.direction,
+      stepPx: input.stepPx,
+      previous,
+      startedAt: input.startedAt,
+      onPulse: input.onPulse,
+    })
     events += 1
-    await input.onPulse?.(Date.now() - started)
-    await page.waitForTimeout(16)
+    if (delta > 0.5) {
+      movingSamples += 1
+      distancePx += delta
+      distinct.add(Math.round(next.scrollTop))
+    }
+    previous = next
+
+    const ratio = next.maxScrollTop > 0 ? next.scrollTop / next.maxScrollTop : 0
+    const reached = input.direction === 1 ? ratio >= input.targetRatio : ratio <= input.targetRatio
+    if (reached && movingSamples >= longScrollMinimumMovingSamples) break
   }
-  return { events, durationMs: Date.now() - started }
+
+  return {
+    events,
+    movingSamples,
+    distinctScrollTopSamples: distinct.size,
+    distancePx,
+    durationMs: Date.now() - started,
+    final: previous,
+  }
+}
+
+async function sustainMovingScrollWindow(
+  page: Parameters<typeof snapshotPerfProbe>[0],
+  input: {
+    startedAt: number
+    stepPx: number
+    onPulse?: (elapsedMs: number) => Promise<void>
+  },
+): Promise<WheelRouteResult> {
+  const started = Date.now()
+  let events = 0
+  let movingSamples = 0
+  let distancePx = 0
+  let direction: 1 | -1 = 1
+  let previous = await readTimelineMetrics(page)
+  const distinct = new Set([Math.round(previous.scrollTop)])
+  await hoverTimelineScrollLane(page)
+
+  while (Date.now() - input.startedAt < longScrollMinimumProbeWindowMs) {
+    const ratio = previous.maxScrollTop > 0 ? previous.scrollTop / previous.maxScrollTop : 0
+    if (ratio >= 0.85) direction = -1
+    if (ratio <= 0.15) direction = 1
+
+    const { next, delta } = await trackWheelMovement(page, {
+      direction,
+      stepPx: input.stepPx,
+      previous,
+      startedAt: input.startedAt,
+      onPulse: input.onPulse,
+    })
+    events += 1
+    if (delta > 0.5) {
+      movingSamples += 1
+      distancePx += delta
+      distinct.add(Math.round(next.scrollTop))
+    }
+    previous = next
+  }
+
+  return {
+    events,
+    movingSamples,
+    distinctScrollTopSamples: distinct.size,
+    distancePx,
+    durationMs: Date.now() - started,
+    final: previous,
+  }
+}
+
+async function expandLongScrollTodoDock(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const dock = page.locator('[data-component="session-todo-dock"]').first()
+  await expect(dock).toBeVisible({ timeout: 10_000 })
+  await dock.locator('[data-action="session-todo-toggle-button"]').click()
+  const list = dock.locator('[data-slot="session-todo-list"]')
+  await expect(list).toHaveAttribute("aria-hidden", "false", { timeout: 5_000 })
+  await expect.poll(async () => (await dock.boundingBox())?.height ?? -1).toBeGreaterThan(60)
 }
 
 async function enableShellToolPartsExpanded(page: Parameters<typeof snapshotPerfProbe>[0]) {
@@ -642,7 +776,7 @@ test.describe("PR0.1 perf probe baseline", () => {
         await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
         await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeGreaterThanOrEqual(8)
         await resetPerfProbe(page)
-        await page.locator(scrollViewportSelector).first().hover()
+        await hoverTimelineScrollLane(page)
         await page.mouse.wheel(0, -3600)
         await settleFrames(page, 2)
         await scrollTimelineTo(page, 0)
@@ -672,39 +806,51 @@ test.describe("PR0.1 perf probe baseline", () => {
         await page.goto(sessionPath(project.directory, session.id))
         await revealLongScrollWindow(page)
         await writeComposerDriver(page, session.id, longScrollTodoDriver(run, 0))
-        await expect(page.locator('[data-component="session-todo-dock"]')).toBeVisible({ timeout: 10_000 })
+        await expandLongScrollTodoDock(page)
 
-        await page.locator(scrollViewportSelector).first().hover()
+        await hoverTimelineScrollLane(page)
         await scrollTimelineTo(page, 0)
         await settleFrames(page, 4)
         const atTop = await readTimelineMetrics(page)
         expect(atTop.maxScrollTop).toBeGreaterThan(4_000)
+        const stepPx = calculateLongScrollStepPx(atTop.maxScrollTop)
 
         await resetPerfProbe(page)
-        const down = await driveWheelStream(page, {
+        const startedAt = Date.now()
+        const pulse = longScrollTodoPulse(page, session.id, run)
+        const down = await driveWheelToRatio(page, {
           direction: 1,
-          durationMs: longScrollWheelDurationMs,
-          stepPx: longScrollWheelStepPx,
-          onPulse: longScrollTodoPulse(page, session.id, run),
+          targetRatio: longScrollCoverageRatio,
+          stepPx,
+          startedAt,
+          onPulse: pulse,
         })
         await settleFrames(page, 2)
-        const atBottom = await readTimelineMetrics(page)
+        const atBottom = down.final
         const downCoverage = atBottom.maxScrollTop > 0 ? atBottom.scrollTop / atBottom.maxScrollTop : 0
-        expect(down.durationMs).toBeGreaterThanOrEqual(6_000)
-        expect(down.events).toBeGreaterThanOrEqual(100)
+        expect(down.movingSamples).toBeGreaterThanOrEqual(longScrollMinimumMovingSamples)
+        expect(down.distinctScrollTopSamples).toBeGreaterThanOrEqual(longScrollMinimumDistinctScrollTops)
         expect(downCoverage).toBeGreaterThanOrEqual(longScrollCoverageRatio)
 
-        const up = await driveWheelStream(page, {
+        const up = await driveWheelToRatio(page, {
           direction: -1,
-          durationMs: longScrollUpWheelDurationMs,
-          stepPx: longScrollWheelStepPx,
+          targetRatio: 1 - longScrollCoverageRatio,
+          stepPx,
+          startedAt,
         })
         await settleFrames(page, 4)
-        const backAtTop = await readTimelineMetrics(page)
-        const remainingTopRatio = atBottom.maxScrollTop > 0 ? backAtTop.scrollTop / atBottom.maxScrollTop : 0
-        expect(up.durationMs).toBeGreaterThanOrEqual(8_500)
-        expect(up.events).toBeGreaterThanOrEqual(100)
+        const backAtTop = up.final
+        const remainingTopRatio = backAtTop.maxScrollTop > 0 ? backAtTop.scrollTop / backAtTop.maxScrollTop : 0
+        expect(up.movingSamples).toBeGreaterThanOrEqual(longScrollMinimumMovingSamples)
+        expect(up.distinctScrollTopSamples).toBeGreaterThanOrEqual(longScrollMinimumDistinctScrollTops)
         expect(remainingTopRatio).toBeLessThanOrEqual(1 - longScrollCoverageRatio)
+
+        const sustain = await sustainMovingScrollWindow(page, { startedAt, stepPx, onPulse: pulse })
+        const totalMovingSamples = down.movingSamples + up.movingSamples + sustain.movingSamples
+        const totalDistinctScrollTops =
+          down.distinctScrollTopSamples + up.distinctScrollTopSamples + sustain.distinctScrollTopSamples
+        expect(totalMovingSamples).toBeGreaterThanOrEqual(longScrollMinimumMovingSamples * 3)
+        expect(totalDistinctScrollTops).toBeGreaterThanOrEqual(longScrollMinimumDistinctScrollTops * 3)
 
         const sample = await snapshotPerfProbe(page)
         expect(sample.window_ms).toBeGreaterThanOrEqual(15_000)

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../selectors"
 import { sessionPath, terminalToggleKey } from "../utils"
 import type { createSdk } from "../utils"
+import { composerEvent, type ComposerDriverState, type ComposerWindow } from "../../src/testing/session-composer"
 import { installPerfProbe, resetPerfProbe, snapshotPerfProbe, summarizeScenarioRuns } from "./probe"
 import { applyPerfProfile, readPerfProfile, shouldRunScenario, type PerfScenarioName } from "./profiles"
 import { TIMELINE_RECOMPUTE_SEED_TURN_COUNT, seedTimelineRecomputeSession } from "./timeline-fixture"
@@ -47,6 +48,13 @@ const inputLagText = [
   "This fixed draft protects the composer path from timeline render regressions.",
 ].join(" ")
 
+const longScrollSeedTurns = 104
+const longScrollMinimumRenderedMessages = 80
+const longScrollCoverageRatio = 0.95
+const longScrollWheelDurationMs = 6_500
+const longScrollUpWheelDurationMs = 9_000
+const longScrollWheelStepPx = 720
+
 const scenarioResults: ReturnType<typeof summarizeScenarioRuns>[] = []
 
 type PerfSdk = ReturnType<typeof createSdk>
@@ -58,6 +66,13 @@ type PerfProject = {
 }
 type PerfLlm = {
   tool: (name: string, input: unknown) => Promise<void>
+}
+
+type TimelineMetrics = {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  maxScrollTop: number
 }
 
 const chatChunk = (delta: Record<string, unknown>, input?: { finish?: string; usage?: { input: number; output: number } }) => ({
@@ -187,6 +202,141 @@ async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], t
     { top, scrollViewportSelector, turnListSelector: sessionTurnListSelector },
   )
   expect(found).toBe(true)
+}
+
+async function readTimelineMetrics(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const metrics = await page.evaluate(
+    ({ scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return undefined
+      const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+      return {
+        scrollTop: viewport.scrollTop,
+        scrollHeight: viewport.scrollHeight,
+        clientHeight: viewport.clientHeight,
+        maxScrollTop,
+      }
+    },
+    { scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+  expect(metrics).toBeTruthy()
+  return metrics as TimelineMetrics
+}
+
+function longScrollSeedText(run: number, index: number) {
+  const code = [
+    "```ts",
+    `export const scrollSeed${index} = { run: ${run}, turn: ${index} }`,
+    "```",
+  ].join("\n")
+  const paragraphs = Array.from(
+    { length: 14 + (index % 6) },
+    (_, line) => `line ${line}: ${"mixed markdown scroll content ".repeat(6)}${index % 5 === 0 ? "中文混排 " : ""}`,
+  ).join("\n")
+  const toolLike = [
+    "Tool output:",
+    `- bash ${index}: ${"completed output ".repeat(8)}`,
+    `- todo ${index % 4}: ${"active dock pressure ".repeat(6)}`,
+  ].join("\n")
+  return [`long scroll seed ${run}-${index}`, paragraphs, code, toolLike].join("\n\n")
+}
+
+async function seedLongScrollSession(project: PerfProject, sessionID: string, run: number) {
+  for (let index = 0; index < longScrollSeedTurns; index += 1) {
+    await project.sdk.session.promptAsync({
+      sessionID,
+      noReply: true,
+      parts: [{ type: "text", text: longScrollSeedText(run, index) }],
+    })
+  }
+}
+
+async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const messages = page.locator(sessionMessageItemSelector)
+  await expect(messages.first()).toBeVisible({ timeout: 30_000 })
+  await page.locator(scrollViewportSelector).first().hover()
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    if ((await messages.count()) >= longScrollMinimumRenderedMessages) return
+    await page.mouse.wheel(0, -2400)
+    await settleFrames(page, 2)
+    await scrollTimelineTo(page, 0)
+    await settleFrames(page, 2)
+  }
+  await expect.poll(async () => messages.count(), { timeout: 1_000 }).toBeGreaterThanOrEqual(longScrollMinimumRenderedMessages)
+}
+
+async function installComposerPerfDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  await page.addInitScript(() => {
+    const win = window as ComposerWindow
+    const saved = window.sessionStorage.getItem("__opencode_e2e_composer_sessions")
+    const sessions = saved ? JSON.parse(saved) : {}
+    win.__opencode_e2e = { ...win.__opencode_e2e, composer: { enabled: true, sessions } }
+  })
+}
+
+async function writeComposerDriver(
+  page: Parameters<typeof snapshotPerfProbe>[0],
+  sessionID: string,
+  driver: ComposerDriverState | undefined,
+) {
+  await page.evaluate(
+    (input: { event: string; sessionID: string; driver: ComposerDriverState | undefined }) => {
+      const win = window as ComposerWindow
+      const composer = win.__opencode_e2e?.composer
+      if (!composer?.enabled) throw new Error("Composer e2e driver is not enabled")
+      composer.sessions ??= {}
+      const prev = composer.sessions[input.sessionID] ?? {}
+      if (!input.driver) {
+        delete composer.sessions[input.sessionID]
+      } else {
+        composer.sessions[input.sessionID] = { ...prev, driver: input.driver }
+      }
+      window.sessionStorage.setItem("__opencode_e2e_composer_sessions", JSON.stringify(composer.sessions))
+      window.dispatchEvent(new CustomEvent(input.event, { detail: { sessionID: input.sessionID } }))
+    },
+    { event: composerEvent, sessionID, driver },
+  )
+}
+
+function longScrollTodoDriver(run: number, phase: number): ComposerDriverState {
+  const count = 4 + phase
+  return {
+    todos: Array.from({ length: count }, (_, index) => ({
+      content: `scroll perf active task ${run}-${phase}-${index}`,
+      priority: index === 0 ? "high" : index % 3 === 0 ? "low" : "medium",
+      status: index < phase ? "completed" : index === phase ? "in_progress" : "pending",
+    })),
+  }
+}
+
+function longScrollTodoPulse(
+  page: Parameters<typeof snapshotPerfProbe>[0],
+  sessionID: string,
+  run: number,
+) {
+  const checkpoints = [900, 2_400, 4_200, 6_800]
+  let next = 0
+  return async (elapsedMs: number) => {
+    if (next >= checkpoints.length || elapsedMs < checkpoints[next]) return
+    next += 1
+    await writeComposerDriver(page, sessionID, longScrollTodoDriver(run, next))
+  }
+}
+
+async function driveWheelStream(
+  page: Parameters<typeof snapshotPerfProbe>[0],
+  input: { direction: 1 | -1; durationMs: number; stepPx: number; onPulse?: (elapsedMs: number) => Promise<void> },
+) {
+  const started = Date.now()
+  let events = 0
+  while (Date.now() - started < input.durationMs) {
+    await page.mouse.wheel(0, input.direction * input.stepPx)
+    events += 1
+    await input.onPulse?.(Date.now() - started)
+    await page.waitForTimeout(16)
+  }
+  return { events, durationMs: Date.now() - started }
 }
 
 async function enableShellToolPartsExpanded(page: Parameters<typeof snapshotPerfProbe>[0]) {
@@ -505,6 +655,68 @@ test.describe("PR0.1 perf probe baseline", () => {
     }
 
     scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-scroll-reading", runs }))
+  })
+
+  test("session-scroll-reading-long emits a low-end full-coverage JSON baseline", async ({ page, project }) => {
+    skipUnlessScenario("session-scroll-reading-long")
+    test.setTimeout(180_000)
+    await installComposerPerfDriver(page)
+    await installPerfProbe(page)
+    await applyPerfProfile(page, PERF_PROFILE)
+    await project.open()
+
+    const runs = []
+    for (let run = 0; run < 3; run += 1) {
+      await withSession(project.sdk, `perf scroll long ${Date.now()}-${run}`, async (session) => {
+        await seedLongScrollSession(project, session.id, run)
+        await page.goto(sessionPath(project.directory, session.id))
+        await revealLongScrollWindow(page)
+        await writeComposerDriver(page, session.id, longScrollTodoDriver(run, 0))
+        await expect(page.locator('[data-component="session-todo-dock"]')).toBeVisible({ timeout: 10_000 })
+
+        await page.locator(scrollViewportSelector).first().hover()
+        await scrollTimelineTo(page, 0)
+        await settleFrames(page, 4)
+        const atTop = await readTimelineMetrics(page)
+        expect(atTop.maxScrollTop).toBeGreaterThan(4_000)
+
+        await resetPerfProbe(page)
+        const down = await driveWheelStream(page, {
+          direction: 1,
+          durationMs: longScrollWheelDurationMs,
+          stepPx: longScrollWheelStepPx,
+          onPulse: longScrollTodoPulse(page, session.id, run),
+        })
+        await settleFrames(page, 2)
+        const atBottom = await readTimelineMetrics(page)
+        const downCoverage = atBottom.maxScrollTop > 0 ? atBottom.scrollTop / atBottom.maxScrollTop : 0
+        expect(down.durationMs).toBeGreaterThanOrEqual(6_000)
+        expect(down.events).toBeGreaterThanOrEqual(100)
+        expect(downCoverage).toBeGreaterThanOrEqual(longScrollCoverageRatio)
+
+        const up = await driveWheelStream(page, {
+          direction: -1,
+          durationMs: longScrollUpWheelDurationMs,
+          stepPx: longScrollWheelStepPx,
+        })
+        await settleFrames(page, 4)
+        const backAtTop = await readTimelineMetrics(page)
+        const remainingTopRatio = atBottom.maxScrollTop > 0 ? backAtTop.scrollTop / atBottom.maxScrollTop : 0
+        expect(up.durationMs).toBeGreaterThanOrEqual(8_500)
+        expect(up.events).toBeGreaterThanOrEqual(100)
+        expect(remainingTopRatio).toBeLessThanOrEqual(1 - longScrollCoverageRatio)
+
+        const sample = await snapshotPerfProbe(page)
+        expect(sample.window_ms).toBeGreaterThanOrEqual(15_000)
+        runs.push(sample)
+        await writeComposerDriver(page, session.id, undefined)
+        if (run < 2) await cooldownAfterRun(page)
+      })
+    }
+
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-scroll-reading-long", runs }),
+    )
   })
 
   test("session-timeline-recompute emits a 3-run low-end JSON baseline", async ({ page, project }) => {

--- a/packages/app/e2e/perf/profiles.ts
+++ b/packages/app/e2e/perf/profiles.ts
@@ -9,6 +9,7 @@ export type PerfScenarioName =
   | "tool-default-open-heavy-bash"
   | "terminal-side-panel-open"
   | "session-scroll-reading"
+  | "session-scroll-reading-long"
   | "session-timeline-recompute"
 
 const defaultScenarios = new Set<PerfScenarioName>([
@@ -21,7 +22,7 @@ const defaultScenarios = new Set<PerfScenarioName>([
   "session-scroll-reading",
 ])
 
-const lowEndScenarios = new Set<PerfScenarioName>(["session-timeline-recompute"])
+const lowEndScenarios = new Set<PerfScenarioName>(["session-scroll-reading-long", "session-timeline-recompute"])
 
 export function readPerfProfile(): PerfProfile {
   return process.env.PAWWORK_PERF_PROFILE === "low-end" ? "low-end" : "default"

--- a/packages/app/e2e/perf/profiles.unit.ts
+++ b/packages/app/e2e/perf/profiles.unit.ts
@@ -14,3 +14,10 @@ test("default profile runs long-session input lag coverage", () => {
   expect(shouldRunScenario("default", scenario)).toBe(true)
   expect(shouldRunScenario("low-end", scenario)).toBe(false)
 })
+
+test("low-end profile runs long scroll reading coverage", () => {
+  const scenario = "session-scroll-reading-long" as PerfScenarioName
+
+  expect(shouldRunScenario("default", scenario)).toBe(false)
+  expect(shouldRunScenario("low-end", scenario)).toBe(true)
+})


### PR DESCRIPTION
## Summary

Adds a low-end `session-scroll-reading-long` perf scenario for the session timeline.

The new scenario:

- Seeds a 104-turn mixed-content session.
- Forces at least 80 rendered message rows before measurement.
- Keeps the todo dock expanded and mutates its state during sustained scroll.
- Drives full-distance down and up wheel streams using actual `scrollTop` movement coverage.
- Keeps the 15s+ measurement window moving with mid-scroll sweep coverage instead of boundary wheel spam.
- Emits the existing perf JSON summary for baseline comparison.

No product behavior is changed in this PR.

## Why

Issue #633 is the first PR in the scroll performance governance series. The current scroll perf probe was too thin to represent the reported long-session reading jank: it used a shorter history, a single short wheel gesture, and no active dock/layout pressure.

This PR only improves measurement coverage so later PRs can make and verify product performance changes against a stronger baseline.

Review follow-up: the long scroll driver now records actual moving samples and distinct scroll positions, uses a dynamic wheel step from timeline height, expands the todo dock before measurement, and keeps wheel coordinates away from the jump-to-latest overlay.

## Related Issue

Part of #633.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether the new scenario is narrow enough for PR1 and whether the moving-sample assertions make the probe meaningful without making it unnecessarily flaky.

## Risk Notes

Low. This is test-only and touches only the Playwright perf probe plus perf profile routing. It does make the low-end perf profile heavier because the new scenario creates three long sessions and samples sustained scrolling.

## How To Verify

```text
Profile routing unit test: 4 passed
packages/app typecheck: passed
Diff check: no whitespace errors
Focused perf probe: 1 passed in about 1.1m
Perf JSON: profile low-end, scenario session-scroll-reading-long, runs 3, window_ms 15006.3, frame_gap_max_ms 65.7, jank_count_50ms 1, cls 0.016
```

Commands run:

```bash
bun test ./packages/app/e2e/perf/profiles.unit.ts
bun run typecheck
git diff --check
PLAYWRIGHT_PORT=3101 PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_BRANCH=i633-local PAWWORK_PERF_OUTPUT=/tmp/pawwork-i633-scroll.json bun run test:e2e:perf -- --project=chromium --grep "session-scroll-reading-long" --reporter=line --workers=1
```

## Screenshots or Recordings

Not applicable. This PR adds perf coverage only and does not change visible UI behavior.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Expanded performance testing suite with new long-scroll baseline tests for timeline operations
* Enhanced scroll profiling capabilities with improved helper functions and metric tracking
* Added support for testing complex scrolling scenarios with deterministic content generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/635)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->