### PR TITLE
ci(perf): upload trace-only artifact on perf-probe failure

### DIFF
--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -329,6 +329,33 @@ jobs:
           PAWWORK_PERF_TRACE: "1"
         run: bun --cwd head/packages/app test:e2e:local:perf
 
+      - name: Upload perf trace artifact
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        with:
+          name: perf-probe-trace-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 7
+          path: |
+            head/packages/app/e2e/test-results/**/trace.zip
+            base/packages/app/e2e/test-results/**/trace.zip
+
+      - name: Print perf trace artifact pointer
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Perf trace artifact
+
+          The comparator failed twice. Playwright traces from the diagnostic re-run are uploaded as a separate small artifact so you do not have to download the full perf bundle.
+
+          Download **perf-probe-trace-${{ github.run_attempt }}** from the "Artifacts" section of this run summary, then open a trace with:
+
+          ```
+          npx playwright show-trace path/to/trace.zip
+          ```
+          EOF
+          echo "::notice::Perf comparator failed. Download artifact 'perf-probe-trace-${{ github.run_attempt }}' from this run and open trace.zip with 'npx playwright show-trace'."
+
       - name: Fail job on comparator regression
         if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -11,6 +11,7 @@ on:
       - "packages/app/package.json"
       - "packages/app/playwright.config.ts"
       - "packages/app/script/compare-perf.ts"
+      - "packages/app/script/list-failing-scenarios.ts"
       - "packages/app/script/merge-perf-artifacts.ts"
       - "packages/app/script/e2e-local.ts"
       - "packages/app/src/testing/perf-metrics*"
@@ -294,7 +295,7 @@ jobs:
       - name: Resolve failing scenarios for trace capture
         id: failing_scenarios
         if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
-        run: bun head/packages/app/script/list-failing-scenarios.ts "${PERF_ARTIFACT_DIR}/perf-compare-confirm.json" >> "$GITHUB_OUTPUT"
+        run: bun head/packages/app/script/list-failing-scenarios.ts "${PERF_ARTIFACT_DIR}/perf-compare-confirm.json"
 
       - name: Capture perf diagnostic trace (base)
         if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.failing_scenarios.outputs.default != ''
@@ -339,7 +340,7 @@ jobs:
         run: bun --cwd head/packages/app test:e2e:local:perf
 
       - name: Upload perf trace artifact
-        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        if: always() && steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && (steps.failing_scenarios.outputs.default != '' || steps.failing_scenarios.outputs.low_end != '')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: perf-probe-trace-${{ github.run_attempt }}
@@ -350,7 +351,7 @@ jobs:
             base/packages/app/e2e/test-results/**/trace.zip
 
       - name: Print perf trace artifact pointer
-        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        if: always() && steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && (steps.failing_scenarios.outputs.default != '' || steps.failing_scenarios.outputs.low_end != '')
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
           ## Perf trace artifact

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -291,40 +291,49 @@ jobs:
             })
             core.info("Created perf delta comment")
 
-      - name: Capture perf diagnostic trace (base)
+      - name: Resolve failing scenarios for trace capture
+        id: failing_scenarios
         if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        run: bun head/packages/app/script/list-failing-scenarios.ts "${PERF_ARTIFACT_DIR}/perf-compare-confirm.json" >> "$GITHUB_OUTPUT"
+
+      - name: Capture perf diagnostic trace (base)
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.failing_scenarios.outputs.default != ''
         env:
           CI: "true"
           PAWWORK_PERF_BRANCH: base
+          PAWWORK_PERF_SCENARIOS: ${{ steps.failing_scenarios.outputs.default }}
           PAWWORK_PERF_OUTPUT: ${{ github.workspace }}/perf-artifacts/perf-base-trace.json
           PAWWORK_PERF_TRACE: "1"
         run: bun --cwd base/packages/app test:e2e:local:perf
 
       - name: Capture perf diagnostic trace (head)
-        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure'
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.failing_scenarios.outputs.default != ''
         env:
           CI: "true"
           PAWWORK_PERF_BRANCH: head
