### PR TITLE
fix(config): gate Instance dispose on actual config change

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1124,18 +1124,27 @@ const rawLayer = Layer.effect(
       const dir = yield* InstanceState.directory
       const file = projectConfigFile(dir)
       const input = writable(config)
+      let changed: boolean
 
       if (!file.endsWith(".jsonc")) {
         const existing = yield* loadFile(file)
-        yield* fs
-          .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), input), null, 2))
-          .pipe(Effect.orDie)
+        // Re-read after loadFile so we see any auto-added $schema, otherwise
+        // the first call would always write and tear instances down.
+        const before = (yield* readConfigFile(file)) ?? "{}"
+        const serialized = JSON.stringify(mergeDeep(writable(existing), input), null, 2)
+        changed = serialized !== before
+        if (changed) yield* fs.writeFileString(file, serialized).pipe(Effect.orDie)
       } else {
         const before = (yield* readConfigFile(file)) ?? "{}"
-        yield* fs.writeFileString(file, patchJsonc(before, input)).pipe(Effect.orDie)
+        const updated = patchJsonc(before, input)
+        changed = updated !== before
+        if (changed) yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
       }
 
-      yield* Effect.promise(() => Instance.dispose())
+      // Only tear down running instances if config actually changed on disk.
+      // No-op writes from UI mounts (see upstream PR #25114) would otherwise
+      // abort any in-flight assistant turn.
+      if (changed) yield* Effect.promise(() => Instance.dispose())
     })
 
     const invalidate = Effect.fn("Config.invalidate")(function* (wait?: boolean) {
@@ -1160,6 +1169,7 @@ const rawLayer = Layer.effect(
       const file = globalConfigFile()
       const lock = yield* Effect.promise(() => Flock.acquire(configFileLockKey(file)))
       let next: Info
+      let changed: boolean
       try {
         if (!Runtime.isPawWork()) yield* Effect.promise(() => fsNode.mkdir(path.dirname(file), { recursive: true }))
         const existingText = yield* readConfigFile(file)
@@ -1186,26 +1196,34 @@ const rawLayer = Layer.effect(
               }
             : undefined
         const before = existingText ?? seed?.text ?? "{}"
+        const fileExisted = existingText !== undefined
         const writeOptions =
           existingText === undefined && Runtime.isPawWork() ? { mode: seed?.mode ?? 0o600 } : undefined
 
         if (!file.endsWith(".jsonc")) {
           const existing = ConfigParse.schema(Info.zod, ConfigParse.jsonc(before, file), file)
           const merged = mergeDeep(writable(existing), writable(config))
-          yield* Effect.promise(() => writeConfigTextAtomic(file, JSON.stringify(merged, null, 2), writeOptions)).pipe(
-            Effect.orDie,
-          )
+          const serialized = JSON.stringify(merged, null, 2)
+          // Always materialize on first run (seed migration), otherwise only
+          // when bytes change. See upstream PR #25114.
+          changed = !fileExisted || serialized !== before
+          if (changed)
+            yield* Effect.promise(() => writeConfigTextAtomic(file, serialized, writeOptions)).pipe(Effect.orDie)
           next = merged
         } else {
           const updated = patchJsonc(before, writable(config))
           next = ConfigParse.schema(Info.zod, ConfigParse.jsonc(updated, file), file)
-          yield* Effect.promise(() => writeConfigTextAtomic(file, updated, writeOptions)).pipe(Effect.orDie)
+          changed = !fileExisted || updated !== before
+          if (changed) yield* Effect.promise(() => writeConfigTextAtomic(file, updated, writeOptions)).pipe(Effect.orDie)
         }
       } finally {
         yield* Effect.promise(() => lock.release())
       }
 
-      yield* invalidate()
+      // Only invalidate (which calls Instance.disposeAll) if config actually
+      // changed on disk. No-op writes from UI mounts would otherwise abort
+      // any in-flight assistant turn across all instances.
+      if (changed) yield* invalidate()
       return next
     })
 

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -1270,6 +1270,44 @@ home command`,
     }
   })
 
+  test("no-op global config write does not rewrite the file", async () => {
+    await using project = await tmpdir({ git: true })
+    await using global = await tmpdir()
+    const globalDir = global.path
+    const previousConfig = Global.Path.config
+    process.env.PAWWORK_HOME = globalDir
+    ;(Global.Path as { config: string }).config = globalDir
+
+    try {
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          // Materialize and canonicalize the file via a real write.
+          await saveGlobal({ model: "stable/model" })
+          // Default first-write target when neither pawwork.json nor pawwork.jsonc
+          // exists yet (see PawWorkHome.configFileForWrite).
+          const filePath = path.join(globalDir, "pawwork.json")
+          const stableText = await Bun.file(filePath).text()
+
+          // Sentinel mtime — if the gate works, the second saveGlobal must
+          // skip the write and leave this timestamp intact. Any rewrite
+          // (atomic temp+rename or in-place) bumps mtime past this date.
+          const sentinel = new Date(2000, 0, 1)
+          await fs.utimes(filePath, sentinel, sentinel)
+
+          await saveGlobal({ model: "stable/model" })
+
+          const afterText = await Bun.file(filePath).text()
+          const afterStat = await fs.stat(filePath)
+          expect(afterText).toBe(stableText)
+          expect(afterStat.mtime.getTime()).toBe(sentinel.getTime())
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = previousConfig
+    }
+  })
+
   test("managed config defaults use PawWork-owned locations", () => {
     const previous = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR
     delete process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR


### PR DESCRIPTION
## Summary

Port upstream PR [anomalyco/opencode#25114](https://github.com/anomalyco/opencode/pull/25114)'s `changed` byte-comparison gate to both `Config.update` and `Config.updateGlobal` so that a no-op config write does not tear down running instances.

## Why

Without the gate, both `Config.update` (project config) and `Config.updateGlobal` (global config) call `Instance.dispose()` / `Instance.disposeAll()` on every write. A write of identical bytes — e.g., a UI mount that re-emits the existing setting — still disposes every running instance, which closes each `SessionRunState` scope mid-turn. The user sees the active assistant turn end with `MessageAbortedError` and an `Tool execution aborted` tool result, then has to resend.

Upstream already fixed this same class of bug in opencode commit `a9d399699` ("Prevent Model response Interruption when opening settings dialog"), but the fix is not in PawWork's `dev` history (`git branch -a --contains a9d399699` returns only `remotes/upstream/dev`). PawWork's `Config.update` and `Config.updateGlobal` are still in the pre-fix shape.

This PR ports just the `changed` gate, not the broader [#25475](https://github.com/anomalyco/opencode/pull/25475) instance-lifecycle decoupling refactor. The minimal change is enough to remove the no-op-write trigger.

## Related Issue

Candidate mitigation for #721. Deliberately not phrased with a closing keyword because we have not yet confirmed via post-#710 abort diagnostics that the silent writer is what's tearing down scopes in the reported cases. This PR removes one known trigger of that class. The #721 diagnostic comments lay out what evidence would confirm or refute that this was the root cause.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

The `!fileExisted` clause in `updateGlobal`. PawWork's `updateGlobal` has a seed-migration path: on a fresh install with no global config file, it seeds from upstream config sources. If we gated purely on byte equality, the seeded content would never materialize because `serialized === before` on first run. The `!fileExisted` guard makes sure we always write on first run even when the merged result equals the seed text. Worth confirming this is correct for the existing seed test cases.

## Risk Notes

Low behavior risk. The change only suppresses dispose when the write would have produced identical bytes. Any write that actually changes config still disposes as before. No public API change. No platform-specific concern.

## How To Verify

```text
Typecheck: bun --cwd packages/opencode run typecheck — pass
Targeted tests: bun --cwd packages/opencode test test/config/pawwork-global-config.test.ts test/config/config.test.ts — 153 pass, 0 fail
Diff check: git diff --check — clean
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
