### PR TITLE
fix(skill): allow missing descriptions

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -275,13 +275,17 @@ export namespace Skill {
     Layer.provide(AppFileSystem.defaultLayer),
   )
 
+  export function displayable(list: Info[]) {
+    return list.filter((skill) => skill.description !== undefined)
+  }
+
   export function fmt(list: Info[], opts: { verbose: boolean }) {
-    const described = list.filter((skill) => skill.description !== undefined)
-    if (described.length === 0) return "No skills are currently available."
+    const displayableSkills = displayable(list)
+    if (displayableSkills.length === 0) return "No skills are currently available."
     if (opts.verbose) {
       return [
         "<available_skills>",
-        ...described
+        ...displayableSkills
           .toSorted((a, b) => a.name.localeCompare(b.name))
           .flatMap((skill) => [
             "  <skill>",
@@ -296,7 +300,7 @@ export namespace Skill {
 
     return [
       "## Available Skills",
-      ...described
+      ...displayableSkills
         .toSorted((a, b) => a.name.localeCompare(b.name))
         .map((skill) => `- **${skill.name}**: ${skill.description}`),
     ].join("\n")

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -29,7 +29,7 @@ export namespace Skill {
 
   export const Info = z.object({
     name: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
     location: z.string(),
     content: z.string(),
   })
@@ -276,12 +276,13 @@ export namespace Skill {
   )
 
   export function fmt(list: Info[], opts: { verbose: boolean }) {
-    if (list.length === 0) return "No skills are currently available."
+    const described = list.filter((skill) => skill.description !== undefined)
+    if (described.length === 0) return "No skills are currently available."
     if (opts.verbose) {
       return [
         "<available_skills>",
-        ...list
-          .sort((a, b) => a.name.localeCompare(b.name))
+        ...described
+          .toSorted((a, b) => a.name.localeCompare(b.name))
           .flatMap((skill) => [
             "  <skill>",
             `    <name>${skill.name}</name>`,
@@ -295,7 +296,7 @@ export namespace Skill {
 
     return [
       "## Available Skills",
-      ...list
+      ...described
         .toSorted((a, b) => a.name.localeCompare(b.name))
         .map((skill) => `- **${skill.name}**: ${skill.description}`),
     ].join("\n")

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -320,7 +320,8 @@ export namespace ToolRegistry {
 
       const describeSkill = Effect.fn("ToolRegistry.describeSkill")(function* (agent: Agent.Info) {
         const list = yield* skill.available(agent)
-        if (list.length === 0) return "No skills are currently available."
+        const visible = Skill.displayable(list)
+        if (visible.length === 0) return Skill.fmt(visible, { verbose: false })
         return [
           "Load a specialized skill that provides domain-specific instructions and workflows.",
           "",
@@ -333,7 +334,7 @@ export namespace ToolRegistry {
           "The following skills provide specialized sets of instructions for particular tasks",
           "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
           "",
-          Skill.fmt(list, { verbose: false }),
+          Skill.fmt(visible, { verbose: false }),
         ].join("\n")
       })
 

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -117,17 +117,18 @@ describe("session.system", () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
-        for (const [name, description] of [
-          ["zeta-skill", "Zeta skill."],
-          ["alpha-skill", "Alpha skill."],
-          ["middle-skill", "Middle skill."],
+        for (const { name, description } of [
+          { name: "zeta-skill", description: "Zeta skill." },
+          { name: "alpha-skill", description: "Alpha skill." },
+          { name: "middle-skill", description: "Middle skill." },
+          { name: "manual-skill" },
         ]) {
           const skillDir = path.join(dir, ".opencode", "skill", name)
           await Bun.write(
             path.join(skillDir, "SKILL.md"),
             `---
 name: ${name}
-description: ${description}
+${description === undefined ? "" : `description: ${description}`}
 ---
 
 # ${name}
@@ -162,6 +163,7 @@ description: ${description}
           expect(alpha).toBeGreaterThan(-1)
           expect(middle).toBeGreaterThan(alpha)
           expect(zeta).toBeGreaterThan(middle)
+          expect(first).not.toContain("manual-skill")
         },
       })
     } finally {

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -157,6 +157,40 @@ Just some content without YAML frontmatter.
   })
 })
 
+test("discovers skills without descriptions but hides them from formatted prompts", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".opencode", "skill", "manual-skill")
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: manual-skill
+---
+
+# Manual Skill
+
+Instructions here.
+`,
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      const item = skills.find((s) => s.name === "manual-skill")
+      expect(item).toBeDefined()
+      expect(item!.description).toBeUndefined()
+      expect(Skill.fmt(skills, { verbose: false })).not.toContain("manual-skill")
+      expect(Skill.fmt(skills, { verbose: true })).not.toContain("manual-skill")
+      expect(Skill.fmt([item!], { verbose: false })).toBe("No skills are currently available.")
+      expect(Skill.fmt([item!], { verbose: true })).toBe("No skills are currently available.")
+    },
+  })
+})
+
 test("returns empty array when no skills exist", async () => {
   await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -124,6 +124,55 @@ description: ${description}
     }
   })
 
+  test("description uses empty state when only manual skills are available", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const skillDir = path.join(dir, ".opencode", "skill", "manual-skill")
+        await Bun.write(
+          path.join(skillDir, "SKILL.md"),
+          `---
+name: manual-skill
+---
+
+# Manual Skill
+`,
+        )
+      },
+    })
+
+    const home = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const agent = {
+            name: "build",
+            mode: "primary" as const,
+            permission: [
+              { permission: "skill", pattern: "*", action: "deny" as const },
+              { permission: "skill", pattern: "manual-skill", action: "allow" as const },
+            ],
+            options: {},
+          }
+          const desc = await ToolRegistry.tools({
+            providerID: "opencode" as any,
+            modelID: "gpt-5" as any,
+            agent,
+          }).then((tools) => tools.find((tool) => tool.id === SkillTool.id)?.description ?? "")
+
+          expect(desc).toContain("No skills are currently available.")
+          expect(desc).not.toContain("manual-skill")
+          expect(desc).not.toContain("The following skills provide specialized sets of instructions")
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = home
+    }
+  })
+
   test("execute returns skill content block with files", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5942,7 +5942,7 @@ export type AppSkillsResponses = {
    */
   200: Array<{
     name: string
-    description: string
+    description?: string
     location: string
     content: string
   }>


### PR DESCRIPTION
## Summary

Allow skill frontmatter to omit `description` while still loading the skill, and keep description-less skills out of automatic skill prompt listings.

## Why

This absorbs the still-relevant part of upstream `opencode` stability follow-up `anomalyco/opencode#26391` for #512. Before this change, PawWork skipped otherwise valid skills when the skill only had a `name`; after this change, those skills remain available for direct loading without being advertised as auto-matchable skills.

## Related Issue

Closes #512 for the `anomalyco/opencode#26391` slice only. Other #512 candidates were checked separately: deterministic tool ordering, npm shim signal forwarding, and shell carriage-return normalization are already covered locally; the network-options AppRuntime follow-up remains a separate possible slice.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that the behavior boundary is right: description-less skills should load through the skill registry/API, but should not appear in formatted automatic skill prompt lists.

## Risk Notes

Low. This changes skill metadata shape from required to optional and updates the generated SDK response type. It does not touch UI, desktop packaging, runtime process behavior, or onboarding.

## How To Verify

```text
Focused tests: bun --cwd packages/opencode test test/skill/skill.test.ts test/session/system.test.ts -> 23 pass, 0 fail
Opencode typecheck: bun --cwd packages/opencode typecheck -> passed
SDK typecheck: bun --cwd packages/sdk/js typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

N/A. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Skill descriptions are now optional in the system, though skills without descriptions remain hidden from visibility
  * Skills without descriptions are filtered from formatted prompt output, keeping generated prompts focused on well-defined entries
  * "No skills available" message displays when the skill list contains no skills with descriptions
  * Enhanced filtering ensures improved skill visibility handling in generated prompts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->