### PR TITLE
fix(session): clear stale pending interactions

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -124,6 +124,7 @@ jobs:
               test/skill
               test/index-runtime-namespace.test.ts
               test/permission-agent.test.ts
+              test/permission-cleanup.test.ts
             report_path: packages/opencode/.artifacts/unit/junit-windows-session.xml
           # Config and project cover configuration, project discovery, file,
           # and GitHub workflow tests.

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -264,6 +264,173 @@ describe("bootstrapDirectory", () => {
     }
   })
 
+  test("skips pending interaction entries when warm session lookup returns 404", async () => {
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    setStore("permission", "ses_missing", [
+      {
+        id: "perm_old",
+        sessionID: "ses_missing",
+        permission: "edit",
+        patterns: ["/tmp/old.txt"],
+        metadata: {},
+        always: ["/tmp/old.txt"],
+      } as any,
+    ])
+    setStore("question", "ses_missing", [
+      {
+        id: "que_old",
+        sessionID: "ses_missing",
+        questions: [{ question: "Old?", header: "Old", options: [{ label: "Old", description: "old" }] }],
+      } as any,
+    ])
+    setStore("blocker", "ses_missing", [
+      {
+        kind: "question",
+        status: "awaiting_user",
+        sessionID: "ses_missing",
+        requestID: "que_old",
+        request: {
+          id: "que_old",
+          sessionID: "ses_missing",
+          questions: [{ question: "Old?", header: "Old", options: [{ label: "Old", description: "old" }] }],
+        },
+        armedAt: 1,
+        updatedAt: 1,
+      } as any,
+    ])
+
+    const notFound = { name: "NotFoundError", response: { status: 404 } }
+    const validSession = {
+      id: "ses_valid",
+      title: "Valid session",
+      directory,
+      version: "test",
+      time: { created: 1, updated: 1 },
+    }
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async ({ sessionID }: { sessionID: string }) => {
+          if (sessionID === "ses_missing") throw notFound
+          return { data: validSession }
+        },
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: {
+        list: async () => ({
+          data: [
+            {
+              id: "perm_missing",
+              sessionID: "ses_missing",
+              permission: "edit",
+              patterns: ["/tmp/missing.txt"],
+              metadata: {},
+              always: ["/tmp/missing.txt"],
+            },
+            {
+              id: "perm_valid",
+              sessionID: "ses_valid",
+              permission: "edit",
+              patterns: ["/tmp/valid.txt"],
+              metadata: {},
+              always: ["/tmp/valid.txt"],
+            },
+          ],
+        }),
+      },
+      question: {
+        list: async () => ({
+          data: [
+            {
+              id: "que_missing",
+              sessionID: "ses_missing",
+              questions: [
+                { question: "Missing?", header: "Missing", options: [{ label: "No", description: "missing" }] },
+              ],
+            },
+            {
+              id: "que_valid",
+              sessionID: "ses_valid",
+              questions: [{ question: "Valid?", header: "Valid", options: [{ label: "Yes", description: "valid" }] }],
+            },
+          ],
+        }),
+      },
+      blocker: {
+        list: async () => ({
+          data: [
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID: "ses_missing",
+              requestID: "que_missing",
+              request: {
+                id: "que_missing",
+                sessionID: "ses_missing",
+                questions: [
+                  { question: "Missing?", header: "Missing", options: [{ label: "No", description: "missing" }] },
+                ],
+              },
+              armedAt: 1,
+              updatedAt: 1,
+            },
+            {
+              kind: "question",
+              status: "awaiting_user",
+              sessionID: "ses_valid",
+              requestID: "que_valid",
+              request: {
+                id: "que_valid",
+                sessionID: "ses_valid",
+                questions: [{ question: "Valid?", header: "Valid", options: [{ label: "Yes", description: "valid" }] }],
+              },
+              armedAt: 2,
+              updatedAt: 2,
+            },
+          ],
+        }),
+      },
+      mcp: { status: async () => ({ data: {} }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    await bootstrapDirectory({
+      directory,
+      sdk,
+      store,
+      setStore,
+      vcsCache: createVcsCache(),
+      loadSessions: () => undefined,
+      translate: (key) => key,
+      global: {
+        config: {} as Config,
+        path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+        project: [] as Project[],
+        provider: { all: [], connected: [], default: {} },
+      },
+      queryClient,
+    })
+
+    await waitFor(() => store.session.some((session) => session.id === "ses_valid"))
+    await waitFor(() => store.permission.ses_valid?.length === 1)
+    await waitFor(() => store.question.ses_valid?.length === 1)
+    await waitFor(() => store.blocker.ses_valid?.length === 1)
+
+    expect(store.permission.ses_missing ?? []).toEqual([])
+    expect(store.question.ses_missing ?? []).toEqual([])
+    expect(store.blocker.ses_missing ?? []).toEqual([])
+    expect(store.permission.ses_valid?.map((entry) => entry.id)).toEqual(["perm_valid"])
+    expect(store.question.ses_valid?.map((entry) => entry.id)).toEqual(["que_valid"])
+    expect(store.blocker.ses_valid?.map((entry) => entry.requestID)).toEqual(["que_valid"])
+  })
+
   test("keeps active status events that arrive before the status snapshot resolves", async () => {
     const directory = "/tmp/project"
     const queryClient = new QueryClient()

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -60,6 +60,14 @@ function errors(list: PromiseSettledResult<unknown>[]) {
   return list.filter((item): item is PromiseRejectedResult => item.status === "rejected").map((item) => item.reason)
 }
 
+function isNotFoundError(error: unknown) {
+  if (!error || typeof error !== "object") return false
+  const value = error as { name?: unknown; status?: unknown; statusCode?: unknown; response?: { status?: unknown } }
+  if (value.name === "NotFoundError") return true
+  if (value.status === 404 || value.statusCode === 404) return true
+  return value.response?.status === 404
+}
+
 const providerRev = new Map<string, number>()
 
 export function clearProviderRev(directory: string) {
@@ -179,7 +187,10 @@ export function activeSessionStatuses(input: State["session_status"]) {
   )
 }
 
-function sameSessionStatus(a: State["session_status"][string] | undefined, b: State["session_status"][string] | undefined) {
+function sameSessionStatus(
+  a: State["session_status"][string] | undefined,
+  b: State["session_status"][string] | undefined,
+) {
   return JSON.stringify(a) === JSON.stringify(b)
 }
 
@@ -206,16 +217,30 @@ function warmSessions(input: {
 }) {
   const known = new Set(input.store.session.map((item) => item.id))
   const ids = [...new Set(input.ids)].filter((id) => !!id && !known.has(id))
-  if (ids.length === 0) return Promise.resolve()
+  const warmed = new Set(input.store.session.map((item) => item.id))
+  const missing = new Set<string>()
+  if (ids.length === 0) return Promise.resolve({ warmed, missing })
   return Promise.all(
     ids.map((sessionID) =>
-      retry(() => input.sdk.session.get({ sessionID })).then((x) => {
-        const session = x.data
-        if (!session?.id) return
-        mergeSession(input.setStore, session)
-      }),
+      retry(() => input.sdk.session.get({ sessionID }))
+        .then((x) => {
+          const session = x.data
+          if (!session?.id) return
+          warmed.add(session.id)
+          mergeSession(input.setStore, session)
+        })
+        .catch((err) => {
+          if (!isNotFoundError(err)) throw err
+          missing.add(sessionID)
+        }),
     ),
-  ).then(() => undefined)
+  ).then(() => ({ warmed, missing }))
+}
+
+function filterGroupedByWarmSessions<T>(grouped: Record<string, T[]>, result: { missing: Set<string> }) {
+  const filtered = { ...grouped }
+  for (const sessionID of result.missing) delete filtered[sessionID]
+  return filtered
 }
 
 const inactiveQueryFn = async () => null
@@ -373,11 +398,14 @@ export async function bootstrapDirectory(input: {
         retry(() =>
           input.sdk.permission.list().then((x) => {
             const ids = (x.data ?? []).map((perm) => perm?.sessionID).filter((id): id is string => !!id)
-            const grouped = groupBySession(
-              (x.data ?? []).filter((perm): perm is PermissionRequest => !!perm?.id && !!perm.sessionID),
-            )
-            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
-              batch(() => {
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then((warm) => {
+              const grouped = filterGroupedByWarmSessions(
+                groupBySession(
+                  (x.data ?? []).filter((perm): perm is PermissionRequest => !!perm?.id && !!perm.sessionID),
+                ),
+                warm,
+              )
+              return batch(() => {
                 for (const sessionID of Object.keys(input.store.permission)) {
                   if (grouped[sessionID]) continue
                   input.setStore("permission", sessionID, [])
@@ -392,17 +420,20 @@ export async function bootstrapDirectory(input: {
                     ),
                   )
                 }
-              }),
-            )
+              })
+            })
           }),
         ),
       () =>
         retry(() =>
           input.sdk.question.list().then((x) => {
             const ids = (x.data ?? []).map((question) => question?.sessionID).filter((id): id is string => !!id)
-            const grouped = groupBySession((x.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID))
-            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
-              batch(() => {
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then((warm) => {
+              const grouped = filterGroupedByWarmSessions(
+                groupBySession((x.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID)),
+                warm,
+              )
+              return batch(() => {
                 for (const sessionID of Object.keys(input.store.question)) {
                   if (grouped[sessionID]) continue
                   input.setStore("question", sessionID, [])
@@ -417,17 +448,17 @@ export async function bootstrapDirectory(input: {
                     ),
                   )
                 }
-              }),
-            )
+              })
+            })
           }),
         ),
       () =>
         retry(() =>
           input.sdk.blocker.list().then((x) => {
             const ids = (x.data ?? []).map((blocker) => blocker?.sessionID).filter((id): id is string => !!id)
-            const grouped = groupBlockersBySession(x.data ?? [])
-            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then(() =>
-              batch(() => {
+            return warmSessions({ ids, store: input.store, setStore: input.setStore, sdk: input.sdk }).then((warm) => {
+              const grouped = filterGroupedByWarmSessions(groupBlockersBySession(x.data ?? []), warm)
+              return batch(() => {
                 for (const sessionID of Object.keys(input.store.blocker)) {
                   if (grouped[sessionID]) continue
                   input.setStore("blocker", sessionID, [])
@@ -436,11 +467,14 @@ export async function bootstrapDirectory(input: {
                   input.setStore(
                     "blocker",
                     sessionID,
-                    reconcile(blockers.sort((a, b) => cmp(a.requestID, b.requestID)), { key: "requestID" }),
+                    reconcile(
+                      blockers.sort((a, b) => cmp(a.requestID, b.requestID)),
+                      { key: "requestID" },
+                    ),
                   )
                 }
-              }),
-            )
+              })
+            })
           }),
         ),
       () => Promise.resolve(input.loadSessions(input.directory)),
@@ -466,6 +500,5 @@ export async function bootstrapDirectory(input: {
     }
 
     if (loading && errs.length === 0 && slowErrs.length === 0) input.setStore("status", "complete")
-
   })()
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -120,6 +120,10 @@ export namespace Permission {
   export interface Interface {
     readonly ask: (input: z.infer<typeof AskInput>) => Effect.Effect<void, Error>
     readonly reply: (input: z.infer<typeof ReplyInput>) => Effect.Effect<void>
+    readonly clearSession: (
+      sessionID: SessionID,
+      reason: "session_deleted" | "session_archived" | "dangling_session",
+    ) => Effect.Effect<void>
     readonly list: () => Effect.Effect<Request[]>
   }
 
@@ -285,12 +289,29 @@ export namespace Permission {
         }
       })
 
+      const clearSession = Effect.fn("Permission.clearSession")(function* (
+        sessionID: SessionID,
+        _reason: "session_deleted" | "session_archived" | "dangling_session",
+      ) {
+        const { pending } = yield* InstanceState.get(state)
+        for (const [id, item] of Array.from(pending.entries())) {
+          if (item.info.sessionID !== sessionID) continue
+          pending.delete(id)
+          yield* bus.publish(Event.Replied, {
+            sessionID: item.info.sessionID,
+            requestID: item.info.id,
+            reply: "reject",
+          })
+          yield* Deferred.fail(item.deferred, new RejectedError())
+        }
+      })
+
       const list = Effect.fn("Permission.list")(function* () {
         const pending = (yield* InstanceState.get(state)).pending
         return Array.from(pending.values(), (item) => item.info)
       })
 
-      return Service.of({ ask, reply, list })
+      return Service.of({ ask, reply, clearSession, list })
     }),
   )
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -8,6 +8,7 @@ import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 import { QuestionID } from "./schema"
 import { SessionBlocker } from "@/session/blocker"
