### PR TITLE
fix(app): stabilize browser subprocess tests on Windows

### DIFF
--- a/packages/app/src/pages/session/session-timeline-staging.test.ts
+++ b/packages/app/src/pages/session/session-timeline-staging.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test"
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
 
 const browserCheck = String.raw`
 import { render } from "solid-js/web"
@@ -187,15 +188,6 @@ const mount = (factory) => {
 
 describe("createTimelineStaging", () => {
   test("preserves browser staging behavior", () => {
-    const result = Bun.spawnSync({
-      cmd: [process.execPath, "--conditions=browser", "--preload", "./happydom.ts", "-e", browserCheck],
-      cwd: new URL("../../..", import.meta.url).pathname,
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-
-    const output = `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`
-    expect(output).toBe("")
-    expect(result.exitCode).toBe(0)
+    runBrowserCheck(browserCheck)
   })
 })

--- a/packages/app/src/pages/session/use-session-deferred-render.test.ts
+++ b/packages/app/src/pages/session/use-session-deferred-render.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test"
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
 
 const browserCheck = String.raw`
 import { createRoot, createSignal } from "solid-js"
@@ -119,15 +120,6 @@ const installTimerQueue = () => {
 
 describe("createSessionDeferredRender", () => {
   test("preserves deferred render scheduling behavior", () => {
-    const result = Bun.spawnSync({
-      cmd: [process.execPath, "--conditions=browser", "--preload", "./happydom.ts", "-e", browserCheck],
-      cwd: new URL("../../..", import.meta.url).pathname,
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-
-    const output = `${new TextDecoder().decode(result.stdout)}${new TextDecoder().decode(result.stderr)}`
-    expect(output).toBe("")
-    expect(result.exitCode).toBe(0)
+    runBrowserCheck(browserCheck)
   })
 })

--- a/packages/app/src/testing/browser-subprocess.ts
+++ b/packages/app/src/testing/browser-subprocess.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url"
+
+const appRoot = fileURLToPath(new URL("../..", import.meta.url))
+
+export function runBrowserCheck(script: string) {
+  const cmd = [process.execPath, "--conditions=browser", "--preload", "./happydom.ts", "-e", script]
+  const result = Bun.spawnSync({
+    cmd,
+    cwd: appRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  const stdout = new TextDecoder().decode(result.stdout)
+  const stderr = new TextDecoder().decode(result.stderr)
+
+  if (stdout === "" && stderr === "" && result.exitCode === 0) return
+
+  throw new Error(
+    [
+      "Browser subprocess check failed.",
+      `cwd: ${appRoot}`,
+      `command: ${cmd.map((part) => JSON.stringify(part)).join(" ")}`,
+      `exitCode: ${result.exitCode}`,
+      stdout === "" ? "stdout: <empty>" : `stdout:\n${stdout}`,
+      stderr === "" ? "stderr: <empty>" : `stderr:\n${stderr}`,
+    ].join("\n"),
+  )
+}


### PR DESCRIPTION
## Summary

- Add a shared app test helper for browser-condition subprocess checks.
- Reuse it in the two session tests that currently spawn Bun with a file URL pathname cwd.

## Why

Windows advisory is failing in app unit tests because these browser subprocess tests build cwd from import.meta.url.pathname. That is not a native Windows path and the child process also depends on relative ./happydom.ts and ./src imports. Converting through fileURLToPath keeps the cwd native on every platform and keeps the fix in test harness code.

## Related Issue

No issue. Follow-up to current Windows advisory CI failures on dev.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the fix stays at the test harness layer and does not change product behavior.
- Confirm the helper keeps the same browser-condition subprocess contract while using a native cwd.

## Risk Notes

Low. This only touches app test code. It changes failure reporting from expect output checks to one thrown error with cwd, command, stdout, stderr, and exit code.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed without lockfile changes
Focused browser subprocess tests: 25 passed, 1100 filtered, 0 failed
App typecheck: bun run --cwd packages/app typecheck passed
Lint: bun run lint:ci passed
Diff check: git diff --cached --check passed before commit
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated test utilities for browser environment checks, improving code reusability and reducing duplication across test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->