### PR TITLE
fix: recover stale persisted sessions and terminals

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -12,7 +12,7 @@ import { usePlatform } from "@/context/platform"
 import { useSDK } from "@/context/sdk"
 import { useServer } from "@/context/server"
 import { monoFontFamily, useSettings } from "@/context/settings"
-import type { LocalPTY } from "@/context/terminal"
+import { isTerminalGoneError, type LocalPTY } from "@/context/terminal"
 import { terminalAttr, terminalProbe } from "@/testing/terminal"
 import { disposeIfDisposable, getHoveredLinkText, setOptionIfSupported } from "@/utils/runtime-adapters"
 import { terminalWebSocketURL } from "@/utils/terminal-websocket-url"
@@ -67,13 +67,6 @@ const DEFAULT_TERMINAL_COLORS: Record<"light" | "dark", TerminalColors> = {
 const debugTerminal = (...values: unknown[]) => {
   if (!import.meta.env.DEV) return
   console.debug("[terminal]", ...values)
-}
-
-const errorName = (err: unknown) => {
-  if (!err || typeof err !== "object") return
-  if (!("name" in err)) return
-  const errorName = err.name
-  return typeof errorName === "string" ? errorName : undefined
 }
 
 const useTerminalUiBindings = (input: {
@@ -496,7 +489,7 @@ export const Terminal = (props: TerminalProps) => {
           .get({ ptyID: id })
           .then(() => false)
           .catch((err) => {
-            if (errorName(err) === "NotFoundError") return true
+            if (isTerminalGoneError(err)) return true
             debugTerminal("failed to inspect terminal session", err)
             return false
           })

--- a/packages/app/src/context/terminal.test.ts
+++ b/packages/app/src/context/terminal.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, mock, test } from "bun:test"
 let getWorkspaceTerminalCacheKey: (dir: string) => string
 let getLegacyTerminalStorageKeys: (dir: string, legacySessionID?: string) => string[]
 let migrateTerminalState: (value: unknown) => unknown
+let replaceTerminalWithClone: typeof import("./terminal")["replaceTerminalWithClone"]
 let createTerminalBinding: typeof import("./terminal")["createTerminalBinding"]
 
 beforeAll(async () => {
@@ -20,6 +21,7 @@ beforeAll(async () => {
   getWorkspaceTerminalCacheKey = mod.getWorkspaceTerminalCacheKey
   getLegacyTerminalStorageKeys = mod.getLegacyTerminalStorageKeys
   migrateTerminalState = mod.migrateTerminalState
+  replaceTerminalWithClone = mod.replaceTerminalWithClone
   createTerminalBinding = mod.createTerminalBinding
 })
 
@@ -80,6 +82,44 @@ describe("migrateTerminalState", () => {
         { id: "two", title: "shell", titleNumber: 7 },
       ],
     })
+  })
+})
+
+describe("replaceTerminalWithClone", () => {
+  test("replaces a stale runtime pty id and keeps the durable tab metadata", () => {
+    expect(
+      replaceTerminalWithClone(
+        {
+          active: "pty_old",
+          all: [
+            {
+              id: "pty_old",
+              title: "Terminal 2",
+              titleNumber: 2,
+              buffer: "old output",
+              cursor: 12,
+              scrollY: 8,
+              rows: 24,
+              cols: 80,
+            },
+          ],
+        },
+        "pty_old",
+        { id: "pty_new", title: "Terminal 2" },
+      ),
+    ).toEqual({
+      active: "pty_new",
+      all: [{ id: "pty_new", title: "Terminal 2", titleNumber: 2 }],
+    })
+  })
+
+  test("returns the original state when the stale id no longer exists", () => {
+    const current = {
+      active: "pty_a",
+      all: [{ id: "pty_a", title: "Terminal 1", titleNumber: 1 }],
+    }
+
+    expect(replaceTerminalWithClone(current, "pty_missing", { id: "pty_new", title: "Terminal 1" })).toBe(current)
   })
 })
 