+import type z from "zod"
 
 export namespace Question {
   const log = Log.create({ service: "question" })
@@ -27,8 +28,7 @@ export namespace Question {
   export class Option extends Schema.Class<Option>("QuestionOption")({
     label: TrimmedString(50, {
       emptyMsg: "Option label cannot be empty.",
-      tooLongMsg:
-        "Option label is too long (max 50 chars). Keep labels to 1–5 words; put detail in description.",
+      tooLongMsg: "Option label is too long (max 50 chars). Keep labels to 1–5 words; put detail in description.",
     }).annotate({ description: "Display text (1–5 words, max 50 chars)" }),
     description: TrimmedString(50, {
       emptyMsg: "Option description cannot be empty.",
@@ -49,8 +49,7 @@ export namespace Question {
     }),
     header: TrimmedString(30, {
       emptyMsg: "Header cannot be empty.",
-      tooLongMsg:
-        "Header is too long (max 30 chars). Use a chip-sized label like 'Auth method' or 'Approach'.",
+      tooLongMsg: "Header is too long (max 30 chars). Use a chip-sized label like 'Auth method' or 'Approach'.",
     }).annotate({ description: "Very short label (max 30 chars)" }),
     options: Schema.mutable(Schema.Array(Option))
       .check(Schema.isMinLength(2, { message: "Each question needs at least 2 options." }))
@@ -197,6 +196,7 @@ export namespace Question {
     }) => Effect.Effect<ReadonlyArray<Answer>, RejectedError>
     readonly reply: (input: { requestID: QuestionID; answers: ReadonlyArray<Answer> }) => Effect.Effect<void>
     readonly reject: (requestID: QuestionID) => Effect.Effect<void>
+    readonly clearSession: (sessionID: SessionID, reason: SessionBlocker.CleanupReason) => Effect.Effect<void>
     readonly list: () => Effect.Effect<ReadonlyArray<Request>>
   }
 
@@ -471,6 +471,32 @@ export namespace Question {
         yield* Deferred.fail(existing.deferred, new RejectedError({ reason: "dismissed" }))
       })
 
+      const rejectedReason = (reason: SessionBlocker.CleanupReason): z.infer<typeof Rejected.zod>["reason"] => {
+        if (reason === "session_deleted" || reason === "session_archived" || reason === "dangling_session")
+          return "shutdown"
+        if (reason === "replied") return "shutdown"
+        return reason
+      }
+
+      const clearSession = Effect.fn("Question.clearSession")(function* (
+        sessionID: SessionID,
+        reason: SessionBlocker.CleanupReason,
+      ) {
+        const pending = (yield* InstanceState.get(state)).pending
+        const terminalReason = rejectedReason(reason)
+        for (const [requestID, entry] of Array.from(pending.entries())) {
+          if (entry.info.sessionID !== sessionID) continue
+          pending.delete(requestID)
+          yield* blockers.removeQuestion({ requestID, reason: terminalReason })
+          yield* bus.publish(Event.Rejected, {
+            sessionID: entry.info.sessionID,
+            requestID: entry.info.id,
+            reason: terminalReason,
+          })
+          yield* Deferred.fail(entry.deferred, new RejectedError({ cancelled: true, reason: terminalReason }))
+        }
+      })
+
       const list = Effect.fn("Question.list")(function* () {
         const pending = (yield* InstanceState.get(state)).pending
         // Hand callers a clone so they can't mutate the stored snapshot
@@ -478,7 +504,7 @@ export namespace Question {
         return Array.from(pending.values(), (x) => structuredClone(x.info))
       })
 
-      return Service.of({ ask, reply, reject, list })
+      return Service.of({ ask, reply, reject, clearSession, list })
     }),
   )
 

