### PR TITLE
fix(opencode): align Zen User-Agent with upstream OpenCode client

### DIFF
--- a/packages/core/src/installation/version.ts
+++ b/packages/core/src/installation/version.ts
@@ -1,8 +1,11 @@
 declare global {
   const OPENCODE_VERSION: string
+  const OPENCODE_UPSTREAM_VERSION: string
   const OPENCODE_CHANNEL: string
 }
 
 export const InstallationVersion = typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"
+export const InstallationUpstreamVersion =
+  typeof OPENCODE_UPSTREAM_VERSION === "string" ? OPENCODE_UPSTREAM_VERSION : InstallationVersion
 export const InstallationChannel = typeof OPENCODE_CHANNEL === "string" ? OPENCODE_CHANNEL : "local"
 export const InstallationLocal = InstallationChannel === "local"

--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -57,6 +57,7 @@ await Bun.build({
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
     OPENCODE_VERSION: `'${Script.version}'`,
+    OPENCODE_UPSTREAM_VERSION: `'${Script.upstreamVersion}'`,
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -200,6 +200,7 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts", ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
+      OPENCODE_UPSTREAM_VERSION: `'${Script.upstreamVersion}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -8,7 +8,11 @@ import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Log } from "@opencode-ai/core/util/log"
-import { InstallationChannel as channel, InstallationVersion as version } from "@opencode-ai/core/installation/version"
+import {
+  InstallationChannel as channel,
+  InstallationUpstreamVersion as upstreamVersion,
+  InstallationVersion as version,
+} from "@opencode-ai/core/installation/version"
 
 import semver from "semver"
 
@@ -56,6 +60,7 @@ export namespace Installation {
   export type Info = z.infer<typeof Info>
 
   export const VERSION = version
+  export const UPSTREAM_VERSION = upstreamVersion
   export const CHANNEL = channel
   export const USER_AGENT = `opencode/${CHANNEL}/${VERSION}/${Flag.OPENCODE_CLIENT}`
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -388,7 +388,7 @@ const live: Layer.Layer<
                 "x-opencode-session": input.sessionID,
                 "x-opencode-request": input.user.id,
                 "x-opencode-client": Flag.OPENCODE_CLIENT,
-                "User-Agent": `opencode/${Installation.VERSION}`,
+                "User-Agent": `opencode/${Installation.UPSTREAM_VERSION}`,
               }
             : {
                 "x-session-affinity": input.sessionID,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -388,6 +388,7 @@ const live: Layer.Layer<
                 "x-opencode-session": input.sessionID,
                 "x-opencode-request": input.user.id,
                 "x-opencode-client": Flag.OPENCODE_CLIENT,
+                "User-Agent": `opencode/${Installation.VERSION}`,
               }
             : {
                 "x-session-affinity": input.sessionID,

--- a/packages/opencode/test/script/build-node.test.ts
+++ b/packages/opencode/test/script/build-node.test.ts
@@ -6,7 +6,9 @@ test("build-node injects both release version and channel defines", async () => 
   const source = await fs.readFile(path.join(import.meta.dir, "../../script/build-node.ts"), "utf8")
 
   expect(source).toContain("OPENCODE_VERSION")
+  expect(source).toContain("OPENCODE_UPSTREAM_VERSION")
   expect(source).toContain("OPENCODE_CHANNEL")
   expect(source).toContain("Script.version")
+  expect(source).toContain("Script.upstreamVersion")
   expect(source).toContain("Script.channel")
 })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -17,6 +17,7 @@ import type { Agent } from "../../src/agent/agent"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { Installation } from "../../src/installation"
 
 async function getModel(providerID: ProviderID, modelID: ModelID) {
   return AppRuntime.runPromise(
@@ -529,6 +530,86 @@ describe("session.llm.stream", () => {
 
         const reasoning = (body.reasoningEffort as string | undefined) ?? (body.reasoning_effort as string | undefined)
         expect(reasoning).toBe("high")
+      },
+    })
+  })
+
+  test("sends upstream OpenCode user agent for opencode provider requests", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "opencode"
+    const modelID = "qwen3.6-plus-free"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "public",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-opencode-user-agent")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-opencode-user-agent"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.headers.get("User-Agent")?.startsWith(`opencode/${Installation.VERSION}`)).toBe(true)
+        expect(capture.headers.get("x-opencode-client")).toBeTruthy()
+        expect(capture.headers.get("x-opencode-project")).toBeTruthy()
+        expect(capture.headers.get("x-opencode-session")).toBe(sessionID)
+        expect(capture.headers.get("x-opencode-request")).toBe(user.id)
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -605,7 +605,7 @@ describe("session.llm.stream", () => {
         })
 
         const capture = await request
-        expect(capture.headers.get("User-Agent")?.startsWith(`opencode/${Installation.VERSION}`)).toBe(true)
+        expect(capture.headers.get("User-Agent")?.startsWith(`opencode/${Installation.UPSTREAM_VERSION} `)).toBe(true)
         expect(capture.headers.get("x-opencode-client")).toBeTruthy()
         expect(capture.headers.get("x-opencode-project")).toBeTruthy()
         expect(capture.headers.get("x-opencode-session")).toBe(sessionID)

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -22,6 +22,7 @@ const env = {
   OPENCODE_BUMP: process.env["OPENCODE_BUMP"],
   OPENCODE_VERSION: process.env["OPENCODE_VERSION"],
   OPENCODE_RELEASE: process.env["OPENCODE_RELEASE"],
+  OPENCODE_UPSTREAM_VERSION: process.env["OPENCODE_UPSTREAM_VERSION"],
 }
 const CHANNEL = await (async () => {
   if (env.OPENCODE_CHANNEL) return env.OPENCODE_CHANNEL
@@ -31,16 +32,20 @@ const CHANNEL = await (async () => {
 })()
 const IS_PREVIEW = CHANNEL !== "latest"
 
+const UPSTREAM_VERSION = await (async () => {
+  if (env.OPENCODE_UPSTREAM_VERSION) return env.OPENCODE_UPSTREAM_VERSION
+  return await fetch("https://registry.npmjs.org/opencode-ai/latest")
+    .then((res) => {
+      if (!res.ok) throw new Error(`opencode-ai latest fetch failed: ${res.statusText}`)
+      return res.json()
+    })
+    .then((data: any) => data.version as string)
+})()
+
 const VERSION = await (async () => {
   if (env.OPENCODE_VERSION) return env.OPENCODE_VERSION
   if (IS_PREVIEW) return `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
-  const version = await fetch("https://registry.npmjs.org/opencode-ai/latest")
-    .then((res) => {
-      if (!res.ok) throw new Error(res.statusText)
-      return res.json()
-    })
-    .then((data: any) => data.version)
-  const [major, minor, patch] = version.split(".").map((x: string) => Number(x) || 0)
+  const [major, minor, patch] = UPSTREAM_VERSION.split(".").map((x: string) => Number(x) || 0)
   const t = env.OPENCODE_BUMP?.toLowerCase()
   if (t === "major") return `${major + 1}.0.0`
   if (t === "minor") return `${major}.${minor + 1}.0`
@@ -63,6 +68,9 @@ export const Script = {
   },
   get version() {
     return VERSION
+  },
+  get upstreamVersion() {
+    return UPSTREAM_VERSION
   },
   get preview() {
     return IS_PREVIEW


### PR DESCRIPTION
## Summary

Make PawWork's `opencode*` provider requests look like the official OpenCode client on the wire: send a `User-Agent` whose prefix and version both match upstream OpenCode (`opencode/<upstream-semver>`), instead of `opencode/<PawWork-CalVer>`.

## Why

PawWork is positioned as a fork that should inherit the same free quota as upstream OpenCode. Two users hit `Free usage exceeded, subscribe to Go https://opencode.ai/go` within a short window, with retry-after values around 50000s, which lines up with the lower `dailyRequestsFallback` bucket rather than the normal free daily limit. Upstream Zen now appears to run requests through a private `checkHeaders` step before choosing which bucket to charge, and PawWork's request shape did not match: the `opencode*` provider branch in `session/llm.ts` was missing `User-Agent` entirely, so the AI SDK was sending `ai-sdk/openai-compatible/...` as the agent, and even after adding the prefix the version suffix was still PawWork's CalVer (`2026.5.18`), which cannot parse as a semver in upstream's known release line (`opencode-ai` npm latest is currently `1.15.4`). Both mismatches are independently sufficient to fail a strict `checkHeaders` match. This PR closes both. We cannot prove `User-Agent` is the only condition since upstream `checkHeaders` is private, so this is "match the highest-probability mismatch" rather than "proven root cause".

## Related Issue

Refs #737

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

Whether the upstream-version injection path is right: `Script.upstreamVersion` always fetches `registry.npmjs.org/opencode-ai/latest` at build time (with `OPENCODE_UPSTREAM_VERSION` env override), Bun `define` writes it into both `build.ts` and `build-node.ts` bundles, `Installation.UPSTREAM_VERSION` falls back to `Installation.VERSION` in dev/test, and only the `opencode*` provider `User-Agent` consumes it. Product-facing version, update channel, telemetry, and the non-`opencode*` provider UA are all unchanged.

## Risk Notes

Build-time network dependency: release builds will fail loudly if `registry.npmjs.org` is unreachable. The `OPENCODE_UPSTREAM_VERSION` env override gives CI an escape hatch (and we should consider adding a pinned fallback in `package.json` if this becomes flaky in practice). The constant is frozen at build time, so if upstream rotates an allowlist and we lag, a patch release is needed to pick up a fresh value. Not a regression risk: in dev/test the fallback to `Installation.VERSION` keeps the local UA shape stable.

## How To Verify

```text
Focused regression test: bun --cwd packages/opencode test test/session/llm.test.ts -t "sends upstream OpenCode user agent" -> 1 passed
Full LLM session test: bun --cwd packages/opencode test test/session/llm.test.ts -> 21 passed
Build define contract: bun --cwd packages/opencode test test/script/build-node.test.ts -> 1 passed (locks in the new define key)
Typecheck opencode: bun --cwd packages/opencode run typecheck -> ok
Typecheck core: bun --cwd packages/core run typecheck -> ok
Diff check: git diff --check -> ok
```

A real A/B against upstream Zen's quota decision still cannot be observed without upstream logs or a live failing-network rerun after release. That residual uncertainty stays with #737.

## Screenshots or Recordings

Not applicable; no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (\`bug\`, \`enhancement\`, \`task\`, or \`documentation\`), at least one primary routing label (\`app\`, \`ui\`, \`platform\`, \`harness\`, or \`ci\`), and exactly one priority label (\`P0\` to \`P3\`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting \`dev\`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added upstream OpenCode version tracking throughout the system
  * Upstream version is now automatically included in LLM provider request headers for better service identification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->