### PR TITLE
fix(app): rewrite prompt-drop-file e2e to match attachment routing gate

### DIFF
--- a/packages/app/e2e/prompt/prompt-drop-file.spec.ts
+++ b/packages/app/e2e/prompt/prompt-drop-file.spec.ts
@@ -46,10 +46,12 @@ test("dropping a text file adds a removable attachment chip", async ({ page, got
 
   await page.dispatchEvent("body", "drop", { dataTransfer: dt })
 
-  await expect(page.getByText("drop.txt").first()).toBeVisible()
+  const chip = page.getByText("drop.txt").first()
+  await expect(chip).toBeVisible()
+  await chip.hover()
+
   const remove = page.getByRole("button", { name: "Remove attachment" }).first()
   await expect(remove).toBeVisible()
-
-  await remove.click({ force: true })
+  await remove.click()
   await expect(page.getByText("drop.txt")).toHaveCount(0)
 })

--- a/packages/app/e2e/prompt/prompt-drop-file.spec.ts
+++ b/packages/app/e2e/prompt/prompt-drop-file.spec.ts
@@ -1,7 +1,15 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
-test("dropping an image file adds an attachment", async ({ page, gotoSession }) => {
+// The shared e2e backend only exposes text-only models, so the image-attach
+// happy path cannot be exercised here. These specs lock in the two paths the
+// drop-file pipeline owns under that constraint:
+//   1. dropping an image with a text-only model surfaces the "choose a vision
+//      model" toast and never adds a chip
+//   2. dropping a non-image file routes through addDirect and renders a chip
+//      with a Remove control
+
+test("dropping an image with a text-only model surfaces the unsupported toast", async ({ page, gotoSession }) => {
   await gotoSession()
 
   const prompt = page.locator(promptSelector)
@@ -18,13 +26,30 @@ test("dropping an image file adds an attachment", async ({ page, gotoSession }) 
 
   await page.dispatchEvent("body", "drop", { dataTransfer: dt })
 
-  const img = page.locator('img[alt="drop.png"]').first()
-  await expect(img).toBeVisible()
+  await expect(page.getByText("This model cannot read images")).toBeVisible()
+  await expect(page.getByRole("button", { name: "Choose model" })).toBeVisible()
+  await expect(page.locator('img[alt="drop.png"]')).toHaveCount(0)
+})
 
+test("dropping a text file adds a removable attachment chip", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const prompt = page.locator(promptSelector)
+  await prompt.click()
+
+  const dt = await page.evaluateHandle(() => {
+    const dt = new DataTransfer()
+    const file = new File(["hello from drop"], "drop.txt", { type: "text/plain" })
+    dt.items.add(file)
+    return dt
+  })
+
+  await page.dispatchEvent("body", "drop", { dataTransfer: dt })
+
+  await expect(page.getByText("drop.txt").first()).toBeVisible()
   const remove = page.getByRole("button", { name: "Remove attachment" }).first()
   await expect(remove).toBeVisible()
 
-  await img.hover()
-  await remove.click()
-  await expect(page.locator('img[alt="drop.png"]')).toHaveCount(0)
+  await remove.click({ force: true })
+  await expect(page.getByText("drop.txt")).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary

Replace the failing `packages/app/e2e/prompt/prompt-drop-file.spec.ts` with two narrow tests that match the behavior the shared e2e backend can actually exercise.

## Why

The legacy spec asserted that dropping any image always renders an attachment chip. After PR #565749412 (`feat: route prompt composer attachments`, 2026-04-22) introduced the model-gated routing in `packages/app/src/components/prompt-input/attachment-routing.ts`, that assertion is impossible to satisfy in e2e: the shared backend only exposes text-only opencode models (big-pickle and four other free models, all `modalities.input: ["text"]`), so `routeBrowserFile` rightly returns `reject-image` and the chip never appears. The spec has been silently failing on dev pushes ever since because it is not tagged `@smoke` and the e2e job downgrades failures to warnings, not blocking checks.

i652 was filed assuming a regression on dev. Investigation confirmed the drop wiring itself is healthy:

- the document-level drop listener in `attachments.ts` fires
- `event.dataTransfer.files` is populated
- `routeBrowserFile` returns `reject-image`
- `warnImageUnsupported` toast renders correctly with the "Choose model" CTA

The product behavior is correct. The test was outdated.

## Related Issue

Closes #652.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Does the rejection-toast assertion read as the right product spec for text-only models? The active model in e2e is big-pickle; the toast title `This model cannot read images` and the `Choose model` button are taken verbatim from `prompt.toast.imageUnsupported.*` in `packages/app/src/i18n/en.ts`.
- Is asserting on the chip via the filename text (`drop.txt`) acceptable as a stand-in for the image happy path? The image branch needs a vision-capable seed model in the e2e backend; tracked as a follow-up rather than bundled here.

## Risk Notes

None. Test-only change, no product code touched. The drop wiring and the routing gate are unchanged.

## How To Verify

```text
Targeted prompt-drop-file.spec.ts (chromium):       2 passed / 4.5s
Targeted prompt-drop-file.spec.ts + uri spec:       3 passed / 4.8s
git diff --check:                                   no whitespace errors
```

## Screenshots or Recordings

Not applicable. Test-only change; no UI surface changed.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File attachments: Users can now drop text files into prompts to create attachments. Each attachment appears as an interactive chip with hover effects and dedicated remove buttons for easy management and control.

* **Bug Fixes**
  * Image handling: Dropping image files now displays an "unsupported images" toast notification, informing users about file type support constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->