### PR TITLE
refactor(app): extract settings general section owners

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -1,18 +1,14 @@
-import { Component, Show, createMemo, createResource, onMount, type JSX } from "solid-js"
-import { createStore } from "solid-js/store"
-import { Button } from "@opencode-ai/ui/button"
-import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Component, Show, createMemo, createResource, onMount } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
-import { showToast } from "@opencode-ai/ui/toast"
 import { useParams } from "@solidjs/router"
 import { useLanguage } from "@/context/language"
 import { usePermission } from "@/context/permission"
-import { canCheckUpdate, canUseDisplayBackend, usePlatform } from "@/context/platform"
+import { canUseDisplayBackend, usePlatform } from "@/context/platform"
 import {
   monoDefault,
   monoFontFamily,
@@ -23,47 +19,17 @@ import {
   useSettings,
 } from "@/context/settings"
 import { decode64 } from "@/utils/base64"
-import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
 import { Link } from "./link"
-import { DialogConnectWebSearch } from "./dialog-connect-websearch"
 import { SettingsList } from "./settings-list"
-
-let demoSoundState = {
-  cleanup: undefined as (() => void) | undefined,
-  timeout: undefined as NodeJS.Timeout | undefined,
-  run: 0,
-}
+import { SettingsNotificationsSection } from "./settings-notifications-section"
+import { SettingsRow } from "./settings-row"
+import { SettingsSoundsSection } from "./settings-sounds-section"
+import { SettingsUpdatesSection } from "./settings-updates-section"
+import { SettingsWebSearchRow } from "./settings-web-search-row"
 
 type ThemeOption = {
   id: string
   name: string
-}
-
-// To prevent audio from overlapping/playing very quickly when navigating the settings menus,
-// delay the playback by 100ms during quick selection changes and pause existing sounds.
-const stopDemoSound = () => {
-  demoSoundState.run += 1
-  if (demoSoundState.cleanup) {
-    demoSoundState.cleanup()
-  }
-  clearTimeout(demoSoundState.timeout)
-  demoSoundState.cleanup = undefined
-}
-
-const playDemoSound = (id: string | undefined) => {
-  stopDemoSound()
-  if (!id) return
-
-  const run = ++demoSoundState.run
-  demoSoundState.timeout = setTimeout(() => {
-    void playSoundById(id).then((cleanup) => {
-      if (demoSoundState.run !== run) {
-        cleanup?.()
-        return
-      }
-      demoSoundState.cleanup = cleanup
-    })
-  }, 100)
 }
 
 export const SettingsGeneral: Component = () => {
@@ -73,14 +39,9 @@ export const SettingsGeneral: Component = () => {
   const platform = usePlatform()
   const params = useParams()
   const settings = useSettings()
-  const dialog = useDialog()
 
   onMount(() => {
     void theme.loadThemes()
-  })
-
-  const [store, setStore] = createStore({
-    checking: false,
   })
 
   const linux = createMemo(() => platform.os === "linux" && canUseDisplayBackend(platform))
@@ -110,96 +71,6 @@ export const SettingsGeneral: Component = () => {
     permission.disableAutoAccept(params.id, value)
   }
 
-  const check = () => {
-    const checkUpdate = platform.checkUpdate
-    if (!canCheckUpdate(platform) || !checkUpdate) return
-    setStore("checking", true)
-
-    void checkUpdate()
-      .then((result) => {
-        if (result.status === "busy") {
-          showToast({
-            title: language.t("settings.updates.toast.busy.title"),
-            description: language.t("settings.updates.toast.busy.description"),
-          })
-          return
-        }
-
-        if (result.status === "disabled") {
-          showToast({
-            title: language.t("settings.updates.toast.disabled.title"),
-            description: language.t("settings.updates.toast.disabled.description"),
-          })
-          return
-        }
-
-        if (result.status === "failed") {
-          showToast({
-            title: language.t("common.requestFailed"),
-            description: result.message || language.t("settings.updates.toast.failed.description"),
-          })
-          return
-        }
-
-        if (!result.updateAvailable) {
-          showToast({
-            variant: "success",
-            icon: "circle-check",
-            title: language.t("settings.updates.toast.latest.title"),
-            description: language.t("settings.updates.toast.latest.description", { version: platform.version ?? "" }),
-          })
-          return
-        }
-
-        const actions = platform.update
-          ? [
-              {
-                label: language.t("toast.update.action.installRestart"),
-                onClick: async () => {
-                  await platform.update!()
-                },
-              },
-              {
-                label: language.t("toast.update.action.notYet"),
-                onClick: "dismiss" as const,
-              },
-            ]
-          : [
-              {
-                label: language.t("toast.update.action.notYet"),
-                onClick: "dismiss" as const,
-              },
-            ]
-
-        showToast({
-          persistent: true,
-          icon: "download",
-          title: language.t("toast.update.title"),
-          description: language.t("toast.update.description", { version: result.version ?? "" }),
-          actions,
-        })
-      })
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
-        showToast({ title: language.t("common.requestFailed"), description: message })
-      })
-      .finally(() => setStore("checking", false))
-  }
-
-  const [webSearchStatusResource, webSearchStatusActions] = createResource(() => window.api?.webSearchStatus?.())
-  const webSearchStatus = createMemo(() => webSearchStatusResource.latest)
-  // Chip label for the current web search auth state.
-  const webSearchChipText = createMemo(() => {
-    const s = webSearchStatus()
-    if (!s) return language.t("settings.general.webSearch.chip.loading")
-    if (s.source === "saved" && s.quotaExceeded) return language.t("settings.general.webSearch.chip.savedQuota")
-    if (s.source === "saved" && s.needsAttention) return language.t("settings.general.webSearch.chip.invalid")
-    if (s.source === "saved") return language.t("settings.general.webSearch.chip.personal")
-    if (s.source === "env") return language.t("settings.general.webSearch.chip.env")
-    if (s.quotaExceeded) return language.t("settings.general.webSearch.chip.exhausted")
-    return language.t("settings.general.webSearch.chip.free")
-  })
-
   const themeOptions = createMemo<ThemeOption[]>(() => theme.ids().map((id) => ({ id, name: theme.name(id) })))
 
   const colorSchemeOptions = createMemo((): { value: ColorScheme; label: string }[] => [
@@ -215,40 +86,8 @@ export const SettingsGeneral: Component = () => {
     })),
   )
 
