### PR TITLE
refactor(app): refresh home welcome heading (#603 PR3/3)

### DIFF
--- a/packages/app/e2e/app/home.spec.ts
+++ b/packages/app/e2e/app/home.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from "../fixtures"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
 
-test("@smoke home renders hero composer without skill-card shortcuts", async ({ page, project }) => {
+test("@smoke home renders hero composer with updated welcome heading", async ({ page, project }) => {
   await project.open()
 
   const home = page.locator('[data-component="session-new-home"]')
   const composer = home.locator(sessionComposerDockSelector)
   const workspaceChip = page.getByRole("button", { name: /Switch workspace|切换工作目录/i })
   await expect(home).toBeVisible()
-  await expect(page.getByRole("heading", { name: "What do you want to do?" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: /今天我们做点什么|What should we work on/ })).toBeVisible()
   await expect(page.locator(sessionComposerDockSelector)).toHaveCount(1)
   await expect(composer).toHaveCount(1)
   await expect(composer).toHaveCSS("text-align", "left")

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -11,10 +11,19 @@ export function NewSessionView(props: { composer?: (ctx: ComposerCtx) => JSX.Ele
   return (
     <div data-component="session-new-home" class="size-full overflow-y-auto">
       <div class="mx-auto flex w-full flex-col items-center px-6 pt-[28vh] pb-10 text-center md:px-8">
-        <h1 class="text-28-regular text-fg-strong">{language.t("session.new.title")}</h1>
+        <h1
+          class="text-[28px] font-medium leading-[1.3] text-fg-strong"
+          classList={{
+            "tracking-[var(--letter-spacing-tightest)]": language.locale().startsWith("en"),
+            "tracking-[var(--letter-spacing-normal)]": language.locale().startsWith("zh"),
+          }}
+          lang={language.locale()}
+        >
+          {language.t("home.hero.title")}
+        </h1>
 
         <Show when={props.composer}>
-          <div class="mt-12 flex w-full max-w-[640px] flex-col items-center">
+          <div class="mt-20 flex w-full max-w-[640px] flex-col items-center">
             {props.composer!({ onModeChange: () => {} })}
           </div>
         </Show>

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -596,6 +596,7 @@ export const dict = {
   "notification.session.error.fallbackDescription": "An error occurred",
 
   "home.recentProjects": "Recent projects",
+  "home.hero.title": "What should we work on?",
 
   "session.tab.session": "Session",
   "session.tab.review": "Review",
@@ -669,7 +670,6 @@ export const dict = {
   "session.revertDock.expand": "Expand rolled back messages",
   "session.revertDock.restore": "Restore message",
 
-  "session.new.title": "What do you want to do?",
   "session.new.reassurance": "Files and conversations stay on your computer",
   "session.new.worktree.main": "Main branch",
   "session.new.worktree.mainWithBranch": "Main branch ({{branch}})",

--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -6,7 +6,7 @@ const locales = [zh]
 const keys = [
   "command.session.previous.unseen",
   "command.session.next.unseen",
-  "session.new.title",
+  "home.hero.title",
   "session.panel.addTab",
   "session.panel.utility",
   "session.panel.files",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -565,6 +565,7 @@ export const dict = {
   "notification.session.error.fallbackDescription": "发生错误",
 
   "home.recentProjects": "最近项目",
+  "home.hero.title": "今天我们做点什么？",
 
   "session.tab.session": "会话",
   "session.tab.review": "审查",
@@ -623,7 +624,6 @@ export const dict = {
   "session.revertDock.collapse": "折叠已回滚消息",
   "session.revertDock.expand": "展开已回滚消息",
   "session.revertDock.restore": "恢复消息",
-  "session.new.title": "今天想做什么？",
   "session.new.reassurance": "文件和对话仅在本机处理",
   "session.new.worktree.main": "主分支",
   "session.new.worktree.mainWithBranch": "主分支（{{branch}}）",

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -7,7 +7,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/home.spec.ts:@smoke home composer shows unified single-row bar with brand orange send",
   "packages/app/e2e/app/home.spec.ts:@smoke home composer submits a slash-prefixed prompt via the fallback path",
   "packages/app/e2e/app/home.spec.ts:@smoke home hero prompt starts a session",
-  "packages/app/e2e/app/home.spec.ts:@smoke home renders hero composer without skill-card shortcuts",
+  "packages/app/e2e/app/home.spec.ts:@smoke home renders hero composer with updated welcome heading",
   "packages/app/e2e/app/home.spec.ts:@smoke project home status panel can open the server picker dialog",
   "packages/app/e2e/app/navigation.spec.ts:@smoke project route redirects to /session",
   "packages/app/e2e/app/root-redirect.spec.ts:@smoke root route falls back to backend project when local store is empty",


### PR DESCRIPTION
## Summary

Refresh the home `<h1>` to the W5 welcome wording locked by the design preview ("今天我们做点什么？" / "What should we work on?") and tune the heading typography toward `--type-display`: medium weight, 28/130, and the documented zh-CJK letter-spacing rule (CJK 0, en tightest). Widen the heading-to-composer gap from `mt-12` to `mt-20` so the hero block breathes. Production layout, `WorkspaceChip` inside the composer, and every other home surface stay untouched.

## Why

PR1 (#651) cleared the dead home page and PR2 (#657) stripped the skill-card pipeline. PR3 originally planned to rewrite `NewSessionView` as a W5 hero (meta-path button + branch chip + extracted `WorkspacePopover`). The maintainer manual-tested the experiment in Electron and decided the cwd signal reads cleaner where it already is (inside the composer), and that the home page should stay minimal. Rolled back to the smallest change that delivers the welcome copy + typography refresh on the existing layout.

## Related Issue

Refs #603. Slice 3 of 3.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- `session-new-view.tsx` — `--type-display` is rendered with arbitrary Tailwind values (`text-[28px] font-medium leading-[1.3]` + `tracking-[var(--letter-spacing-tightest|normal)]`) because there is no `text-display` utility class yet. Introducing one would be a cross-package utility addition (would touch `packages/ui` and the error-page heading); kept out of scope and noted as a follow-up candidate.
- i18n: `home.hero.title` replaces `session.new.title`. Both `parity.test.ts` and the `home.spec.ts` heading assertion are updated. `session.new.title` is removed in both locales — grep confirms no other consumer.
- The opencode `@smoke` inventory in `packages/opencode/test/config/e2e-smoke-tagging.test.ts` is updated alphabetically to match the new home smoke title.

## Risk Notes

None. No behavioral or platform-impacting change. No new schema, no migration, no IPC surface touched.

## How To Verify

```text
packages/app typecheck (tsgo -b):                clean
packages/opencode typecheck (tsgo --noEmit):     clean
packages/app unit tests (bun test src/):         1103 pass / 0 fail / 2649 expect()
packages/app E2E home.spec.ts (chromium):        6 pass / 10.0s
packages/opencode e2e-smoke-tagging unit:        2 pass
Electron `bun run dev:desktop` manual check:     heading copy + medium-weight display tier + heading↔composer gap visible; WorkspaceChip remains inside composer; zh + en letter-spacing rules both render
Crosscheck (Claude Opus + Codex):                0 P0 / 0 P1; one P2 (`tracking-[var(--letter-spacing-tightest)]` token swap) applied in-PR; other P2/P3 deferred (new utility class out of scope; pre-existing parity-test observation)
```

## Screenshots or Recordings

Manual screenshot to be attached after PR open — the visible change is the heading copy ("今天我们做点什么？" / "What should we work on?") plus the slightly heavier medium-weight 28/130 display heading and the wider heading-to-composer gap. The composer, workspace chip, and overall layout are byte-for-byte unchanged from production.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English