--- a/packages/opencode/src/server/instance/blocker.ts
+++ b/packages/opencode/src/server/instance/blocker.ts
@@ -5,22 +5,21 @@ import { AppRuntime } from "@/effect/app-runtime"
 import { SessionBlocker } from "@/session/blocker"
 import { lazy } from "../../util/lazy"
 import { Env } from "@/env"
+import { SessionLiveness } from "@/session/liveness"
+import { Effect } from "effect"
 
 const e2eBlockerRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 export const BlockerRoutes = lazy(() =>
   new Hono()
-    .post(
-      "/__e2e/publish-upserted",
-      async (c) => {
-        if (!e2eBlockerRoutesEnabled()) return c.notFound()
-        const json = await c.req.json()
-        await AppRuntime.runPromise(
-          SessionBlocker.Service.use((svc) => svc.upsertQuestion(SessionBlocker.QuestionRequest.parse(json.request))),
-        )
-        return c.body(null, 204)
-      },
-    )
+    .post("/__e2e/publish-upserted", async (c) => {
+      if (!e2eBlockerRoutesEnabled()) return c.notFound()
+      const json = await c.req.json()
+      await AppRuntime.runPromise(
+        SessionBlocker.Service.use((svc) => svc.upsertQuestion(SessionBlocker.QuestionRequest.parse(json.request))),
+      )
+      return c.body(null, 204)
+    })
     .get(
       "/",
       describeRoute({
@@ -39,7 +38,24 @@ export const BlockerRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const blockers = await AppRuntime.runPromise(SessionBlocker.Service.use((svc) => svc.list()))
+        const blockers = await AppRuntime.runPromise(
+          SessionBlocker.Service.use((svc) =>
+            svc.list().pipe(
+              Effect.flatMap((items) => {
+                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
+                const inactiveSessionIDs = new Set(
+                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
+                )
+                return Effect.gen(function* () {
+                  for (const sessionID of inactiveSessionIDs) {
+                    yield* svc.clearSession(sessionID, "dangling_session")
+                  }
+                  return items.filter((item) => active.has(item.sessionID))
+                })
+              }),
+            ),
+          ),
+        )
         return c.json(blockers)
       },
     ),

--- a/packages/opencode/src/server/instance/blocker.ts
+++ b/packages/opencode/src/server/instance/blocker.ts
@@ -40,20 +40,13 @@ export const BlockerRoutes = lazy(() =>
       async (c) => {
         const blockers = await AppRuntime.runPromise(
           SessionBlocker.Service.use((svc) =>
-            svc.list().pipe(
-              Effect.flatMap((items) => {
-                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
-                const inactiveSessionIDs = new Set(
-                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
-                )
-                return Effect.gen(function* () {
-                  for (const sessionID of inactiveSessionIDs) {
-                    yield* svc.clearSession(sessionID, "dangling_session")
-                  }
-                  return items.filter((item) => active.has(item.sessionID))
-                })
-              }),
-            ),
+            svc
+              .list()
+              .pipe(
+                Effect.flatMap((items) =>
+                  SessionLiveness.pruneDangling(items, (sessionID) => svc.clearSession(sessionID, "dangling_session")),
+                ),
+              ),
           ),
         )
         return c.json(blockers)

--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -9,10 +9,11 @@ import { lazy } from "../../util/lazy"
 import { Env } from "@/env"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Log } from "@opencode-ai/core/util/log"
+import { SessionLiveness } from "@/session/liveness"
+import { Effect } from "effect"
 
 const log = Log.create({ service: "server" })
-const e2ePermissionRoutesEnabled = () =>
-  Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+const e2ePermissionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 export const PermissionRoutes = lazy(() =>
   new Hono()
@@ -104,7 +105,24 @@ export const PermissionRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const permissions = await Permission.list()
+        const permissions = await AppRuntime.runPromise(
+          Permission.Service.use((svc) =>
+            svc.list().pipe(
+              Effect.flatMap((items) => {
+                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
+                const inactiveSessionIDs = new Set(
+                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
+                )
+                return Effect.gen(function* () {
+                  for (const sessionID of inactiveSessionIDs) {
+                    yield* svc.clearSession(sessionID, "dangling_session")
+                  }
+                  return items.filter((item) => active.has(item.sessionID))
+                })
+              }),
+            ),
+          ),
+        )
         return c.json(permissions)
       },
     ),

--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -107,20 +107,13 @@ export const PermissionRoutes = lazy(() =>
       async (c) => {
         const permissions = await AppRuntime.runPromise(
           Permission.Service.use((svc) =>
-            svc.list().pipe(
-              Effect.flatMap((items) => {
-                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
-                const inactiveSessionIDs = new Set(
-                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
-                )
-                return Effect.gen(function* () {
-                  for (const sessionID of inactiveSessionIDs) {
-                    yield* svc.clearSession(sessionID, "dangling_session")
-                  }
-                  return items.filter((item) => active.has(item.sessionID))
-                })
-              }),
-            ),
+            svc
+              .list()
+              .pipe(
+                Effect.flatMap((items) =>
+                  SessionLiveness.pruneDangling(items, (sessionID) => svc.clearSession(sessionID, "dangling_session")),
+                ),
+              ),
           ),
         )
         return c.json(permissions)

--- a/packages/opencode/src/server/instance/question.ts
+++ b/packages/opencode/src/server/instance/question.ts
@@ -11,10 +11,11 @@ import { Log } from "@opencode-ai/core/util/log"
 import z from "zod"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { SessionLiveness } from "@/session/liveness"
+import { Effect } from "effect"
 
 const log = Log.create({ service: "server" })
-const e2eQuestionRoutesEnabled = () =>
-  Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+const e2eQuestionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 export const QuestionRoutes = lazy(() =>
   new Hono()
@@ -81,7 +82,24 @@ export const QuestionRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const questions = await AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))
+        const questions = await AppRuntime.runPromise(
+          Question.Service.use((svc) =>
+            svc.list().pipe(
+              Effect.flatMap((items) => {
+                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
+                const inactiveSessionIDs = new Set(
+                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
+                )
+                return Effect.gen(function* () {
+                  for (const sessionID of inactiveSessionIDs) {
+                    yield* svc.clearSession(sessionID, "dangling_session")
+                  }
+                  return items.filter((item) => active.has(item.sessionID))
+                })
+              }),
+            ),
+          ),
+        )
         return c.json(questions)
       },
     )

--- a/packages/opencode/src/server/instance/question.ts
+++ b/packages/opencode/src/server/instance/question.ts
@@ -84,20 +84,13 @@ export const QuestionRoutes = lazy(() =>
       async (c) => {
         const questions = await AppRuntime.runPromise(
           Question.Service.use((svc) =>
-            svc.list().pipe(
-              Effect.flatMap((items) => {
-                const active = SessionLiveness.activeSessionIDs(items.map((item) => item.sessionID))
-                const inactiveSessionIDs = new Set(
-                  items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID),
-                )
-                return Effect.gen(function* () {
-                  for (const sessionID of inactiveSessionIDs) {
-                    yield* svc.clearSession(sessionID, "dangling_session")
-                  }
-                  return items.filter((item) => active.has(item.sessionID))
-                })
-              }),
-            ),
+            svc
+              .list()
+              .pipe(
+                Effect.flatMap((items) =>
+                  SessionLiveness.pruneDangling(items, (sessionID) => svc.clearSession(sessionID, "dangling_session")),
+                ),
+              ),
           ),
         )
         return c.json(questions)

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -15,9 +15,6 @@ import { ServerAuth } from "./auth"
 const log = Log.create({ service: "server" })
 
 export const ErrorMiddleware: ErrorHandler = (err, c) => {
-  log.error("failed", {
-    error: err,
-  })
   if (err instanceof NamedError) {
     let status: ContentfulStatusCode
     if (err instanceof NotFoundError) status = 404
@@ -25,8 +22,16 @@ export const ErrorMiddleware: ErrorHandler = (err, c) => {
     else if (err.name === "ProviderAuthValidationFailed") status = 400
     else if (err.name.startsWith("Worktree")) status = 400
     else status = 500
+    if (!(err instanceof NotFoundError)) {
+      log.error("failed", {
+        error: err,
+      })
+    }
     return c.json(err.toObject(), { status })
   }
+  log.error("failed", {
+    error: err,
+  })
   if (err instanceof Session.BusyError) {
     return c.json(new NamedError.Unknown({ message: err.message }).toObject(), { status: 400 })
   }

--- a/packages/opencode/src/session/blocker.ts
+++ b/packages/opencode/src/session/blocker.ts
@@ -9,6 +9,7 @@ import { QuestionID } from "@/question/schema"
 export namespace SessionBlocker {
   export const TerminalReason = z.enum(["replied", "cancelled", "dismissed", "shutdown", "rejected"])
   export type TerminalReason = z.infer<typeof TerminalReason>
+  export type CleanupReason = TerminalReason | "session_deleted" | "session_archived" | "dangling_session"
 
   export const QuestionRequest = z.object({
     id: QuestionID.zod,
@@ -73,10 +74,8 @@ export namespace SessionBlocker {
 
   export interface Interface {
     readonly upsertQuestion: (request: QuestionRequest) => Effect.Effect<void>
-    readonly removeQuestion: (input: {
-      requestID: QuestionID
-      reason: TerminalReason
-    }) => Effect.Effect<void>
+    readonly removeQuestion: (input: { requestID: QuestionID; reason: TerminalReason }) => Effect.Effect<void>
+    readonly clearSession: (sessionID: SessionID, reason: CleanupReason) => Effect.Effect<void>
     readonly list: () => Effect.Effect<ReadonlyArray<Entry>>
     readonly hasAwaitingQuestion: (sessionID: SessionID) => Effect.Effect<boolean>
   }
@@ -122,6 +121,30 @@ export namespace SessionBlocker {
         })
       })
 
+      const clearReason = (reason: CleanupReason): TerminalReason => {
+        if (reason === "session_deleted" || reason === "session_archived" || reason === "dangling_session")
+          return "shutdown"
+        return reason
+      }
+
+      const clearSession = Effect.fn("SessionBlocker.clearSession")(function* (
+        sessionID: SessionID,
+        reason: CleanupReason,
+      ) {
+        const pending = questionState(yield* InstanceState.directory)
+        const terminalReason = clearReason(reason)
+        for (const entry of Array.from(pending.values())) {
+          if (entry.sessionID !== sessionID) continue
+          pending.delete(entry.requestID)
+          yield* bus.publish(Event.Removed, {
+            kind: "question",
+            sessionID: entry.sessionID,
+            requestID: entry.requestID,
+            reason: terminalReason,
+          })
+        }
+      })
+
       const list = Effect.fn("SessionBlocker.list")(function* () {
         const pending = questionState(yield* InstanceState.directory)
         return Array.from(pending.values(), (entry) => structuredClone(entry))
@@ -135,7 +158,7 @@ export namespace SessionBlocker {
         return false
       })
 
-      return Service.of({ upsertQuestion, removeQuestion, list, hasAwaitingQuestion })
+      return Service.of({ upsertQuestion, removeQuestion, clearSession, list, hasAwaitingQuestion })
     }),
   )
 

--- a/packages/opencode/src/session/liveness.ts
+++ b/packages/opencode/src/session/liveness.ts
@@ -1,0 +1,27 @@
+import { Instance } from "@/project/instance"
+import { Database, and, eq, inArray, isNull } from "@/storage/db"
+import { SessionTable } from "./session.sql"
+import { SessionID } from "./schema"
+
+export namespace SessionLiveness {
+  export function activeSessionIDs(sessionIDs: ReadonlyArray<SessionID>) {
+    const unique = [...new Set(sessionIDs)]
+    if (unique.length === 0) return new Set<SessionID>()
+
+    const rows = Database.use((db) =>
+      db
+        .select({ id: SessionTable.id })
+        .from(SessionTable)
+        .where(
+          and(
+            eq(SessionTable.project_id, Instance.project.id),
+            isNull(SessionTable.time_archived),
+            inArray(SessionTable.id, unique),
+          ),
+        )
+        .all(),
+    )
+
+    return new Set(rows.map((row) => row.id))
+  }
+}

--- a/packages/opencode/src/session/liveness.ts
+++ b/packages/opencode/src/session/liveness.ts
@@ -2,6 +2,7 @@ import { Instance } from "@/project/instance"
 import { Database, and, eq, inArray, isNull } from "@/storage/db"
 import { SessionTable } from "./session.sql"
 import { SessionID } from "./schema"
+import { Effect } from "effect"
 
 export namespace SessionLiveness {
   export function activeSessionIDs(sessionIDs: ReadonlyArray<SessionID>) {
@@ -23,5 +24,19 @@ export namespace SessionLiveness {
     )
 
     return new Set(rows.map((row) => row.id))
+  }
+
+  export function pruneDangling<T extends { sessionID: SessionID }, E, R>(
+    items: ReadonlyArray<T>,
+    clearSession: (sessionID: SessionID) => Effect.Effect<void, E, R>,
+  ) {
+    const active = activeSessionIDs(items.map((item) => item.sessionID))
+    return Effect.gen(function* () {
+      const inactive = new Set(items.filter((item) => !active.has(item.sessionID)).map((item) => item.sessionID))
+      for (const sessionID of inactive) {
+        yield* clearSession(sessionID)
+      }
+      return items.filter((item) => active.has(item.sessionID))
+    })
   }
 }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -557,19 +557,35 @@ const backfillExecutionContextEffect = Effect.fn("Session.backfillExecutionConte
 
 export const backfillExecutionContext = backfillExecutionContextEffect()
 
-export const layer: Layer.Layer<
-  Service,
-  never,
-  Bus.Service | Storage.Service | Question.Service | Permission.Service | SessionBlocker.Service
-> = Layer.effect(
+export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const storage = yield* Storage.Service
-    const questions = yield* Question.Service
-    const permissions = yield* Permission.Service
-    const blockers = yield* SessionBlocker.Service
     yield* backfillExecutionContextEffect()
+
+    const hasInstanceContext = Effect.fn("Session.hasInstanceContext")(function* () {
+      return yield* InstanceState.directory.pipe(
+        Effect.as(true),
+        Effect.catchCause(() => Effect.succeed(false)),
+      )
+    })
+
+    const clearPendingInteractions = Effect.fn("Session.clearPendingInteractions")(function* (
+      sessionID: SessionID,
+      reason: "session_deleted" | "session_archived",
+    ) {
+      if (!(yield* hasInstanceContext())) return
+      yield* Question.Service.use((svc) => svc.clearSession(sessionID, reason)).pipe(
+        Effect.provide(Question.defaultLayer),
+      )
+      yield* Permission.Service.use((svc) => svc.clearSession(sessionID, reason)).pipe(
+        Effect.provide(Permission.defaultLayer),
+      )
+      yield* SessionBlocker.Service.use((svc) => svc.clearSession(sessionID, reason)).pipe(
+        Effect.provide(SessionBlocker.defaultLayer),
+      )
+    })
 
     const createNext = Effect.fn("Session.createNext")(function* (input: {
       id?: SessionID
@@ -664,9 +680,7 @@ export const layer: Layer.Layer<
     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {
       try {
         const session = yield* get(sessionID)
-        yield* questions.clearSession(sessionID, "session_deleted")
-        yield* permissions.clearSession(sessionID, "session_deleted")
-        yield* blockers.clearSession(sessionID, "session_deleted")
+        yield* clearPendingInteractions(sessionID, "session_deleted")
         const kids = yield* children(sessionID)
         for (const child of kids) {
           yield* remove(child.id)
@@ -835,9 +849,7 @@ export const layer: Layer.Layer<
 
     const setArchived = Effect.fn("Session.setArchived")(function* (input: { sessionID: SessionID; time?: number }) {
       if (input.time !== undefined) {
-        yield* questions.clearSession(input.sessionID, "session_archived")
-        yield* permissions.clearSession(input.sessionID, "session_archived")
-        yield* blockers.clearSession(input.sessionID, "session_archived")
+        yield* clearPendingInteractions(input.sessionID, "session_archived")
       }
       yield* patch(input.sessionID, { time: { archived: input.time } })
     })
@@ -1036,9 +1048,6 @@ export const layer: Layer.Layer<
 )
 
 export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(
-  Layer.provide(Question.defaultLayer),
-  Layer.provide(Permission.defaultLayer),
-  Layer.provide(SessionBlocker.defaultLayer),
   Layer.provide(Bus.layer),
   Layer.provide(Storage.defaultLayer),
 )

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -45,10 +45,18 @@ import { Runtime } from "@opencode-ai/core/runtime"
 
 import type { Provider } from "@/provider"
 import { Permission } from "@/permission"
+import { Question } from "@/question"
+import { SessionBlocker } from "@/session/blocker"
 import { Global } from "@/global"
 import { Effect, Layer, Option, Context } from "effect"
 import { SubagentRunWriterContext, SubagentRunGuardViolation, lifecycleFieldsChanged } from "./subagent-run-context"
-import { ActiveWorktree, SessionExecutionContext, canonicalDirectory, rootContext, sameDirectory } from "./execution-context"
+import {
+  ActiveWorktree,
+  SessionExecutionContext,
+  canonicalDirectory,
+  rootContext,
+  sameDirectory,
+} from "./execution-context"
 import { backfillExecutionContextRows } from "./execution-context-store"
 
 const log = Log.create({ service: "session" })
@@ -549,11 +557,18 @@ const backfillExecutionContextEffect = Effect.fn("Session.backfillExecutionConte
 
 export const backfillExecutionContext = backfillExecutionContextEffect()
 
-export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> = Layer.effect(
+export const layer: Layer.Layer<
+  Service,
+  never,
+  Bus.Service | Storage.Service | Question.Service | Permission.Service | SessionBlocker.Service
+> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const storage = yield* Storage.Service
+    const questions = yield* Question.Service
+    const permissions = yield* Permission.Service
+    const blockers = yield* SessionBlocker.Service
     yield* backfillExecutionContextEffect()
 
     const createNext = Effect.fn("Session.createNext")(function* (input: {
@@ -649,6 +664,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {
       try {
         const session = yield* get(sessionID)
+        yield* questions.clearSession(sessionID, "session_deleted")
+        yield* permissions.clearSession(sessionID, "session_deleted")
+        yield* blockers.clearSession(sessionID, "session_deleted")
         const kids = yield* children(sessionID)
         for (const child of kids) {
           yield* remove(child.id)
@@ -816,6 +834,11 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
     })
 
     const setArchived = Effect.fn("Session.setArchived")(function* (input: { sessionID: SessionID; time?: number }) {
+      if (input.time !== undefined) {
+        yield* questions.clearSession(input.sessionID, "session_archived")
+        yield* permissions.clearSession(input.sessionID, "session_archived")
+        yield* blockers.clearSession(input.sessionID, "session_archived")
+      }
       yield* patch(input.sessionID, { time: { archived: input.time } })
     })
 
@@ -1013,6 +1036,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
 )
 
 export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(
+  Layer.provide(Question.defaultLayer),
+  Layer.provide(Permission.defaultLayer),
+  Layer.provide(SessionBlocker.defaultLayer),
   Layer.provide(Bus.layer),
   Layer.provide(Storage.defaultLayer),
 )
@@ -1222,11 +1248,8 @@ export function* listGlobal(input?: {
             .select(sort === "activity" ? activitySelect : getTableColumns(SessionTable))
             .from(SessionTable)
             .where(and(...conditions))
-        : db
-            .select(sort === "activity" ? activitySelect : getTableColumns(SessionTable))
-            .from(SessionTable)
-    const order =
-      sort === "activity" ? [desc(activityAtExpr), asc(SessionTable.id)] : sessionOrder(sort)
+        : db.select(sort === "activity" ? activitySelect : getTableColumns(SessionTable)).from(SessionTable)
+    const order = sort === "activity" ? [desc(activityAtExpr), asc(SessionTable.id)] : sessionOrder(sort)
     return query
       .orderBy(...order)
       .limit(limit)
@@ -1267,8 +1290,7 @@ export function* listGlobal(input?: {
       sort === "activity"
         ? (row.lastUserMessageAt ?? (row.activityAt !== row.time_created ? row.activityAt : undefined))
         : undefined
-    const lastUserMessage =
-      lastUserMessageAt !== null && lastUserMessageAt !== undefined ? { lastUserMessageAt } : {}
+    const lastUserMessage = lastUserMessageAt !== null && lastUserMessageAt !== undefined ? { lastUserMessageAt } : {}
     yield { ...fromRow(row, projectFallbacks.get(row.project_id)), project, ...activity, ...lastUserMessage }
   }
 }

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -51,7 +51,7 @@ const windowsOpencodeShards = [
     suffix: "opencode-session",
     usesTurbo: false,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-session.xml test/session test/plugin test/permission test/util test/skill test/index-runtime-namespace.test.ts test/permission-agent.test.ts",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-session.xml test/session test/plugin test/permission test/util test/skill test/index-runtime-namespace.test.ts test/permission-agent.test.ts test/permission-cleanup.test.ts",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-session.xml",
   },
   {

--- a/packages/opencode/test/permission-cleanup.test.ts
+++ b/packages/opencode/test/permission-cleanup.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Permission } from "../src/permission"
+import { AppRuntime } from "../src/effect/app-runtime"
+import { Instance } from "../src/project/instance"
+import { SessionID } from "../src/session/schema"
+import { tmpdir } from "./fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const askPermission = (sessionID: SessionID) =>
+  AppRuntime.runPromise(
+    Permission.Service.use((svc) =>
+      svc.ask({
+        sessionID,
+        permission: "edit",
+        patterns: ["/tmp/file.txt"],
+        always: ["/tmp/file.txt"],
+        metadata: {},
+        ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+      }),
+    ),
+  )
+
+const listPermissions = () => AppRuntime.runPromise(Permission.Service.use((svc) => svc.list()))
+
+const clearPermissionsForSession = (sessionID: SessionID) =>
+  AppRuntime.runPromise(Permission.Service.use((svc) => svc.clearSession(sessionID, "session_deleted")))
+
+async function waitForPending(timeoutMs = 1000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const pending = await listPermissions()
+    if (pending.length === 1) return pending[0]!
+    await Bun.sleep(10)
+  }
+  expect(await listPermissions()).toHaveLength(1)
+  throw new Error("unreachable: assertion above always throws on miss")
+}
+
+describe("Permission.clearSession", () => {
+  test("rejects pending permissions for the session and removes them from the list", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const sessionID = SessionID.make("ses_permission_cleanup")
+        const promise = askPermission(sessionID)
+
+        await waitForPending()
+        await clearPermissionsForSession(sessionID)
+
+        await expect(promise).rejects.toThrow("The user rejected permission to use this specific tool call.")
+        expect(await listPermissions()).toEqual([])
+      },
+    })
+  })
+})

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -11,7 +11,11 @@ import { AppRuntime } from "../../src/effect/app-runtime"
 const ask = (
   input: { sessionID: SessionID; questions: Question.Info[]; tool?: { messageID: any; callID: string } },
   options?: { signal?: AbortSignal },
-) => AppRuntime.runPromise(Question.Service.use((svc) => svc.ask(input)), options)
+) =>
+  AppRuntime.runPromise(
+    Question.Service.use((svc) => svc.ask(input)),
+    options,
+  )
 
 const list = () => AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))
 
@@ -20,7 +24,13 @@ const reply = (input: { requestID: QuestionID; answers: Question.Answer[] }) =>
 
 const reject = (id: QuestionID) => AppRuntime.runPromise(Question.Service.use((svc) => svc.reject(id)))
 
+const clearQuestionsForSession = (sessionID: SessionID) =>
+  AppRuntime.runPromise(Question.Service.use((svc) => svc.clearSession(sessionID, "session_deleted")))
+
 const listBlockers = () => AppRuntime.runPromise(SessionBlocker.Service.use((svc) => svc.list()))
+
+const clearBlockersForSession = (sessionID: SessionID) =>
+  AppRuntime.runPromise(SessionBlocker.Service.use((svc) => svc.clearSession(sessionID, "session_deleted")))
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -45,6 +55,15 @@ async function waitForPending(timeoutMs = 1000) {
   }
   expect(await list(), "expected exactly one pending question before continuing").toHaveLength(1)
   throw new Error("unreachable: assertion above always throws on miss")
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, timeoutMs = 1000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return
+    await Bun.sleep(10)
+  }
+  throw new Error("timed out waiting for condition")
 }
 
 test("ask - returns pending promise", async () => {
@@ -137,6 +156,86 @@ test("ask - records an awaiting question blocker", async () => {
 
       await rejectAll()
       await promise.catch(() => {})
+    },
+  })
+})
+
+test("clearSession - rejects pending questions and removes associated blockers", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const sessionID = SessionID.make("ses_question_cleanup")
+      const promise = ask({
+        sessionID,
+        questions: [
+          {
+            question: "Continue?",
+            header: "Confirm",
+            options: [
+              { label: "Yes", description: "continue" },
+              { label: "No", description: "stop" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make("msg_question_cleanup"), callID: "call_question_cleanup" },
+      })
+
+      await waitForPending()
+      expect(await listBlockers()).toHaveLength(1)
+
+      await clearQuestionsForSession(sessionID)
+
+      await expect(promise).rejects.toThrow("Question cancelled before the user answered it.")
+      expect(await list()).toEqual([])
+      expect(await listBlockers()).toEqual([])
+    },
+  })
+})
+
+test("SessionBlocker.clearSession removes only blockers for that session", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const first = ask({
+        sessionID: SessionID.make("ses_blocker_cleanup_a"),
+        questions: [
+          {
+            question: "A?",
+            header: "A",
+            options: [
+              { label: "A", description: "first" },
+              { label: "Skip", description: "skip" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make("msg_blocker_cleanup_a"), callID: "call_a" },
+      })
+      const second = ask({
+        sessionID: SessionID.make("ses_blocker_cleanup_b"),
+        questions: [
+          {
+            question: "B?",
+            header: "B",
+            options: [
+              { label: "B", description: "second" },
+              { label: "Skip", description: "skip" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make("msg_blocker_cleanup_b"), callID: "call_b" },
+      })
+
+      await waitFor(async () => (await listBlockers()).length === 2)
+      await clearBlockersForSession(SessionID.make("ses_blocker_cleanup_a"))
+
+      const blockers = await listBlockers()
+      expect(blockers).toHaveLength(1)
+      expect(blockers[0]!.sessionID).toBe(SessionID.make("ses_blocker_cleanup_b"))
+
+      await rejectAll()
+      await Promise.all([first.catch(() => {}), second.catch(() => {})])
     },
   })
 })
@@ -465,7 +564,10 @@ test("list - returns all pending requests", async () => {
           {
             question: "Question 1?",
             header: "Q1",
-            options: [{ label: "A", description: "A" }, { label: "B", description: "B" }],
+            options: [
+              { label: "A", description: "A" },
+              { label: "B", description: "B" },
+            ],
           },
         ],
       })
@@ -476,7 +578,10 @@ test("list - returns all pending requests", async () => {
           {
             question: "Question 2?",
             header: "Q2",
-            options: [{ label: "B", description: "B" }, { label: "C", description: "C" }],
+            options: [
+              { label: "B", description: "B" },
+              { label: "C", description: "C" },
+            ],
           },
         ],
       })
@@ -514,7 +619,10 @@ test("questions stay isolated by directory", async () => {
           {
             question: "Question 1?",
             header: "Q1",
-            options: [{ label: "A", description: "A" }, { label: "B", description: "B" }],
+            options: [
+              { label: "A", description: "A" },
+              { label: "B", description: "B" },
+            ],
           },
         ],
       }),
@@ -529,7 +637,10 @@ test("questions stay isolated by directory", async () => {
           {
             question: "Question 2?",
             header: "Q2",
-            options: [{ label: "B", description: "B" }, { label: "C", description: "C" }],
+            options: [
+              { label: "B", description: "B" },
+              { label: "C", description: "C" },
+            ],
           },
         ],
       }),
@@ -769,7 +880,10 @@ test("pending question rejects on instance dispose", async () => {
           {
             question: "Dispose me?",
             header: "Dispose",
-            options: [{ label: "Yes", description: "Yes" }, { label: "No", description: "No" }],
+            options: [
+              { label: "Yes", description: "Yes" },
+              { label: "No", description: "No" },
+            ],
           },
         ],
       })
@@ -804,7 +918,10 @@ test("pending question rejects on instance reload", async () => {
           {
             question: "Reload me?",
             header: "Reload",
-            options: [{ label: "Yes", description: "Yes" }, { label: "No", description: "No" }],
+            options: [
+              { label: "Yes", description: "Yes" },
+              { label: "No", description: "No" },
+            ],
           },
         ],
       })

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -182,7 +182,7 @@ test("clearSession - rejects pending questions and removes associated blockers",
       })
 
       await waitForPending()
