### PR TITLE
feat(ui): align message-flow attachment chip to dock spec

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -34,37 +34,31 @@
   }
 
   [data-slot="user-message-attachment"] {
+    position: relative;
+    width: 64px;
+    height: 64px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background: var(--surface-base);
+    border: 1px solid var(--border-base);
+    cursor: default;
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 0;
-    border-radius: 6px;
-    overflow: hidden;
-    background: var(--bg-cream);
-    border: 1px solid var(--border-weak);
-    cursor: default;
-    transition:
-      border-color 0.15s ease,
-      opacity 0.3s ease;
-
-    &:hover {
-      border-color: var(--border-base);
-    }
+    flex-shrink: 0;
+    outline: none;
 
     &[data-clickable] {
       cursor: pointer;
     }
 
     &[data-type="image"] {
-      width: 48px;
-      height: 48px;
+      background: transparent;
     }
 
-    &[data-type="file"] {
-      width: min(220px, 100%);
-      height: 48px;
-      padding: 0 10px;
+    &:focus-visible {
+      outline: 1px solid var(--brand-primary);
+      outline-offset: 2px;
     }
   }
 
@@ -72,43 +66,42 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
-  }
-
-  [data-slot="user-message-attachment-icon"] {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--icon-weak);
-
-    [data-component="icon"] {
-      width: 20px;
-      height: 20px;
-    }
+    display: block;
   }
 
   [data-slot="user-message-attachment-file"] {
-    width: 100%;
-    min-width: 0;
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: center;
+    color: var(--fg-weak);
 
     [data-component="file-icon"] {
-      width: 20px;
-      height: 20px;
-      flex: none;
+      width: 24px;
+      height: 24px;
     }
   }
 
+  [data-slot="user-message-attachment-name-overlay"] {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 2px 4px;
+    background: rgba(0, 0, 0, 0.5);
+    border-bottom-left-radius: var(--radius-sm);
+    border-bottom-right-radius: var(--radius-sm);
+  }
+
   [data-slot="user-message-attachment-name"] {
+    display: block;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--fg-base);
+    color: #ffffff;
+    font-family: var(--font-family-sans);
     font-size: var(--font-size-small);
+    font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large);
   }
 

--- a/packages/ui/src/components/message-part/user-message.tsx
+++ b/packages/ui/src/components/message-part/user-message.tsx
@@ -91,27 +91,40 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
               const type = kind(file)
               const name = file.filename ?? i18n.t("ui.message.attachment.alt")
 
+              const isImage = type === "image"
+              const activate = () => {
+                if (isImage) openImagePreview(file.url, name)
+              }
               return (
                 <div
                   data-slot="user-message-attachment"
                   data-type={type}
-                  data-clickable={type === "image" ? "true" : undefined}
-                  title={type === "file" ? name : undefined}
-                  onClick={() => {
-                    if (type === "image") openImagePreview(file.url, name)
+                  data-clickable={isImage ? "true" : undefined}
+                  title={name}
+                  role={isImage ? "button" : undefined}
+                  tabIndex={isImage ? 0 : undefined}
+                  onClick={activate}
+                  onKeyDown={(event) => {
+                    if (!isImage) return
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault()
+                      activate()
+                    }
                   }}
                 >
                   <Show
                     when={type === "image"}
                     fallback={
-                      <div data-slot="user-message-attachment-file">
+                      <span data-slot="user-message-attachment-file">
                         <FileIcon node={{ path: name, type: "file" }} />
-                        <span data-slot="user-message-attachment-name">{name}</span>
-                      </div>
+                      </span>
                     }
                   >
                     <img data-slot="user-message-attachment-image" src={file.url} alt={name} />
                   </Show>
+                  <span data-slot="user-message-attachment-name-overlay">
+                    <span data-slot="user-message-attachment-name">{name}</span>
+                  </span>
                 </div>
               )
             }}

