### PR TITLE
fix: keep tar archive paths local

### DIFF
--- a/packages/desktop-electron/scripts/sync-officecli-skills.test.ts
+++ b/packages/desktop-electron/scripts/sync-officecli-skills.test.ts
@@ -128,6 +128,12 @@ describe("localTarArchive", () => {
     expect(archive.archiveArg).toBe("./bundle.tar.gz")
     expect(archive.archiveArg).not.toContain(":")
   })
+
+  test("uses POSIX path semantics for non-Windows platform simulations", () => {
+    const archive = localTarArchive("/tmp/pawwork/bundle.tar.gz", "linux")
+    expect(archive.cwd).toBe("/tmp/pawwork")
+    expect(archive.archiveArg).toBe("./bundle.tar.gz")
+  })
 })
 
 async function setupSkillsFixture(names: string[]): Promise<string> {

--- a/packages/desktop-electron/scripts/sync-officecli-skills.test.ts
+++ b/packages/desktop-electron/scripts/sync-officecli-skills.test.ts
@@ -5,7 +5,14 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
-import { computeContentSha, extractTarball, injectOverride, pruneSkillsDir, syncSkills } from "./sync-officecli-skills"
+import {
+  computeContentSha,
+  extractTarball,
+  injectOverride,
+  localTarArchive,
+  pruneSkillsDir,
+  syncSkills,
+} from "./sync-officecli-skills"
 
 const execFileAsync = promisify(execFile)
 
@@ -114,6 +121,15 @@ describe("computeContentSha", () => {
   })
 })
 
+describe("localTarArchive", () => {
+  test("keeps Windows drive letters out of tar archive arguments", () => {
+    const archive = localTarArchive("D:\\a\\pawwork\\bundle.tar.gz", "win32")
+    expect(archive.cwd).toBe("D:\\a\\pawwork")
+    expect(archive.archiveArg).toBe("./bundle.tar.gz")
+    expect(archive.archiveArg).not.toContain(":")
+  })
+})
+
 async function setupSkillsFixture(names: string[]): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), "prune-test-"))
   for (const n of names) {
@@ -194,7 +210,8 @@ async function buildFixtureTarball(rootName: string, layout: Record<string, stri
     }
   }
   const tarballPath = path.join(stagingDir, `${rootName}.tar.gz`)
-  await execFileAsync("tar", ["-czf", tarballPath, "-C", stagingDir, rootName])
+  const archive = localTarArchive(tarballPath)
+  await execFileAsync("tar", ["-czf", archive.archiveArg, "-C", stagingDir, rootName], { cwd: archive.cwd })
   return tarballPath
 }
 

--- a/packages/desktop-electron/scripts/sync-officecli-skills.ts
+++ b/packages/desktop-electron/scripts/sync-officecli-skills.ts
@@ -112,7 +112,7 @@ export function localTarArchive(
   tarballPath: string,
   platform: NodeJS.Platform = process.platform,
 ): { cwd: string; archiveArg: string } {
-  const pathApi = platform === "win32" ? path.win32 : path
+  const pathApi = platform === "win32" ? path.win32 : path.posix
   const archiveName = pathApi.basename(tarballPath)
   return {
     cwd: pathApi.dirname(tarballPath),

--- a/packages/desktop-electron/scripts/sync-officecli-skills.ts
+++ b/packages/desktop-electron/scripts/sync-officecli-skills.ts
@@ -108,6 +108,18 @@ export function computeContentSha(files: Map<string, Buffer>): string {
   return outer.digest("hex")
 }
 
+export function localTarArchive(
+  tarballPath: string,
+  platform: NodeJS.Platform = process.platform,
+): { cwd: string; archiveArg: string } {
+  const pathApi = platform === "win32" ? path.win32 : path
+  const archiveName = pathApi.basename(tarballPath)
+  return {
+    cwd: pathApi.dirname(tarballPath),
+    archiveArg: `./${archiveName}`,
+  }
+}
+
 export type ExtractedFiles = Map<string, Buffer>
 
 async function walkFiles(rootDir: string, relPrefix: string, out: Map<string, Buffer>) {
@@ -134,7 +146,8 @@ async function walkFiles(rootDir: string, relPrefix: string, out: Map<string, Bu
 export async function extractTarball(tarballPath: string): Promise<ExtractedFiles> {
   const extractDir = await mkdtemp(path.join(tmpdir(), "officecli-skills-"))
   try {
-    await execFileAsync("tar", ["-xzf", tarballPath, "-C", extractDir])
+    const archive = localTarArchive(tarballPath)
+    await execFileAsync("tar", ["-xzf", archive.archiveArg, "-C", extractDir], { cwd: archive.cwd })
     // The tarball root is `<repo-name>-<sha>` (GitHub convention). Find the single top-level dir.
     const topEntries = await readdir(extractDir, { withFileTypes: true })
     const topDirs = topEntries.filter((e) => e.isDirectory())


### PR DESCRIPTION
## Summary

Fix `sync-officecli-skills` tar invocations so local tarball paths are passed to `tar` as `./<basename>` from the tarball directory instead of as absolute archive paths.

## Why

Current `dev` has required CI green after #717, but `windows-advisory / unit-windows-desktop` still fails in the OfficeCLI skills sync tests. On Windows, GNU tar treats absolute paths like `D:\...\bundle.tar.gz` or `C:\...\bundle.tar.gz` as remote `host:file` archive syntax, producing errors such as `Cannot connect to D: resolve failed`.

## Related Issue

No linked issue. This is a focused follow-up to the failing `windows-advisory` run on current `dev` head `d5e6186cca6adca930793872892e26e8cdf67e07`.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Please check that `localTarArchive()` is the right boundary: both extraction and the test helper's fixture tarball creation now avoid passing drive-letter archive paths directly to `tar`.

## Risk Notes

Low. This only changes how the maintenance script calls local `tar`; archive contents and sync behavior are unchanged. Windows impact is the main target. macOS/Linux keep using standard `tar` with a directory-local archive argument.

## How To Verify

```text
Focused red test: localTarArchive test failed before implementation because the export did not exist
Focused tests: cd packages/desktop-electron && bun test scripts/sync-officecli-skills.test.ts -> 24 pass, 0 fail
Desktop typecheck: cd packages/desktop-electron && bun run typecheck -> pass
Desktop CI entry: bun turbo test:ci --filter=@opencode-ai/desktop-electron -> 396 pass, 0 fail
Diff check: git diff --check -> no whitespace errors
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English
