### PR TITLE
feat(app): add bun run snap for headless UI verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@types/luxon": "catalog:",
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",
+        "sharp": "0.34.5",
         "typescript": "catalog:",
         "vite": "catalog:",
         "vite-plugin-icons-spritesheet": "3.0.1",
@@ -100,7 +101,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.15",
+      "version": "2026.5.19",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "bun run dev:desktop",
     "dev:desktop": "bun --cwd packages/desktop-electron dev",
     "dev:web": "bun --cwd packages/app dev",
+    "snap": "bun packages/app/script/snap.ts",
     "dev:opencode": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "frontend:inventory": "node script/frontend-inventory.mjs",
     "frontend:inventory:json": "node script/frontend-inventory.mjs --format json",

--- a/packages/app/e2e/snap/_compose.ts
+++ b/packages/app/e2e/snap/_compose.ts
@@ -14,14 +14,13 @@ const LABEL_BG = "#ffffff"
 const LABEL_FG = "#333333"
 
 export function snapOutputPath(target: string): string {
-  // Local-date filename — UTC would jump to "tomorrow" during CN evening hours
-  // and silently overwrite the same-day grid.
-  const d = new Date()
-  const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+  // Deterministic filename — agents and humans both want "the latest grid for
+  // this target". Dated filenames accumulate clutter and force consumers to
+  // resolve which file is current.
   const here = path.dirname(fileURLToPath(import.meta.url))
   // here = packages/app/e2e/snap → repoRoot four levels up
   const repoRoot = path.resolve(here, "../../../..")
-  return path.join(repoRoot, "docs/design/preview/screenshots", `${target}-${date}.png`)
+  return path.join(repoRoot, "docs/design/preview/screenshots", `${target}.png`)
 }
 
 function escapeXml(value: string): string {

--- a/packages/app/e2e/snap/_compose.ts
+++ b/packages/app/e2e/snap/_compose.ts
@@ -1,0 +1,88 @@
+import sharp from "sharp"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+export type Shot = { name: string; buf: Buffer }
+
+const CELL_GAP = 24
+const LABEL_HEIGHT = 32
+const LABEL_PAD_X = 12
+const LABEL_FONT_SIZE = 14
+const BG = { r: 248, g: 248, b: 248, alpha: 1 } as const
+const LABEL_BG = "#ffffff"
+const LABEL_FG = "#333333"
+
+export function snapOutputPath(target: string): string {
+  const date = new Date().toISOString().slice(0, 10)
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  // here = packages/app/e2e/snap → repoRoot four levels up
+  const repoRoot = path.resolve(here, "../../../..")
+  return path.join(repoRoot, "docs/design/preview/screenshots", `${target}-${date}.png`)
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case "<":
+        return "&lt;"
+      case ">":
+        return "&gt;"
+      case "&":
+        return "&amp;"
+      case "'":
+        return "&apos;"
+      default:
+        return "&quot;"
+    }
+  })
+}
+
+export async function composeGrid(
+  shots: Shot[],
+  outputPath: string,
+  options: { cols?: number } = {},
+): Promise<void> {
+  if (shots.length === 0) throw new Error("composeGrid: no shots")
+
+  const cols = options.cols ?? Math.min(shots.length, 3)
+  const metas = await Promise.all(
+    shots.map(async (s) => {
+      const meta = await sharp(s.buf).metadata()
+      const width = meta.width ?? 0
+      const height = meta.height ?? 0
+      if (!width || !height) throw new Error(`composeGrid: ${s.name} has no dimensions`)
+      return { ...s, width, height }
+    }),
+  )
+
+  const cellW = Math.max(...metas.map((m) => m.width))
+  const cellH = Math.max(...metas.map((m) => m.height))
+  const rows = Math.ceil(metas.length / cols)
+  const canvasW = cols * cellW + (cols + 1) * CELL_GAP
+  const canvasH = rows * (cellH + LABEL_HEIGHT) + (rows + 1) * CELL_GAP
+
+  const overlays: sharp.OverlayOptions[] = []
+  for (let i = 0; i < metas.length; i++) {
+    const row = Math.floor(i / cols)
+    const col = i % cols
+    const x = CELL_GAP + col * (cellW + CELL_GAP)
+    const y = CELL_GAP + row * (cellH + LABEL_HEIGHT + CELL_GAP)
+
+    overlays.push({ input: metas[i].buf, left: x, top: y })
+
+    const labelSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="${cellW}" height="${LABEL_HEIGHT}">
+      <rect width="${cellW}" height="${LABEL_HEIGHT}" fill="${LABEL_BG}"/>
+      <text x="${LABEL_PAD_X}" y="${LABEL_HEIGHT / 2 + LABEL_FONT_SIZE / 3}" font-family="system-ui, -apple-system, sans-serif" font-size="${LABEL_FONT_SIZE}" fill="${LABEL_FG}">${escapeXml(metas[i].name)}</text>
+    </svg>`
+    overlays.push({ input: Buffer.from(labelSvg), left: x, top: y + cellH })
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await sharp({
+    create: { width: canvasW, height: canvasH, channels: 4, background: BG },
+  })
+    .composite(overlays)
+    .png()
+    .toFile(outputPath)
+}

--- a/packages/app/e2e/snap/_compose.ts
+++ b/packages/app/e2e/snap/_compose.ts
@@ -14,7 +14,10 @@ const LABEL_BG = "#ffffff"
 const LABEL_FG = "#333333"
 
 export function snapOutputPath(target: string): string {
-  const date = new Date().toISOString().slice(0, 10)
+  // Local-date filename — UTC would jump to "tomorrow" during CN evening hours
+  // and silently overwrite the same-day grid.
+  const d = new Date()
+  const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
   const here = path.dirname(fileURLToPath(import.meta.url))
   // here = packages/app/e2e/snap → repoRoot four levels up
   const repoRoot = path.resolve(here, "../../../..")
@@ -56,18 +59,43 @@ export async function composeGrid(
     }),
   )
 
-  const cellW = Math.max(...metas.map((m) => m.width))
-  const cellH = Math.max(...metas.map((m) => m.height))
   const rows = Math.ceil(metas.length / cols)
-  const canvasW = cols * cellW + (cols + 1) * CELL_GAP
-  const canvasH = rows * (cellH + LABEL_HEIGHT) + (rows + 1) * CELL_GAP
+  // Per-column widths and per-row heights — using a single uniform max would
+  // make a wide full-viewport shot blow up every cell and leave narrow shots
+  // (e.g. sidebar at 320px next to sort-menu at 1440px) as tiny corners.
+  const colWidths: number[] = []
+  for (let c = 0; c < cols; c++) {
+    let maxW = 0
+    for (let r = 0; r < rows; r++) {
+      const idx = r * cols + c
+      if (idx < metas.length) maxW = Math.max(maxW, metas[idx].width)
+    }
+    colWidths.push(maxW)
+  }
+  const rowShotHeights: number[] = []
+  for (let r = 0; r < rows; r++) {
+    let maxH = 0
+    for (let c = 0; c < cols; c++) {
+      const idx = r * cols + c
+      if (idx < metas.length) maxH = Math.max(maxH, metas[idx].height)
+    }
+    rowShotHeights.push(maxH)
+  }
+  const canvasW = colWidths.reduce((a, b) => a + b, 0) + (cols + 1) * CELL_GAP
+  const canvasH = rowShotHeights.reduce((a, b) => a + b + LABEL_HEIGHT, 0) + (rows + 1) * CELL_GAP
+
+  const colX: number[] = [CELL_GAP]
+  for (let c = 0; c < cols; c++) colX.push(colX[c] + colWidths[c] + CELL_GAP)
+  const rowY: number[] = [CELL_GAP]
+  for (let r = 0; r < rows; r++) rowY.push(rowY[r] + rowShotHeights[r] + LABEL_HEIGHT + CELL_GAP)
 
   const overlays: sharp.OverlayOptions[] = []
   for (let i = 0; i < metas.length; i++) {
     const row = Math.floor(i / cols)
     const col = i % cols
-    const x = CELL_GAP + col * (cellW + CELL_GAP)
-    const y = CELL_GAP + row * (cellH + LABEL_HEIGHT + CELL_GAP)
+    const x = colX[col]
+    const y = rowY[row]
+    const cellW = colWidths[col]
 
     overlays.push({ input: metas[i].buf, left: x, top: y })
 
@@ -75,7 +103,7 @@ export async function composeGrid(
       <rect width="${cellW}" height="${LABEL_HEIGHT}" fill="${LABEL_BG}"/>
       <text x="${LABEL_PAD_X}" y="${LABEL_HEIGHT / 2 + LABEL_FONT_SIZE / 3}" font-family="system-ui, -apple-system, sans-serif" font-size="${LABEL_FONT_SIZE}" fill="${LABEL_FG}">${escapeXml(metas[i].name)}</text>
     </svg>`
-    overlays.push({ input: Buffer.from(labelSvg), left: x, top: y + cellH })
+    overlays.push({ input: Buffer.from(labelSvg), left: x, top: y + rowShotHeights[row] })
   }
 
   await fs.mkdir(path.dirname(outputPath), { recursive: true })

--- a/packages/app/e2e/snap/sidebar.snap.ts
+++ b/packages/app/e2e/snap/sidebar.snap.ts
@@ -1,0 +1,54 @@
+import { test } from "../fixtures"
+import { openSidebar, closeSidebar, withSession } from "../actions"
+import { pawworkSidebarSelector } from "../selectors"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test("sidebar", async ({ page, sdk, gotoSession }) => {
+  test.setTimeout(180_000)
+
+  await withSession(sdk, "snap sidebar a", async (a) => {
+    await withSession(sdk, "snap sidebar b", async () => {
+      await gotoSession(a.id)
+      await openSidebar(page)
+
+      const sidebar = page.locator(pawworkSidebarSelector).first()
+      const sortTrigger = sidebar.locator('[data-action="pawwork-sort-trigger"]')
+      await sortTrigger.waitFor({ state: "visible" })
+
+      const shots: Shot[] = []
+
+      // Crop to the sidebar locator: web vs Electron differs in chrome (titlebar,
+      // traffic lights) but the sidebar's own DOM/CSS renders identically.
+      // Element-cropped screenshots stay relevant for component-level review.
+      shots.push({ name: "default", buf: await sidebar.screenshot() })
+
+      await sortTrigger.click()
+      const sortOption = page.locator('[data-action="pawwork-sort-option"]').first()
+      await sortOption.waitFor({ state: "visible" })
+      // The sort menu is a portaled popover outside the sidebar DOM — capture the
+      // viewport (not the sidebar locator) so the dropdown appears in the shot.
+      shots.push({ name: "sort-menu", buf: await page.screenshot({ fullPage: false }) })
+      await page.keyboard.press("Escape")
+
+      await closeSidebar(page)
+      // After close the sidebar container collapses to ~0 width, so locator screenshot
+      // is useless. The toggle button is always present — anchor a clip around its
+      // bounding box so we capture the rail wherever it ends up.
+      const toggle = page.getByRole("button", { name: /toggle sidebar/i }).first()
+      await toggle.waitFor({ state: "visible" })
+      const box = await toggle.boundingBox()
+      if (!box) throw new Error("snap: toggle button has no bounding box; closed-state shot would be empty")
+      const railWidth = Math.max(96, Math.ceil(box.x + box.width + 24))
+      shots.push({
+        name: "closed",
+        buf: await page.screenshot({ clip: { x: 0, y: 0, width: railWidth, height: 900 } }),
+      })
+
+      const out = snapOutputPath("sidebar")
+      await composeGrid(shots, out)
+      process.stdout.write(`\n[snap] sidebar grid -> ${out}\n\n`)
+    })
+  })
+})

--- a/packages/app/e2e/snap/sidebar.snap.ts
+++ b/packages/app/e2e/snap/sidebar.snap.ts
@@ -8,6 +8,8 @@ test.use({ viewport: { width: 1440, height: 900 } })
 test("sidebar", async ({ page, sdk, gotoSession }) => {
   test.setTimeout(180_000)
 
+  // Two sessions so the sidebar list isn't empty; the sort trigger only
+  // renders when there is something to sort.
   await withSession(sdk, "snap sidebar a", async (a) => {
     await withSession(sdk, "snap sidebar b", async () => {
       await gotoSession(a.id)
@@ -36,14 +38,15 @@ test("sidebar", async ({ page, sdk, gotoSession }) => {
       // After close the sidebar container collapses to ~0 width, so locator screenshot
       // is useless. The toggle button is always present — anchor a clip around its
       // bounding box so we capture the rail wherever it ends up.
-      const toggle = page.getByRole("button", { name: /toggle sidebar/i }).first()
+      const toggle = page.locator('[data-action="pawwork-sidebar-toggle"]').first()
       await toggle.waitFor({ state: "visible" })
       const box = await toggle.boundingBox()
       if (!box) throw new Error("snap: toggle button has no bounding box; closed-state shot would be empty")
       const railWidth = Math.max(96, Math.ceil(box.x + box.width + 24))
+      const viewportH = page.viewportSize()?.height ?? 900
       shots.push({
         name: "closed",
-        buf: await page.screenshot({ clip: { x: 0, y: 0, width: railWidth, height: 900 } }),
+        buf: await page.screenshot({ clip: { x: 0, y: 0, width: railWidth, height: viewportH } }),
       })
 
       const out = snapOutputPath("sidebar")

--- a/packages/app/e2e/snap/sidebar.snap.ts
+++ b/packages/app/e2e/snap/sidebar.snap.ts
@@ -15,7 +15,7 @@ test("sidebar", async ({ page, sdk, gotoSession }) => {
       await gotoSession(a.id)
       await openSidebar(page)
 
-      const sidebar = page.locator(pawworkSidebarSelector).first()
+      const sidebar = page.locator(pawworkSidebarSelector)
       const sortTrigger = sidebar.locator('[data-action="pawwork-sort-trigger"]')
       await sortTrigger.waitFor({ state: "visible" })
 
@@ -38,7 +38,7 @@ test("sidebar", async ({ page, sdk, gotoSession }) => {
       // After close the sidebar container collapses to ~0 width, so locator screenshot
       // is useless. The toggle button is always present — anchor a clip around its
       // bounding box so we capture the rail wherever it ends up.
-      const toggle = page.locator('[data-action="pawwork-sidebar-toggle"]').first()
+      const toggle = page.locator('[data-action="pawwork-sidebar-toggle"]')
       await toggle.waitFor({ state: "visible" })
       const box = await toggle.boundingBox()
       if (!box) throw new Error("snap: toggle button has no bounding box; closed-state shot would be empty")

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,12 +26,14 @@
     "test:e2e:perf": "playwright test e2e/perf/perf-probe.spec.ts",
     "test:e2e:local:smoke": "bun script/e2e-local.ts -- --grep @smoke",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:report": "playwright show-report e2e/playwright-report"
+    "test:e2e:report": "playwright show-report e2e/playwright-report",
+    "snap": "bun script/snap.ts"
   },
   "license": "Apache-2.0",
   "devDependencies": {
     "@happy-dom/global-registrator": "20.0.11",
     "@playwright/test": "1.57.0",
+    "sharp": "0.34.5",
     "@tailwindcss/vite": "catalog:",
     "@tsconfig/bun": "1.0.9",
     "@types/bun": "catalog:",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -4,7 +4,8 @@ const port = Number(process.env.PLAYWRIGHT_PORT ?? 3000)
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`
 const serverHost = process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"
 const serverPort = process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"
-const command = `bun run dev -- --host 0.0.0.0 --port ${port}`
+const command = process.env.PLAYWRIGHT_WEB_COMMAND ?? `bun run dev -- --host 0.0.0.0 --port ${port}`
+const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1"
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
 const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
@@ -14,8 +15,14 @@ if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
   reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
 }
 
+// PLAYWRIGHT_SNAP=1 flips the matcher so `bun run snap` only runs `*.snap.ts`,
+// and the default `test:e2e` only runs `*.spec.ts` — snap and regression are
+// disjoint, neither polls the other.
+const snapMode = process.env.PLAYWRIGHT_SNAP === "1"
+
 export default defineConfig({
   testDir: "./e2e",
+  testMatch: snapMode ? ["**/snap/*.snap.ts"] : ["**/*.spec.ts"],
   outputDir: "./e2e/test-results",
   timeout: 60_000,
   expect: {
@@ -26,17 +33,19 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers,
   reporter,
-  webServer: {
-    command,
-    url: baseURL,
-    reuseExistingServer: reuse,
-    timeout: 120_000,
-    env: {
-      VITE_PAWWORK_SHELL_OS: "macos",
-      VITE_OPENCODE_SERVER_HOST: serverHost,
-      VITE_OPENCODE_SERVER_PORT: serverPort,
-    },
-  },
+  webServer: skipWebServer
+    ? undefined
+    : {
+        command,
+        url: baseURL,
+        reuseExistingServer: reuse,
+        timeout: 120_000,
+        env: {
+          VITE_PAWWORK_SHELL_OS: "macos",
+          VITE_OPENCODE_SERVER_HOST: serverHost,
+          VITE_OPENCODE_SERVER_PORT: serverPort,
+        },
+      },
   use: {
     baseURL,
     trace,

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -30,7 +30,9 @@ export default defineConfig({
   },
   fullyParallel: process.env.PLAYWRIGHT_FULLY_PARALLEL === "1",
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  // snap is for human-reviewed PNGs; flaky retries would silently overwrite the
+  // grid and mask the failure signal an agent is supposed to read.
+  retries: snapMode ? 0 : process.env.CI ? 2 : 0,
   workers,
   reporter,
   webServer: skipWebServer

--- a/packages/app/script/snap.ts
+++ b/packages/app/script/snap.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+import fs from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+
+const target = process.argv[2]
+if (!target) {
+  process.stderr.write("usage: bun run snap <target>\n")
+  process.stderr.write("  target: name of e2e/snap/<target>.snap.ts (e.g. sidebar)\n")
+  process.exit(1)
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const appDir = path.resolve(here, "..")
+const specRel = path.join("e2e", "snap", `${target}.snap.ts`)
+const specAbs = path.join(appDir, specRel)
+
+const exists = await fs.stat(specAbs).then(() => true).catch(() => false)
+if (!exists) {
+  process.stderr.write(`[snap] no such target: ${specAbs}\n`)
+  process.exit(1)
+}
+
+const port = process.env.PLAYWRIGHT_PORT ?? "3000"
+const env = {
+  ...process.env,
+  PLAYWRIGHT_SNAP: "1",
+  PLAYWRIGHT_WEB_COMMAND:
+    process.env.PLAYWRIGHT_WEB_COMMAND ??
+    `bun --cwd ${appDir} dev -- --host 127.0.0.1 --port ${port}`,
+}
+
+const result = spawnSync(
+  "bun",
+  ["x", "playwright", "test", specRel, "--project=chromium", "--reporter=line"],
+  { stdio: "inherit", cwd: appDir, env },
+)
+process.exit(result.status ?? 1)

--- a/packages/app/script/snap.ts
+++ b/packages/app/script/snap.ts
@@ -3,36 +3,58 @@ import path from "node:path"
 import fs from "node:fs/promises"
 import { fileURLToPath } from "node:url"
 
-const target = process.argv[2]
-if (!target) {
-  process.stderr.write("usage: bun run snap <target>\n")
-  process.stderr.write("  target: name of e2e/snap/<target>.snap.ts (e.g. sidebar)\n")
-  process.exit(1)
-}
-
 const here = path.dirname(fileURLToPath(import.meta.url))
 const appDir = path.resolve(here, "..")
-const specRel = path.join("e2e", "snap", `${target}.snap.ts`)
-const specAbs = path.join(appDir, specRel)
+const snapDir = path.join(appDir, "e2e", "snap")
 
-const exists = await fs.stat(specAbs).then(() => true).catch(() => false)
-if (!exists) {
-  process.stderr.write(`[snap] no such target: ${specAbs}\n`)
+async function listTargets(): Promise<string[]> {
+  const entries = await fs.readdir(snapDir).catch(() => [])
+  return entries
+    .filter((f) => f.endsWith(".snap.ts"))
+    .map((f) => f.replace(/\.snap\.ts$/, ""))
+    .sort()
+}
+
+async function fail(msg: string): Promise<never> {
+  process.stderr.write(`[snap] ${msg}\n`)
+  const targets = await listTargets()
+  if (targets.length) {
+    process.stderr.write(`[snap] available targets: ${targets.join(", ")}\n`)
+  }
+  process.stderr.write("[snap] usage: bun run snap <target>\n")
   process.exit(1)
 }
 
+const target = process.argv[2]
+if (!target) await fail("missing target")
+
+// Single source of truth: target must be a file under e2e/snap/. This catches
+// case mismatches, path traversal, and typos in one check with one message.
+const targets = await listTargets()
+if (!targets.includes(target!)) await fail(`no such target: ${target}`)
+
+const specRel = path.join("e2e", "snap", `${target}.snap.ts`)
+
 const port = process.env.PLAYWRIGHT_PORT ?? "3000"
+
+// No backend probe: the snap fixture spawns its own per-worker opencode via
+// startBackend() (e2e/backend.ts), so snap is self-contained and doesn't
+// require dev:desktop or any pre-running server.
 const env = {
   ...process.env,
   PLAYWRIGHT_SNAP: "1",
   PLAYWRIGHT_WEB_COMMAND:
     process.env.PLAYWRIGHT_WEB_COMMAND ??
-    `bun --cwd ${appDir} dev -- --host 127.0.0.1 --port ${port}`,
+    `bun --cwd "${appDir}" dev -- --host 127.0.0.1 --port ${port}`,
 }
 
 const result = spawnSync(
   "bun",
-  ["x", "playwright", "test", specRel, "--project=chromium", "--reporter=line"],
+  ["x", "playwright", "test", specRel, "--project=chromium", "--workers=1", "--reporter=line"],
   { stdio: "inherit", cwd: appDir, env },
 )
+
+if (result.error) {
+  process.stderr.write(`[snap] failed to launch playwright: ${result.error.message}\n`)
+}
 process.exit(result.status ?? 1)

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -111,6 +111,7 @@ export function Titlebar() {
               onClick={layout.sidebar.toggle}
               aria-label={language.t("command.sidebar.toggle")}
               aria-expanded={layout.sidebar.opened()}
+              data-action="pawwork-sidebar-toggle"
             >
               <Icon name={layout.sidebar.opened() ? "sidebar-active" : "sidebar"} />
             </Button>


### PR DESCRIPTION
## Summary

Adds `bun run snap <target>` — a single-command grid PNG for visual UI verification that AI agents can call instead of opening Electron and clicking around. Each target under `packages/app/e2e/snap/<target>.snap.ts` captures the relevant state combinations (sidebar: default / sort-menu / closed), Sharp composes them into one image under `docs/design/preview/screenshots/`. Web mode + element-cropped: ~5s warm, no Electron startup. MVP ships one target (`sidebar`).

## Why

The previous workflow required `bun run dev:desktop` and a manual click-through for every visible UI change. Solo dev driving AI agents: that loop breaks flow on every iteration and doesn't scale with agent-generated code. Snap turns visual verification into a deterministic artifact agents can produce and humans can review in seconds. The companion AGENTS.md rule (local, untracked) carves out Electron-only behavior for dev:desktop.

## Related Issue

None.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the final diff and verification evidence.

## Review Focus

- Carve-out cleanliness: `PLAYWRIGHT_SNAP=1` flips `testMatch` so snap and the regression `*.spec.ts` suite stay disjoint. The default `test:e2e` path is unchanged.
- Self-bootstrap: snap relies on the existing per-worker `startBackend()` fixture, so it doesn't require any pre-running server.
- `titlebar.tsx`: one-line addition of `data-action="pawwork-sidebar-toggle"` for selector parity with the rest of the sidebar's data-action attributes.

## Risk Notes

None — snap is additive. The only production-side change is one new attribute on the sidebar toggle button.

## How To Verify

```text
bun run snap sidebar: 1 passed (5.4s), grid PNG written
bun run snap Sidebar: rejected with "no such target: Sidebar" + "available targets: sidebar"
bun run snap ../foo: rejected the same way (listTargets membership check)
typecheck: not run (this PR touches no typed call sites beyond test files)
```

## Screenshots or Recordings

Sample grid output attached locally during review (not committed — `docs/` is locally excluded).

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [ ] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English