### PR TITLE
refactor: align TodoItem with SDK type and fix tsconfig inconsistencies

### DIFF
--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -1,8 +1,9 @@
 import { For, Show, createMemo, type Accessor, type JSX } from "solid-js"
 import type { Part } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
-import { extractSources, type TodoItem } from "@/pages/session/session-status-extractors"
+import { extractSources } from "@/pages/session/session-status-extractors"
 import { selectSessionTodos } from "@/pages/session/session-todos"
+import type { SessionTodoItem } from "@/pages/session/todos/todo-model"
 
 const TODO_STATUS_STYLES: Record<string, { dot: string; text: string }> = {
   completed: { dot: "bg-icon-success-base", text: "" },
@@ -24,7 +25,7 @@ function Empty(props: { text: string }) {
   return <div class="text-13-regular text-fg-weaker">{props.text}</div>
 }
 
-function TodoRow(props: { todo: TodoItem }) {
+function TodoRow(props: { todo: SessionTodoItem }) {
   const style = () => TODO_STATUS_STYLES[props.todo.status] ?? TODO_STATUS_STYLES.pending
   return (
     <div class="flex items-start gap-2.5 py-1">

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -1,4 +1,5 @@
 import type { Message, Part } from "@opencode-ai/sdk/v2"
+import { TOOL_QUESTION } from "@/pages/session/session-status-extractors"
 
 // Minimal sync-entry shape this matcher needs. Widened from the full
 // QuestionRequest so callers (e.g. reverify) can pass narrower generics
@@ -41,8 +42,7 @@ export function findRunningQuestionFallbackSession(input: {
     const parts = input.partsByMessageID[m.id]
     if (!parts) continue
     for (const part of parts) {
-      const QUESTION_TOOL = "question"
-      if (part.type !== "tool" || part.tool !== QUESTION_TOOL || part.state.status !== "running") continue
+      if (part.type !== "tool" || part.tool !== TOOL_QUESTION || part.state.status !== "running") continue
       const callID = part.callID
       const messageID = part.messageID
       if (!callID || !messageID || !coveredKeys.has(`${messageID}:${callID}`)) {

--- a/packages/app/src/pages/session/blockers/question-fallback.ts
+++ b/packages/app/src/pages/session/blockers/question-fallback.ts
@@ -41,7 +41,8 @@ export function findRunningQuestionFallbackSession(input: {
     const parts = input.partsByMessageID[m.id]
     if (!parts) continue
     for (const part of parts) {
-      if (part.type !== "tool" || part.tool !== "question" || part.state.status !== "running") continue
+      const QUESTION_TOOL = "question"
+      if (part.type !== "tool" || part.tool !== QUESTION_TOOL || part.state.status !== "running") continue
       const callID = part.callID
       const messageID = part.messageID
       if (!callID || !messageID || !coveredKeys.has(`${messageID}:${callID}`)) {

--- a/packages/app/src/pages/session/session-status-extractors.test.ts
+++ b/packages/app/src/pages/session/session-status-extractors.test.ts
@@ -146,6 +146,7 @@ describe("tool name sanity", () => {
     [TOOL_TODOWRITE, "todo.ts"],
     [TOOL_WEBFETCH, "webfetch.ts"],
     [TOOL_WEBSEARCH, "websearch.ts"],
+    ["question", "question.ts"],
   ]
   for (const [tool, filename] of cases) {
     it(`"${tool}" literal appears in packages/opencode/src/tool/${filename}`, () => {

--- a/packages/app/src/pages/session/session-status-extractors.test.ts
+++ b/packages/app/src/pages/session/session-status-extractors.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import { describe, expect, it } from "bun:test"
 import type { Part, ToolState } from "@opencode-ai/sdk/v2"
 import {
+  TOOL_QUESTION,
   TOOL_TODOWRITE,
   TOOL_WEBFETCH,
   TOOL_WEBSEARCH,
@@ -146,7 +147,7 @@ describe("tool name sanity", () => {
     [TOOL_TODOWRITE, "todo.ts"],
     [TOOL_WEBFETCH, "webfetch.ts"],
     [TOOL_WEBSEARCH, "websearch.ts"],
-    ["question", "question.ts"],
+    [TOOL_QUESTION, "question.ts"],
   ]
   for (const [tool, filename] of cases) {
     it(`"${tool}" literal appears in packages/opencode/src/tool/${filename}`, () => {

--- a/packages/app/src/pages/session/session-status-extractors.ts
+++ b/packages/app/src/pages/session/session-status-extractors.ts
@@ -11,17 +11,13 @@
 // so these extractors stay as pure functions testable against SDK fixtures.
 
 import type { Part } from "@opencode-ai/sdk/v2"
+import type { Todo } from "@opencode-ai/sdk/v2/client"
 
 export const TOOL_TODOWRITE = "todowrite"
 export const TOOL_WEBFETCH = "webfetch"
 export const TOOL_WEBSEARCH = "websearch"
 
-export interface TodoItem {
-  id?: string
-  content: string
-  status: string
-  priority: string
-}
+export type TodoItem = Pick<Todo, "content" | "status" | "priority"> & Partial<Pick<Todo, "id">>
 
 function isToolPart(part: Part): part is Extract<Part, { type: "tool" }> {
   return part.type === "tool"

--- a/packages/app/src/pages/session/session-status-extractors.ts
+++ b/packages/app/src/pages/session/session-status-extractors.ts
@@ -4,6 +4,7 @@
 //   todowrite → packages/opencode/src/tool/todo.ts
 //   webfetch  → packages/opencode/src/tool/webfetch.ts
 //   websearch → packages/opencode/src/tool/websearch.ts
+//   question  → packages/opencode/src/tool/question.ts
 //
 // Input shape: parts live in sync.data.part[message.id], keyed by messageID.
 // Callers pass a pre-flattened Part[] — produced by
@@ -11,21 +12,20 @@
 // so these extractors stay as pure functions testable against SDK fixtures.
 
 import type { Part } from "@opencode-ai/sdk/v2"
-import type { Todo } from "@opencode-ai/sdk/v2/client"
+import type { SessionTodoItem } from "@/pages/session/todos/todo-model"
 
 export const TOOL_TODOWRITE = "todowrite"
 export const TOOL_WEBFETCH = "webfetch"
 export const TOOL_WEBSEARCH = "websearch"
-
-export type TodoItem = Pick<Todo, "content" | "status" | "priority"> & Partial<Pick<Todo, "id">>
+export const TOOL_QUESTION = "question"
 
 function isToolPart(part: Part): part is Extract<Part, { type: "tool" }> {
   return part.type === "tool"
 }
 
-function isValidTodo(value: unknown): value is TodoItem {
+function isValidTodo(value: unknown): value is SessionTodoItem {
   if (typeof value !== "object" || value === null) return false
-  const v = value as Partial<TodoItem>
+  const v = value as Partial<SessionTodoItem>
   return (
     (v.id === undefined || typeof v.id === "string") &&
     typeof v.content === "string" &&
@@ -34,7 +34,7 @@ function isValidTodo(value: unknown): value is TodoItem {
   )
 }
 
-function todosFromMetadata(part: Extract<Part, { type: "tool" }>): TodoItem[] | undefined {
+function todosFromMetadata(part: Extract<Part, { type: "tool" }>): SessionTodoItem[] | undefined {
   const metadata = part.state.status === "completed" ? part.state.metadata : undefined
   const todos = (metadata as { todos?: unknown } | undefined)?.todos
   if (!Array.isArray(todos)) return undefined
@@ -42,8 +42,8 @@ function todosFromMetadata(part: Extract<Part, { type: "tool" }>): TodoItem[] | 
   return valid.length === todos.length ? valid : undefined
 }
 
-export function extractTodos(parts: Part[]): TodoItem[] {
-  let latest: TodoItem[] = []
+export function extractTodos(parts: Part[]): SessionTodoItem[] {
+  let latest: SessionTodoItem[] = []
   for (const part of parts) {
     if (!isToolPart(part)) continue
     if (part.tool !== TOOL_TODOWRITE) continue

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -3,8 +3,8 @@
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
+    "jsxImportSource": "solid-js",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": [],
     "noUncheckedIndexedAccess": false,
     "customConditions": ["browser"],
     "paths": {

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "noUncheckedIndexedAccess": false,
     "customConditions": ["browser"],


### PR DESCRIPTION
## Summary

A targeted fix for a subset of the interface inconsistencies identified in #638. Two scopes: drop one tsconfig misconfiguration in `opencode`, and collapse same-shape Todo type aliases plus the `question` tool name into a single source of truth.

## Changes

### 1. `opencode/tsconfig.json`: restore default ambient type discovery

Removed `"types": []`. That setting blocked TypeScript's default behavior of picking up visible `@types/*` packages. Since `packages/opencode` depends on `@types/bun`, deleting this line restores Bun ambient globals (and other ambient types) without any further configuration.

Note: the previous PR body said `@tsconfig/bun` declares `types: ["bun"]`. It does not — the base config simply omits the field, which is why removing `"types": []` is enough to let auto-discovery do its job. If the project prefers an explicit allow-list, the equivalent narrower form would be `"types": ["bun"]`.

### 2. Collapse `TodoItem` into `SessionTodoItem`

`session-status-extractors.ts` used to export a `TodoItem` alias that was structurally identical to `SessionTodoItem` in `todos/todo-model.ts`. The summary component (`session-status-summary.tsx`) typed its row prop as `TodoItem` even though `selectSessionTodos()` returns `SessionTodoItem[]` — that compiled only because the two shapes happened to match.

This PR removes the `TodoItem` alias entirely. `isValidTodo`, `todosFromMetadata`, and `extractTodos` now consume `SessionTodoItem`, and `TodoRow` does too. One name, one definition, end-to-end.

### 3. Shared `TOOL_QUESTION` constant, bound to the sanity test

`session-status-extractors.ts` already exports `TOOL_TODOWRITE`, `TOOL_WEBFETCH`, and `TOOL_WEBSEARCH`. This PR adds `TOOL_QUESTION = "question"` next to them and:

- `question-fallback.ts` imports and uses `TOOL_QUESTION` (the previous local `QUESTION_TOOL` constant was loop-scoped and not reachable from tests).
- The tool-name sanity test case is now `[TOOL_QUESTION, "question.ts"]` rather than a bare `"question"` string, so a rename of the production constant actually flips the assertion.

The header comment in `session-status-extractors.ts` now lists `question` alongside the existing tool-name pointers.

## Test Results

- `packages/opencode` typecheck: clean (`bun --cwd packages/opencode run typecheck`).
- `packages/app` typecheck: clean (`bun --cwd packages/app run typecheck`).
- `packages/app` unit tests: **1072 pass / 0 fail** (`bun --cwd packages/app run test:unit`).

No user-facing UI behavior changes; this is type plumbing and a dead tsconfig field. No Electron smoke needed.

## Related Issue

Relates to #638.