### PR TITLE
refactor(opencode): default it.live tests to platform-aware timeout

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -270,10 +270,25 @@ function makeHttp(httpLayer: Layer.Layer<HttpClient.HttpClient> = FetchHttpClien
   ).pipe(Layer.provide(summary))
 }
 
-const it = testEffect(makeHttp())
-const itWithExaQuota = testEffect(makeHttp(httpWithExaQuotaFixture))
+// Windows runner is consistently slow on Effect-fiber + SQLite + tmpdir-server
+// setup; default the live() timeout instead of bandaging individual tests.
+// An explicit third-arg timeout still overrides.
+const defaultLiveTimeout = process.platform === "win32" ? 10_000 : 3_000
+
+function withDefaultLiveTimeout<
+  T extends { live: ((...args: any[]) => any) & { only: any; skip: any } },
+>(raw: T): T {
+  const wrap = (fn: (...args: any[]) => any) =>
+    (name: any, body: any, opts?: any) => fn(name, body, opts ?? defaultLiveTimeout)
+  const live = wrap(raw.live) as T["live"]
+  live.only = wrap(raw.live.only)
+  live.skip = wrap(raw.live.skip)
+  return { ...raw, live }
+}
+
+const it = withDefaultLiveTimeout(testEffect(makeHttp()))
+const itWithExaQuota = withDefaultLiveTimeout(testEffect(makeHttp(httpWithExaQuotaFixture)))
 const unix = process.platform !== "win32" ? it.live : it.live.skip
-const slowIOTimeout = process.platform === "win32" ? 10_000 : 3_000
 
 // Config that registers a custom "test" provider with a "test-model" model
 // so provider model lookup succeeds inside the loop.
@@ -1294,7 +1309,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  slowIOTimeout,
 )
 
 // Cancel semantics
@@ -1324,7 +1338,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  slowIOTimeout,
 )
 
 it.live(
@@ -1352,7 +1365,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
 )
 
 it.live(
@@ -1395,7 +1407,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
 )
 
 it.live(
@@ -1486,7 +1497,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
 )
 
 it.live(
@@ -1564,7 +1574,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
 )
 
 // Queue semantics
@@ -1608,7 +1617,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  slowIOTimeout,
 )
 
 it.live(
@@ -1677,7 +1685,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  slowIOTimeout,
 )
 
 it.live(
@@ -1707,7 +1714,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  slowIOTimeout,
 )
 
 it.live("assertNotBusy succeeds when idle", () =>
@@ -1752,7 +1758,6 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
 )
 
 unix("shell captures stdout and stderr in completed tool output", () =>
@@ -2036,8 +2041,6 @@ unix(
   30_000,
 )
 
-const shellQueueTimeout = process.platform === "win32" ? 10_000 : 3_000
-
 unix(
   "loop waits while shell runs and starts after shell exits",
   () =>
@@ -2073,7 +2076,6 @@ unix(
       }),
       { git: true, config: providerCfg },
     ),
-  shellQueueTimeout,
 )
 
 unix(
@@ -2113,7 +2115,6 @@ unix(
       }),
       { git: true, config: providerCfg },
     ),
-  shellQueueTimeout,
 )
 
 unix(


### PR DESCRIPTION
## Summary

Replace hand-tuned per-test timeouts in `packages/opencode/test/session/prompt-effect.test.ts` with a single Windows-aware default applied through an `it.live` wrapper. Removes 12 third-arg timeout literals (5 × `3_000`, 5 × `slowIOTimeout`, 2 × `shellQueueTimeout`) plus the two duplicated `const ... Timeout` definitions. Explicit non-default timeouts (`5_000`, `10_000`, `30_000`) still override. The wrapper also covers `.only` and `.skip` so debug and skip variants do not fall back to bun's 3-second default.

## Why

windows-advisory has been flaking at ~55% on dev push (27 failures / 50 runs in the latest sample), driven by three independent failure modes, only one of which is fixable in our test code. H1: bun's default 3-second `it.live` timeout is consistently tight on the Windows runner for Effect-fiber + SQLite + tmpdir-server tests in this file. Over the past 11 days four prior PRs (#543, a3b8e54, cf6d1cda, #579) each bumped one or two tests at a time to a `slowIOTimeout` constant without converging — today's failure on `cancel records MessageAbortedError on interrupted process` was the fifth instance of the same root cause. This change makes the slow-runner default the right thing once and ends the per-test bandaging pattern. H2 (bun 1.3.13 `watcher.node` segfault on Windows process exit) and H3 (transient `actions/cache`) are upstream / infra and intentionally left to fail "normally" per the design decision in d6fa1e6de: the advisory workflow is already not in branch protection, and existing `if: always()` artifact and summary uploads preserve the diagnostic signal without masking the red run.

## Related Issue

No issue. Surfaced from a direct investigation of dev-push CI noise.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

The `withDefaultLiveTimeout` wrapper's type signature in `prompt-effect.test.ts:276` intentionally uses structural `any[]` parameters to avoid widening the `testEffect` runtime layer's generic to `unknown` (an earlier `ReturnType<typeof testEffect>` attempt failed typecheck with a layer-incompatibility cascade). Confirm this trade-off is acceptable. The wrapper now also covers `.only` and `.skip` after a Gemini suggestion — there is currently no `.only` usage in the file, but applying defaults consistently avoids a future Windows-debug surprise. Every previously hand-tuned site (`3_000` / `slowIOTimeout` / `shellQueueTimeout`) now relies on the 10-second Windows default — confirm none of those sites used a tight timeout as a deliberate budget assertion rather than "slowest we'll tolerate".

## Risk Notes

If a future bug makes a live test actually hang, detection on Windows now takes up to 10 seconds rather than 3. Acceptable for an advisory signal. No production code paths touched. windows-advisory will still show occasional red runs from H2 / H3 by design.

## How To Verify

```text
typecheck (tsgo --noEmit): clean
bun test test/session/prompt-effect.test.ts --timeout 30000: 54 pass / 0 fail / 28.69s (macOS)
bun test test/github/ci-workflow.test.ts --timeout 30000: 9 pass / 0 fail / 5.04s
```

Windows-side validation will come from windows-advisory runs on the post-merge dev push: the `cancel records ...` test and the other four hard-coded `3_000` sites should stop timing out. The bun-watcher and cache failure modes are deferred and will continue to show as occasional red runs by design.

## Screenshots or Recordings

N/A — no UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English