### PR TITLE
feat: add durable terminal storage helpers

### DIFF
--- a/packages/app/src/context/terminal-storage.test.ts
+++ b/packages/app/src/context/terminal-storage.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import {
+  assertNoUnsafeTerminalStorageFields,
+  migratePersistedTerminalState,
+  sanitizePersistedTerminalState,
+  unsafeTerminalStorageFieldNames,
+} from "./terminal-storage"
+
+describe("migratePersistedTerminalState", () => {
+  test("migrates legacy PTY ids into durable tab ids and remaps active", () => {
+    const migrated = migratePersistedTerminalState({
+      active: "pty_old",
+      all: [
+        {
+          id: "pty_old",
+          title: "Terminal 2",
+          titleNumber: 2,
+          rows: 24,
+          cols: 80,
+          buffer: "old output",
+          cursor: 12,
+          scrollY: 8,
+          ptyID: "pty_runtime",
+        },
+      ],
+    })
+
+    expect(migrated.version).toBe(2)
+    expect(migrated.tabs).toHaveLength(1)
+    expect(migrated.tabs[0]?.tabID).toStartWith("tab_")
+    expect(migrated.tabs[0]?.tabID).not.toBe("pty_old")
+    expect(migrated.activeTabID).toBe(migrated.tabs[0]?.tabID)
+    expect(JSON.stringify(migrated)).not.toContain("pty_old")
+    expect(JSON.stringify(migrated)).not.toContain("pty_runtime")
+    expect(migrated.tabs[0]?.snapshot).toEqual({
+      size: { rows: 24, cols: 80 },
+      buffer: "old output",
+      cursor: 12,
+      scrollY: 8,
+    })
+  })
+
+  test("migration is idempotent for v2 state", () => {
+    const first = migratePersistedTerminalState({
+      active: "pty_old",
+      all: [{ id: "pty_old", title: "Terminal 1", titleNumber: 1, buffer: "output", cursor: 6 }],
+    })
+    const second = migratePersistedTerminalState(first)
+
+    expect(second).toEqual(first)
+  })
+
+  test("drops invalid legacy terminals and keeps stable order", () => {
+    const migrated = migratePersistedTerminalState({
+      active: "pty_second",
+      all: [
+        null,
+        { title: "missing id" },
+        { id: "pty_first", title: "Terminal 1", titleNumber: 1 },
+        { id: "pty_first", title: "duplicate", titleNumber: 9 },
+        { id: "pty_second", title: "logs", titleNumber: 4, rows: 30, cols: 100 },
+      ],
+    })
+
+    expect(migrated.tabs.map((tab) => tab.title)).toEqual(["Terminal 1", "logs"])
+    expect(migrated.tabs.map((tab) => tab.order)).toEqual([0, 1])
+    expect(migrated.activeTabID).toBe(migrated.tabs[1]?.tabID)
+    expect(new Set(migrated.tabs.map((tab) => tab.tabID)).size).toBe(2)
+  })
+})
+
+describe("sanitizePersistedTerminalState", () => {
+  test("drops runtime fields before persistence", () => {
+    const state = {
+      version: 2,
+      activeTabID: "tab_one",
+      tabs: [
+        {
+          tabID: "tab_one",
+          title: "Terminal 1",
+          titleNumber: 1,
+          order: 0,
+          ptyID: "pty_runtime",
+          ptyId: "pty_runtime",
+          runtimePtyID: "pty_runtime",
+          runtimePtyId: "pty_runtime",
+          runtimePTYID: "pty_runtime",
+          snapshot: {
+            size: { rows: 24, cols: 80 },
+            buffer: "visible",
+            cursor: 7,
+            scrollY: 1,
+            ptyID: "pty_nested",
+          },
+        },
+      ],
+    }
+
+    const sanitized = sanitizePersistedTerminalState(state)
+    const serialized = JSON.stringify(sanitized)
+
+    for (const field of unsafeTerminalStorageFieldNames) {
+      expect(serialized).not.toContain(field)
+    }
+    expect(serialized).not.toContain("pty_runtime")
+    expect(serialized).not.toContain("pty_nested")
+    expect(sanitized.tabs[0]?.snapshot).toEqual({
+      size: { rows: 24, cols: 80 },
+      buffer: "visible",
+      cursor: 7,
+      scrollY: 1,
+    })
+  })
+
+  test("fail-loud assertion reports runtime fields in test and development paths", () => {
+    expect(() =>
+      assertNoUnsafeTerminalStorageFields({
+        version: 2,
+        activeTabID: "tab_one",
+        tabs: [{ tabID: "tab_one", title: "Terminal 1", titleNumber: 1, order: 0, ptyID: "pty_runtime" }],
+      }),
+    ).toThrow("Unsafe terminal storage field: tabs.0.ptyID")
+  })
+})

