### PR TITLE
refactor(ui): extract session turn diffs

### DIFF
--- a/packages/ui/src/components/session-turn-diffs.tsx
+++ b/packages/ui/src/components/session-turn-diffs.tsx
@@ -1,0 +1,129 @@
+import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2/client"
+import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
+import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { createStore } from "solid-js/store"
+import { useFileComponent } from "../context/file"
+import { useI18n } from "../context/i18n"
+import { Accordion } from "./accordion"
+import { DiffChanges } from "./diff-changes"
+import { Icon } from "./icon"
+import { normalize } from "./session-diff"
+import { StickyAccordionHeader } from "./sticky-accordion-header"
+
+const MAX_FILES = 10
+
+export function SessionTurnDiffs(props: {
+  diffs: SnapshotFileDiff[]
+  onShowAllToggle?: () => void
+}) {
+  const i18n = useI18n()
+  const fileComponent = useFileComponent()
+  const [state, setState] = createStore({
+    showAll: false,
+    expanded: [] as string[],
+  })
+  const showAll = () => state.showAll
+  const expanded = () => state.expanded
+  const edited = createMemo(() => props.diffs.length)
+  const overflow = createMemo(() => Math.max(0, edited() - MAX_FILES))
+  const visible = createMemo(() => (showAll() ? props.diffs : props.diffs.slice(0, MAX_FILES)))
+  const toggleAll = () => {
+    props.onShowAllToggle?.()
+    setState("showAll", !showAll())
+  }
+
+  return (
+    <div
+      data-slot="session-turn-diffs"
+      data-component="session-turn-diffs-group"
+      data-show-all={showAll() || undefined}
+    >
+      <div data-slot="session-turn-diffs-header">
+        <span data-slot="session-turn-diffs-label">
+          {edited()} {i18n.t("ui.sessionTurn.diffs.changed")}{" "}
+          {i18n.t(edited() === 1 ? "ui.common.file.one" : "ui.common.file.other")}
+        </span>
+        <DiffChanges changes={props.diffs} />
+        <Show when={overflow() > 0}>
+          <span data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
+            {showAll() ? i18n.t("ui.sessionTurn.diffs.showLess") : i18n.t("ui.sessionTurn.diffs.showAll")}
+          </span>
+        </Show>
+      </div>
+      <div data-component="session-turn-diffs-content">
+        <Accordion
+          multiple
+          style={{ "--sticky-accordion-offset": "44px" }}
+          value={expanded()}
+          onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
+        >
+          <For each={visible()}>
+            {(diff) => {
+              const view = normalize(diff)
+              const active = createMemo(() => expanded().includes(diff.file))
+              const [shown, setShown] = createSignal(false)
+
+              createEffect(
+                on(
+                  active,
+                  (value) => {
+                    if (!value) {
+                      setShown(false)
+                      return
+                    }
+
+                    requestAnimationFrame(() => {
+                      if (!active()) return
+                      setShown(true)
+                    })
+                  },
+                  { defer: true },
+                ),
+              )
+
+              return (
+                <Accordion.Item value={diff.file}>
+                  <StickyAccordionHeader>
+                    <Accordion.Trigger>
+                      <div data-slot="session-turn-diff-trigger">
+                        <span data-slot="session-turn-diff-path">
+                          <Show when={diff.file.includes("/")}>
+                            <span data-slot="session-turn-diff-directory">
+                              {`\u202A${getDirectory(diff.file)}\u202C`}
+                            </span>
+                          </Show>
+                          <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
+                        </span>
+                        <div data-slot="session-turn-diff-meta">
+                          <span data-slot="session-turn-diff-changes">
+                            <DiffChanges changes={diff} />
+                          </span>
+                          <span data-slot="session-turn-diff-chevron">
+                            <Icon name="chevron-down" />
+                          </span>
+                        </div>
+                      </div>
+                    </Accordion.Trigger>
+                  </StickyAccordionHeader>
+                  <Accordion.Content>
+                    <Show when={shown()}>
+                      <div data-slot="session-turn-diff-view" data-scrollable>
+                        <Dynamic component={fileComponent} mode="diff" fileDiff={view.fileDiff} />
+                      </div>
+                    </Show>
+                  </Accordion.Content>
+                </Accordion.Item>
+              )
+            }}
+          </For>
+        </Accordion>
+        <Show when={!showAll() && overflow() > 0}>
+          <div data-slot="session-turn-diffs-more" onClick={toggleAll}>
+            {i18n.t("ui.sessionTurn.diffs.more", { count: String(overflow()) })}
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/session-turn-diffs.tsx
+++ b/packages/ui/src/components/session-turn-diffs.tsx
@@ -46,9 +46,9 @@ export function SessionTurnDiffs(props: {
         </span>
         <DiffChanges changes={props.diffs} />
         <Show when={overflow() > 0}>
-          <span data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
+          <button type="button" data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
             {showAll() ? i18n.t("ui.sessionTurn.diffs.showLess") : i18n.t("ui.sessionTurn.diffs.showAll")}
-          </span>
+          </button>
         </Show>
       </div>
       <div data-component="session-turn-diffs-content">
@@ -119,9 +119,9 @@ export function SessionTurnDiffs(props: {
           </For>
         </Accordion>
         <Show when={!showAll() && overflow() > 0}>
-          <div data-slot="session-turn-diffs-more" onClick={toggleAll}>
-            {i18n.t("ui.sessionTurn.diffs.more", { count: String(overflow()) })}
-          </div>
+          <button type="button" data-slot="session-turn-diffs-more" onClick={toggleAll}>
+            {i18n.t("ui.sessionTurn.diffs.more", { count: overflow() })}
+          </button>
         </Show>
       </div>
     </div>

--- a/packages/ui/src/components/session-turn-parent.test.ts
+++ b/packages/ui/src/components/session-turn-parent.test.ts
@@ -16,7 +16,7 @@ test("session turn collects assistant messages by parent id across the full mess
 test("legacy diff fallback is gated by visible turn-change data", () => {
   const source = readFileSync(new URL("./session-turn.tsx", import.meta.url), "utf8")
 
-  expect(source).toContain("!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()")
+  expect(source).toContain("!hasVisibleTurnChanges(turnChange()) && diffs().length > 0 && !working()")
   expect(source).not.toContain("props.turnChanges === undefined &&")
 })
 

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -313,6 +313,12 @@
     opacity: 1;
   }
 
+  [data-slot="session-turn-diffs-toggle"]:focus-visible {
+    opacity: 1;
+    outline: 1px solid var(--border-active);
+    outline-offset: 2px;
+  }
+
   [data-slot="session-turn-diffs-more"] {
     appearance: none;
     border: 0;
@@ -324,6 +330,7 @@
     margin-top: 12px;
     padding: 0 0 6px;
     cursor: pointer;
+    text-align: left;
     transition: color 0.15s ease;
 
     &:hover {

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -290,6 +290,9 @@
   }
 
   [data-slot="session-turn-diffs-toggle"] {
+    appearance: none;
+    border: 0;
+    background: none;
     color: var(--brand-primary);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-body);
@@ -299,6 +302,7 @@
     opacity: 0;
     transition: opacity 0.15s ease;
     margin-left: 4px;
+    padding: 0;
   }
 
   [data-component="session-turn-diffs-group"]:hover [data-slot="session-turn-diffs-toggle"] {
@@ -310,6 +314,9 @@
   }
 
   [data-slot="session-turn-diffs-more"] {
+    appearance: none;
+    border: 0;
+    background: none;
     color: var(--fg-weak);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-caption);

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -7,27 +7,20 @@ import {
 } from "@opencode-ai/sdk/v2/client"
 import type { SessionStatus } from "@opencode-ai/sdk/v2"
 import { useData } from "../context"
-import { useFileComponent } from "../context/file"
 
 import { Binary } from "@opencode-ai/core/util/binary"
-import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
-import { createEffect, createMemo, createSignal, For, on, ParentProps, Show } from "solid-js"
-import { createStore } from "solid-js/store"
-import { Dynamic } from "solid-js/web"
+import { createEffect, createMemo, createSignal, ParentProps, Show } from "solid-js"
 import { AssistantParts, Message, MessageDivider, PART_MAPPING, type UserActions } from "./message-part"
 import { Card } from "./card"
-import { Accordion } from "./accordion"
-import { StickyAccordionHeader } from "./sticky-accordion-header"
-import { DiffChanges } from "./diff-changes"
 import { Icon } from "./icon"
 import { TextShimmer } from "./text-shimmer"
 import { SessionRetry } from "./session-retry"
 import { TextReveal } from "./text-reveal"
 import { createAutoScroll } from "../hooks"
 import { useI18n } from "../context/i18n"
-import { normalize } from "./session-diff"
 import { hasVisibleTurnChanges, type TurnChangeActions, type TurnChangeDisplay } from "./session-turn-changes"
 import { SessionTurnChangesPanel } from "./session-turn-changes-panel"
+import { SessionTurnDiffs } from "./session-turn-diffs"
 
 function record(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -171,7 +164,6 @@ export function SessionTurn(
 ) {
   const data = useData()
   const i18n = useI18n()
-  const fileComponent = useFileComponent()
 
   const emptyMessages: MessageType[] = []
   const emptyParts: PartType[] = []
@@ -254,20 +246,6 @@ export function SessionTurn(
       }, [])
       .reverse()
   })
-  const MAX_FILES = 10
-  const edited = createMemo(() => diffs().length)
-  const [state, setState] = createStore({
-    showAll: false,
-    expanded: [] as string[],
-  })
-  const showAll = () => state.showAll
-  const expanded = () => state.expanded
-  const overflow = createMemo(() => Math.max(0, edited() - MAX_FILES))
-  const visible = createMemo(() => (showAll() ? diffs() : diffs().slice(0, MAX_FILES)))
-  const toggleAll = () => {
-    autoScroll.pause()
-    setState("showAll", !showAll())
-  }
 
   const assistantMessages = createMemo(
     () => {
@@ -454,98 +432,8 @@ export function SessionTurn(
                     />
                   )}
                 </Show>
-                <Show when={!hasVisibleTurnChanges(turnChange()) && edited() > 0 && !working()}>
-                  <div
-                    data-slot="session-turn-diffs"
-                    data-component="session-turn-diffs-group"
-                    data-show-all={showAll() || undefined}
-                  >
-                    <div data-slot="session-turn-diffs-header">
-                      <span data-slot="session-turn-diffs-label">
-                        {edited()} {i18n.t("ui.sessionTurn.diffs.changed")}{" "}
-                        {i18n.t(edited() === 1 ? "ui.common.file.one" : "ui.common.file.other")}
-                      </span>
-                      <DiffChanges changes={diffs()} />
-                      <Show when={overflow() > 0}>
-                        <span data-slot="session-turn-diffs-toggle" onClick={toggleAll}>
-                          {showAll() ? i18n.t("ui.sessionTurn.diffs.showLess") : i18n.t("ui.sessionTurn.diffs.showAll")}
-                        </span>
-                      </Show>
-                    </div>
-                    <div data-component="session-turn-diffs-content">
-                      <Accordion
-                        multiple
-                        style={{ "--sticky-accordion-offset": "44px" }}
-                        value={expanded()}
-                        onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
-                      >
-                        <For each={visible()}>
-                          {(diff) => {
-                            const view = normalize(diff)
-                            const active = createMemo(() => expanded().includes(diff.file))
-                            const [shown, setShown] = createSignal(false)
-
-                            createEffect(
-                              on(
-                                active,
-                                (value) => {
-                                  if (!value) {
-                                    setShown(false)
-                                    return
-                                  }
-
-                                  requestAnimationFrame(() => {
-                                    if (!active()) return
-                                    setShown(true)
-                                  })
-                                },
-                                { defer: true },
-                              ),
-                            )
-
-                            return (
-                              <Accordion.Item value={diff.file}>
-                                <StickyAccordionHeader>
-                                  <Accordion.Trigger>
-                                    <div data-slot="session-turn-diff-trigger">
-                                      <span data-slot="session-turn-diff-path">
-                                        <Show when={diff.file.includes("/")}>
-                                          <span data-slot="session-turn-diff-directory">
-                                            {`\u202A${getDirectory(diff.file)}\u202C`}
-                                          </span>
-                                        </Show>
-                                        <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
-                                      </span>
-                                      <div data-slot="session-turn-diff-meta">
-                                        <span data-slot="session-turn-diff-changes">
-                                          <DiffChanges changes={diff} />
-                                        </span>
-                                        <span data-slot="session-turn-diff-chevron">
-                                          <Icon name="chevron-down" />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </Accordion.Trigger>
-                                </StickyAccordionHeader>
-                                <Accordion.Content>
-                                  <Show when={shown()}>
-                                    <div data-slot="session-turn-diff-view" data-scrollable>
-                                      <Dynamic component={fileComponent} mode="diff" fileDiff={view.fileDiff} />
-                                    </div>
-                                  </Show>
-                                </Accordion.Content>
-                              </Accordion.Item>
-                            )
-                          }}
-                        </For>
-                      </Accordion>
-                      <Show when={!showAll() && overflow() > 0}>
-                        <div data-slot="session-turn-diffs-more" onClick={toggleAll}>
-                          {i18n.t("ui.sessionTurn.diffs.more", { count: String(overflow()) })}
-                        </div>
-                      </Show>
-                    </div>
-                  </div>
+                <Show when={!hasVisibleTurnChanges(turnChange()) && diffs().length > 0 && !working()}>
+                  <SessionTurnDiffs diffs={diffs()} onShowAllToggle={() => autoScroll.pause()} />
                 </Show>
                 <Show when={error()}>
                   <Card variant="error" class="error-card">


### PR DESCRIPTION
## Topology Update (2026-05-16)

Final base: `dev` after #676 was squash merged.
Dependency status: true short stack dependency. #676 and #677 both modify `packages/ui/src/components/session-turn.tsx`; #677 is now restacked on `dev` after #676 landed.
Review order: final PR in the session-turn UI stack. This stack is independent from the message-timeline stack, whose lower PRs have already landed.
Latest head after fresh-eyes follow-up: `c0fa4e99e`.

---

## Summary

Extracted the legacy `SessionTurn` diff summary accordion into `packages/ui/src/components/session-turn-diffs.tsx` and preserved the existing `SessionTurn` fallback wiring.

## Why

This continues the #601 message-flow architecture stack after #676. The previous PR separated the turn-change panel but left the legacy diff summary inside `session-turn.tsx`. This PR moves that summary into its own owner component while keeping the fallback behavior unchanged.

Canonical manifest: `.github/frontend-architecture-manifest.md`

## Related Issue

- #601
- Parent: #599

## Human Review Status

Fresh-eyes review clean after `c0fa4e99e`. The first fresh-eyes pass found a P2 keyboard-focus visibility issue; `c0fa4e99e` fixed it, and the second fresh-eyes review found no P0-P3 issues.

## Review Focus

- Confirm the extracted diff summary preserves the existing accordion, show-all toggle, delayed diff mount, and `data-slot` names.
- Confirm `SessionTurn` still owns assistant rendering, retry/thinking state, message lookup, and fallback gating.
- Confirm the interactive show-all/more controls are accessible native buttons without visual drift.
- Confirm stack base is correct: base is now `dev` after #676 was squash merged.

## Risk Notes

Behavior is intended unchanged. Main risk is a legacy diff summary regression because the accordion state moved into a child component. No dependency, persistence, platform, or public export change.

## Architecture Boundary

Owner lane: #601 message flow.

Base/depends on: #667 -> #669 -> #670 -> #671 -> #672 -> #674 -> #675 -> #676. This PR is now restacked on `dev`.

Touched files:
- `packages/ui/src/components/session-turn.tsx`
- `packages/ui/src/components/session-turn-diffs.tsx`
- `packages/ui/src/components/session-turn.css`
- `packages/ui/src/components/session-turn-parent.test.ts`

Architecture effect:
- owner extracted
- legacy diff fallback remains wired through `SessionTurnDiffs`
- `session-turn.tsx` sheds the inline diff accordion code

## Review Follow-up

- Gemini accessibility threads fixed and resolved. The show-all and more controls are now `button type="button"`, with existing data-slot styling preserved through button reset rules, and the i18n `count` is passed as a number.
- Restack follow-up: after #676 was squash merged, the original #677 commit only retained the new file; the follow-up restores the intended `SessionTurn` wiring so the component is actually used.
- Fresh-eyes P2 fixed in `c0fa4e99e`: keyboard focus now reveals the show-all toggle with a visible outline, and the more button explicitly remains left-aligned.

## How To Verify

```text
Focused UI tests: bun test src/components/session-turn-turn-changes.test.ts src/components/session-turn-parent.test.ts -> 7 pass, 0 fail
bun run typecheck -> 8 successful, 8 total
bun run lint -> pass
Targeted #600 timeline perf: bun script/e2e-local.ts -- e2e/perf/perf-probe.spec.ts --grep "long-session-input-lag|session-timeline-recompute" -> 1 passed, 1 skipped
git diff --check origin/dev...HEAD && git diff --check -> pass
Review threads: all resolved
Fresh-eyes review: clean after c0fa4e99e
GitHub required checks: all pass except perf-probe-baseline
```

## Current Blocker

`perf-probe-baseline` is not green on `c0fa4e99e`, so this PR is not mergeable yet.

Evidence:
- First run `25964690195` / job `76325995214` failed after 30m7s. Confirmed compare failed on `default:homepage-cold:frame_gap_max_ms_delta`; diagnostic then failed in base checkout on low-end `session-scroll-reading-long` coverage.
- One rerun was attempted per CI rule. Rerun job `76327884487` failed after 30m28s with different confirmed failures: initial compare `default:terminal-side-panel-open:interaction_ms_median`, confirmed compare `default:session-streaming-long:*` and `default:tool-default-open-heavy-bash:frame_gap_max_ms_delta`; diagnostic was cancelled during base low-end trace after timeout.
- The failures are inconsistent across runs and include base diagnostic failures/cancellation, which points to perf-gate flake or infra noise rather than a stable #677 regression. Because the required check remains failed, this PR should not be merged until the perf gate is green or the gate owner manually clears/reruns it.

## Screenshots or Recordings

Not included. This PR is intended as a behavior-preserving component extraction with no visible copy change; Electron manual visual verification was not run.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev` after the merged stack base, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized diff rendering functionality for improved code organization and maintainability.

* **Style**
  * Enhanced accessibility of diff controls with improved focus visibility states.
  * Refined button styling for cleaner diff toggle appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->