### PR TITLE
docs: add agent quickstart to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ Please open an issue first for larger feature proposals or changes that affect p
 - Optimize for non-technical users, not developer convenience alone.
 - Do not rewrite broad areas of the fork without prior discussion.
 
+## Agent Quickstart
+
+AI coding agents should use the same public contribution contract as human contributors.
+
+- Use GitHub issues, pull requests, and CI as the public sources of truth for scope, review state, and merge readiness.
+- Do not rely on private local notes, local coordination boards, or personal agent rules to build, test, review, or merge a contribution.
+- Start from the smallest issue or task boundary that can be reviewed independently.
+- Before changing code, identify the affected product layer and the smallest relevant verification path.
+- For visible UI changes, manually check the desktop app and include screenshots or a short recording in the pull request.
+
 ## Development Setup
 
 PawWork uses Bun and requires Node 24 in CI.
@@ -38,8 +48,7 @@ bun install --frozen-lockfile
 For local development:
 
 ```bash
-cd packages/desktop-electron
-bun run dev
+bun run dev:desktop
 ```
 
 ## Branches and Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ AI coding agents should use the same public contribution contract as human contr
 - Do not rely on private local notes, local coordination boards, or personal agent rules to build, test, review, or merge a contribution.
 - Start from the smallest issue or task boundary that can be reviewed independently.
 - Before changing code, identify the affected product layer and the smallest relevant verification path.
-- For visible UI changes, manually check the desktop app and include screenshots or a short recording in the pull request.
+- For visible UI changes, follow the verification and reporting steps in the [Verification](#verification) section.
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

Add a short Agent Quickstart section to the public contribution guide and align the local desktop dev command with the root `dev:desktop` script.

## Why

External agents and new contributors need a public, stable starting contract without relying on private local `AGENTS.md`, `STATUS.md`, or personal coordination notes. This keeps local workflow state private while making the public contribution path clearer.

## Related Issue

No issue. Small documentation-only DX clarification.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Confirm the wording keeps private local coordination out of the public repo while giving agents enough public guidance to start safely.

## Risk Notes

None. Documentation-only change.

## How To Verify

```text
Diff check: git diff --check -- CONTRIBUTING.md passed
Scope check: only CONTRIBUTING.md changed
Local-private check: no AGENTS.md or STATUS.md changes
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