--- a/packages/app/src/context/terminal-storage.test.ts
+++ b/packages/app/src/context/terminal-storage.test.ts
@@ -121,4 +121,13 @@ describe("sanitizePersistedTerminalState", () => {
       }),
     ).toThrow("Unsafe terminal storage field: tabs.0.ptyID")
   })
+
+  test("fail-loud assertion traverses nested arrays", () => {
+    expect(() => assertNoUnsafeTerminalStorageFields({ tabs: [[{ ptyID: "pty_runtime" }]] })).toThrow(
+      "Unsafe terminal storage field: tabs.0.0.ptyID",
+    )
+    expect(() => assertNoUnsafeTerminalStorageFields([{ runtimePtyID: "pty_runtime" }])).toThrow(
+      "Unsafe terminal storage field: 0.runtimePtyID",
+    )
+  })
 })

--- a/packages/app/src/context/terminal-storage.ts
+++ b/packages/app/src/context/terminal-storage.ts
@@ -205,17 +205,18 @@ export function assertNoUnsafeTerminalStorageFields(value: unknown) {
 }
 
 function findUnsafeField(value: unknown, path = ""): string | undefined {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const nextPath = path ? `${path}.${index}` : String(index)
+      const found = findUnsafeField(value[index], nextPath)
+      if (found) return found
+    }
+    return
+  }
   if (!record(value)) return
   for (const [key, child] of Object.entries(value)) {
     const nextPath = path ? `${path}.${key}` : key
     if ((unsafeTerminalStorageFieldNames as readonly string[]).includes(key)) return nextPath
-    if (Array.isArray(child)) {
-      for (let index = 0; index < child.length; index += 1) {
-        const found = findUnsafeField(child[index], `${nextPath}.${index}`)
-        if (found) return found
-      }
-      continue
-    }
     const found = findUnsafeField(child, nextPath)
     if (found) return found
   }