-  const noneSound = { id: "none", label: "sound.option.none" } as const
-  const soundOptions = [noneSound, ...SOUND_OPTIONS]
   const mono = () => monoInput(settings.appearance.font())
   const sans = () => sansInput(settings.appearance.uiFont())
-
-  const soundSelectProps = (
-    enabled: () => boolean,
-    current: () => string,
-    setEnabled: (value: boolean) => void,
-    set: (id: string) => void,
-  ) => ({
-    options: soundOptions,
-    current: enabled() ? (soundOptions.find((o) => o.id === current()) ?? noneSound) : noneSound,
-    value: (o: (typeof soundOptions)[number]) => o.id,
-    label: (o: (typeof soundOptions)[number]) => language.t(o.label),
-    onHighlight: (option: (typeof soundOptions)[number] | undefined) => {
-      if (!option) return
-      playDemoSound(option.id === "none" ? undefined : option.id)
-    },
-    onSelect: (option: (typeof soundOptions)[number] | undefined) => {
-      if (!option) return
-      if (option.id === "none") {
-        setEnabled(false)
-        stopDemoSound()
-        return
-      }
-      setEnabled(true)
-      set(option.id)
-      playDemoSound(option.id)
-    },
-    variant: "secondary" as const,
-    size: "small" as const,
-    triggerVariant: "settings" as const,
-  })
 
   const GeneralSection = () => (
     <div class="flex flex-col gap-1">
@@ -279,53 +118,7 @@ export const SettingsGeneral: Component = () => {
           </div>
         </SettingsRow>
 
-        <SettingsRow
-          title={
-            <div class="flex items-center gap-2">
-              <span>{language.t("settings.general.webSearch.title")}</span>
-              <span class="text-body text-fg-weaker rounded px-1.5 py-0.5 bg-bg-cream">
-                {webSearchChipText()}
-              </span>
-            </div>
-          }
-          description={
-            <>
-              <span>{language.t("settings.general.webSearch.description")}</span>
-              {webSearchStatus()?.source === "saved" && webSearchStatus()?.quotaExceeded && (
-                <span class="block pt-1 text-body text-fg-weaker">
-                  {language.t("settings.general.webSearch.secondary.savedQuota")}
-                </span>
-              )}
-              {webSearchStatus()?.source === "saved" && webSearchStatus()?.needsAttention && (
-                <span class="block pt-1 text-body text-fg-weaker">
-                  {language.t("settings.general.webSearch.secondary.failed")}
-                </span>
-              )}
-              {webSearchStatus()?.source === "anonymous" && webSearchStatus()?.quotaExceeded && (
-                <span class="block pt-1 text-body text-fg-weaker">
-                  {language.t("settings.general.webSearch.secondary.exhausted")}
-                </span>
-              )}
-            </>
-          }
-        >
-          <div class="flex items-center gap-2">
-            <Button
-              data-action="settings-web-search-manage"
-              size="small"
-              variant="ghost"
-              onClick={() => dialog.show(() => <DialogConnectWebSearch onStatusChanged={webSearchStatusActions.refetch} />)}
-            >
-              {language.t("settings.general.webSearch.action.manage")}
-            </Button>
-            <div data-action="settings-web-search-enabled">
-              <Switch
-                checked={settings.general.webSearchEnabled()}
-                onChange={(checked) => settings.general.setWebSearchEnabled(checked)}
-              />
-            </div>
-          </div>
-        </SettingsRow>
+        <SettingsWebSearchRow />
 
         <SettingsRow
           title={language.t("settings.general.row.reasoningSummaries.title")}
@@ -486,147 +279,6 @@ export const SettingsGeneral: Component = () => {
     </div>
   )
 
-  const NotificationsSection = () => (
-    <div class="flex flex-col gap-1">
-      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.notifications")}</h3>
-
-      <SettingsList>
-        <SettingsRow
-          title={language.t("settings.general.notifications.agent.title")}
-          description={language.t("settings.general.notifications.agent.description")}
-        >
-          <div data-action="settings-notifications-agent">
-            <Switch
-              checked={settings.notifications.agent()}
-              onChange={(checked) => settings.notifications.setAgent(checked)}
-            />
-          </div>
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.general.notifications.permissions.title")}
-          description={language.t("settings.general.notifications.permissions.description")}
-        >
-          <div data-action="settings-notifications-permissions">
-            <Switch
-              checked={settings.notifications.permissions()}
-              onChange={(checked) => settings.notifications.setPermissions(checked)}
-            />
-          </div>
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.general.notifications.errors.title")}
-          description={language.t("settings.general.notifications.errors.description")}
-        >
-          <div data-action="settings-notifications-errors">
-            <Switch
-              checked={settings.notifications.errors()}
-              onChange={(checked) => settings.notifications.setErrors(checked)}
-            />
-          </div>
-        </SettingsRow>
-      </SettingsList>
-    </div>
-  )
-
-  const SoundsSection = () => (
-    <div class="flex flex-col gap-1">
-      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.sounds")}</h3>
-
-      <SettingsList>
-        <SettingsRow
-          title={language.t("settings.general.sounds.agent.title")}
-          description={language.t("settings.general.sounds.agent.description")}
-        >
-          <Select
-            data-action="settings-sounds-agent"
-            {...soundSelectProps(
-              () => settings.sounds.agentEnabled(),
-              () => settings.sounds.agent(),
-              (value) => settings.sounds.setAgentEnabled(value),
-              (id) => settings.sounds.setAgent(id),
-            )}
-          />
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.general.sounds.permissions.title")}
-          description={language.t("settings.general.sounds.permissions.description")}
-        >
-          <Select
-            data-action="settings-sounds-permissions"
-            {...soundSelectProps(
-              () => settings.sounds.permissionsEnabled(),
-              () => settings.sounds.permissions(),
-              (value) => settings.sounds.setPermissionsEnabled(value),
-              (id) => settings.sounds.setPermissions(id),
-            )}
-          />
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.general.sounds.errors.title")}
-          description={language.t("settings.general.sounds.errors.description")}
-        >
-          <Select
-            data-action="settings-sounds-errors"
-            {...soundSelectProps(
-              () => settings.sounds.errorsEnabled(),
-              () => settings.sounds.errors(),
-              (value) => settings.sounds.setErrorsEnabled(value),
-              (id) => settings.sounds.setErrors(id),
-            )}
-          />
-        </SettingsRow>
-      </SettingsList>
-    </div>
-  )
-
-  const UpdatesSection = () => (
-    <div class="flex flex-col gap-1">
-      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.updates")}</h3>
-
-      <SettingsList>
-        <SettingsRow
-          title={language.t("settings.updates.row.startup.title")}
-          description={language.t("settings.updates.row.startup.description")}
-        >
-          <div data-action="settings-updates-startup">
-            <Switch
-              checked={settings.updates.startup()}
-              disabled={!canCheckUpdate(platform)}
-              onChange={(checked) => settings.updates.setStartup(checked)}
-            />
-          </div>
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.general.row.releaseNotes.title")}
-          description={language.t("settings.general.row.releaseNotes.description")}
-        >
-          <div data-action="settings-release-notes">
-            <Switch
-              checked={settings.general.releaseNotes()}
-              onChange={(checked) => settings.general.setReleaseNotes(checked)}
-            />
-          </div>
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.updates.row.check.title")}
-          description={language.t("settings.updates.row.check.description")}
-        >
-          <Button variant="secondary" disabled={store.checking || !canCheckUpdate(platform)} onClick={check}>
-            {store.checking
-              ? language.t("settings.updates.action.checking")
-              : language.t("settings.updates.action.checkNow")}
-          </Button>
-        </SettingsRow>
-      </SettingsList>
-    </div>
-  )
-
   return (
     <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
       <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-raised)_calc(100%_-_24px),transparent)]">
