### PR TITLE
fix(app): isolate home composer from session-only docks (#753)

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -8,7 +8,14 @@ import {
   type ComposerStateProbeState,
   type ComposerWindow,
 } from "../../src/testing/session-composer"
-import { cleanupSession, clearSessionDockSeed, closeSettingsPanel, openSettings, seedSessionQuestion } from "../actions"
+import {
+  cleanupSession,
+  clearSessionDockSeed,
+  closeSettingsPanel,
+  openSettings,
+  openSidebar,
+  seedSessionQuestion,
+} from "../actions"
 import {
   permissionDockSelector,
   promptSelector,
@@ -1676,6 +1683,69 @@ test("todo dock stays hidden after same-count terminal session switch", async ({
         },
         { trackSession: project.trackSession },
       )
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("todo dock does not flash on home after navigating from a session", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock no home flash",
+    async (session) => {
+      const dock = await todoDock(page, session.id)
+      await project.gotoSession(session.id)
+      await expect(page.locator(sessionComposerDockSelector)).toBeVisible()
+
+      try {
+        await dock.open([
+          { content: "first task", status: "pending", priority: "high" },
+          { content: "second task", status: "in_progress", priority: "medium" },
+        ])
+        await dock.expectCollapsed(["pending", "in_progress"])
+        await expect(page.locator('[data-component="session-todo-dock"]')).toBeVisible()
+
+        await page.evaluate(() => {
+          const SELECTOR = '[data-component="session-todo-dock"]'
+          const records: string[] = []
+          const observer = new MutationObserver((mutations) => {
+            for (const m of mutations) {
+              for (const node of Array.from(m.addedNodes)) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue
+                const el = node as Element
+                if (el.matches(SELECTOR) || el.querySelector(SELECTOR)) {
+                  records.push(el.outerHTML.slice(0, 200))
+                }
+              }
+            }
+          })
+          observer.observe(document.body, { childList: true, subtree: true })
+          ;(window as unknown as {
+            __todoDockObserver: { observer: MutationObserver; records: string[] }
+          }).__todoDockObserver = { observer, records }
+        })
+
+        await openSidebar(page)
+        await page.locator('[data-action="pawwork-session-new"]').click()
+        await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
+
+        const flashes = await page.evaluate(() => {
+          const w = window as unknown as {
+            __todoDockObserver?: { observer: MutationObserver; records: string[] }
+          }
+          const o = w.__todoDockObserver
+          if (!o) return null
+          o.observer.disconnect()
+          delete w.__todoDockObserver
+          return o.records
+        })
+
+        expect(flashes, "session-todo-dock must not appear on home during the transition").toEqual([])
+        await expect(page.locator('[data-component="session-todo-dock"]')).toHaveCount(0)
+      } finally {
+        await dock.clear()
+      }
     },
     { trackSession: project.trackSession },
   )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -375,7 +375,6 @@ export default function Page() {
     onModeChange: (mode: "normal" | "shell") => void
   }) => (
     <SessionPageComposerRegion
-      variant="session"
       state={composer}
       ready={!deferRender() && sessionActionReady()}
       actionReady={submitReady()}
@@ -494,7 +493,7 @@ export default function Page() {
       onRetryOpenSession={retryOpenRouteSession}
       onOpenNewSession={openNewRouteSession}
       composerSession={renderComposerRegion()}
-      composerHome={(ctx) => renderHomeComposerRegion(ctx)}
+      composerHome={renderHomeComposerRegion}
       canReview={canReview}
       reviewDiffs={reviewPanel.diffs}
       hasReview={reviewPanel.hasReview}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -17,7 +17,7 @@ import { useShellSurface } from "@/context/shell-surface"
 import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { buildDesktopContext } from "@/utils/desktop-context"
-import { createSessionComposerState } from "@/pages/session/composer"
+import { createSessionComposerState, HomeComposerRegion } from "@/pages/session/composer"
 import { createExecutionScopeTracker, type ExecutionScope } from "@/pages/session/execution-scope"
 import { createSizing } from "@/pages/session/helpers"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -371,20 +371,17 @@ export default function Page() {
     ),
   )
 
-  const renderComposerRegion = (
-    variant: "session" | "home",
-    ctx?: {
-      onModeChange: (mode: "normal" | "shell") => void
-    },
-  ) => (
+  const renderComposerRegion = (ctx?: {
+    onModeChange: (mode: "normal" | "shell") => void
+  }) => (
     <SessionPageComposerRegion
-      variant={variant}
+      variant="session"
       state={composer}
-      ready={!deferRender() && (variant === "home" ? timelineMessagesReady() : sessionActionReady())}
-      actionReady={variant === "home" ? workspaceSubmitReady() : submitReady()}
-      abortReady={variant === "home" ? true : sessionActionReady()}
-      displaySessionID={variant === "session" ? timelineSessionID() : undefined}
-      displaySessionKey={variant === "session" && timelineSessionID() ? timelineSessionKey() : undefined}
+      ready={!deferRender() && sessionActionReady()}
+      actionReady={submitReady()}
+      abortReady={sessionActionReady()}
+      displaySessionID={timelineSessionID()}
+      displaySessionKey={timelineSessionID() ? timelineSessionKey() : undefined}
       centered={centered()}
       inputRef={(el) => {
         inputRef = el
@@ -398,7 +395,7 @@ export default function Page() {
       onResponseSubmit={submitLatest}
       onModeChange={ctx?.onModeChange}
       followup={
-        variant === "session" && timelineSessionID() && submitReady() && !timelineIsChildSession()
+        timelineSessionID() && submitReady() && !timelineIsChildSession()
           ? {
               queue: followups.queueEnabled,
               items: followups.followupDock(),
@@ -426,6 +423,25 @@ export default function Page() {
             }
           : undefined
       }
+      setPromptDockRef={scrollDock.setPromptDockRef}
+    />
+  )
+
+  const renderHomeComposerRegion = (ctx?: {
+    onModeChange: (mode: "normal" | "shell") => void
+  }) => (
+    <HomeComposerRegion
+      inputRef={(el) => {
+        inputRef = el
+      }}
+      actionReady={workspaceSubmitReady()}
+      newSessionWorktree={newSessionWorktree.selected()}
+      onNewSessionWorktreeReset={newSessionWorktree.reset}
+      onSubmit={() => {
+        comments.clear()
+        submitLatest()
+      }}
+      onModeChange={ctx?.onModeChange}
       setPromptDockRef={scrollDock.setPromptDockRef}
     />
   )
@@ -477,8 +493,8 @@ export default function Page() {
       anchor={timelineInteraction.anchor}
       onRetryOpenSession={retryOpenRouteSession}
       onOpenNewSession={openNewRouteSession}
-      composerSession={renderComposerRegion("session")}
-      composerHome={(ctx) => renderComposerRegion("home", ctx)}
+      composerSession={renderComposerRegion()}
+      composerHome={(ctx) => renderHomeComposerRegion(ctx)}
       canReview={canReview}
       reviewDiffs={reviewPanel.diffs}
       hasReview={reviewPanel.hasReview}

--- a/packages/app/src/pages/session/composer/home-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/home-composer-region.tsx
@@ -21,7 +21,7 @@ export function HomeComposerRegion(props: HomeComposerRegionProps) {
   const language = useLanguage()
   const route = useSessionRouteKey()
 
-  const handoffKey = createMemo(() => route.layoutRouteKey())
+  const handoffKey = route.layoutRouteKey
   const handoffPrompt = createMemo(() => {
     const key = handoffKey()
     return key ? getSessionHandoff(key)?.prompt : undefined

--- a/packages/app/src/pages/session/composer/home-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/home-composer-region.tsx
@@ -1,0 +1,88 @@
+import { Show, createEffect, createMemo } from "solid-js"
+import { DockCard, DockSegment } from "@opencode-ai/ui/dock-card"
+import { PromptInput } from "@/components/prompt-input"
+import { useLanguage } from "@/context/language"
+import { usePrompt } from "@/context/prompt"
+import { getSessionHandoff, setSessionHandoff } from "@/pages/session/handoff"
+import { useSessionRouteKey } from "@/pages/session/session-layout"
+
+export type HomeComposerRegionProps = {
+  inputRef: (el: HTMLDivElement) => void
+  actionReady: boolean
+  newSessionWorktree: string
+  onNewSessionWorktreeReset: () => void
+  onSubmit: () => void
+  onModeChange?: (mode: "normal" | "shell") => void
+  setPromptDockRef: (el: HTMLDivElement) => void
+}
+
+export function HomeComposerRegion(props: HomeComposerRegionProps) {
+  const prompt = usePrompt()
+  const language = useLanguage()
+  const route = useSessionRouteKey()
+
+  const handoffKey = createMemo(() => route.layoutRouteKey())
+  const handoffPrompt = createMemo(() => {
+    const key = handoffKey()
+    return key ? getSessionHandoff(key)?.prompt : undefined
+  })
+
+  const previewPrompt = () =>
+    prompt
+      .current()
+      .map((part) => {
+        if (part.type === "file") return `[file:${part.path}]`
+        if (part.type === "agent") return `@${part.name}`
+        if (part.type === "image") return `[image:${part.filename}]`
+        return part.content
+      })
+      .join("")
+      .trim()
+
+  createEffect(() => {
+    if (!prompt.ready()) return
+    const key = handoffKey()
+    if (!key) return
+    setSessionHandoff(key, { prompt: previewPrompt() })
+  })
+
+  return (
+    <div
+      ref={props.setPromptDockRef}
+      data-component="session-prompt-dock"
+      data-variant="home"
+      data-dock-kind="prompt"
+      class="w-full flex flex-col justify-center items-center pointer-events-none py-0 bg-transparent text-left"
+    >
+      <div
+        data-component="session-composer-column"
+        class="w-full pointer-events-auto px-3 md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]"
+      >
+        <Show
+          when={prompt.ready()}
+          fallback={
+            <DockCard>
+              <DockSegment class="w-full min-h-32 md:min-h-40 px-4 py-3 text-body text-fg-weak whitespace-pre-wrap pointer-events-none">
+                {handoffPrompt() || language.t("prompt.loading")}
+              </DockSegment>
+            </DockCard>
+          }
+        >
+          <div class="relative z-30">
+            <DockCard class="overflow-visible!">
+              <PromptInput
+                ref={props.inputRef}
+                homeMode
+                newSessionWorktree={props.newSessionWorktree}
+                onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
+                onSubmit={props.onSubmit}
+                onModeChange={props.onModeChange}
+                actionReady={() => props.actionReady}
+              />
+            </DockCard>
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/pages/session/composer/index.ts
+++ b/packages/app/src/pages/session/composer/index.ts
@@ -1,2 +1,3 @@
 export { SessionComposerRegion } from "./session-composer-region"
+export { HomeComposerRegion, type HomeComposerRegionProps } from "./home-composer-region"
 export { createSessionComposerState } from "./session-composer-state"

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -18,7 +18,6 @@ import { SessionTodoDock } from "@/pages/session/composer/session-todo-dock"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
 
 export function SessionComposerRegion(props: {
-  variant?: "session"
   state: SessionComposerState
   ready: boolean
   actionReady?: boolean

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -18,7 +18,7 @@ import { SessionTodoDock } from "@/pages/session/composer/session-todo-dock"
 import type { FollowupDraft } from "@/components/prompt-input/submit"
 
 export function SessionComposerRegion(props: {
-  variant?: "session" | "home"
+  variant?: "session"
   state: SessionComposerState
   ready: boolean
   actionReady?: boolean
@@ -56,10 +56,8 @@ export function SessionComposerRegion(props: {
   const language = useLanguage()
   const route = useSessionRouteKey()
   const sync = useSync()
-  const displaySessionID = createMemo(() => (props.variant === "session" ? props.displaySessionID : route.params.id))
-  const displaySessionKey = createMemo(() =>
-    props.variant === "session" ? props.displaySessionKey : route.layoutRouteKey(),
-  )
+  const displaySessionID = () => props.displaySessionID
+  const displaySessionKey = () => props.displaySessionKey
 
   const handoffPrompt = createMemo(() => {
     const key = displaySessionKey()
@@ -68,7 +66,6 @@ export function SessionComposerRegion(props: {
   const info = createMemo(() => (displaySessionID() ? sync.session.get(displaySessionID()!) : undefined))
   const parentID = createMemo(() => info()?.parentID)
   const child = createMemo(() => !!parentID())
-  const home = createMemo(() => props.variant === "home")
   const showComposer = createMemo(() => !!props.state.permissionRequest() || !props.state.blocked() || child())
 
   const previewPrompt = () =>
@@ -120,22 +117,15 @@ export function SessionComposerRegion(props: {
     <div
       ref={props.setPromptDockRef}
       data-component="session-prompt-dock"
-      data-variant={home() ? "home" : "session"}
+      data-variant="session"
       data-dock-kind={dockKind()}
-      classList={{
-        "w-full flex flex-col justify-center items-center pointer-events-none": true,
-        "absolute inset-x-0 bottom-0 pb-6": !home(),
-        "py-0 bg-transparent": home(),
-        "text-left": home(),
-      }}
+      class="w-full flex flex-col justify-center items-center pointer-events-none absolute inset-x-0 bottom-0 pb-6"
     >
       <div
         data-component="session-composer-column"
         classList={{
-          "w-full pointer-events-auto": true,
-          "px-4 md:px-3": !home(),
-          "px-3": home(),
-          "md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]": props.centered || home(),
+          "w-full pointer-events-auto px-4 md:px-3": true,
+          "md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]": props.centered,
         }}
       >
         <Show when={props.state.questionRequest()} keyed>
@@ -226,9 +216,8 @@ export function SessionComposerRegion(props: {
                         <Show when={!props.state.blocked()}>
                           <PromptInput
                             ref={props.inputRef}
-                            homeMode={home()}
                             sessionID={displaySessionID()}
-                            sessionIDControlled={!home()}
+                            sessionIDControlled={true}
                             newSessionWorktree={props.newSessionWorktree}
                             onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
                             edit={props.followup?.edit}

--- a/packages/app/src/pages/session/session-composer-region.tsx
+++ b/packages/app/src/pages/session/session-composer-region.tsx
@@ -4,7 +4,7 @@ import { SessionComposerRegion, type createSessionComposerState } from "@/pages/
 type ComposerRegionProps = ComponentProps<typeof SessionComposerRegion>
 
 export function SessionPageComposerRegion(props: {
-  variant: "session" | "home"
+  variant: "session"
   state: ReturnType<typeof createSessionComposerState>
   ready: boolean
   actionReady?: boolean

--- a/packages/app/src/pages/session/session-composer-region.tsx
+++ b/packages/app/src/pages/session/session-composer-region.tsx
@@ -4,7 +4,6 @@ import { SessionComposerRegion, type createSessionComposerState } from "@/pages/
 type ComposerRegionProps = ComponentProps<typeof SessionComposerRegion>
 
 export function SessionPageComposerRegion(props: {
-  variant: "session"
   state: ReturnType<typeof createSessionComposerState>
   ready: boolean
   actionReady?: boolean

--- a/packages/app/src/shell-frame-contract.test.ts
+++ b/packages/app/src/shell-frame-contract.test.ts
@@ -156,12 +156,43 @@ test("session composer is docked outside the scroll-clipped timeline region", ()
   const messageTimeline = read("./pages/session/message-timeline.tsx")
 
   expect(session).toContain("const renderComposerRegion = (")
-  expect(session).toContain('variant: "session" | "home"')
+  expect(session).toContain("const renderHomeComposerRegion = (")
+  expect(session).toContain('variant="session"')
+  expect(session).not.toContain('| "home"')
   expect(sessionMainView).toContain('<div class="flex-1 min-h-0 overflow-hidden">')
   expect(sessionMainView).toContain(
     "</div>\n          <Show when={props.activeSessionID && !showSessionOpeningState()}>",
   )
   expect(messageTimeline).toContain('"padding-bottom": "calc(var(--composer-dock-height, 0px) + 32px)"')
+})
+
+test("home composer region does not import session-only docks or composer state", () => {
+  const src = stripComments(read("./pages/session/composer/home-composer-region.tsx"))
+  const importDeclMatches = [
+    ...src.matchAll(/^\s*import[\s\S]+?from\s+["'][^"']+["']\s*;?/gm),
+    ...src.matchAll(/^\s*import\s+["'][^"']+["']\s*;?/gm),
+  ]
+  const importsOnly = importDeclMatches.map((m) => m[0]).join("\n")
+
+  const bannedSymbols = [
+    "SessionTodoDock",
+    "SessionQuestionDock",
+    "SessionPermissionContent",
+    "SessionRevertDock",
+    "SessionFollowupDock",
+    "SessionComposerState",
+  ]
+  const bannedPaths = [
+    "session-todo-dock",
+    "session-question-dock",
+    "session-permission-dock",
+    "session-revert-dock",
+    "session-followup-dock",
+    "session-composer-state",
+  ]
+  for (const token of [...bannedSymbols, ...bannedPaths]) {
+    expect(importsOnly, `home-composer-region must not import ${token}`).not.toContain(token)
+  }
 })
 
 test("session header uses a view title on home and breadcrumb title in sessions", () => {

--- a/packages/app/src/shell-frame-contract.test.ts
+++ b/packages/app/src/shell-frame-contract.test.ts
@@ -157,8 +157,7 @@ test("session composer is docked outside the scroll-clipped timeline region", ()
 
   expect(session).toContain("const renderComposerRegion = (")
   expect(session).toContain("const renderHomeComposerRegion = (")
-  expect(session).toContain('variant="session"')
-  expect(session).not.toContain('| "home"')
+  expect(session).toMatch(/composerHome=\{[^}]*renderHomeComposerRegion/)
   expect(sessionMainView).toContain('<div class="flex-1 min-h-0 overflow-hidden">')
   expect(sessionMainView).toContain(
     "</div>\n          <Show when={props.activeSessionID && !showSessionOpeningState()}>",


### PR DESCRIPTION
## Summary

Split a dedicated `HomeComposerRegion` off from `SessionComposerRegion` so the home route can no longer mount session-only docks with stale composer state. Removes the visible 1-frame full-height todo-dock flash that appeared when navigating session → home.

## Why

`session.tsx` is a single route component serving both `/:dir/session` and `/:dir/session/:id`. It constructed one `composer = createSessionComposerState({...})` and passed it into the same `SessionComposerRegion` for both variants. On a session→home transition, the home variant re-mounted while `composer.dock()` was still stale-true from the session view; `useSpring` initialises from the current target on mount (no animate-from-0), so `SessionTodoDock` rendered immediately at full height before the todos effect re-ran and animated it out — a phantom dock collapse on a page that should never show the dock.

The fix moves Home onto a region that never receives `SessionComposerState` and never imports `SessionTodoDock` / `SessionQuestionDock` / `SessionPermissionContent` / `SessionRevertDock` / `SessionFollowupDock`. The boundary is structural, so the next field added to `SessionComposerState` cannot leak the same way.

Plan iteration: 10 review rounds (3× Claude+Codex crosscheck + 5× GPT Pro external) before code was written; final plan at https://github.com/Astro-Han/pawwork/issues/753#issuecomment-4484743928. Post-implementation crosscheck (Claude+Codex) returned 0 P0/P1; P2 findings folded into the cleanup commit.

## Related Issue

Fixes #753

## Human Review Status

Pending

## Review Focus

- The boundary itself: `home-composer-region.tsx` has zero imports from session-only docks and no `SessionComposerState` prop (locked by an import-grep contract test).
- `composerHome` rewire in `session.tsx`: now points at `renderHomeComposerRegion` instead of branching `renderComposerRegion("home", ...)`.
- The narrowed session-only `SessionComposerRegion` still serves child-session "back to parent" + disabled-prompt path (uses `useNavigate`, `useSync`, `useSessionRouteKey` for `route.params.dir` — preserved intentionally; only the `home()` memo and home-only classList branches are removed).
- E2E shape: `packages/app/e2e/session/session-composer-dock.spec.ts:1691` installs a `MutationObserver` on `document.body` BEFORE clicking the sidebar new-session button and asserts zero transient `[data-component="session-todo-dock"]` additions until `[data-component="session-new-home"]` is visible. This catches the one-frame flash that a steady-state `toHaveCount(0)` assertion would miss.

## Risk Notes

- **Known residual, out of scope for this PR**: a fast `session_A → home → session_B` sequence may still mount session_B's region while `composer.dock()` is stale-true from session_A's snapshot. Different navigation pattern, separate flash surface. Will be tracked as a follow-up issue post-merge. The cheapest remedy when it surfaces is a per-call `{ from: 0 }` option on `useSpring` applied at `session-composer-region.tsx`.
- **Skipped conditional — visible UI manual check with screenshots/recordings**: the bug is a 1-frame DOM mutation during a route transition; a static screenshot cannot capture it, and a 25fps video (40ms per frame) would straddle the ~30ms flash window unreliably (a missing capture would not prove the fix; a captured frame would not prove regression). The MutationObserver assertion at `session-composer-dock.spec.ts:1691` is the precise dynamic contract — TDD-verified red against pre-fix code (the dock element was recorded in `addedNodes` during the transition) and green after the split.
- **Skipped conditional — macOS/Windows platform impact**: no platform/packaging/updater/signing/paths/shell/permissions surface was touched. Pure SolidJS route component split.
- **Skipped conditional — docs/release notes/dependencies/permissions/credentials/deletion/generated/local files**: none of those surfaces were touched.

## How To Verify

```text
app typecheck (tsgo -b):           passed
eslint (root lint):                passed
shell-frame-contract test:         9/9 passed (covers the new boundary)
session-composer-dock e2e:         41/41 passed incl. new "todo dock does not flash on home" case
home.spec.ts / theme-helper / a11y-chip e2e: clean (1 pre-existing failure on `active workspace has a check icon` exists on origin/dev too, unrelated)
TDD verification:                  new e2e runs RED on pre-fix code, GREEN after the split (manually stashed impl to confirm)
```

## Screenshots or Recordings

Not applicable — the bug is a single-frame DOM mutation during route transition; static screenshots cannot capture it. The new MutationObserver-based e2e at `packages/app/e2e/session/session-composer-dock.spec.ts:1691` records the dock element being added to the DOM during the transition and asserts it is empty post-fix. Verified red→green.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the session todo dock would briefly appear during navigation to the home view.

* **Tests**
  * Added end-to-end tests to verify the dock no longer flashes on navigation and prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->