### PR TITLE
ci: harden OfficeCLI bump PR creation

### DIFF
--- a/.github/workflows/officecli-bump.yml
+++ b/.github/workflows/officecli-bump.yml
@@ -12,9 +12,7 @@ on:
     - cron: "17 3 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   officecli-bump:
@@ -69,6 +67,19 @@ jobs:
         if: ${{ steps.versions.outputs.current_version == steps.versions.outputs.latest_version }}
         run: echo "Bundled OfficeCLI is already at ${{ steps.versions.outputs.current_version }}."
 
+      - name: Validate bump pull request token
+        if: ${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version && inputs.dry_run != true }}
+        shell: bash
+        env:
+          OFFICECLI_BUMP_TOKEN: ${{ secrets.OFFICECLI_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${OFFICECLI_BUMP_TOKEN:-}" ]; then
+            echo "::error title=Missing OFFICECLI_BUMP_TOKEN::Set repository secret OFFICECLI_BUMP_TOKEN to a bot token allowed to push ci/officecli-bump-* branches and create pull requests."
+            exit 1
+          fi
+
       - name: Bump manifest and verify all bundled assets
         if: ${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version }}
         id: verify
@@ -119,7 +130,7 @@ jobs:
         if: ${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version }}
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          OFFICECLI_BUMP_TOKEN: ${{ secrets.OFFICECLI_BUMP_TOKEN }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest_version }}
           RELEASE_URL: ${{ steps.versions.outputs.release_url }}
@@ -138,14 +149,6 @@ jobs:
           if [ "$dry_run" = false ] && [ "$GITHUB_REF_NAME" != "dev" ]; then
             echo "Non-dry bump runs must start from dev, got $GITHUB_REF_NAME"
             exit 1
-          fi
-
-          if existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq '.[0].url // empty')"; then
-            if [ -n "$existing_pr" ]; then
-              echo "Open bump PR already exists: $existing_pr"
-              echo "Skipping duplicate OfficeCLI bump."
-              exit 0
-            fi
           fi
 
           echo "Verified targets:"
@@ -170,13 +173,30 @@ jobs:
             exit 0
           fi
 
+          if [ -z "${OFFICECLI_BUMP_TOKEN:-}" ]; then
+            echo "::error title=Missing OFFICECLI_BUMP_TOKEN::Set repository secret OFFICECLI_BUMP_TOKEN to a bot token allowed to push ci/officecli-bump-* branches and create pull requests."
+            exit 1
+          fi
+
+          export GH_TOKEN="$OFFICECLI_BUMP_TOKEN"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           gh auth setup-git
           git switch -c "$branch"
           git add packages/desktop-electron/bundled-tools.json skills/
+          if git diff --cached --quiet; then
+            echo "No OfficeCLI bump changes were produced after verification; skipping branch and PR update."
+            exit 0
+          fi
           git commit -m "$title and sync skills"
-          git push --set-upstream origin "$branch"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Updating existing bump branch: $branch"
+            git fetch origin "$branch"
+            git push --force-with-lease=refs/heads/"$branch" --set-upstream origin "$branch"
+          else
+            git push --set-upstream origin "$branch"
+          fi
 
           body_file="$(mktemp)"
           cat > "$body_file" <<EOF
@@ -190,7 +210,7 @@ jobs:
 
           ## Related Issue
 
-          Closes #330.
+          Follow-up to #330. The issue is already closed; this PR is the generated OfficeCLI version bump from the scheduled maintenance workflow.
 
           ## Human Review Status
 
