### PR TITLE
fix: preserve abort interrupt provenance

### DIFF
--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
@@ -131,6 +131,37 @@ describe("renderer diagnostics sanitizer", () => {
     })
   })
 
+  test("keeps session abort diagnostics and drops unrelated fields", () => {
+    const event = sanitizeRendererDiagnosticEvent(
+      {
+        name: "session.action.abort",
+        route_session_id: "ses_route",
+        visible_session_id: "ses_visible",
+        timeline_session_id: "ses_timeline",
+        data: {
+          source: "emptyEnter",
+          mode: "soft",
+          result: "aborted",
+          prompt_text: "do not keep me",
+        },
+      },
+      { appLaunchID: "launch_1", now: () => new Date("2026-05-02T10:30:12.123Z"), windowID: 1 },
+    )
+
+    expect(event).toMatchObject({
+      "event.name": "session.action.abort",
+      route_session_id: "ses_route",
+      visible_session_id: "ses_visible",
+      timeline_session_id: "ses_timeline",
+      data: {
+        source: "emptyEnter",
+        mode: "soft",
+        result: "aborted",
+      },
+    })
+    expect(JSON.stringify(event)).not.toContain("do not keep me")
+  })
+
   test("accepts typed session timeline scroll controller diagnostics", () => {
     const event = sanitizeRendererDiagnosticEvent(
       {

--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.ts
@@ -35,6 +35,7 @@ const eventDataFields = {
     "image_count",
     "comment_count",
   ],
+  "session.action.abort": ["source", "mode", "result"],
   "session.timeline.mount": ["rendered_count", "visible_first_message_id", "visible_last_message_id"],
   "session.timeline.unmount": ["rendered_count", "visible_first_message_id", "visible_last_message_id"],
   "session.timeline.visible": ["rendered_count", "visible_first_message_id", "visible_last_message_id"],

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -56,6 +56,7 @@ export const make = <A, E = never>(
     onIdle?: Effect.Effect<void>
     onBusy?: Effect.Effect<void>
     onInterrupt?: (meta?: InterruptMeta) => Effect.Effect<A, E>
+    interruptFallback?: InterruptMeta
     busy?: () => never
   },
 ): Runner<A, E> => {
@@ -69,6 +70,15 @@ export const make = <A, E = never>(
   const next = () => {
     ids += 1
     return ids
+  }
+  const withRecordedInterruptMeta = (meta: InterruptMeta | undefined, fallback: InterruptMeta): InterruptMeta => ({
+    ...fallback,
+    ...meta,
+    recordedAt: meta?.recordedAt ?? Date.now(),
+  })
+  const interruptFallback = opts?.interruptFallback ?? {
+    source: "runner.interrupt_without_meta",
+    reason: "fiber_interrupt_without_meta",
   }
 
   const complete = (done: Deferred.Deferred<A, E | Cancelled>, exit: Exit.Exit<A, E>) =>
@@ -108,7 +118,7 @@ export const make = <A, E = never>(
 
   const resolveInterrupt = (interruptMeta: Ref.Ref<InterruptMeta | undefined>): Effect.Effect<A, E> =>
     Effect.gen(function* () {
-      const meta = yield* Ref.get(interruptMeta)
+      const meta = withRecordedInterruptMeta(yield* Ref.get(interruptMeta), interruptFallback)
       if (onInterrupt) return yield* onInterrupt(meta)
       return yield* Effect.die(new Cancelled())
     })
@@ -218,14 +228,10 @@ export const make = <A, E = never>(
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
-        const snapshot = meta
-          ? {
-              ...meta,
-              recordedAt: meta.recordedAt ?? Date.now(),
-            }
-          : {
-              recordedAt: Date.now(),
-            }
+        const snapshot = withRecordedInterruptMeta(meta, {
+          source: "runner.cancel_without_meta",
+          reason: "cancel_without_meta",
+        })
         switch (st._tag) {
           case "Idle":
             return [Effect.void, st] as const

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -35,10 +35,18 @@ export const layer = Layer.effect(
         const runners = new Map<SessionID, Runner<MessageV2.WithParts>>()
         yield* Effect.addFinalizer(
           Effect.fnUntraced(function* () {
-            yield* Effect.forEach(runners.values(), (runner) => runner.cancel, {
-              concurrency: "unbounded",
-              discard: true,
-            })
+            yield* Effect.forEach(
+              runners.values(),
+              (runner) =>
+                runner.cancelWith({
+                  source: "session.run_state.finalizer",
+                  reason: "scope_finalizer",
+                }),
+              {
+                concurrency: "unbounded",
+                discard: true,
+              },
+            )
             runners.clear()
           }),
         )
@@ -60,6 +68,10 @@ export const layer = Layer.effect(
         }),
         onBusy: status.set(sessionID, { type: "busy" }),
         onInterrupt,
+        interruptFallback: {
+          source: "session.run_state.scope",
+          reason: "scope_closed_without_cancel_meta",
+        },
         busy: () => {
           throw new Session.BusyError(sessionID)
         },

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -155,6 +155,44 @@ describe("Runner", () => {
   )
 
   it.live(
+    "cancel without metadata annotates the interrupt source",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s, {
+        onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
+      })
+      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancel
+
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) expect(exit.value).toBe("runner.cancel_without_meta:cancel_without_meta:number")
+    }),
+  )
+
+  it.live(
+    "scope interruption without metadata annotates the interrupt source",
+    Effect.gen(function* () {
+      const s = yield* Scope.make()
+      const runner = Runner.make<string>(s, {
+        onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
+      })
+      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* Scope.close(s, Exit.void)
+
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value).toBe("runner.interrupt_without_meta:fiber_interrupt_without_meta:number")
+      }
+    }),
+  )
+
+  it.live(
     "cancel with queued callers resolves all",
     Effect.gen(function* () {
       const s = yield* Scope.Scope

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect } from "bun:test"
+import { Effect, Exit, Fiber, Layer } from "effect"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { SessionRunState } from "../../src/session/run-state"
+import { SessionID } from "../../src/session/schema"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, SessionRunState.defaultLayer))
+
+describe("SessionRunState", () => {
+  it.live("annotates runner interrupts caused by the run-state scope closing", () => {
+    let captured: { source?: string; reason?: string; recordedAt?: number } | undefined
+
+    return provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_run_state_scope"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Effect.never,
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Instance.dispose())
+
+          const exit = yield* Fiber.await(fiber)
+          expect(Exit.isSuccess(exit)).toBe(true)
+
+          expect(captured).toMatchObject({
+            source: "session.run_state.scope",
+            reason: "scope_closed_without_cancel_meta",
+          })
+          expect(typeof captured?.recordedAt).toBe("number")
+        }),
+      { git: true },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Preserve abort provenance in the minimal diagnostic paths needed for first-turn tool interruption triage.

- Allow renderer `session.action.abort` diagnostics through the desktop sanitizer with only `source`, `mode`, and `result`.
- Annotate runner interrupts that previously reached `onInterrupt` without source metadata.
- Give `SessionRunState` scope-close interruptions a session-specific fallback source.

## Why

The GPT-5.5 first-submit interruption logs narrowed the failure to a runner/session interruption, but the exported diagnostics could not identify who triggered the abort. The renderer already emitted abort diagnostics, but the main-process sanitizer dropped them. On the backend side, direct runner cancel and scope-driven fiber interruption could still arrive at `onInterrupt` with no provenance.

This PR does not try to change prompt execution behavior. It only makes the next exported session tell us whether the interruption came from the renderer abort path, an unattributed runner cancel, or the session run-state scope closing.

## Related Issue

No GitHub issue yet. This came from user-provided diagnostic logs for recurring first-turn tool aborts.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please focus on whether the new provenance labels are stable and specific enough for future exported-session debugging, especially the distinction between `runner.cancel_without_meta`, `runner.interrupt_without_meta`, `session.run_state.finalizer`, and `session.run_state.scope`.

## Risk Notes

Low behavior risk. The change does not alter which runs are cancelled or when they are cancelled; it only attaches metadata to existing interrupt paths and allows an already-emitted renderer abort event through sanitization. No visible UI change.

## How To Verify

```text
Renderer sanitizer test: bun --cwd packages/desktop-electron test src/main/renderer-diagnostics-sanitize.test.ts -> 6 pass, 0 fail
Runner/run-state tests: bun --cwd packages/opencode test test/effect/runner.test.ts test/session/run-state.test.ts -> 31 pass, 0 fail
Desktop Electron typecheck: bun --cwd packages/desktop-electron typecheck -> pass
Opencode typecheck: bun --cwd packages/opencode typecheck -> pass
Diff check: git diff --check -> pass
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