--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -1,4 +1,4 @@
-import { createStore, produce } from "solid-js/store"
+import { createStore, produce, reconcile } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { batch, createEffect, createMemo, createRoot, on, onCleanup, type Accessor } from "solid-js"
 import { useParams } from "@solidjs/router"
@@ -133,6 +133,40 @@ const trimTerminal = (pty: LocalPTY) => {
   }
 }
 
+export function isTerminalGoneError(error: unknown) {
+  if (!error || typeof error !== "object") return false
+  const value = error as {
+    name?: unknown
+    status?: unknown
+    statusCode?: unknown
+    response?: { status?: unknown }
+  }
+  if (value.name === "NotFoundError") return true
+  if (value.status === 404 || value.statusCode === 404) return true
+  return value.response?.status === 404
+}
+
+export function replaceTerminalWithClone(
+  current: { active?: string; all: LocalPTY[] },
+  id: string,
+  clone: { id?: string; title?: string },
+) {
+  if (!clone.id) return current
+  const index = current.all.findIndex((pty) => pty.id === id)
+  const pty = current.all[index]
+  if (!pty) return current
+  const all = current.all.slice()
+  all[index] = {
+    id: clone.id,
+    title: clone.title ?? pty.title,
+    titleNumber: pty.titleNumber,
+  }
+  return {
+    active: current.active === id ? clone.id : current.active,
+    all,
+  }
+}
+
 export function clearWorkspaceTerminals(dir: string, sessionIDs?: string[], platform?: Platform) {
   const key = getWorkspaceTerminalCacheKey(dir)
   for (const cache of caches) {
@@ -155,6 +189,7 @@ export function clearWorkspaceTerminals(dir: string, sessionIDs?: string[], plat
 
 function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, legacySessionID?: string) {
   const legacy = getLegacyTerminalStorageKeys(dir, legacySessionID)
+  const recovering = new Set<string>()
 
   const [store, setStore, _, ready] = persisted(
     {
@@ -236,6 +271,10 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
         size: pty.cols && pty.rows ? { rows: pty.rows, cols: pty.cols } : undefined,
       })
       .catch((error: unknown) => {
+        if (isTerminalGoneError(error)) {
+          void clone(client, pty.id)
+          return
+        }
         if (previous) {
           const currentIndex = store.all.findIndex((item) => item.id === pty.id)
           if (currentIndex >= 0) setStore("all", currentIndex, previous)
@@ -245,9 +284,11 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
   }
 
   const clone = async (client: ReturnType<typeof useSDK>["client"], id: string) => {
+    if (recovering.has(id)) return
     const index = store.all.findIndex((x) => x.id === id)
     const pty = store.all[index]
     if (!pty) return
+    recovering.add(id)
     const next = await client.pty
       .create({
         title: pty.title,
@@ -256,24 +297,17 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
         console.error("Failed to clone terminal", error)
         return undefined
       })
+      .finally(() => {
+        recovering.delete(id)
+      })
     if (!next?.data) return
 
-    const active = store.active === pty.id
+    const nextState = replaceTerminalWithClone({ active: store.active, all: store.all }, pty.id, next.data)
+    if (nextState.all === store.all) return
 
     batch(() => {
-      setStore("all", index, {
-        id: next.data.id,
-        title: next.data.title ?? pty.title,
-        titleNumber: pty.titleNumber,
-        buffer: undefined,
-        cursor: undefined,
-        scrollY: undefined,
-        rows: undefined,
-        cols: undefined,
-      })
-      if (active) {
-        setStore("active", next.data.id)
-      }
+      setStore("all", reconcile(nextState.all, { key: "id" }))
+      setStore("active", nextState.active)
     })
   }
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -100,7 +100,7 @@ import {
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { PawworkTitlebar } from "./layout/pawwork-titlebar"
-import { createDefaultLayoutPageState, createLayoutPagePersistTarget } from "./layout/layout-page-store"
+import { createDefaultLayoutPageState, createLayoutPagePersistTarget, removePinnedSessionIDs } from "./layout/layout-page-store"
 import { SettingsPage, type SettingsPageTab } from "@/components/settings-page"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
 import { sessionTitle } from "@/utils/session-title"
@@ -556,16 +556,41 @@ export default function Layout(props: ParentProps) {
     return pawworkSessionWindowState.normal.find((session) => session.id === sessionID)
   }
 
-  const loadSessionByID = async (sessionID: string | undefined) => {
-    if (!sessionID) return
+  const missingResourceError = (error: unknown) => {
+    if (!error || typeof error !== "object") return false
+    const value = error as {
+      name?: unknown
+      status?: unknown
+      statusCode?: unknown
+      response?: { status?: unknown }
+    }
+    if (value.name === "NotFoundError") return true
+    if (value.status === 404 || value.statusCode === 404) return true
+    return value.response?.status === 404
+  }
+
+  type SessionLoadResult =
+    | { state: "found"; session: PawworkWindowSession }
+    | { state: "gone" }
+    | { state: "transient" }
+
+  const loadSessionByIDResult = async (sessionID: string | undefined): Promise<SessionLoadResult> => {
+    if (!sessionID) return { state: "gone" }
     const loaded = findLoadedSession(sessionID)
-    if (loaded) return loaded
+    if (loaded) return { state: "found", session: loaded }
     try {
       const response = await globalSDK.client.session.get({ sessionID })
-      return response.data && !response.data.time?.archived ? response.data : undefined
-    } catch {
-      return undefined
+      const session = response.data
+      if (session && !session.time?.archived) return { state: "found", session }
+      return { state: "gone" }
+    } catch (error) {
+      return missingResourceError(error) ? { state: "gone" } : { state: "transient" }
     }
+  }
+
+  const loadSessionByID = async (sessionID: string | undefined) => {
+    const result = await loadSessionByIDResult(sessionID)
+    return result.state === "found" ? result.session : undefined
   }
 
   const projectKeyForSession = (session: Session | GlobalSession) => {
@@ -675,14 +700,20 @@ export default function Layout(props: ParentProps) {
           ...(pawworkSessionWindowState.active ? [pawworkSessionWindowState.active] : []),
         ].map((session) => [session.id, session] as const),
       )
-      const pinned = (
-        await Promise.all(
-          store.pawworkPinnedSessions.map(async (id) => {
-            const session = loaded.get(id) ?? (await loadSessionByID(id))
-            return session ? mergePawworkWindowSessionMetadata(session, existing.get(id)) : undefined
-          }),
+      const pinnedResults = await Promise.all(
+        store.pawworkPinnedSessions.map(async (id) => ({
+          id,
+          result: loaded.has(id) ? ({ state: "found", session: loaded.get(id)! } as const) : await loadSessionByIDResult(id),
+        })),
+      )
+      const gonePinnedIDs = new Set(pinnedResults.filter((entry) => entry.result.state === "gone").map((entry) => entry.id))
+      const pinned = pinnedResults
+        .map((entry) =>
+          entry.result.state === "found"
+            ? mergePawworkWindowSessionMetadata(entry.result.session, existing.get(entry.id))
+            : undefined,
         )
-      ).filter((session): session is PawworkWindowSession => !!session)
+        .filter((session): session is PawworkWindowSession => !!session)
       const activeID = params.id
       const active = activeID
         ? await (async () => {
@@ -701,6 +732,9 @@ export default function Layout(props: ParentProps) {
 
       if (rev !== pawworkSessionWindowRev) return
       batch(() => {
+        if (gonePinnedIDs.size) {
+          setStore("pawworkPinnedSessions", (current) => removePinnedSessionIDs(current, gonePinnedIDs))
+        }
         setPawworkSessionWindowState("normal", reconcile(sortPawworkSessionWindowSessions(normal), { key: "id" }))
         setPawworkSessionWindowState("pinned", reconcile(pinned, { key: "id" }))
         setPawworkSessionWindowState("active", activeRoot)
@@ -755,6 +789,7 @@ export default function Layout(props: ParentProps) {
   }
 
   const removePawworkWindowSession = (sessionID: string) => {
+    setStore("pawworkPinnedSessions", (current) => removePinnedSessionIDs(current, new Set([sessionID])))
     setPawworkSessionWindowState("normal", (current) => current.filter((session) => session.id !== sessionID))
     setPawworkSessionWindowState("pinned", (current) => current.filter((session) => session.id !== sessionID))
     if (pawworkSessionWindowState.active?.id === sessionID) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -34,7 +34,7 @@ import { showToast, Toast, toaster } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { LayoutPageContext } from "@/context/layout-page"
 import { ShellSurfaceContext } from "@/context/shell-surface"
-import { clearWorkspaceTerminals } from "@/context/terminal"
+import { clearWorkspaceTerminals, isTerminalGoneError } from "@/context/terminal"
 import { dropSessionCaches, pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
 import {
   clearSessionPrefetchInflight,
@@ -556,19 +556,6 @@ export default function Layout(props: ParentProps) {
     return pawworkSessionWindowState.normal.find((session) => session.id === sessionID)
   }
 
-  const missingResourceError = (error: unknown) => {
-    if (!error || typeof error !== "object") return false
-    const value = error as {
-      name?: unknown
-      status?: unknown
-      statusCode?: unknown
-      response?: { status?: unknown }
-    }
-    if (value.name === "NotFoundError") return true
-    if (value.status === 404 || value.statusCode === 404) return true
-    return value.response?.status === 404
-  }
-
   type SessionLoadResult =
     | { state: "found"; session: PawworkWindowSession }
     | { state: "gone" }
@@ -584,7 +571,7 @@ export default function Layout(props: ParentProps) {
       if (session && !session.time?.archived) return { state: "found", session }
       return { state: "gone" }
     } catch (error) {
-      return missingResourceError(error) ? { state: "gone" } : { state: "transient" }
+      return isTerminalGoneError(error) ? { state: "gone" } : { state: "transient" }
     }
   }
 

--- a/packages/app/src/pages/layout/layout-page-store.test.ts
+++ b/packages/app/src/pages/layout/layout-page-store.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import type { AsyncStorage } from "@solid-primitives/storage"
 import { PersistTesting } from "@/utils/persist"
-import { createDefaultLayoutPageState, createLayoutPagePersistTarget, migrateLayoutPageState } from "./layout-page-store"
+import {
+  createDefaultLayoutPageState,
+  createLayoutPagePersistTarget,
+  migrateLayoutPageState,
+  removePinnedSessionIDs,
+} from "./layout-page-store"
 
 class ElectronPathStorage implements AsyncStorage {
   constructor(readonly data: Record<string, unknown> = {}) {}
@@ -116,6 +121,18 @@ describe("layout page state migration", () => {
         page: { sidebar: { opened: true } },
       }),
     ).toBeUndefined()
+  })
+})
+
+describe("pinned session recovery", () => {
+  test("removes only stale pinned session ids", () => {
+    expect(removePinnedSessionIDs(["ses_a", "ses_b", "ses_c"], new Set(["ses_b"]))).toEqual(["ses_a", "ses_c"])
+  })
+
+  test("keeps pinned sessions when no ids are confirmed stale", () => {
+    const current = ["ses_a", "ses_b"]
+
+    expect(removePinnedSessionIDs(current, new Set())).toBe(current)
   })
 })
 

--- a/packages/app/src/pages/layout/layout-page-store.ts
+++ b/packages/app/src/pages/layout/layout-page-store.ts
@@ -25,6 +25,12 @@ function pinnedSessions(value: unknown) {
   })
 }
 
+export function removePinnedSessionIDs(current: string[], stale: ReadonlySet<string>) {
+  if (stale.size === 0) return current
+  const next = current.filter((id) => !stale.has(id))
+  return next.length === current.length ? current : next
+}
+
 function projectCollapsed(value: unknown) {
   if (!record(value)) return {} as Record<string, boolean>
   const out: Record<string, boolean> = {}

--- a/packages/app/src/utils/persist.test.ts
+++ b/packages/app/src/utils/persist.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 
 type PersistTestingType = typeof import("./persist").PersistTesting
+type ShouldDebugPersistedTerminalRead = typeof import("./persist").shouldDebugPersistedTerminalRead
 
 class MemoryStorage implements Storage {
   private values = new Map<string, string>()
@@ -56,6 +57,7 @@ class MemoryStorage implements Storage {
 const storage = new MemoryStorage()
 
 let persistTesting: PersistTestingType
+let shouldDebugPersistedTerminalRead: ShouldDebugPersistedTerminalRead
 
 beforeAll(async () => {
   mock.module("@/context/platform", () => ({
@@ -64,6 +66,7 @@ beforeAll(async () => {
 
   const mod = await import("./persist")
   persistTesting = mod.PersistTesting
+  shouldDebugPersistedTerminalRead = mod.shouldDebugPersistedTerminalRead
 })
 
 beforeEach(() => {
@@ -201,5 +204,14 @@ describe("persist localStorage resilience", () => {
     expect(result).toStartWith("pawwork.workspace.")
     expect(result.endsWith(".dat")).toBeTrue()
     expect(/[:\\/]/.test(result)).toBeFalse()
+  })
+
+  test("does not emit workspace terminal persisted debug logs outside dev", () => {
+    expect(shouldDebugPersistedTerminalRead("workspace:terminal", false)).toBe(false)
+  })
+
+  test("keeps workspace terminal persisted debug logs dev-only", () => {
+    expect(shouldDebugPersistedTerminalRead("workspace:terminal", true)).toBe(true)
+    expect(shouldDebugPersistedTerminalRead("layout-page", true)).toBe(false)
   })
 })

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -411,6 +411,10 @@ export const PersistTesting = {
   workspaceStorage,
 }
 
+export function shouldDebugPersistedTerminalRead(key: string, dev = !!import.meta.env?.DEV) {
+  return dev && key === "workspace:terminal"
+}
+
 export const Persist = {
   global(key: string, legacy?: string[]): PersistTarget {
     return { storage: GLOBAL_STORAGE, key, legacy }
@@ -471,7 +475,7 @@ export function persisted<T>(
     if (!isDesktop) {
       const current = currentStorage as SyncStorage
       const legacyStore = legacyStorage as SyncStorage
-      const debugTerminal = config.key === "workspace:terminal"
+      const debugTerminal = shouldDebugPersistedTerminalRead(config.key)
 
       const api: SyncStorage = {
         getItem: (key) => {
@@ -485,7 +489,7 @@ export function persisted<T>(
             migrate: config.migrate,
           })
           if (debugTerminal) {
-            console.error("[persisted:workspace:terminal:sync]", {
+            console.debug("[persisted:workspace:terminal:sync]", {
               storage: config.storage,
               key,
               normalizedPreview: next?.slice(0, 240),
@@ -507,7 +511,7 @@ export function persisted<T>(
 
     const current = currentStorage as AsyncStorage
     const legacyStore = legacyStorage as AsyncStorage | undefined
-    const debugTerminal = config.key === "workspace:terminal"
+    const debugTerminal = shouldDebugPersistedTerminalRead(config.key)
 
     const api: AsyncStorage = {
       getItem: async (key) => {
@@ -521,7 +525,7 @@ export function persisted<T>(
           migrate: config.migrate,
         })
         if (debugTerminal) {
-          console.error("[persisted:workspace:terminal:async]", {
+          console.debug("[persisted:workspace:terminal:async]", {
             storage: config.storage,
             key,
             normalizedPreview: next?.slice(0, 240),

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -7,6 +7,12 @@ import { PtyID } from "@/pty/schema"
 import { NotFoundError } from "../../storage/db"
 import { errors } from "../error"
 
+export function assertPtyConnectTarget(info: unknown) {
+  if (!info) {
+    throw new NotFoundError({ message: "PTY session not found" })
+  }
+}
+
 export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
   return new Hono()
     .get(
@@ -159,7 +165,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
           return parsed
         })()
         let handler: Awaited<ReturnType<typeof Pty.connect>>
-        if (!(await Pty.get(id))) throw new Error("Session not found")
+        assertPtyConnectTarget(await Pty.get(id))
 
         type Socket = {
           readyState: number

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { assertPtyConnectTarget } from "../../src/server/instance/pty"
+import { NotFoundError } from "../../src/storage/db"
+
+describe("pty routes", () => {
+  test("reports missing websocket connect targets as not found", () => {
+    expect(() => assertPtyConnectTarget(undefined)).toThrow(NotFoundError)
+  })
+
+  test("accepts existing websocket connect targets", () => {
+    expect(() => assertPtyConnectTarget({ id: "pty_present" })).not.toThrow()
+  })
+})

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, test } from "bun:test"
-import { assertPtyConnectTarget } from "../../src/server/instance/pty"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import type { UpgradeWebSocket } from "hono/ws"
+import { Log } from "@opencode-ai/core/util/log"
+import { assertPtyConnectTarget, PtyRoutes } from "../../src/server/instance/pty"
+import { ErrorMiddleware } from "../../src/server/middleware"
 import { NotFoundError } from "../../src/storage/db"
+import { PtyID } from "../../src/pty/schema"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const testUpgradeWebSocket = ((createEvents: (c: unknown) => unknown | Promise<unknown>) => {
+  return async (c: { text: (value: string) => Response | Promise<Response> }) => {
+    await createEvents(c)
+    return c.text("upgraded")
+  }
+}) as unknown as UpgradeWebSocket
 
 describe("pty routes", () => {
   test("reports missing websocket connect targets as not found", () => {
@@ -9,5 +29,22 @@ describe("pty routes", () => {
 
   test("accepts existing websocket connect targets", () => {
     expect(() => assertPtyConnectTarget({ id: "pty_present" })).not.toThrow()
+  })
+
+  test("maps missing websocket connect targets through the route as not found", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+        app.onError(ErrorMiddleware)
+
+        const response = await app.request(`/pty/${PtyID.ascending()}/connect`)
+        const body = await response.json()
+
+        expect(response.status).toBe(404)
+        expect(body.name).toBe("NotFoundError")
+      },
+    })
   })
 })


### PR DESCRIPTION
## Summary

Prunes stale persisted pinned sessions and recovers stale persisted terminal PTYs instead of retrying dead runtime ids.

## Why

Fixes #647. A local profile can contain pinned session ids or workspace terminal PTY ids that no longer exist after restart, reset, or deleted state. Those stale values caused repeated 404/500 restore attempts and renderer noise. This PR keeps the fix narrow to the confirmed stale persisted state path.

## Related Issue

Fixes #647

Follow-up #648 remains out of scope: durable terminal tab ids and runtime PTY id separation should be handled as the later architecture cleanup, not in this hotfix.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm stale pinned sessions are pruned only for confirmed missing or archived sessions, not transient request failures.
- Confirm terminal recovery stays inside the existing LocalPTY model and does not pre-implement #648.
- Confirm missing PTY websocket connect now reports NotFoundError semantics instead of a generic 500.

## Risk Notes

Medium-low. This changes local persisted state recovery behavior. Confirmed stale pinned sessions are removed from local pinned state, and stale terminal runtime ids can be replaced with a fresh PTY. It intentionally does not migrate terminal storage to durable tab ids.

## How To Verify

```text
App targeted unit tests: 31 passed
- bun test --preload ./happydom.ts src/pages/layout/layout-page-store.test.ts src/context/terminal.test.ts src/utils/persist.test.ts

OpenCode targeted unit tests: 3 passed
- bun test --timeout 30000 test/server/pty-routes.test.ts

Route coverage added after review: missing /pty/:id/connect returns 404/NotFound through the route and ErrorMiddleware

App typecheck: passed
- bun --cwd packages/app typecheck

OpenCode typecheck: passed
- bun --cwd packages/opencode typecheck

Diff check: passed
- git diff --check

Electron isolated smoke: passed, ci-smoke-ready.json written
- PAWWORK_CI_SMOKE=true PAWWORK_CI_SMOKE_HOME=<tmp> OPENCODE_CHANNEL=dev bun --cwd packages/desktop-electron dev
```

## Screenshots or Recordings

Not included. This is state recovery and error semantics, not a visible UI or copy change. Electron was manually smoke-checked with an isolated profile.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
