### PR TITLE
ci: auto-label workflow PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,16 @@ ci:
       - any-glob-to-any-file:
           - ".github/workflows/**"
 
+task:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+P3:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
 platform:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,11 +8,6 @@ task:
       - any-glob-to-any-file:
           - ".github/workflows/**"
 
-P3:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/workflows/**"
-
 platform:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/scripts/label-policy-check.js
+++ b/.github/scripts/label-policy-check.js
@@ -18,6 +18,9 @@ function labelList(labels) {
   return `${labels.slice(0, -1).join(", ")}, or ${labels[labels.length - 1]}`
 }
 
+/**
+ * @param {{ itemType: string, labels?: string[] }} input
+ */
 export function validateLabelPolicy({ itemType, labels = [] }) {
   const labelSet = new Set(labels)
   const errors = []

--- a/.github/scripts/pr-priority-triage.js
+++ b/.github/scripts/pr-priority-triage.js
@@ -1,5 +1,7 @@
 export const TRIAGE_MARKER = "<!-- pawwork-pr-priority-triage-v1 -->"
 
+export const PRIORITY_LABELS = ["P0", "P1", "P2", "P3"]
+
 const LOW_RISK_GLOBS = [
   "docs/**",
   "**/*.md",
@@ -91,5 +93,24 @@ export function buildPriorityReview(paths) {
 Suggested priority: ${verdict.priority} (${verdict.reason}).
 
 ${manualOverride}`,
+  }
+}
+
+/**
+ * @param {string[]} paths
+ * @param {string[]} labels
+ */
+export function planPriorityLabels(paths, labels = []) {
+  const { priority } = classifyPriority(paths)
+  const labelSet = new Set(labels)
+  const existingPriorities = PRIORITY_LABELS.filter((label) => labelSet.has(label))
+  const manualPriority = PRIORITY_LABELS.find((label) => label !== "P3" && labelSet.has(label))
+  const desiredPriority = manualPriority ?? priority
+
+  return {
+    suggestedPriority: priority,
+    desiredPriority,
+    addLabels: labelSet.has(desiredPriority) ? [] : [desiredPriority],
+    removeLabels: existingPriorities.filter((label) => label !== desiredPriority),
   }
 }

--- a/.github/scripts/pr-priority-triage.js
+++ b/.github/scripts/pr-priority-triage.js
@@ -106,13 +106,10 @@ export function planPriorityLabels(paths, labels = []) {
   const existingPriorities = PRIORITY_LABELS.filter((label) => labelSet.has(label))
   const manualPriority = PRIORITY_LABELS.find((label) => label !== "P3" && labelSet.has(label))
   const desiredPriority = manualPriority ?? priority
-  const nextLabels = labels.filter((label) => !PRIORITY_LABELS.includes(label))
-  nextLabels.push(desiredPriority)
 
   return {
     suggestedPriority: priority,
     desiredPriority,
-    labels: nextLabels,
     addLabels: labelSet.has(desiredPriority) ? [] : [desiredPriority],
     removeLabels: existingPriorities.filter((label) => label !== desiredPriority),
   }

--- a/.github/scripts/pr-priority-triage.js
+++ b/.github/scripts/pr-priority-triage.js
@@ -106,10 +106,13 @@ export function planPriorityLabels(paths, labels = []) {
   const existingPriorities = PRIORITY_LABELS.filter((label) => labelSet.has(label))
   const manualPriority = PRIORITY_LABELS.find((label) => label !== "P3" && labelSet.has(label))
   const desiredPriority = manualPriority ?? priority
+  const nextLabels = labels.filter((label) => !PRIORITY_LABELS.includes(label))
+  nextLabels.push(desiredPriority)
 
   return {
     suggestedPriority: priority,
     desiredPriority,
+    labels: nextLabels,
     addLabels: labelSet.has(desiredPriority) ? [] : [desiredPriority],
     removeLabels: existingPriorities.filter((label) => label !== desiredPriority),
   }

--- a/.github/workflows/label-policy.yml
+++ b/.github/workflows/label-policy.yml
@@ -40,7 +40,13 @@ jobs:
             const item =
               context.eventName === "issues" ? context.payload.issue : context.payload.pull_request
             const itemType = context.eventName === "issues" ? "issue" : "pull_request"
-            const labels = item.labels.map((label) => label.name)
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: item.number,
+              per_page: 100,
+            })
+            const labels = currentLabels.map((label) => label.name)
             const result = policy.validateLabelPolicy({ itemType, labels })
 
             if (!result.ok) {

--- a/.github/workflows/pr-priority-triage.yml
+++ b/.github/workflows/pr-priority-triage.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -33,7 +34,7 @@ jobs:
             const triage = await import(
               pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/pr-priority-triage.js")).href,
             )
-            const { buildPriorityReview, TRIAGE_MARKER } = triage
+            const { buildPriorityReview, planPriorityLabels, TRIAGE_MARKER } = triage
             const pull_number = Number(process.env.PR_NUMBER)
             const owner = context.repo.owner
             const repo = context.repo.repo
@@ -45,6 +46,37 @@ jobs:
               per_page: 100,
             })
             const paths = files.map((file) => file.filename)
+
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            })
+            const labelPlan = planPriorityLabels(paths, currentLabels.map((label) => label.name))
+
+            for (const name of labelPlan.removeLabels) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name })
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error
+                }
+              }
+            }
+
+            if (labelPlan.addLabels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pull_number,
+                labels: labelPlan.addLabels,
+              })
+            }
+
+            core.info(
+              `Synced priority label: suggested=${labelPlan.suggestedPriority}, desired=${labelPlan.desiredPriority}`,
+            )
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,

--- a/.github/workflows/pr-priority-triage.yml
+++ b/.github/workflows/pr-priority-triage.yml
@@ -55,13 +55,23 @@ jobs:
             })
             const labelPlan = planPriorityLabels(paths, currentLabels.map((label) => label.name))
 
-            if (labelPlan.addLabels.length > 0 || labelPlan.removeLabels.length > 0) {
-              await github.rest.issues.setLabels({
+            if (labelPlan.addLabels.length > 0) {
+              await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: pull_number,
-                labels: labelPlan.labels,
+                labels: labelPlan.addLabels,
               })
+            }
+
+            for (const name of labelPlan.removeLabels) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name })
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error
+                }
+              }
             }
 
             core.info(

--- a/.github/workflows/pr-priority-triage.yml
+++ b/.github/workflows/pr-priority-triage.yml
@@ -55,22 +55,12 @@ jobs:
             })
             const labelPlan = planPriorityLabels(paths, currentLabels.map((label) => label.name))
 
-            for (const name of labelPlan.removeLabels) {
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name })
-              } catch (error) {
-                if (error.status !== 404) {
-                  throw error
-                }
-              }
-            }
-
-            if (labelPlan.addLabels.length > 0) {
-              await github.rest.issues.addLabels({
+            if (labelPlan.addLabels.length > 0 || labelPlan.removeLabels.length > 0) {
+              await github.rest.issues.setLabels({
                 owner,
                 repo,
                 issue_number: pull_number,
-                labels: labelPlan.addLabels,
+                labels: labelPlan.labels,
               })
             }
 

--- a/packages/opencode/test/github/codeql-workflow.test.ts
+++ b/packages/opencode/test/github/codeql-workflow.test.ts
@@ -51,8 +51,8 @@ describe("codeql workflow", () => {
     expect(job?.["timeout-minutes"]).toBe(30)
     expect(steps).toHaveLength(3)
     expect(checkoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
-    expect(initStep?.uses).toBe("github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7")
-    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7")
+    expect(initStep?.uses).toBe("github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e")
+    expect(analyzeStep?.uses).toBe("github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e")
 
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(initStep?.with).toEqual({ languages: "javascript-typescript" })

--- a/packages/opencode/test/github/label-policy-workflow.test.ts
+++ b/packages/opencode/test/github/label-policy-workflow.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { parseWorkflow, readWorkflow } from "./workflow-parser"
+
+const repoRoot = path.join(import.meta.dir, "../../../..")
+const workflowPath = path.join(repoRoot, ".github", "workflows", "label-policy.yml")
+
+describe("label policy workflow", () => {
+  test("validates current labels instead of labeled event snapshots", () => {
+    const workflow = readWorkflow(workflowPath)
+    const parsed = parseWorkflow(workflowPath)
+    const job = parsed.jobs?.["label-policy"]
+    const steps = job?.steps ?? []
+    const scriptStep = steps.find((step) => step.uses?.startsWith("actions/github-script@"))
+
+    expect(parsed.name).toBe("label-policy")
+    expect(parsed.permissions).toEqual({
+      contents: "read",
+      issues: "read",
+      "pull-requests": "read",
+    })
+    expect(scriptStep?.uses).toBe("actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3")
+    expect(workflow).toContain("github.rest.issues.listLabelsOnIssue")
+    expect(workflow).toContain("issue_number: item.number")
+    expect(workflow).toContain("const labels = currentLabels.map((label) => label.name)")
+    expect(workflow).not.toContain("const labels = item.labels.map((label) => label.name)")
+  })
+})

--- a/packages/opencode/test/github/pr-routing-triage.test.ts
+++ b/packages/opencode/test/github/pr-routing-triage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import path from "node:path"
+import { validateLabelPolicy } from "../../../../.github/scripts/label-policy-check.js"
 import { buildPriorityReview, classifyPriority, TRIAGE_MARKER } from "../../../../.github/scripts/pr-priority-triage.js"
 import { parseWorkflow, readWorkflow } from "./workflow-parser"
 
@@ -8,10 +9,33 @@ const labelerConfigPath = path.join(repoRoot, ".github", "labeler.yml")
 const labelerWorkflowPath = path.join(repoRoot, ".github", "workflows", "labeler.yml")
 const triageWorkflowPath = path.join(repoRoot, ".github", "workflows", "pr-priority-triage.yml")
 
+type LabelerRule = {
+  "changed-files"?: Array<{
+    "any-glob-to-any-file"?: string[]
+  }>
+}
+
+type LabelerConfig = Record<string, LabelerRule[]>
+
+function labelerLabelsForGlob(glob: string) {
+  const config = parseWorkflow(labelerConfigPath) as unknown as LabelerConfig
+  return Object.entries(config)
+    .filter(([, rules]) =>
+      rules.some((rule) =>
+        rule["changed-files"]?.some((changedFilesRule) =>
+          changedFilesRule["any-glob-to-any-file"]?.includes(glob),
+        ),
+      ),
+    )
+    .map(([label]) => label)
+}
+
 describe("pr routing workflows", () => {
-  test("defines labeler routing without automatic type labels", () => {
+  test("defines labeler routing for repo areas and workflow policy labels", () => {
     const config = readWorkflow(labelerConfigPath)
     expect(config).toContain("ci:")
+    expect(config).toContain("task:")
+    expect(config).toContain("P3:")
     expect(config).toContain("platform:")
     expect(config).toContain("app:")
     expect(config).toContain("ui:")
@@ -23,6 +47,13 @@ describe("pr routing workflows", () => {
     expect(config).toContain("packages/opencode/**")
     expect(config).toContain("**/*.tsx")
     expect(config).not.toContain("**/*.md")
+  })
+
+  test("labels workflow PRs with the full pull request policy set", () => {
+    const labels = labelerLabelsForGlob(".github/workflows/**")
+
+    expect(new Set(labels)).toEqual(new Set(["ci", "task", "P3"]))
+    expect(validateLabelPolicy({ itemType: "pull_request", labels }).ok).toBe(true)
   })
 
   test("pins labeler and triage workflow contracts", () => {
@@ -40,7 +71,7 @@ describe("pr routing workflows", () => {
       contents: "read",
       "pull-requests": "write",
     })
-    expect(labelerStep?.uses).toBe("actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9")
+    expect(labelerStep?.uses).toBe("actions/labeler@f27b608878404679385c85cfa523b85ccb86e213")
     expect(labelerStep?.with).toEqual({ "sync-labels": true })
     expect(labelerWorkflow).not.toContain("persist-credentials: true")
 
@@ -66,7 +97,7 @@ describe("pr routing workflows", () => {
       "persist-credentials": false,
       ref: "${{ github.event.pull_request.base.sha }}",
     })
-    expect(script?.uses).toBe("actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b")
+    expect(script?.uses).toBe("actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3")
     expect(script?.env).toEqual({ PR_NUMBER: "${{ github.event.pull_request.number }}" })
     expect(script?.run).toBeUndefined()
     expect(triageWorkflow).toContain('event: "COMMENT"')

--- a/packages/opencode/test/github/pr-routing-triage.test.ts
+++ b/packages/opencode/test/github/pr-routing-triage.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import path from "node:path"
 import { validateLabelPolicy } from "../../../../.github/scripts/label-policy-check.js"
-import { buildPriorityReview, classifyPriority, TRIAGE_MARKER } from "../../../../.github/scripts/pr-priority-triage.js"
+import {
+  buildPriorityReview,
+  classifyPriority,
+  planPriorityLabels,
+  TRIAGE_MARKER,
+} from "../../../../.github/scripts/pr-priority-triage.js"
 import { parseWorkflow, readWorkflow } from "./workflow-parser"
 
 const repoRoot = path.join(import.meta.dir, "../../../..")
@@ -35,7 +40,7 @@ describe("pr routing workflows", () => {
     const config = readWorkflow(labelerConfigPath)
     expect(config).toContain("ci:")
     expect(config).toContain("task:")
-    expect(config).toContain("P3:")
+    expect(config).not.toContain("P3:")
     expect(config).toContain("platform:")
     expect(config).toContain("app:")
     expect(config).toContain("ui:")
@@ -49,11 +54,11 @@ describe("pr routing workflows", () => {
     expect(config).not.toContain("**/*.md")
   })
 
-  test("labels workflow PRs with the full pull request policy set", () => {
+  test("labels workflow PRs with type and routing while priority triage owns priority", () => {
     const labels = labelerLabelsForGlob(".github/workflows/**")
 
-    expect(new Set(labels)).toEqual(new Set(["ci", "task", "P3"]))
-    expect(validateLabelPolicy({ itemType: "pull_request", labels }).ok).toBe(true)
+    expect(new Set(labels)).toEqual(new Set(["ci", "task"]))
+    expect(validateLabelPolicy({ itemType: "pull_request", labels: [...labels, "P3"] }).ok).toBe(true)
   })
 
   test("pins labeler and triage workflow contracts", () => {
@@ -88,6 +93,7 @@ describe("pr routing workflows", () => {
     })
     expect(triageParsed.permissions).toEqual({
       contents: "read",
+      issues: "write",
       "pull-requests": "write",
     })
     expect(triageParsed.concurrency?.group).toBe("pr-priority-triage-${{ github.event.pull_request.number }}")
@@ -103,12 +109,15 @@ describe("pr routing workflows", () => {
     expect(triageWorkflow).toContain('event: "COMMENT"')
     expect(triageWorkflow).toContain("TRIAGE_MARKER")
     expect(triageWorkflow).toContain("github.rest.pulls.listFiles")
+    expect(triageWorkflow).toContain("github.rest.issues.listLabelsOnIssue")
+    expect(triageWorkflow).toContain("github.rest.issues.removeLabel")
+    expect(triageWorkflow).toContain("github.rest.issues.addLabels")
+    expect(triageWorkflow).toContain("planPriorityLabels")
     expect(triageWorkflow).toContain("github.rest.pulls.listReviews")
     expect(triageWorkflow).toContain("pathToFileURL")
     expect(triageWorkflow).toContain("process.env.GITHUB_WORKSPACE")
     expect(triageWorkflow).toContain("await import(")
     expect(triageWorkflow).not.toContain('require("./.github/scripts/pr-priority-triage.js")')
-    expect(triageWorkflow).not.toContain("issues:")
   })
 })
 
@@ -143,6 +152,36 @@ describe("pr priority triage helper", () => {
     expect(review.body).toContain(TRIAGE_MARKER)
     expect(review.body).toContain("Suggested priority: P3")
     expect(review.body).toContain("P1/P0 are reserved for maintainer confirmation")
+  })
+
+  test("plans priority labels without letting default P3 override mixed or manual priority", () => {
+    expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task"])).toEqual({
+      suggestedPriority: "P3",
+      desiredPriority: "P3",
+      addLabels: ["P3"],
+      removeLabels: [],
+    })
+
+    expect(
+      planPriorityLabels([".github/workflows/labeler.yml", "packages/app/src/context/global-sync.tsx"], [
+        "ci",
+        "task",
+        "app",
+        "P3",
+      ]),
+    ).toEqual({
+      suggestedPriority: "P2",
+      desiredPriority: "P2",
+      addLabels: ["P2"],
+      removeLabels: ["P3"],
+    })
+
+    expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task", "P2", "P3"])).toEqual({
+      suggestedPriority: "P3",
+      desiredPriority: "P2",
+      addLabels: [],
+      removeLabels: ["P3"],
+    })
   })
 
   test("matches recent PR sanity cases", () => {

--- a/packages/opencode/test/github/pr-routing-triage.test.ts
+++ b/packages/opencode/test/github/pr-routing-triage.test.ts
@@ -110,8 +110,9 @@ describe("pr routing workflows", () => {
     expect(triageWorkflow).toContain("TRIAGE_MARKER")
     expect(triageWorkflow).toContain("github.rest.pulls.listFiles")
     expect(triageWorkflow).toContain("github.rest.issues.listLabelsOnIssue")
-    expect(triageWorkflow).toContain("github.rest.issues.removeLabel")
-    expect(triageWorkflow).toContain("github.rest.issues.addLabels")
+    expect(triageWorkflow).toContain("github.rest.issues.setLabels")
+    expect(triageWorkflow).not.toContain("github.rest.issues.removeLabel")
+    expect(triageWorkflow).not.toContain("github.rest.issues.addLabels")
     expect(triageWorkflow).toContain("planPriorityLabels")
     expect(triageWorkflow).toContain("github.rest.pulls.listReviews")
     expect(triageWorkflow).toContain("pathToFileURL")
@@ -158,6 +159,7 @@ describe("pr priority triage helper", () => {
     expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task"])).toEqual({
       suggestedPriority: "P3",
       desiredPriority: "P3",
+      labels: ["ci", "task", "P3"],
       addLabels: ["P3"],
       removeLabels: [],
     })
@@ -172,6 +174,7 @@ describe("pr priority triage helper", () => {
     ).toEqual({
       suggestedPriority: "P2",
       desiredPriority: "P2",
+      labels: ["ci", "task", "app", "P2"],
       addLabels: ["P2"],
       removeLabels: ["P3"],
     })
@@ -179,6 +182,7 @@ describe("pr priority triage helper", () => {
     expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task", "P2", "P3"])).toEqual({
       suggestedPriority: "P3",
       desiredPriority: "P2",
+      labels: ["ci", "task", "P2"],
       addLabels: [],
       removeLabels: ["P3"],
     })

--- a/packages/opencode/test/github/pr-routing-triage.test.ts
+++ b/packages/opencode/test/github/pr-routing-triage.test.ts
@@ -110,9 +110,9 @@ describe("pr routing workflows", () => {
     expect(triageWorkflow).toContain("TRIAGE_MARKER")
     expect(triageWorkflow).toContain("github.rest.pulls.listFiles")
     expect(triageWorkflow).toContain("github.rest.issues.listLabelsOnIssue")
-    expect(triageWorkflow).toContain("github.rest.issues.setLabels")
-    expect(triageWorkflow).not.toContain("github.rest.issues.removeLabel")
-    expect(triageWorkflow).not.toContain("github.rest.issues.addLabels")
+    expect(triageWorkflow).toContain("github.rest.issues.addLabels")
+    expect(triageWorkflow).toContain("github.rest.issues.removeLabel")
+    expect(triageWorkflow).not.toContain("github.rest.issues.setLabels")
     expect(triageWorkflow).toContain("planPriorityLabels")
     expect(triageWorkflow).toContain("github.rest.pulls.listReviews")
     expect(triageWorkflow).toContain("pathToFileURL")
@@ -159,7 +159,13 @@ describe("pr priority triage helper", () => {
     expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task"])).toEqual({
       suggestedPriority: "P3",
       desiredPriority: "P3",
-      labels: ["ci", "task", "P3"],
+      addLabels: ["P3"],
+      removeLabels: [],
+    })
+
+    expect(planPriorityLabels([".github/workflows/labeler.yml"], [])).toEqual({
+      suggestedPriority: "P3",
+      desiredPriority: "P3",
       addLabels: ["P3"],
       removeLabels: [],
     })
@@ -174,7 +180,6 @@ describe("pr priority triage helper", () => {
     ).toEqual({
       suggestedPriority: "P2",
       desiredPriority: "P2",
-      labels: ["ci", "task", "app", "P2"],
       addLabels: ["P2"],
       removeLabels: ["P3"],
     })
@@ -182,7 +187,6 @@ describe("pr priority triage helper", () => {
     expect(planPriorityLabels([".github/workflows/labeler.yml"], ["ci", "task", "P2", "P3"])).toEqual({
       suggestedPriority: "P3",
       desiredPriority: "P2",
-      labels: ["ci", "task", "P2"],
       addLabels: [],
       removeLabels: ["P3"],
     })


### PR DESCRIPTION
## Summary

- Keep workflow-file labeler routing scoped to `ci` and `task` for `.github/workflows/**` changes.
- Move PR priority ownership to `pr-priority-triage`, which defaults low-risk workflow-only PRs to `P3`, upgrades mixed-risk paths to `P2`, and preserves manual `P2` / `P1` / `P0` relabeling.
- Make `label-policy` validate the current label set from the GitHub API instead of labeled/unlabeled event snapshots, avoiding transient failures while priority labels are synchronized.
- Refresh workflow action pin assertions that changed after Dependabot PRs #711, #713, and #714 landed.

## Why

Dependabot GitHub Actions PRs #711-#714 exposed two gaps in PR metadata automation:

- Workflow-only PRs needed automatic type and priority metadata so `label-policy` would not open red.
- A fixed labeler `P3` rule was too blunt for mixed-risk PRs that also touch app, desktop, or harness code.

This keeps area/type routing in labeler and puts risk-based priority decisions in the existing priority triage workflow.

## Related Issue

No dedicated issue. Follow-up from Dependabot PRs #711-#714.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm `pr-priority-triage` is the right owner for PR priority labels.
- Confirm manual priority upgrades remain stable after `synchronize` events.
- Confirm `label-policy` reading current labels is the right protection against labeled/unlabeled event ordering.

## Risk Notes

Low-to-medium. This changes GitHub PR label automation only, but it now writes priority labels from the triage workflow. The workflow preserves manual `P2`, `P1`, and `P0` labels and only defaults to `P3` when no higher manual priority exists.

## How To Verify

```text
Focused workflow tests: bun --cwd packages/opencode test test/github -> 30 pass, 0 fail.
Typecheck: cd packages/opencode && bun run typecheck -> pass.
Diff check: git diff --check -> no whitespace errors.
GitHub PR checks: rerun after each pushed commit; latest head should be green before merge.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request auto-labeling system with improved priority classification and label management via GitHub API integration.
  * Updated GitHub Actions workflow permissions and versions for better label automation and validation.

* **Tests**
  * Added and updated workflow tests to verify improved labeling behavior and GitHub Action version requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->