### PR TITLE
fix: address race-condition and error-handling bugs from automated audit

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -423,7 +423,9 @@ export const Terminal = (props: TerminalProps) => {
       if (local.autoFocus !== false) focusTerminal()
 
       if (typeof document !== "undefined" && document.fonts) {
-        document.fonts.ready.then(scheduleFit)
+        document.fonts.ready.then(scheduleFit).catch(() => {
+          // Ignore font loading errors — scheduleFit is best-effort
+        })
       }
 
       const onResize = t.onResize((size) => {
@@ -435,7 +437,7 @@ export const Terminal = (props: TerminalProps) => {
       })
       cleanups.push(() => disposeIfDisposable(onData))
       const onKey = t.onKey((key) => {
-        if (key.key == "Enter") {
+        if (key.key === "Enter") {
           props.onSubmit?.()
         }
       })

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -445,6 +445,7 @@ function createGlobalSync() {
     if (typeof requestAnimationFrame === "function") {
       eventFrame = requestAnimationFrame(() => {
         eventFrame = undefined
+        if (!active) return
         eventTimer = setTimeout(() => {
           eventTimer = undefined
           void globalSDK.event.start()

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -148,13 +148,17 @@ function createGlobalSync() {
   }) as typeof setGlobalStore
 
   if (projectInit instanceof Promise) {
-    void projectInit.then(() => {
-      if (!active) return
-      if (projectWritten) return
-      const cached = projectCache.value
-      if (cached.length === 0) return
-      setGlobalStore("project", cached)
-    })
+    void projectInit
+      .then(() => {
+        if (!active) return
+        if (projectWritten) return
+        const cached = projectCache.value
+        if (cached.length === 0) return
+        setGlobalStore("project", cached)
+      })
+      .catch(() => {
+        // Project init failed — ignore; the sync loop will retry
+      })
   }
 
   const setSessionTodo = (

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -321,6 +321,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       clearSessionPrefetch(directory, sessionIDs)
       for (const sessionID of sessionIDs) {
         globalSync.todo.set(sessionID, undefined)
+        clearOptimistic(directory, sessionID)
       }
       setStore(
         produce((draft) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1546,18 +1546,26 @@ export default function Layout(props: ParentProps) {
 
   function connectProvider() {
     const run = ++dialogRun
-    void import("@/components/dialog-select-provider").then((x) => {
-      if (dialogDead || dialogRun !== run) return
-      dialog.show(() => <x.DialogSelectProvider />)
-    })
+    void import("@/components/dialog-select-provider")
+      .then((x) => {
+        if (dialogDead || dialogRun !== run) return
+        dialog.show(() => <x.DialogSelectProvider />)
+      })
+      .catch(() => {
+        // Chunk failed to load — ignore; user can retry
+      })
   }
 
   function openServer() {
     const run = ++dialogRun
-    void import("@/components/dialog-select-server").then((x) => {
-      if (dialogDead || dialogRun !== run) return
-      dialog.show(() => <x.DialogSelectServer />)
-    })
+    void import("@/components/dialog-select-server")
+      .then((x) => {
+        if (dialogDead || dialogRun !== run) return
+        dialog.show(() => <x.DialogSelectServer />)
+      })
+      .catch(() => {
+        // Chunk failed to load — ignore; user can retry
+      })
   }
 
   function openSettingsSurface() {
@@ -1774,13 +1782,18 @@ export default function Layout(props: ParentProps) {
       resolve(result)
     } else {
       const run = ++dialogRun
-      void import("@/components/dialog-select-directory").then((x) => {
-        if (dialogDead || dialogRun !== run) return
-        dialog.show(
-          () => <x.DialogSelectDirectory multiple={true} onSelect={resolve} />,
-          () => resolve(null),
-        )
-      })
+      void import("@/components/dialog-select-directory")
+        .then((x) => {
+          if (dialogDead || dialogRun !== run) return
+          dialog.show(
+            () => <x.DialogSelectDirectory multiple={true} onSelect={resolve} />,
+            () => resolve(null),
+          )
+        })
+        .catch(() => {
+          // Chunk failed to load — resolve gracefully
+          resolve(null)
+        })
     }
   }
 

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -338,20 +338,27 @@ export namespace Workspace {
         continue
       }
       setStatus(space.id, "connected")
-      await parseSSE(res.body, signal, (evt) => {
-        const event = evt as SyncEvent.SerializedEvent
+      try {
+        await parseSSE(res.body, signal, (evt) => {
+          const event = evt as SyncEvent.SerializedEvent
 
-        try {
-          if (!event.type.startsWith("server.")) {
-            SyncEvent.replay(event)
+          try {
+            if (!event.type.startsWith("server.")) {
+              SyncEvent.replay(event)
+            }
+          } catch (err) {
+            log.warn("failed to replay sync event", {
+              workspaceID: space.id,
+              error: err,
+            })
           }
-        } catch (err) {
-          log.warn("failed to replay sync event", {
-            workspaceID: space.id,
-            error: err,
-          })
-        }
-      })
+        })
+      } catch (err) {
+        log.warn("sync stream parse error", {
+          workspaceID: space.id,
+          error: err,
+        })
+      }
       setStatus(space.id, "disconnected")
       log.info("disconnected to sync: " + space.id)
       await sleep(250)

--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -153,6 +153,10 @@ const synthesizeOutput = (
       header = "status: running"
       body = wrapper("")
       break
+    default:
+      header = `status: ${(part as { status: string }).status}`
+      body = wrapper("")
+      break
   }
 
   return {

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -32,7 +32,9 @@ function isSensitiveFile(filePath: string) {
 }
 
 function notFound(error: unknown) {
-  return typeof error === "object" && error !== null && "reason" in error && (error as any).reason?._tag === "NotFound"
+  if (typeof error !== "object" || error === null || !("reason" in error)) return false
+  const reason = (error as Record<string, unknown>).reason
+  return typeof reason === "object" && reason !== null && "_tag" in reason && reason._tag === "NotFound"
 }
 
 function safeTotalDiff(changes: Array<{ diff: string; sensitive: boolean }>) {


### PR DESCRIPTION
Fixes identified during full-stack bug hunt (issues #643, #644, #645).

## app
- **terminal.tsx**:
  - Use strict equality (`===`) for Enter key check instead of loose (`==`)
  - Add `.catch()` to `document.fonts.ready` promise to prevent unhandled rejection
- **layout.tsx**: Add `.catch()` handlers to 3 dynamic imports (provider/server/directory dialogs) — prevents unhandled rejections if chunks fail to load
- **global-sync.tsx**:
  - Add `.catch()` to `projectInit` promise — prevents unhandled rejection if project initialization fails
  - Guard the `requestAnimationFrame` callback with `if (!active) return` to avoid scheduling work after cleanup
- **sync.tsx**: Call `clearOptimistic(directory, sessionID)` when dropping sessions, so the optimistic Map does not leak entries

## opencode
- **tool/agent.ts**: Add `default` case to `part.status` switch — prevents `header` and `body` from remaining `undefined` when a new status value is introduced
- **control-plane/workspace.ts**: Wrap `parseSSE` call in try/catch — prevents malformed SSE events from terminating the sync loop entirely
- **tool/apply_patch.ts**: Replace `(error as any)` with proper `Record<string, unknown>` narrowing in `notFound()` helper

## Verification
- packages/ui typecheck: clean
- packages/app typecheck: clean
- packages/opencode typecheck: clean