### PR TITLE
refactor(ui): split pierre diff theme from markdown fence theme (#705)

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -6,375 +6,393 @@ import { bundledLanguages, type BundledLanguage } from "shiki"
 import { createSimpleContext } from "./helper"
 import { getSharedHighlighter, registerCustomTheme, ThemeRegistrationResolved } from "@pierre/diffs"
 
-registerCustomTheme("OpenCode", () => {
-  return Promise.resolve({
-    name: "OpenCode",
+// fence-code in markdown (chat thread) sits on --code-surface, the alpha overlay
+// locked by #642 PR0. pierre diff in the review panel inherits editor.background
+// as an inline <pre> style, so it needs a separate theme that points the surface
+// at --bg-base. The two themes share tokenColors + semanticTokenColors; only
+// editor.background differs. Issue #705.
+const OPENCODE_THEME = {
+  name: "OpenCode",
+  colors: {
+    "editor.background": "var(--code-surface)",
+    "editor.foreground": "var(--fg-base)",
+    "gitDecoration.addedResourceForeground": "var(--syntax-diff-add)",
+    "gitDecoration.deletedResourceForeground": "var(--syntax-diff-delete)",
+    // "gitDecoration.conflictingResourceForeground": "#ffca00",
+    // "gitDecoration.modifiedResourceForeground": "#1a76d4",
+    // "gitDecoration.untrackedResourceForeground": "#00cab1",
+    // "gitDecoration.ignoredResourceForeground": "#84848A",
+    // "terminal.titleForeground": "#adadb1",
+    // "terminal.titleInactiveForeground": "#84848A",
+    // "terminal.background": "#141415",
+    // "terminal.foreground": "#adadb1",
+    // "terminal.ansiBlack": "#141415",
+    // "terminal.ansiRed": "#ff2e3f",
+    // "terminal.ansiGreen": "#0dbe4e",
+    // "terminal.ansiYellow": "#ffca00",
+    // "terminal.ansiBlue": "#008cff",
+    // "terminal.ansiMagenta": "#c635e4",
+    // "terminal.ansiCyan": "#08c0ef",
+    // "terminal.ansiWhite": "#c6c6c8",
+    // "terminal.ansiBrightBlack": "#141415",
+    // "terminal.ansiBrightRed": "#ff2e3f",
+    // "terminal.ansiBrightGreen": "#0dbe4e",
+    // "terminal.ansiBrightYellow": "#ffca00",
+    // "terminal.ansiBrightBlue": "#008cff",
+    // "terminal.ansiBrightMagenta": "#c635e4",
+    // "terminal.ansiBrightCyan": "#08c0ef",
+    // "terminal.ansiBrightWhite": "#c6c6c8",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment", "string.comment"],
+      settings: {
+        foreground: "var(--syntax-comment)",
+      },
+    },
+    {
+      scope: ["entity.other.attribute-name"],
+      settings: {
+        foreground: "var(--syntax-property)", // maybe attribute
+      },
+    },
+    {
+      scope: ["constant", "entity.name.constant", "variable.other.constant", "variable.language", "entity"],
+      settings: {
+        foreground: "var(--syntax-constant)",
+      },
+    },
+    {
+      scope: ["entity.name", "meta.export.default", "meta.definition.variable"],
+      settings: {
+        foreground: "var(--syntax-type)",
+      },
+    },
+    {
+      scope: ["meta.object.member"],
+      settings: {
+        foreground: "var(--syntax-primitive)",
+      },
+    },
+    {
+      scope: [
+        "variable.parameter.function",
+        "meta.jsx.children",
+        "meta.block",
+        "meta.tag.attributes",
+        "entity.name.constant",
+        "meta.embedded.expression",
+        "meta.template.expression",
+        "string.other.begin.yaml",
+        "string.other.end.yaml",
+      ],
+      settings: {
+        foreground: "var(--syntax-punctuation)",
+      },
+    },
+    {
+      scope: ["entity.name.function", "support.type.primitive"],
+      settings: {
+        foreground: "var(--syntax-primitive)",
+      },
+    },
+    {
+      scope: ["support.class.component"],
+      settings: {
+        foreground: "var(--syntax-type)",
+      },
+    },
+    {
+      scope: "keyword",
+      settings: {
+        foreground: "var(--syntax-keyword)",
+      },
+    },
+    {
+      scope: [
+        "keyword.operator",
+        "storage.type.function.arrow",
+        "punctuation.separator.key-value.css",
+        "entity.name.tag.yaml",
+        "punctuation.separator.key-value.mapping.yaml",
+      ],
+      settings: {
+        foreground: "var(--syntax-operator)",
+      },
+    },
+    {
+      scope: ["storage", "storage.type"],
+      settings: {
+        foreground: "var(--syntax-keyword)",
+      },
+    },
+    {
+      scope: ["storage.modifier.package", "storage.modifier.import", "storage.type.java"],
+      settings: {
+        foreground: "var(--syntax-primitive)",
+      },
+    },
+    {
+      scope: [
+        "string",
+        "punctuation.definition.string",
+        "string punctuation.section.embedded source",
+        "entity.name.tag",
+      ],
+      settings: {
+        foreground: "var(--syntax-string)",
+      },
+    },
+    {
+      scope: "support",
+      settings: {
+        foreground: "var(--syntax-primitive)",
+      },
+    },
+    {
+      scope: ["support.type.object.module", "variable.other.object", "support.type.property-name.css"],
+      settings: {
+        foreground: "var(--syntax-object)",
+      },
+    },
+    {
+      scope: "meta.property-name",
+      settings: {
+        foreground: "var(--syntax-property)",
+      },
+    },
+    {
+      scope: "variable",
+      settings: {
+        foreground: "var(--syntax-variable)",
+      },
+    },
+    {
+      scope: "variable.other",
+      settings: {
+        foreground: "var(--syntax-variable)",
+      },
+    },
+    {
+      scope: [
+        "invalid.broken",
+        "invalid.illegal",
+        "invalid.unimplemented",
+        "invalid.deprecated",
+        "message.error",
+        "markup.deleted",
+        "meta.diff.header.from-file",
+        "punctuation.definition.deleted",
+        "brackethighlighter.unmatched",
+        "token.error-token",
+      ],
+      settings: {
+        foreground: "var(--syntax-critical)",
+      },
+    },
+    {
+      scope: "carriage-return",
+      settings: {
+        foreground: "var(--syntax-keyword)",
+      },
+    },
+    {
+      scope: "string source",
+      settings: {
+        foreground: "var(--syntax-variable)",
+      },
+    },
+    {
+      scope: "string variable",
+      settings: {
+        foreground: "var(--syntax-constant)",
+      },
+    },
+    {
+      scope: [
+        "source.regexp",
+        "string.regexp",
+        "string.regexp.character-class",
+        "string.regexp constant.character.escape",
+        "string.regexp source.ruby.embedded",
+        "string.regexp string.regexp.arbitrary-repitition",
+        "string.regexp constant.character.escape",
+      ],
+      settings: {
+        foreground: "var(--syntax-regexp)",
+      },
+    },
+    {
+      scope: "support.constant",
+      settings: {
+        foreground: "var(--syntax-primitive)",
+      },
+    },
+    {
+      scope: "support.variable",
+      settings: {
+        foreground: "var(--syntax-variable)",
+      },
+    },
+    {
+      scope: "meta.module-reference",
+      settings: {
+        foreground: "var(--syntax-info)",
+      },
+    },
+    {
+      scope: "punctuation.definition.list.begin.markdown",
+      settings: {
+        foreground: "var(--syntax-punctuation)",
+      },
+    },
+    {
+      scope: ["markup.heading", "markup.heading entity.name"],
+      settings: {
+        fontStyle: "bold",
+        foreground: "var(--syntax-info)",
+      },
+    },
+    {
+      scope: "markup.quote",
+      settings: {
+        foreground: "var(--syntax-info)",
+      },
+    },
+    {
+      scope: "markup.italic",
+      settings: {
+        fontStyle: "italic",
+        // foreground: "",
+      },
+    },
+    {
+      scope: "markup.bold",
+      settings: {
+        fontStyle: "bold",
+        foreground: "var(--fg-strong)",
+      },
+    },
+    {
+      scope: [
+        "markup.raw",
+        "markup.inserted",
+        "meta.diff.header.to-file",
+        "punctuation.definition.inserted",
+        "markup.changed",
+        "punctuation.definition.changed",
+        "markup.ignored",
+        "markup.untracked",
+      ],
+      settings: {
+        foreground: "var(--fg-base)",
+      },
+    },
+    {
+      scope: "meta.diff.range",
+      settings: {
+        fontStyle: "bold",
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: "meta.diff.header",
+      settings: {
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: "meta.separator",
+      settings: {
+        fontStyle: "bold",
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: "meta.output",
+      settings: {
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: "meta.export.default",
+      settings: {
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: [
+        "brackethighlighter.tag",
+        "brackethighlighter.curly",
+        "brackethighlighter.round",
+        "brackethighlighter.square",
+        "brackethighlighter.angle",
+        "brackethighlighter.quote",
+      ],
+      settings: {
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: ["constant.other.reference.link", "string.other.link"],
+      settings: {
+        fontStyle: "underline",
+        foreground: "var(--syntax-unknown)",
+      },
+    },
+    {
+      scope: "token.info-token",
+      settings: {
+        foreground: "var(--syntax-info)",
+      },
+    },
+    {
+      scope: "token.warn-token",
+      settings: {
+        foreground: "var(--syntax-warning)",
+      },
+    },
+    {
+      scope: "token.debug-token",
+      settings: {
+        foreground: "var(--syntax-info)",
+      },
+    },
+  ],
+  semanticTokenColors: {
+    comment: "var(--syntax-comment)",
+    string: "var(--syntax-string)",
+    number: "var(--syntax-constant)",
+    regexp: "var(--syntax-regexp)",
+    keyword: "var(--syntax-keyword)",
+    variable: "var(--syntax-variable)",
+    parameter: "var(--syntax-variable)",
+    property: "var(--syntax-property)",
+    function: "var(--syntax-primitive)",
+    method: "var(--syntax-primitive)",
+    type: "var(--syntax-type)",
+    class: "var(--syntax-type)",
+    namespace: "var(--syntax-type)",
+    enumMember: "var(--syntax-primitive)",
+    "variable.constant": "var(--syntax-constant)",
+    "variable.defaultLibrary": "var(--syntax-unknown)",
+  },
+}
+
+registerCustomTheme("OpenCode", () =>
+  Promise.resolve(OPENCODE_THEME as unknown as ThemeRegistrationResolved),
+)
+
+registerCustomTheme("PawWorkDiff", () =>
+  Promise.resolve({
+    ...OPENCODE_THEME,
+    name: "PawWorkDiff",
     colors: {
+      ...OPENCODE_THEME.colors,
       "editor.background": "var(--bg-base)",
-      "editor.foreground": "var(--fg-base)",
-      "gitDecoration.addedResourceForeground": "var(--syntax-diff-add)",
-      "gitDecoration.deletedResourceForeground": "var(--syntax-diff-delete)",
-      // "gitDecoration.conflictingResourceForeground": "#ffca00",
-      // "gitDecoration.modifiedResourceForeground": "#1a76d4",
-      // "gitDecoration.untrackedResourceForeground": "#00cab1",
-      // "gitDecoration.ignoredResourceForeground": "#84848A",
-      // "terminal.titleForeground": "#adadb1",
-      // "terminal.titleInactiveForeground": "#84848A",
-      // "terminal.background": "#141415",
-      // "terminal.foreground": "#adadb1",
-      // "terminal.ansiBlack": "#141415",
-      // "terminal.ansiRed": "#ff2e3f",
-      // "terminal.ansiGreen": "#0dbe4e",
-      // "terminal.ansiYellow": "#ffca00",
-      // "terminal.ansiBlue": "#008cff",
-      // "terminal.ansiMagenta": "#c635e4",
-      // "terminal.ansiCyan": "#08c0ef",
-      // "terminal.ansiWhite": "#c6c6c8",
-      // "terminal.ansiBrightBlack": "#141415",
-      // "terminal.ansiBrightRed": "#ff2e3f",
-      // "terminal.ansiBrightGreen": "#0dbe4e",
-      // "terminal.ansiBrightYellow": "#ffca00",
-      // "terminal.ansiBrightBlue": "#008cff",
-      // "terminal.ansiBrightMagenta": "#c635e4",
-      // "terminal.ansiBrightCyan": "#08c0ef",
-      // "terminal.ansiBrightWhite": "#c6c6c8",
     },
-    tokenColors: [
-      {
-        scope: ["comment", "punctuation.definition.comment", "string.comment"],
-        settings: {
-          foreground: "var(--syntax-comment)",
-        },
-      },
-      {
-        scope: ["entity.other.attribute-name"],
-        settings: {
-          foreground: "var(--syntax-property)", // maybe attribute
-        },
-      },
-      {
-        scope: ["constant", "entity.name.constant", "variable.other.constant", "variable.language", "entity"],
-        settings: {
-          foreground: "var(--syntax-constant)",
-        },
-      },
-      {
-        scope: ["entity.name", "meta.export.default", "meta.definition.variable"],
-        settings: {
-          foreground: "var(--syntax-type)",
-        },
-      },
-      {
-        scope: ["meta.object.member"],
-        settings: {
-          foreground: "var(--syntax-primitive)",
-        },
-      },
-      {
-        scope: [
-          "variable.parameter.function",
-          "meta.jsx.children",
-          "meta.block",
-          "meta.tag.attributes",
-          "entity.name.constant",
-          "meta.embedded.expression",
-          "meta.template.expression",
-          "string.other.begin.yaml",
-          "string.other.end.yaml",
-        ],
-        settings: {
-          foreground: "var(--syntax-punctuation)",
-        },
-      },
-      {
-        scope: ["entity.name.function", "support.type.primitive"],
-        settings: {
-          foreground: "var(--syntax-primitive)",
-        },
-      },
-      {
-        scope: ["support.class.component"],
-        settings: {
-          foreground: "var(--syntax-type)",
-        },
-      },
-      {
-        scope: "keyword",
-        settings: {
-          foreground: "var(--syntax-keyword)",
-        },
-      },
-      {
-        scope: [
-          "keyword.operator",
-          "storage.type.function.arrow",
-          "punctuation.separator.key-value.css",
-          "entity.name.tag.yaml",
-          "punctuation.separator.key-value.mapping.yaml",
-        ],
-        settings: {
-          foreground: "var(--syntax-operator)",
-        },
-      },
-      {
-        scope: ["storage", "storage.type"],
-        settings: {
-          foreground: "var(--syntax-keyword)",
-        },
-      },
-      {
-        scope: ["storage.modifier.package", "storage.modifier.import", "storage.type.java"],
-        settings: {
-          foreground: "var(--syntax-primitive)",
-        },
-      },
-      {
-        scope: [
-          "string",
-          "punctuation.definition.string",
-          "string punctuation.section.embedded source",
-          "entity.name.tag",
-        ],
-        settings: {
-          foreground: "var(--syntax-string)",
-        },
-      },
-      {
-        scope: "support",
-        settings: {
-          foreground: "var(--syntax-primitive)",
-        },
-      },
-      {
-        scope: ["support.type.object.module", "variable.other.object", "support.type.property-name.css"],
-        settings: {
-          foreground: "var(--syntax-object)",
-        },
-      },
-      {
-        scope: "meta.property-name",
-        settings: {
-          foreground: "var(--syntax-property)",
-        },
-      },
-      {
-        scope: "variable",
-        settings: {
-          foreground: "var(--syntax-variable)",
-        },
-      },
-      {
-        scope: "variable.other",
-        settings: {
-          foreground: "var(--syntax-variable)",
-        },
-      },
-      {
-        scope: [
-          "invalid.broken",
-          "invalid.illegal",
-          "invalid.unimplemented",
-          "invalid.deprecated",
-          "message.error",
-          "markup.deleted",
-          "meta.diff.header.from-file",
-          "punctuation.definition.deleted",
-          "brackethighlighter.unmatched",
-          "token.error-token",
-        ],
-        settings: {
-          foreground: "var(--syntax-critical)",
-        },
-      },
-      {
-        scope: "carriage-return",
-        settings: {
-          foreground: "var(--syntax-keyword)",
-        },
-      },
-      {
-        scope: "string source",
-        settings: {
-          foreground: "var(--syntax-variable)",
-        },
-      },
-      {
-        scope: "string variable",
-        settings: {
-          foreground: "var(--syntax-constant)",
-        },
-      },
-      {
-        scope: [
-          "source.regexp",
-          "string.regexp",
-          "string.regexp.character-class",
-          "string.regexp constant.character.escape",
-          "string.regexp source.ruby.embedded",
-          "string.regexp string.regexp.arbitrary-repitition",
-          "string.regexp constant.character.escape",
-        ],
-        settings: {
-          foreground: "var(--syntax-regexp)",
-        },
-      },
-      {
-        scope: "support.constant",
-        settings: {
-          foreground: "var(--syntax-primitive)",
-        },
-      },
-      {
-        scope: "support.variable",
-        settings: {
-          foreground: "var(--syntax-variable)",
-        },
-      },
-      {
-        scope: "meta.module-reference",
-        settings: {
-          foreground: "var(--syntax-info)",
-        },
-      },
-      {
-        scope: "punctuation.definition.list.begin.markdown",
-        settings: {
-          foreground: "var(--syntax-punctuation)",
-        },
-      },
-      {
-        scope: ["markup.heading", "markup.heading entity.name"],
-        settings: {
-          fontStyle: "bold",
-          foreground: "var(--syntax-info)",
-        },
-      },
-      {
-        scope: "markup.quote",
-        settings: {
-          foreground: "var(--syntax-info)",
-        },
-      },
-      {
-        scope: "markup.italic",
-        settings: {
-          fontStyle: "italic",
-          // foreground: "",
-        },
-      },
-      {
-        scope: "markup.bold",
-        settings: {
-          fontStyle: "bold",
-          foreground: "var(--fg-strong)",
-        },
-      },
-      {
-        scope: [
-          "markup.raw",
-          "markup.inserted",
-          "meta.diff.header.to-file",
-          "punctuation.definition.inserted",
-          "markup.changed",
-          "punctuation.definition.changed",
-          "markup.ignored",
-          "markup.untracked",
-        ],
-        settings: {
-          foreground: "var(--fg-base)",
-        },
-      },
-      {
-        scope: "meta.diff.range",
-        settings: {
-          fontStyle: "bold",
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: "meta.diff.header",
-        settings: {
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: "meta.separator",
-        settings: {
-          fontStyle: "bold",
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: "meta.output",
-        settings: {
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: "meta.export.default",
-        settings: {
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: [
-          "brackethighlighter.tag",
-          "brackethighlighter.curly",
-          "brackethighlighter.round",
-          "brackethighlighter.square",
-          "brackethighlighter.angle",
-          "brackethighlighter.quote",
-        ],
-        settings: {
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: ["constant.other.reference.link", "string.other.link"],
-        settings: {
-          fontStyle: "underline",
-          foreground: "var(--syntax-unknown)",
-        },
-      },
-      {
-        scope: "token.info-token",
-        settings: {
-          foreground: "var(--syntax-info)",
-        },
-      },
-      {
-        scope: "token.warn-token",
-        settings: {
-          foreground: "var(--syntax-warning)",
-        },
-      },
-      {
-        scope: "token.debug-token",
-        settings: {
-          foreground: "var(--syntax-info)",
-        },
-      },
-    ],
-    semanticTokenColors: {
-      comment: "var(--syntax-comment)",
-      string: "var(--syntax-string)",
-      number: "var(--syntax-constant)",
-      regexp: "var(--syntax-regexp)",
-      keyword: "var(--syntax-keyword)",
-      variable: "var(--syntax-variable)",
-      parameter: "var(--syntax-variable)",
-      property: "var(--syntax-property)",
-      function: "var(--syntax-primitive)",
-      method: "var(--syntax-primitive)",
-      type: "var(--syntax-type)",
-      class: "var(--syntax-type)",
-      namespace: "var(--syntax-type)",
-      enumMember: "var(--syntax-primitive)",
-      "variable.constant": "var(--syntax-constant)",
-      "variable.defaultLibrary": "var(--syntax-unknown)",
-    },
-  } as unknown as ThemeRegistrationResolved)
-})
+  } as unknown as ThemeRegistrationResolved),
+)
 
 function renderMathInText(text: string): string {
   let result = text

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -10,7 +10,7 @@ registerCustomTheme("OpenCode", () => {
   return Promise.resolve({
     name: "OpenCode",
     colors: {
-      "editor.background": "var(--code-surface)",
+      "editor.background": "var(--bg-base)",
       "editor.foreground": "var(--fg-base)",
       "gitDecoration.addedResourceForeground": "var(--syntax-diff-add)",
       "gitDecoration.deletedResourceForeground": "var(--syntax-diff-delete)",

--- a/packages/ui/src/pierre/index.ts
+++ b/packages/ui/src/pierre/index.ts
@@ -17,24 +17,26 @@ export type DiffProps<T = {}> = FileDiffOptions<T> & {
 const unsafeCSS = `
 [data-diff],
 [data-file] {
-  --diffs-bg: light-dark(var(--diffs-light-bg), var(--diffs-dark-bg));
-  --diffs-bg-buffer: var(--diffs-bg-buffer-override, light-dark( color-mix(in lab, var(--diffs-bg) 92%, var(--diffs-mixer)), color-mix(in lab, var(--diffs-bg) 92%, var(--diffs-mixer))));
-  --diffs-bg-hover: var(--diffs-bg-hover-override, light-dark( color-mix(in lab, var(--diffs-bg) 97%, var(--diffs-mixer)), color-mix(in lab, var(--diffs-bg) 91%, var(--diffs-mixer))));
-  --diffs-bg-context: var(--diffs-bg-context-override, light-dark( color-mix(in lab, var(--diffs-bg) 98.5%, var(--diffs-mixer)), color-mix(in lab, var(--diffs-bg) 92.5%, var(--diffs-mixer))));
-  --diffs-bg-separator: var(--diffs-bg-separator-override, light-dark( color-mix(in lab, var(--diffs-bg) 96%, var(--diffs-mixer)), color-mix(in lab, var(--diffs-bg) 85%, var(--diffs-mixer))));
-  --diffs-fg: light-dark(var(--diffs-light), var(--diffs-dark));
-  --diffs-fg-number: var(--diffs-fg-number-override, light-dark(color-mix(in lab, var(--diffs-fg) 65%, var(--diffs-bg)), color-mix(in lab, var(--diffs-fg) 65%, var(--diffs-bg))));
-  --diffs-deletion-base: var(--syntax-diff-delete);
-  --diffs-addition-base: var(--syntax-diff-add);
-  --diffs-modified-base: var(--syntax-diff-unknown);
-  --diffs-bg-deletion: var(--diffs-bg-deletion-override, light-dark( color-mix(in lab, var(--diffs-bg) 98%, var(--diffs-deletion-base)), color-mix(in lab, var(--diffs-bg) 92%, var(--diffs-deletion-base))));
-  --diffs-bg-deletion-number: var(--diffs-bg-deletion-number-override, light-dark( color-mix(in lab, var(--diffs-bg) 91%, var(--diffs-deletion-base)), color-mix(in lab, var(--diffs-bg) 85%, var(--diffs-deletion-base))));
-  --diffs-bg-deletion-hover: var(--diffs-bg-deletion-hover-override, light-dark( color-mix(in lab, var(--diffs-bg) 80%, var(--diffs-deletion-base)), color-mix(in lab, var(--diffs-bg) 75%, var(--diffs-deletion-base))));
-  --diffs-bg-deletion-emphasis: var(--diffs-bg-deletion-emphasis-override, light-dark(rgb(from var(--diffs-deletion-base) r g b / 0.7), rgb(from var(--diffs-deletion-base) r g b / 0.1)));
-  --diffs-bg-addition: var(--diffs-bg-addition-override, light-dark( color-mix(in lab, var(--diffs-bg) 98%, var(--diffs-addition-base)), color-mix(in lab, var(--diffs-bg) 92%, var(--diffs-addition-base))));
-  --diffs-bg-addition-number: var(--diffs-bg-addition-number-override, light-dark( color-mix(in lab, var(--diffs-bg) 91%, var(--diffs-addition-base)), color-mix(in lab, var(--diffs-bg) 85%, var(--diffs-addition-base))));
-  --diffs-bg-addition-hover: var(--diffs-bg-addition-hover-override, light-dark( color-mix(in lab, var(--diffs-bg) 80%, var(--diffs-addition-base)), color-mix(in lab, var(--diffs-bg) 70%, var(--diffs-addition-base))));
-  --diffs-bg-addition-emphasis: var(--diffs-bg-addition-emphasis-override, light-dark(rgb(from var(--diffs-addition-base) r g b / 0.07), rgb(from var(--diffs-addition-base) r g b / 0.1)));
+  /* pierre's OpenCode theme writes --diffs-bg as inline style on <pre> via */
+  /* editor.background = var(--bg-base) (see context/marked.tsx). pierre's own */
+  /* color-mix formulas then derive context/separator off that base. We only */
+  /* point add/del at the PawWork semantic alpha tokens, which carry their own */
+  /* light/dark values (see packages/ui/src/styles/theme.css and */
+  /* themes/pawwork.json), so no :host([data-color-scheme='dark']) branch is */
+  /* needed for the row tints. Issue #705. */
+  --diffs-bg-addition-override: var(--diff-add);
+  --diffs-bg-addition-number-override: var(--diff-add);
+  --diffs-bg-deletion-override: var(--diff-del);
+  --diffs-bg-deletion-number-override: var(--diff-del);
+
+  /* Buffer, context rows, and hunk separators ("N unmodified lines") stay flat */
+  /* over --bg-base. The chevron expand button shares --diffs-bg-separator */
+  /* (pierre dist/style.js L672), so transparent here also kills the gray */
+  /* raised-block look. */
+  --diffs-bg-buffer-override: transparent;
+  --diffs-bg-context-override: transparent;
+  --diffs-bg-separator-override: transparent;
+
   --diffs-selection-base: var(--warning-bg);
   --diffs-selection-border: var(--warning);
   --diffs-selection-number-fg: #1c1917;
@@ -138,7 +140,6 @@ const unsafeCSS = `
     height: 24px;
   }
   [data-column-number] {
-    background-color: var(--bg-base);
     cursor: default !important;
   }
 
@@ -166,7 +167,10 @@ export function createDefaultOptions<T>(style: FileDiffOptions<T>["diffStyle"]) 
     disableLineNumbers: false,
     overflow: "wrap",
     diffStyle: style ?? "unified",
-    diffIndicators: "bars",
+    /* "classic" renders +/− char markers (matches DESIGN.md L482 marker column intent). */
+    /* "bars" would draw a 4px solid side stripe per row, which collides with the */
+    /* side-stripe ban in our design principles. Issue #705. */
+    diffIndicators: "classic",
     lineHoverHighlight: "both",
     disableBackground: false,
     expansionLineCount: 20,
@@ -188,4 +192,9 @@ export const styleVariables = {
   "--diffs-header-font-family": "var(--font-family-sans)",
   "--diffs-gap-block": 0,
   "--diffs-min-number-column-width": "4ch",
+  /* pierre's default --diffs-gap-style ("2px solid var(--diffs-bg)") paints a visible */
+  /* seam between the number column and the code column. Keep the 2px width for spacing */
+  /* but make the color transparent so the row's --diffs-line-bg (which already matches */
+  /* --diffs-bg-addition / --diffs-bg-deletion) shows through. Issue #705. */
+  "--diffs-gap-style": "2px solid transparent",
 }

--- a/packages/ui/src/pierre/index.ts
+++ b/packages/ui/src/pierre/index.ts
@@ -17,11 +17,11 @@ export type DiffProps<T = {}> = FileDiffOptions<T> & {
 const unsafeCSS = `
 [data-diff],
 [data-file] {
-  /* pierre's OpenCode theme writes --diffs-bg as inline style on <pre> via */
-  /* editor.background = var(--bg-base) (see context/marked.tsx). pierre's own */
-  /* color-mix formulas then derive context/separator off that base. We only */
-  /* point add/del at the PawWork semantic alpha tokens, which carry their own */
-  /* light/dark values (see packages/ui/src/styles/theme.css and */
+  /* pierre renders diffs through codeToHtml with the PawWorkDiff theme (see */
+  /* context/marked.tsx), so the inline <pre> background is var(--bg-base). */
+  /* pierre's own color-mix formulas derive context/separator off that base. */
+  /* We point add/del at the PawWork semantic alpha tokens, which carry their */
+  /* own light/dark values (see packages/ui/src/styles/theme.css and */
   /* themes/pawwork.json), so no :host([data-color-scheme='dark']) branch is */
   /* needed for the row tints. Issue #705. */
   --diffs-bg-addition-override: var(--diff-add);
@@ -162,7 +162,7 @@ ${lineCommentStyles}
 
 export function createDefaultOptions<T>(style: FileDiffOptions<T>["diffStyle"]) {
   return {
-    theme: "OpenCode",
+    theme: "PawWorkDiff",
     themeType: "system",
     disableLineNumbers: false,
     overflow: "wrap",


### PR DESCRIPTION
## Summary

- Fork a new `PawWorkDiff` shiki theme alongside `OpenCode` in `marked.tsx`. PawWorkDiff spreads OpenCode's `tokenColors` and `semanticTokenColors` and only overrides `editor.background` to `var(--bg-base)`. OpenCode itself is restored to `editor.background = var(--code-surface)`, restoring the #642 PR0 contract.
- Point `pierre.createDefaultOptions` at `theme: "PawWorkDiff"`. Markdown fence-code keeps using `OpenCode`. The two surfaces are now decoupled at the theme layer.
- Bind pierre's `--diffs-bg-{addition,deletion}{,-number}-override` to PawWork's `--diff-add` / `--diff-del` semantic tokens. The dark `:host([data-color-scheme='dark'])` add/del branch is dropped because the tokens already carry their own light/dark values (and the dropped branch had drifted to `rgba(63,179,115,0.18)` vs the token's `rgba(58,176,107,0.15)`).
- Flatten the hunk separator + chevron expand button (`--diffs-bg-{buffer,context,separator}-override: transparent`) and hide the 2 px gutter seam (`--diffs-gap-style: 2px solid transparent`) so non-add/non-del rows sit flat on the PawWorkDiff surface.
- Drop the local `[data-column-number] { background-color: var(--bg-base) }` rule that was clobbering pierre's own number-column tint on add/del rows.
- Switch `diffIndicators` from `bars` (4 px side-stripe — banned by DESIGN.md absolute bans) to `classic` (+/− char markers).

## Why

Resolves #705. The issue surfaced as "diff viewer is cool gray, not warm `--bg-base`," but the root cause was deeper: pierre serializes `editor.background` from its shiki theme into a `<pre>` inline style, and that inline value wins the cascade against every `--diffs-bg` rule in `unsafeCSS`. The earlier iteration on this branch (1df010569) routed the fix through `OpenCode.editor.background = var(--bg-base)`, but that surface is shared with markdown fence-code and is pinned to `var(--code-surface)` by the #642 PR0 contract (`theme-parity.test.ts:354`). CI broke; chat-thread fence-code became visually identical to body in dark.

The fence-code surface and the diff surface have different jobs — fence-code is a card-like alpha overlay against chat body, the diff viewer is a flat surface so add/del row tints carry the signal — so coupling them through one theme is the wrong architecture. Forking PawWorkDiff lets each surface declare its own `editor.background` while sharing all syntax highlighting (tokenColors / semanticTokenColors via spread). Future edits to chat code rendering cannot silently move the review diff, and vice versa.

## Related Issue

Closes #705.

Adjacent: #709 (rework dark mode color system) will revisit `--bg-base` / `--code-surface` / etc. holistically; this PR ships independently.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- The new `PawWorkDiff` theme is the load-bearing change. It is `OpenCode` with one field overridden; both themes share `tokenColors` via spread so there is no duplicated palette to maintain.
- `OpenCode.editor.background` is back to `var(--code-surface)`. The `#642 PR0` theme-parity contract (`packages/ui/test/theme-parity.test.ts:354`) is green again.
- The `:host([data-color-scheme='dark'])` block under `[data-diff], [data-file]` now contains only selection-related tokens. Add/del live in the PawWork `--diff-add` / `--diff-del` tokens.
- `marked.tsx` shows a large diff because the OpenCode theme object was extracted to a top-level `OPENCODE_THEME` const (indent shift). Use "Hide whitespace changes" or `git diff -w` to see the real delta (+29 / -11 lines logical).

## Risk Notes

- Markdown fence-code rendering is unchanged from `dev`. The earlier iteration's "unified `--bg-base` background" idea is reverted in this commit; that direction will be revisited under #709 if it makes sense at all.
- `diffIndicators: "bars"` → `"classic"` changes the per-row marker style; affects every diff render path.
- `DESIGN.md` L191 + L482 were updated locally to permit the `--diff-add` / `--diff-del` tokens and to align the dark alpha to the runtime `0.15` value; `docs/` is excluded from this worktree's tracking, so the doc change is not in this PR — flagged here for spec coherence.

## How To Verify

```text
bun --cwd packages/ui test test/theme-parity.test.ts → 202 pass / 0 fail (includes #642 PR0 contract)
bun turbo typecheck → 8 packages successful (tsgo --noEmit)
E2E chat fence-code light + dark (ad-hoc probe spec):
  inline style    = background-color: var(--code-surface)
  light fence bg  = rgba(0, 0, 0, 0.04)      (= --code-surface, alpha overlay)
  dark fence bg   = rgba(255, 255, 255, 0.06) (= --code-surface, alpha overlay)
  body bg matches --bg-base in both modes; fence sits above on the alpha overlay
```

## Screenshots or Recordings

Review-panel + chat-fence screenshots were taken locally via E2E (`docs/debug-screens/i705-{chat,}-{light,dark}.png`). Attaching them to the PR body requires the GitHub web UI's drag-and-drop. I will add them as a follow-up comment once the human reviewer is ready.

## Checklist

- [ ] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [ ] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [ ] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English