### PR TITLE
fix(provider): widen Kimi anthropic-SDK thinking match to K2.x

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -683,7 +683,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("glm") ||
     (id.includes("mistral") && model.api.npm !== "@ai-sdk/mistral") ||
     id.includes("kimi") ||
-    id.includes("k2p5") ||
+    id.includes("k2p") ||
     id.includes("qwen") ||
     id.includes("big-pickle")
   )
@@ -1154,11 +1154,11 @@ export function options(input: {
     }
   }
 
-  // Enable thinking by default for kimi-k2.5/k2p5 models using anthropic SDK
+  // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
-    (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))
+    (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))
   ) {
     result["thinking"] = {
       type: "enabled",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -479,8 +479,8 @@ describe("ProviderTransform.options - Kimi anthropic thinking", () => {
       headers: {},
     }) as any
 
-  test("enables thinking for the supported Kimi K2.5 anthropic variants", () => {
-    for (const apiId of ["kimi-k2.5", "kimi-k2p5", "k2p5"]) {
+  test("enables thinking for supported Kimi K2.x anthropic variants", () => {
+    for (const apiId of ["kimi-k2.5", "kimi-k2p5", "k2p5", "kimi-k2.6", "kimi-k2p6", "k2p6"]) {
       const result = ProviderTransform.options({
         model: createModel(apiId),
         sessionID,
@@ -493,8 +493,8 @@ describe("ProviderTransform.options - Kimi anthropic thinking", () => {
     }
   })
 
-  test("does not broaden thinking to unrelated Kimi K2 or K2P variants", () => {
-    for (const apiId of ["kimi-k2.6", "kimi-k2-preview", "kimi-k2p6", "k2p6"]) {
+  test("does not enable thinking for Kimi variants that lack a K2 dot or K2P tag", () => {
+    for (const apiId of ["kimi-k2-preview", "kimi-k2", "kimi-k2-thinking"]) {
       const result = ProviderTransform.options({
         model: createModel(apiId),
         sessionID,


### PR DESCRIPTION
## Summary

Widen the `transform.ts` substring match that enables `thinking` on Kimi models served over the Anthropic SDK path, so Kimi K2.6 (`k2p6`) is covered the same way K2.5 already is. Cherry-pick from upstream anomalyco/opencode commit `58232d896` (PR #23696, 2026-04-21).

## Why

Upstream widened the Anthropic-SDK Kimi match from K2.5-only to all `k2.x` ids a month ago. PawWork missed that sync, so on the Anthropic-SDK Kimi path (`kimi-for-coding` provider), K2.6 requests went out without the `thinking` block that Moonshot's coding endpoint expects on reasoning models. This is a latent protocol-level gap on a paid Kimi tier.

Note on scope: a user-reported "death loop on Kimi for Coding K2.6" arrived at the same time, and this PR was initially expected to fix it. End-to-end testing on a real Kimi for Coding plan account showed that the death-loop symptom is actually `HTTP 429 + rate_limit_error` from Moonshot side (a quota / rate-limit issue, not a protocol issue). Builds on this branch send the correct `thinking` block but still hit 429 when the account is rate-limited. So this PR fixes a real protocol gap but is not the fix for the rate-limit report; that needs separate work on retry behavior and error messaging.

## Related Issue

No GitHub issue. The rate-limit UX follow-up will be tracked separately.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- The widened substring matches mirror upstream `58232d896` exactly (`k2p5` -> `k2p`, `kimi-k2.5` -> `kimi-k2.`). The intent is to stay sync-friendly, not to micro-optimize the match shape.
- The updated negative-case fixtures (`kimi-k2-preview`, `kimi-k2`, `kimi-k2-thinking`) are the only K2-family ids in our snapshot that should still be excluded.

## Risk Notes

- Behavior change only affects models on the Anthropic SDK code path. Today that is `kimi-for-coding` per `models-snapshot.js`. OpenAI-compatible Kimi paths (volcengine plan, moonshot.cn, moonshot.ai) are untouched.
- `kimi-k2-thinking` returns reasoning content by design and intentionally stays out of this branch; covered by the negative test.

## How To Verify

Targeted local checks from the worktree:

```text
bun --cwd packages/opencode test test/provider/transform.test.ts:
  201 pass, 0 fail, 385 expect() calls
bun --cwd packages/opencode test test/provider/provider.test.ts:
  95 pass, 0 fail, 252 expect() calls
bun turbo typecheck:
  5/5 successful (opencode + 4 cached)
```

Manual desktop verification on a real Kimi for Coding K2.6 account confirmed the request body now includes `thinking: { type: enabled, budget_tokens: 16000 }` on this branch. Server-side rate-limit behavior is out of scope for this PR.

## Screenshots or Recordings

Not applicable; provider-layer change with no UI surface.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English