@@ -640,9 +292,9 @@ export const SettingsGeneral: Component = () => {
 
         <AppearanceSection />
 
-        <NotificationsSection />
+        <SettingsNotificationsSection />
 
-        <SoundsSection />
+        <SettingsSoundsSection />
 
         {/*<Show when={platform.platform === "desktop" && platform.os === "windows" && platform.getWslEnabled}>
           {(_) => {
@@ -672,7 +324,7 @@ export const SettingsGeneral: Component = () => {
           }}
         </Show>*/}
 
-        <UpdatesSection />
+        <SettingsUpdatesSection />
 
         <Show when={linux()}>
           {(_) => {
@@ -710,24 +362,6 @@ export const SettingsGeneral: Component = () => {
           }}
         </Show>
       </div>
-    </div>
-  )
-}
-
-interface SettingsRowProps {
-  title: string | JSX.Element
-  description: string | JSX.Element
-  children: JSX.Element
-}
-
-const SettingsRow: Component<SettingsRowProps> = (props) => {
-  return (
-    <div class="flex flex-wrap items-center gap-4 py-3 border-b border-border-weak last:border-none sm:flex-nowrap">
-      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span class="text-h3 text-fg-strong">{props.title}</span>
-        <span class="text-body text-fg-weak">{props.description}</span>
-      </div>
-      <div class="flex w-full justify-end sm:w-auto sm:shrink-0">{props.children}</div>
     </div>
   )
 }

