### PR TITLE
test(app): add real dark-mode e2e helper

### DIFF
--- a/packages/app/e2e/app/theme-helper.spec.ts
+++ b/packages/app/e2e/app/theme-helper.spec.ts
@@ -1,16 +1,10 @@
+import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { sessionComposerDockSelector } from "../selectors"
 import { applyDarkModeForTests } from "../utils"
 
-test("dark-mode e2e helper uses the real theme boot path", async ({ page, project }) => {
-  await applyDarkModeForTests(page)
-  await project.open()
-
-  const home = page.locator('[data-component="session-new-home"]')
-  const composerCard = home.locator(`${sessionComposerDockSelector} [data-dock="card"]`).first()
-  await expect(composerCard).toBeVisible()
-
-  const colors = await page.evaluate(() => {
+async function readHomeDockThemeColors(page: Page) {
+  return page.evaluate(() => {
     const html = document.documentElement
     const card = document.querySelector('[data-component="session-new-home"] [data-dock="card"]')
     if (!(card instanceof HTMLElement)) throw new Error("Missing dock card")
@@ -20,6 +14,17 @@ test("dark-mode e2e helper uses the real theme boot path", async ({ page, projec
       cardBackground: getComputedStyle(card).backgroundColor,
     }
   })
+}
+
+test("dark-mode e2e helper uses the real theme boot path", async ({ page, project }) => {
+  await applyDarkModeForTests(page)
+  await project.open()
+
+  const home = page.locator('[data-component="session-new-home"]')
+  const composerCard = home.locator(`${sessionComposerDockSelector} [data-dock="card"]`).first()
+  await expect(composerCard).toBeVisible()
+
+  const colors = await readHomeDockThemeColors(page)
 
   expect(colors).toEqual({
     attr: "dark",
@@ -35,16 +40,7 @@ test("raw data-color-scheme mutation does not switch injected theme tokens", asy
     document.documentElement.dataset.colorScheme = "dark"
   })
 
-  const colors = await page.evaluate(() => {
-    const html = document.documentElement
-    const card = document.querySelector('[data-component="session-new-home"] [data-dock="card"]')
-    if (!(card instanceof HTMLElement)) throw new Error("Missing dock card")
-    return {
-      attr: html.dataset.colorScheme,
-      bgBase: getComputedStyle(html).getPropertyValue("--bg-base").trim(),
-      cardBackground: getComputedStyle(card).backgroundColor,
-    }
-  })
+  const colors = await readHomeDockThemeColors(page)
 
   expect(colors).toEqual({
     attr: "dark",

--- a/packages/app/e2e/app/theme-helper.spec.ts
+++ b/packages/app/e2e/app/theme-helper.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "../fixtures"
+import { sessionComposerDockSelector } from "../selectors"
+import { applyDarkModeForTests } from "../utils"
+
+test("dark-mode e2e helper uses the real theme boot path", async ({ page, project }) => {
+  await applyDarkModeForTests(page)
+  await project.open()
+
+  const home = page.locator('[data-component="session-new-home"]')
+  const composerCard = home.locator(`${sessionComposerDockSelector} [data-dock="card"]`).first()
+  await expect(composerCard).toBeVisible()
+
+  const colors = await page.evaluate(() => {
+    const html = document.documentElement
+    const card = document.querySelector('[data-component="session-new-home"] [data-dock="card"]')
+    if (!(card instanceof HTMLElement)) throw new Error("Missing dock card")
+    return {
+      attr: html.dataset.colorScheme,
+      bgBase: getComputedStyle(html).getPropertyValue("--bg-base").trim(),
+      cardBackground: getComputedStyle(card).backgroundColor,
+    }
+  })
+
+  expect(colors).toEqual({
+    attr: "dark",
+    bgBase: "#1a1714",
+    cardBackground: "rgb(58, 52, 49)",
+  })
+})
+
+test("raw data-color-scheme mutation does not switch injected theme tokens", async ({ page, project }) => {
+  await project.open()
+
+  await page.evaluate(() => {
+    document.documentElement.dataset.colorScheme = "dark"
+  })
+
+  const colors = await page.evaluate(() => {
+    const html = document.documentElement
+    const card = document.querySelector('[data-component="session-new-home"] [data-dock="card"]')
+    if (!(card instanceof HTMLElement)) throw new Error("Missing dock card")
+    return {
+      attr: html.dataset.colorScheme,
+      bgBase: getComputedStyle(html).getPropertyValue("--bg-base").trim(),
+      cardBackground: getComputedStyle(card).backgroundColor,
+    }
+  })
+
+  expect(colors).toEqual({
+    attr: "dark",
+    bgBase: "#ffffff",
+    cardBackground: "rgb(255, 255, 255)",
+  })
+})

--- a/packages/app/e2e/utils.ts
+++ b/packages/app/e2e/utils.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { base64Encode, checksum } from "@opencode-ai/util/encode"
 
@@ -60,4 +61,22 @@ export function workspacePersistKey(directory: string, key: string) {
   const head = (directory.slice(0, 12) || "workspace").replace(/[^a-zA-Z0-9._-]/g, "-")
   const sum = checksum(directory) ?? "0"
   return `pawwork.workspace.${head}.${sum}.dat:workspace:${key}`
+}
+
+const applyPawWorkDarkModeStorage = () => {
+  localStorage.setItem("pawwork-theme-id", "pawwork")
+  localStorage.setItem("pawwork-color-scheme", "dark")
+  localStorage.removeItem("pawwork-theme-css-light")
+  localStorage.removeItem("pawwork-theme-css-dark")
+}
+
+export async function applyDarkModeForTests(page: Page) {
+  // Dark-mode tests must use the same storage + boot path as the app. Mutating
+  // data-color-scheme directly flips selector-only rules but leaves the injected
+  // oc-theme token sheet on its previous light values.
+  await page.addInitScript(applyPawWorkDarkModeStorage)
+  if (!page.url().startsWith("about:")) {
+    await page.evaluate(applyPawWorkDarkModeStorage)
+    await page.reload({ waitUntil: "domcontentloaded" })
+  }
 }

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -274,10 +274,10 @@
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
- * Dark mode source of truth: explicit toggle attribute.
- * The Settings → Appearance toggle (context.tsx) writes dataset.colorScheme
- * to this element; loader.ts handles the CSS color-scheme property separately.
- * This block IS the dark theme; the @media block below is a first-paint mirror only.
+ * Dark first-paint mirror for the explicit toggle attribute.
+ * Runtime dark tokens are written by applyThemeCss() in theme/context.tsx via
+ * the injected <style id="oc-theme"> sheet. This selector keeps pre-boot paint
+ * aligned with that runtime path; it is not the runtime source of truth.
  * ────────────────────────────────────────────────────────────────────────── */
 :root[data-color-scheme="dark"] {
   /* Dark surface · STANDARDS L10 (6-tier warm coffee) */


### PR DESCRIPTION
## Summary

- Add `applyDarkModeForTests(page)` for E2E specs that need the real PawWork dark-mode boot path.
- Add focused E2E coverage proving the helper rewrites runtime theme tokens while raw `data-color-scheme` mutation does not.
- Correct the `theme.css` dark-mode comment so the selector is documented as a first-paint mirror, not the runtime source of truth.

## Why

`#658` found that `document.documentElement.dataset.colorScheme = "dark"` only flips selector-only rules. It does not rewrite the injected `<style id="oc-theme">` token sheet, so tests can accidentally create a half-switched page with dark attributes but light CSS variables.

The app's real path is storage plus boot: `oc-theme-preload.js` reads `pawwork-color-scheme`, then `ThemeProvider` runs `applyThemeCss()` and rewrites the injected runtime token sheet. The helper follows that path so future screenshots and E2E assertions do not rely on a misleading shortcut.

## Related Issue

Closes #658.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the helper stays test-only and uses `pawwork-theme-id` / `pawwork-color-scheme` storage plus reload instead of direct dataset mutation.
- Confirm the negative E2E guard accurately locks the old broken path: raw dataset mutation leaves `--bg-base` at `#ffffff`.
- Confirm `theme.css` comment wording is accurate without changing token values or cascade behavior.

## Risk Notes

Low. No product runtime behavior, theme tokens, dependencies, migrations, permissions, packaging, signing, or platform behavior changed. The only runtime-adjacent file change is a comment in `theme.css`.

## How To Verify

```text
Red check: bun --cwd packages/app test:e2e:local -- e2e/app/theme-helper.spec.ts -> failed before implementation because ../utils did not export applyDarkModeForTests
Focused E2E: bun --cwd packages/app test:e2e:local -- e2e/app/theme-helper.spec.ts -> 2 passed
App typecheck: bun --cwd packages/app typecheck -> passed
App unit tests: bun --cwd packages/app test:unit -> 1103 pass / 0 fail / 2649 expect()
Diff check: git diff --cached --check -> no whitespace errors
```

## Screenshots or Recordings

N/A. This PR changes test infrastructure and documentation comments only; it does not change visible UI behavior.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
