### PR TITLE
fix(app): make model picker height adaptive to model count

### DIFF
--- a/packages/app/e2e/model-picker-height.spec.ts
+++ b/packages/app/e2e/model-picker-height.spec.ts
@@ -4,7 +4,7 @@ import { promptModelSelector } from "./selectors"
 const pickerContentSelector = '[data-picker-content=""]'
 const thinkingTriggerSelector = '[data-action="prompt-model-thinking-trigger"]'
 
-test("model picker height fits content, no empty bottom space", async ({ page, gotoSession }, testInfo) => {
+test("@smoke model picker height fits content, no empty bottom space", async ({ page, gotoSession }, testInfo) => {
   await gotoSession()
 
   const chip = page.locator(promptModelSelector).locator('[data-action="prompt-model"]').first()

--- a/packages/app/e2e/model-picker-height.spec.ts
+++ b/packages/app/e2e/model-picker-height.spec.ts
@@ -11,7 +11,11 @@ test("model picker height fits content, no empty bottom space", async ({ page, g
   await expect(chip).toBeVisible()
   await chip.click()
 
-  const picker = page.locator(pickerContentSelector).first()
+  // Variant (Thinking) sub-popover also uses [data-picker-content]; scope by the
+  // model list scroll container so the locator stays unambiguous if both render.
+  const picker = page
+    .locator(pickerContentSelector)
+    .filter({ has: page.locator('[data-slot="list-scroll"]') })
   await expect(picker).toBeVisible()
 
   const thinking = page.locator(thinkingTriggerSelector)

--- a/packages/app/e2e/model-picker-height.spec.ts
+++ b/packages/app/e2e/model-picker-height.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "./fixtures"
+import { promptModelSelector } from "./selectors"
+
+const pickerContentSelector = '[data-picker-content=""]'
+const thinkingTriggerSelector = '[data-action="prompt-model-thinking-trigger"]'
+
+test("model picker height fits content, no empty bottom space", async ({ page, gotoSession }, testInfo) => {
+  await gotoSession()
+
+  const chip = page.locator(promptModelSelector).locator('[data-action="prompt-model"]').first()
+  await expect(chip).toBeVisible()
+  await chip.click()
+
+  const picker = page.locator(pickerContentSelector).first()
+  await expect(picker).toBeVisible()
+
+  const thinking = page.locator(thinkingTriggerSelector)
+  await expect(thinking).toBeVisible()
+
+  const items = picker.locator('[data-slot="list-item"]')
+  const itemCount = await items.count()
+  expect(itemCount, "expected at least one model in the picker").toBeGreaterThan(0)
+  const lastItem = items.nth(itemCount - 1)
+
+  const pickerBox = await picker.boundingBox()
+  const lastItemBox = await lastItem.boundingBox()
+  const thinkingBox = await thinking.boundingBox()
+  if (!pickerBox || !lastItemBox || !thinkingBox) throw new Error("picker layout box missing")
+
+  // The model list and the Thinking row are stacked in a flex-col. Between the last
+  // visible model and the Thinking row only the list's own gap (12px) plus the
+  // section's border + padding belong. When the popover is forced to a fixed 400px
+  // and the model list happens to be short, the list-scroll grows to fill flex-1
+  // and an empty band appears above the Thinking row.
+  const scrollHeight = await picker
+    .locator('[data-slot="list-scroll"]')
+    .evaluate((el) => el.scrollHeight)
+  const clientHeight = await picker
+    .locator('[data-slot="list-scroll"]')
+    .evaluate((el) => el.clientHeight)
+  const listOverflowing = scrollHeight > clientHeight + 1
+
+  const lastItemBottom = lastItemBox.y + lastItemBox.height
+  const gapBelowLastItem = thinkingBox.y - lastItemBottom
+
+  // If the list scrolls, the last DOM item may be clipped offscreen, so we only
+  // require the no-empty-band invariant when the content fits without scrolling.
+  if (!listOverflowing) {
+    expect(
+      gapBelowLastItem,
+      "no empty band should appear between last model and Thinking row",
+    ).toBeLessThan(40)
+  }
+
+  expect(pickerBox.height, "popover height should not exceed the 400px cap").toBeLessThanOrEqual(400)
+
+  const screenshotPath = testInfo.outputPath("model-picker.png")
+  await picker.screenshot({ path: screenshotPath })
+  await testInfo.attach("model-picker", { path: screenshotPath, contentType: "image/png" })
+})

--- a/packages/app/e2e/model-picker-height.spec.ts
+++ b/packages/app/e2e/model-picker-height.spec.ts
@@ -31,30 +31,34 @@ test("model picker height fits content, no empty bottom space", async ({ page, g
   const thinkingBox = await thinking.boundingBox()
   if (!pickerBox || !lastItemBox || !thinkingBox) throw new Error("picker layout box missing")
 
-  // The model list and the Thinking row are stacked in a flex-col. Between the last
-  // visible model and the Thinking row only the list's own gap (12px) plus the
-  // section's border + padding belong. When the popover is forced to a fixed 400px
-  // and the model list happens to be short, the list-scroll grows to fill flex-1
-  // and an empty band appears above the Thinking row.
+  // Precondition: this regression case targets the short-list scenario from the
+  // bug report. If the fixture's default visible model count ever grows large
+  // enough to overflow the 400px cap, the gap assertion below would silently
+  // skip and stop protecting the regression. Fail loudly instead so a future
+  // maintainer notices and either restores a short-list fixture or adds a
+  // separate spec for the overflow case.
   const scrollHeight = await picker
     .locator('[data-slot="list-scroll"]')
     .evaluate((el) => el.scrollHeight)
   const clientHeight = await picker
     .locator('[data-slot="list-scroll"]')
     .evaluate((el) => el.clientHeight)
-  const listOverflowing = scrollHeight > clientHeight + 1
+  expect(
+    scrollHeight,
+    "expected the fixture to render a short list that fits without scrolling",
+  ).toBeLessThanOrEqual(clientHeight + 1)
 
+  // The model list and the Thinking row are stacked in a flex-col. Between the
+  // last visible model and the Thinking row only the list's own gap (12px) plus
+  // the section's border + padding belong. When the popover is forced to a
+  // fixed 400px and the model list happens to be short, the list-scroll grows
+  // to fill flex-1 and an empty band appears above the Thinking row.
   const lastItemBottom = lastItemBox.y + lastItemBox.height
   const gapBelowLastItem = thinkingBox.y - lastItemBottom
-
-  // If the list scrolls, the last DOM item may be clipped offscreen, so we only
-  // require the no-empty-band invariant when the content fits without scrolling.
-  if (!listOverflowing) {
-    expect(
-      gapBelowLastItem,
-      "no empty band should appear between last model and Thinking row",
-    ).toBeLessThan(40)
-  }
+  expect(
+    gapBelowLastItem,
+    "no empty band should appear between last model and Thinking row",
+  ).toBeLessThan(40)
 
   expect(pickerBox.height, "popover height should not exceed the 400px cap").toBeLessThanOrEqual(400)
 

--- a/packages/app/src/components/prompt-input/model-picker.tsx
+++ b/packages/app/src/components/prompt-input/model-picker.tsx
@@ -215,7 +215,7 @@ export function ModelSelectorPopover(props: {
       <Kobalte.Portal>
         <Kobalte.Content
           data-picker-content=""
-          class="w-[240px] h-[400px] flex flex-col z-50 outline-none overflow-hidden"
+          class="w-[240px] max-h-[400px] flex flex-col z-50 outline-none overflow-hidden"
           onEscapeKeyDown={(event) => {
             close("escape")
             event.preventDefault()

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -14,6 +14,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/session.spec.ts:@smoke session composer matches home structure without docktray or agent control",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke review tab no longer renders the legacy file-tree sub-panel",
+  "packages/app/e2e/model-picker-height.spec.ts:@smoke model picker height fits content, no empty bottom space",
   "packages/app/e2e/models/model-picker-thinking.spec.ts:@smoke thinking option click updates variant from nested model picker",
   "packages/app/e2e/onboarding/home-suggestion-chips.spec.ts:@smoke clicking a suggestion row prefills the composer",
   "packages/app/e2e/onboarding/home-suggestion-chips.spec.ts:@smoke composer placeholder is the static home string",


### PR DESCRIPTION
## Summary

Switch the model selector popover from a fixed `h-[400px]` to `max-h-[400px]` so it hugs its natural content height and only scrolls when models exceed the 400px cap. Add an E2E spec that locks the geometry invariant.

## Why

When a user only has a handful of visible models (e.g. the OpenCode Zen free tier with four entries), the popover was still forced to 400px tall, leaving a ~190px empty band between the last model row and the Thinking row at the bottom. The popover should adapt to model count.

Root cause: `packages/app/src/components/prompt-input/model-picker.tsx:218` set a fixed height on the `Kobalte.Content`. The inner `ModelList` uses `flex-1 min-h-0`, so it expanded to fill the fixed 400px and produced a visible empty band above the Thinking row.

## Related Issue

Closes #719.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- The single CSS class change on `Kobalte.Content`. The `flex-1 min-h-0` chain on `ModelList` -> `list-scroll` still works under `max-h` because the chain stays unbroken when the cap kicks in; when content fits, the column shrinks to content height instead.
- The new E2E spec: it asserts the fixture renders a short list that fits without scrolling (precondition), then asserts there is no empty band between the last `[data-slot="list-item"]` and `[data-action="prompt-model-thinking-trigger"]`, and finally that `popover.height <= 400`. If a future fixture grows large enough to overflow the cap, the precondition fails loudly rather than silently skipping the regression check.
- The spec is tagged `@smoke` so the regression is enforced by the PR `e2e-artifacts` gate. The smoke inventory in `packages/opencode/test/config/e2e-smoke-tagging.test.ts` is updated in lockstep (alphabetical order).

## Risk Notes

None. The fix is a single CSS class swap with no behavioral side effects. The new spec runs in the existing Playwright project, no infra changes.

## How To Verify

```text
Negative check (revert fix, run spec): 1 failed — gap below last model = 193.25px
Positive check (apply fix, run spec):  1 passed — popover hugs content
bun --cwd packages/app run test:e2e:local e2e/model-picker-height.spec.ts
```

Smoke inventory contract: `bun --cwd packages/opencode test test/config/e2e-smoke-tagging.test.ts` -> 2 pass.

## Screenshots or Recordings

E2E captures a screenshot artifact at `e2e/test-results/.../model-picker.png` on every run. With the fix applied the popover ends right under the four visible models and the Thinking row, with no empty band. Local screenshot reviewed and confirmed visually before opening this PR.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


