### PR TITLE
fix(session): preserve abort caller source in diagnostics

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -26,7 +26,7 @@ const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
 let commandsReady = true
 let promptAsyncFailure: Error | undefined
-const abortedSessions: Array<{ sessionID: string; mode?: string }> = []
+const abortedSessions: Array<{ sessionID: string; mode?: string; source?: string }> = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
@@ -75,8 +75,8 @@ const clientFor = (directory: string) => {
         commandCalls.push(input)
         return { data: undefined }
       },
-      abort: async (input: { sessionID: string; mode?: string }) => {
-        abortedSessions.push({ sessionID: input.sessionID, mode: input.mode })
+      abort: async (input: { sessionID: string; mode?: string; source?: string }) => {
+        abortedSessions.push({ sessionID: input.sessionID, mode: input.mode, source: input.source })
         return { data: true }
       },
     },
@@ -303,7 +303,7 @@ describe("prompt submit worktree selection", () => {
     await submit.abort()
 
     expect(aborts).toEqual(["called"])
-    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft" }])
+    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft", source: "renderer.stopButton" }])
     expect(globalTodoSets).toEqual([])
     expect(childTodoSets).toEqual([])
   })
@@ -431,9 +431,36 @@ describe("prompt submit worktree selection", () => {
     await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
 
     expect(aborts).toEqual(["called"])
-    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft" }])
+    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft", source: "renderer.stopButton" }])
     expect(submits).toEqual([])
     expect(promptAsyncCalls).toEqual([])
+  })
+
+  test("marks keyboard empty-enter abort with caller source", async () => {
+    params = { id: "session-visible" }
+    promptValue = [{ type: "text", content: "", start: 0, end: 0 }]
+    const submit = createPromptSubmit({
+      sessionID: () => "session-visible",
+      isNewSession: () => false,
+      info: () => ({ id: "session-visible" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => true,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) =>
+        value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+    })
+
+    await submit.handleSubmit(new KeyboardEvent("keydown", { key: "Enter" }))
+
+    expect(abortedSessions).toEqual([{ sessionID: "session-visible", mode: "soft", source: "renderer.emptyEnter" }])
   })
 
   test("reads the latest worktree accessor value per submit", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -31,6 +31,7 @@ type PendingPrompt = {
 const pending = new Map<string, PendingPrompt>()
 type AbortMode = "soft" | "hard"
 type AbortSource = "stopButton" | "emptyEnter" | "ctrlG" | "escape"
+const abortSourceDiagnostic = (source: AbortSource) => `renderer.${source}`
 
 export type FollowupDraft = {
   sessionID: string
@@ -281,6 +282,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       .abort({
         sessionID: activeSessionID,
         mode,
+        source: abortSourceDiagnostic(source),
       })
       .then((result) => {
         emitAbortDiagnostic({

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -17,6 +17,7 @@ import { useSync } from "@/context/sync"
 import { promptProbe } from "@/testing/prompt"
 import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
+import { rendererAbortDiagnosticSource, type RendererAbortSource } from "@/session/abort-source"
 import { buildRequestParts } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
 import { formatServerError } from "@/utils/server-errors"
@@ -30,8 +31,7 @@ type PendingPrompt = {
 
 const pending = new Map<string, PendingPrompt>()
 type AbortMode = "soft" | "hard"
-type AbortSource = "stopButton" | "emptyEnter" | "ctrlG" | "escape"
-const abortSourceDiagnostic = (source: AbortSource) => `renderer.${source}`
+type AbortSource = Extract<RendererAbortSource, "ctrlG" | "emptyEnter" | "escape" | "stopButton">
 
 export type FollowupDraft = {
   sessionID: string
@@ -282,7 +282,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       .abort({
         sessionID: activeSessionID,
         mode,
-        source: abortSourceDiagnostic(source),
+        source: rendererAbortDiagnosticSource({ sessionID: activeSessionID, source }),
       })
       .then((result) => {
         emitAbortDiagnostic({

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -141,7 +141,7 @@ export default function Page() {
   const emitAbortDiagnostic = diagnostics.emitAbortDiagnostic
   const haltAbort = (sessionID: string, source: "revert" | "autoHeal" = "autoHeal") =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? sdk.client.session.abort({ sessionID, mode: "hard" }).then((result) => {
+      ? sdk.client.session.abort({ sessionID, mode: "hard", source: `renderer.${source}` }).then((result) => {
           emitAbortDiagnostic(sessionID, source, result.data === false ? "ignored_awaiting_question" : "aborted")
           return result
         })
@@ -151,7 +151,7 @@ export default function Page() {
     sessionID: string,
   ) =>
     isSessionRunning(snapshot.store.session_status[sessionID], snapshot.store.message[sessionID])
-      ? snapshot.client.session.abort({ sessionID, mode: "hard" }).then((result) => {
+      ? snapshot.client.session.abort({ sessionID, mode: "hard", source: "renderer.revert" }).then((result) => {
           emitAbortDiagnostic(sessionID, "revert", result.data === false ? "ignored_awaiting_question" : "aborted")
           return result
         })

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -42,6 +42,7 @@ import { createSessionDeferredRender } from "@/pages/session/use-session-deferre
 import { createSessionPageDiagnostics } from "@/pages/session/use-session-page-diagnostics"
 import { useSessionRoutePromptBootstrap } from "@/pages/session/use-session-route-prompt-bootstrap"
 import { useSessionVcsRefresh } from "@/pages/session/use-session-vcs-refresh"
+import { rendererAbortDiagnosticSource } from "@/session/abort-source"
 import { diffs as list } from "@/utils/diffs"
 import { decode64 } from "@/utils/base64"
 
@@ -141,20 +142,24 @@ export default function Page() {
   const emitAbortDiagnostic = diagnostics.emitAbortDiagnostic
   const haltAbort = (sessionID: string, source: "revert" | "autoHeal" = "autoHeal") =>
     isSessionRunning(sync.data.session_status[sessionID], sync.data.message[sessionID])
-      ? sdk.client.session.abort({ sessionID, mode: "hard", source: `renderer.${source}` }).then((result) => {
-          emitAbortDiagnostic(sessionID, source, result.data === false ? "ignored_awaiting_question" : "aborted")
-          return result
-        })
+      ? sdk.client.session
+          .abort({ sessionID, mode: "hard", source: rendererAbortDiagnosticSource({ sessionID, source }) })
+          .then((result) => {
+            emitAbortDiagnostic(sessionID, source, result.data === false ? "ignored_awaiting_question" : "aborted")
+            return result
+          })
       : Promise.resolve()
   const haltWithSnapshot = (
     snapshot: ReturnType<typeof sync.retainDirectory> & { client: typeof sdk.client },
     sessionID: string,
   ) =>
     isSessionRunning(snapshot.store.session_status[sessionID], snapshot.store.message[sessionID])
-      ? snapshot.client.session.abort({ sessionID, mode: "hard", source: "renderer.revert" }).then((result) => {
-          emitAbortDiagnostic(sessionID, "revert", result.data === false ? "ignored_awaiting_question" : "aborted")
-          return result
-        })
+      ? snapshot.client.session
+          .abort({ sessionID, mode: "hard", source: rendererAbortDiagnosticSource({ sessionID, source: "revert" }) })
+          .then((result) => {
+            emitAbortDiagnostic(sessionID, "revert", result.data === false ? "ignored_awaiting_question" : "aborted")
+            return result
+          })
       : Promise.resolve()
   // sessionRevert chains halt with .then(), so its existing outer .catch
   // already handles abort failures. The auto-heal clock wants to see the

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -23,6 +23,7 @@ import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { emitRendererDiagnostic, sessionAbortDiagnosticEvent } from "@/context/renderer-diagnostics"
 import { shareSessionCommand, unshareSessionCommand } from "@/pages/session/session-share-command"
+import { rendererAbortDiagnosticSource } from "@/session/abort-source"
 
 export type SessionCommandContext = {
   navigateMessageByOffset: (offset: number) => void
@@ -236,7 +237,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
 
     if (status().type !== "idle") {
       await sdk.client.session
-        .abort({ sessionID, mode: "hard", source: "renderer.undo" })
+        .abort({ sessionID, mode: "hard", source: rendererAbortDiagnosticSource({ sessionID, source: "undo" }) })
         .then((result) => {
           void emitRendererDiagnostic(
             sessionAbortDiagnosticEvent({

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -236,7 +236,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
 
     if (status().type !== "idle") {
       await sdk.client.session
-        .abort({ sessionID, mode: "hard" })
+        .abort({ sessionID, mode: "hard", source: "renderer.undo" })
         .then((result) => {
           void emitRendererDiagnostic(
             sessionAbortDiagnosticEvent({

--- a/packages/app/src/session/abort-source.ts
+++ b/packages/app/src/session/abort-source.ts
@@ -1,0 +1,6 @@
+export type RendererAbortSource = "autoHeal" | "ctrlG" | "emptyEnter" | "escape" | "revert" | "stopButton" | "undo"
+
+export function rendererAbortDiagnosticSource(input: { sessionID: string; source: RendererAbortSource }) {
+  if (!input.sessionID) throw new Error("sessionID is required for abort diagnostics")
+  return `renderer.${input.source}`
+}

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1548,6 +1548,7 @@ export namespace ACP {
         {
           sessionID: params.sessionId,
           directory: session.cwd,
+          source: "acp.cancel",
         },
         { throwOnError: true },
       )

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -37,7 +37,7 @@ import { Env } from "@/env"
 
 const log = Log.create({ service: "server" })
 const AbortMode = z.enum(["soft", "hard"])
-const AbortSource = z.string().trim().min(1).max(80)
+const AbortSource = z.string().regex(/^[A-Za-z0-9._-]{1,80}$/)
 const e2eSessionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 function publishTurnChangeFiles(display: TurnChangeDisplay, mode: "undo" | "redo", mutatedPaths?: string[]) {

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -37,6 +37,7 @@ import { Env } from "@/env"
 
 const log = Log.create({ service: "server" })
 const AbortMode = z.enum(["soft", "hard"])
+const AbortSource = z.string().trim().min(1).max(80)
 const e2eSessionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 function publishTurnChangeFiles(display: TurnChangeDisplay, mode: "undo" | "redo", mutatedPaths?: string[]) {
@@ -475,11 +476,14 @@ export const SessionRoutes = lazy(() =>
         "query",
         z.object({
           mode: AbortMode.optional(),
+          source: AbortSource.optional(),
         }),
       ),
       async (c) => {
+        const query = c.req.valid("query")
         const aborted = await SessionPrompt.cancel(c.req.valid("param").sessionID, {
-          mode: c.req.valid("query").mode ?? "hard",
+          mode: query.mode ?? "hard",
+          source: query.source,
         })
         return c.json(aborted)
       },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -254,7 +254,7 @@ function modelCanReadMedia(model: Provider.Model, kind: MediaInputKind) {
 }
 
 export interface Interface {
-  readonly cancel: (sessionID: SessionID, options?: { mode?: "soft" | "hard" }) => Effect.Effect<boolean>
+  readonly cancel: (sessionID: SessionID, options?: { mode?: "soft" | "hard"; source?: string }) => Effect.Effect<boolean>
   readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
   readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
@@ -318,16 +318,17 @@ export const layer = Layer.effect(
 
     const cancel = Effect.fn("SessionPrompt.cancel")(function* (
       sessionID: SessionID,
-      options?: { mode?: "soft" | "hard" },
+      options?: { mode?: "soft" | "hard"; source?: string },
     ) {
       const mode = options?.mode ?? "hard"
-      yield* elog.info("cancel", { sessionID, mode })
+      const source = options?.source ?? "session.prompt.cancel"
+      yield* elog.info("cancel", { sessionID, mode, source })
       if (mode === "soft" && (yield* blockers.hasAwaitingQuestion(sessionID))) {
-        yield* elog.info("cancel ignored", { sessionID, mode, reason: "awaiting_question" })
+        yield* elog.info("cancel ignored", { sessionID, mode, source, reason: "awaiting_question" })
         return false
       }
       yield* state.cancel(sessionID, {
-        source: "session.prompt.cancel",
+        source,
         reason: mode === "soft" ? "soft_cancel" : "hard_cancel",
         mode,
         viaCtxAbort: false,
@@ -2362,7 +2363,7 @@ export async function resolvePromptParts(template: string) {
   return runPromise((svc) => svc.resolvePromptParts(z.string().parse(template)))
 }
 
-export async function cancel(sessionID: SessionID, options?: { mode?: "soft" | "hard" }) {
+export async function cancel(sessionID: SessionID, options?: { mode?: "soft" | "hard"; source?: string }) {
   return runPromise((svc) => svc.cancel(SessionID.zod.parse(sessionID), options))
 }
 

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -49,4 +49,45 @@ describe("session action routes", () => {
       },
     })
   })
+
+  test("abort route forwards token source", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue(true)
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/abort?mode=soft&source=renderer.stopButton`, {
+          method: "POST",
+        })
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toBe(true)
+        expect(cancel).toHaveBeenCalledWith(session.id, { mode: "soft", source: "renderer.stopButton" })
+
+        await svc.remove(session.id)
+      },
+    })
+  })
+
+  test("abort route rejects non-token source", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue(true)
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/abort?source=renderer%20stop`, { method: "POST" })
+
+        expect(res.status).toBe(400)
+        expect(cancel).not.toHaveBeenCalled()
+
+        await svc.remove(session.id)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1500,6 +1500,37 @@ it.live(
 )
 
 it.live(
+  "soft cancel preserves explicit caller source in abort diagnostics",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Caller source" })
+        yield* llm.hang
+        yield* user(chat.id, "hello")
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        const cancelled = yield* prompt.cancel(chat.id, { mode: "soft", source: "renderer.emptyEnter" })
+        expect(cancelled).toBe(true)
+
+        const exit = yield* Fiber.await(fiber)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        if (Exit.isSuccess(exit) && exit.value.info.role === "assistant") {
+          expect(exit.value.info.diagnostics?.abort).toMatchObject({
+            source: "renderer.emptyEnter",
+            reason: "soft_cancel",
+            mode: "soft",
+            propagation_point: "session.prompt.loop.onInterrupt",
+          })
+        }
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
   "cancel finalizes subtask tool state",
   () =>
     provideTmpdirInstance(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1932,6 +1932,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       mode?: "soft" | "hard"
+      source?: string
       workspace?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -1944,6 +1945,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "mode" },
+            { in: "query", key: "source" },
             { in: "query", key: "workspace" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3743,6 +3743,7 @@ export type SessionAbortData = {
   query?: {
     directory?: string
     mode?: "soft" | "hard"
+    source?: string
     workspace?: string
   }
   url: "/session/{sessionID}/abort"


### PR DESCRIPTION
## Summary

- Preserve explicit abort caller sources through the session abort API and `SessionPrompt.cancel` diagnostics.
- Propagate renderer, ACP, auto-heal, revert, undo, and empty-enter abort sources instead of collapsing them to `session.prompt.cancel`.
- Restrict external abort `source` labels to a compact token charset and cover route-level accept/reject behavior.
- Add focused regression coverage for backend abort diagnostics and prompt-input abort source propagation.

## Why

A follow-up log for #721/#756 showed `Tool execution aborted` with `source: "session.prompt.cancel"`, `reason: "soft_cancel"`, and `via_ctx_abort: false`. That proved the UI symptom can come from an explicit soft cancel path, but the diagnostic source was too generic to identify which caller initiated the abort.

## Related Issue

Refs #721
Refs #756

## Human Review Status

Pending

## Review Focus

- Confirm the abort `source` query parameter is narrowly validated and correctly forwarded into `SessionPrompt.cancel`.
- Confirm renderer/ACP source names are useful for future diagnostics and do not change cancel semantics.
- Confirm the SDK generated type updates match the server route shape.

## Risk Notes

- No visible UI or copy changed, so the visual-check checklist item is intentionally left unticked.
- No platform, packaging, updater, signing, path, shell, or permission behavior changed, so the platform checklist item is intentionally left unticked.
- SDK generated files were updated by hand to match the existing generated client shape for the new abort query parameter.
- Shell-mode abort diagnostics are intentionally deferred: shell cancel currently updates bash tool output, not assistant `diagnostics.abort`; wiring that meta path needs a separate design decision for whether the source belongs on assistant diagnostics, tool metadata, or both.

## How To Verify

```text
opencode abort route tests: 3 pass, 0 fail
bun --cwd packages/opencode test test/server/session-actions.test.ts -t "abort route"

opencode abort tests: 2 pass, 0 fail
bun --cwd packages/opencode test test/session/prompt-effect.test.ts -t "soft cancel without a pending question still interrupts|soft cancel preserves explicit caller source"

app prompt submit tests: 3 pass, 0 fail
bun test --preload ./happydom.ts src/components/prompt-input/submit.test.ts -t "keeps cached todos|allows abort while submit readiness|keyboard empty-enter"

opencode typecheck: passed
bun run --cwd packages/opencode typecheck

app typecheck: passed
bun --cwd packages/app typecheck

diff check: no whitespace errors
git diff --check

code review pass: no remaining Critical/Important findings after adding acp.cancel source
```

## Screenshots or Recordings

Not applicable — no visible UI changed.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