--- a/packages/ui/src/components/message-part/user-message.tsx
+++ b/packages/ui/src/components/message-part/user-message.tsx
@@ -116,7 +116,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
                     when={type === "image"}
                     fallback={
                       <span data-slot="user-message-attachment-file">
-                        <FileIcon node={{ path: name, type: "file" }} />
+                        <FileIcon node={{ path: name, type: "file" }} mono={true} />
                       </span>
                     }
                   >


### PR DESCRIPTION
## Summary

Reshape the user-message attachment renderer so the archived chip uses the same geometry as the dock composer chip. Image and file chips become a uniform 64×64 square at `--radius-sm` with a 1px `--border-base` outline; the previous 48×48 image / 220×48 file-row / `--bg-cream` / `--border-weak` layout is retired. File variant fills `--surface-base` and centers a 24px file-type icon at `--fg-weak`; image variant uses `object-fit: cover` on the full square; both share a bottom `rgba(0, 0, 0, 0.5)` filename overlay with 13px white text truncated to one line. The image chip also gains a small a11y baseline (`role="button"`, `tabIndex=0`, Enter/Space activation, `:focus-visible` outline) because it is now click-activated for image preview.

## Why

#601 slice D. The visual spec is locked in DESIGN.md L504 and `docs/design/preview/message-flow.html` so the archived attachment chip is identical to the dock composer chip — one geometry across the product, zero form-jump at the moment of sending. The dock side (`packages/app/src/components/prompt-input/image-attachments.tsx`) already matches the spec and is intentionally unchanged in this slice; code-level sharing is deferred to #642.

## Related Issue

Parent: #601. Surfaced regression while testing this slice (pre-existing on `dev`, not introduced here): #652.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Chip geometry / overlay CSS in `message-part.css` matches DESIGN.md L504 verbatim (64×64, `--radius-sm`, `--border-base`, `--surface-base`, 24px icon, overlay padding 2/4, 13px white name).
- a11y wiring on the image attachment is minimal: `role` / `tabIndex` / `onKeyDown` (Enter/Space) and a `:focus-visible` style; the file variant stays non-interactive.
- The dock implementation (`image-attachments.tsx`) is intentionally untouched in this slice.

## Risk Notes

- The chip is now interactive (focusable, keyboard-activatable) for the image variant; the file variant remains non-interactive.
- `[data-slot="user-message-attachment-icon"]` selector (dead CSS, never rendered by the JSX) is removed; grep across `packages/` confirmed no callsites.
- No behavior change for the dock composer side.
- No data, permission, dependency, or platform-specific risks.

## How To Verify

```text
packages/ui typecheck (tsgo --noEmit): ok
packages/app typecheck (tsgo -b): ok
Root lint (eslint packages/{app,ui,desktop-electron}/src): ok
packages/ui bun test: 418 pass / 3 fail — pre-existing icon-button 24->30 assertions on dev, unrelated (verified by re-running on stashed working tree)
packages/app bun test:unit: 1078 pass / 0 fail
packages/app E2E prompt/prompt-drop-file.spec.ts: pre-existing fail on dev — tracked as #652, not introduced here
dev:desktop Electron manual: uploaded image + file via the + button, sent message; new 64x64 chip + filename overlay renders in light and dark and matches docs/design/preview/message-flow.html; image chip Tab focus shows the brand-primary outline; Enter and Space both open the image preview
Two-round crosscheck (Claude Opus + Codex high effort): both rounds 0 P0/P1; round 1 fixed one P2 (image chip had no keyboard activation); round 2 fixed one P2 (no :focus-visible style on the now-focusable chip); remaining P3 / Design findings declined to keep dock parity and slice scope
```

## Screenshots or Recordings

Visual reference: the four attachment demo cards from `docs/design/preview/message-flow.html` (light + dark, file-only + mixed); in-product Electron rendering verified by the author to match this reference.

<img width="2104" height="890" alt="slice-d-mf-attach" src="https://github.com/user-attachments/assets/d87fb336-c40b-4c89-8a04-15386b097e0b" />

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English