-      expect(await listBlockers()).toHaveLength(1)
+      await waitFor(async () => (await listBlockers()).length === 1)
 
       await clearQuestionsForSession(sessionID)
 

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -70,6 +70,7 @@ describe("server error middleware", () => {
 
   test("does not error-log expected not found responses", async () => {
     await Log.init({ print: false })
+    const before = await readLogFile()
     const app = new Hono().get("/missing", () => {
       throw new NotFoundError({ message: "Session not found: ses_missing" })
     })
@@ -77,7 +78,8 @@ describe("server error middleware", () => {
 
     const response = await app.request("/missing")
     const body = await response.json()
-    const logs = await readLogFile()
+    const after = await readLogFile()
+    const logs = after.slice(before.length)
 
     expect(response.status).toBe(404)
     expect(body.name).toBe("NotFoundError")
@@ -87,13 +89,15 @@ describe("server error middleware", () => {
 
   test("still error-logs unexpected server failures", async () => {
     await Log.init({ print: false })
+    const before = await readLogFile()
     const app = new Hono().get("/boom", () => {
       throw new Error("boom")
     })
     app.onError(ErrorMiddleware)
 
     const response = await app.request("/boom")
-    const logs = await readLogFile()
+    const after = await readLogFile()
+    const logs = after.slice(before.length)
 
     expect(response.status).toBe(500)
     expect(logs).toContain("ERROR")

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, test } from "bun:test"
+import { readFile } from "fs/promises"
 import { Hono } from "hono"
+import { Log } from "@opencode-ai/core/util/log"
 import { InvalidError, JsonError } from "../../src/config/error"
 import { ErrorMiddleware } from "../../src/server/middleware"
+import { NotFoundError } from "../../src/storage/db"
+
+async function readLogFile() {
+  for (let i = 0; i < 20; i++) {
+    const text = await readFile(Log.file(), "utf8").catch(() => "")
+    if (text.length > 0) return text
+    await Bun.sleep(10)
+  }
+  return readFile(Log.file(), "utf8").catch(() => "")
+}
 
 describe("server error middleware", () => {
   test("serializes config named errors instead of wrapping them as unknown errors", async () => {
@@ -54,5 +66,38 @@ describe("server error middleware", () => {
     expect(body.data.path).toBe("opencode.json")
     expect(body.data.message).toBe("bad config")
     expect(body.data.issues).toBeUndefined()
+  })
+
+  test("does not error-log expected not found responses", async () => {
+    await Log.init({ print: false })
+    const app = new Hono().get("/missing", () => {
+      throw new NotFoundError({ message: "Session not found: ses_missing" })
+    })
+    app.onError(ErrorMiddleware)
+
+    const response = await app.request("/missing")
+    const body = await response.json()
+    const logs = await readLogFile()
+
+    expect(response.status).toBe(404)
+    expect(body.name).toBe("NotFoundError")
+    expect(logs).not.toContain("ERROR")
+    expect(logs).not.toContain("failed")
+  })
+
+  test("still error-logs unexpected server failures", async () => {
+    await Log.init({ print: false })
+    const app = new Hono().get("/boom", () => {
+      throw new Error("boom")
+    })
+    app.onError(ErrorMiddleware)
+
+    const response = await app.request("/boom")
+    const logs = await readLogFile()
+
+    expect(response.status).toBe(500)
+    expect(logs).toContain("ERROR")
+    expect(logs).toContain("failed")
+    expect(logs).toContain("boom")
   })
 })

--- a/packages/opencode/test/server/pending-interaction-routes.test.ts
+++ b/packages/opencode/test/server/pending-interaction-routes.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Instance } from "../../src/project/instance"
+import { Permission } from "../../src/permission"
+import { Question } from "../../src/question"
+import { QuestionID } from "../../src/question/schema"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+import type { Effect } from "effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const run = <A, E, R>(effect: Effect.Effect<A, E, R>) => AppRuntime.runPromise(effect as never) as Promise<A>
+
+async function askQuestion(sessionID: SessionID, suffix: string) {
+  const promise = run(
+    Question.Service.use((svc) =>
+      svc.ask({
+        sessionID,
+        questions: [
+          {
+            question: `Question ${suffix}?`,
+            header: suffix,
+            options: [
+              { label: "Yes", description: "yes" },
+              { label: "No", description: "no" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make(`msg_${suffix}`), callID: `call_${suffix}` },
+      }),
+    ),
+  )
+  await waitFor(async () => (await listQuestions()).some((item) => item.sessionID === sessionID))
+  return { promise }
+}
+
+async function askPermission(sessionID: SessionID) {
+  const promise = run(
+    Permission.Service.use((svc) =>
+      svc.ask({
+        sessionID,
+        permission: "edit",
+        patterns: ["/tmp/file.txt"],
+        always: ["/tmp/file.txt"],
+        metadata: {},
+        ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+      }),
+    ),
+  )
+  await waitFor(async () => (await listPermissions()).some((item) => item.sessionID === sessionID))
+  return { promise }
+}
+
+const listQuestions = () => run(Question.Service.use((svc) => svc.list()))
+const listPermissions = () => run(Permission.Service.use((svc) => svc.list()))
+
+async function rejectAllQuestions() {
+  for (const request of await listQuestions()) {
+    await run(Question.Service.use((svc) => svc.reject(request.id)))
+  }
+}
+
+async function rejectAllPermissions() {
+  for (const request of await listPermissions()) {
+    await run(Permission.Service.use((svc) => svc.reply({ requestID: request.id, reply: "reject" })))
+  }
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, timeoutMs = 1000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return
+    await Bun.sleep(10)
+  }
+  throw new Error("timed out waiting for condition")
+}
+
+describe("pending interaction routes", () => {
+  test("question, permission, and blocker list routes prune missing-session entries", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.Default().app
+        const instanceQuery = `?directory=${encodeURIComponent(tmp.path)}`
+        const session = await run(Session.Service.use((svc) => svc.create({})))
+        const missingSessionID = SessionID.make("ses_missing_pending_route")
+        const missingQuestion = await askQuestion(missingSessionID, "missing")
+        const validQuestion = await askQuestion(session.id, "valid")
+        const missingPermission = await askPermission(missingSessionID)
+        const validPermission = await askPermission(session.id)
+
+        try {
+          const questionRes = await app.request(`/question${instanceQuery}`)
+          expect(questionRes.status).toBe(200)
+          const questions = (await questionRes.json()) as Array<{ id: QuestionID; sessionID: SessionID }>
+          expect(questions.map((item) => item.sessionID)).toEqual([session.id])
+
+          const permissionRes = await app.request(`/permission${instanceQuery}`)
+          expect(permissionRes.status).toBe(200)
+          const permissions = (await permissionRes.json()) as Array<{ sessionID: SessionID }>
+          expect(permissions.map((item) => item.sessionID)).toEqual([session.id])
+
+          const blockerRes = await app.request(`/blocker${instanceQuery}`)
+          expect(blockerRes.status).toBe(200)
+          const blockers = (await blockerRes.json()) as Array<{ sessionID: SessionID }>
+          expect(blockers.map((item) => item.sessionID)).toEqual([session.id])
+
+          await expect(missingQuestion.promise).rejects.toThrow("Question cancelled before the user answered it.")
+          await expect(missingPermission.promise).rejects.toThrow(
+            "The user rejected permission to use this specific tool call.",
+          )
+        } finally {
+          await rejectAllQuestions()
+          await rejectAllPermissions()
+          await Promise.all([
+            missingQuestion.promise.catch(() => {}),
+            validQuestion.promise.catch(() => {}),
+            missingPermission.promise.catch(() => {}),
+            validPermission.promise.catch(() => {}),
+          ])
+        }
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/pending-interaction-lifecycle.test.ts
+++ b/packages/opencode/test/session/pending-interaction-lifecycle.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Instance } from "../../src/project/instance"
+import { Permission } from "../../src/permission"
+import { Question } from "../../src/question"
+import { Session } from "../../src/session"
+import { SessionBlocker } from "../../src/session/blocker"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+import type { Effect } from "effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const run = <A, E, R>(effect: Effect.Effect<A, E, R>) => AppRuntime.runPromise(effect as never) as Promise<A>
+
+async function createPendingQuestion(sessionID: SessionID) {
+  const promise = run(
+    Question.Service.use((svc) =>
+      svc.ask({
+        sessionID,
+        questions: [
+          {
+            question: "Continue?",
+            header: "Confirm",
+            options: [
+              { label: "Yes", description: "continue" },
+              { label: "No", description: "stop" },
+            ],
+          },
+        ],
+        tool: { messageID: MessageID.make("msg_lifecycle_question"), callID: "call_lifecycle_question" },
+      }),
+    ),
+  )
+  await waitFor(async () => (await listQuestions()).length === 1)
+  return { promise }
+}
+
+async function createPendingPermission(sessionID: SessionID) {
+  const promise = run(
+    Permission.Service.use((svc) =>
+      svc.ask({
+        sessionID,
+        permission: "edit",
+        patterns: ["/tmp/file.txt"],
+        always: ["/tmp/file.txt"],
+        metadata: {},
+        ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+      }),
+    ),
+  )
+  await waitFor(async () => (await listPermissions()).length === 1)
+  return { promise }
+}
+
+const listQuestions = () => run(Question.Service.use((svc) => svc.list()))
+const listPermissions = () => run(Permission.Service.use((svc) => svc.list()))
+const listBlockers = () => run(SessionBlocker.Service.use((svc) => svc.list()))
+
+async function waitFor(check: () => boolean | Promise<boolean>, timeoutMs = 1000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return
+    await Bun.sleep(10)
+  }
+  throw new Error("timed out waiting for condition")
+}
+
+describe("session pending interaction lifecycle", () => {
+  test("deleting a session terminates question, permission, and blocker state", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await run(Session.Service.use((svc) => svc.create({})))
+        const question = await createPendingQuestion(session.id)
+        const permission = await createPendingPermission(session.id)
+
+        expect(await listQuestions()).toHaveLength(1)
+        expect(await listPermissions()).toHaveLength(1)
+        expect(await listBlockers()).toHaveLength(1)
+
+        await run(Session.Service.use((svc) => svc.remove(session.id)))
+
+        await expect(question.promise).rejects.toThrow("Question cancelled before the user answered it.")
+        await expect(permission.promise).rejects.toThrow("The user rejected permission to use this specific tool call.")
+        expect(await listQuestions()).toEqual([])
+        expect(await listPermissions()).toEqual([])
+        expect(await listBlockers()).toEqual([])
+      },
+    })
+  })
+
+  test("archiving a session terminates question, permission, and blocker state", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await run(Session.Service.use((svc) => svc.create({})))
+        const question = await createPendingQuestion(session.id)
+        const permission = await createPendingPermission(session.id)
+
+        await run(Session.Service.use((svc) => svc.setArchived({ sessionID: session.id, time: Date.now() })))
+
+        await expect(question.promise).rejects.toThrow("Question cancelled before the user answered it.")
+        await expect(permission.promise).rejects.toThrow("The user rejected permission to use this specific tool call.")
+        expect(await listQuestions()).toEqual([])
+        expect(await listPermissions()).toEqual([])
+        expect(await listBlockers()).toEqual([])
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add session-scoped cleanup for pending question, permission, and blocker state when sessions are deleted or archived.
- Defensively prune missing-session pending interactions from question, permission, and blocker list routes, terminating the stale deferred work instead of returning it to the UI.
- Treat frontend warm-session 404s as a race fallback by filtering those pending entries from bootstrap stores, and stop logging expected `NotFoundError` responses as server `ERROR failed` entries.

## Why

Installed builds could surface stale in-memory pending interaction state for a session that no longer exists, causing repeated session warm-up 404s and uncaught promise errors during bootstrap. The backend now owns the lifecycle invariant, while the app bootstrap keeps a narrow race fallback.

## Related Issue

Closes #744

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Confirm the new pending-interaction lifecycle cleanup releases deferred question/permission promises rather than only hiding stale rows.
- Check the route-level pruning boundary: service `list()` remains raw for tests/internal use, while HTTP list routes only return active non-archived sessions.
- Check the frontend fallback only swallows expected 404s and still surfaces other session warm-up failures.

## Risk Notes

- Pending permission cleanup publishes a reject reply to reuse the existing terminal event shape.
- No visible UI changes; no screenshots required.
- No migrations, dependencies, generated files, credentials, or deletion behavior changes.
- Platform impact is limited to installed app bootstrap/server behavior on all desktop platforms.

## How To Verify

```text
opencode targeted tests: 34 passed, 0 failed
  bun test test/question/question.test.ts test/permission-cleanup.test.ts test/session/pending-interaction-lifecycle.test.ts test/server/pending-interaction-routes.test.ts test/server/middleware.test.ts

app bootstrap tests: 11 passed, 0 failed
  bun test src/context/global-sync/bootstrap.test.ts

typecheck: 8/8 packages successful
  bun run typecheck

diff check: no whitespace errors
  git diff --check
```

## Screenshots or Recordings

Not required; this is backend/bootstrap lifecycle behavior with no visible UI surface change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] Label bot should apply type/routing/priority labels; no manual labels were specified per maintainer instruction
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending interactions (permissions, questions, blockers) are now automatically cleared when sessions become inactive, deleted, or archived.
  * Added session liveness detection to identify and clean up "dangling" session entries.
  * New E2E test endpoint for blocker management.

* **Bug Fixes**
  * Improved error handling for missing sessions with proper NotFound error detection.
  * Server routes now filter out stale session data before responding.

* **Tests**
  * Comprehensive test coverage for session cleanup during deletion and archival.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->