@@ -236,6 +256,20 @@ jobs:
           - [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
           - [x] I am targeting \`dev\`, and my PR title and commit messages use Conventional Commits in English
           EOF
+
+          if existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq '.[0].url // empty')"; then
+            if [ -n "$existing_pr" ]; then
+              echo "Open bump PR already exists: $existing_pr"
+              echo "Updating PR title and body instead of creating a duplicate."
+              gh pr edit "$existing_pr" \
+                --title "$title" \
+                --body-file "$body_file" \
+                --add-label enhancement \
+                --add-label ci \
+                --add-label upstream
+              exit 0
+            fi
+          fi
 
           gh pr create \
             --base dev \

--- a/.github/workflows/officecli-bump.yml
+++ b/.github/workflows/officecli-bump.yml
@@ -192,7 +192,7 @@ jobs:
           git commit -m "$title and sync skills"
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
             echo "Updating existing bump branch: $branch"
-            git fetch origin "$branch"
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
             git push --force-with-lease=refs/heads/"$branch" --set-upstream origin "$branch"
           else
             git push --set-upstream origin "$branch"
@@ -257,18 +257,17 @@ jobs:
           - [x] I am targeting \`dev\`, and my PR title and commit messages use Conventional Commits in English
           EOF
 
-          if existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq '.[0].url // empty')"; then
-            if [ -n "$existing_pr" ]; then
-              echo "Open bump PR already exists: $existing_pr"
-              echo "Updating PR title and body instead of creating a duplicate."
-              gh pr edit "$existing_pr" \
-                --title "$title" \
-                --body-file "$body_file" \
-                --add-label enhancement \
-                --add-label ci \
-                --add-label upstream
-              exit 0
-            fi
+          existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq '.[0].url // empty')"
+          if [ -n "$existing_pr" ]; then
+            echo "Open bump PR already exists: $existing_pr"
+            echo "Updating PR title and body instead of creating a duplicate."
+            gh pr edit "$existing_pr" \
+              --title "$title" \
+              --body-file "$body_file" \
+              --add-label enhancement \
+              --add-label ci \
+              --add-label upstream
+            exit 0
           fi
 
           gh pr create \

--- a/packages/opencode/test/github/officecli-bump-workflow.test.ts
+++ b/packages/opencode/test/github/officecli-bump-workflow.test.ts
@@ -13,6 +13,8 @@ describe("officecli bump workflow", () => {
     const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
     const setupNode = steps.find((step) => step.uses?.startsWith("actions/setup-node@"))
     const setupBun = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const validateToken = steps.find((step) => step.name === "Validate bump pull request token")
+    const createPr = steps.find((step) => step.name === "Create bump pull request")
 
     expect(parsed.name).toBe("officecli-bump")
     expect(parsed.on?.workflow_dispatch).toEqual({
@@ -27,9 +29,7 @@ describe("officecli bump workflow", () => {
     })
     expect(parsed.on?.schedule).toEqual([{ cron: "17 3 * * 1" }])
     expect(parsed.permissions).toEqual({
-      contents: "write",
-      "pull-requests": "write",
-      issues: "write",
+      contents: "read",
     })
 
     expect(checkout?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
@@ -45,11 +45,23 @@ describe("officecli bump workflow", () => {
     expect(workflow).toContain(
       "bun packages/desktop-electron/scripts/prepare-officecli.ts --platform \"$platform\" --arch \"$arch\"",
     )
+    expect(validateToken?.if).toBe(
+      "${{ steps.versions.outputs.current_version != steps.versions.outputs.latest_version && inputs.dry_run != true }}",
+    )
+    expect(validateToken?.env?.OFFICECLI_BUMP_TOKEN).toBe("${{ secrets.OFFICECLI_BUMP_TOKEN }}")
+    expect(validateToken?.run).toContain("Missing OFFICECLI_BUMP_TOKEN")
+    expect(createPr?.env?.OFFICECLI_BUMP_TOKEN).toBe("${{ secrets.OFFICECLI_BUMP_TOKEN }}")
+    expect(createPr?.env).not.toHaveProperty("GH_TOKEN")
     expect(workflow).toContain("Dry run requested; skipping branch push and PR creation.")
     expect(workflow).toContain("gh auth setup-git")
+    expect(workflow).toContain('git ls-remote --exit-code --heads origin "$branch"')
+    expect(workflow).toContain('git fetch origin "$branch"')
+    expect(workflow).toContain('git push --force-with-lease=refs/heads/"$branch" --set-upstream origin "$branch"')
+    expect(workflow).toContain("gh pr edit")
     expect(workflow).toContain("--label enhancement")
     expect(workflow).toContain("--label ci")
     expect(workflow).toContain("--label upstream")
-    expect(workflow).toContain("Closes #330.")
+    expect(workflow).toContain("Follow-up to #330.")
+    expect(workflow).not.toContain("Closes #330.")
   })
 })

--- a/packages/opencode/test/github/officecli-bump-workflow.test.ts
+++ b/packages/opencode/test/github/officecli-bump-workflow.test.ts
@@ -55,9 +55,16 @@ describe("officecli bump workflow", () => {
     expect(workflow).toContain("Dry run requested; skipping branch push and PR creation.")
     expect(workflow).toContain("gh auth setup-git")
     expect(workflow).toContain('git ls-remote --exit-code --heads origin "$branch"')
-    expect(workflow).toContain('git fetch origin "$branch"')
+    expect(workflow).toContain('git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"')
     expect(workflow).toContain('git push --force-with-lease=refs/heads/"$branch" --set-upstream origin "$branch"')
+    expect(workflow).toContain(
+      'existing_pr="$(gh pr list --state open --base dev --head "$branch" --json url --jq \'.[0].url // empty\')"',
+    )
+    expect(workflow).not.toContain('if existing_pr="$(gh pr list')
     expect(workflow).toContain("gh pr edit")
+    expect(workflow).toContain("--add-label enhancement")
+    expect(workflow).toContain("--add-label ci")
+    expect(workflow).toContain("--add-label upstream")
     expect(workflow).toContain("--label enhancement")
     expect(workflow).toContain("--label ci")
     expect(workflow).toContain("--label upstream")


### PR DESCRIPTION
## Summary

- Route the OfficeCLI bump branch and PR write path through a dedicated `OFFICECLI_BUMP_TOKEN` secret instead of `github.token`.
- Reduce the workflow `GITHUB_TOKEN` permissions to read-only.
- Make the bump PR path idempotent by updating an existing bump branch and editing an existing open PR instead of creating duplicates.

## Why

The scheduled OfficeCLI bump run could verify assets and push `ci/officecli-bump-v1.0.93`, but failed at PR creation with `GitHub Actions is not permitted to create or approve pull requests`. This keeps repository-wide Actions PR creation disabled while giving this one maintenance workflow a scoped bot-token path.

## Related Issue

No separate issue. Follow-up to #730 and the OfficeCLI automation from #330.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm `OFFICECLI_BUMP_TOKEN` is the right repository secret name and will be provisioned after merge.
- Confirm the workflow token boundary is narrow: default `GITHUB_TOKEN` is read-only, and write operations export the dedicated secret as `GH_TOKEN` only after dry-run exits.
- Confirm the `ci/officecli-bump-*` branch update behavior is acceptable: existing bump branches are updated with `--force-with-lease`, then existing PRs are edited instead of duplicated.

## Risk Notes

- The next non-dry OfficeCLI bump requires repository secret `OFFICECLI_BUMP_TOKEN`; without it, the workflow now fails early with a clear error before pushing a branch.
- The workflow can update only the generated `ci/officecli-bump-*` branch path it creates for a target OfficeCLI version.
- No product runtime code changed.

## How To Verify

```text
Workflow test: bun --cwd packages/opencode test test/github/officecli-bump-workflow.test.ts test/github/pr-routing-triage.test.ts
Result: 10 pass, 0 fail

actionlint: actionlint .github/workflows/officecli-bump.yml
Result: passed

Diff check: git diff --check
Result: passed
```

## Screenshots or Recordings

Not needed. This is a CI workflow change with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened GitHub Actions workflow permissions to reduce write scope, added fail-fast behavior when the bump token is missing, improved token-based authentication for bump PR creation, updated branch push behavior to force-update or create the target branch, and changed bump PR wording to "Follow-up to `#330`." Duplicate bump handling now updates existing PRs (title/body/labels) instead of skipping.

* **Tests**
  * Strengthened workflow tests to assert stricter step behavior, token usage, permissions, git/gh commands, and updated PR phrasing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->