### PR TITLE
fix: defer LLM stream connect timeout to after HTTP request is sent

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -494,12 +494,17 @@ const live: Layer.Layer<
                       })
                   }, currentTimeoutMs())
                 }
-                arm()
                 return {
                   ctrl,
                   timeoutFailure,
                   timeoutError() {
                     return timeoutError
+                  },
+                  // Start the connect timeout. Called after run() returns so the
+                  // timer only measures actual network/provider wait time, not
+                  // the internal setup work (provider lookup, config, plugins).
+                  startTimeout() {
+                    arm()
                   },
                   resetTimeout(event: Event) {
                     if (!providerProgressed && !isProviderProgressEvent(event)) return
@@ -518,6 +523,12 @@ const live: Layer.Layer<
             )
 
             const result = yield* run({ ...input, abort: request.ctrl.signal })
+
+            // Arm the connect timeout now that the HTTP request has been sent.
+            // Previously this was called during request object creation, which
+            // meant setup time (provider lookup, config, plugin hooks) ate into
+            // the 30s window, causing premature timeouts.
+            request.startTimeout()
 
             // This is a silent-stream timeout: it limits how long we wait for
             // the next provider event, not the total model runtime.


### PR DESCRIPTION
## Summary

Defer the LLM stream connect timeout (`arm()` call) until after `run()` returns, so the 30-second window measures only network/provider response time, not internal async setup (provider lookup, config, plugin hooks).

## Why

The connect timer was started during request-object construction, before the HTTP request was actually sent. `run()`'s async setup work (provider lookup, config load, `experimental.chat.system.transform` / `chat.params` / `chat.headers` plugin hooks) ate into the 30s window, so users on slower providers (Kimi, Xiaomi token plan, other domestic-China endpoints) saw "timed out after 30000ms" before they had actually waited 30 seconds. Issue #728 documents 12 occurrences in a single user's database.

Fix moves `arm()` into a new `startTimeout()` method on the request object and calls it after `run()` returns, right before stream consumption.

## Related Issue

Fixes #728.

## Human Review Status

Pending.

## Review Focus

- `packages/opencode/src/session/llm.ts`: the `arm()` call site move. Confirm nothing else in the request lifecycle depends on the timer being armed during construction.
- `resetTimeout()` and `timeoutFailure` semantics are unchanged.

## Risk Notes

- Behavior change is scoped to the connect timer. The "silent stream" timeout (between events after the first one) is untouched.
- If `run()` itself never returns (e.g., provider lookup hangs), the connect timer never starts. This is the same failure mode as before — `run()` hangs were never covered by the connect timer. No new regression surface.
- Issue #728 also lists two follow-ups not addressed here: (1) `SessionRetry.policy` does not treat connect timeouts as retryable, (2) `connectTimeoutMs` is not configurable end-to-end. Both intentionally left for separate PRs.

## How To Verify

```text
typecheck (packages/opencode):                 ok
bun test packages/opencode/test/session/llm:   20 pass, 0 fail
```

## Screenshots or Recordings

Not applicable (no UI change).

## Checklist

- [x] Human review status is stated above as pending
- [x] I linked the related issue (#728)
- [ ] Labels: maintainer to apply (`bug`, `platform`, priority)
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] Not a UI change
- [x] No macOS/Windows platform impact
- [x] Targeting `dev`, Conventional Commits in English

---

**Note to @Spongeacer**: The branch was rewritten by a maintainer to narrow scope to just the `llm.ts` fix (the original PR also pulled in unrelated audit/dead-code changes that broke typecheck via a duplicate function in `tool-info.ts`). The other changes can be reproposed individually if you still want them in. To resync your local branch:

\`\`\`
git fetch origin
git checkout fix/llm-stream-connect-timeout
git reset --hard origin/fix/llm-stream-connect-timeout
\`\`\`