--- a/packages/app/src/components/settings-notifications-section.tsx
+++ b/packages/app/src/components/settings-notifications-section.tsx
@@ -1,0 +1,55 @@
+import { type Component } from "solid-js"
+import { Switch } from "@opencode-ai/ui/switch"
+import { useLanguage } from "@/context/language"
+import { useSettings } from "@/context/settings"
+import { SettingsList } from "./settings-list"
+import { SettingsRow } from "./settings-row"
+
+export const SettingsNotificationsSection: Component = () => {
+  const language = useLanguage()
+  const settings = useSettings()
+
+  return (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.notifications")}</h3>
+
+      <SettingsList>
+        <SettingsRow
+          title={language.t("settings.general.notifications.agent.title")}
+          description={language.t("settings.general.notifications.agent.description")}
+        >
+          <div data-action="settings-notifications-agent">
+            <Switch
+              checked={settings.notifications.agent()}
+              onChange={(checked) => settings.notifications.setAgent(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.notifications.permissions.title")}
+          description={language.t("settings.general.notifications.permissions.description")}
+        >
+          <div data-action="settings-notifications-permissions">
+            <Switch
+              checked={settings.notifications.permissions()}
+              onChange={(checked) => settings.notifications.setPermissions(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.notifications.errors.title")}
+          description={language.t("settings.general.notifications.errors.description")}
+        >
+          <div data-action="settings-notifications-errors">
+            <Switch
+              checked={settings.notifications.errors()}
+              onChange={(checked) => settings.notifications.setErrors(checked)}
+            />
+          </div>
+        </SettingsRow>
+      </SettingsList>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-row.tsx
+++ b/packages/app/src/components/settings-row.tsx
@@ -1,0 +1,19 @@
+import { type Component, type JSX } from "solid-js"
+
+interface SettingsRowProps {
+  title: string | JSX.Element
+  description: string | JSX.Element
+  children: JSX.Element
+}
+
+export const SettingsRow: Component<SettingsRowProps> = (props) => {
+  return (
+    <div class="flex flex-wrap items-center gap-4 py-3 border-b border-border-weak last:border-none sm:flex-nowrap">
+      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span class="text-h3 text-fg-strong">{props.title}</span>
+        <span class="text-body text-fg-weak">{props.description}</span>
+      </div>
+      <div class="flex w-full justify-end sm:w-auto sm:shrink-0">{props.children}</div>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-sounds-section.tsx
+++ b/packages/app/src/components/settings-sounds-section.tsx
@@ -1,0 +1,129 @@
+import { type Component } from "solid-js"
+import { Select } from "@opencode-ai/ui/select"
+import { useLanguage } from "@/context/language"
+import { useSettings } from "@/context/settings"
+import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
+import { SettingsList } from "./settings-list"
+import { SettingsRow } from "./settings-row"
+
+let demoSoundState = {
+  cleanup: undefined as (() => void) | undefined,
+  timeout: undefined as NodeJS.Timeout | undefined,
+  run: 0,
+}
+
+const noneSound = { id: "none", label: "sound.option.none" } as const
+const soundOptions = [noneSound, ...SOUND_OPTIONS]
+
+const stopDemoSound = () => {
+  demoSoundState.run += 1
+  if (demoSoundState.cleanup) {
+    demoSoundState.cleanup()
+  }
+  clearTimeout(demoSoundState.timeout)
+  demoSoundState.cleanup = undefined
+}
+
+const playDemoSound = (id: string | undefined) => {
+  stopDemoSound()
+  if (!id) return
+
+  const run = ++demoSoundState.run
+  demoSoundState.timeout = setTimeout(() => {
+    void playSoundById(id).then((cleanup) => {
+      if (demoSoundState.run !== run) {
+        cleanup?.()
+        return
+      }
+      demoSoundState.cleanup = cleanup
+    })
+  }, 100)
+}
+
+export const SettingsSoundsSection: Component = () => {
+  const language = useLanguage()
+  const settings = useSettings()
+
+  const soundSelectProps = (
+    enabled: () => boolean,
+    current: () => string,
+    setEnabled: (value: boolean) => void,
+    set: (id: string) => void,
+  ) => ({
+    options: soundOptions,
+    current: enabled() ? (soundOptions.find((o) => o.id === current()) ?? noneSound) : noneSound,
+    value: (o: (typeof soundOptions)[number]) => o.id,
+    label: (o: (typeof soundOptions)[number]) => language.t(o.label),
+    onHighlight: (option: (typeof soundOptions)[number] | undefined) => {
+      if (!option) return
+      playDemoSound(option.id === "none" ? undefined : option.id)
+    },
+    onSelect: (option: (typeof soundOptions)[number] | undefined) => {
+      if (!option) return
+      if (option.id === "none") {
+        setEnabled(false)
+        stopDemoSound()
+        return
+      }
+      setEnabled(true)
+      set(option.id)
+      playDemoSound(option.id)
+    },
+    variant: "secondary" as const,
+    size: "small" as const,
+    triggerVariant: "settings" as const,
+  })
+
+  return (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.sounds")}</h3>
+
+      <SettingsList>
+        <SettingsRow
+          title={language.t("settings.general.sounds.agent.title")}
+          description={language.t("settings.general.sounds.agent.description")}
+        >
+          <Select
+            data-action="settings-sounds-agent"
+            {...soundSelectProps(
+              () => settings.sounds.agentEnabled(),
+              () => settings.sounds.agent(),
+              (value) => settings.sounds.setAgentEnabled(value),
+              (id) => settings.sounds.setAgent(id),
+            )}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.sounds.permissions.title")}
+          description={language.t("settings.general.sounds.permissions.description")}
+        >
+          <Select
+            data-action="settings-sounds-permissions"
+            {...soundSelectProps(
+              () => settings.sounds.permissionsEnabled(),
+              () => settings.sounds.permissions(),
+              (value) => settings.sounds.setPermissionsEnabled(value),
+              (id) => settings.sounds.setPermissions(id),
+            )}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.sounds.errors.title")}
+          description={language.t("settings.general.sounds.errors.description")}
+        >
+          <Select
+            data-action="settings-sounds-errors"
+            {...soundSelectProps(
+              () => settings.sounds.errorsEnabled(),
+              () => settings.sounds.errors(),
+              (value) => settings.sounds.setErrorsEnabled(value),
+              (id) => settings.sounds.setErrors(id),
+            )}
+          />
+        </SettingsRow>
+      </SettingsList>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-updates-section.tsx
+++ b/packages/app/src/components/settings-updates-section.tsx
@@ -1,0 +1,139 @@
+import { type Component } from "solid-js"
+import { createStore } from "solid-js/store"
+import { Button } from "@opencode-ai/ui/button"
+import { Switch } from "@opencode-ai/ui/switch"
+import { showToast } from "@opencode-ai/ui/toast"
+import { useLanguage } from "@/context/language"
+import { canCheckUpdate, usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
+import { SettingsList } from "./settings-list"
+import { SettingsRow } from "./settings-row"
+
+export const SettingsUpdatesSection: Component = () => {
+  const language = useLanguage()
+  const platform = usePlatform()
+  const settings = useSettings()
+  const [store, setStore] = createStore({
+    checking: false,
+  })
+
+  const check = () => {
+    const checkUpdate = platform.checkUpdate
+    if (!canCheckUpdate(platform) || !checkUpdate) return
+    setStore("checking", true)
+
+    void checkUpdate()
+      .then((result) => {
+        if (result.status === "busy") {
+          showToast({
+            title: language.t("settings.updates.toast.busy.title"),
+            description: language.t("settings.updates.toast.busy.description"),
+          })
+          return
+        }
+
+        if (result.status === "disabled") {
+          showToast({
+            title: language.t("settings.updates.toast.disabled.title"),
+            description: language.t("settings.updates.toast.disabled.description"),
+          })
+          return
+        }
+
+        if (result.status === "failed") {
+          showToast({
+            title: language.t("common.requestFailed"),
+            description: result.message || language.t("settings.updates.toast.failed.description"),
+          })
+          return
+        }
+
+        if (!result.updateAvailable) {
+          showToast({
+            variant: "success",
+            icon: "circle-check",
+            title: language.t("settings.updates.toast.latest.title"),
+            description: language.t("settings.updates.toast.latest.description", { version: platform.version ?? "" }),
+          })
+          return
+        }
+
+        const actions = platform.update
+          ? [
+              {
+                label: language.t("toast.update.action.installRestart"),
+                onClick: async () => {
+                  await platform.update!()
+                },
+              },
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
+          : [
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
+
+        showToast({
+          persistent: true,
+          icon: "download",
+          title: language.t("toast.update.title"),
+          description: language.t("toast.update.description", { version: result.version ?? "" }),
+          actions,
+        })
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        showToast({ title: language.t("common.requestFailed"), description: message })
+      })
+      .finally(() => setStore("checking", false))
+  }
+
+  return (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-h3 text-fg-strong pb-2">{language.t("settings.general.section.updates")}</h3>
+
+      <SettingsList>
+        <SettingsRow
+          title={language.t("settings.updates.row.startup.title")}
+          description={language.t("settings.updates.row.startup.description")}
+        >
+          <div data-action="settings-updates-startup">
+            <Switch
+              checked={settings.updates.startup()}
+              disabled={!canCheckUpdate(platform)}
+              onChange={(checked) => settings.updates.setStartup(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.releaseNotes.title")}
+          description={language.t("settings.general.row.releaseNotes.description")}
+        >
+          <div data-action="settings-release-notes">
+            <Switch
+              checked={settings.general.releaseNotes()}
+              onChange={(checked) => settings.general.setReleaseNotes(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.updates.row.check.title")}
+          description={language.t("settings.updates.row.check.description")}
+        >
+          <Button variant="secondary" disabled={store.checking || !canCheckUpdate(platform)} onClick={check}>
+            {store.checking
+              ? language.t("settings.updates.action.checking")
+              : language.t("settings.updates.action.checkNow")}
+          </Button>
+        </SettingsRow>
+      </SettingsList>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-web-search-row.tsx
+++ b/packages/app/src/components/settings-web-search-row.tsx
@@ -1,0 +1,75 @@
+import { createMemo, createResource, type Component } from "solid-js"
+import { Button } from "@opencode-ai/ui/button"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Switch } from "@opencode-ai/ui/switch"
+import { useLanguage } from "@/context/language"
+import { useSettings } from "@/context/settings"
+import { DialogConnectWebSearch } from "./dialog-connect-websearch"
+import { SettingsRow } from "./settings-row"
+
+export const SettingsWebSearchRow: Component = () => {
+  const dialog = useDialog()
+  const language = useLanguage()
+  const settings = useSettings()
+
+  const [webSearchStatusResource, webSearchStatusActions] = createResource(() => window.api?.webSearchStatus?.())
+  const webSearchStatus = createMemo(() => webSearchStatusResource.latest)
+  const webSearchChipText = createMemo(() => {
+    const status = webSearchStatus()
+    if (!status) return language.t("settings.general.webSearch.chip.loading")
+    if (status.source === "saved" && status.quotaExceeded) return language.t("settings.general.webSearch.chip.savedQuota")
+    if (status.source === "saved" && status.needsAttention) return language.t("settings.general.webSearch.chip.invalid")
+    if (status.source === "saved") return language.t("settings.general.webSearch.chip.personal")
+    if (status.source === "env") return language.t("settings.general.webSearch.chip.env")
+    if (status.quotaExceeded) return language.t("settings.general.webSearch.chip.exhausted")
+    return language.t("settings.general.webSearch.chip.free")
+  })
+
+  return (
+    <SettingsRow
+      title={
+        <div class="flex items-center gap-2">
+          <span>{language.t("settings.general.webSearch.title")}</span>
+          <span class="text-body text-fg-weaker rounded px-1.5 py-0.5 bg-bg-cream">{webSearchChipText()}</span>
+        </div>
+      }
+      description={
+        <>
+          <span>{language.t("settings.general.webSearch.description")}</span>
+          {webSearchStatus()?.source === "saved" && webSearchStatus()?.quotaExceeded && (
+            <span class="block pt-1 text-body text-fg-weaker">
+              {language.t("settings.general.webSearch.secondary.savedQuota")}
+            </span>
+          )}
+          {webSearchStatus()?.source === "saved" && webSearchStatus()?.needsAttention && (
+            <span class="block pt-1 text-body text-fg-weaker">
+              {language.t("settings.general.webSearch.secondary.failed")}
+            </span>
+          )}
+          {webSearchStatus()?.source === "anonymous" && webSearchStatus()?.quotaExceeded && (
+            <span class="block pt-1 text-body text-fg-weaker">
+              {language.t("settings.general.webSearch.secondary.exhausted")}
+            </span>
+          )}
+        </>
+      }
+    >
+      <div class="flex items-center gap-2">
+        <Button
+          data-action="settings-web-search-manage"
+          size="small"
+          variant="ghost"
+          onClick={() => dialog.show(() => <DialogConnectWebSearch onStatusChanged={webSearchStatusActions.refetch} />)}
+        >
+          {language.t("settings.general.webSearch.action.manage")}
+        </Button>
+        <div data-action="settings-web-search-enabled">
+          <Switch
+            checked={settings.general.webSearchEnabled()}
+            onChange={(checked) => settings.general.setWebSearchEnabled(checked)}
+          />
+        </div>
+      </div>
+    </SettingsRow>
+  )
+}

--- a/packages/app/src/pages/session/settings-websearch-source.test.ts
+++ b/packages/app/src/pages/session/settings-websearch-source.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs"
 
 const settingsSource = readFileSync(new URL("../../context/settings.tsx", import.meta.url), "utf8")
 const generalSource = readFileSync(new URL("../../components/settings-general.tsx", import.meta.url), "utf8")
+const webSearchRowSource = readFileSync(new URL("../../components/settings-web-search-row.tsx", import.meta.url), "utf8")
 const appSource = readFileSync(new URL("../../app.tsx", import.meta.url), "utf8")
 const enSource = readFileSync(new URL("../../i18n/en.ts", import.meta.url), "utf8")
 const zhSource = readFileSync(new URL("../../i18n/zh.ts", import.meta.url), "utf8")
@@ -16,10 +17,11 @@ describe("settings web search source contract", () => {
   })
 
   test("renders the General Web Search controls without persisting API key input in settings state", () => {
-    expect(generalSource).toContain('data-action="settings-web-search-enabled"')
-    expect(generalSource).toContain('data-action="settings-web-search-manage"')
-    expect(generalSource).toContain("DialogConnectWebSearch")
-    expect(generalSource).not.toContain("savingExaKey")
+    expect(generalSource).toContain("<SettingsWebSearchRow />")
+    expect(webSearchRowSource).toContain('data-action="settings-web-search-enabled"')
+    expect(webSearchRowSource).toContain('data-action="settings-web-search-manage"')
+    expect(webSearchRowSource).toContain("DialogConnectWebSearch")
+    expect(webSearchRowSource).not.toContain("savingExaKey")
     expect(settingsSource).not.toContain("exaApiKey")
   })
 
@@ -62,16 +64,16 @@ describe("settings web search source contract", () => {
   })
 
   test("refreshes the General row status after dialog credential changes", () => {
-    expect(generalSource).toContain("webSearchStatusActions")
-    expect(generalSource).toContain("onStatusChanged={webSearchStatusActions.refetch}")
-    expect(generalSource).toContain("settings.general.webSearch.chip.savedQuota")
+    expect(webSearchRowSource).toContain("webSearchStatusActions")
+    expect(webSearchRowSource).toContain("onStatusChanged={webSearchStatusActions.refetch}")
+    expect(webSearchRowSource).toContain("settings.general.webSearch.chip.savedQuota")
   })
 
   test("prioritizes saved quota over saved invalid-key attention in General status copy", () => {
-    const quotaChip = generalSource.indexOf("settings.general.webSearch.chip.savedQuota")
-    const invalidChip = generalSource.indexOf("settings.general.webSearch.chip.invalid")
-    const quotaSecondary = generalSource.indexOf("settings.general.webSearch.secondary.savedQuota")
-    const failedSecondary = generalSource.indexOf("settings.general.webSearch.secondary.failed")
+    const quotaChip = webSearchRowSource.indexOf("settings.general.webSearch.chip.savedQuota")
+    const invalidChip = webSearchRowSource.indexOf("settings.general.webSearch.chip.invalid")
+    const quotaSecondary = webSearchRowSource.indexOf("settings.general.webSearch.secondary.savedQuota")
+    const failedSecondary = webSearchRowSource.indexOf("settings.general.webSearch.secondary.failed")
 
     expect(quotaChip).toBeGreaterThan(-1)
     expect(invalidChip).toBeGreaterThan(-1)

--- a/packages/app/src/pages/update-install-flow-source.test.ts
+++ b/packages/app/src/pages/update-install-flow-source.test.ts
@@ -3,24 +3,24 @@ import { describe, expect, test } from "bun:test"
 
 const layout = readFileSync(new URL("./layout.tsx", import.meta.url), "utf8")
 const errorPage = readFileSync(new URL("./error.tsx", import.meta.url), "utf8")
-const settings = readFileSync(new URL("../components/settings-general.tsx", import.meta.url), "utf8")
+const settingsUpdates = readFileSync(new URL("../components/settings-updates-section.tsx", import.meta.url), "utf8")
 const platform = readFileSync(new URL("../context/platform.tsx", import.meta.url), "utf8")
 
 describe("update install renderer contracts", () => {
   test("renderer install actions do not relaunch after platform update", () => {
     expect(layout).not.toMatch(/await\s+platform\.restart!\(\)/)
-    expect(settings).not.toMatch(/await\s+platform\.restart!\(\)/)
+    expect(settingsUpdates).not.toMatch(/await\s+platform\.restart!\(\)/)
     expect(errorPage).not.toMatch(/await\s+platform\.restart!\(\)/)
     expect(layout).not.toMatch(/\.then\(\(\)\s*=>\s*platform\.restart!\(\)\)/)
-    expect(settings).not.toMatch(/\.then\(\(\)\s*=>\s*platform\.restart!\(\)\)/)
+    expect(settingsUpdates).not.toMatch(/\.then\(\(\)\s*=>\s*platform\.restart!\(\)\)/)
     expect(errorPage).not.toMatch(/\.then\(\(\)\s*=>\s*platform\.restart!\(\)\)/)
   })
 
   test("renderer update prompts only require platform update", () => {
     expect(layout).toContain("if (!platform.checkUpdate || !platform.update) return")
     expect(layout).not.toContain("if (!platform.checkUpdate || !platform.update || !platform.restart) return")
-    expect(settings).toContain("platform.update")
-    expect(settings).not.toContain("platform.update && platform.restart")
+    expect(settingsUpdates).toContain("platform.update")
+    expect(settingsUpdates).not.toContain("platform.update && platform.restart")
   })
 
   test("cache update failures are part of the renderer-facing type", () => {


### PR DESCRIPTION
## Summary

Extracts owner components from the oversized General settings surface:

- `SettingsRow` shared settings row wrapper
- `SettingsWebSearchRow` for Web Search status/manage/toggle controls
- `SettingsNotificationsSection` for notification toggles
- `SettingsSoundsSection` for sound selects and preview playback ownership
- `SettingsUpdatesSection` for update toggles/check flow

`settings-general.tsx` drops from 733 LOC on `dev` to 367 LOC in this PR.

## Why

This is a #604 settings-lane frontend governance slice. The goal is to make the General settings surface agent-readable without changing behavior or mixing in unrelated settings work.

## Related Issue

Part of #604.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm this is a pure settings owner extraction with no behavior changes.
- Confirm `settings-general.tsx` now delegates section ownership cleanly.
- Confirm source-contract tests now follow the new owner files instead of weakening coverage.

## Topology

- Base: `dev`
- Head: `codex/settings-websearch-row-owner`
- Dependency status: independent flat PR. It does not depend on #667, #669, #670-#675, #676-#677, #673, or #678.
- Review order: can be reviewed after or alongside the existing flat PRs; it does not touch files modified by the current flat PR set.

## Touched Files

- `packages/app/src/components/settings-general.tsx`
- `packages/app/src/components/settings-row.tsx`
- `packages/app/src/components/settings-web-search-row.tsx`
- `packages/app/src/components/settings-notifications-section.tsx`
- `packages/app/src/components/settings-sounds-section.tsx`
- `packages/app/src/components/settings-updates-section.tsx`
- `packages/app/src/pages/session/settings-websearch-source.test.ts`
- `packages/app/src/pages/update-install-flow-source.test.ts`

## Risk Notes

Behavior should be unchanged. Risk is import wiring or source-contract drift after moving row/section owners. No dependency, migration, data, credential, or platform behavior changes are intended.

## How To Verify

```text
Focused app tests: 24 passed
Command: bun test --preload ./happydom.ts src/pages/session/settings-websearch-source.test.ts src/components/dialog-connect-websearch-source.test.ts src/pages/update-install-flow-source.test.ts src/shell-frame-contract.test.ts

Typecheck: 8 successful, 8 total
Command: bun run typecheck

Diff check: no whitespace errors
Command: git diff --check && git diff --cached --check

File-size check: settings-general.tsx 733 LOC on dev -> 367 LOC in this PR
Command: wc -l packages/app/src/components/settings-general.tsx packages/app/src/components/settings-notifications-section.tsx packages/app/src/components/settings-sounds-section.tsx packages/app/src/components/settings-updates-section.tsx packages/app/src/components/settings-web-search-row.tsx packages/app/src/components/settings-row.tsx
```

## Screenshots or Recordings

Not captured. This PR is a structure-only extraction with no intended visual change; the visible row/action contracts are covered by focused source tests and typecheck.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English