### PR TITLE
test: relax Windows pwsh bash smoke timeout

### DIFF
--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -529,6 +529,13 @@ describe("plugin.workspace", () => {
     const second = await waitForCounter(tmp.extra.counter, first, workspaceSyncRetryTimeout)
     expect(second).toBeGreaterThan(first)
 
+    await waitFor(
+      () =>
+        Workspace.status()
+          .find((item) => item.workspaceID === workspace.id)
+          ?.error?.includes("target unavailable") ?? false,
+      workspaceSyncRetryTimeout,
+    )
     const status = Workspace.status().find((item) => item.workspaceID === workspace.id)
     expect(status?.error).toContain("target unavailable")
   })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -153,9 +153,7 @@ const each = (
 ) => {
   for (const item of shells) {
     const run = withShell(item, () => fn(item))
-    const opts = options?.(item)
-    if (opts) test(`${name} [${item.label}]`, run, opts)
-    else test(`${name} [${item.label}]`, run)
+    test(`${name} [${item.label}]`, run, options?.(item))
   }
 }
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -146,12 +146,16 @@ const withShell = (item: { label: string; shell: string }, fn: () => Promise<voi
   }
 }
 
-const each = (name: string, fn: (item: { label: string; shell: string }) => Promise<void>) => {
+const each = (
+  name: string,
+  fn: (item: { label: string; shell: string }) => Promise<void>,
+  options?: (item: { label: string; shell: string }) => Parameters<typeof test>[2] | undefined,
+) => {
   for (const item of shells) {
-    test(
-      `${name} [${item.label}]`,
-      withShell(item, () => fn(item)),
-    )
+    const run = withShell(item, () => fn(item))
+    const opts = options?.(item)
+    if (opts) test(`${name} [${item.label}]`, run, opts)
+    else test(`${name} [${item.label}]`, run)
   }
 }
 
@@ -175,25 +179,30 @@ const mustTruncate = (result: {
 }
 
 describe("tool.bash", () => {
-  each("basic", async () => {
-    await Instance.provide({
-      directory: projectRoot,
-      fn: async () => {
-        const bash = await initBash()
-        const result = await Effect.runPromise(
-          bash.execute(
-            {
-              command: "echo test",
-              description: "Echo test message",
-            },
-            ctx,
-          ),
-        )
-        expect(result.metadata.exit).toBe(0)
-        expect(result.metadata.output).toContain("test")
-      },
-    })
-  })
+  each(
+    "basic",
+    async () => {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const bash = await initBash()
+          const result = await Effect.runPromise(
+            bash.execute(
+              {
+                command: "echo test",
+                description: "Echo test message",
+              },
+              ctx,
+            ),
+          )
+          expect(result.metadata.exit).toBe(0)
+          expect(result.metadata.output).toContain("test")
+        },
+      })
+    },
+    // pwsh cold start on Windows hosted runners can exceed Bun's default 30s.
+    (item) => (item.label === "pwsh" ? { timeout: 60_000 } : undefined),
+  )
 
   each("does not expose internal server auth env to user commands", async () => {
     const previousUsername = process.env.OPENCODE_SERVER_USERNAME


### PR DESCRIPTION
## Summary

Relax the Windows `pwsh` timeout budget for the `tool.bash > basic` smoke test, and make the Windows workspace-adaptor flaky test wait for the async error status it asserts.

## Why

The latest `dev` Windows advisory failure was isolated to `unit-windows-opencode-server-tools` / `tool.bash > basic [pwsh]` timing out at 30s. Adjacent evidence shows the same `pwsh` smoke can pass but still take 6s, 9s, or 25s on hosted Windows runners, while `powershell` and `cmd` pass quickly. This keeps the fix at the test-timeout layer instead of changing BashTool or Shell behavior.

A follow-up Windows advisory run on this PR proved `unit-windows-opencode-server-tools` now passes, but exposed an unrelated `unit-windows-opencode-session` test race in `plugin.workspace > cold-start Workspace.get retries sync after owner bootstrap for remote adaptors`: the test had observed the retry counter but asserted `Workspace.status()` before the async error status was visible. The second commit waits for that status before asserting it.

This is not a #685 regression: the post-#685 `3c4959ae` Windows advisory run was green, including `unit-windows-opencode-server-tools`.

## Related Issue

No issue. This addresses live Windows advisory failures on `dev` / this PR branch.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that only test synchronization/timeout boundaries changed and that production shell execution and workspace sync behavior remain unchanged.

## Risk Notes

Low. Test-only changes. The residual risk is hosted Windows runner slowness beyond 60s for `pwsh`, but observed successful runs were below 30s except the timeout case.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in the new worktree without lockfile changes
Focused bash smoke: bun --cwd packages/opencode test test/tool/bash.test.ts -t "basic" -> 1 pass, 0 fail
Focused bash suite: bun --cwd packages/opencode test test/tool/bash.test.ts -> 35 pass, 0 fail
Focused workspace adaptor: bun --cwd packages/opencode test test/plugin/workspace-adaptor.test.ts -t "cold-start Workspace.get retries sync" -> 1 pass, 0 fail
Typecheck: bun run --cwd packages/opencode typecheck -> exit 0
Lint: bun run lint:ci -> exit 0
Diff check: git diff --check -> exit 0
First Windows advisory run on PR branch: unit-windows-opencode-server-tools passed; unit-windows-opencode-session exposed the workspace-adaptor race now covered by commit 2
Second Windows advisory run on head 2504fd4e2dc33cfb076a963abc68878c46bf3b7a: https://github.com/Astro-Han/pawwork/actions/runs/25964041614 -> completed/success; all matrix jobs passed, including unit-windows-opencode-server-tools and unit-windows-opencode-session
Final Windows advisory run after review follow-up on head 2ce99894cae15a039b58c4927133e3c6d033ea00: https://github.com/Astro-Han/pawwork/actions/runs/25964388313 -> completed/success; all matrix jobs passed, including unit-windows-opencode-server-tools and unit-windows-opencode-session
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has type, primary area, and priority labels, or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