--- a/packages/app/src/context/terminal-storage.ts
+++ b/packages/app/src/context/terminal-storage.ts
@@ -1,0 +1,223 @@
+import { titleNumber } from "./terminal-title"
+import {
+  terminalTabID,
+  type PersistedTerminalStateV2,
+  type TerminalSnapshot,
+  type TerminalTab,
+  type TerminalTabID,
+} from "./terminal-types"
+
+const TERMINAL_STORAGE_VERSION = 2
+const MAX_TERMINAL_SESSIONS = 20
+
+export const unsafeTerminalStorageFieldNames = [
+  "ptyID",
+  "ptyId",
+  "runtimePtyID",
+  "runtimePtyId",
+  "runtimePTYID",
+] as const
+
+type LegacyTerminal = {
+  id: string
+  title: string
+  titleNumber: number
+  rows?: number
+  cols?: number
+  buffer?: string
+  cursor?: number
+  scrollY?: number
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function text(value: unknown) {
+  return typeof value === "string" ? value : undefined
+}
+
+function num(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function positiveInteger(value: unknown) {
+  const number = num(value)
+  if (number === undefined) return
+  return Number.isSafeInteger(number) && number > 0 ? number : undefined
+}
+
+function isV2(value: unknown): value is PersistedTerminalStateV2 {
+  return record(value) && value.version === TERMINAL_STORAGE_VERSION && Array.isArray(value.tabs)
+}
+
+function legacyTerminal(value: unknown): LegacyTerminal | undefined {
+  if (!record(value)) return
+
+  const id = text(value.id)
+  if (!id) return
+
+  const title = text(value.title) ?? ""
+  const directNumber = positiveInteger(value.titleNumber)
+  const parsedNumber = titleNumber(title, MAX_TERMINAL_SESSIONS)
+  const rows = positiveInteger(value.rows)
+  const cols = positiveInteger(value.cols)
+  const buffer = text(value.buffer)
+  const cursor = num(value.cursor)
+  const scrollY = num(value.scrollY)
+
+  return {
+    id,
+    title,
+    titleNumber: directNumber ?? parsedNumber ?? 0,
+    ...(rows !== undefined ? { rows } : {}),
+    ...(cols !== undefined ? { cols } : {}),
+    ...(buffer !== undefined ? { buffer } : {}),
+    ...(cursor !== undefined ? { cursor } : {}),
+    ...(scrollY !== undefined ? { scrollY } : {}),
+  }
+}
+
+function snapshotFromLegacy(value: LegacyTerminal): TerminalSnapshot | undefined {
+  const snapshot: TerminalSnapshot = {}
+  if (value.rows !== undefined && value.cols !== undefined) {
+    snapshot.size = { rows: value.rows, cols: value.cols }
+  }
+  if (value.buffer !== undefined) snapshot.buffer = value.buffer
+  if (value.cursor !== undefined) snapshot.cursor = value.cursor
+  if (value.scrollY !== undefined) snapshot.scrollY = value.scrollY
+  return Object.keys(snapshot).length ? snapshot : undefined
+}
+
+function snapshotFromValue(value: unknown): TerminalSnapshot | undefined {
+  if (!record(value)) return
+  const size = record(value.size) ? value.size : undefined
+  const rows = positiveInteger(size?.rows)
+  const cols = positiveInteger(size?.cols)
+  const buffer = text(value.buffer)
+  const cursor = num(value.cursor)
+  const scrollY = num(value.scrollY)
+  const snapshot: TerminalSnapshot = {}
+  if (rows !== undefined && cols !== undefined) snapshot.size = { rows, cols }
+  if (buffer !== undefined) snapshot.buffer = buffer
+  if (cursor !== undefined) snapshot.cursor = cursor
+  if (scrollY !== undefined) snapshot.scrollY = scrollY
+  return Object.keys(snapshot).length ? snapshot : undefined
+}
+
+function stableTabID(legacyID: string, order: number, seen: Set<string>): TerminalTabID {
+  let candidate = terminalTabID(`tab_${hash(`${legacyID}:${order}`)}`)
+  let suffix = 1
+  while (seen.has(candidate)) {
+    candidate = terminalTabID(`tab_${hash(`${legacyID}:${order}:${suffix}`)}`)
+    suffix += 1
+  }
+  return candidate
+}
+
+function hash(value: string) {
+  let next = 0x811c9dc5
+  for (let i = 0; i < value.length; i += 1) {
+    next ^= value.charCodeAt(i)
+    next = Math.imul(next, 0x01000193)
+  }
+  return (next >>> 0).toString(16).padStart(8, "0")
+}
+
+function sanitizeTab(value: unknown, fallbackOrder: number): TerminalTab | undefined {
+  if (!record(value)) return
+  const rawTabID = text(value.tabID)
+  if (!rawTabID || rawTabID.startsWith("pty_")) return
+  const title = text(value.title) ?? ""
+  const order = num(value.order)
+  const snapshot = snapshotFromValue(value.snapshot)
+  return {
+    tabID: terminalTabID(rawTabID),
+    title,
+    titleNumber: positiveInteger(value.titleNumber) ?? titleNumber(title, MAX_TERMINAL_SESSIONS) ?? 0,
+    order: order !== undefined ? order : fallbackOrder,
+    ...(snapshot ? { snapshot } : {}),
+  }
+}
+
+function sanitizeV2(value: unknown): PersistedTerminalStateV2 {
+  if (!record(value)) return { version: TERMINAL_STORAGE_VERSION, tabs: [] }
+  const tabs = Array.isArray(value.tabs) ? value.tabs.flatMap((tab, index) => sanitizeTab(tab, index) ?? []) : []
+  const seen = new Set<string>()
+  const uniqueTabs = tabs.flatMap((tab) => {
+    if (seen.has(tab.tabID)) return []
+    seen.add(tab.tabID)
+    return [tab]
+  })
+  const active = text(value.activeTabID)
+  return {
+    version: TERMINAL_STORAGE_VERSION,
+    ...(active && seen.has(active) ? { activeTabID: terminalTabID(active) } : {}),
+    tabs: uniqueTabs,
+  }
+}
+
+export function migratePersistedTerminalState(value: unknown): PersistedTerminalStateV2 {
+  if (isV2(value)) return sanitizeV2(value)
+  if (!record(value)) return { version: TERMINAL_STORAGE_VERSION, tabs: [] }
+
+  const seenLegacy = new Set<string>()
+  const seenTabs = new Set<string>()
+  const legacy = Array.isArray(value.all)
+    ? value.all.flatMap((item) => {
+        const terminal = legacyTerminal(item)
+        if (!terminal || seenLegacy.has(terminal.id)) return []
+        seenLegacy.add(terminal.id)
+        return [terminal]
+      })
+    : []
+
+  const active = text(value.active)
+  const tabs = legacy.map((terminal, order) => {
+    const snapshot = snapshotFromLegacy(terminal)
+    const tabID = stableTabID(terminal.id, order, seenTabs)
+    seenTabs.add(tabID)
+    return {
+      tabID,
+      title: terminal.title,
+      titleNumber: terminal.titleNumber,
+      order,
+      ...(snapshot ? { snapshot } : {}),
+    }
+  })
+
+  const activeIndex = active ? legacy.findIndex((terminal) => terminal.id === active) : -1
+  return {
+    version: TERMINAL_STORAGE_VERSION,
+    ...(activeIndex >= 0 ? { activeTabID: tabs[activeIndex]?.tabID } : tabs[0] ? { activeTabID: tabs[0].tabID } : {}),
+    tabs,
+  }
+}
+
+export function sanitizePersistedTerminalState(value: unknown): PersistedTerminalStateV2 {
+  return sanitizeV2(value)
+}
+
+export function assertNoUnsafeTerminalStorageFields(value: unknown) {
+  const path = findUnsafeField(value)
+  if (!path) return
+  throw new Error(`Unsafe terminal storage field: ${path}`)
+}
+
+function findUnsafeField(value: unknown, path = ""): string | undefined {
+  if (!record(value)) return
+  for (const [key, child] of Object.entries(value)) {
+    const nextPath = path ? `${path}.${key}` : key
+    if ((unsafeTerminalStorageFieldNames as readonly string[]).includes(key)) return nextPath
+    if (Array.isArray(child)) {
+      for (let index = 0; index < child.length; index += 1) {
+        const found = findUnsafeField(child[index], `${nextPath}.${index}`)
+        if (found) return found
+      }
+      continue
+    }
+    const found = findUnsafeField(child, nextPath)
+    if (found) return found
+  }
+  return
+}

--- a/packages/app/src/context/terminal-types.ts
+++ b/packages/app/src/context/terminal-types.ts
@@ -1,0 +1,36 @@
+type Brand<T, Name extends string> = T & { readonly __brand: Name }
+
+export type TerminalTabID = Brand<string, "TerminalTabID">
+export type RuntimePTYID = Brand<string, "RuntimePTYID">
+
+export type TerminalSnapshot = {
+  size?: {
+    rows: number
+    cols: number
+  }
+  buffer?: string
+  cursor?: number
+  scrollY?: number
+}
+
+export type TerminalTab = {
+  tabID: TerminalTabID
+  title: string
+  titleNumber: number
+  order: number
+  snapshot?: TerminalSnapshot
+}
+
+export type PersistedTerminalStateV2 = {
+  version: 2
+  activeTabID?: TerminalTabID
+  tabs: TerminalTab[]
+}
+
+export function terminalTabID(value: string): TerminalTabID {
+  return value as TerminalTabID
+}
+
+export function runtimePTYID(value: string): RuntimePTYID {
+  return value as RuntimePTYID
+}


### PR DESCRIPTION
## Summary

- Add durable terminal storage types for the #648 PR1 slice: `TerminalTab`, `TerminalSnapshot`, `TerminalTabID`, and `RuntimePTYID`.
- Add helper-only v1-to-v2 terminal storage migration that turns legacy `LocalPTY.id` values into durable `tab_...` ids and preserves display snapshots.
- Add outbound sanitization and fail-loud assertion coverage so runtime PTY fields cannot enter persisted terminal payloads unnoticed.

## Why

#648 needs terminal tabs to be durable UI state while runtime PTY handles remain memory-only. This PR is the first storage-only slice. It deliberately does not wire the new schema into `TerminalProvider`, `TerminalPanel`, websocket connection code, or backend PTY routes, so it cannot create the half-migrated state where tab ids are sent to `/pty/:id`.

## Related Issue

Related to #648. This does not close the issue; PR2 will wire the runtime lifecycle split.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm PR1 is helper/test only and does not change live terminal runtime behavior.
- Check legacy migration behavior: old `pty_...` ids become durable `tab_...` ids, active tab is remapped, snapshot fields are preserved, and migration is idempotent for v2 payloads.
- Check outbound storage protection: runtime-looking fields are sanitized before persistence and the assertion helper can fail loudly in dev/test paths.

## Risk Notes

Low runtime risk: the new helpers are not connected to the live provider yet. The main risk is future PR2 relying on these helper contracts, so this PR keeps the storage semantics explicit and tested.

## How To Verify

```text
Focused app unit: bun --cwd packages/app test:unit src/context/terminal.test.ts src/context/terminal-storage.test.ts -> 1112 passed, 0 failed
App typecheck: bun --cwd packages/app typecheck -> passed
Diff check: git diff --check -> passed
Scope guard: git diff -- packages/app/src/context/terminal.tsx packages/app/src/components/terminal.tsx packages/app/src/pages/session/terminal-panel.tsx -> no diff
```

## Screenshots or Recordings

Not applicable. This PR has no visible UI changes and does not connect the new storage helpers to runtime behavior.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English