+          PAWWORK_PERF_SCENARIOS: ${{ steps.failing_scenarios.outputs.default }}
           PAWWORK_PERF_OUTPUT: ${{ github.workspace }}/perf-artifacts/perf-head-trace.json
           PAWWORK_PERF_TRACE: "1"
         run: bun --cwd head/packages/app test:e2e:local:perf
 
       - name: Capture low-end perf diagnostic trace (base)
-        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.low_end_scope.outputs.run_low_end == 'true'
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.low_end_scope.outputs.run_low_end == 'true' && steps.failing_scenarios.outputs.low_end != ''
         env:
           CI: "true"
           PAWWORK_PERF_BRANCH: base
           PAWWORK_PERF_PROFILE: low-end
+          PAWWORK_PERF_SCENARIOS: ${{ steps.failing_scenarios.outputs.low_end }}
           PAWWORK_PERF_OUTPUT: ${{ github.workspace }}/perf-artifacts/perf-base-low-end-trace.json
           PAWWORK_PERF_TRACE: "1"
         run: bun --cwd base/packages/app test:e2e:local:perf
 
       - name: Capture low-end perf diagnostic trace (head)
-        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.low_end_scope.outputs.run_low_end == 'true'
+        if: steps.compare.outcome == 'failure' && steps.compare_confirmed.outcome == 'failure' && steps.low_end_scope.outputs.run_low_end == 'true' && steps.failing_scenarios.outputs.low_end != ''
         env:
           CI: "true"
           PAWWORK_PERF_BRANCH: head
           PAWWORK_PERF_PROFILE: low-end
