### PR TITLE
fix: lock terminal stale restore contract

### DIFF
--- a/packages/app/e2e/terminal/terminal-stale-restore.spec.ts
+++ b/packages/app/e2e/terminal/terminal-stale-restore.spec.ts
@@ -1,0 +1,111 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { waitSession, waitTerminalReady } from "../actions"
+import { terminalSelector } from "../selectors"
+import { terminalToggleKey } from "../utils"
+
+type PersistedTerminalStateV2 = {
+  version: 2
+  activeTabID?: string
+  tabs: Array<{
+    tabID: string
+    title: string
+    titleNumber: number
+    order: number
+    snapshot?: {
+      buffer?: string
+      cursor?: number
+      scrollY?: number
+      size?: { rows: number; cols: number }
+    }
+  }>
+}
+
+function readPersistedTerminalEntry() {
+  const keys = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(
+    (key): key is string => !!key && key.endsWith(":workspace:terminal"),
+  )
+  for (const key of keys) {
+    const raw = localStorage.getItem(key)
+    if (!raw) continue
+    const state = JSON.parse(raw) as PersistedTerminalStateV2
+    if (state.version === 2) return { key, state }
+  }
+  return undefined
+}
+
+async function openTerminal(page: Page) {
+  const terminal = page.locator(terminalSelector).first()
+  const visible = await terminal.isVisible().catch(() => false)
+  if (!visible) await page.keyboard.press(terminalToggleKey)
+  await waitTerminalReady(page, { term: terminal })
+  return terminal
+}
+
+test("restored legacy terminal state creates a fresh runtime pty", async ({ page, project }) => {
+  const oldRequests: string[] = []
+
+  page.on("request", (request) => {
+    const url = request.url()
+    if (url.includes("/pty/pty_old")) oldRequests.push(url)
+  })
+  page.on("websocket", (socket) => {
+    const url = socket.url()
+    if (url.includes("/pty/pty_old")) oldRequests.push(url)
+  })
+
+  await project.open()
+  const initialTerminal = await openTerminal(page)
+  const initialTabID = await initialTerminal.getAttribute("data-pty-id")
+  expect(initialTabID).toMatch(/^tab_/)
+
+  const entry = await expect
+    .poll(() => page.evaluate(readPersistedTerminalEntry), { timeout: 5_000 })
+    .toMatchObject({ state: { version: 2 } })
+    .then(() => page.evaluate(readPersistedTerminalEntry))
+  if (!entry) throw new Error("Terminal storage entry was not persisted")
+
+  await page.evaluate((key) => {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        active: "pty_old",
+        all: [
+          {
+            id: "pty_old",
+            title: "Legacy terminal",
+            titleNumber: 1,
+            rows: 24,
+            cols: 80,
+            buffer: "LEGACY_BUFFER",
+            cursor: 13,
+            scrollY: 0,
+          },
+        ],
+      }),
+    )
+  }, entry.key)
+  oldRequests.length = 0
+  await page.reload()
+  await waitSession(page, { directory: project.directory, serverUrl: project.url, allowAnySession: true })
+
+  const terminal = await openTerminal(page)
+  const tabID = await terminal.getAttribute("data-pty-id")
+  expect(tabID).toMatch(/^tab_/)
+  expect(tabID).not.toBe("pty_old")
+
+  const state = await expect
+    .poll(() => page.evaluate(readPersistedTerminalEntry), { timeout: 5_000 })
+    .toMatchObject({ state: { version: 2 } })
+    .then(() => page.evaluate(readPersistedTerminalEntry).then((entry) => entry?.state))
+
+  expect(oldRequests).toEqual([])
+  expect(state?.version).toBe(2)
+  expect(state?.activeTabID).toBe(tabID)
+  expect(state?.tabs).toHaveLength(1)
+  expect(state?.tabs[0]?.tabID).toBe(tabID)
+  expect(state?.tabs[0]?.title).toBe("Legacy terminal")
+  expect(state?.tabs[0]?.order).toBe(0)
+  expect(JSON.stringify(state)).not.toContain("pty_old")
+  expect(JSON.stringify(state)).not.toContain("runtimePty")
+})

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -136,7 +136,12 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
-        await Pty.remove(c.req.valid("param").ptyID)
+        const id = c.req.valid("param").ptyID
+        const info = await Pty.get(id)
+        if (!info) {
+          throw new NotFoundError({ message: "Session not found" })
+        }
+        await Pty.remove(id)
         return c.json(true)
       },
     )

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -68,4 +68,23 @@ describe("pty routes", () => {
       },
     })
   })
