### PR TITLE
fix: widen LLM connect timeout for reasoning models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1087,6 +1087,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
 const REASONING_CONNECT_TIMEOUT_MS = 120_000
 
+/**
+ * Returns watchdog timeout overrides for reasoning-capable models.
+ * Apply at every llm.stream() call site to keep coverage uniform.
+ */
 export function streamTimeouts(model: Provider.Model): { connectTimeoutMs?: number } {
   if (!model.capabilities.reasoning) return {}
   return { connectTimeoutMs: REASONING_CONNECT_TIMEOUT_MS }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1085,6 +1085,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   return {}
 }
 
+const REASONING_CONNECT_TIMEOUT_MS = 120_000
+
+export function streamTimeouts(model: Provider.Model): { connectTimeoutMs?: number } {
+  if (!model.capabilities.reasoning) return {}
+  return { connectTimeoutMs: REASONING_CONNECT_TIMEOUT_MS }
+}
+
 export function options(input: {
   model: Provider.Model
   sessionID: string
@@ -1497,6 +1504,7 @@ const ProviderTransformTemperatureValue = temperature
 const ProviderTransformTopPValue = topP
 const ProviderTransformTopKValue = topK
 const ProviderTransformSmallOptionsValue = smallOptions
+const ProviderTransformStreamTimeoutsValue = streamTimeouts
 
 export namespace ProviderTransform {
   export const OUTPUT_TOKEN_MAX = ProviderTransformOutputTokenMaxValue
@@ -1512,4 +1520,5 @@ export namespace ProviderTransform {
   export const topP = ProviderTransformTopPValue
   export const topK = ProviderTransformTopKValue
   export const smallOptions = ProviderTransformSmallOptionsValue
+  export const streamTimeouts = ProviderTransformStreamTimeoutsValue
 }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -17,6 +17,7 @@ import { SessionSummary } from "./summary"
 import { SessionDiagnostics } from "./diagnostics"
 import { classifyToolFailure } from "./tool-failure"
 import type { Provider } from "@/provider"
+import { ProviderTransform } from "@/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { Log } from "@opencode-ai/core/util/log"
@@ -949,7 +950,11 @@ export const layer: Layer.Layer<
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
-            const stream = llm.stream({ ...streamInput, trace: ctx.trace })
+            const stream = llm.stream({
+              ...ProviderTransform.streamTimeouts(streamInput.model),
+              ...streamInput,
+              trace: ctx.trace,
+            })
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -462,6 +462,7 @@ export const layer = Layer.effect(
       titleGenerationProgress.set(input.session.id, { startedAt })
       const titleExit = yield* llm
         .stream({
+          ...ProviderTransform.streamTimeouts(mdl),
           agent: ag,
           user: firstInfo,
           system: [],

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4755,10 +4755,14 @@ describe("ProviderTransform.streamTimeouts", () => {
   }
   const nonReasoningModel = baseModel
 
-  test("policy floor: reasoning model connect timeout strictly exceeds default", () => {
+  // Floor of 90_000ms guards against a regression like 31s that would still
+  // exceed the 30s default but defeat the purpose of the widened ceiling.
+  // 90s is the lowest value considered for reasoning models in #755.
+  test("policy floor: reasoning model connect timeout meets minimum ceiling", () => {
     const result = ProviderTransform.streamTimeouts(reasoningModel)
     expect(result.connectTimeoutMs).toBeDefined()
     expect(result.connectTimeoutMs!).toBeGreaterThan(LLM.CONNECT_STREAM_TIMEOUT_MS)
+    expect(result.connectTimeoutMs!).toBeGreaterThanOrEqual(90_000)
   })
 
   test("routing contract: reasoning model emits override, non-reasoning model emits empty", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { ProviderTransform } from "../../src/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { LLM } from "../../src/session/llm"
 
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
@@ -4718,5 +4719,58 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(result).toEqual({})
     })
+  })
+})
+
+describe("ProviderTransform.streamTimeouts", () => {
+  const baseModel = {
+    id: "test/test-model",
+    providerID: "test",
+    api: {
+      id: "test-model",
+      url: "https://api.test.com",
+      npm: "@ai-sdk/openai",
+    },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 100_000, output: 8_192 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2024-01-01",
+  } as any
+
+  const reasoningModel = {
+    ...baseModel,
+    capabilities: { ...baseModel.capabilities, reasoning: true },
+  }
+  const nonReasoningModel = baseModel
+
+  test("policy floor: reasoning model connect timeout strictly exceeds default", () => {
+    const result = ProviderTransform.streamTimeouts(reasoningModel)
+    expect(result.connectTimeoutMs).toBeDefined()
+    expect(result.connectTimeoutMs!).toBeGreaterThan(LLM.CONNECT_STREAM_TIMEOUT_MS)
+  })
+
+  test("routing contract: reasoning model emits override, non-reasoning model emits empty", () => {
+    expect(ProviderTransform.streamTimeouts(reasoningModel).connectTimeoutMs).toBeGreaterThan(0)
+    expect(ProviderTransform.streamTimeouts(nonReasoningModel).connectTimeoutMs).toBeUndefined()
+  })
+
+  // Mirrors the helper-first spread order at the production call sites so a
+  // caller-provided override on StreamInput still wins after the helper is applied.
+  test("caller override precedence: explicit connectTimeoutMs wins over helper", () => {
+    const callerInput = { connectTimeoutMs: 5_000 }
+    const merged = { ...ProviderTransform.streamTimeouts(reasoningModel), ...callerInput }
+    expect(merged.connectTimeoutMs).toBe(5_000)
   })
 })


### PR DESCRIPTION
## Summary

Add `ProviderTransform.streamTimeouts(model)` returning `{ connectTimeoutMs: 120_000 }` for reasoning-capable models (gated on `model.capabilities.reasoning`), and apply it at the two production `llm.stream()` call sites — `session/processor.ts` (main response) and `session/prompt.ts` (title generation) — with helper-first spread order so any caller-provided `StreamInput.connectTimeoutMs` still wins. The default `CONNECT_STREAM_TIMEOUT_MS` is untouched; non-reasoning models keep the 30s ceiling.

## Why

The 30-second first-progress watchdog in `session/llm.ts` aborts reasoning-model streams whose first observable provider event arrives later than the ceiling. The incident recorded in #755 shows OpenAI `gpt-5.5` on a long session spending 30204ms with only `start: 1` and zero content events before the watchdog aborted. PR #729 fixed an earlier residual where the connect timer armed before the HTTP request was actually sent; the residual addressed here is the 30s ceiling itself, which #729's body explicitly deferred. The capability gate keys off `model.capabilities.reasoning` after verifying the current models.json catalog has correct `reasoning=true` labels on the gpt-5 family (22/23, only `gpt-5.3-chat-latest` excluded), all o-series, Claude haiku/sonnet/opus 4.x thinking variants, and the Gemini 2.5+/3.1 series — so no provider-id allowlist fallback is needed at this time.

## Related Issue

Refs #755 (short-term path; the full deferred set — `SessionRetry.policy.retryable()` not classifying local timeouts, watchdog architectural rewrite, and the parallel mid-stream `terminated` failure mode — is documented in the issue body and left to follow-up PRs).

## Human Review Status

Pending

## Review Focus

- Helper-first spread order at `session/processor.ts:954` and `session/prompt.ts:465`. `processor.ts` receives `streamInput` from `process()` callers (`session/prompt.ts:2020`, `session/compaction.ts:480`); neither sets `connectTimeoutMs` today, so the spread defaults to the helper value. The order is helper-first specifically so that a future caller wishing to override does not need code changes here.
- Capability-based gate vs model-id-pattern matching. Catalog cross-checked at PR-prep time and labels are reliable across the four target families; a second pair of eyes on whether `model.capabilities.reasoning === true` is the right axis is welcome.
- The new contract test floor at `>= 90_000` in `transform.test.ts` codifies the policy direction (the lowest value considered for reasoning models during the issue discussion). Worth questioning whether a corresponding upper bound is also needed.
- Title-generation path applies the helper to `mdl` from `provider.getSmallModel(input.providerID)` or the title agent's explicit override. The typical small model is non-reasoning so the helper returns `{}`; only when a user explicitly configures a reasoning small variant for the title agent does the 120s apply, and the failure mode is silent (caught at `prompt.ts:482-488`, logs and falls back to the default title). The deliberate choice was to avoid a per-mode branch inside the helper.

## Risk Notes

- After the 120s ceiling is reached, a first-progress timeout still surfaces as a hard `UnknownError` because `SessionRetry.policy.retryable()` does not type-tag local timeouts and does not match the bare error message. The user-experience improvement here is the lower hit rate; no automatic retry is added in this PR. Retry classification is deferred until the parallel mid-stream `terminated` failure mode is analyzed, so retry can be designed once against both failure shapes rather than speculatively per-shape.
- Explicit `connectTimeoutMs: undefined` from a caller would clobber the helper value during spread and fall through to the 30s default via `llm.ts:434-439`. No production path constructs `streamInput` this way today, but a future caller with conditional override should pass a positive number or omit the field rather than set it to `undefined`.
- Behavior change is strictly scoped to reasoning-capable models. Non-reasoning models keep the 30s default.
- No visible UI or copy changed; the visible-UI conditional checkbox is left unticked for that reason.
- No platform / packaging / updater / signing / paths / shell / permissions surface was touched; the macOS/Windows conditional checkbox is left unticked for that reason.
- No docs / release notes / dependencies / permissions / credentials / deletion behavior / generated content / local file changes; the related conditional checkbox is left unticked for that reason.

## How To Verify

```text
typecheck (bun --cwd packages/opencode run typecheck):                       ok
bun test packages/opencode/test/provider/transform.test.ts (streamTimeouts):  3 pass / 0 fail
bun test packages/opencode/test/session/ packages/opencode/test/provider/:    940 pass / 4 skip / 1 todo / 0 fail
internal cross-review (Claude Opus + Codex high, parallel):                   0 P0 / 0 P1 / 1 P3 both reviewers flagged (policy floor too loose) fixed by tightening test to >= 90_000
```

## Screenshots or Recordings

Not applicable (no UI change).

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent timeout management for AI model streaming with extended timeouts for reasoning-capable models, improving stability during complex inference tasks.
  * Enhanced title generation streams with optimized timeout configuration for better performance on reasoning models.

* **Tests**
  * Added test coverage for new timeout management functionality, validating behavior across different model types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->