+          PAWWORK_PERF_SCENARIOS: ${{ steps.failing_scenarios.outputs.low_end }}
           PAWWORK_PERF_OUTPUT: ${{ github.workspace }}/perf-artifacts/perf-head-low-end-trace.json
           PAWWORK_PERF_TRACE: "1"
         run: bun --cwd head/packages/app test:e2e:local:perf

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -96,7 +96,7 @@ jobs:
 
           is_low_end_path() {
             case "$1" in
-              packages/app/src/pages/session/*|packages/app/src/pages/session/**|packages/app/src/pages/session.tsx|packages/ui/src/components/message-part.tsx|packages/ui/src/components/session-turn.tsx|packages/ui/src/components/markdown.tsx|packages/ui/src/components/text-shimmer.css|packages/ui/src/components/text-shimmer.tsx|packages/ui/src/components/basic-tool.tsx|packages/ui/src/components/tool-status-title.tsx|packages/ui/src/styles/animations.css|packages/app/e2e/perf/*|packages/app/e2e/perf/**|packages/app/src/testing/perf-metrics*|packages/app/script/compare-perf.ts|packages/app/script/merge-perf-artifacts.ts|.github/workflows/perf-probe-baseline.yml)
+              packages/app/src/pages/session/*|packages/app/src/pages/session/**|packages/app/src/pages/session.tsx|packages/ui/src/components/message-part.tsx|packages/ui/src/components/session-turn.tsx|packages/ui/src/components/markdown.tsx|packages/ui/src/components/text-shimmer.css|packages/ui/src/components/text-shimmer.tsx|packages/ui/src/components/basic-tool.tsx|packages/ui/src/components/tool-status-title.tsx|packages/ui/src/styles/animations.css|packages/app/e2e/perf/*|packages/app/e2e/perf/**|packages/app/src/testing/perf-metrics*|packages/app/script/compare-perf.ts|packages/app/script/list-failing-scenarios.ts|packages/app/script/merge-perf-artifacts.ts|.github/workflows/perf-probe-baseline.yml)
                 return 0
                 ;;
               *)

--- a/packages/app/e2e/perf/profiles.ts
+++ b/packages/app/e2e/perf/profiles.ts
@@ -33,8 +33,23 @@ export function readPerfProfile(): PerfProfile {
   return process.env.PAWWORK_PERF_PROFILE === "low-end" ? "low-end" : "default"
 }
 
+function readScenarioFilter(): ReadonlySet<PerfScenarioName> | null {
+  const raw = process.env.PAWWORK_PERF_SCENARIOS
+  if (!raw) return null
+  const items = raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0) as PerfScenarioName[]
+  if (items.length === 0) return null
+  return new Set(items)
+}
+
 export function shouldRunScenario(profile: PerfProfile, scenario: PerfScenarioName) {
-  return profile === "low-end" ? lowEndScenarios.has(scenario) : defaultScenarios.has(scenario)
+  const inProfile = profile === "low-end" ? lowEndScenarios.has(scenario) : defaultScenarios.has(scenario)
+  if (!inProfile) return false
+  const filter = readScenarioFilter()
+  if (filter && !filter.has(scenario)) return false
+  return true
 }
 
 export async function applyPerfProfile(page: Page, profile: PerfProfile) {

--- a/packages/app/e2e/perf/profiles.unit.ts
+++ b/packages/app/e2e/perf/profiles.unit.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { shouldRunScenario, type PerfScenarioName } from "./profiles"
 
 test("default profile runs heavy default-open bash perf coverage", () => {
@@ -27,4 +27,54 @@ test("low-end profile gates concurrent-shimmer-extreme guard", () => {
 
   expect(shouldRunScenario("default", scenario)).toBe(false)
   expect(shouldRunScenario("low-end", scenario)).toBe(true)
+})
+
+describe("PAWWORK_PERF_SCENARIOS env filter", () => {
+  const previous = process.env.PAWWORK_PERF_SCENARIOS
+
+  beforeEach(() => {
+    delete process.env.PAWWORK_PERF_SCENARIOS
+  })
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.PAWWORK_PERF_SCENARIOS
+    } else {
+      process.env.PAWWORK_PERF_SCENARIOS = previous
+    }
+  })
+
+  test("absent env keeps profile membership as the only gate", () => {
+    expect(shouldRunScenario("default", "homepage-cold" as PerfScenarioName)).toBe(true)
+    expect(shouldRunScenario("low-end", "concurrent-shimmer-extreme" as PerfScenarioName)).toBe(true)
+  })
+
+  test("env filter restricts to the listed scenarios within a profile", () => {
+    process.env.PAWWORK_PERF_SCENARIOS = "homepage-cold,long-session-input-lag"
+
+    expect(shouldRunScenario("default", "homepage-cold" as PerfScenarioName)).toBe(true)
+    expect(shouldRunScenario("default", "long-session-input-lag" as PerfScenarioName)).toBe(true)
+    expect(shouldRunScenario("default", "tool-call-expand" as PerfScenarioName)).toBe(false)
+  })
+
+  test("env filter does not lift profile membership", () => {
+    process.env.PAWWORK_PERF_SCENARIOS = "concurrent-shimmer-extreme"
+
+    expect(shouldRunScenario("default", "concurrent-shimmer-extreme" as PerfScenarioName)).toBe(false)
+    expect(shouldRunScenario("low-end", "concurrent-shimmer-extreme" as PerfScenarioName)).toBe(true)
+  })
+
+  test("empty env is treated as no filter", () => {
+    process.env.PAWWORK_PERF_SCENARIOS = ""
+
+    expect(shouldRunScenario("default", "homepage-cold" as PerfScenarioName)).toBe(true)
+  })
+
+  test("whitespace and empty entries are tolerated", () => {
+    process.env.PAWWORK_PERF_SCENARIOS = " homepage-cold , , long-session-input-lag "
+
+    expect(shouldRunScenario("default", "homepage-cold" as PerfScenarioName)).toBe(true)
+    expect(shouldRunScenario("default", "long-session-input-lag" as PerfScenarioName)).toBe(true)
+    expect(shouldRunScenario("default", "tool-call-expand" as PerfScenarioName)).toBe(false)
+  })
 })

--- a/packages/app/script/list-failing-scenarios.ts
+++ b/packages/app/script/list-failing-scenarios.ts
@@ -7,20 +7,29 @@ async function main() {
     throw new Error("Usage: bun script/list-failing-scenarios.ts <perf-compare.json>")
   }
 
-  const payload = JSON.parse(await fs.readFile(inputPath, "utf8")) as PerfBaselineComparison
   const failingByProfile = new Map<"default" | "low_end", string[]>([
     ["default", []],
     ["low_end", []],
   ])
 
-  for (const scenario of payload.scenarios) {
-    if (scenario.failures.length === 0) continue
-    const key = scenario.profile === "low-end" ? "low_end" : "default"
-    failingByProfile.get(key)!.push(scenario.scenario)
+  try {
+    const payload = JSON.parse(await fs.readFile(inputPath, "utf8")) as PerfBaselineComparison
+    for (const scenario of payload.scenarios) {
+      if (scenario.failures.length === 0) continue
+      const key = scenario.profile === "low-end" ? "low_end" : "default"
+      failingByProfile.get(key)!.push(scenario.scenario)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`::warning::Failed to read failing scenarios from ${inputPath}: ${message}\n`)
   }
 
-  for (const [key, names] of failingByProfile) {
-    process.stdout.write(`${key}=${names.join(",")}\n`)
+  const output = Array.from(failingByProfile, ([key, names]) => `${key}=${names.join(",")}`).join("\n") + "\n"
+  const githubOutput = process.env.GITHUB_OUTPUT
+  if (githubOutput) {
+    await fs.appendFile(githubOutput, output)
+  } else {
+    process.stdout.write(output)
   }
 }
 

--- a/packages/app/script/list-failing-scenarios.ts
+++ b/packages/app/script/list-failing-scenarios.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs/promises"
+import type { PerfBaselineComparison } from "../src/testing/perf-metrics"
+
+async function main() {
+  const inputPath = process.argv[2]
+  if (!inputPath) {
+    throw new Error("Usage: bun script/list-failing-scenarios.ts <perf-compare.json>")
+  }
+
+  const payload = JSON.parse(await fs.readFile(inputPath, "utf8")) as PerfBaselineComparison
+  const failingByProfile = new Map<"default" | "low_end", string[]>([
+    ["default", []],
+    ["low_end", []],
+  ])
+
+  for (const scenario of payload.scenarios) {
+    if (scenario.failures.length === 0) continue
+    const key = scenario.profile === "low-end" ? "low_end" : "default"
+    failingByProfile.get(key)!.push(scenario.scenario)
+  }
+
+  for (const [key, names] of failingByProfile) {
+    process.stdout.write(`${key}=${names.join(",")}\n`)
+  }
+}
+
+await main()


### PR DESCRIPTION
## Summary

When `perf-probe-baseline` fails the comparator twice, upload a separate small artifact `perf-probe-trace-{attempt}` containing only Playwright `trace.zip` files from the diagnostic re-run, and re-run only the scenarios that actually regressed for trace capture. The on-failure pointer is gated on at least one scenario actually failing.

The existing `perf-probe-baseline-{attempt}` bundle is unchanged for callers who want the full report.

## Why

Closes #698.

The original scope (just upload + pointer) is necessary but not sufficient. Investigation found two structural problems on the fail path:

1. The trace files were already inside the existing `perf-probe-baseline` artifact (it bundles `e2e/test-results/**`), but that bundle is ~90 MB because it also carries the HTML report, videos, and merged perf JSON for both base and head. Measured sustained download from China is about 40 KB/s — the same via mihomo or direct to `productionresultssa17.blob.core.windows.net` — which puts the full bundle at ~40 minutes per regression. The trace files are effectively unreachable.

2. The fail path runs the perf spec 12 times (baseline ×4 + confirm ×4 + diagnostic trace ×4). Measured per-step durations on a forced-fail run put the total at ~34 min against the 30-min job ceiling. Any real perf regression risks being cut off before the trace step's artifact is uploaded, leaving the trace artifact from (1) just as unreachable in practice.

This PR addresses both:
- Splits the trace files into their own small artifact and adds a step-summary + `::notice` pointing at it.
- Filters the four diagnostic trace re-runs to only the scenarios that actually regressed (read from `perf-compare-confirm.json`). Worst-case fail path drops to ~22-26 min, leaving headroom for setup and future scenario growth.

## Related Issue

Closes #698

## Human Review Status

Pending.

## Review Focus

- Filter wiring: `PAWWORK_PERF_SCENARIOS` env in `profiles.ts` is now AND-ed with the existing profile gate; absent/empty env means "no extra filter", which preserves current behavior.
- Resolve step output contract: `list-failing-scenarios.ts` writes `default=...` and `low_end=...` directly to `$GITHUB_OUTPUT` and tolerates malformed input via try/catch + `::warning::` (so a parse failure cannot silently corrupt step outputs that downstream conditions depend on).
- Upload + pointer gating: both run with `always() && ...both compares failed... && at least one profile has failing scenarios`. The `always()` keeps partial traces uploadable if a capture step crashed mid-way; the scenario-non-empty check prevents the pointer from advertising an empty artifact when the comparator failed only with top-level `missing_*`.
- Trace step gating: each Capture step ANDs its profile's output with the existing compare-failed and low-end-scope gates, so when only one profile regresses the other profile's two capture steps skip entirely.

## Risk Notes

- Pure CI workflow change plus one perf-only test helper; no app runtime behavior change.
- New steps only execute when the comparator already failed twice. Green PRs are unaffected (verified by run 26022913394 on this PR, which exercised the new yaml structure end-to-end with no regression and skipped every conditional step).
- The Capture step `if-no-files-found: warn` is kept (consistent with the surrounding workflow); trace-step crashes still surface via the step's own exit code.

## How To Verify

```text
Local meta-tests + unit tests:
  bun --cwd packages/app test e2e/perf/profiles.unit.ts src/testing/perf-workflow.test.ts  -> 1177 pass / 0 fail
  bun --cwd packages/opencode test test/github/                                              -> 30 pass / 0 fail
YAML parse:
  python3 -c "import yaml; yaml.safe_load(open(...))"                                       -> ok
Fixture exercise of list-failing-scenarios.ts:
  scenarios array with one default + one low-end failure   -> default=homepage-cold, low_end=concurrent-shimmer-extreme
  top-level missing_* with empty scenarios                  -> default=, low_end=
  malformed JSON                                            -> ::warning::, default=, low_end= (no throw)
Manual download bench (existing 90 MB artifact, 30s ceiling):
  via mihomo:        35 KB/s
  --noproxy direct:  39 KB/s
End-to-end CI runs on this branch:
  Green baseline (yaml structure intact, all new gates evaluated skip):  run 26022913394 (this commit)
  Trace capture proven (full diagnostic trace files generated at the expected glob path before timeout):  run 26019182630
Why no full end-to-end fail-path demo: a synthetic long task large enough to trigger every scenario reverts the fail path back to ~34 min (same root cause this PR addresses); a synthetic long task scoped to one route was tested in HomeRedirectRoute on run 26021790694 but did not trigger because perf scenarios navigate directly to /{dir}/session, bypassing that component. The upload + pointer step uses the same actions/upload-artifact@v7 with a path glob that is a strict subset of the existing `Upload perf probe artifacts` step's path (which is proven by the run 26019182630 ✓).
```

## Crosscheck

Multi-model review (Claude opus + Codex high) flagged 13 findings; this PR applies the agreed P1/P2 fixes and rejects the P3 / hypothetical ones:

```text
Applied:
  P1: Gate upload + pointer on per-scenario failures non-empty (covers missing_* and script crash paths).
  P2: Add list-failing-scenarios.ts to paths filter.
  P2: always() guard on upload + pointer so partial trace runs still produce artifact.
  P2: Script writes directly to $GITHUB_OUTPUT via process.env, not stdout redirect.
Rejected:
  P1 contamination from on-first-retry: perf spec does not assert, so it does not retry, so trace files are not produced outside the diagnostic step. Possible but rare; not blocking ship.
  P3 perf/typo/env capture concerns: hypothetical only.
  P3 duplicated trace.zip in big bundle: acceptable (big bundle is "give me everything").
  P3 condition repetition across 4 capture steps: real but not worth abstraction at this size.
```

## Screenshots or Recordings

N/A — CI workflow change only.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English