+
+  test("maps missing remove targets as not found", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+        app.onError(ErrorMiddleware)
+
+        const response = await app.request(`/pty/${PtyID.ascending()}`, {
+          method: "DELETE",
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(404)
+        expect(body.name).toBe("NotFoundError")
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Lock `DELETE /pty/:id` missing-target behavior to `404 NotFoundError`.
- Add backend route coverage for missing PTY remove targets.
- Add a stale terminal restore E2E that rewrites real workspace terminal storage to legacy `pty_old`, reloads, and verifies restore uses a durable `tab_...` without hitting `/pty/pty_old`.

## Why

#648 split terminal identity into durable UI tabs and memory-only runtime PTY handles. PR1 added the storage schema, and PR2 wired the runtime lifecycle. PR3 closes the remaining contract gap: missing delete semantics must be explicit, and stale persisted terminal state must not send old runtime ids back to backend PTY routes.

## Related Issue

Closes #648.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Check that `DELETE /pty/:id` now matches the existing GET / PUT / connect missing-target contract.
- Check that frontend durable-tab close behavior still tolerates missing runtime PTYs.
- Check that the new E2E covers the stale persisted restore path without depending on guessed storage keys.

## Risk Notes

- `terminal-reconnect.spec.ts` still fails locally at the known Ghostty input path: the command is typed, but the expected token does not render before the reconnect assertion. This is unchanged from PR2 and is not caused by this diff.
- Manual desktop interaction through Computer Use timed out reading the Electron window. To keep verification bounded, I used isolated desktop startup plus the repo raw CI smoke after building renderer output.
- No UI layout, copy, terminal rendering, or PTY process implementation is redesigned here.

## How To Verify

```text
OpenCode PTY route test: bun --cwd packages/opencode test test/server/pty-routes.test.ts -> 5 pass, 0 fail
App terminal unit tests: bun --cwd packages/app test:unit src/context/terminal.test.ts src/context/terminal-storage.test.ts src/context/terminal-lifecycle.test.ts -> 1112 pass, 0 fail
App typecheck: bun --cwd packages/app typecheck -> passed
OpenCode typecheck: bun --cwd packages/opencode typecheck -> passed
Diff check: git diff --check -> passed
Terminal stale restore E2E: bun --cwd packages/app test:e2e:local -- e2e/terminal/terminal-stale-restore.spec.ts -> 1 passed
Terminal init E2E: bun --cwd packages/app test:e2e:local -- e2e/terminal/terminal-init.spec.ts -> 1 passed
Terminal reconnect E2E: bun --cwd packages/app test:e2e:local -- e2e/terminal/terminal-reconnect.spec.ts -> failed at known Ghostty input token render step before reconnect assertion
Desktop build: bun --cwd packages/desktop-electron build -> passed
Desktop raw smoke: bun packages/desktop-electron/scripts/ci-smoke.ts raw dev -> passed
```

## Screenshots or Recordings

N/A. This PR changes runtime recovery contracts and regression coverage, not visible UI layout or copy.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal session deletion to validate session existence before removal, providing clearer error messages

* **New Features**
  * Terminal restoration now creates fresh runtime sessions when resuming previously persisted terminal states

* **Tests**
  * Added comprehensive test coverage for terminal state restoration workflows and error handling in terminal session operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->