### PR TITLE
test(app): cover session thinking variant restore

### DIFF
--- a/packages/app/e2e/models/model-picker-thinking.spec.ts
+++ b/packages/app/e2e/models/model-picker-thinking.spec.ts
@@ -84,6 +84,19 @@ async function chooseModelWithVariants(page: Page): Promise<string[] | undefined
   return undefined
 }
 
+async function chooseThinkingVariantFromPicker(page: Page, target: string) {
+  await page.locator('[data-action="prompt-model"]').first().click()
+
+  const thinkingTrigger = page.locator('[data-action="prompt-model-thinking-trigger"]').first()
+  await expect(thinkingTrigger).toBeVisible()
+  await expect(thinkingTrigger).toBeEnabled()
+  await thinkingTrigger.click()
+
+  const option = page.locator(`[data-action="prompt-model-thinking-option"][data-variant="${target}"]`).first()
+  await expect(option).toBeVisible()
+  await option.click()
+}
+
 test("@smoke thinking option click updates variant from nested model picker", async ({ page, project }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
   await project.open()
@@ -97,17 +110,34 @@ test("@smoke thinking option click updates variant from nested model picker", as
   await setVariant(page, undefined)
   await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(null)
 
-  await page.locator('[data-action="prompt-model"]').first().click()
-
-  const thinkingTrigger = page.locator('[data-action="prompt-model-thinking-trigger"]').first()
-  await expect(thinkingTrigger).toBeVisible()
-  await expect(thinkingTrigger).toBeEnabled()
-  await thinkingTrigger.click()
-
-  const option = page.locator(`[data-action="prompt-model-thinking-option"][data-variant="${target}"]`).first()
-  await expect(option).toBeVisible()
-  await option.click()
+  await chooseThinkingVariantFromPicker(page, target)
 
   await expect.poll(() => probe(page).then((state) => state?.selected ?? null), { timeout: 30_000 }).toBe(target)
+  await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(target)
+})
+
+test("session re-entry restores thinking variant from the last user message", async ({ page, project }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await project.open()
+
+  const variants = await chooseModelWithVariants(page)
+  test.skip(!variants, "no visible e2e model with thinking variants")
+  if (!variants) return
+  const target = variants.includes("xhigh") ? "xhigh" : variants[0]
+  if (!target) throw new Error("Expected at least one thinking variant")
+
+  await setVariant(page, undefined)
+  await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(null)
+
+  await chooseThinkingVariantFromPicker(page, target)
+  await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(target)
+
+  const sessionID = await project.user(`session thinking variant ${Date.now()}`)
+
+  await expect.poll(() => probe(page).then((state) => state?.sessionID), { timeout: 30_000 }).toBe(sessionID)
+  await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(target)
+
+  await project.gotoSession()
+  await project.gotoSession(sessionID)
   await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(target)
 })

--- a/packages/app/e2e/models/model-picker-thinking.spec.ts
+++ b/packages/app/e2e/models/model-picker-thinking.spec.ts
@@ -7,6 +7,7 @@ type ModelKey = {
 }
 
 type Probe = {
+  sessionID?: string
   model?: ModelKey
   variant?: string | null
   selected?: string | null
@@ -116,7 +117,7 @@ test("@smoke thinking option click updates variant from nested model picker", as
   await expect.poll(() => probe(page).then((state) => state?.variant ?? null), { timeout: 30_000 }).toBe(target)
 })
 
-test("session re-entry restores thinking variant from the last user message", async ({ page, project }) => {
+test("@smoke session re-entry restores thinking variant from the last user message", async ({ page, project }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
   await project.open()
 

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -14,6 +14,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/session.spec.ts:@smoke session composer matches home structure without docktray or agent control",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke review tab no longer renders the legacy file-tree sub-panel",
+  "packages/app/e2e/models/model-picker-thinking.spec.ts:@smoke session re-entry restores thinking variant from the last user message",
   "packages/app/e2e/models/model-picker-thinking.spec.ts:@smoke thinking option click updates variant from nested model picker",
   "packages/app/e2e/onboarding/home-suggestion-chips.spec.ts:@smoke clicking a suggestion row prefills the composer",
   "packages/app/e2e/onboarding/home-suggestion-chips.spec.ts:@smoke composer placeholder is the static home string",

--- a/packages/opencode/test/github/codeql-workflow.test.ts
+++ b/packages/opencode/test/github/codeql-workflow.test.ts
@@ -51,8 +51,8 @@ describe("codeql workflow", () => {
     expect(job?.["timeout-minutes"]).toBe(30)
     expect(steps).toHaveLength(3)
     expect(checkoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
-    expect(initStep?.uses).toBe("github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7")
-    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7")
+    expect(initStep?.uses).toBe("github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e")
+    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e")
 
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(initStep?.with).toEqual({ languages: "javascript-typescript" })

--- a/packages/opencode/test/github/pr-routing-triage.test.ts
+++ b/packages/opencode/test/github/pr-routing-triage.test.ts
@@ -40,7 +40,7 @@ describe("pr routing workflows", () => {
       contents: "read",
       "pull-requests": "write",
     })
-    expect(labelerStep?.uses).toBe("actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9")
+    expect(labelerStep?.uses).toBe("actions/labeler@f27b608878404679385c85cfa523b85ccb86e213")
     expect(labelerStep?.with).toEqual({ "sync-labels": true })
     expect(labelerWorkflow).not.toContain("persist-credentials: true")
 
@@ -66,7 +66,7 @@ describe("pr routing workflows", () => {
       "persist-credentials": false,
       ref: "${{ github.event.pull_request.base.sha }}",
     })
-    expect(script?.uses).toBe("actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b")
+    expect(script?.uses).toBe("actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3")
     expect(script?.env).toEqual({ PR_NUMBER: "${{ github.event.pull_request.number }}" })
     expect(script?.run).toBeUndefined()
     expect(triageWorkflow).toContain('event: "COMMENT"')


### PR DESCRIPTION
## Summary

Add a focused Playwright regression test for restoring a selected thinking variant after re-entering an existing session.

This also extracts the nested thinking-picker click path into a small helper so the existing #702 click test and the new re-entry test exercise the same UI path. The re-entry test is tagged as `@smoke`, so PR smoke E2E runs both the click regression and the session restore regression.

After the branch was updated onto latest `dev`, PR CI exposed existing workflow pin contract drift from recent action bump commits. This PR also aligns the two opencode workflow contract tests with the current pinned CodeQL, labeler, and github-script SHAs so `unit-opencode` can pass against the latest merge ref.

## Why

PR #702 fixed the frontend picker interaction layer: nested thinking options can be clicked and applied. The remaining risk was coverage, not a confirmed product-code gap: `model-picker-thinking.spec.ts` did not prove that an existing session restores its saved `model.variant` after leaving and re-entering the session.

The new test locks that session re-entry path so a future regression back to the default reasoning effort fails in PR smoke E2E.

## Related Issue

Related to #701 and #702. No new issue is closed by this PR.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that the new smoke test covers the real session re-entry path without adding product-code behavior or widening the model picker scope. Also check that the workflow contract updates only reflect the action SHAs already present on latest `dev`.

## Risk Notes

Low. Test-only change limited to model picker E2E coverage, the smoke inventory assertion, and workflow pin contract expectations. No provider, persistence, routing, product code, or generated files changed.

## How To Verify

```text
Focused re-entry E2E: passed
PLAYWRIGHT_PORT=3132 PLAYWRIGHT_SERVER_PORT=4132 bun run --cwd packages/app test:e2e -- e2e/models/model-picker-thinking.spec.ts --grep "session re-entry restores thinking variant"

Focused model-picker E2E file: passed
PLAYWRIGHT_PORT=3133 PLAYWRIGHT_SERVER_PORT=4133 bun run --cwd packages/app test:e2e -- e2e/models/model-picker-thinking.spec.ts

Focused model-picker smoke grep: passed, 2 tests executed including the re-entry regression
PLAYWRIGHT_PORT=3136 PLAYWRIGHT_SERVER_PORT=4136 bun run --cwd packages/app test:e2e -- e2e/models/model-picker-thinking.spec.ts --grep @smoke

Smoke inventory and workflow contract unit tests: passed, 10 tests
bun test test/github/codeql-workflow.test.ts test/github/pr-routing-triage.test.ts test/config/e2e-smoke-tagging.test.ts

Opencode package CI mirror: passed, 2766 tests
bun turbo test:ci --filter=opencode

Diff check: passed
git diff --check
```

## Screenshots or Recordings

Not attached. This is a test-only regression coverage PR with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
