### PR TITLE
refactor(ui): extract session turn changes panel

### DIFF
--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -16,10 +16,13 @@ import {
 } from "./session-turn-changes"
 
 const emptyTurnFiles: TurnChangeFile[] = []
+const emptyExpanded: readonly string[] = []
 
 export function SessionTurnChangesPanel(props: {
   turnChange: TurnChangeDisplay
   actions?: TurnChangeActions
+  expanded?: readonly string[]
+  onExpandedChange?: (value: string[]) => void
 }) {
   const i18n = useI18n()
   const fileComponent = useFileComponent()
@@ -28,9 +31,9 @@ export function SessionTurnChangesPanel(props: {
   const turnEdited = createMemo(() => turnFiles().length)
   const turnAdditions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.additions ?? 0), 0))
   const turnDeletions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.deletions ?? 0), 0))
-  const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])
   const [confirmAction, setConfirmAction] = createSignal<"undo" | "redo" | undefined>()
   let confirmTimer: ReturnType<typeof setTimeout> | undefined
+  const expandedPaths = () => props.expanded ?? emptyExpanded
 
   const resetConfirm = () => {
     if (confirmTimer) clearTimeout(confirmTimer)
@@ -112,10 +115,11 @@ export function SessionTurnChangesPanel(props: {
       <div data-slot="session-turn-changes-list">
         <For each={turnFiles()}>
           {(file) => {
-            const expanded = createMemo(() => turnExpanded().includes(file.path))
+            const expanded = createMemo(() => expandedPaths().includes(file.path))
             const toggle = () => {
               if (!file.expandable) return
-              setTurnExpanded((current) =>
+              const current = expandedPaths()
+              props.onExpandedChange?.(
                 current.includes(file.path) ? current.filter((item) => item !== file.path) : [...current, file.path],
               )
             }

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -1,0 +1,209 @@
+import { createMemo, createSignal, For, onCleanup, Show } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { getDirectory } from "@opencode-ai/core/util/path"
+import { useFileComponent } from "../context/file"
+import { useI18n } from "../context/i18n"
+import { Icon } from "./icon"
+import { IconButton } from "./icon-button"
+import { Tooltip } from "./tooltip"
+import { normalize } from "./session-diff"
+import {
+  hasTurnChangeActionHandler,
+  turnChangeAction,
+  type TurnChangeActions,
+  type TurnChangeDisplay,
+  type TurnChangeFile,
+} from "./session-turn-changes"
+
+const emptyTurnFiles: TurnChangeFile[] = []
+
+export function SessionTurnChangesPanel(props: {
+  turnChange: TurnChangeDisplay
+  actions?: TurnChangeActions
+}) {
+  const i18n = useI18n()
+  const fileComponent = useFileComponent()
+
+  const turnFiles = createMemo(() => props.turnChange.files ?? emptyTurnFiles)
+  const turnEdited = createMemo(() => turnFiles().length)
+  const turnAdditions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.additions ?? 0), 0))
+  const turnDeletions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.deletions ?? 0), 0))
+  const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])
+  const [confirmAction, setConfirmAction] = createSignal<"undo" | "redo" | undefined>()
+  let confirmTimer: ReturnType<typeof setTimeout> | undefined
+
+  const resetConfirm = () => {
+    if (confirmTimer) clearTimeout(confirmTimer)
+    confirmTimer = undefined
+    setConfirmAction(undefined)
+  }
+  const primeConfirm = (action: "undo" | "redo") => {
+    if (confirmAction() === action) return true
+    setConfirmAction(action)
+    if (confirmTimer) clearTimeout(confirmTimer)
+    confirmTimer = setTimeout(resetConfirm, 3000)
+    return false
+  }
+  onCleanup(resetConfirm)
+
+  const mutateTurnChange = async () => {
+    const id = props.turnChange.messageID
+    const action = turnChangeAction(props.turnChange)
+    if (!action || !hasTurnChangeActionHandler(props.turnChange, props.actions)) return
+    if (!primeConfirm(action)) return
+    resetConfirm()
+    if (action === "undo") await props.actions?.undo?.(id)
+    else await props.actions?.redo?.(id)
+  }
+
+  const turnActionLabel = createMemo(() => {
+    const action = turnChangeAction(props.turnChange)
+    if (!action) return ""
+    const base = action === "undo" ? i18n.t("ui.sessionTurn.turnChanges.undo") : i18n.t("ui.sessionTurn.turnChanges.reapply")
+    return confirmAction() === action
+      ? action === "undo"
+        ? i18n.t("ui.sessionTurn.turnChanges.undoConfirm")
+        : i18n.t("ui.sessionTurn.turnChanges.redoConfirm")
+      : base
+  })
+
+  const isUndoneTurn = createMemo(() => props.turnChange.redoAvailable && !props.turnChange.undoAvailable)
+  const turnStatusLabel = (status: TurnChangeFile["status"]) => {
+    if (status === "added") return i18n.t("ui.sessionTurn.turnChanges.status.added")
+    if (status === "deleted") return i18n.t("ui.sessionTurn.turnChanges.status.deleted")
+    return i18n.t("ui.sessionTurn.turnChanges.status.updated")
+  }
+
+  return (
+    <div data-slot="session-turn-changes" data-component="session-turn-changes">
+      <div data-slot="session-turn-changes-header">
+        <div data-slot="session-turn-changes-summary">
+          <span>
+            {i18n.t(
+              turnEdited() === 1
+                ? "ui.sessionTurn.turnChanges.summary.one"
+                : "ui.sessionTurn.turnChanges.summary.other",
+              { count: turnEdited() },
+            )}
+          </span>
+          <span data-slot="session-turn-changes-additions">+{turnAdditions()}</span>
+          <span data-slot="session-turn-changes-deletions">-{turnDeletions()}</span>
+          <Show when={props.turnChange.truncated && (props.turnChange.omittedCount ?? 0) > 0}>
+            <span data-slot="session-turn-changes-omitted">
+              {i18n.t("ui.sessionTurn.turnChanges.omitted", { count: props.turnChange.omittedCount ?? 0 })}
+            </span>
+          </Show>
+          <Show when={isUndoneTurn()}>
+            <span data-slot="session-turn-changes-undone">{i18n.t("ui.sessionTurn.turnChanges.undone")}</span>
+          </Show>
+        </div>
+        <Show when={turnActionLabel() && hasTurnChangeActionHandler(props.turnChange, props.actions)}>
+          <button
+            type="button"
+            data-slot="session-turn-changes-action"
+            data-confirm={confirmAction() || undefined}
+            onClick={mutateTurnChange}
+            onMouseLeave={resetConfirm}
+          >
+            {turnActionLabel()}
+          </button>
+        </Show>
+      </div>
+      <div data-slot="session-turn-changes-list">
+        <For each={turnFiles()}>
+          {(file) => {
+            const expanded = createMemo(() => turnExpanded().includes(file.path))
+            const toggle = () => {
+              if (!file.expandable) return
+              setTurnExpanded((current) =>
+                current.includes(file.path) ? current.filter((item) => item !== file.path) : [...current, file.path],
+              )
+            }
+            const view = createMemo(() =>
+              file.patch
+                ? normalize({
+                    file: file.path,
+                    patch: file.patch,
+                    additions: file.additions ?? 0,
+                    deletions: file.deletions ?? 0,
+                    status: file.status,
+                  })
+                : undefined,
+            )
+            return (
+              <div data-slot="session-turn-change-item" data-expanded={expanded() || undefined}>
+                <div
+                  data-slot="session-turn-change-row"
+                  data-expandable={file.expandable || undefined}
+                  onClick={toggle}
+                >
+                  <span data-slot="session-turn-change-chevron">
+                    <Show when={file.expandable}>
+                      <Icon name="chevron-down" />
+                    </Show>
+                  </span>
+                  <span data-slot="session-turn-change-path">{file.path}</span>
+                  <span data-slot="session-turn-change-meta">
+                    <Show
+                      when={file.additions !== undefined || file.deletions !== undefined}
+                      fallback={<span data-slot="session-turn-change-status">{turnStatusLabel(file.status)}</span>}
+                    >
+                      <span data-slot="session-turn-changes-additions">+{file.additions ?? 0}</span>
+                      <span data-slot="session-turn-changes-deletions">-{file.deletions ?? 0}</span>
+                    </Show>
+                    <Show when={file.large && file.restoreAvailable === false}>
+                      <span data-slot="session-turn-change-unrestorable">
+                        {i18n.t("ui.sessionTurn.turnChanges.unrestorable")}
+                      </span>
+                    </Show>
+                  </span>
+                  <span data-slot="session-turn-change-actions" onClick={(event) => event.stopPropagation()}>
+                    <Tooltip value={i18n.t("ui.sessionTurn.turnChanges.openFile")} placement="top">
+                      <IconButton
+                        icon="open-file"
+                        size="small"
+                        variant="ghost"
+                        aria-label={i18n.t("ui.sessionTurn.turnChanges.openFile")}
+                        disabled={file.status === "deleted" || !file.openPath || !props.actions?.openFile}
+                        onClick={() => file.openPath && props.actions?.openFile?.(file.openPath)}
+                      />
+                    </Tooltip>
+                    <Tooltip value={i18n.t("ui.sessionTurn.turnChanges.showInFolder")} placement="top">
+                      <IconButton
+                        icon="folder-add-left"
+                        size="small"
+                        variant="ghost"
+                        aria-label={i18n.t("ui.sessionTurn.turnChanges.showInFolder")}
+                        disabled={!file.openPath || !props.actions?.showInFolder}
+                        onClick={() =>
+                          file.openPath &&
+                          props.actions?.showInFolder?.(
+                            file.status === "deleted" ? getDirectory(file.openPath) : file.openPath,
+                          )
+                        }
+                      />
+                    </Tooltip>
+                  </span>
+                </div>
+                <Show when={expanded() && view()}>
+                  {(diff) => (
+                    <div data-slot="session-turn-change-diff" data-scrollable>
+                      <Dynamic component={fileComponent} mode="diff" fileDiff={diff().fileDiff} />
+                    </div>
+                  )}
+                </Show>
+              </div>
+            )
+          }}
+        </For>
+      </div>
+      <Show when={(props.turnChange.skippedCount ?? 0) > 0}>
+        <div data-slot="session-turn-changes-skipped-notice">
+          {i18n.t("ui.sessionTurn.turnChanges.skippedNotice", {
+            count: props.turnChange.skippedCount ?? 0,
+          })}
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/packages/ui/src/components/session-turn-changes.ts
+++ b/packages/ui/src/components/session-turn-changes.ts
@@ -24,6 +24,13 @@ export type TurnChangeDisplay = {
   files: TurnChangeFile[]
 }
 
+export type TurnChangeActions = {
+  undo?: (userMessageID: string, options?: { force?: boolean }) => Promise<TurnChangeDisplay | undefined> | void
+  redo?: (userMessageID: string, options?: { force?: boolean }) => Promise<TurnChangeDisplay | undefined> | void
+  openFile?: (path: string) => void
+  showInFolder?: (path: string) => void
+}
+
 export function hasVisibleTurnChanges(display: TurnChangeDisplay | null | undefined) {
   return !!display && (display.files.length > 0 || !!display.truncated)
 }
@@ -39,7 +46,7 @@ export function turnChangeAction(display: TurnChangeDisplay | null | undefined):
 
 export function hasTurnChangeActionHandler(
   display: TurnChangeDisplay | null | undefined,
-  actions: { undo?: unknown; redo?: unknown } | null | undefined,
+  actions: TurnChangeActions | null | undefined,
 ) {
   const action = turnChangeAction(display)
   if (action === "undo") return typeof actions?.undo === "function"

--- a/packages/ui/src/components/session-turn-parent.test.ts
+++ b/packages/ui/src/components/session-turn-parent.test.ts
@@ -19,3 +19,13 @@ test("legacy diff fallback is gated by visible turn-change data", () => {
   expect(source).toContain("!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()")
   expect(source).not.toContain("props.turnChanges === undefined &&")
 })
+
+test("turn-change expansion state stays owned by session turn", () => {
+  const turnSource = readFileSync(new URL("./session-turn.tsx", import.meta.url), "utf8")
+  const panelSource = readFileSync(new URL("./session-turn-changes-panel.tsx", import.meta.url), "utf8")
+
+  expect(turnSource).toContain("const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])")
+  expect(turnSource).toContain("expanded={turnExpanded()}")
+  expect(turnSource).toContain("onExpandedChange={(value) => setTurnExpanded(value)}")
+  expect(panelSource).not.toContain("const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])")
+})

--- a/packages/ui/src/components/session-turn-parent.test.ts
+++ b/packages/ui/src/components/session-turn-parent.test.ts
@@ -12,3 +12,10 @@ test("session turn collects assistant messages by parent id across the full mess
   expect(source).toContain("item.parentID === msg.id")
   expect(source).not.toContain('if (item.role === "user") break')
 })
+
+test("legacy diff fallback is gated by visible turn-change data", () => {
+  const source = readFileSync(new URL("./session-turn.tsx", import.meta.url), "utf8")
+
+  expect(source).toContain("!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()")
+  expect(source).not.toContain("props.turnChanges === undefined &&")
+})

--- a/packages/ui/src/components/session-turn-parent.test.ts
+++ b/packages/ui/src/components/session-turn-parent.test.ts
@@ -29,3 +29,9 @@ test("turn-change expansion state stays owned by session turn", () => {
   expect(turnSource).toContain("onExpandedChange={(value) => setTurnExpanded(value)}")
   expect(panelSource).not.toContain("const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])")
 })
+
+test("visible turn-change memo is declared after working state", () => {
+  const source = readFileSync(new URL("./session-turn.tsx", import.meta.url), "utf8")
+
+  expect(source.indexOf("const working = createMemo")).toBeLessThan(source.indexOf("const visibleTurnChange = createMemo"))
+})

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -11,7 +11,7 @@ import { useFileComponent } from "../context/file"
 
 import { Binary } from "@opencode-ai/core/util/binary"
 import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
-import { createEffect, createMemo, createSignal, For, on, onCleanup, ParentProps, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, on, ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
 import { AssistantParts, Message, MessageDivider, PART_MAPPING, type UserActions } from "./message-part"
@@ -20,21 +20,14 @@ import { Accordion } from "./accordion"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 import { DiffChanges } from "./diff-changes"
 import { Icon } from "./icon"
-import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
-import { Tooltip } from "./tooltip"
 import { SessionRetry } from "./session-retry"
 import { TextReveal } from "./text-reveal"
 import { createAutoScroll } from "../hooks"
 import { useI18n } from "../context/i18n"
 import { normalize } from "./session-diff"
-import {
-  hasTurnChangeActionHandler,
-  hasVisibleTurnChanges,
-  turnChangeAction,
-  type TurnChangeDisplay,
-  type TurnChangeFile,
-} from "./session-turn-changes"
+import { hasVisibleTurnChanges, type TurnChangeActions, type TurnChangeDisplay } from "./session-turn-changes"
+import { SessionTurnChangesPanel } from "./session-turn-changes-panel"
 
 function record(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -165,18 +158,7 @@ export function SessionTurn(
     shellToolDefaultOpen?: boolean
     editToolDefaultOpen?: boolean
     turnChanges?: Record<string, TurnChangeDisplay | null | undefined>
-    turnChangeActions?: {
-      undo?: (
-        userMessageID: string,
-        options?: { force?: boolean },
-      ) => Promise<TurnChangeDisplay | undefined> | void
-      redo?: (
-        userMessageID: string,
-        options?: { force?: boolean },
-      ) => Promise<TurnChangeDisplay | undefined> | void
-      openFile?: (path: string) => void
-      showInFolder?: (path: string) => void
-    }
+    turnChangeActions?: TurnChangeActions
     active?: boolean
     status?: SessionStatus
     onUserInteracted?: () => void
@@ -195,7 +177,6 @@ export function SessionTurn(
   const emptyParts: PartType[] = []
   const emptyAssistant: AssistantMessage[] = []
   const emptyDiffs: SnapshotFileDiff[] = []
-  const emptyTurnFiles: TurnChangeFile[] = []
   const idle = { type: "idle" as const }
 
   const allMessages = createMemo(() => props.messages ?? list(data.store.message?.[props.sessionID], emptyMessages))
@@ -312,57 +293,11 @@ export function SessionTurn(
     if (!messages.length) return false
     return messages.some((item) => typeof item.time.completed !== "number")
   })
-  const turnFiles = createMemo(() => turnChange()?.files ?? emptyTurnFiles)
-  const turnEdited = createMemo(() => turnFiles().length)
-  const turnAdditions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.additions ?? 0), 0))
-  const turnDeletions = createMemo(() => turnFiles().reduce((sum, file) => sum + (file.deletions ?? 0), 0))
-  const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])
-  const [confirmAction, setConfirmAction] = createSignal<"undo" | "redo" | undefined>()
-  let confirmTimer: ReturnType<typeof setTimeout> | undefined
-  const resetConfirm = () => {
-    if (confirmTimer) clearTimeout(confirmTimer)
-    confirmTimer = undefined
-    setConfirmAction(undefined)
-  }
-  const primeConfirm = (action: "undo" | "redo") => {
-    if (confirmAction() === action) return true
-    setConfirmAction(action)
-    if (confirmTimer) clearTimeout(confirmTimer)
-    confirmTimer = setTimeout(resetConfirm, 3000)
-    return false
-  }
-  onCleanup(resetConfirm)
-  const mutateTurnChange = async () => {
+  const visibleTurnChange = createMemo(() => {
     const current = turnChange()
-    const id = current?.messageID
-    if (!id) return
-    const action = turnChangeAction(current)
-    if (!action || !hasTurnChangeActionHandler(current, props.turnChangeActions)) return
-    if (!primeConfirm(action)) return
-    resetConfirm()
-    if (action === "undo") await props.turnChangeActions?.undo?.(id)
-    else await props.turnChangeActions?.redo?.(id)
-  }
-  const turnActionLabel = createMemo(() => {
-    const current = turnChange()
-    const action = turnChangeAction(current)
-    if (!action) return ""
-    const base = action === "undo" ? i18n.t("ui.sessionTurn.turnChanges.undo") : i18n.t("ui.sessionTurn.turnChanges.reapply")
-    return confirmAction() === action
-      ? action === "undo"
-        ? i18n.t("ui.sessionTurn.turnChanges.undoConfirm")
-        : i18n.t("ui.sessionTurn.turnChanges.redoConfirm")
-      : base
+    if (!hasVisibleTurnChanges(current) || working() || turnInProgress()) return
+    return current
   })
-  const isUndoneTurn = createMemo(() => {
-    const current = turnChange()
-    return !!(current && current.redoAvailable && !current.undoAvailable)
-  })
-  const turnStatusLabel = (status: TurnChangeFile["status"]) => {
-    if (status === "added") return i18n.t("ui.sessionTurn.turnChanges.status.added")
-    if (status === "deleted") return i18n.t("ui.sessionTurn.turnChanges.status.deleted")
-    return i18n.t("ui.sessionTurn.turnChanges.status.updated")
-  }
   const interrupted = createMemo(() => assistantMessages().some((m) => m.error?.name === "MessageAbortedError"))
   const divider = createMemo(() => {
     if (compaction()) return i18n.t("ui.messagePart.compaction")
@@ -508,143 +443,12 @@ export function SessionTurn(
                   </div>
                 </Show>
                 <SessionRetry status={status()} show={active()} />
-                <Show when={hasVisibleTurnChanges(turnChange()) && !working() && !turnInProgress()}>
-                  <div data-slot="session-turn-changes" data-component="session-turn-changes">
-                    <div data-slot="session-turn-changes-header">
-                      <div data-slot="session-turn-changes-summary">
-                        <span>
-                          {i18n.t(
-                            turnEdited() === 1
-                              ? "ui.sessionTurn.turnChanges.summary.one"
-                              : "ui.sessionTurn.turnChanges.summary.other",
-                            { count: turnEdited() },
-                          )}
-                        </span>
-                        <span data-slot="session-turn-changes-additions">+{turnAdditions()}</span>
-                        <span data-slot="session-turn-changes-deletions">-{turnDeletions()}</span>
-                        <Show when={turnChange()?.truncated && (turnChange()?.omittedCount ?? 0) > 0}>
-                          <span data-slot="session-turn-changes-omitted">
-                            {i18n.t("ui.sessionTurn.turnChanges.omitted", { count: turnChange()?.omittedCount ?? 0 })}
-                          </span>
-                        </Show>
-                        <Show when={isUndoneTurn()}>
-                          <span data-slot="session-turn-changes-undone">
-                            {i18n.t("ui.sessionTurn.turnChanges.undone")}
-                          </span>
-                        </Show>
-                      </div>
-                      <Show when={turnActionLabel() && hasTurnChangeActionHandler(turnChange(), props.turnChangeActions)}>
-                        <button
-                          type="button"
-                          data-slot="session-turn-changes-action"
-                          data-confirm={confirmAction() || undefined}
-                          onClick={mutateTurnChange}
-                          onMouseLeave={resetConfirm}
-                        >
-                          {turnActionLabel()}
-                        </button>
-                      </Show>
-                    </div>
-                    <div data-slot="session-turn-changes-list">
-                      <For each={turnFiles()}>
-                        {(file) => {
-                          const expanded = createMemo(() => turnExpanded().includes(file.path))
-                          const toggle = () => {
-                            if (!file.expandable) return
-                            setTurnExpanded((current) =>
-                              current.includes(file.path)
-                                ? current.filter((item) => item !== file.path)
-                                : [...current, file.path],
-                            )
-                          }
-                          const view = createMemo(() =>
-                            file.patch
-                              ? normalize({
-                                  file: file.path,
-                                  patch: file.patch,
-                                  additions: file.additions ?? 0,
-                                  deletions: file.deletions ?? 0,
-                                  status: file.status,
-                                })
-                              : undefined,
-                          )
-                          return (
-                            <div data-slot="session-turn-change-item" data-expanded={expanded() || undefined}>
-                              <div
-                                data-slot="session-turn-change-row"
-                                data-expandable={file.expandable || undefined}
-                                onClick={toggle}
-                              >
-                                <span data-slot="session-turn-change-chevron">
-                                  <Show when={file.expandable}>
-                                    <Icon name="chevron-down" />
-                                  </Show>
-                                </span>
-                                <span data-slot="session-turn-change-path">{file.path}</span>
-                                <span data-slot="session-turn-change-meta">
-                                  <Show
-                                    when={file.additions !== undefined || file.deletions !== undefined}
-                                    fallback={<span data-slot="session-turn-change-status">{turnStatusLabel(file.status)}</span>}
-                                  >
-                                    <span data-slot="session-turn-changes-additions">+{file.additions ?? 0}</span>
-                                    <span data-slot="session-turn-changes-deletions">-{file.deletions ?? 0}</span>
-                                  </Show>
-                                  <Show when={file.large && file.restoreAvailable === false}>
-                                    <span data-slot="session-turn-change-unrestorable">
-                                      {i18n.t("ui.sessionTurn.turnChanges.unrestorable")}
-                                    </span>
-                                  </Show>
-                                </span>
-                                <span data-slot="session-turn-change-actions" onClick={(event) => event.stopPropagation()}>
-                                  <Tooltip value={i18n.t("ui.sessionTurn.turnChanges.openFile")} placement="top">
-                                    <IconButton
-                                      icon="open-file"
-                                      size="small"
-                                      variant="ghost"
-                                      aria-label={i18n.t("ui.sessionTurn.turnChanges.openFile")}
-                                      disabled={file.status === "deleted" || !file.openPath || !props.turnChangeActions?.openFile}
-                                      onClick={() => file.openPath && props.turnChangeActions?.openFile?.(file.openPath)}
-                                    />
-                                  </Tooltip>
-                                  <Tooltip value={i18n.t("ui.sessionTurn.turnChanges.showInFolder")} placement="top">
-                                    <IconButton
-                                      icon="folder-add-left"
-                                      size="small"
-                                      variant="ghost"
-                                      aria-label={i18n.t("ui.sessionTurn.turnChanges.showInFolder")}
-                                      disabled={!file.openPath || !props.turnChangeActions?.showInFolder}
-                                      onClick={() =>
-                                        file.openPath &&
-                                        props.turnChangeActions?.showInFolder?.(
-                                          file.status === "deleted" ? getDirectory(file.openPath) : file.openPath,
-                                        )
-                                      }
-                                    />
-                                  </Tooltip>
-                                </span>
-                              </div>
-                              <Show when={expanded() && view()}>
-                                {(diff) => (
-                                  <div data-slot="session-turn-change-diff" data-scrollable>
-                                    <Dynamic component={fileComponent} mode="diff" fileDiff={diff().fileDiff} />
-                                  </div>
-                                )}
-                              </Show>
-                            </div>
-                          )
-                        }}
-                      </For>
-                    </div>
-                    <Show when={(turnChange()?.skippedCount ?? 0) > 0}>
-                      <div data-slot="session-turn-changes-skipped-notice">
-                        {i18n.t("ui.sessionTurn.turnChanges.skippedNotice", {
-                          count: turnChange()?.skippedCount ?? 0,
-                        })}
-                      </div>
-                    </Show>
-                  </div>
+                <Show when={visibleTurnChange()}>
+                  {(display) => <SessionTurnChangesPanel turnChange={display()} actions={props.turnChangeActions} />}
                 </Show>
-                <Show when={props.turnChanges === undefined && turnEdited() === 0 && edited() > 0 && !working()}>
+                <Show
+                  when={props.turnChanges === undefined && (turnChange()?.files.length ?? 0) === 0 && edited() > 0 && !working()}
+                >
                   <div
                     data-slot="session-turn-diffs"
                     data-component="session-turn-diffs-group"

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -294,11 +294,6 @@ export function SessionTurn(
     if (!messages.length) return false
     return messages.some((item) => typeof item.time.completed !== "number")
   })
-  const visibleTurnChange = createMemo(() => {
-    const current = turnChange()
-    if (!hasVisibleTurnChanges(current) || working() || turnInProgress()) return
-    return current
-  })
   const interrupted = createMemo(() => assistantMessages().some((m) => m.error?.name === "MessageAbortedError"))
   const divider = createMemo(() => {
     if (compaction()) return i18n.t("ui.messagePart.compaction")
@@ -339,6 +334,11 @@ export function SessionTurn(
     return data.store.session_status[props.sessionID] ?? idle
   })
   const working = createMemo(() => status().type !== "idle" && active())
+  const visibleTurnChange = createMemo(() => {
+    const current = turnChange()
+    if (!hasVisibleTurnChanges(current) || working() || turnInProgress()) return
+    return current
+  })
   const showReasoningSummaries = createMemo(() => props.showReasoningSummaries ?? true)
 
   const assistantCopyPartID = createMemo(() => {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -446,9 +446,7 @@ export function SessionTurn(
                 <Show when={visibleTurnChange()}>
                   {(display) => <SessionTurnChangesPanel turnChange={display()} actions={props.turnChangeActions} />}
                 </Show>
-                <Show
-                  when={props.turnChanges === undefined && (turnChange()?.files.length ?? 0) === 0 && edited() > 0 && !working()}
-                >
+                <Show when={!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()}>
                   <div
                     data-slot="session-turn-diffs"
                     data-component="session-turn-diffs-group"

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -288,6 +288,7 @@ export function SessionTurn(
   )
 
   const turnChange = createMemo(() => props.turnChanges?.[props.messageID])
+  const [turnExpanded, setTurnExpanded] = createSignal<string[]>([])
   const turnInProgress = createMemo(() => {
     const messages = assistantMessages()
     if (!messages.length) return false
@@ -444,7 +445,14 @@ export function SessionTurn(
                 </Show>
                 <SessionRetry status={status()} show={active()} />
                 <Show when={visibleTurnChange()}>
-                  {(display) => <SessionTurnChangesPanel turnChange={display()} actions={props.turnChangeActions} />}
+                  {(display) => (
+                    <SessionTurnChangesPanel
+                      turnChange={display()}
+                      actions={props.turnChangeActions}
+                      expanded={turnExpanded()}
+                      onExpandedChange={(value) => setTurnExpanded(value)}
+                    />
+                  )}
                 </Show>
                 <Show when={!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()}>
                   <div


### PR DESCRIPTION
## Topology Update (2026-05-16)

Final base: `dev`.
Dependency status: independent flat PR and parent of the short SessionTurn stack. #677 is stacked on this PR because both slices modify `packages/ui/src/components/session-turn.tsx`, and reviewing the diff-summary extraction is cleaner after this panel extraction lands.
Review order: review and merge #676 before #677. This PR is independent from #667/#669 and from the message-timeline stack #670 -> #671 -> #672 -> #674 -> #675.
Latest head after review follow-up: `d50f897bd`.

## Summary

Extracted the `SessionTurn` turn-change summary/action/file panel into `packages/ui/src/components/session-turn-changes-panel.tsx` and moved the turn-change action type into the existing `session-turn-changes.ts` contract helper.

## Why

This continues the #601 message-flow architecture work. `session-turn.tsx` still mixed assistant rendering, legacy diff summary, and turn-change UI. This PR gives the turn-change panel a clear owner before the next #601 slice tackles the remaining `session-turn.tsx` over-500 debt.

## Related Issue

- #601
- Parent: #599
- Stack child: #677

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the extracted panel preserves the existing `data-slot` names, action confirmation behavior, file expansion behavior, and open/show-in-folder callbacks.
- Confirm the legacy diff summary still appears when `turnChanges` exists but has no visible entry for the current turn.
- Confirm the turn-change file expansion state remains owned by `SessionTurn` so it survives panel hide/show transitions.
- Confirm `visibleTurnChange` is initialized after `working` so initial renders with turn-change data cannot hit a Solid memo temporal-dead-zone error.
- Confirm this PR does not touch assistant content rendering or product behavior beyond the behavior-preserving extraction and review fixes.

## Risk Notes

Behavior is intended unchanged. Main risk is a UI wiring regression in turn-change file rows, legacy diff fallback visibility, or the two-click undo/redo confirmation because the panel moved to a separate component. No dependency, persistence, platform, or public package export change.

## Architecture Boundary

Owner lane: #601 message flow.

Base/depends on: `dev`. #677 depends on this PR.

Touched files:
- `packages/ui/src/components/session-turn.tsx`
- `packages/ui/src/components/session-turn-changes.ts`
- `packages/ui/src/components/session-turn-changes-panel.tsx`
- `packages/ui/src/components/session-turn-parent.test.ts`

Architecture effect:
- owner extracted
- `session-turn.tsx` reduced in this slice but remains over 500 LOC for later #601 work
- no new public package export or dependency change

## Review Follow-up

- CodeRabbit legacy diff fallback thread fixed in `e11b0cbce` and resolved. The fallback now gates on `hasVisibleTurnChanges(turnChange())` instead of the presence of the whole `turnChanges` map.
- Fresh-eyes P3 expansion-state finding fixed in `b0b187e35`; turn-change expansion state is owned by `SessionTurn` and passed into the extracted panel.
- Fresh-eyes P1 Solid memo initialization finding fixed in `d50f897bd`; `visibleTurnChange` is declared after `working`.
- Added focused regression assertions covering the fallback gate, expansion-state ownership, and memo declaration order.

## How To Verify

```text
bun install --frozen-lockfile: ok in new worktree
Focused UI tests: bun test src/components/session-turn-turn-changes.test.ts src/components/session-turn-parent.test.ts -> 7 pass, 0 fail
bun run typecheck -> 8 successful, 8 total
Targeted perf gate: bun script/e2e-local.ts -- e2e/perf/perf-probe.spec.ts --grep "long-session-input-lag|session-timeline-recompute" -> 1 passed, 1 skipped
git diff --check origin/dev...HEAD && git diff --check -> pass
GitHub required checks: rerunning after d50f897bd
```

## Screenshots or Recordings

Not included. This PR is intended as a behavior-preserving component extraction with no visual or copy changes; Electron manual visual verification was not run.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting the declared stack base, and my PR title and commit messages use Conventional Commits in English
