### PR TITLE
feat(prompt): isolate drafts and history across workspaces

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -484,6 +484,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             prompt.context.remove(item.key)
           }}
           t={(key) => language.t(key as Parameters<typeof language.t>[0])}
+          sourceFilesystemDirectory={sdk.directory}
         />
         <PromptImageAttachments
           attachments={imageAttachments()}

--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Prompt } from "@/context/prompt"
 import { buildRequestParts } from "./build-request-parts"
+import { captureCommentMentions } from "./mention-metadata"
 
 describe("buildRequestParts", () => {
   test("builds typed request and optimistic parts without cast path", () => {
@@ -101,6 +102,9 @@ describe("buildRequestParts", () => {
   })
 
   test("adds file parts for @mentions inside comment text", () => {
+    const comment = "Compare with @src/shared.ts and @src/review.ts."
+    const resolvedMentions = captureCommentMentions({ comment, sourceFilesystemDirectory: "/repo" })
+
     const result = buildRequestParts({
       prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
       context: [
@@ -108,7 +112,8 @@ describe("buildRequestParts", () => {
           key: "ctx:comment-mention",
           type: "file",
           path: "src/review.ts",
-          comment: "Compare with @src/shared.ts and @src/review.ts.",
+          comment,
+          resolvedMentions,
         },
       ],
       images: [],
@@ -122,6 +127,59 @@ describe("buildRequestParts", () => {
     expect(files).toHaveLength(2)
     expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
     expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/shared.ts")).toBe(true)
+  })
+
+  test("attaches mention with resolved metadata pointing outside sessionDirectory", () => {
+    const comment = "compare with @src/shared.ts"
+    // Metadata was captured against repo-A, but submit happens in repo-B context
+    const resolvedMentions = captureCommentMentions({ comment, sourceFilesystemDirectory: "/repo-A" })
+
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "compare", start: 0, end: 7 }],
+      context: [
+        {
+          key: "ctx:cross-workspace",
+          type: "file",
+          path: "/repo-A/src/a.ts",
+          comment,
+          resolvedMentions,
+        },
+      ],
+      images: [],
+      text: "compare",
+      messageID: "msg_cross",
+      sessionID: "ses_cross",
+      sessionDirectory: "/repo-B",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    // The mention should resolve to /repo-A/src/shared.ts, NOT /repo-B/src/shared.ts
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo-A/src/shared.ts")).toBe(true)
+    expect(files.every((part) => !(part.type === "file" && part.url.startsWith("file:///repo-B/src/shared")))).toBe(true)
+  })
+
+  test("free-text @ in comment without resolvedMentions is not attached", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:no-metadata",
+          type: "file",
+          path: "src/main.ts",
+          comment: "see @src/lost.ts for details",
+          // resolvedMentions deliberately omitted (undefined)
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_no_meta",
+      sessionID: "ses_no_meta",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    // Only src/main.ts should appear — @src/lost.ts has no metadata so it is dropped
+    expect(files.every((part) => !(part.type === "file" && part.url.includes("lost.ts")))).toBe(true)
   })
 
   test("handles Windows paths correctly (simulated on macOS)", () => {

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -6,6 +6,8 @@ import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt } from 
 import { Identifier } from "@/utils/id"
 import { createCommentMetadata, formatCommentNote } from "@/utils/comment-note"
 import { toAbsoluteFilePath } from "./path-canonical"
+import type { ResolvedMention } from "./mention-metadata"
+import { resolveCommentMentions } from "./mention-metadata"
 
 type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: string }
 
@@ -18,6 +20,7 @@ type ContextFile = {
   commentID?: string
   commentOrigin?: "review" | "file"
   preview?: string
+  resolvedMentions?: ResolvedMention[]
 }
 
 type BuildRequestPartsInput = {
@@ -37,16 +40,6 @@ const fileURL = (path: string, selection?: FileSelection) => {
   const encoded = encodeFilePath(path)
   const body = path.startsWith("\\\\") || path.startsWith("//") ? encoded.replace(/^\/+/, "") : encoded
   return `file://${body}${fileQuery(selection)}`
-}
-
-const mention = /(^|[\s([{"'])@(\S+)/g
-
-const parseCommentMentions = (comment: string) => {
-  return Array.from(comment.matchAll(mention)).flatMap((match) => {
-    const path = (match[2] ?? "").replace(/[.,!?;:)}\]"']+$/, "")
-    if (!path) return []
-    return [path]
-  })
 }
 
 const isFileAttachment = (part: Prompt[number]): part is FileAttachmentPart => part.type === "file"
@@ -148,8 +141,13 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
 
     if (!comment) return [filePart]
 
-    const mentions = parseCommentMentions(comment).flatMap((path) => {
-      const url = fileURL(toAbsoluteFilePath(input.sessionDirectory, path))
+    // resolveCommentMentions returns [] when resolvedMentions is undefined —
+    // free-text @mentions without metadata are intentionally dropped.
+    const mentions = resolveCommentMentions({
+      comment,
+      metadata: item.resolvedMentions,
+    }).flatMap((match) => {
+      const url = fileURL(match.resolvedPath)
       if (used.has(url)) return []
       used.add(url)
       return [
@@ -158,7 +156,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
           type: "file",
           mime: "text/plain",
           url,
-          filename: getFilename(path),
+          filename: getFilename(match.resolvedPath),
         } satisfies PromptRequestPart,
       ]
     })

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -5,6 +5,7 @@ import { encodeFilePath } from "@/context/file/path"
 import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt } from "@/context/prompt"
 import { Identifier } from "@/utils/id"
 import { createCommentMetadata, formatCommentNote } from "@/utils/comment-note"
+import { toAbsoluteFilePath } from "./path-canonical"
 
 type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: string }
 
@@ -27,13 +28,6 @@ type BuildRequestPartsInput = {
   messageID: string
   sessionID: string
   sessionDirectory: string
-}
-
-const absolute = (directory: string, path: string) => {
-  if (path.startsWith("/")) return path
-  if (/^[A-Za-z]:[\\/]/.test(path) || /^[A-Za-z]:$/.test(path)) return path
-  if (path.startsWith("\\\\") || path.startsWith("//")) return path
-  return `${directory.replace(/[\\/]+$/, "")}/${path}`
 }
 
 const fileQuery = (selection: FileSelection | undefined) =>
@@ -104,7 +98,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
   ]
 
   const files = input.prompt.filter(isFileAttachment).map((attachment) => {
-    const path = absolute(input.sessionDirectory, attachment.path)
+    const path = toAbsoluteFilePath(input.sessionDirectory, attachment.path)
     return {
       id: Identifier.ascending("part"),
       type: "file",
@@ -138,7 +132,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
 
   const used = new Set(files.map((part) => part.url))
   const context = input.context.flatMap((item) => {
-    const path = absolute(input.sessionDirectory, item.path)
+    const path = toAbsoluteFilePath(input.sessionDirectory, item.path)
     const url = fileURL(path, item.selection)
     const comment = item.comment?.trim()
     if (!comment && used.has(url)) return []
@@ -155,7 +149,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
     if (!comment) return [filePart]
 
     const mentions = parseCommentMentions(comment).flatMap((path) => {
-      const url = fileURL(absolute(input.sessionDirectory, path))
+      const url = fileURL(toAbsoluteFilePath(input.sessionDirectory, path))
       if (used.has(url)) return []
       used.add(url)
       return [

--- a/packages/app/src/components/prompt-input/comment-routing.ts
+++ b/packages/app/src/components/prompt-input/comment-routing.ts
@@ -6,8 +6,10 @@ import { createMemo } from "solid-js"
 import { useFile } from "@/context/file"
 import { useComments } from "@/context/comments"
 import { useSync } from "@/context/sync"
+import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
+import { isAbsoluteLike, isUnderDirectory } from "./path-canonical"
 
 export interface CommentRoutingDeps {
   activeSessionID: () => string | undefined
@@ -24,6 +26,7 @@ export function createCommentRouting(deps: CommentRoutingDeps): CommentRouting {
   const files = useFile()
   const comments = useComments()
   const sync = useSync()
+  const sdk = useSDK()
 
   const activeFileTab = createSessionTabs({
     tabs,
@@ -41,6 +44,10 @@ export function createCommentRouting(deps: CommentRoutingDeps): CommentRouting {
   }
 
   const openComment = (item: { path: string; commentID?: string; commentOrigin?: "review" | "file" }) => {
+    // Belt-and-suspenders: reject external absolute paths so we never try to
+    // open a same-named file that happens to live inside the current workspace.
+    if (isAbsoluteLike(item.path) && !isUnderDirectory(item.path, sdk.directory)) return
+
     if (!item.commentID) return
 
     const focus = { file: item.path, id: item.commentID }

--- a/packages/app/src/components/prompt-input/context-items.test.ts
+++ b/packages/app/src/components/prompt-input/context-items.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { isExternalChip } from "./path-canonical"
+
+// isExternalChip is the pure helper that backs the external-chip guard in
+// context-items.tsx and the defensive short-circuit in comment-routing.ts.
+// Component-level rendering tests (aria-disabled attribute, click no-op) are
+// deferred to T10 E2E because Bun's SolidJS harness requires non-trivial mock
+// scaffolding; the logic tested here covers the decision boundary completely.
+
+describe("isExternalChip", () => {
+  test("relative path returns false (never external)", () => {
+    expect(isExternalChip("src/foo.ts", "/workspace/project")).toBe(false)
+  })
+
+  test("absolute path under source directory returns false (internal)", () => {
+    expect(isExternalChip("/workspace/project/src/foo.ts", "/workspace/project")).toBe(false)
+  })
+
+  test("absolute path that exactly matches source directory returns false (internal)", () => {
+    expect(isExternalChip("/workspace/project", "/workspace/project")).toBe(false)
+  })
+
+  test("absolute path outside source directory returns true (external)", () => {
+    expect(isExternalChip("/other/workspace/bar.ts", "/workspace/project")).toBe(true)
+  })
+
+  test("Windows drive path outside source returns true", () => {
+    expect(isExternalChip("C:/Users/alice/other-project/file.ts", "D:/workspace/project")).toBe(true)
+  })
+
+  test("Windows drive path under same drive returns false when inside source", () => {
+    expect(isExternalChip("C:/workspace/project/src/file.ts", "C:/workspace/project")).toBe(false)
+  })
+
+  test("UNC path is external from a POSIX root", () => {
+    // UNC \\\\server\\share is absolute but not under /workspace
+    expect(isExternalChip("\\\\server\\share\\file.ts", "/workspace/project")).toBe(true)
+  })
+
+  test("UNC forward-slash style is external from a POSIX root", () => {
+    expect(isExternalChip("//server/share/file.ts", "/workspace/project")).toBe(true)
+  })
+
+  test("missing sourceFilesystemDirectory returns false (cannot determine externality)", () => {
+    expect(isExternalChip("/absolute/path/file.ts", undefined)).toBe(false)
+  })
+
+  test("sibling directory with shared prefix is external", () => {
+    // /workspace/project-B is NOT under /workspace/project-A
+    expect(isExternalChip("/workspace/project-B/file.ts", "/workspace/project-A")).toBe(true)
+  })
+})

--- a/packages/app/src/components/prompt-input/context-items.test.ts
+++ b/packages/app/src/components/prompt-input/context-items.test.ts
@@ -3,9 +3,11 @@ import { isExternalChip } from "./path-canonical"
 
 // isExternalChip is the pure helper that backs the external-chip guard in
 // context-items.tsx and the defensive short-circuit in comment-routing.ts.
-// Component-level rendering tests (aria-disabled attribute, click no-op) are
+// Component-level rendering tests (data-external attribute, click no-op) are
 // deferred to T10 E2E because Bun's SolidJS harness requires non-trivial mock
 // scaffolding; the logic tested here covers the decision boundary completely.
+// (aria-disabled was dropped from the chip wrapper — its inner remove button
+// stays operable, so advertising the container as disabled was misleading.)
 
 describe("isExternalChip", () => {
   test("relative path returns false (never external)", () => {

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getDirectory, getFilename, getFilenameTruncated } from "@opencode-ai/util/path"
 import type { ContextItem } from "@/context/prompt"
+import { isExternalChip } from "./path-canonical"
 
 type PromptContextItem = ContextItem & { key: string }
 
@@ -13,6 +14,8 @@ type ContextItemsProps = {
   openComment: (item: PromptContextItem) => void
   remove: (item: PromptContextItem) => void
   t: (key: string) => string
+  /** Workspace root directory; used to detect external absolute-path chips. */
+  sourceFilesystemDirectory?: string
 }
 
 export const PromptContextItems: Component<ContextItemsProps> = (props) => {
@@ -25,6 +28,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
             const filename = getFilename(item.path)
             const label = getFilenameTruncated(item.path, 18)
             const selected = props.active(item)
+            const external = isExternalChip(item.path, props.sourceFilesystemDirectory)
             const range = () => {
               const sel = item.selection
               if (!sel) return ""
@@ -35,10 +39,17 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
               <Tooltip
                 value={
                   <span class="flex flex-col gap-0.5 max-w-[300px]">
-                    <span class="flex">
-                      <span class="text-fg-on-brand truncate-start [unicode-bidi:plaintext] min-w-0">{directory}</span>
-                      <span class="shrink-0">{filename}</span>
-                    </span>
+                    <Show when={external}>
+                      <span class="text-fg-on-brand opacity-80 text-xs">
+                        {props.t("prompt.context.externalFile")} · {item.path}
+                      </span>
+                    </Show>
+                    <Show when={!external}>
+                      <span class="flex">
+                        <span class="text-fg-on-brand truncate-start [unicode-bidi:plaintext] min-w-0">{directory}</span>
+                        <span class="shrink-0">{filename}</span>
+                      </span>
+                    </Show>
                     <Show when={item.comment}>
                       {(comment) => <span class="text-fg-on-brand opacity-80 break-words">{comment()}</span>}
                     </Show>
@@ -50,11 +61,16 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 <div
                   data-component="prompt-context-chip"
                   data-selected={selected ? "" : undefined}
+                  data-external={external ? "" : undefined}
+                  aria-disabled={external ? "true" : undefined}
                   classList={{
-                    "group inline-flex shrink-0 items-center gap-1 cursor-default transition-colors": true,
+                    "group inline-flex shrink-0 items-center gap-1 transition-colors": true,
                     "h-[26px] rounded-full pl-2 pr-1 max-w-[200px]": true,
-                    "bg-surface-interactive-hover": selected,
-                    "bg-bg-weak hover:bg-surface-interactive-base": !selected,
+                    "cursor-not-allowed opacity-70": external,
+                    "cursor-default": !external,
+                    "bg-surface-interactive-hover": selected && !external,
+                    "bg-bg-weak hover:bg-surface-interactive-base": !selected && !external,
+                    "bg-bg-weak": external,
                   }}
                   style={{
                     "font-family": "var(--font-family-mono)",
@@ -64,7 +80,14 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                     color: "var(--fg-base)",
                     "white-space": "nowrap",
                   }}
-                  onClick={() => props.openComment(item)}
+                  onClick={(event) => {
+                    // External chips: path is outside current workspace; block navigation.
+                    if (external) {
+                      event.preventDefault()
+                      return
+                    }
+                    props.openComment(item)
+                  }}
                 >
                   <FileIcon
                     node={{ path: item.path, type: "file" }}

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -62,7 +62,6 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                   data-component="prompt-context-chip"
                   data-selected={selected ? "" : undefined}
                   data-external={external ? "" : undefined}
-                  aria-disabled={external ? "true" : undefined}
                   classList={{
                     "group inline-flex shrink-0 items-center gap-1 transition-colors": true,
                     "h-[26px] rounded-full pl-2 pr-1 max-w-[200px]": true,

--- a/packages/app/src/components/prompt-input/draft-carryover.test.ts
+++ b/packages/app/src/components/prompt-input/draft-carryover.test.ts
@@ -64,4 +64,74 @@ describe("portable homepage owner — integration scenarios", () => {
     })
     expect(owner.snapshot()).toBeNull()
   })
+
+  test("homepage A with context items: snapshot moves with context preserved", () => {
+    const owner = createPortableDraftOwner()
+    const contextItems = [
+      {
+        type: "file" as const,
+        path: "/a/readme.md",
+        key: "file:/a/readme.md:undefined:undefined",
+        comment: "review this section",
+        commentID: "c-1",
+      },
+    ]
+
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      prompt: [{ type: "text", content: "draft text", start: 0, end: 10 }],
+      context: contextItems,
+      images: [],
+      resolvedMentions: {},
+    })
+
+    const moved = owner.consumeForHomepage("/b", true)
+    expect(moved).not.toBeNull()
+    // Context items must survive the move intact.
+    expect(moved?.context).toEqual(contextItems)
+    expect(moved?.sourceFilesystemDirectory).toBe("/b")
+  })
+
+  test("homepage A with resolvedMentions: metadata carries through", () => {
+    const owner = createPortableDraftOwner()
+    const resolvedMentions = {
+      "file:/a/readme.md:undefined:undefined:c=c-1": [
+        { displayText: "@readme.md", resolvedPath: "/a/readme.md", fingerprint: "fp1", start: 0, end: 10 },
+      ],
+    }
+
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      prompt: [{ type: "text", content: "draft text", start: 0, end: 10 }],
+      context: [
+        { type: "file" as const, path: "/a/readme.md", key: "file:/a/readme.md:undefined:undefined" },
+      ],
+      images: [],
+      resolvedMentions,
+    })
+
+    const moved = owner.consumeForHomepage("/b", true)
+    expect(moved).not.toBeNull()
+    expect(moved?.resolvedMentions).toEqual(resolvedMentions)
+  })
+
+  test("homepage A → homepage A: no self-consume even with context present", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      prompt: [{ type: "text", content: "draft text", start: 0, end: 10 }],
+      context: [
+        { type: "file" as const, path: "/a/file.ts", key: "file:/a/file.ts:undefined:undefined" },
+      ],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    // Self-consume attempt must return null — context or not.
+    const result = owner.consumeForHomepage("/a", true)
+    expect(result).toBeNull()
+    // Snapshot is still alive.
+    expect(owner.snapshot()).not.toBeNull()
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/a")
+  })
 })

--- a/packages/app/src/components/prompt-input/draft-carryover.test.ts
+++ b/packages/app/src/components/prompt-input/draft-carryover.test.ts
@@ -1,40 +1,67 @@
-import { describe, expect, test, beforeEach } from "bun:test"
-import { recordDraftEdit, consumeCarryOver, clearCarryOver, _peekLastTouched } from "./draft-carryover"
+/**
+ * Integration-style tests for v7 portable homepage owner semantics,
+ * exercised via the shim re-export from draft-carryover.ts.
+ */
 
-describe("draft carry-over", () => {
-  beforeEach(() => clearCarryOver())
+import { describe, expect, test } from "bun:test"
+import { createPortableDraftOwner } from "./portable-draft"
+import type { PortableDraftPayload } from "./portable-draft"
 
-  test("recording empty text clears the pointer", () => {
-    recordDraftEdit("/a", { text: "hi" })
-    recordDraftEdit("/a", { text: "" })
-    expect(_peekLastTouched()).toBeNull()
+function makePayload(text: string): PortableDraftPayload {
+  return {
+    prompt: [{ type: "text", content: text, start: 0, end: text.length }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+describe("portable homepage owner — integration scenarios", () => {
+  test("homepage A → homepage B: snapshot moves", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("draft text") })
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/a")
+
+    // Navigate to empty homepage B — snapshot moves
+    const moved = owner.consumeForHomepage("/b", true)
+    expect(moved).not.toBeNull()
+    expect(moved?.sourceFilesystemDirectory).toBe("/b")
+    expect(moved?.revision).toBeGreaterThan(1) // bumped on move
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/b")
   })
 
-  test("consume returns the previous dir's snapshot when target is empty", () => {
-    recordDraftEdit("/a", { text: "hello" })
-    const carry = consumeCarryOver("/b", true)
-    expect(carry?.text).toBe("hello")
+  test("homepage A → homepage A: no self-consume", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("draft text") })
+    const result = owner.consumeForHomepage("/a", true)
+    expect(result).toBeNull()
+    // Snapshot still exists
+    expect(owner.snapshot()).not.toBeNull()
   })
 
-  test("consume returns null when target is non-empty (no overwrite of existing draft)", () => {
-    recordDraftEdit("/a", { text: "hello" })
-    const carry = consumeCarryOver("/b", false)
-    expect(carry).toBeNull()
+  test("homepage A → homepage B when B already has draft: no overwrite", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("draft text") })
+    // B is NOT empty (targetIsEmpty = false)
+    const result = owner.consumeForHomepage("/b", false)
+    expect(result).toBeNull()
+    // Snapshot still anchored to A
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/a")
   })
 
-  test("consume returns null when target dir matches the source dir (no self-carry)", () => {
-    recordDraftEdit("/a", { text: "hello" })
-    expect(consumeCarryOver("/a", true)).toBeNull()
-  })
+  test("record with empty payload clears", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("draft text") })
+    expect(owner.snapshot()).not.toBeNull()
 
-  test("consume is one-shot: second call does not re-deliver", () => {
-    recordDraftEdit("/a", { text: "hello" })
-    expect(consumeCarryOver("/b", true)?.text).toBe("hello")
-    expect(consumeCarryOver("/c", true)).toBeNull()
-  })
-
-  test("recordDraftEdit ignores empty directory", () => {
-    recordDraftEdit("", { text: "hi" })
-    expect(_peekLastTouched()).toBeNull()
+    // Record empty content
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(owner.snapshot()).toBeNull()
   })
 })

--- a/packages/app/src/components/prompt-input/draft-carryover.ts
+++ b/packages/app/src/components/prompt-input/draft-carryover.ts
@@ -1,31 +1,5 @@
-import { createSignal } from "solid-js"
+// Backwards-compat shim: route-aware portable homepage owner.
+// The previous broad cross-directory carry-over is removed (PR #750, design v7).
+// New consumers should use `usePortableDraft()` from `./portable-draft`.
 
-export interface DraftSnapshot {
-  text: string
-}
-
-const [lastTouched, setLastTouched] = createSignal<{ directory: string; snapshot: DraftSnapshot } | null>(null)
-
-export function recordDraftEdit(directory: string, snapshot: DraftSnapshot) {
-  if (!directory) return
-  if (!snapshot.text) {
-    if (lastTouched()?.directory === directory) setLastTouched(null)
-    return
-  }
-  setLastTouched({ directory, snapshot })
-}
-
-export function consumeCarryOver(targetDirectory: string, targetIsEmpty: boolean): DraftSnapshot | null {
-  const current = lastTouched()
-  if (!current) return null
-  if (current.directory === targetDirectory) return null
-  if (!targetIsEmpty) return null
-  setLastTouched(null)
-  return current.snapshot
-}
-
-export function clearCarryOver() {
-  setLastTouched(null)
-}
-
-export const _peekLastTouched = () => lastTouched()
+export { usePortableDraft } from "./portable-draft"

--- a/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
+++ b/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
@@ -12,6 +12,8 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 import { createPortableDraftOwner } from "./portable-draft"
 import { createPinnedDraftOwner } from "./pinned-draft"
+import { buildRequestParts } from "./build-request-parts"
+import { captureCommentMentions } from "./mention-metadata"
 
 let detectSubmitOwnership: typeof import("./submit").detectSubmitOwnership
 
@@ -183,5 +185,75 @@ describe("draft isolation invariants (cross-owner chain)", () => {
     expect(pinned.clearAll(capturedRev)).toBe(false)
     expect(pinned.current()).not.toBeNull()
     expect(pinned.current()!.prompt[0]).toMatchObject({ content: "user typed more" })
+  })
+
+  // ------------------------------------------------------------------
+  // Path-anchoring across A→B carry (P1 #1 regression guard)
+  // ------------------------------------------------------------------
+
+  test("portable carry from A→B: relative context path resolves to A's directory, not B's", () => {
+    // Record an A-workspace draft that picks src/app.ts (relative).
+    portable.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: payload("look at this").prompt,
+      context: [{ key: "ctx:1", type: "file", path: "src/app.ts" }],
+      images: [],
+      resolvedMentions: {},
+    })
+    const moved = portable.consumeForHomepage("/repo-B", true)
+    expect(moved).not.toBeNull()
+
+    // Submit happens on /repo-B but the carried context must still point to A's file.
+    const result = buildRequestParts({
+      prompt: moved!.prompt,
+      context: moved!.context as { key: string; type: "file"; path: string }[],
+      images: [],
+      text: "look at this",
+      messageID: "msg_carry",
+      sessionID: "ses_carry",
+      sessionDirectory: "/repo-B",
+    })
+
+    const files = result.requestParts.filter((p) => p.type === "file")
+    expect(files.some((p) => p.type === "file" && p.url === "file:///repo-A/src/app.ts")).toBe(true)
+    expect(files.every((p) => !(p.type === "file" && p.url.startsWith("file:///repo-B/src/app")))).toBe(true)
+  })
+
+  test("portable carry from A→B: comment @mention resolves to A even when submitted from B", () => {
+    const comment = "compare with @src/shared.ts"
+    const resolvedMentions = captureCommentMentions({ comment, sourceFilesystemDirectory: "/repo-A" })
+
+    portable.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: payload("review").prompt,
+      context: [
+        {
+          key: "ctx:c1",
+          type: "file",
+          path: "src/main.ts",
+          comment,
+          commentID: "c1",
+          resolvedMentions,
+        },
+      ],
+      images: [],
+      resolvedMentions: { "ctx:c1": resolvedMentions },
+    })
+    const moved = portable.consumeForHomepage("/repo-B", true)!
+
+    const result = buildRequestParts({
+      prompt: moved.prompt,
+      context: moved.context as { key: string; type: "file"; path: string; comment?: string; resolvedMentions?: typeof resolvedMentions }[],
+      images: [],
+      text: "review",
+      messageID: "msg_carry_mention",
+      sessionID: "ses_carry_mention",
+      sessionDirectory: "/repo-B",
+    })
+
+    const files = result.requestParts.filter((p) => p.type === "file")
+    // Comment mention must stay anchored to /repo-A even though submit is on /repo-B
+    expect(files.some((p) => p.type === "file" && p.url === "file:///repo-A/src/shared.ts")).toBe(true)
+    expect(files.every((p) => !(p.type === "file" && p.url.startsWith("file:///repo-B/src/shared")))).toBe(true)
   })
 })

--- a/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
+++ b/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for cross-workspace draft isolation (PR #750 v7, T10).
+ *
+ * These tests exercise the full owner-chain contract that individual unit tests
+ * cover in isolation: portable carry (A→B), detectSubmitOwnership binding,
+ * and the stale-revision guard on clear/clearAll.
+ *
+ * Each test is a "slice" through multiple owner calls so that regressions in
+ * the hand-off between owners are caught here even if isolated unit tests pass.
+ */
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { createPortableDraftOwner } from "./portable-draft"
+import { createPinnedDraftOwner } from "./pinned-draft"
+
+let detectSubmitOwnership: typeof import("./submit").detectSubmitOwnership
+
+beforeAll(async () => {
+  // submit.ts pulls in router/sdk/etc. at module scope; mock bare minimum.
+  mock.module("@solidjs/router", () => ({
+    useNavigate: () => () => undefined,
+    useParams: () => ({}),
+  }))
+  // Use a real FNV-1a checksum so that Persist.workspace() still produces
+  // distinct storage names for different directories (the string-length mock
+  // used in submit-ownership.test.ts is order-dependent and leaks into
+  // history-navigation.test.ts when files run together).
+  const fnv1a = (value: string): string | undefined => {
+    if (!value) return undefined
+    let h = 0x811c9dc5
+    for (let i = 0; i < value.length; i++) {
+      h ^= value.charCodeAt(i)
+      h = Math.imul(h, 0x01000193)
+    }
+    return (h >>> 0).toString(36)
+  }
+  mock.module("@opencode-ai/util/encode", () => ({
+    base64Encode: (value: string) => value,
+    base64Decode: (value: string) => value,
+    checksum: fnv1a,
+    sampledChecksum: fnv1a,
+  }))
+  const mod = await import("./submit")
+  detectSubmitOwnership = mod.detectSubmitOwnership
+})
+
+// Minimal non-empty payload for a given text string.
+function payload(text: string) {
+  return {
+    prompt: [{ type: "text" as const, content: text, start: 0, end: text.length }],
+    context: [] as [],
+    images: [] as [],
+    resolvedMentions: {} as Record<string, never[]>,
+  }
+}
+
+const ROUTE_SCOPE_A = { dir: "L0E", id: undefined } as const
+const ROUTE_SCOPE_B = { dir: "L0F", id: undefined } as const
+
+describe("draft isolation invariants (cross-owner chain)", () => {
+  let portable: ReturnType<typeof createPortableDraftOwner>
+  let pinned: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    portable = createPortableDraftOwner()
+    pinned = createPinnedDraftOwner()
+  })
+
+  // ------------------------------------------------------------------
+  // Core regression: cross-workspace portable carry
+  // ------------------------------------------------------------------
+
+  test("portable draft moves from /A to /B and is bound to /B afterward", () => {
+    // User types on homepage /A, then navigates to homepage /B (empty).
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("workspace A text") })
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/A")
+
+    const moved = portable.consumeForHomepage("/B", true)
+    // consumeForHomepage returns the moved snapshot.
+    expect(moved).not.toBeNull()
+    expect(moved?.prompt[0]).toMatchObject({ content: "workspace A text" })
+    // After the move, the internal snapshot is anchored to /B, not /A.
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/B")
+  })
+
+  test("portable draft moved to /B is NOT detected as owned by /A (cross-workspace isolation)", () => {
+    // A draft from /A travels to /B.
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("workspace A text") })
+    portable.consumeForHomepage("/B", true)
+
+    // Back on homepage /A: the snapshot is now anchored to /B, so /A gets "route".
+    const ownershipOnA = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/A",
+      routeScope: ROUTE_SCOPE_A,
+    })
+    expect(ownershipOnA.kind).toBe("route")
+  })
+
+  test("portable draft moved to /B IS detected as owned by /B (content reaches target workspace)", () => {
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("workspace A text") })
+    portable.consumeForHomepage("/B", true)
+
+    // On homepage /B: ownership should be portable, bound to /B.
+    const ownershipOnB = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/B",
+      routeScope: ROUTE_SCOPE_B,
+    })
+    expect(ownershipOnB.kind).toBe("portable")
+    if (ownershipOnB.kind === "portable") {
+      expect(ownershipOnB.sourceFilesystemDirectory).toBe("/B")
+    }
+  })
+
+  test("portable draft is never detected on a session route even after move (session isolation)", () => {
+    // Draft travels A→B, but user opens a session on /B instead of staying on homepage.
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("workspace A text") })
+    portable.consumeForHomepage("/B", true)
+
+    // isHomepage: false means a concrete session route; ownership must be "route".
+    const ownershipOnSession = detectSubmitOwnership({
+      isHomepage: false,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/B",
+      routeScope: { dir: "L0F", id: "ses_42" },
+    })
+    expect(ownershipOnSession.kind).toBe("route")
+  })
+
+  // ------------------------------------------------------------------
+  // Pinned beats portable (cross-owner priority)
+  // ------------------------------------------------------------------
+
+  test("pinned slot beats portable when both are anchored to the same directory", () => {
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("portable content") })
+    pinned.adopt({ directory: "/A", prompt: "pinned content" })
+
+    const ownership = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/A",
+      routeScope: ROUTE_SCOPE_A,
+    })
+    expect(ownership.kind).toBe("pinned")
+    if (ownership.kind === "pinned") {
+      expect(ownership.directory).toBe("/A")
+    }
+  })
+
+  // ------------------------------------------------------------------
+  // Stale-revision guard: delayed-success safety across owners
+  // ------------------------------------------------------------------
+
+  test("portable.clear with stale revision is a no-op (user typed more during await)", () => {
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("first") })
+    const capturedRev = portable.revision()
+
+    // User types more during the async submit.
+    portable.record({ sourceFilesystemDirectory: "/A", ...payload("first PLUS new typing") })
+
+    // Stale clear must not wipe the new content.
+    expect(portable.clear(capturedRev)).toBe(false)
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "first PLUS new typing" })
+  })
+
+  test("pinned.clearAll with stale revision is a no-op (user typed more during await)", () => {
+    pinned.adopt({ directory: "/A", prompt: "initial" })
+    const capturedRev = pinned.current()!.revision
+
+    pinned.recordEdit({
+      directory: "/A",
+      ...payload("user typed more"),
+    })
+
+    // Stale clearAll must not release the slot.
+    expect(pinned.clearAll(capturedRev)).toBe(false)
+    expect(pinned.current()).not.toBeNull()
+    expect(pinned.current()!.prompt[0]).toMatchObject({ content: "user typed more" })
+  })
+})

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -31,6 +31,7 @@ import { promptLength } from "./history"
 import type { EditorImperatives } from "./editor-imperatives"
 import type { PopoverControllers } from "./popover-controllers"
 import type { PromptStore } from "./store-types"
+import type { ResolvedMention } from "./mention-metadata"
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
 
@@ -145,13 +146,20 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
         const carry = portable.consumeForHomepage(dir, isEmpty)
         if (!carry) return
-        // Hydrate this homepage's text from the moved snapshot.
-        // Context + image hydration is deferred to Task 5 (portable comments).
+        // Hydrate prompt text.
         const text = carry.prompt
           .filter((p) => p.type === "text")
           .map((p) => p.content)
           .join("")
         prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
+        // Hydrate context items atomically. Strip keys so contextItemKey regenerates
+        // them for the target route, avoiding collisions with pre-existing items.
+        prompt.context.replaceAll(
+          carry.context.map(({ key: _omitKey, ...rest }) => rest),
+        )
+        // Image hydration: imageAttachments is fed by an external signal in the
+        // parent component and does not expose a setter here. Image carryover is
+        // deferred to a follow-up task (no write path available in this layer).
       },
     ),
   )
@@ -204,13 +212,19 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     prompt.set([...rawParts, ...images], cursorPosition)
     if (!params.id) {
       // Homepage route: mirror edit into portable owner after prompt.set.
-      // T5 will start populating resolvedMentions; PR1 leaves it empty.
+      // Build resolvedMentions from current context items.
+      const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
+      for (const item of prompt.context.items()) {
+        if (item.type === "file" && item.resolvedMentions?.length) {
+          resolvedMentionsMap[item.key] = item.resolvedMentions
+        }
+      }
       portable.record({
         sourceFilesystemDirectory: sdk.directory,
         prompt: prompt.current(),
         context: prompt.context.items().slice(),
         images: imageAttachments(),
-        resolvedMentions: {},
+        resolvedMentions: resolvedMentionsMap,
       })
     }
     // Session routes do not mirror into the portable owner.

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -132,6 +132,22 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     ),
   )
 
+  // Centralized "is the homepage draft empty" check.
+  // The prompt store, the context-item store, AND the imageAttachments accessor
+  // are three independent surfaces. A homepage with chips or images is NOT
+  // empty even if the text part is whitespace — using a text-only check would
+  // overwrite those surfaces on pinned/portable hydration (Bug 4).
+  const isHomepageDraftEmpty = () => {
+    const parts = prompt.current()
+    const textIsEmpty =
+      parts.length === 0 ||
+      (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
+    if (!textIsEmpty) return false
+    if (prompt.context.items().length > 0) return false
+    if (imageAttachments().length > 0) return false
+    return true
+  }
+
   createEffect(
     on(
       () => [sdk.directory, prompt.ready(), params.id] as const,
@@ -148,11 +164,11 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         // displayed prompt and suppress portable consumption for this homepage.
         const pinnedSlot = pinned.current()
         if (pinnedSlot && pinnedSlot.directory === dir) {
-          const parts = prompt.current()
-          const isEmpty =
-            parts.length === 0 ||
-            (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
+          const isEmpty = isHomepageDraftEmpty()
           if (isEmpty) {
+            // Replay the full Prompt array (file/agent/text parts) directly.
+            // The snapshot already stored a well-formed Prompt; reconstructing
+            // from text-only would silently drop attachment parts (Bug 6).
             prompt.set(pinnedSlot.prompt, undefined)
             prompt.context.replaceAll(pinnedSlot.context.map(({ key: _omit, ...rest }) => rest))
           }
@@ -161,26 +177,21 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         }
 
         // Homepage route: attempt to consume a snapshot that moved here from another homepage.
-        const parts = prompt.current()
-        const isEmpty =
-          parts.length === 0 ||
-          (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
+        const isEmpty = isHomepageDraftEmpty()
         const carry = portable.consumeForHomepage(dir, isEmpty)
         if (!carry) return
-        // Hydrate prompt text.
-        const text = carry.prompt
-          .filter((p) => p.type === "text")
-          .map((p) => p.content)
-          .join("")
-        prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
+        // Replay the full Prompt array from the snapshot, preserving file/agent
+        // attachment parts (Bug 6). Previously this filtered to text-only and
+        // joined into a single text part, which dropped attachments.
+        prompt.set(carry.prompt, undefined)
         // Hydrate context items atomically. Strip keys so contextItemKey regenerates
         // them for the target route, avoiding collisions with pre-existing items.
         prompt.context.replaceAll(
           carry.context.map(({ key: _omitKey, ...rest }) => rest),
         )
         // Image hydration: imageAttachments is fed by an external signal in the
-        // parent component and does not expose a setter here. Image carryover is
-        // deferred to a follow-up task (no write path available in this layer).
+        // parent component and does not expose a setter here. File/agent parts
+        // hydrate via prompt.set above; image parts remain a follow-up.
       },
     ),
   )
@@ -205,6 +216,35 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         prompt.set(DEFAULT_PROMPT, 0)
       }
       imperatives.queueScroll()
+
+      // Homepage route: clearing all input must also clear the active owner
+      // (Bug 3). Without this, navigating away later carries the stale
+      // snapshot — the user thinks they cleared the draft but the portable
+      // owner still has it.
+      if (!params.id) {
+        const pinnedSlot = pinned.current()
+        if (pinnedSlot && pinnedSlot.directory === sdk.directory) {
+          // Don't release the pinned binding. Recording an empty payload keeps
+          // the slot bound for future edits while signaling that the user
+          // cleared the prefill.
+          pinned.recordEdit({
+            directory: sdk.directory,
+            prompt: DEFAULT_PROMPT,
+            context: [],
+            images: [],
+            resolvedMentions: {},
+          })
+        } else {
+          // Portable owner: record({empty}) tears down the snapshot.
+          portable.record({
+            sourceFilesystemDirectory: sdk.directory,
+            prompt: DEFAULT_PROMPT,
+            context: [],
+            images: [],
+            resolvedMentions: {},
+          })
+        }
+      }
       return
     }
 

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -14,7 +14,8 @@ import {
   type usePrompt,
 } from "@/context/prompt"
 import type { useSDK } from "@/context/sdk"
-import { recordDraftEdit, consumeCarryOver } from "./draft-carryover"
+import { useParams } from "@solidjs/router"
+import { usePortableDraft } from "./portable-draft"
 import {
   createTextFragment,
   getCursorPosition,
@@ -77,6 +78,9 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     resetHistoryNavigation,
   } = deps
 
+  const params = useParams()
+  const portable = usePortableDraft()
+
   const [composing, setComposing] = createSignal(false)
   const isImeComposing = (event: KeyboardEvent) =>
     event.isComposing || composing() || event.keyCode === 229
@@ -126,16 +130,27 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
 
   createEffect(
     on(
-      () => [sdk.directory, prompt.ready()] as const,
-      ([dir, ready]) => {
+      () => [sdk.directory, prompt.ready(), params.id] as const,
+      ([dir, ready, sessionID]) => {
         if (!ready || !dir) return
+        if (sessionID) {
+          // Concrete session route: do nothing with the portable owner.
+          portable.hide()
+          return
+        }
+        // Homepage route: attempt to consume a snapshot that moved here from another homepage.
         const parts = prompt.current()
         const isEmpty =
           parts.length === 0 ||
           (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
-        const carry = consumeCarryOver(dir, isEmpty)
+        const carry = portable.consumeForHomepage(dir, isEmpty)
         if (!carry) return
-        const text = carry.text
+        // Hydrate this homepage's text from the moved snapshot.
+        // Context + image hydration is deferred to Task 5 (portable comments).
+        const text = carry.prompt
+          .filter((p) => p.type === "text")
+          .map((p) => p.content)
+          .join("")
         prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
       },
     ),
@@ -187,7 +202,18 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
 
     mirror.input = true
     prompt.set([...rawParts, ...images], cursorPosition)
-    recordDraftEdit(sdk.directory, { text: rawText })
+    if (!params.id) {
+      // Homepage route: mirror edit into portable owner after prompt.set.
+      // T5 will start populating resolvedMentions; PR1 leaves it empty.
+      portable.record({
+        sourceFilesystemDirectory: sdk.directory,
+        prompt: prompt.current(),
+        context: prompt.context.items().slice(),
+        images: imageAttachments(),
+        resolvedMentions: {},
+      })
+    }
+    // Session routes do not mirror into the portable owner.
     imperatives.queueScroll()
   }
 

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -16,6 +16,7 @@ import {
 import type { useSDK } from "@/context/sdk"
 import { useParams } from "@solidjs/router"
 import { usePortableDraft } from "./portable-draft"
+import { usePinnedDraft } from "./pinned-draft"
 import {
   createTextFragment,
   getCursorPosition,
@@ -81,6 +82,8 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
 
   const params = useParams()
   const portable = usePortableDraft()
+  // Pinned owner is created once per factory call (not inside handleInput).
+  const pinned = usePinnedDraft()
 
   const [composing, setComposing] = createSignal(false)
   const isImeComposing = (event: KeyboardEvent) =>
@@ -139,6 +142,24 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           portable.hide()
           return
         }
+
+        // Homepage route: check pinned scope BEFORE portable.
+        // If a pinned slot is bound to this directory, project it into the
+        // displayed prompt and suppress portable consumption for this homepage.
+        const pinnedSlot = pinned.current()
+        if (pinnedSlot && pinnedSlot.directory === dir) {
+          const parts = prompt.current()
+          const isEmpty =
+            parts.length === 0 ||
+            (parts.length === 1 && parts[0]?.type === "text" && !parts[0].content.trim())
+          if (isEmpty) {
+            prompt.set(pinnedSlot.prompt, undefined)
+            prompt.context.replaceAll(pinnedSlot.context.map(({ key: _omit, ...rest }) => rest))
+          }
+          // Do NOT fall through to portable consumption while pinned is active.
+          return
+        }
+
         // Homepage route: attempt to consume a snapshot that moved here from another homepage.
         const parts = prompt.current()
         const isEmpty =
@@ -211,7 +232,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     mirror.input = true
     prompt.set([...rawParts, ...images], cursorPosition)
     if (!params.id) {
-      // Homepage route: mirror edit into portable owner after prompt.set.
+      // Homepage route: mirror edit into pinned or portable owner after prompt.set.
       // Build resolvedMentions from current context items.
       const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
       for (const item of prompt.context.items()) {
@@ -219,13 +240,27 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           resolvedMentionsMap[item.key] = item.resolvedMentions
         }
       }
-      portable.record({
-        sourceFilesystemDirectory: sdk.directory,
-        prompt: prompt.current(),
-        context: prompt.context.items().slice(),
-        images: imageAttachments(),
-        resolvedMentions: resolvedMentionsMap,
-      })
+      const currentPinnedSlot = pinned.current()
+      if (currentPinnedSlot && currentPinnedSlot.directory === sdk.directory) {
+        // Pinned scope is active for this directory: route edits to pinned owner.
+        // This ensures "clearing pinned prefill and typing fresh text remains pinned-scope".
+        pinned.recordEdit({
+          directory: sdk.directory,
+          prompt: prompt.current(),
+          context: prompt.context.items().slice(),
+          images: imageAttachments(),
+          resolvedMentions: resolvedMentionsMap,
+        })
+      } else {
+        // No active pinned slot for this directory: route edits to portable owner.
+        portable.record({
+          sourceFilesystemDirectory: sdk.directory,
+          prompt: prompt.current(),
+          context: prompt.context.items().slice(),
+          images: imageAttachments(),
+          resolvedMentions: resolvedMentionsMap,
+        })
+      }
     }
     // Session routes do not mirror into the portable owner.
     imperatives.queueScroll()

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -206,7 +206,13 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         ? rawParts[0].content
         : rawParts.map((p) => ("content" in p ? p.content : "")).join("")
     const hasNonText = rawParts.some((part) => part.type !== "text")
-    const shouldReset = !NON_EMPTY_TEXT.test(rawText) && !hasNonText && images.length === 0
+    // Context chips (drag/drop, picker, hand-off draft, comment hydration) live
+    // in prompt.context.items() and don't appear as editor parts, so we have to
+    // include them — otherwise an empty textarea with existing chips would hit
+    // the reset branch and record {empty} into the owner, clearing ownership
+    // while the chips are still rendered.
+    const shouldReset =
+      !NON_EMPTY_TEXT.test(rawText) && !hasNonText && images.length === 0 && prompt.context.items().length === 0
 
     if (shouldReset) {
       closePopover()

--- a/packages/app/src/components/prompt-input/history-comment-map.ts
+++ b/packages/app/src/components/prompt-input/history-comment-map.ts
@@ -1,0 +1,18 @@
+/**
+ * Build the comment lookup map used by historyComments().
+ *
+ * When `portableActive` is true the target route's useComments() store belongs
+ * to a different workspace; returning an empty map forces historyComments() to
+ * fall through to the self-contained data on each context item (item.selection,
+ * Date.now()), preventing cross-workspace comment metadata from leaking.
+ *
+ * Lives in its own module so the unit test can import it without pulling the
+ * full history-navigation graph (useSDK / usePortableDraft → Solid router).
+ */
+export function buildCommentByIDMap<T extends { file: string; id: string }>(
+  comments: T[],
+  portableActive: boolean,
+): Map<string, T> {
+  if (portableActive) return new Map()
+  return new Map(comments.map((item) => [`${item.file}\n${item.id}`, item] as const))
+}

--- a/packages/app/src/components/prompt-input/history-navigation.test.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.test.ts
@@ -1,0 +1,74 @@
+// Tests for directory-scoped prompt history (Task 3 of PR #750).
+//
+// We test the Persist.workspace target shape directly rather than calling
+// createDirectoryHistoryStore(), because persisted() internally calls
+// usePlatform() which requires a Solid reactive context that is not
+// available in the bun:test environment.
+//
+// NOTE: The rAF stale-guard cannot be meaningfully tested in this unit-test
+// layer because it requires a real DOM and a live Solid reactive root with
+// directoryToken signals firing across animation frames.
+// The E2E coverage for that branch is deferred to Task 10.
+
+import { describe, expect, test } from "bun:test"
+import { Persist, PersistTesting } from "@/utils/persist"
+
+/** Mirrors the target-building logic in createDirectoryHistoryStore. */
+function buildHistoryTarget(directory: string, mode: "normal" | "shell") {
+  const key = mode === "shell" ? "prompt-history-shell" : "prompt-history"
+  return Persist.workspace(directory, key)
+  // No legacy keys — per v7, old global history is ignored.
+}
+
+describe("directory-scoped prompt history targets", () => {
+  test("different directories produce different storage files", () => {
+    const targetA = buildHistoryTarget("/home/user/project-a", "normal")
+    const targetB = buildHistoryTarget("/home/user/project-b", "normal")
+
+    expect(targetA.storage).not.toBe(targetB.storage)
+
+    // Confirm against PersistTesting helper.
+    expect(targetA.storage).toBe(PersistTesting.workspaceStorage("/home/user/project-a"))
+    expect(targetB.storage).toBe(PersistTesting.workspaceStorage("/home/user/project-b"))
+  })
+
+  test("normal and shell modes share storage file but use distinct keys", () => {
+    const normalTarget = buildHistoryTarget("/workspace/foo", "normal")
+    const shellTarget = buildHistoryTarget("/workspace/foo", "shell")
+
+    // Same directory → same file.
+    expect(normalTarget.storage).toBe(shellTarget.storage)
+
+    // Different mode → different key.
+    expect(normalTarget.key).not.toBe(shellTarget.key)
+    expect(normalTarget.key).toContain("prompt-history")
+    expect(shellTarget.key).toContain("prompt-history-shell")
+  })
+
+  test("does NOT include legacy global history keys (v7: old global history is ignored)", () => {
+    const normalTarget = buildHistoryTarget("/workspace/foo", "normal")
+    const shellTarget = buildHistoryTarget("/workspace/foo", "shell")
+
+    // Persist.workspace() with no legacy arg leaves it undefined.
+    expect(normalTarget.legacy).toBeUndefined()
+    expect(shellTarget.legacy).toBeUndefined()
+  })
+
+  test("workspace key uses workspace: prefix (Persist.workspace contract)", () => {
+    const target = buildHistoryTarget("/my/dir", "normal")
+    expect(target.key).toMatch(/^workspace:/)
+  })
+
+  test("storage file name encodes the directory path via checksum", () => {
+    const dir = "/Users/someone/my-project"
+    const target = buildHistoryTarget(dir, "normal")
+    expect(target.storage).toBe(PersistTesting.workspaceStorage(dir))
+  })
+
+  test("two identical directories with identical modes produce identical targets", () => {
+    const t1 = buildHistoryTarget("/same/dir", "shell")
+    const t2 = buildHistoryTarget("/same/dir", "shell")
+    expect(t1.storage).toBe(t2.storage)
+    expect(t1.key).toBe(t2.key)
+  })
+})

--- a/packages/app/src/components/prompt-input/history-navigation.test.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { Persist, PersistTesting } from "@/utils/persist"
+import { buildCommentByIDMap } from "./history-comment-map"
 
 /** Mirrors the target-building logic in createDirectoryHistoryStore. */
 function buildHistoryTarget(directory: string, mode: "normal" | "shell") {
@@ -70,5 +71,41 @@ describe("directory-scoped prompt history targets", () => {
     const t2 = buildHistoryTarget("/same/dir", "shell")
     expect(t1.storage).toBe(t2.storage)
     expect(t1.key).toBe(t2.key)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildCommentByIDMap — portable-active gate (Task 5 of PR #750)
+// ---------------------------------------------------------------------------
+//
+// When portable is active (the homepage received a carried snapshot from
+// another workspace), the byID cross-reference to route-scoped useComments()
+// must be skipped so that wrong-workspace comment metadata is never used.
+
+type FakeComment = { file: string; id: string; selection: { start: number; end: number }; time: number; comment: string }
+
+describe("buildCommentByIDMap — portable-active gate", () => {
+  const comments: FakeComment[] = [
+    { file: "/a/foo.ts", id: "c-1", selection: { start: 1, end: 5 }, time: 1000, comment: "hello" },
+    { file: "/a/bar.ts", id: "c-2", selection: { start: 2, end: 3 }, time: 2000, comment: "world" },
+  ]
+
+  test("returns empty map when portableActive is true", () => {
+    const map = buildCommentByIDMap(comments, true)
+    expect(map.size).toBe(0)
+  })
+
+  test("returns populated map when portableActive is false and comments exist", () => {
+    const map = buildCommentByIDMap(comments, false)
+    expect(map.size).toBe(2)
+    // Key format: "${file}\n${id}"
+    expect(map.has("/a/foo.ts\nc-1")).toBe(true)
+    expect(map.has("/a/bar.ts\nc-2")).toBe(true)
+    expect(map.get("/a/foo.ts\nc-1")?.selection.start).toBe(1)
+  })
+
+  test("returns empty map when portableActive is false but no comments given", () => {
+    const map = buildCommentByIDMap([], false)
+    expect(map.size).toBe(0)
   })
 })

--- a/packages/app/src/components/prompt-input/history-navigation.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.ts
@@ -23,6 +23,8 @@ import {
 } from "./history"
 import type { HistoryStore, PromptStore } from "./store-types"
 import { createDirectoryHistoryStore, MAX_DIRECTORY_CACHE } from "./history-store-factory"
+import { buildCommentByIDMap } from "./history-comment-map"
+import { usePortableDraft } from "./portable-draft"
 
 // --- Per-directory cache types ---
 
@@ -55,6 +57,7 @@ export interface HistoryNavigation {
 export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNavigation {
   const { store, setStore, prompt, comments, editorRef, queueScroll } = deps
   const sdk = useSDK()
+  const portable = usePortableDraft()
 
   // --- Per-directory store cache (LRU, capped at MAX_DIRECTORY_CACHE) ---
 
@@ -119,7 +122,10 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   // --- Comment helpers ---
 
   const historyComments = () => {
-    const byID = new Map(comments.all().map((item) => [`${item.file}\n${item.id}`, item] as const))
+    // When portable has an active snapshot the route-scoped useComments() store
+    // belongs to a potentially different workspace; gate the cross-reference to
+    // prevent wrong-workspace metadata from leaking into comment history.
+    const byID = buildCommentByIDMap(comments.all(), portable.snapshot() !== null)
     return prompt.context.items().flatMap((item) => {
       if (item.type !== "file") return []
       const comment = item.comment?.trim()

--- a/packages/app/src/components/prompt-input/history-navigation.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.ts
@@ -100,6 +100,12 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   const history = () => currentStores().history.store
   const shellHistory = () => currentStores().shellHistory.store
 
+  // Pre-warm the cache for the current directory while we are still inside
+  // Solid setup (where useContext works). createDirectoryHistoryStore reaches
+  // persisted() which calls usePlatform(); calling that lazily from a submit
+  // async tail would land outside the reactive root and throw.
+  ensureStores(sdk.directory)
+
   // --- Directory-change token for rAF stale guard ---
   //
   // Increments every time sdk.directory changes.  The rAF callback compares
@@ -110,7 +116,10 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   createEffect(
     on(
       () => sdk.directory,
-      () => {
+      (dir) => {
+        // Pre-warm the cache for the new directory inside the reactive root
+        // so later cache reads from outside the root are guaranteed hits.
+        ensureStores(dir)
         setDirectoryToken((t) => t + 1)
         // Also reset navigation state so ArrowUp in the new workspace
         // doesn't resume mid-navigation from the previous workspace.

--- a/packages/app/src/components/prompt-input/history-navigation.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.ts
@@ -165,6 +165,7 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
           time: item.commentID ? (byID.get(`${item.path}\n${item.commentID}`)?.time ?? Date.now()) : Date.now(),
           origin: item.commentOrigin,
           preview: item.preview,
+          resolvedMentions: item.resolvedMentions,
         } satisfies PromptHistoryComment,
       ]
     })
@@ -189,6 +190,7 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
         commentID: item.id,
         commentOrigin: item.origin,
         preview: item.preview,
+        resolvedMentions: item.resolvedMentions,
       })),
     )
   }

--- a/packages/app/src/components/prompt-input/history-navigation.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.ts
@@ -7,6 +7,7 @@
 
 import { createEffect, createSignal, on } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
+import { useParams } from "@solidjs/router"
 import { selectionFromLines } from "@/context/file"
 import type { Prompt, usePrompt } from "@/context/prompt"
 import type { useComments } from "@/context/comments"
@@ -58,6 +59,7 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   const { store, setStore, prompt, comments, editorRef, queueScroll } = deps
   const sdk = useSDK()
   const portable = usePortableDraft()
+  const params = useParams()
 
   // --- Per-directory store cache (LRU, capped at MAX_DIRECTORY_CACHE) ---
 
@@ -122,10 +124,13 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   // --- Comment helpers ---
 
   const historyComments = () => {
-    // When portable has an active snapshot the route-scoped useComments() store
-    // belongs to a potentially different workspace; gate the cross-reference to
-    // prevent wrong-workspace metadata from leaking into comment history.
-    const byID = buildCommentByIDMap(comments.all(), portable.snapshot() !== null)
+    // The portable byID gate (Bug 5) is only meaningful on a HOMEPAGE route.
+    // On a session route the route-scoped useComments() store IS the correct
+    // source even when a portable snapshot exists for some other homepage;
+    // disabling the byID map there would lose comment selection/time metadata
+    // for the active session.
+    const portableActive = portable.snapshot() !== null && !params.id
+    const byID = buildCommentByIDMap(comments.all(), portableActive)
     return prompt.context.items().flatMap((item) => {
       if (item.type !== "file") return []
       const comment = item.comment?.trim()

--- a/packages/app/src/components/prompt-input/history-navigation.ts
+++ b/packages/app/src/components/prompt-input/history-navigation.ts
@@ -1,11 +1,16 @@
 // Prompt input history (persisted entries, apply, navigate). A complete
 // subsystem: two persisted stores (normal + shell), apply logic, navigation
 // logic, and comment synchronization.
+//
+// History is scoped per workspace directory (Task 3 of PR #750).
+// ArrowUp in workspace B no longer surfaces entries typed in workspace A.
 
+import { createEffect, createSignal, on } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import { selectionFromLines } from "@/context/file"
 import type { Prompt, usePrompt } from "@/context/prompt"
 import type { useComments } from "@/context/comments"
+import { useSDK } from "@/context/sdk"
 import { Persist, persisted } from "@/utils/persist"
 import { setCursorPosition } from "./editor-dom"
 import {
@@ -17,6 +22,16 @@ import {
   type PromptHistoryStoredEntry,
 } from "./history"
 import type { HistoryStore, PromptStore } from "./store-types"
+import { createDirectoryHistoryStore, MAX_DIRECTORY_CACHE } from "./history-store-factory"
+
+// --- Per-directory cache types ---
+
+type DirectoryHistoryStores = {
+  history: ReturnType<typeof createDirectoryHistoryStore>
+  shellHistory: ReturnType<typeof createDirectoryHistoryStore>
+  /** LRU order: bump on each access so we can evict oldest. */
+  lastUsed: number
+}
 
 export interface HistoryNavigationDeps {
   store: PromptStore
@@ -28,8 +43,10 @@ export interface HistoryNavigationDeps {
 }
 
 export interface HistoryNavigation {
-  history: HistoryStore
-  shellHistory: HistoryStore
+  /** Accessor — returns the history store for the current directory. */
+  history: () => HistoryStore
+  /** Accessor — returns the shell history store for the current directory. */
+  shellHistory: () => HistoryStore
   historyComments: () => PromptHistoryComment[]
   addToHistory: (prompt: Prompt, mode: "normal" | "shell") => void
   navigateHistory: (direction: "up" | "down") => boolean
@@ -37,15 +54,69 @@ export interface HistoryNavigation {
 
 export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNavigation {
   const { store, setStore, prompt, comments, editorRef, queueScroll } = deps
+  const sdk = useSDK()
 
-  const [history, setHistory] = persisted(
-    Persist.global("prompt-history", ["prompt-history.v1"]),
-    createStore<HistoryStore>({ entries: [] }),
+  // --- Per-directory store cache (LRU, capped at MAX_DIRECTORY_CACHE) ---
+
+  const cache = new Map<string, DirectoryHistoryStores>()
+  let lruClock = 0
+
+  const ensureStores = (directory: string): DirectoryHistoryStores => {
+    const existing = cache.get(directory)
+    if (existing) {
+      existing.lastUsed = ++lruClock
+      return existing
+    }
+
+    // Prune the oldest entry when the cache is full.
+    if (cache.size >= MAX_DIRECTORY_CACHE) {
+      let oldestKey: string | undefined
+      let oldestTime = Infinity
+      for (const [key, entry] of cache) {
+        if (entry.lastUsed < oldestTime) {
+          oldestTime = entry.lastUsed
+          oldestKey = key
+        }
+      }
+      if (oldestKey) cache.delete(oldestKey)
+    }
+
+    const stores: DirectoryHistoryStores = {
+      history: createDirectoryHistoryStore(directory, "normal"),
+      shellHistory: createDirectoryHistoryStore(directory, "shell"),
+      lastUsed: ++lruClock,
+    }
+    cache.set(directory, stores)
+    return stores
+  }
+
+  // Reactive accessors — always read from the current directory's stores.
+  const currentStores = () => ensureStores(sdk.directory)
+  const history = () => currentStores().history.store
+  const shellHistory = () => currentStores().shellHistory.store
+
+  // --- Directory-change token for rAF stale guard ---
+  //
+  // Increments every time sdk.directory changes.  The rAF callback compares
+  // its captured token to the live value; if they differ, the directory
+  // changed between schedule and execution, and the DOM write is abandoned.
+  const [directoryToken, setDirectoryToken] = createSignal(0)
+
+  createEffect(
+    on(
+      () => sdk.directory,
+      () => {
+        setDirectoryToken((t) => t + 1)
+        // Also reset navigation state so ArrowUp in the new workspace
+        // doesn't resume mid-navigation from the previous workspace.
+        setStore("historyIndex", -1)
+        setStore("savedPrompt", null)
+      },
+      { defer: true },
+    ),
   )
-  const [shellHistory, setShellHistory] = persisted(
-    Persist.global("prompt-history-shell", ["prompt-history-shell.v1"]),
-    createStore<HistoryStore>({ entries: [] }),
-  )
+
+  // --- Comment helpers ---
 
   const historyComments = () => {
     const byID = new Map(comments.all().map((item) => [`${item.file}\n${item.id}`, item] as const))
@@ -102,13 +173,24 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
     )
   }
 
+  // --- rAF stale guard ---
+  //
+  // Capture the directory token at schedule time.  If the directory changes
+  // between the requestAnimationFrame call and its execution, the write is
+  // abandoned to avoid corrupting the wrong editor's state.
   const applyHistoryPrompt = (entry: PromptHistoryEntry, position: "start" | "end") => {
+    const tokenAtSchedule = directoryToken()
     const p = entry.prompt
     const length = position === "start" ? 0 : promptLength(p)
     setStore("applyingHistory", true)
     applyHistoryComments(entry.comments)
     prompt.set(p, length)
     requestAnimationFrame(() => {
+      if (directoryToken() !== tokenAtSchedule) {
+        // Directory changed between schedule and frame; abandon DOM write.
+        setStore("applyingHistory", false)
+        return
+      }
       const editor = editorRef()
       editor.focus()
       setCursorPosition(editor, length)
@@ -118,8 +200,9 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   }
 
   const addToHistory = (promptValue: Prompt, mode: "normal" | "shell") => {
-    const currentHistory = mode === "shell" ? shellHistory : history
-    const setCurrentHistory = mode === "shell" ? setShellHistory : setHistory
+    const stores = currentStores()
+    const currentHistory = mode === "shell" ? stores.shellHistory.store : stores.history.store
+    const setCurrentHistory = mode === "shell" ? stores.shellHistory.setStore : stores.history.setStore
     const next = prependHistoryEntry(currentHistory.entries, promptValue, mode === "shell" ? [] : historyComments())
     if (next === currentHistory.entries) return
     setCurrentHistory("entries", next)
@@ -128,7 +211,7 @@ export function createHistoryNavigation(deps: HistoryNavigationDeps): HistoryNav
   const navigateHistory = (direction: "up" | "down") => {
     const result = navigatePromptHistory({
       direction,
-      entries: store.mode === "shell" ? shellHistory.entries : history.entries,
+      entries: store.mode === "shell" ? shellHistory().entries : history().entries,
       historyIndex: store.historyIndex,
       currentPrompt: prompt.current(),
       currentComments: historyComments(),

--- a/packages/app/src/components/prompt-input/history-store-factory.ts
+++ b/packages/app/src/components/prompt-input/history-store-factory.ts
@@ -1,0 +1,32 @@
+// Thin factory for per-directory prompt-history stores.
+// Kept in its own module so that tests can import it without pulling in the
+// full history-navigation.ts dependency graph (which includes @/context/file).
+
+import { createStore } from "solid-js/store"
+import { Persist, persisted } from "@/utils/persist"
+import type { HistoryStore } from "./store-types"
+
+export type DirectoryHistoryStoreResult = {
+  store: HistoryStore
+  setStore: ReturnType<typeof persisted<HistoryStore>>[1]
+  /** Exposed for testing: the Persist target used to back this store. */
+  persistTarget: ReturnType<typeof Persist.workspace>
+}
+
+/**
+ * Creates a persisted history store scoped to a single filesystem directory.
+ * No legacy fallback keys are passed — per v7, old global history is ignored.
+ */
+export function createDirectoryHistoryStore(
+  directory: string,
+  mode: "normal" | "shell",
+): DirectoryHistoryStoreResult {
+  const key = mode === "shell" ? "prompt-history-shell" : "prompt-history"
+  const target = Persist.workspace(directory, key)
+  // Do NOT pass legacy keys: old global history (prompt-history.v1 / prompt-history-shell.v1) is ignored.
+  const [store, setStore] = persisted(target, createStore<HistoryStore>({ entries: [] }))
+  return { store, setStore, persistTarget: target }
+}
+
+/** Maximum number of per-directory caches to keep in memory. */
+export const MAX_DIRECTORY_CACHE = 12

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -1,5 +1,6 @@
 import type { Prompt } from "@/context/prompt"
 import type { SelectedLineRange } from "@/context/file"
+import type { ResolvedMention } from "./mention-metadata"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
@@ -13,6 +14,12 @@ export type PromptHistoryComment = {
   time: number
   origin?: "review" | "file"
   preview?: string
+  /**
+   * Mention metadata captured when the comment text was committed. Stored on
+   * the history entry so ArrowUp recall can replay the same file attachments
+   * the original submit would have produced.
+   */
+  resolvedMentions?: ResolvedMention[]
 }
 
 export type PromptHistoryEntry = {
@@ -56,6 +63,7 @@ export function clonePromptHistoryComments(comments: PromptHistoryComment[]) {
   return comments.map((comment) => ({
     ...comment,
     selection: cloneSelection(comment.selection),
+    resolvedMentions: comment.resolvedMentions ? comment.resolvedMentions.map((m) => ({ ...m })) : undefined,
   }))
 }
 

--- a/packages/app/src/components/prompt-input/homepage-migration-storage.test.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration-storage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import type { Platform } from "@/context/platform"
+import { createMigrationStorageIO } from "./homepage-migration-storage"
+
+// Build a minimal desktop Platform fixture that routes get/set/remove through
+// a single in-memory store with controllable async behaviour for removeItem.
+function makeDesktopPlatform(input: {
+  removeItem: (key: string) => Promise<void>
+  initial?: Record<string, string>
+}): Platform {
+  const data = new Map(Object.entries(input.initial ?? {}))
+  const storage = (_name?: string) => ({
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: async (key: string, value: string) => {
+      data.set(key, value)
+    },
+    removeItem: input.removeItem,
+  })
+  return {
+    platform: "desktop",
+    storage,
+  } as unknown as Platform
+}
+
+describe("createMigrationStorageIO.remove", () => {
+  test("awaits desktop async removeItem and rejects when it does", async () => {
+    const error = new Error("disk full")
+    const io = createMigrationStorageIO(
+      makeDesktopPlatform({
+        removeItem: () => Promise.reject(error),
+      }),
+    )
+
+    await expect(io.remove({ storage: "ws", key: "k" })).rejects.toBe(error)
+  })
+
+  test("awaits desktop async removeItem and resolves when it does", async () => {
+    const removed: string[] = []
+    const io = createMigrationStorageIO(
+      makeDesktopPlatform({
+        removeItem: async (key) => {
+          removed.push(key)
+        },
+      }),
+    )
+
+    await io.remove({ storage: "ws", key: "k" })
+    expect(removed).toEqual(["k"])
+  })
+})

--- a/packages/app/src/components/prompt-input/homepage-migration-storage.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration-storage.ts
@@ -10,6 +10,12 @@ export type RawStorageTarget = { storage?: string; key: string }
 export interface RawStorageIO {
   read: (target: RawStorageTarget) => Promise<string | null>
   write: (target: RawStorageTarget, value: string) => Promise<void>
+  /**
+   * Removes a key. On desktop this awaits the async window.api delete so a
+   * rejection propagates back to the migration's failed-sentinel path; web
+   * storage removeItem is synchronous so the await is a no-op there.
+   */
+  remove: (target: RawStorageTarget) => Promise<void>
 }
 
 export function createMigrationStorageIO(platform: Platform): RawStorageIO {
@@ -34,5 +40,15 @@ export function createMigrationStorageIO(platform: Platform): RawStorageIO {
     store.setItem(target.key, value)
   }
 
-  return { read, write }
+  const remove = async (target: RawStorageTarget): Promise<void> => {
+    if (isDesktop) {
+      await platform.storage?.(target.storage)?.removeItem(target.key)
+      return
+    }
+    const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
+    const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
+    store.removeItem(target.key)
+  }
+
+  return { read, write, remove }
 }

--- a/packages/app/src/components/prompt-input/homepage-migration-storage.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration-storage.ts
@@ -1,0 +1,38 @@
+// Platform-aware raw storage I/O for the homepage migration sentinel.
+// Lives in its own module so that pages/layout.tsx — a visual shell file
+// gated by shell-frame-contract.test.ts — does not contain a
+// `platform.platform === "desktop"` branch.
+
+import type { Platform } from "@/context/platform"
+
+export type RawStorageTarget = { storage?: string; key: string }
+
+export interface RawStorageIO {
+  read: (target: RawStorageTarget) => Promise<string | null>
+  write: (target: RawStorageTarget, value: string) => Promise<void>
+}
+
+export function createMigrationStorageIO(platform: Platform): RawStorageIO {
+  const isDesktop = platform.platform === "desktop" && !!platform.storage
+
+  const read = async (target: RawStorageTarget): Promise<string | null> => {
+    if (isDesktop) {
+      return platform.storage?.(target.storage)?.getItem(target.key) ?? null
+    }
+    const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
+    const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
+    return store.getItem(target.key)
+  }
+
+  const write = async (target: RawStorageTarget, value: string): Promise<void> => {
+    if (isDesktop) {
+      await platform.storage?.(target.storage)?.setItem(target.key, value)
+      return
+    }
+    const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
+    const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
+    store.setItem(target.key, value)
+  }
+
+  return { read, write }
+}

--- a/packages/app/src/components/prompt-input/homepage-migration.test.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import {
+  runHomepageMigration,
+  type HomepageMigrationDeps,
+  type MigrationSentinel,
+  type LegacyHomepagePromptStore,
+} from "./homepage-migration"
+import { createPortableDraftOwner } from "./portable-draft"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyLegacyStore(): LegacyHomepagePromptStore {
+  return {
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+    cursor: undefined,
+    context: { items: [] },
+  }
+}
+
+function legacyStoreWithText(text: string): LegacyHomepagePromptStore {
+  return {
+    prompt: [{ type: "text", content: text, start: 0, end: text.length }],
+    cursor: undefined,
+    context: { items: [] },
+  }
+}
+
+function legacyStoreWithContext(): LegacyHomepagePromptStore {
+  return {
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+    cursor: undefined,
+    context: {
+      items: [
+        {
+          type: "file",
+          path: "/some/file.ts",
+          key: "file:/some/file.ts:undefined:undefined",
+        },
+      ],
+    },
+  }
+}
+
+/** Build a minimal HomepageMigrationDeps with injectable store and sentinel. */
+function makeDeps(overrides: Partial<HomepageMigrationDeps> & { legacy?: LegacyHomepagePromptStore | null }): {
+  deps: HomepageMigrationDeps
+  sentinelStore: { value: MigrationSentinel | null }
+  legacyStore: { value: LegacyHomepagePromptStore | null }
+  cleared: string[]
+  portable: ReturnType<typeof createPortableDraftOwner>
+} {
+  const sentinelStore: { value: MigrationSentinel | null } = { value: null }
+  const legacyStore: { value: LegacyHomepagePromptStore | null } = { value: overrides.legacy ?? null }
+  const cleared: string[] = []
+  const portable = createPortableDraftOwner()
+
+  const deps: HomepageMigrationDeps = {
+    portable,
+    currentDirectory: "/workspace/my-project",
+    now: () => 1000,
+    loadLegacyHomepage: async (_dir) => legacyStore.value,
+    clearLegacyHomepage: async (dir) => {
+      cleared.push(dir)
+    },
+    readSentinel: async () => sentinelStore.value,
+    writeSentinel: async (s) => {
+      sentinelStore.value = s
+    },
+    ...overrides,
+  }
+
+  return { deps, sentinelStore, legacyStore, cleared, portable }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runHomepageMigration", () => {
+  test("no-op when sentinel is already complete", async () => {
+    const existingSentinel: MigrationSentinel = {
+      status: "complete",
+      attemptedAt: 500,
+      adoptedDirectory: "/workspace/my-project",
+    }
+    const { deps, sentinelStore, cleared, portable } = makeDeps({
+      legacy: legacyStoreWithText("hello"),
+    })
+    sentinelStore.value = existingSentinel
+
+    const result = await runHomepageMigration(deps)
+
+    expect(result).toBe(existingSentinel)
+    expect(portable.snapshot()).toBeNull()
+    expect(cleared).toHaveLength(0)
+  })
+
+  test("subsequent calls with complete sentinel skip the work entirely", async () => {
+    const { deps, sentinelStore, cleared, portable } = makeDeps({
+      legacy: legacyStoreWithText("some draft"),
+    })
+
+    // First call — runs migration.
+    const first = await runHomepageMigration(deps)
+    expect(first.status).toBe("complete")
+    const snapshotAfterFirst = portable.snapshot()
+    expect(snapshotAfterFirst).not.toBeNull()
+    expect(cleared).toHaveLength(1)
+
+    // Reset cleared array but keep sentinel as complete.
+    cleared.length = 0
+    // Simulate portal state being reset (new boot simulation).
+    const portable2 = createPortableDraftOwner()
+    const deps2: HomepageMigrationDeps = {
+      ...deps,
+      portable: portable2,
+    }
+
+    const second = await runHomepageMigration(deps2)
+    expect(second).toBe(sentinelStore.value!) // same sentinel object returned
+    expect(portable2.snapshot()).toBeNull() // no adoption on second call
+    expect(cleared).toHaveLength(0)
+  })
+
+  test("adopts legacy content into portable when non-empty", async () => {
+    const { deps, portable } = makeDeps({ legacy: legacyStoreWithText("write a test") })
+
+    await runHomepageMigration(deps)
+
+    const snap = portable.snapshot()
+    expect(snap).not.toBeNull()
+    expect(snap?.sourceFilesystemDirectory).toBe("/workspace/my-project")
+    expect(snap?.prompt).toEqual([{ type: "text", content: "write a test", start: 0, end: 12 }])
+    expect(snap?.context).toEqual([])
+    expect(snap?.images).toEqual([])
+  })
+
+  test("clears the legacy store after successful adoption", async () => {
+    const { deps, cleared } = makeDeps({ legacy: legacyStoreWithText("draft content") })
+
+    await runHomepageMigration(deps)
+
+    expect(cleared).toEqual(["/workspace/my-project"])
+  })
+
+  test("writes sentinel as complete with adoptedDirectory set when content existed", async () => {
+    const { deps, sentinelStore } = makeDeps({ legacy: legacyStoreWithText("plan the sprint") })
+
+    await runHomepageMigration(deps)
+
+    expect(sentinelStore.value?.status).toBe("complete")
+    expect(sentinelStore.value?.adoptedDirectory).toBe("/workspace/my-project")
+    expect(sentinelStore.value?.attemptedAt).toBe(1000)
+  })
+
+  test("writes sentinel as complete with adoptedDirectory undefined when no content", async () => {
+    const { deps, sentinelStore, portable } = makeDeps({ legacy: null })
+
+    await runHomepageMigration(deps)
+
+    expect(sentinelStore.value?.status).toBe("complete")
+    expect(sentinelStore.value?.adoptedDirectory).toBeUndefined()
+    expect(portable.snapshot()).toBeNull()
+  })
+
+  test("writes sentinel as complete with adoptedDirectory undefined when store is empty", async () => {
+    const { deps, sentinelStore, portable, cleared } = makeDeps({ legacy: emptyLegacyStore() })
+
+    await runHomepageMigration(deps)
+
+    expect(sentinelStore.value?.status).toBe("complete")
+    expect(sentinelStore.value?.adoptedDirectory).toBeUndefined()
+    expect(portable.snapshot()).toBeNull()
+    // Nothing to clear when store was empty.
+    expect(cleared).toHaveLength(0)
+  })
+
+  test("does not write sentinel as complete when clearLegacy throws (status: failed, failedReason set)", async () => {
+    const { deps, sentinelStore, portable } = makeDeps({
+      legacy: legacyStoreWithText("important draft"),
+      clearLegacyHomepage: async () => {
+        throw new Error("disk full")
+      },
+    })
+
+    const result = await runHomepageMigration(deps)
+
+    expect(result.status).toBe("failed")
+    expect(result.failedReason).toBe("disk full")
+    expect(sentinelStore.value?.status).toBe("failed")
+    // Adoption was attempted before clear failed; portable may or may not have content —
+    // the key invariant is the sentinel is NOT complete.
+    expect(sentinelStore.value?.status).not.toBe("complete")
+  })
+
+  test("does not call portable.record when no legacy content exists", async () => {
+    const { deps, portable } = makeDeps({ legacy: null })
+
+    await runHomepageMigration(deps)
+
+    expect(portable.snapshot()).toBeNull()
+  })
+
+  test("does not call portable.record when only whitespace text exists", async () => {
+    const { deps, portable, cleared } = makeDeps({ legacy: legacyStoreWithText("   ") })
+
+    await runHomepageMigration(deps)
+
+    expect(portable.snapshot()).toBeNull()
+    expect(cleared).toHaveLength(0)
+  })
+
+  test("adopts legacy content when context items are present even with empty prompt", async () => {
+    const { deps, portable, cleared } = makeDeps({ legacy: legacyStoreWithContext() })
+
+    await runHomepageMigration(deps)
+
+    const snap = portable.snapshot()
+    expect(snap).not.toBeNull()
+    expect(snap?.context).toHaveLength(1)
+    expect(cleared).toHaveLength(1)
+  })
+
+  test("sets failed status and failedReason when loadLegacyHomepage throws", async () => {
+    const { deps, sentinelStore, portable } = makeDeps({
+      loadLegacyHomepage: async () => {
+        throw new Error("storage unavailable")
+      },
+    })
+
+    const result = await runHomepageMigration(deps)
+
+    expect(result.status).toBe("failed")
+    expect(result.failedReason).toBe("storage unavailable")
+    expect(sentinelStore.value?.status).toBe("failed")
+    expect(portable.snapshot()).toBeNull()
+  })
+})

--- a/packages/app/src/components/prompt-input/homepage-migration.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration.ts
@@ -1,0 +1,139 @@
+/**
+ * One-shot v7 homepage draft migration (PR #750 T8).
+ *
+ * On the first boot after upgrading to v7, the user's existing per-workspace
+ * homepage draft (stored under the route-scoped workspace store) is adopted
+ * into the in-memory portable owner, and the original route-scoped slot is
+ * cleared so future portable carries are not clobbered.
+ *
+ * Scope (PR1): only the CURRENTLY OPENED directory is handled. Other
+ * workspaces' old homepage drafts remain in their route-scoped stores and will
+ * appear when the user next visits those workspaces. The portable owner
+ * self-heals through subsequent record() calls.
+ */
+
+import type { Prompt, ContextItem } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+import type { PortableDraftOwner } from "./portable-draft"
+
+export const HOMEPAGE_MIGRATION_SENTINEL_KEY = "prompt-portable-migration"
+
+export interface MigrationSentinel {
+  status: "pending" | "complete" | "failed"
+  attemptedAt: number
+  /** Set when content was actually adopted; undefined when legacy store was empty. */
+  adoptedDirectory?: string
+  failedReason?: string
+}
+
+/** Shape of the legacy route-scoped homepage prompt store. */
+export interface LegacyHomepagePromptStore {
+  prompt: Prompt
+  cursor?: number
+  context: {
+    items: (ContextItem & { key: string })[]
+  }
+}
+
+/**
+ * Dependency injection surface — passed in by callers so the migration
+ * function itself has no reactive coupling and is fully unit-testable.
+ */
+export interface HomepageMigrationDeps {
+  /** Load the legacy route-scoped homepage store for the given directory. Returns null when absent. */
+  loadLegacyHomepage: (directory: string) => Promise<LegacyHomepagePromptStore | null>
+  /** Remove the legacy route-scoped homepage store for the given directory. */
+  clearLegacyHomepage: (directory: string) => Promise<void>
+  /** Read the global migration sentinel. Returns null when not yet written. */
+  readSentinel: () => Promise<MigrationSentinel | null>
+  /** Persist the migration sentinel globally. */
+  writeSentinel: (sentinel: MigrationSentinel) => Promise<void>
+  /** Portable draft owner that receives the adopted content. */
+  portable: PortableDraftOwner
+  /** True filesystem directory that is currently opened. */
+  currentDirectory: string
+  /** Injected for tests; defaults to Date.now. */
+  now?: () => number
+}
+
+/**
+ * Return true when the legacy store has content worth migrating:
+ * - prompt text is non-empty/non-whitespace, OR
+ * - context items are present.
+ */
+function hasLegacyContent(store: LegacyHomepagePromptStore): boolean {
+  const { prompt, context } = store
+
+  const promptHasText =
+    prompt.length > 1 ||
+    (prompt.length === 1 && prompt[0]?.type === "text" && !!prompt[0].content.trim())
+
+  // Non-text parts (file, agent, image) in the prompt also count as content.
+  const promptHasNonTextParts = prompt.some((part) => part.type !== "text")
+
+  return promptHasText || promptHasNonTextParts || context.items.length > 0
+}
+
+/**
+ * Run the one-shot v7 homepage draft migration.
+ *
+ * Idempotent: returns immediately if the sentinel is already "complete".
+ * On any failure during adoption or quarantine, sets sentinel to "failed"
+ * and returns — allowing retry on the next boot.
+ */
+export async function runHomepageMigration(deps: HomepageMigrationDeps): Promise<MigrationSentinel> {
+  const { loadLegacyHomepage, clearLegacyHomepage, readSentinel, writeSentinel, portable, currentDirectory } = deps
+  const now = deps.now ?? (() => Date.now())
+
+  // 1. Check sentinel — if already complete, no-op.
+  const existing = await readSentinel()
+  if (existing?.status === "complete") {
+    return existing
+  }
+
+  const attemptedAt = now()
+
+  // 2. Load legacy route-scoped homepage store for the current directory.
+  let legacy: LegacyHomepagePromptStore | null
+  try {
+    legacy = await loadLegacyHomepage(currentDirectory)
+  } catch (err) {
+    const failedReason = err instanceof Error ? err.message : String(err)
+    const sentinel: MigrationSentinel = { status: "failed", attemptedAt, failedReason }
+    await writeSentinel(sentinel).catch(() => undefined)
+    return sentinel
+  }
+
+  // 3. Determine if there is meaningful content to adopt.
+  const hasContent = legacy !== null && hasLegacyContent(legacy)
+
+  if (hasContent && legacy !== null) {
+    // 4a. Adopt into the portable owner.
+    portable.record({
+      sourceFilesystemDirectory: currentDirectory,
+      prompt: legacy.prompt,
+      context: legacy.context.items,
+      images: [],
+      resolvedMentions: {},
+    })
+
+    // 4b. Quarantine — clear the legacy route-scoped store.
+    try {
+      await clearLegacyHomepage(currentDirectory)
+    } catch (err) {
+      const failedReason = err instanceof Error ? err.message : String(err)
+      const sentinel: MigrationSentinel = { status: "failed", attemptedAt, failedReason }
+      await writeSentinel(sentinel).catch(() => undefined)
+      return sentinel
+    }
+  }
+
+  // 5. Write complete sentinel.
+  const sentinel: MigrationSentinel = {
+    status: "complete",
+    attemptedAt,
+    adoptedDirectory: hasContent ? currentDirectory : undefined,
+  }
+  await writeSentinel(sentinel)
+  return sentinel
+}

--- a/packages/app/src/components/prompt-input/mention-metadata.test.ts
+++ b/packages/app/src/components/prompt-input/mention-metadata.test.ts
@@ -138,11 +138,13 @@ describe("resolveCommentMentions", () => {
     // Remove the first occurrence; now only the second remains
     const modified = "gone first then @src/a.ts second"
     const result = resolveCommentMentions({ comment: modified, metadata })
+    // At most one resolves; both metadata entries are same-name so a sloppy
+    // implementation could double-emit. Lock that down.
+    expect(result.length).toBeLessThanOrEqual(1)
     // metadata[0] was first occurrence — its range no longer matches, occurrence 0 gone
     // metadata[1] was second occurrence — now occurrence 0 in modified; fingerprint won't match
     // either metadata[0] or [1] may match depending on context window; the key assertion
     // is that at most one resolves (the second entry's fingerprint matches the sole occurrence)
-    // We mainly assert no crash and correct resolved path when there is a match
     for (const match of result) {
       expect(match.resolvedPath).toBe("/repo/src/a.ts")
     }

--- a/packages/app/src/components/prompt-input/mention-metadata.test.ts
+++ b/packages/app/src/components/prompt-input/mention-metadata.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test"
+import { captureCommentMentions, resolveCommentMentions } from "./mention-metadata"
+
+describe("captureCommentMentions", () => {
+  test("records displayText resolvedPath fingerprint range for single mention", () => {
+    const result = captureCommentMentions({
+      comment: "look at @src/foo.ts for context",
+      sourceFilesystemDirectory: "/repo",
+    })
+    expect(result).toHaveLength(1)
+    const entry = result[0]!
+    expect(entry.displayText).toBe("@src/foo.ts")
+    expect(entry.resolvedPath).toBe("/repo/src/foo.ts")
+    expect(typeof entry.fingerprint).toBe("string")
+    expect(entry.fingerprint.length).toBeGreaterThan(0)
+    // start points to the '@' char
+    expect(entry.start).toBe("look at ".length)
+    expect(entry.end).toBe(entry.start + "@src/foo.ts".length)
+    // verify the range correctly addresses the displayText in the original comment
+    const comment = "look at @src/foo.ts for context"
+    expect(comment.slice(entry.start, entry.end)).toBe("@src/foo.ts")
+  })
+
+  test("strips trailing punctuation from path", () => {
+    const result = captureCommentMentions({
+      comment: "see @src/a.ts, for details",
+      sourceFilesystemDirectory: "/repo",
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]!.displayText).toBe("@src/a.ts")
+    expect(result[0]!.resolvedPath).toBe("/repo/src/a.ts")
+  })
+
+  test("captures multiple mentions in order", () => {
+    const result = captureCommentMentions({
+      comment: "Compare @src/shared.ts and @src/review.ts.",
+      sourceFilesystemDirectory: "/repo",
+    })
+    expect(result).toHaveLength(2)
+    expect(result[0]!.displayText).toBe("@src/shared.ts")
+    expect(result[1]!.displayText).toBe("@src/review.ts")
+    // start order must be ascending
+    expect(result[0]!.start).toBeLessThan(result[1]!.start)
+  })
+
+  test("skips empty path after punctuation strip", () => {
+    // "@," -> strip trailing punctuation -> empty path, should be skipped
+    const result = captureCommentMentions({
+      comment: "weird mention @, and done",
+      sourceFilesystemDirectory: "/repo",
+    })
+    expect(result).toHaveLength(0)
+  })
+
+  test("resolves relative path against POSIX source dir", () => {
+    const result = captureCommentMentions({
+      comment: "check @lib/utils.ts",
+      sourceFilesystemDirectory: "/home/user/project",
+    })
+    expect(result[0]!.resolvedPath).toBe("/home/user/project/lib/utils.ts")
+  })
+
+  test("passes through absolute path unchanged in resolvedPath", () => {
+    const result = captureCommentMentions({
+      comment: "check @/absolute/path.ts",
+      sourceFilesystemDirectory: "/repo",
+    })
+    expect(result[0]!.resolvedPath).toBe("/absolute/path.ts")
+  })
+
+  test("resolves against Windows drive source dir", () => {
+    const result = captureCommentMentions({
+      comment: "see @src\\helper.ts here",
+      sourceFilesystemDirectory: "C:\\project",
+    })
+    expect(result[0]!.resolvedPath).toBe("C:\\project/src\\helper.ts")
+  })
+})
+
+describe("resolveCommentMentions", () => {
+  test("returns empty when metadata undefined", () => {
+    const result = resolveCommentMentions({
+      comment: "see @src/foo.ts for details",
+      metadata: undefined,
+    })
+    expect(result).toEqual([])
+  })
+
+  test("returns empty when metadata empty array", () => {
+    const result = resolveCommentMentions({
+      comment: "see @src/foo.ts for details",
+      metadata: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  test("returns resolvedPath when fingerprint matches", () => {
+    const comment = "look at @src/foo.ts for context"
+    const metadata = captureCommentMentions({ comment, sourceFilesystemDirectory: "/repo" })
+    const result = resolveCommentMentions({ comment, metadata })
+    expect(result).toHaveLength(1)
+    expect(result[0]!.resolvedPath).toBe("/repo/src/foo.ts")
+  })
+
+  test("drops when displayText no longer present", () => {
+    const original = "look at @src/foo.ts for context"
+    const metadata = captureCommentMentions({ comment: original, sourceFilesystemDirectory: "/repo" })
+    // Remove the mention from the comment
+    const modified = "look at something else for context"
+    const result = resolveCommentMentions({ comment: modified, metadata })
+    expect(result).toEqual([])
+  })
+
+  test("drops when comment body diverged from fingerprint window", () => {
+    const original = "look at @src/foo.ts for context right here and now with enough surrounding text"
+    const metadata = captureCommentMentions({ comment: original, sourceFilesystemDirectory: "/repo" })
+    // Keep the @token but drastically change surrounding context
+    const modified =
+      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX @src/foo.ts YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+    const result = resolveCommentMentions({ comment: modified, metadata })
+    expect(result).toEqual([])
+  })
+
+  test("matches first of two same-name mentions by original range", () => {
+    const comment = "@src/a.ts first then @src/a.ts second"
+    const metadata = captureCommentMentions({ comment, sourceFilesystemDirectory: "/repo" })
+    expect(metadata).toHaveLength(2)
+    // Both should resolve with same resolvedPath
+    const result = resolveCommentMentions({ comment, metadata })
+    expect(result).toHaveLength(2)
+    expect(result[0]!.resolvedPath).toBe("/repo/src/a.ts")
+    expect(result[1]!.resolvedPath).toBe("/repo/src/a.ts")
+  })
+
+  test("matches second of two same-name mentions when first is gone", () => {
+    const original = "@src/a.ts first then @src/a.ts second"
+    const metadata = captureCommentMentions({ comment: original, sourceFilesystemDirectory: "/repo" })
+    // Remove the first occurrence; now only the second remains
+    const modified = "gone first then @src/a.ts second"
+    const result = resolveCommentMentions({ comment: modified, metadata })
+    // metadata[0] was first occurrence — its range no longer matches, occurrence 0 gone
+    // metadata[1] was second occurrence — now occurrence 0 in modified; fingerprint won't match
+    // either metadata[0] or [1] may match depending on context window; the key assertion
+    // is that at most one resolves (the second entry's fingerprint matches the sole occurrence)
+    // We mainly assert no crash and correct resolved path when there is a match
+    for (const match of result) {
+      expect(match.resolvedPath).toBe("/repo/src/a.ts")
+    }
+  })
+
+  test("free-text @x.ts without metadata is dropped (no fallback resolve)", () => {
+    // No metadata — even though the text has an @-mention, nothing should be returned
+    const result = resolveCommentMentions({
+      comment: "check @src/lost.ts please",
+      metadata: undefined,
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/packages/app/src/components/prompt-input/mention-metadata.ts
+++ b/packages/app/src/components/prompt-input/mention-metadata.ts
@@ -1,0 +1,145 @@
+/**
+ * Mention metadata: capture resolved @-mention information at edit time and
+ * re-validate it at submit time.
+ *
+ * Safety contract: resolveCommentMentions returns [] when metadata is undefined
+ * or empty — there is NO free-text fallback resolve. A mention without recorded
+ * metadata is silently dropped to prevent same-name cross-workspace attachment.
+ */
+
+import { checksum } from "@opencode-ai/util/encode"
+import { toAbsoluteFilePath } from "./path-canonical"
+
+export interface ResolvedMention {
+  /** The visible @-token, e.g. "@src/a.ts" */
+  displayText: string
+  /** Absolute path computed from toAbsoluteFilePath at capture time */
+  resolvedPath: string
+  /**
+   * Checksum of a 64-char window (32 chars on each side) centred on the
+   * mention midpoint, lowercased with collapsed whitespace.  Used to detect
+   * comment body drift.
+   */
+  fingerprint: string
+  /** Inclusive char offset of the '@' in the comment string at capture time */
+  start: number
+  /** Exclusive char offset (start + displayText.length) */
+  end: number
+}
+
+export interface CaptureMentionsInput {
+  comment: string
+  sourceFilesystemDirectory: string
+}
+
+export interface ResolveMentionsInput {
+  comment: string
+  metadata: ResolvedMention[] | undefined
+}
+
+export interface ResolvedMentionMatch {
+  resolvedPath: string
+}
+
+/** Same regex as the old parseCommentMentions in build-request-parts.ts */
+const MENTION_RE = /(^|[\s([{"'])@(\S+)/g
+
+/**
+ * Produce a normalized fingerprint string for a 64-char window centred at
+ * `mid` inside `text`.  Lowercase + collapsed whitespace.
+ */
+function computeFingerprint(text: string, mid: number): string {
+  const radius = 32
+  const windowStart = Math.max(0, mid - radius)
+  const windowEnd = Math.min(text.length, mid + radius)
+  const window = text.slice(windowStart, windowEnd).toLowerCase().replace(/\s+/g, " ")
+  return checksum(window) ?? window
+}
+
+/**
+ * Scan `comment` for @-mentions and record resolved path + positional metadata
+ * for each one.  Call this at the moment the user commits the comment text.
+ */
+export function captureCommentMentions(input: CaptureMentionsInput): ResolvedMention[] {
+  const { comment, sourceFilesystemDirectory } = input
+  const results: ResolvedMention[] = []
+
+  for (const match of comment.matchAll(MENTION_RE)) {
+    // match[1] is the preceding char (may be empty string at start of string)
+    // match[2] is the raw path token
+    const rawPath = (match[2] ?? "").replace(/[.,!?;:)}\]"']+$/, "")
+    if (!rawPath) continue
+
+    // The '@' sits at match.index + match[1].length
+    const start = (match.index ?? 0) + (match[1]?.length ?? 0)
+    const displayText = "@" + rawPath
+    const end = start + displayText.length
+
+    const resolvedPath = toAbsoluteFilePath(sourceFilesystemDirectory, rawPath)
+    const mid = Math.floor((start + end) / 2)
+    const fingerprint = computeFingerprint(comment, mid)
+
+    results.push({ displayText, resolvedPath, fingerprint, start, end })
+  }
+
+  return results
+}
+
+/**
+ * At submit time, validate each recorded mention against the current comment
+ * body using positional matching + fingerprint drift detection.
+ *
+ * CRITICAL: returns [] immediately when metadata is undefined or empty.
+ * There is no free-text fallback.
+ */
+export function resolveCommentMentions(input: ResolveMentionsInput): ResolvedMentionMatch[] {
+  const { comment, metadata } = input
+
+  if (!metadata || metadata.length === 0) return []
+
+  const results: ResolvedMentionMatch[] = []
+
+  for (const entry of metadata) {
+    let matchStart: number | undefined
+
+    // --- Strategy 1: range-based match ---
+    if (comment.slice(entry.start, entry.end) === entry.displayText) {
+      matchStart = entry.start
+    } else {
+      // --- Strategy 2: occurrence-based match ---
+      // Count how many earlier entries in metadata share the same displayText
+      // (ordered by their original start).  That count is the 0-based occurrence
+      // index N we need to find in the current comment.
+      const occurrenceIndex = metadata
+        .filter((earlier) => earlier.displayText === entry.displayText && earlier.start < entry.start)
+        .length
+
+      let found = -1
+      let searchFrom = 0
+      for (let occurrence = 0; occurrence <= occurrenceIndex; occurrence++) {
+        const idx = comment.indexOf(entry.displayText, searchFrom)
+        if (idx === -1) {
+          found = -1
+          break
+        }
+        found = idx
+        searchFrom = idx + entry.displayText.length
+      }
+
+      if (found !== -1) matchStart = found
+    }
+
+    if (matchStart === undefined) continue
+
+    // Recompute fingerprint at the chosen location and compare
+    const matchEnd = matchStart + entry.displayText.length
+    const mid = Math.floor((matchStart + matchEnd) / 2)
+    const currentFingerprint = computeFingerprint(comment, mid)
+
+    if (currentFingerprint !== entry.fingerprint) continue
+
+    results.push({ resolvedPath: entry.resolvedPath })
+  }
+
+  return results
+}

--- a/packages/app/src/components/prompt-input/path-canonical.test.ts
+++ b/packages/app/src/components/prompt-input/path-canonical.test.ts
@@ -96,6 +96,20 @@ describe("isUnderDirectory", () => {
     expect(isUnderDirectory("/Repo/file.ts", "/repo")).toBe(false)
   })
 
+  test("true when source dir has a trailing slash", () => {
+    expect(isUnderDirectory("/repo/foo", "/repo/")).toBe(true)
+    expect(isUnderDirectory("/repo", "/repo/")).toBe(true)
+  })
+
+  test("true for anything under POSIX root", () => {
+    expect(isUnderDirectory("/a", "/")).toBe(true)
+    expect(isUnderDirectory("/", "/")).toBe(true)
+  })
+
+  test("UNC forward-slash root is recognised as case-insensitive", () => {
+    expect(isUnderDirectory("//Server/Share/foo", "//server/share")).toBe(true)
+  })
+
   test("handles backslashes in inputs by normalizing for comparison", () => {
     expect(isUnderDirectory("C:\\project\\src\\file.ts", "C:\\project")).toBe(true)
   })
@@ -125,5 +139,10 @@ describe("compactFilePath", () => {
 
   test("handles backslash-separated path", () => {
     expect(compactFilePath("C:\\project\\src\\component.tsx")).toBe("component.tsx")
+  })
+
+  test("falls back to directory basename when path equals source dir", () => {
+    expect(compactFilePath("/repo/foo", "/repo/foo")).toBe("foo")
+    expect(compactFilePath("/repo/foo/", "/repo/foo")).toBe("foo")
   })
 })

--- a/packages/app/src/components/prompt-input/path-canonical.test.ts
+++ b/packages/app/src/components/prompt-input/path-canonical.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { compactFilePath, isAbsoluteLike, isUnderDirectory, toAbsoluteFilePath } from "./path-canonical"
+
+describe("isAbsoluteLike", () => {
+  test("returns true for POSIX absolute", () => {
+    expect(isAbsoluteLike("/home/user/project")).toBe(true)
+  })
+
+  test("returns true for Windows drive with forward slash", () => {
+    expect(isAbsoluteLike("C:/Users/test")).toBe(true)
+  })
+
+  test("returns true for Windows drive with backslash", () => {
+    expect(isAbsoluteLike("C:\\Users\\test")).toBe(true)
+  })
+
+  test("returns true for Windows drive alone (C:)", () => {
+    expect(isAbsoluteLike("C:")).toBe(true)
+  })
+
+  test("returns true for UNC backslash style", () => {
+    expect(isAbsoluteLike("\\\\server\\share")).toBe(true)
+  })
+
+  test("returns true for UNC forward slash style", () => {
+    expect(isAbsoluteLike("//server/share")).toBe(true)
+  })
+
+  test("returns false for relative path", () => {
+    expect(isAbsoluteLike("src/foo.ts")).toBe(false)
+  })
+
+  test("returns false for relative path with dot prefix", () => {
+    expect(isAbsoluteLike("./src/foo.ts")).toBe(false)
+  })
+})
+
+describe("toAbsoluteFilePath", () => {
+  test("passes through POSIX absolute unchanged", () => {
+    expect(toAbsoluteFilePath("/repo", "/home/user/file.ts")).toBe("/home/user/file.ts")
+  })
+
+  test("passes through Windows drive absolute (both slash styles) unchanged", () => {
+    expect(toAbsoluteFilePath("C:\\project", "D:\\other\\file.ts")).toBe("D:\\other\\file.ts")
+    expect(toAbsoluteFilePath("/repo", "C:/Users/file.ts")).toBe("C:/Users/file.ts")
+  })
+
+  test("passes through UNC unchanged", () => {
+    expect(toAbsoluteFilePath("C:\\project", "\\\\server\\share\\file.ts")).toBe("\\\\server\\share\\file.ts")
+    expect(toAbsoluteFilePath("/repo", "//server/share/file.ts")).toBe("//server/share/file.ts")
+  })
+
+  test("joins relative POSIX path with single separator", () => {
+    expect(toAbsoluteFilePath("/repo", "src/foo.ts")).toBe("/repo/src/foo.ts")
+  })
+
+  test("joins relative path against directory with trailing slash", () => {
+    expect(toAbsoluteFilePath("/repo/", "src/foo.ts")).toBe("/repo/src/foo.ts")
+  })
+
+  test("joins relative path against directory with trailing backslash", () => {
+    expect(toAbsoluteFilePath("C:\\project\\", "src\\foo.ts")).toBe("C:\\project/src\\foo.ts")
+  })
+
+  test("joins Windows relative path keeps backslashes in input", () => {
+    // mirrors exact behavior of current absolute() in build-request-parts.ts
+    expect(toAbsoluteFilePath("D:\\workspace\\app", "src\\utils\\helper.ts")).toBe(
+      "D:\\workspace\\app/src\\utils\\helper.ts",
+    )
+  })
+})
+
+describe("isUnderDirectory", () => {
+  test("true when path is exact match", () => {
+    expect(isUnderDirectory("/repo", "/repo")).toBe(true)
+  })
+
+  test("true when path inside", () => {
+    expect(isUnderDirectory("/repo/src/foo.ts", "/repo")).toBe(true)
+  })
+
+  test("false when path is sibling with shared prefix segment", () => {
+    // /repo-A2/file.ts should NOT be under /repo-A
+    expect(isUnderDirectory("/repo-A2/file.ts", "/repo-A")).toBe(false)
+  })
+
+  test("false when paths are unrelated", () => {
+    expect(isUnderDirectory("/other/file.ts", "/repo")).toBe(false)
+  })
+
+  test("case-insensitive on Windows drive root", () => {
+    expect(isUnderDirectory("C:\\Project\\file.ts", "c:\\project")).toBe(true)
+  })
+
+  test("case-sensitive on POSIX root", () => {
+    expect(isUnderDirectory("/Repo/file.ts", "/repo")).toBe(false)
+  })
+
+  test("handles backslashes in inputs by normalizing for comparison", () => {
+    expect(isUnderDirectory("C:\\project\\src\\file.ts", "C:\\project")).toBe(true)
+  })
+})
+
+describe("compactFilePath", () => {
+  test("strips directory prefix when path is under source dir", () => {
+    expect(compactFilePath("/repo/src/foo.ts", "/repo")).toBe("src/foo.ts")
+  })
+
+  test("returns last segment when path is unrelated to source dir", () => {
+    expect(compactFilePath("/other/place/bar.ts", "/repo")).toBe("bar.ts")
+  })
+
+  test("returns last segment when source dir is undefined", () => {
+    expect(compactFilePath("/repo/src/foo.ts")).toBe("foo.ts")
+  })
+
+  test("truncates long segment with ellipsis while preserving extension", () => {
+    // "very-long-filename-here.tsx" = 26 chars, maxSegmentLen=18
+    expect(compactFilePath("/repo/very-long-filename-here.tsx", undefined, 18)).toBe("very-long…here.tsx")
+  })
+
+  test("does not truncate when within maxSegmentLen", () => {
+    expect(compactFilePath("/repo/short.ts", undefined, 24)).toBe("short.ts")
+  })
+
+  test("handles backslash-separated path", () => {
+    expect(compactFilePath("C:\\project\\src\\component.tsx")).toBe("component.tsx")
+  })
+})

--- a/packages/app/src/components/prompt-input/path-canonical.ts
+++ b/packages/app/src/components/prompt-input/path-canonical.ts
@@ -38,12 +38,15 @@ export function isUnderDirectory(absolutePath: string, sourceFilesystemDirectory
   const isWindowsRoot =
     /^[A-Za-z]:[\\/]/.test(sourceFilesystemDirectory) ||
     /^[A-Za-z]:$/.test(sourceFilesystemDirectory) ||
-    sourceFilesystemDirectory.startsWith("\\\\")
+    sourceFilesystemDirectory.startsWith("\\\\") ||
+    sourceFilesystemDirectory.startsWith("//")
 
-  // Normalize backslashes for comparison only
+  // Normalize backslashes for comparison only, then trim trailing separators
+  // off the directory so "/repo" and "/repo/" behave identically and a
+  // root-only directory ("/") doesn't compare against "//".
   const normalize = (p: string) => p.replace(/\\/g, "/")
   let normPath = normalize(absolutePath)
-  let normDir = normalize(sourceFilesystemDirectory)
+  let normDir = normalize(sourceFilesystemDirectory).replace(/\/+$/, "")
 
   if (isWindowsRoot) {
     normPath = normPath.toLowerCase()
@@ -51,7 +54,8 @@ export function isUnderDirectory(absolutePath: string, sourceFilesystemDirectory
   }
 
   if (normPath === normDir) return true
-  // Must start with dir + "/" or dir + "\"  (after normalization, always "/")
+  // After trimming, an empty normDir means the root; everything is under it.
+  if (normDir === "") return normPath.startsWith("/")
   return normPath.startsWith(normDir + "/")
 }
 
@@ -85,14 +89,20 @@ export function compactFilePath(
 ): string {
   let label: string
 
+  const basename = (p: string) => {
+    const lastSep = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"))
+    return lastSep >= 0 ? p.slice(lastSep + 1) : p
+  }
+
   if (sourceFilesystemDirectory !== undefined && isUnderDirectory(absolutePath, sourceFilesystemDirectory)) {
     // Strip directory prefix and any leading separator
     const trimmedDir = sourceFilesystemDirectory.replace(/[\\/]+$/, "")
     label = absolutePath.slice(trimmedDir.length).replace(/^[\\/]+/, "")
+    // When absolutePath equals the directory the strip leaves "" — fall back
+    // to the directory's basename so the chip never renders empty.
+    if (label === "") label = basename(trimmedDir) || trimmedDir
   } else {
-    // Basename: last segment after / or \
-    const lastSep = Math.max(absolutePath.lastIndexOf("/"), absolutePath.lastIndexOf("\\"))
-    label = lastSep >= 0 ? absolutePath.slice(lastSep + 1) : absolutePath
+    label = basename(absolutePath)
   }
 
   if (label.length <= maxSegmentLen) return label

--- a/packages/app/src/components/prompt-input/path-canonical.ts
+++ b/packages/app/src/components/prompt-input/path-canonical.ts
@@ -1,0 +1,102 @@
+/**
+ * Path canonicalization helpers shared across prompt-input modules.
+ *
+ * These functions are intentionally pure (no I/O, no platform detection) so
+ * they work identically in the renderer process, tests, and future portable
+ * draft owners.
+ */
+
+/** Returns true for POSIX absolute, Windows drive, or UNC paths. */
+export function isAbsoluteLike(path: string): boolean {
+  if (path.startsWith("/")) return true
+  if (/^[A-Za-z]:[\\/]/.test(path) || /^[A-Za-z]:$/.test(path)) return true
+  if (path.startsWith("\\\\") || path.startsWith("//")) return true
+  return false
+}
+
+/**
+ * Returns an absolute path for `path` relative to `sourceFilesystemDirectory`.
+ * If `path` is already absolute-like, it is returned unchanged.
+ * The join always uses a forward slash separator between dir and relative path
+ * (matching the original inline `absolute()` in build-request-parts.ts).
+ */
+export function toAbsoluteFilePath(sourceFilesystemDirectory: string, path: string): string {
+  if (isAbsoluteLike(path)) return path
+  const trimmedDir = sourceFilesystemDirectory.replace(/[\\/]+$/, "")
+  return `${trimmedDir}/${path}`
+}
+
+/**
+ * Returns true iff `absolutePath` is the same as, or inside, `sourceFilesystemDirectory`.
+ *
+ * Comparison strategy:
+ * - Backslashes are normalized to forward slashes for comparison only (inputs unchanged).
+ * - Case-insensitive only when `sourceFilesystemDirectory` looks like a Windows root
+ *   (drive letter `C:/...` or UNC `\\...`). POSIX comparison is case-sensitive.
+ */
+export function isUnderDirectory(absolutePath: string, sourceFilesystemDirectory: string): boolean {
+  const isWindowsRoot =
+    /^[A-Za-z]:[\\/]/.test(sourceFilesystemDirectory) ||
+    /^[A-Za-z]:$/.test(sourceFilesystemDirectory) ||
+    sourceFilesystemDirectory.startsWith("\\\\")
+
+  // Normalize backslashes for comparison only
+  const normalize = (p: string) => p.replace(/\\/g, "/")
+  let normPath = normalize(absolutePath)
+  let normDir = normalize(sourceFilesystemDirectory)
+
+  if (isWindowsRoot) {
+    normPath = normPath.toLowerCase()
+    normDir = normDir.toLowerCase()
+  }
+
+  if (normPath === normDir) return true
+  // Must start with dir + "/" or dir + "\"  (after normalization, always "/")
+  return normPath.startsWith(normDir + "/")
+}
+
+/**
+ * Returns a compact display label for a file path.
+ *
+ * - If `sourceFilesystemDirectory` is provided and the path is under it:
+ *   strips the directory prefix and leading separator.
+ * - Otherwise: returns the basename (last `/` or `\` segment).
+ * - If the result exceeds `maxSegmentLen` (default 24), truncates the middle
+ *   with an ellipsis `…`, keeping the extension intact.
+ *
+ * Example: `very-long-filename-here.tsx` with maxSegmentLen=18 → `very-long…here.tsx`
+ */
+export function compactFilePath(
+  absolutePath: string,
+  sourceFilesystemDirectory?: string,
+  maxSegmentLen = 24,
+): string {
+  let label: string
+
+  if (sourceFilesystemDirectory !== undefined && isUnderDirectory(absolutePath, sourceFilesystemDirectory)) {
+    // Strip directory prefix and any leading separator
+    const trimmedDir = sourceFilesystemDirectory.replace(/[\\/]+$/, "")
+    label = absolutePath.slice(trimmedDir.length).replace(/^[\\/]+/, "")
+  } else {
+    // Basename: last segment after / or \
+    const lastSep = Math.max(absolutePath.lastIndexOf("/"), absolutePath.lastIndexOf("\\"))
+    label = lastSep >= 0 ? absolutePath.slice(lastSep + 1) : absolutePath
+  }
+
+  if (label.length <= maxSegmentLen) return label
+
+  // Truncate middle, keeping extension visible
+  const dotIndex = label.lastIndexOf(".")
+  const ext = dotIndex > 0 ? label.slice(dotIndex) : ""
+  const stem = dotIndex > 0 ? label.slice(0, dotIndex) : label
+
+  // Budget: maxSegmentLen minus ellipsis (1 char) minus ext
+  const budget = maxSegmentLen - 1 - ext.length
+  // Give 2/3 of the budget to the head so the tail shows the meaningful end
+  const headLen = Math.ceil((budget * 2) / 3)
+  const tailLen = budget - headLen
+
+  const head = stem.slice(0, headLen)
+  const tail = tailLen > 0 ? stem.slice(-tailLen) : ""
+  return `${head}…${tail}${ext}`
+}

--- a/packages/app/src/components/prompt-input/path-canonical.ts
+++ b/packages/app/src/components/prompt-input/path-canonical.ts
@@ -56,6 +56,18 @@ export function isUnderDirectory(absolutePath: string, sourceFilesystemDirectory
 }
 
 /**
+ * Returns true iff the chip item's path is absolute AND outside the given
+ * workspace directory. Relative paths (workspace-relative) always return false.
+ * An empty or missing sourceFilesystemDirectory also returns false (no workspace
+ * root known, so we cannot judge externality).
+ */
+export function isExternalChip(path: string, sourceFilesystemDirectory: string | undefined): boolean {
+  if (!sourceFilesystemDirectory) return false
+  if (!isAbsoluteLike(path)) return false
+  return !isUnderDirectory(path, sourceFilesystemDirectory)
+}
+
+/**
  * Returns a compact display label for a file path.
  *
  * - If `sourceFilesystemDirectory` is provided and the path is under it:

--- a/packages/app/src/components/prompt-input/pinned-draft.test.ts
+++ b/packages/app/src/components/prompt-input/pinned-draft.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { createPinnedDraftOwner } from "./pinned-draft"
+import { createPortableDraftOwner } from "./portable-draft"
+import type { PinnedDraftPayload } from "./pinned-draft"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePayload(text: string): PinnedDraftPayload {
+  return {
+    prompt: [{ type: "text", content: text, start: 0, end: text.length }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+function emptyPayload(): PinnedDraftPayload {
+  return {
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+// ---------------------------------------------------------------------------
+// adopt
+// ---------------------------------------------------------------------------
+
+describe("PinnedDraftOwner.adopt", () => {
+  let owner: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    owner = createPinnedDraftOwner()
+  })
+
+  test("creates a pinned slot with revision 1 and the deep-link prompt as text", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "fix the bug" })
+    const slot = owner.current()
+    expect(slot).not.toBeNull()
+    expect(slot?.revision).toBe(1)
+    expect(slot?.directory).toBe("/repo-x")
+    expect(slot?.prompt).toEqual([{ type: "text", content: "fix the bug", start: 0, end: 11 }])
+    expect(slot?.context).toEqual([])
+    expect(slot?.images).toEqual([])
+    expect(slot?.resolvedMentions).toEqual({})
+  })
+
+  test("replaces existing slot when called twice with different directories", () => {
+    owner.adopt({ directory: "/repo-a", prompt: "first" })
+    owner.adopt({ directory: "/repo-b", prompt: "second" })
+    const slot = owner.current()
+    expect(slot?.directory).toBe("/repo-b")
+    expect(slot?.prompt[0]).toMatchObject({ content: "second" })
+    // Revision resets to 1 on each adopt (last-write-wins semantics).
+    expect(slot?.revision).toBe(1)
+  })
+
+  test("replaces existing slot when called twice with same directory (latest wins)", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "old" })
+    owner.adopt({ directory: "/repo-x", prompt: "new" })
+    const slot = owner.current()
+    expect(slot?.directory).toBe("/repo-x")
+    expect(slot?.prompt[0]).toMatchObject({ content: "new" })
+    expect(slot?.revision).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recordEdit
+// ---------------------------------------------------------------------------
+
+describe("PinnedDraftOwner.recordEdit", () => {
+  let owner: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    owner = createPinnedDraftOwner()
+  })
+
+  test("no-op when slot is null", () => {
+    // No adopt before recordEdit.
+    owner.recordEdit({ directory: "/repo-x", ...makePayload("hello") })
+    expect(owner.current()).toBeNull()
+  })
+
+  test("no-op when directory does not match bound slot", () => {
+    owner.adopt({ directory: "/repo-a", prompt: "original" })
+    const revBefore = owner.revision()
+    owner.recordEdit({ directory: "/repo-b", ...makePayload("different dir") })
+    expect(owner.revision()).toBe(revBefore)
+    expect(owner.current()?.directory).toBe("/repo-a")
+  })
+
+  test("updates content and bumps revision when directory matches", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "initial" })
+    expect(owner.revision()).toBe(1)
+    owner.recordEdit({ directory: "/repo-x", ...makePayload("edited") })
+    expect(owner.revision()).toBe(2)
+    expect(owner.current()?.prompt[0]).toMatchObject({ content: "edited" })
+  })
+
+  test("does not bump revision when payload deep-equal", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "same" })
+    owner.recordEdit({ directory: "/repo-x", ...makePayload("same") })
+    // Payload matches initial adopt content => no revision bump.
+    expect(owner.revision()).toBe(1)
+  })
+
+  test("empty content does NOT release the slot (revision bumps, slot still bound)", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "something" })
+    owner.recordEdit({ directory: "/repo-x", ...emptyPayload() })
+    // Slot must still exist.
+    expect(owner.current()).not.toBeNull()
+    expect(owner.current()?.directory).toBe("/repo-x")
+    // Revision bumped because content changed.
+    expect(owner.revision()).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearAll / release
+// ---------------------------------------------------------------------------
+
+describe("PinnedDraftOwner.clearAll / release", () => {
+  let owner: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    owner = createPinnedDraftOwner()
+  })
+
+  test("clearAll without expectedRevision releases the slot", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "hello" })
+    const result = owner.clearAll()
+    expect(result).toBe(true)
+    expect(owner.current()).toBeNull()
+  })
+
+  test("clearAll with matching revision releases", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "hello" })
+    const rev = owner.revision()
+    const result = owner.clearAll(rev)
+    expect(result).toBe(true)
+    expect(owner.current()).toBeNull()
+  })
+
+  test("clearAll with stale revision returns false and does not release", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "hello" })
+    const result = owner.clearAll(999)
+    expect(result).toBe(false)
+    expect(owner.current()).not.toBeNull()
+  })
+
+  test("release is equivalent to clearAll(undefined)", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "hello" })
+    owner.release()
+    expect(owner.current()).toBeNull()
+  })
+
+  test("after release, recordEdit on the same directory is no-op (slot is gone, not auto-recreated)", () => {
+    owner.adopt({ directory: "/repo-x", prompt: "hello" })
+    owner.release()
+    owner.recordEdit({ directory: "/repo-x", ...makePayload("fresh text") })
+    expect(owner.current()).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Coexistence with PortableDraftOwner
+// ---------------------------------------------------------------------------
+
+describe("PinnedDraftOwner + PortableDraftOwner coexistence", () => {
+  let pinned: ReturnType<typeof createPinnedDraftOwner>
+  let portable: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    pinned = createPinnedDraftOwner()
+    portable = createPortableDraftOwner()
+  })
+
+  test("portable record while pinned slot bound: portable still accepts edits for OTHER directories", () => {
+    // Pinned bound to /a; user edits homepage /b via portable.
+    pinned.adopt({ directory: "/repo-a", prompt: "pinned text" })
+    portable.record({
+      sourceFilesystemDirectory: "/repo-b",
+      prompt: [{ type: "text", content: "portable text", start: 0, end: 13 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(pinned.current()?.directory).toBe("/repo-a")
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/repo-b")
+    // Both owners hold independent state.
+    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "pinned text" })
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "portable text" })
+  })
+
+  test("portable record for the pinned directory while pinned slot bound: owners hold independent state without interfering", () => {
+    // Pinned is bound to /repo-x; portable also records for /repo-x.
+    // In the real app, editor-input.ts branches so only one is updated,
+    // but at the owner level both can hold state simultaneously.
+    pinned.adopt({ directory: "/repo-x", prompt: "deep-link text" })
+    portable.record({
+      sourceFilesystemDirectory: "/repo-x",
+      prompt: [{ type: "text", content: "portable text", start: 0, end: 13 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    // Each owner is unaffected by the other.
+    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "deep-link text" })
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "portable text" })
+  })
+
+  test("after pinned.release(), recordEdit pinned no-ops but portable still works for that directory", () => {
+    pinned.adopt({ directory: "/repo-x", prompt: "prefill" })
+    pinned.release()
+
+    // Pinned recordEdit is now a no-op (slot gone).
+    pinned.recordEdit({ directory: "/repo-x", ...makePayload("new text") })
+    expect(pinned.current()).toBeNull()
+
+    // Portable is unaffected and still works.
+    portable.record({
+      sourceFilesystemDirectory: "/repo-x",
+      prompt: [{ type: "text", content: "portable still works", start: 0, end: 20 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "portable still works" })
+  })
+})

--- a/packages/app/src/components/prompt-input/pinned-draft.ts
+++ b/packages/app/src/components/prompt-input/pinned-draft.ts
@@ -1,0 +1,154 @@
+/**
+ * Pinned draft owner (PR #750 T6).
+ *
+ * Holds a directory-bound draft created exclusively by deep-link prefill.
+ * Unlike the portable owner (which floats between homepages), the pinned slot
+ * stays bound to one directory until explicitly released.
+ *
+ * Key rules:
+ * - Only adopt() creates a pinned slot. recordEdit() never auto-creates one.
+ * - Empty content does NOT release the slot; the directory binding persists.
+ * - release() / clearAll() are the only ways to destroy the slot.
+ * - Submit lifecycle (T7) calls clearAll(expectedRevision) for stale-safe teardown.
+ */
+
+import { createSignal } from "solid-js"
+import type { Prompt, ContextItem, ImageAttachmentPart } from "@/context/prompt"
+import type { ResolvedMention } from "./mention-metadata"
+
+export interface PinnedDraftPayload {
+  prompt: Prompt
+  context: (ContextItem & { key: string })[]
+  images: ImageAttachmentPart[]
+  resolvedMentions: Record<string, ResolvedMention[]>
+}
+
+export interface PinnedDraft extends PinnedDraftPayload {
+  /** Filesystem directory the pinned scope is bound to. */
+  directory: string
+  /** Monotonic revision; bumps on adopt and on every content change. */
+  revision: number
+}
+
+export interface PinnedDraftOwner {
+  /** Returns the current pinned slot if any; null if released. Reactive. */
+  current(): PinnedDraft | null
+  /** Returns current revision, or 0 when not bound. Reactive. */
+  revision(): number
+  /**
+   * Adopt a deep-link prefill. Replaces any existing pinned slot (last-write-wins).
+   * The slot stays bound to `directory` until release() or clearAll() is called.
+   */
+  adopt(input: { directory: string; prompt: string }): void
+  /**
+   * Update content of the slot. Only writes if `directory` matches the bound slot.
+   * Empty content does NOT release the slot.
+   */
+  recordEdit(input: { directory: string } & PinnedDraftPayload): void
+  /**
+   * Release the slot entirely. After this, current() returns null.
+   * Used by submit-success and explicit discard actions (T7).
+   * Returns false if `expectedRevision` was passed and did not match (caller used stale revision).
+   */
+  clearAll(expectedRevision?: number): boolean
+  /** Alias for clearAll(undefined). */
+  release(): void
+}
+
+export function createPinnedDraftOwner(): PinnedDraftOwner {
+  const [slot, setSlot] = createSignal<PinnedDraft | null>(null)
+
+  function current(): PinnedDraft | null {
+    return slot()
+  }
+
+  function revision(): number {
+    return slot()?.revision ?? 0
+  }
+
+  function adopt(input: { directory: string; prompt: string }): void {
+    const text = input.prompt
+    const initialPrompt: Prompt = [{ type: "text", content: text, start: 0, end: text.length }]
+    setSlot({
+      directory: input.directory,
+      prompt: initialPrompt,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+      revision: 1,
+    })
+  }
+
+  function recordEdit(input: { directory: string } & PinnedDraftPayload): void {
+    const existing = slot()
+    // No-op if no slot exists; adopt() is the only slot creator.
+    if (existing === null) return
+    // No-op if directory does not match the bound slot.
+    if (existing.directory !== input.directory) return
+
+    // Skip revision bump when payload is deep-equal to current content.
+    const payloadEqual =
+      JSON.stringify({
+        prompt: existing.prompt,
+        context: existing.context,
+        images: existing.images,
+        resolvedMentions: existing.resolvedMentions,
+      }) ===
+      JSON.stringify({
+        prompt: input.prompt,
+        context: input.context,
+        images: input.images,
+        resolvedMentions: input.resolvedMentions,
+      })
+
+    if (payloadEqual) return
+
+    setSlot({
+      ...existing,
+      prompt: input.prompt,
+      context: input.context,
+      images: input.images,
+      resolvedMentions: input.resolvedMentions,
+      revision: existing.revision + 1,
+    })
+  }
+
+  function clearAll(expectedRevision?: number): boolean {
+    const existing = slot()
+
+    if (existing === null) {
+      // Already clear; accept any call without expectedRevision or with 0.
+      if (expectedRevision !== undefined && expectedRevision !== 0) return false
+      return true
+    }
+
+    if (expectedRevision !== undefined && existing.revision !== expectedRevision) {
+      return false
+    }
+
+    setSlot(null)
+    return true
+  }
+
+  function release(): void {
+    clearAll(undefined)
+  }
+
+  return { current, revision, adopt, recordEdit, clearAll, release }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton accessed via usePinnedDraft().
+// ---------------------------------------------------------------------------
+
+const owner = createPinnedDraftOwner()
+
+/** Access the app-wide pinned deep-link draft owner. */
+export function usePinnedDraft(): PinnedDraftOwner {
+  return owner
+}
+
+/** Testing-only: reset the module singleton between test runs. */
+export const _pinnedDraftTesting = {
+  reset: () => owner.release(),
+}

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { createPortableDraftOwner } from "./portable-draft"
+import type { PortableDraftPayload } from "./portable-draft"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+
+// Helper: build a non-empty payload
+function makePayload(text: string): PortableDraftPayload {
+  return {
+    prompt: [{ type: "text", content: text, start: 0, end: text.length }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+// Helper: empty payload (DEFAULT_PROMPT shape)
+function emptyPayload(): PortableDraftPayload {
+  return {
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+describe("PortableDraftOwner.record", () => {
+  let owner: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    owner = createPortableDraftOwner()
+  })
+
+  test("creates snapshot with revision 1 on first record", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    const snap = owner.snapshot()
+    expect(snap).not.toBeNull()
+    expect(snap?.revision).toBe(1)
+    expect(snap?.sourceFilesystemDirectory).toBe("/a")
+  })
+
+  test("does not bump revision when payload deep-equal and same source dir", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    expect(owner.snapshot()?.revision).toBe(1)
+  })
+
+  test("bumps revision when text changes", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("world") })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
+
+  test("bumps revision when context items change", () => {
+    const base = makePayload("hello")
+    owner.record({ sourceFilesystemDirectory: "/a", ...base })
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      ...base,
+      context: [{ type: "file", path: "/a/foo.ts", key: "file:/a/foo.ts:undefined:undefined" }],
+    })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
+
+  test("bumps revision when images change", () => {
+    const base = makePayload("hello")
+    owner.record({ sourceFilesystemDirectory: "/a", ...base })
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      ...base,
+      images: [{ type: "image", id: "img1", filename: "a.png", mime: "image/png", dataUrl: "data:..." }],
+    })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
+
+  test("bumps revision when resolvedMentions change", () => {
+    const base = makePayload("hello")
+    owner.record({ sourceFilesystemDirectory: "/a", ...base })
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      ...base,
+      resolvedMentions: {
+        someKey: [
+          {
+            displayText: "@src/a.ts",
+            resolvedPath: "/a/src/a.ts",
+            fingerprint: "abc123",
+            start: 0,
+            end: 9,
+          },
+        ],
+      },
+    })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
+
+  test("bumps revision when sourceFilesystemDirectory changes", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    owner.record({ sourceFilesystemDirectory: "/b", ...makePayload("hello") })
+    expect(owner.snapshot()?.revision).toBe(2)
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/b")
+  })
+
+  test("clears snapshot when payload becomes empty", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    owner.record({ sourceFilesystemDirectory: "/a", ...emptyPayload() })
+    expect(owner.snapshot()).toBeNull()
+  })
+})
+
+describe("PortableDraftOwner.consumeForHomepage", () => {
+  let owner: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    owner = createPortableDraftOwner()
+  })
+
+  test("returns null when no snapshot exists", () => {
+    expect(owner.consumeForHomepage("/b", true)).toBeNull()
+  })
+
+  test("returns null when target dir equals source dir", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    expect(owner.consumeForHomepage("/a", true)).toBeNull()
+  })
+
+  test("returns null when target is not empty", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    expect(owner.consumeForHomepage("/b", false)).toBeNull()
+  })
+
+  test("moves snapshot to target dir and bumps revision when target empty and dirs differ", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    const snap = owner.consumeForHomepage("/b", true)
+    expect(snap).not.toBeNull()
+    expect(snap?.sourceFilesystemDirectory).toBe("/b")
+    expect(snap?.revision).toBe(2) // original 1, move bumps to 2
+    // The internal snapshot now tracks /b
+    expect(owner.snapshot()?.sourceFilesystemDirectory).toBe("/b")
+  })
+
+  test("subsequent consume from same target returns null (no self-move)", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    owner.consumeForHomepage("/b", true)
+    // Now snapshot is at /b; trying to consume to /b again is self-move
+    expect(owner.consumeForHomepage("/b", true)).toBeNull()
+  })
+})
+
+describe("PortableDraftOwner.clear", () => {
+  let owner: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    owner = createPortableDraftOwner()
+  })
+
+  test("clear without expectedRevision clears the snapshot", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    const result = owner.clear()
+    expect(result).toBe(true)
+    expect(owner.snapshot()).toBeNull()
+  })
+
+  test("clear with matching expectedRevision clears", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    const rev = owner.revision()
+    const result = owner.clear(rev)
+    expect(result).toBe(true)
+    expect(owner.snapshot()).toBeNull()
+  })
+
+  test("clear with stale expectedRevision does not clear", () => {
+    owner.record({ sourceFilesystemDirectory: "/a", ...makePayload("hello") })
+    const result = owner.clear(999)
+    expect(result).toBe(false)
+    expect(owner.snapshot()).not.toBeNull()
+  })
+
+  test("clear when no snapshot exists returns true (already cleared)", () => {
+    expect(owner.clear()).toBe(true)
+    expect(owner.clear(0)).toBe(true)
+  })
+})

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -105,6 +105,35 @@ describe("PortableDraftOwner.record", () => {
     owner.record({ sourceFilesystemDirectory: "/a", ...emptyPayload() })
     expect(owner.snapshot()).toBeNull()
   })
+
+  test("bumps revision when image attachment list changes", () => {
+    const base = makePayload("hello")
+    owner.record({ sourceFilesystemDirectory: "/a", ...base })
+    expect(owner.snapshot()?.revision).toBe(1)
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      ...base,
+      images: [{ type: "image", id: "img2", filename: "b.png", mime: "image/png", dataUrl: "data:b" }],
+    })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
+
+  test("does not bump revision when context items are reordered identically", () => {
+    // Same content in same order => no bump (JSON.stringify order-sensitive)
+    const base = makePayload("hello")
+    const ctx = [
+      { type: "file" as const, path: "/a/x.ts", key: "file:/a/x.ts:undefined:undefined" },
+      { type: "file" as const, path: "/a/y.ts", key: "file:/a/y.ts:undefined:undefined" },
+    ]
+    owner.record({ sourceFilesystemDirectory: "/a", ...base, context: ctx })
+    expect(owner.snapshot()?.revision).toBe(1)
+    // Same items in same order — revision must not bump.
+    owner.record({ sourceFilesystemDirectory: "/a", ...base, context: [...ctx] })
+    expect(owner.snapshot()?.revision).toBe(1)
+    // Reversed order is treated as different (JSON.stringify is order-sensitive).
+    owner.record({ sourceFilesystemDirectory: "/a", ...base, context: [...ctx].reverse() })
+    expect(owner.snapshot()?.revision).toBe(2)
+  })
 })
 
 describe("PortableDraftOwner.consumeForHomepage", () => {
@@ -143,6 +172,49 @@ describe("PortableDraftOwner.consumeForHomepage", () => {
     owner.consumeForHomepage("/b", true)
     // Now snapshot is at /b; trying to consume to /b again is self-move
     expect(owner.consumeForHomepage("/b", true)).toBeNull()
+  })
+})
+
+describe("PortableDraftOwner consumption hydrates context items", () => {
+  let owner: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    owner = createPortableDraftOwner()
+  })
+
+  test("consumeForHomepage returns the full payload including context, images, resolvedMentions", () => {
+    const contextItems = [
+      {
+        type: "file" as const,
+        path: "/a/foo.ts",
+        key: "file:/a/foo.ts:undefined:undefined",
+        comment: "check this",
+        commentID: "cmt-1",
+      },
+    ]
+    const images = [{ type: "image" as const, id: "img1", filename: "a.png", mime: "image/png", dataUrl: "data:a" }]
+    const resolvedMentions = {
+      "file:/a/foo.ts:undefined:undefined:c=cmt-1": [
+        { displayText: "@foo.ts", resolvedPath: "/a/foo.ts", fingerprint: "f1", start: 0, end: 7 },
+      ],
+    }
+
+    owner.record({
+      sourceFilesystemDirectory: "/a",
+      prompt: [{ type: "text", content: "check this", start: 0, end: 10 }],
+      context: contextItems,
+      images,
+      resolvedMentions,
+    })
+
+    const snap = owner.consumeForHomepage("/b", true)
+    expect(snap).not.toBeNull()
+    // Full payload must be present in the returned snapshot.
+    expect(snap?.context).toEqual(contextItems)
+    expect(snap?.images).toEqual(images)
+    expect(snap?.resolvedMentions).toEqual(resolvedMentions)
+    // sourceFilesystemDirectory must be updated to target.
+    expect(snap?.sourceFilesystemDirectory).toBe("/b")
   })
 })
 

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -252,3 +252,62 @@ describe("PortableDraftOwner.clear", () => {
     expect(owner.clear(0)).toBe(true)
   })
 })
+
+describe("PortableDraftOwner canonicalizes file paths against the source directory", () => {
+  let owner: ReturnType<typeof createPortableDraftOwner>
+
+  beforeEach(() => {
+    owner = createPortableDraftOwner()
+  })
+
+  test("record rewrites relative context file paths to absolute", () => {
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: DEFAULT_PROMPT,
+      context: [{ key: "k1", type: "file", path: "src/app.ts" }],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(owner.snapshot()?.context[0]?.path).toBe("/repo-A/src/app.ts")
+  })
+
+  test("record rewrites relative prompt file parts to absolute", () => {
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: [
+        { type: "text", content: "see ", start: 0, end: 4 },
+        { type: "file", content: "@src/app.ts", path: "src/app.ts", start: 4, end: 15 },
+      ],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    const filePart = owner.snapshot()?.prompt.find((p) => p.type === "file")
+    expect(filePart && "path" in filePart ? filePart.path : undefined).toBe("/repo-A/src/app.ts")
+  })
+
+  test("record leaves already-absolute paths untouched", () => {
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: DEFAULT_PROMPT,
+      context: [{ key: "k1", type: "file", path: "/home/elsewhere/file.ts" }],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(owner.snapshot()?.context[0]?.path).toBe("/home/elsewhere/file.ts")
+  })
+
+  test("A→B carry preserves the source workspace's absolute path", () => {
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: DEFAULT_PROMPT,
+      context: [{ key: "k1", type: "file", path: "src/app.ts" }],
+      images: [],
+      resolvedMentions: {},
+    })
+    const moved = owner.consumeForHomepage("/repo-B", true)
+    expect(moved?.sourceFilesystemDirectory).toBe("/repo-B")
+    // Path stays anchored to /repo-A — this is the whole point of canonicalization
+    expect(moved?.context[0]?.path).toBe("/repo-A/src/app.ts")
+  })
+})

--- a/packages/app/src/components/prompt-input/portable-draft.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.ts
@@ -1,0 +1,198 @@
+/**
+ * Portable homepage runtime owner (PR #750 v7).
+ *
+ * Holds at most ONE snapshot of the user's currently-active homepage draft.
+ * Runtime only — NOT persisted to localStorage or anywhere else.
+ *
+ * Key rules:
+ * - A session route NEVER reads or writes this owner.
+ * - A homepage route writes-mirrors its draft here on every edit.
+ * - On homepage→homepage navigation with an empty target, the snapshot "moves"
+ *   (sourceFilesystemDirectory becomes the new homepage's dir).
+ * - `revision` is a monotonic counter; submit lifecycle can guard stale clears.
+ */
+
+import { createSignal } from "solid-js"
+import type { Prompt, ContextItem, ImageAttachmentPart } from "@/context/prompt"
+import type { ResolvedMention } from "./mention-metadata"
+
+export interface PortableDraftPayload {
+  prompt: Prompt
+  context: (ContextItem & { key: string })[]
+  images: ImageAttachmentPart[]
+  /** Comment-mention metadata indexed by context item key, captured when the comment text was committed. */
+  resolvedMentions: Record<string, ResolvedMention[]>
+}
+
+export interface PortableDraftSnapshot extends PortableDraftPayload {
+  /** True filesystem directory the snapshot is currently anchored to. */
+  sourceFilesystemDirectory: string
+  /** Monotonic revision counter. Increments on every content change AND on every successful move. */
+  revision: number
+}
+
+export interface PortableDraftOwner {
+  /** Returns the current snapshot if any, else null. Reactive (Solid signal accessor). */
+  snapshot(): PortableDraftSnapshot | null
+  /** Returns the current revision, or 0 when no snapshot exists. Reactive. */
+  revision(): number
+  /**
+   * Mirror the active homepage's draft into the owner.
+   * - If the payload is "empty" (no meaningful prompt text, no context, no images,
+   *   no resolvedMentions), the snapshot is cleared.
+   * - If unchanged from the last record (deep-equal payload AND same sourceFilesystemDirectory),
+   *   revision is NOT bumped.
+   * - Otherwise revision is incremented.
+   */
+  record(input: { sourceFilesystemDirectory: string } & PortableDraftPayload): void
+  /**
+   * Consume the snapshot for a new homepage target. Returns the snapshot only if:
+   * - A snapshot exists.
+   * - `targetSourceFilesystemDirectory !== snapshot.sourceFilesystemDirectory`.
+   * - `targetIsEmpty === true`.
+   * After consumption, the snapshot's `sourceFilesystemDirectory` becomes
+   * `targetSourceFilesystemDirectory` and revision is incremented. (It "moved".)
+   */
+  consumeForHomepage(targetSourceFilesystemDirectory: string, targetIsEmpty: boolean): PortableDraftSnapshot | null
+  /** Marker for "current route is not a homepage"; snapshot is preserved (currently a no-op). */
+  hide(): void
+  /** Returns current snapshot without mutating it. */
+  restore(): PortableDraftSnapshot | null
+  /**
+   * Clear the snapshot.
+   * Returns true if cleared.
+   * Returns false if expectedRevision was provided and did not match (guards against stale clears).
+   */
+  clear(expectedRevision?: number): boolean
+}
+
+/**
+ * Determine whether a payload carries no meaningful content.
+ * Empty means: prompt has only a blank/whitespace text part (or is empty),
+ * AND no context items, no images, no resolvedMentions.
+ */
+function isPayloadEmpty(payload: PortableDraftPayload): boolean {
+  const { prompt, context, images, resolvedMentions } = payload
+
+  const promptIsBlank =
+    prompt.length === 0 ||
+    (prompt.length === 1 && prompt[0]?.type === "text" && !prompt[0].content.trim())
+
+  return (
+    promptIsBlank &&
+    context.length === 0 &&
+    images.length === 0 &&
+    Object.keys(resolvedMentions).length === 0
+  )
+}
+
+export function createPortableDraftOwner(): PortableDraftOwner {
+  const [snapshot, setSnapshot] = createSignal<PortableDraftSnapshot | null>(null)
+
+  function revision(): number {
+    return snapshot()?.revision ?? 0
+  }
+
+  function record(input: { sourceFilesystemDirectory: string } & PortableDraftPayload): void {
+    if (isPayloadEmpty(input)) {
+      setSnapshot(null)
+      return
+    }
+
+    const current = snapshot()
+    const nextRevision = (current?.revision ?? 0) + 1
+
+    // Skip if payload and source dir are identical to the current snapshot.
+    if (
+      current !== null &&
+      current.sourceFilesystemDirectory === input.sourceFilesystemDirectory &&
+      JSON.stringify({
+        prompt: current.prompt,
+        context: current.context,
+        images: current.images,
+        resolvedMentions: current.resolvedMentions,
+      }) ===
+        JSON.stringify({
+          prompt: input.prompt,
+          context: input.context,
+          images: input.images,
+          resolvedMentions: input.resolvedMentions,
+        })
+    ) {
+      return
+    }
+
+    setSnapshot({
+      prompt: input.prompt,
+      context: input.context,
+      images: input.images,
+      resolvedMentions: input.resolvedMentions,
+      sourceFilesystemDirectory: input.sourceFilesystemDirectory,
+      revision: nextRevision,
+    })
+  }
+
+  function consumeForHomepage(
+    targetSourceFilesystemDirectory: string,
+    targetIsEmpty: boolean,
+  ): PortableDraftSnapshot | null {
+    const current = snapshot()
+    if (!current) return null
+    if (current.sourceFilesystemDirectory === targetSourceFilesystemDirectory) return null
+    if (!targetIsEmpty) return null
+
+    // Move: update source dir and bump revision.
+    const moved: PortableDraftSnapshot = {
+      ...current,
+      sourceFilesystemDirectory: targetSourceFilesystemDirectory,
+      revision: current.revision + 1,
+    }
+    setSnapshot(moved)
+    return moved
+  }
+
+  function hide(): void {
+    // Currently a no-op — snapshot is preserved across route changes.
+    // Future tasks may track a hidden flag here.
+  }
+
+  function restore(): PortableDraftSnapshot | null {
+    return snapshot()
+  }
+
+  function clear(expectedRevision?: number): boolean {
+    const current = snapshot()
+
+    // Already clear.
+    if (current === null) {
+      // If caller passed 0 as expectedRevision (meaning "revision when nothing exists"), accept it.
+      if (expectedRevision !== undefined && expectedRevision !== 0) return false
+      return true
+    }
+
+    if (expectedRevision !== undefined && current.revision !== expectedRevision) {
+      return false
+    }
+
+    setSnapshot(null)
+    return true
+  }
+
+  return { snapshot, revision, record, consumeForHomepage, hide, restore, clear }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton accessed via usePortableDraft().
+// ---------------------------------------------------------------------------
+
+const owner = createPortableDraftOwner()
+
+/** Access the app-wide portable homepage draft owner. */
+export function usePortableDraft(): PortableDraftOwner {
+  return owner
+}
+
+/** Testing-only: reset the module singleton between test runs. */
+export const _portableDraftTesting = {
+  reset: () => owner.clear(),
+}

--- a/packages/app/src/components/prompt-input/portable-draft.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.ts
@@ -15,6 +15,7 @@
 import { createSignal } from "solid-js"
 import type { Prompt, ContextItem, ImageAttachmentPart } from "@/context/prompt"
 import type { ResolvedMention } from "./mention-metadata"
+import { toAbsoluteFilePath } from "./path-canonical"
 
 export interface PortableDraftPayload {
   prompt: Prompt
@@ -99,6 +100,17 @@ export function createPortableDraftOwner(): PortableDraftOwner {
       return
     }
 
+    // Canonicalize relative file-bearing paths against the source filesystem
+    // directory so the snapshot is portable across workspaces. After a move,
+    // build-request-parts will receive absolute paths and won't re-anchor them
+    // to the destination workspace's sessionDirectory.
+    const canonicalPrompt: Prompt = input.prompt.map((part) =>
+      part.type === "file" ? { ...part, path: toAbsoluteFilePath(input.sourceFilesystemDirectory, part.path) } : part,
+    )
+    const canonicalContext = input.context.map((item) =>
+      item.type === "file" ? { ...item, path: toAbsoluteFilePath(input.sourceFilesystemDirectory, item.path) } : item,
+    )
+
     const current = snapshot()
     const nextRevision = (current?.revision ?? 0) + 1
 
@@ -113,8 +125,8 @@ export function createPortableDraftOwner(): PortableDraftOwner {
         resolvedMentions: current.resolvedMentions,
       }) ===
         JSON.stringify({
-          prompt: input.prompt,
-          context: input.context,
+          prompt: canonicalPrompt,
+          context: canonicalContext,
           images: input.images,
           resolvedMentions: input.resolvedMentions,
         })
@@ -123,8 +135,8 @@ export function createPortableDraftOwner(): PortableDraftOwner {
     }
 
     setSnapshot({
-      prompt: input.prompt,
-      context: input.context,
+      prompt: canonicalPrompt,
+      context: canonicalContext,
       images: input.images,
       resolvedMentions: input.resolvedMentions,
       sourceFilesystemDirectory: input.sourceFilesystemDirectory,

--- a/packages/app/src/components/prompt-input/submit-ownership.test.ts
+++ b/packages/app/src/components/prompt-input/submit-ownership.test.ts
@@ -1,0 +1,198 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { createPortableDraftOwner } from "./portable-draft"
+import { createPinnedDraftOwner } from "./pinned-draft"
+
+// Submit module pulls in router/sdk/etc.; mock the bare minimum so a pure-function
+// import does not blow up on solid-js server-side guards.
+let detectSubmitOwnership: typeof import("./submit").detectSubmitOwnership
+type SubmitOwnership = import("./submit").SubmitOwnership
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useNavigate: () => () => undefined,
+    useParams: () => ({}),
+  }))
+  mock.module("@opencode-ai/util/encode", () => ({
+    base64Encode: (value: string) => value,
+    base64Decode: (value: string) => value,
+    checksum: (value: string) => String(value.length),
+    sampledChecksum: (value: string) => String(value.length),
+  }))
+  const mod = await import("./submit")
+  detectSubmitOwnership = mod.detectSubmitOwnership
+})
+
+const ROUTE_SCOPE = { dir: "L3JlcG8vbWFpbg", id: undefined } as const
+
+function nonEmptyPayload(text: string) {
+  return {
+    prompt: [{ type: "text" as const, content: text, start: 0, end: text.length }],
+    context: [],
+    images: [],
+    resolvedMentions: {},
+  }
+}
+
+describe("detectSubmitOwnership", () => {
+  let portable: ReturnType<typeof createPortableDraftOwner>
+  let pinned: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    portable = createPortableDraftOwner()
+    pinned = createPinnedDraftOwner()
+  })
+
+  test("returns route when on a concrete session (isHomepage=false)", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("hello") })
+    pinned.adopt({ directory: "/repo/main", prompt: "hi" })
+    const result = detectSubmitOwnership({
+      isHomepage: false,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    expect(result.kind).toBe("route")
+    if (result.kind === "route") {
+      expect(result.scope).toEqual(ROUTE_SCOPE)
+    }
+  })
+
+  test("returns portable when on homepage and portable matches directory", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("hello") })
+    const snapAtCapture = portable.snapshot()
+    const result = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    expect(result.kind).toBe("portable")
+    if (result.kind === "portable") {
+      expect(result.revision).toBe(snapAtCapture!.revision)
+      expect(result.sourceFilesystemDirectory).toBe("/repo/main")
+    }
+  })
+
+  test("returns pinned when on homepage and pinned matches directory (pinned beats portable)", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("portable") })
+    pinned.adopt({ directory: "/repo/main", prompt: "deep-link" })
+    const pinnedAtCapture = pinned.current()
+    const result = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    expect(result.kind).toBe("pinned")
+    if (result.kind === "pinned") {
+      expect(result.revision).toBe(pinnedAtCapture!.revision)
+      expect(result.directory).toBe("/repo/main")
+    }
+  })
+
+  test("returns route when on homepage but neither owner matches directory", () => {
+    // Portable snapshot bound to a DIFFERENT directory should not be claimed.
+    portable.record({ sourceFilesystemDirectory: "/repo/other", ...nonEmptyPayload("elsewhere") })
+    const result = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    expect(result.kind).toBe("route")
+  })
+
+  test("returns route when on homepage and both owners are empty", () => {
+    const result = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    expect(result.kind).toBe("route")
+  })
+
+  test("captured ownership is a snapshot value, not a live reference", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("v1") })
+    const result: SubmitOwnership = detectSubmitOwnership({
+      isHomepage: true,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: "/repo/main",
+      routeScope: ROUTE_SCOPE,
+    })
+    const capturedRevision = result.kind === "portable" ? result.revision : -1
+    // Simulate user typing during the submit's await.
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("v2") })
+    // Captured revision is frozen and now diverges from the live owner.
+    expect(portable.snapshot()!.revision).not.toBe(capturedRevision)
+    expect(capturedRevision).toBeGreaterThan(0)
+  })
+})
+
+describe("revision-guarded clear and restore", () => {
+  let portable: ReturnType<typeof createPortableDraftOwner>
+  let pinned: ReturnType<typeof createPinnedDraftOwner>
+
+  beforeEach(() => {
+    portable = createPortableDraftOwner()
+    pinned = createPinnedDraftOwner()
+  })
+
+  test("portable.clear returns true and empties owner when revision matches", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("hello") })
+    const captured = portable.snapshot()!.revision
+    const cleared = portable.clear(captured)
+    expect(cleared).toBe(true)
+    expect(portable.snapshot()).toBeNull()
+  })
+
+  test("portable.clear returns false and leaves owner when revision diverged", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("hello") })
+    const captured = portable.snapshot()!.revision
+    // User types new content during the submit await.
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("typed-new") })
+    const cleared = portable.clear(captured)
+    expect(cleared).toBe(false)
+    expect(portable.snapshot()).not.toBeNull()
+    expect(portable.snapshot()!.prompt[0]).toMatchObject({ content: "typed-new" })
+  })
+
+  test("pinned.clearAll returns true and releases slot when revision matches", () => {
+    pinned.adopt({ directory: "/repo/main", prompt: "deep-link" })
+    const captured = pinned.current()!.revision
+    const cleared = pinned.clearAll(captured)
+    expect(cleared).toBe(true)
+    expect(pinned.current()).toBeNull()
+  })
+
+  test("pinned.clearAll returns false and preserves slot when revision diverged", () => {
+    pinned.adopt({ directory: "/repo/main", prompt: "deep-link" })
+    const captured = pinned.current()!.revision
+    // User types during await.
+    pinned.recordEdit({
+      directory: "/repo/main",
+      prompt: [{ type: "text", content: "typed-new", start: 0, end: 9 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    const cleared = pinned.clearAll(captured)
+    expect(cleared).toBe(false)
+    expect(pinned.current()).not.toBeNull()
+    expect(pinned.current()!.prompt[0]).toMatchObject({ content: "typed-new" })
+  })
+
+  test("portable revision moves monotonically across record/clear cycles", () => {
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("v1") })
+    const r1 = portable.snapshot()!.revision
+    portable.record({ sourceFilesystemDirectory: "/repo/main", ...nonEmptyPayload("v2") })
+    const r2 = portable.snapshot()!.revision
+    expect(r2).toBeGreaterThan(r1)
+  })
+})

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -418,6 +418,14 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     input.resetHistoryNavigation()
     promptProbe.start()
 
+    // Capture context items and the "isHomepage" route bit BEFORE any await.
+    // navigate() lands the new session route mid-await and switches params.id
+    // from undefined to the created id; reading these after navigate() would
+    // observe an EMPTY new-session store and a "session route" verdict, which
+    // breaks ownership detection (Bug 1) and the comment-restore path.
+    const submittedContext = prompt.context.items().slice()
+    const submittedIsHomepage = !params.id
+
     const projectDirectory = sdk.directory
     // Capture the source scope before any await so navigate() cannot change params.id under us
     const sourcePromptScope: PromptRouteScope = {
@@ -504,7 +512,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
     const locale = language.intl()
     const agent = creatingNewSession ? "build" : currentAgent!.name
-    const context = prompt.context.items().slice()
+    // Use the pre-await capture; reading prompt.context.items() here would land
+    // in the freshly-created session's empty context store after navigate().
+    const context = submittedContext
     const draft: FollowupDraft = {
       sessionID: session.id,
       sessionDirectory,
@@ -521,7 +531,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     // Ownership is frozen here; clear/restore below check this captured revision
     // against the owner's current revision so a user typing during the await is
     // never trampled.
-    const isHomepage = !params.id
+    const isHomepage = submittedIsHomepage
     const ownership: SubmitOwnership = detectSubmitOwnership({
       isHomepage,
       pinned,
@@ -537,29 +547,45 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       sessionID: session.id,
     })
 
+    // Two-phase clear (Bug 2):
+    //   1) clearInput(owned) runs SYNCHRONOUSLY before the await. It resets the
+    //      visible UI only; the owner snapshot is intentionally preserved so
+    //      restoreInput() can push it back on async failure.
+    //   2) confirmOwnerCleared(owned) runs in each success path AFTER the await
+    //      resolves. It tears down the owner snapshot under the captured revision
+    //      so a user who typed during the await is never trampled.
+    //   restoreInput(owned) (failure path) reads from the still-intact owner.
     const clearInput = (owned: SubmitOwnership) => {
       switch (owned.kind) {
-        case "portable": {
-          const cleared = portable.clear(owned.revision)
-          // Revision diverged: user typed new content during the submit. Leave the
-          // UI alone so the new draft remains visible.
-          if (!cleared) return
+        case "portable":
+        case "pinned":
+          // Reset the visible UI to homepage source scope. The owner snapshot
+          // stays put for now; confirmOwnerCleared/restoreInput own its fate.
           prompt.reset(sourcePromptScope)
           break
-        }
-        case "pinned": {
-          const cleared = pinned.clearAll(owned.revision)
-          if (!cleared) return
-          prompt.reset(sourcePromptScope)
-          break
-        }
-        case "route": {
+        case "route":
           prompt.reset(owned.scope)
           break
-        }
       }
       input.setMode("normal")
       input.setPopover(null)
+    }
+
+    const confirmOwnerCleared = (owned: SubmitOwnership) => {
+      // Owner-backed cases: clear under the captured revision. If the user typed
+      // during the await the revision diverged and clear() returns false; we
+      // leave their fresh content in place.
+      switch (owned.kind) {
+        case "portable":
+          portable.clear(owned.revision)
+          break
+        case "pinned":
+          pinned.clearAll(owned.revision)
+          break
+        case "route":
+          // route store was reset synchronously by clearInput; no owner snapshot.
+          break
+      }
     }
 
     const restoreInput = (owned: SubmitOwnership) => {
@@ -614,6 +640,10 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       input.onQueue?.(draft)
       clearContext()
       clearInput(ownership)
+      // Queue path is synchronous; tear down owner snapshot immediately.
+      // ownership.kind is "route" here (see comment above), so this is a no-op
+      // for the only kind reachable, but the call is kept for parity.
+      confirmOwnerCleared(ownership)
       return
     }
 
@@ -628,6 +658,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
           agent,
           model,
           command: text,
+        })
+        .then(() => {
+          confirmOwnerCleared(ownership)
         })
         .catch((err) => {
           showToast({
@@ -661,6 +694,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
               url: attachment.dataUrl,
               filename: attachment.filename,
             })),
+          })
+          .then(() => {
+            confirmOwnerCleared(ownership)
           })
           .catch((err) => {
             showToast({
@@ -769,6 +805,12 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       messageID,
       optimisticBusy: sessionDirectory === projectDirectory,
       before: waitForWorktree,
+    }).then((ok) => {
+      // Only tear down the owner snapshot if the send actually went through.
+      // sendFollowupDraft returns false when `before` (worktree wait) bailed; in
+      // that case the cleanup path already restored the input via the pending
+      // controller's cleanup() handler.
+      if (ok) confirmOwnerCleared(ownership)
     }).catch((err) => {
       pending.delete(session.id)
       if (sessionDirectory === projectDirectory) {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -432,6 +432,20 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       dir: params.dir ?? base64Encode(projectDirectory),
       id: params.id,
     }
+
+    // Capture submit ownership BEFORE any await. Reading pinned.current() and
+    // portable.snapshot() here freezes the revision at submit time; if the user
+    // types into the editor during the await, the owner's live revision bumps
+    // past this value and confirmOwnerCleared will refuse to wipe under that
+    // mismatch — preserving the post-submit typing.
+    const ownership: SubmitOwnership = detectSubmitOwnership({
+      isHomepage: submittedIsHomepage,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: projectDirectory,
+      routeScope: sourcePromptScope,
+    })
+
     const shouldAutoAccept = creatingNewSession && input.autoAccept()
     const worktreeSelection = input.newSessionWorktree?.() || "main"
 
@@ -525,20 +539,6 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       locale,
       variant,
     }
-
-    // Capture submit ownership BEFORE any clear. isHomepage uses the route at submit
-    // start (params.id can change once navigate() lands the new session route).
-    // Ownership is frozen here; clear/restore below check this captured revision
-    // against the owner's current revision so a user typing during the await is
-    // never trampled.
-    const isHomepage = submittedIsHomepage
-    const ownership: SubmitOwnership = detectSubmitOwnership({
-      isHomepage,
-      pinned,
-      portable,
-      sourceFilesystemDirectory: projectDirectory,
-      routeScope: sourcePromptScope,
-    })
 
     const promptScope = promptScopeForSession({
       routeDir: params.dir,

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -24,6 +24,7 @@ import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
 import { type PromptRouteScope, promptScopeForSession } from "@/pages/session/prompt-route-scope"
 import { type PortableDraftOwner, usePortableDraft } from "./portable-draft"
 import { type PinnedDraftOwner, usePinnedDraft } from "./pinned-draft"
+import type { ResolvedMention } from "./mention-metadata"
 
 /**
  * Submit ownership identifies which draft owner a given submit attempt operates on.
@@ -258,6 +259,7 @@ type CommentItem = {
   commentID?: string
   commentOrigin?: "review" | "file"
   preview?: string
+  resolvedMentions?: ResolvedMention[]
 }
 
 export function createPromptSubmit(input: PromptSubmitInput) {
@@ -349,6 +351,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         commentID: item.commentID,
         commentOrigin: item.commentOrigin,
         preview: item.preview,
+        resolvedMentions: item.resolvedMentions,
       })
     }
   }

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -22,6 +22,48 @@ import { setCursorPosition } from "./editor-dom"
 import { formatServerError } from "@/utils/server-errors"
 import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
 import { type PromptRouteScope, promptScopeForSession } from "@/pages/session/prompt-route-scope"
+import { type PortableDraftOwner, usePortableDraft } from "./portable-draft"
+import { type PinnedDraftOwner, usePinnedDraft } from "./pinned-draft"
+
+/**
+ * Submit ownership identifies which draft owner a given submit attempt operates on.
+ * Captured once at the top of handleSubmit and frozen for the lifetime of that submit.
+ * Used by clearInput/restoreInput so a successful clear or failure restore only
+ * touches the owner whose revision matches the captured value at submit time.
+ */
+export type SubmitOwnership =
+  | { kind: "portable"; revision: number; sourceFilesystemDirectory: string }
+  | { kind: "pinned"; revision: number; directory: string }
+  | { kind: "route"; scope: PromptRouteScope }
+
+/**
+ * Decide which owner owns this submit. Pinned beats portable when both match the
+ * current homepage directory. When on a concrete session route (id present),
+ * ownership is always the route-scoped prompt store.
+ */
+export function detectSubmitOwnership(params: {
+  isHomepage: boolean
+  pinned: PinnedDraftOwner
+  portable: PortableDraftOwner
+  sourceFilesystemDirectory: string
+  routeScope: PromptRouteScope
+}): SubmitOwnership {
+  if (params.isHomepage) {
+    const pinnedSlot = params.pinned.current()
+    if (pinnedSlot && pinnedSlot.directory === params.sourceFilesystemDirectory) {
+      return { kind: "pinned", revision: pinnedSlot.revision, directory: pinnedSlot.directory }
+    }
+    const portableSnapshot = params.portable.snapshot()
+    if (portableSnapshot && portableSnapshot.sourceFilesystemDirectory === params.sourceFilesystemDirectory) {
+      return {
+        kind: "portable",
+        revision: portableSnapshot.revision,
+        sourceFilesystemDirectory: portableSnapshot.sourceFilesystemDirectory,
+      }
+    }
+  }
+  return { kind: "route", scope: params.routeScope }
+}
 
 type PendingPrompt = {
   abort: AbortController
@@ -229,6 +271,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const layout = useLayout()
   const language = useLanguage()
   const params = useParams()
+  const portable = usePortableDraft()
+  const pinned = usePinnedDraft()
   const sessionID = input.sessionID ?? (() => params.id)
   const isNewSession = input.isNewSession ?? (() => !sessionID())
   const actionReady = input.actionReady ?? (() => true)
@@ -472,11 +516,19 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       variant,
     }
 
-    const clearInput = () => {
-      prompt.reset(sourcePromptScope)
-      input.setMode("normal")
-      input.setPopover(null)
-    }
+    // Capture submit ownership BEFORE any clear. isHomepage uses the route at submit
+    // start (params.id can change once navigate() lands the new session route).
+    // Ownership is frozen here; clear/restore below check this captured revision
+    // against the owner's current revision so a user typing during the await is
+    // never trampled.
+    const isHomepage = !params.id
+    const ownership: SubmitOwnership = detectSubmitOwnership({
+      isHomepage,
+      pinned,
+      portable,
+      sourceFilesystemDirectory: projectDirectory,
+      routeScope: sourcePromptScope,
+    })
 
     const promptScope = promptScopeForSession({
       routeDir: params.dir,
@@ -485,23 +537,83 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       sessionID: session.id,
     })
 
-    const restoreInput = () => {
-      prompt.set(currentPrompt, input.promptLength(currentPrompt), promptScope)
+    const clearInput = (owned: SubmitOwnership) => {
+      switch (owned.kind) {
+        case "portable": {
+          const cleared = portable.clear(owned.revision)
+          // Revision diverged: user typed new content during the submit. Leave the
+          // UI alone so the new draft remains visible.
+          if (!cleared) return
+          prompt.reset(sourcePromptScope)
+          break
+        }
+        case "pinned": {
+          const cleared = pinned.clearAll(owned.revision)
+          if (!cleared) return
+          prompt.reset(sourcePromptScope)
+          break
+        }
+        case "route": {
+          prompt.reset(owned.scope)
+          break
+        }
+      }
+      input.setMode("normal")
+      input.setPopover(null)
+    }
+
+    const restoreInput = (owned: SubmitOwnership) => {
+      // Revision-guarded restore: only push the captured draft back if the user
+      // has not typed new content since submit. For owner-backed cases this means
+      // the owner's current revision still matches the captured revision (the
+      // owner is the source of truth). For route, the prompt store is a UI
+      // mirror with no separate owner, so we always re-push the captured value.
+      switch (owned.kind) {
+        case "portable": {
+          const current = portable.snapshot()
+          if (!current || current.revision !== owned.revision) return
+          prompt.set(current.prompt, input.promptLength(current.prompt), promptScope)
+          prompt.context.replaceAll(current.context.map(({ key: _omit, ...rest }) => rest))
+          break
+        }
+        case "pinned": {
+          const current = pinned.current()
+          if (!current || current.revision !== owned.revision) return
+          prompt.set(current.prompt, input.promptLength(current.prompt), promptScope)
+          prompt.context.replaceAll(current.context.map(({ key: _omit, ...rest }) => rest))
+          break
+        }
+        case "route": {
+          prompt.set(currentPrompt, input.promptLength(currentPrompt), promptScope)
+          restoreCommentItems(commentItems)
+          break
+        }
+      }
       input.setMode(mode)
       input.setPopover(null)
       requestAnimationFrame(() => {
         const editor = input.editor()
         if (!editor) return
         editor.focus()
-        setCursorPosition(editor, input.promptLength(currentPrompt))
+        const cursorPrompt = owned.kind === "route" ? currentPrompt : prompt.current()
+        setCursorPosition(editor, input.promptLength(cursorPrompt))
         input.queueScroll()
       })
     }
 
+    // commentItems is referenced by restoreInput (route case) and by the prompt
+    // path below. Compute it before the queue branch so both can use it.
+    // Note: it is only meaningful for the prompt-submit path (where comment
+    // context items exist); the queue branch ignores it.
+    const commentItems = context.filter((item) => item.type === "file" && !!item.comment?.trim())
+
     if (!creatingNewSession && mode === "normal" && input.shouldQueue?.()) {
+      // Queue path is unreachable for portable/pinned homepage submits because
+      // shouldQueue only fires when !creatingNewSession — homepage submits always
+      // create a new session. SubmitOwnership.kind is always "route" here.
       input.onQueue?.(draft)
       clearContext()
-      clearInput()
+      clearInput(ownership)
       return
     }
 
@@ -509,7 +621,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     input.onSubmit?.()
 
     if (mode === "shell") {
-      clearInput()
+      clearInput(ownership)
       client.session
         .shell({
           sessionID: session.id,
@@ -522,7 +634,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             title: language.t("prompt.toast.shellSendFailed.title"),
             description: errorMessage(err),
           })
-          restoreInput()
+          restoreInput(ownership)
         })
       return
     }
@@ -532,7 +644,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       const commandName = cmdName.slice(1)
       const customCommand = sync.data.command.find((c) => c.name === commandName)
       if (customCommand) {
-        clearInput()
+        clearInput(ownership)
         client.session
           .command({
             sessionID: session.id,
@@ -555,13 +667,12 @@ export function createPromptSubmit(input: PromptSubmitInput) {
               title: language.t("prompt.toast.commandSendFailed.title"),
               description: formatServerError(err, language.t, language.t("common.requestFailed")),
             })
-            restoreInput()
+            restoreInput(ownership)
           })
         return
       }
     }
 
-    const commentItems = context.filter((item) => item.type === "file" && !!item.comment?.trim())
     const messageID = Identifier.ascending("message")
     const submittedPromptLength = input.promptLength(currentPrompt)
     const submittedImageCount = images.length
@@ -576,7 +687,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     removeCommentItems(commentItems)
-    clearInput()
+    clearInput(ownership)
     void emitRendererDiagnostic({
       name: "session.action.submit",
       trace_id: messageID,
@@ -608,8 +719,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
           sync.set("session_status", session.id, { type: "idle" })
         }
         removeOptimisticMessage()
-        restoreCommentItems(commentItems)
-        restoreInput()
+        // restoreInput handles route-case comment items internally; owner-backed
+        // cases re-push context from the snapshot via replaceAll.
+        restoreInput(ownership)
       }
 
       pending.set(session.id, { abort: controller, cleanup })
@@ -667,8 +779,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         description: errorMessage(err),
       })
       removeOptimisticMessage()
-      restoreCommentItems(commentItems)
-      restoreInput()
+      // restoreInput handles route-case comment items internally; owner-backed
+      // cases re-push context from the snapshot via replaceAll.
+      restoreInput(ownership)
     })
   }
 

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -49,6 +49,7 @@ function promptSession() {
       removeComment: () => markDirty(),
       updateComment: () => markDirty(),
       replaceComments: () => markDirty(),
+      replaceAll: () => markDirty(),
     },
     set: (next: Prompt, nextCursor?: number) => {
       prompt = next

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -1,5 +1,6 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { checksum } from "@opencode-ai/util/encode"
+import type { ResolvedMention } from "@/components/prompt-input/mention-metadata"
 import { useParams } from "@solidjs/router"
 import { batch, createMemo, createRoot, getOwner, onCleanup } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
@@ -46,6 +47,8 @@ export type FileContextItem = {
   commentID?: string
   commentOrigin?: "review" | "file"
   preview?: string
+  /** Resolved mention metadata captured at the moment the comment text was committed */
+  resolvedMentions?: ResolvedMention[]
 }
 
 export type ContextItem = FileContextItem

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -176,6 +176,8 @@ type PromptBindingSession = {
     removeComment: (path: string, commentID: string) => void
     updateComment: (path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) => void
     replaceComments: (items: FileContextItem[]) => void
+    /** Atomic full-replace: swaps ALL context items at once. Used by carry hydration. */
+    replaceAll: (items: ContextItem[]) => void
   }
   set: (prompt: Prompt, cursorPosition?: number) => void
   reset: () => void
@@ -205,6 +207,7 @@ export function createPromptBinding(
       updateComment: (path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) =>
         session()?.context.updateComment(path, commentID, next),
       replaceComments: (items: FileContextItem[]) => session()?.context.replaceComments(items),
+      replaceAll: (items: ContextItem[]) => session()?.context.replaceAll(items),
     },
     set: (prompt: Prompt, cursorPosition?: number, target?: Scope) => pick(target)?.set(prompt, cursorPosition),
     reset: (target?: Scope) => pick(target)?.reset(),
@@ -267,6 +270,11 @@ function createPromptSession(dir: string, id: string | undefined) {
           ...current.filter((item) => !isCommentItem(item)),
           ...items.map((item) => ({ ...item, key: contextItemKey(item) })),
         ])
+      },
+      replaceAll(items: ContextItem[]) {
+        // Atomic full-replace used by carry hydration (portable snapshot).
+        // Regenerates keys so snapshot keys do not collide with the target route.
+        setStore("context", "items", items.map((item) => ({ ...item, key: contextItemKey(item) })))
       },
     },
     set: actions.set,

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -278,6 +278,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Include active file",
   "prompt.context.removeActiveFile": "Remove active file from context",
   "prompt.context.removeFile": "Remove file from context",
+  "prompt.context.externalFile": "External",
   "prompt.action.attachFile": "Add files",
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -295,6 +295,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "包含当前文件",
   "prompt.context.removeActiveFile": "从上下文移除活动文件",
   "prompt.context.removeFile": "从上下文移除文件",
+  "prompt.context.externalFile": "外部",
   "prompt.action.attachFile": "附加文件",
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "发送",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -60,6 +60,7 @@ import {
   type LegacyHomepagePromptStore,
 } from "@/components/prompt-input/homepage-migration"
 import { usePortableDraft } from "@/components/prompt-input/portable-draft"
+import { createMigrationStorageIO } from "@/components/prompt-input/homepage-migration-storage"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -1731,29 +1732,7 @@ export default function Layout(props: ParentProps) {
 
     const portable = usePortableDraft()
     const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)
-    const workspaceTarget = Persist.workspace(directory, "prompt")
-
-    // Build real implementations of the injectable deps against Persist APIs.
-    const isDesktop = platform.platform === "desktop" && !!platform.storage
-
-    const readRaw = async (target: { storage?: string; key: string }): Promise<string | null> => {
-      if (isDesktop) {
-        return platform.storage?.(target.storage)?.getItem(target.key) ?? null
-      }
-      const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
-      const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
-      return store.getItem(target.key)
-    }
-
-    const writeRaw = async (target: { storage?: string; key: string }, value: string): Promise<void> => {
-      if (isDesktop) {
-        await platform.storage?.(target.storage)?.setItem(target.key, value)
-        return
-      }
-      const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
-      const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
-      store.setItem(target.key, value)
-    }
+    const { read: readRaw, write: writeRaw } = createMigrationStorageIO(platform)
 
     void runHomepageMigration({
       portable,

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1725,10 +1725,17 @@ export default function Layout(props: ParentProps) {
     makeEventListener(window, deepLinkEvent, handler as EventListener)
   })
 
-  // Run the v7 homepage-draft migration once at app boot (fire-and-forget).
-  onMount(() => {
+  // Run the v7 homepage-draft migration as soon as a directory becomes
+  // available (fire-and-forget). currentDir() can be empty during the initial
+  // autoselect phase, so onMount alone would skip migration for that session.
+  // The migration writes a sentinel internally and is idempotent, so subsequent
+  // effect ticks are no-ops once it has run.
+  let homepageMigrationStarted = false
+  createEffect(() => {
+    if (homepageMigrationStarted) return
     const directory = currentDir()
     if (!directory) return
+    homepageMigrationStarted = true
 
     const portable = usePortableDraft()
     const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -17,7 +17,7 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { useLayout, LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
-import { Persist, persisted, removePersisted } from "@/utils/persist"
+import { Persist, persisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
@@ -1739,7 +1739,7 @@ export default function Layout(props: ParentProps) {
 
     const portable = usePortableDraft()
     const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)
-    const { read: readRaw, write: writeRaw } = createMigrationStorageIO(platform)
+    const { read: readRaw, write: writeRaw, remove: removeRaw } = createMigrationStorageIO(platform)
 
     void runHomepageMigration({
       portable,
@@ -1767,8 +1767,11 @@ export default function Layout(props: ParentProps) {
         }
       },
       clearLegacyHomepage: async (dir) => {
-        const target = Persist.workspace(dir, "prompt")
-        removePersisted(target, platform)
+        // Must await: desktop removeItem is async and a rejection here must
+        // propagate up to homepage-migration's failed-sentinel path. Without
+        // the await, the migration would write status: "complete" even if
+        // the legacy store delete failed.
+        await removeRaw(Persist.workspace(dir, "prompt"))
       },
     }).catch((err) => {
       // Log diagnostic; migration retries automatically on next boot.

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -53,6 +53,7 @@ import { playSoundById } from "@/utils/sound"
 import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
+import { usePinnedDraft } from "@/components/prompt-input/pinned-draft"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -1677,6 +1678,9 @@ export default function Layout(props: ParentProps) {
     if (shouldNavigate) return navigateToProject(directory)
   }
 
+  // Singleton; same instance returned every call.
+  const pinned = usePinnedDraft()
+
   const handleDeepLinks = (urls: string[]) => {
     if (!server.isLocal()) return
 
@@ -1688,9 +1692,16 @@ export default function Layout(props: ParentProps) {
       openProject(link.directory, false)
       const slug = base64Encode(link.directory)
       if (link.prompt) {
+        // Pin the prompt to this directory so it is NOT carried portably to
+        // other homepages. The pinned slot is consumed by editor-input.ts when
+        // the user lands on the /repo homepage.
+        pinned.adopt({ directory: link.directory, prompt: link.prompt })
+        // Also keep the session handoff for the new-session composer region
+        // that shows the prefill text before the session is created (T7 will
+        // decide whether to clear it on submit).
         setSessionHandoff(slug, { prompt: link.prompt })
       }
-      const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
+      const href = `/${slug}/session`
       navigate(href)
     }
   }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -17,7 +17,7 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { useLayout, LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
-import { persisted } from "@/utils/persist"
+import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
@@ -54,6 +54,12 @@ import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { usePinnedDraft } from "@/components/prompt-input/pinned-draft"
+import {
+  runHomepageMigration,
+  HOMEPAGE_MIGRATION_SENTINEL_KEY,
+  type LegacyHomepagePromptStore,
+} from "@/components/prompt-input/homepage-migration"
+import { usePortableDraft } from "@/components/prompt-input/portable-draft"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -1716,6 +1722,72 @@ export default function Layout(props: ParentProps) {
 
     handleDeepLinks(drainPendingDeepLinks(window))
     makeEventListener(window, deepLinkEvent, handler as EventListener)
+  })
+
+  // Run the v7 homepage-draft migration once at app boot (fire-and-forget).
+  onMount(() => {
+    const directory = currentDir()
+    if (!directory) return
+
+    const portable = usePortableDraft()
+    const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)
+    const workspaceTarget = Persist.workspace(directory, "prompt")
+
+    // Build real implementations of the injectable deps against Persist APIs.
+    const isDesktop = platform.platform === "desktop" && !!platform.storage
+
+    const readRaw = async (target: { storage?: string; key: string }): Promise<string | null> => {
+      if (isDesktop) {
+        return platform.storage?.(target.storage)?.getItem(target.key) ?? null
+      }
+      const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
+      const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
+      return store.getItem(target.key)
+    }
+
+    const writeRaw = async (target: { storage?: string; key: string }, value: string): Promise<void> => {
+      if (isDesktop) {
+        await platform.storage?.(target.storage)?.setItem(target.key, value)
+        return
+      }
+      const { localStorageWithPrefix, localStorageDirect } = await import("@/utils/persist-local-storage")
+      const store = target.storage ? localStorageWithPrefix(target.storage) : localStorageDirect()
+      store.setItem(target.key, value)
+    }
+
+    void runHomepageMigration({
+      portable,
+      currentDirectory: directory,
+      readSentinel: async () => {
+        const raw = await readRaw(sentinelTarget)
+        if (!raw) return null
+        try {
+          return JSON.parse(raw) as import("@/components/prompt-input/homepage-migration").MigrationSentinel
+        } catch {
+          return null
+        }
+      },
+      writeSentinel: async (sentinel) => {
+        await writeRaw(sentinelTarget, JSON.stringify(sentinel))
+      },
+      loadLegacyHomepage: async (dir) => {
+        const target = Persist.workspace(dir, "prompt")
+        const raw = await readRaw(target)
+        if (!raw) return null
+        try {
+          return JSON.parse(raw) as LegacyHomepagePromptStore
+        } catch {
+          return null
+        }
+      },
+      clearLegacyHomepage: async (dir) => {
+        const target = Persist.workspace(dir, "prompt")
+        removePersisted(target, platform)
+      },
+    }).catch((err) => {
+      // Log diagnostic; migration retries automatically on next boot.
+      console.warn("[homepage-migration] unexpected failure", err)
+    })
   })
 
   async function renameProject(project: LocalProject, next: string) {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -235,6 +235,7 @@ export default function Page() {
   const commentContext = createSessionCommentContext({
     attachmentLabel: () => language.t("common.attachment"),
     getFileContent: (path) => file.get(path)?.content?.content,
+    sourceFilesystemDirectory: () => sdk.directory,
     comments,
     promptContext: prompt.context,
   })

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -4,6 +4,8 @@ import { Dynamic } from "solid-js/web"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import type { FileSearchHandle } from "@opencode-ai/ui/file"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
+import { useSDK } from "@/context/sdk"
+import { captureCommentMentions } from "@/components/prompt-input/mention-metadata"
 import { cloneSelectedLineRange, previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
 import { createLineCommentController } from "@opencode-ai/ui/line-comment-annotations"
 import { sampledChecksum } from "@opencode-ai/util/encode"
@@ -176,6 +178,7 @@ export function FileTabContent(props: { tab: string }) {
   const comments = useComments()
   const language = useLanguage()
   const prompt = usePrompt()
+  const sdk = useSDK()
   const fileComponent = useFileComponent()
   const { layoutRouteKey, tabs, view } = useSessionLayout()
   const activeFileTab = createSessionTabs({
@@ -239,6 +242,10 @@ export function FileTabContent(props: { tab: string }) {
       selection: input.selection,
       comment: input.comment,
     })
+    const resolvedMentions = captureCommentMentions({
+      comment: input.comment,
+      sourceFilesystemDirectory: sdk.directory,
+    })
     prompt.context.add({
       type: "file",
       path: input.file,
@@ -247,6 +254,7 @@ export function FileTabContent(props: { tab: string }) {
       commentID: saved.id,
       commentOrigin: input.origin,
       preview,
+      resolvedMentions,
     })
   }
 
@@ -258,8 +266,16 @@ export function FileTabContent(props: { tab: string }) {
   }) => {
     comments.update(input.file, input.id, input.comment)
     const preview = input.file === path() ? buildPreview(input.file, selectionFromLines(input.selection)) : undefined
+    // Always recapture: an updated body may have added, removed, or moved
+    // @mentions, so stale resolvedMentions from the previous text must be
+    // dropped (an empty array clears them).
+    const resolvedMentions = captureCommentMentions({
+      comment: input.comment,
+      sourceFilesystemDirectory: sdk.directory,
+    })
     prompt.context.updateComment(input.file, input.id, {
       comment: input.comment,
+      resolvedMentions,
       ...(preview ? { preview } : {}),
     })
   }

--- a/packages/app/src/pages/session/use-session-comment-context.test.ts
+++ b/packages/app/src/pages/session/use-session-comment-context.test.ts
@@ -7,6 +7,7 @@ describe("session comment context", () => {
     const promptAdds: unknown[] = []
     const controller = createSessionCommentContext({
       attachmentLabel: () => "Attachment",
+      sourceFilesystemDirectory: () => "/repo",
       getFileContent: () => "one\ntwo\nthree\n",
       comments: {
         add(input) {
@@ -48,6 +49,7 @@ describe("session comment context", () => {
     const removed: unknown[] = []
     const controller = createSessionCommentContext({
       attachmentLabel: () => "Attachment",
+      sourceFilesystemDirectory: () => "/repo",
       getFileContent: () => undefined,
       comments: {
         add() {
@@ -76,11 +78,81 @@ describe("session comment context", () => {
     controller.remove({ id: "c1", file: "src/a.ts" })
 
     expect(updated).toContainEqual({ file: "src/a.ts", id: "c1", comment: "new" })
-    expect(updated).toContainEqual({ file: "src/a.ts", id: "c1", patch: { comment: "new", preview: "one" } })
-    expect(updated).toContainEqual({ file: "src/b.ts", id: "c2", patch: { comment: "blank", preview: "" } })
+    expect(updated).toContainEqual({
+      file: "src/a.ts",
+      id: "c1",
+      patch: { comment: "new", preview: "one", resolvedMentions: [] },
+    })
+    expect(updated).toContainEqual({
+      file: "src/b.ts",
+      id: "c2",
+      patch: { comment: "blank", preview: "", resolvedMentions: [] },
+    })
     expect(removed).toEqual([
       { file: "src/a.ts", id: "c1" },
       { file: "src/a.ts", id: "c1" },
     ])
+  })
+
+  test("add captures @mention metadata using the source workspace directory", () => {
+    const promptAdds: Array<{ resolvedMentions?: Array<{ resolvedPath: string }> }> = []
+    const controller = createSessionCommentContext({
+      attachmentLabel: () => "Attachment",
+      sourceFilesystemDirectory: () => "/repo-A",
+      getFileContent: () => "x",
+      comments: { add: () => ({ id: "c1" }), update() {}, remove() {} },
+      promptContext: {
+        add(entry) {
+          promptAdds.push(entry)
+        },
+        updateComment() {},
+        removeComment() {},
+      },
+    })
+
+    controller.add({
+      file: "src/main.ts",
+      selection: { start: 1, end: 1 },
+      comment: "see @src/shared.ts",
+    })
+
+    expect(promptAdds[0]?.resolvedMentions?.length).toBe(1)
+    expect(promptAdds[0]?.resolvedMentions?.[0]?.resolvedPath).toBe("/repo-A/src/shared.ts")
+  })
+
+  test("update recaptures @mention metadata so stale references are dropped", () => {
+    const patches: Array<{ resolvedMentions?: unknown[] }> = []
+    const controller = createSessionCommentContext({
+      attachmentLabel: () => "Attachment",
+      sourceFilesystemDirectory: () => "/repo-A",
+      getFileContent: () => "x",
+      comments: { add: () => ({ id: "c1" }), update() {}, remove() {} },
+      promptContext: {
+        add() {},
+        updateComment(_file, _id, patch) {
+          patches.push(patch as { resolvedMentions?: unknown[] })
+        },
+        removeComment() {},
+      },
+    })
+
+    // First update keeps the mention.
+    controller.update({
+      id: "c1",
+      file: "src/main.ts",
+      selection: { start: 1, end: 1 },
+      comment: "see @src/shared.ts",
+    })
+    expect(patches[0]?.resolvedMentions?.length).toBe(1)
+
+    // Second update removes the mention; resolvedMentions must be an empty
+    // array so the old metadata is overwritten, not preserved.
+    controller.update({
+      id: "c1",
+      file: "src/main.ts",
+      selection: { start: 1, end: 1 },
+      comment: "no mention any more",
+    })
+    expect(patches[1]?.resolvedMentions).toEqual([])
   })
 })

--- a/packages/app/src/pages/session/use-session-comment-context.ts
+++ b/packages/app/src/pages/session/use-session-comment-context.ts
@@ -1,9 +1,16 @@
 import { selectionFromLines, type FileSelection, type SelectedLineRange } from "@/context/file/types"
 import { previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
+import { captureCommentMentions, type ResolvedMention } from "@/components/prompt-input/mention-metadata"
 
 export function createSessionCommentContext(input: {
   attachmentLabel: () => string
   getFileContent: (path: string) => string | undefined
+  /**
+   * Filesystem directory the comment is being authored from. Required so that
+   * @mention paths captured at comment-create time resolve against the source
+   * workspace and survive a homepage move to a different workspace.
+   */
+  sourceFilesystemDirectory: () => string
   comments: {
     add: (comment: { file: string; selection: SelectedLineRange; comment: string }) => { id: string }
     update: (file: string, id: string, comment: string) => void
@@ -18,8 +25,13 @@ export function createSessionCommentContext(input: {
       commentID: string
       commentOrigin?: "review" | "file"
       preview?: string
+      resolvedMentions?: ResolvedMention[]
     }) => void
-    updateComment: (file: string, id: string, patch: { comment: string; preview?: string }) => void
+    updateComment: (
+      file: string,
+      id: string,
+      patch: { comment: string; preview?: string; resolvedMentions?: ResolvedMention[] },
+    ) => void
     removeComment: (file: string, id: string) => void
   }
 }) {
@@ -44,6 +56,10 @@ export function createSessionCommentContext(input: {
         selection: comment.selection,
         comment: comment.comment,
       })
+      const resolvedMentions = captureCommentMentions({
+        comment: comment.comment,
+        sourceFilesystemDirectory: input.sourceFilesystemDirectory(),
+      })
       input.promptContext.add({
         type: "file",
         path: comment.file,
@@ -52,12 +68,18 @@ export function createSessionCommentContext(input: {
         commentID: saved.id,
         commentOrigin: comment.origin,
         preview,
+        resolvedMentions,
       })
     },
     update(comment: { id: string; file: string; selection: SelectedLineRange; comment: string; preview?: string }) {
       input.comments.update(comment.file, comment.id, comment.comment)
+      const resolvedMentions = captureCommentMentions({
+        comment: comment.comment,
+        sourceFilesystemDirectory: input.sourceFilesystemDirectory(),
+      })
       input.promptContext.updateComment(comment.file, comment.id, {
         comment: comment.comment,
+        resolvedMentions,
         ...(comment.preview !== undefined ? { preview: comment.preview } : {}),
       })
     },


### PR DESCRIPTION
## Summary

Implements v7 of the prompt-draft + history isolation design for #750. Adds a route-aware portable homepage runtime owner that follows the user across workspace homepages without ever entering concrete sessions, a deep-link pinned draft scope that coexists with portable while staying bound to its target directory, directory-scoped prompt history with a stale-rAF guard, resolved comment @mention metadata captured at create-time so moved comments don't re-resolve into a different workspace, a revision-guarded two-phase submit lifecycle (synchronous UI reset; owner teardown only on async success; restore reads from the still-intact owner on failure), a fire-and-forget homepage-draft migration sentinel that adopts the current opened directory's pre-v7 draft into the portable owner, external-absolute-chip click no-op, and a shared path-canonicalization helper.

## Why

#750 reported that homepage drafts, file chips, comments, and ArrowUp history were silently crossing workspace and session boundaries. Concrete examples: a draft typed on workspace A's homepage appeared inside workspace B's session, an `@src/a.ts` mention sent from workspace B's homepage resolved to B's same-named file instead of A's, and pressing ArrowUp in workspace B surfaced entries typed in workspace A. The root causes were a broad cross-directory carry-over module, global prompt-history persistence, send-time path resolution against the submit `sessionDirectory`, and unguarded async clear/restore paths that overwrote newer user input on delayed callbacks.

## Related Issue

Closes #750.

PR2 follow-up #749 (typed `@src/app.ts` unique-match auto-conversion into file chips) is explicitly out of scope; this PR preserves the current behavior that only suggestion-list selections become file pills.

## Human Review Status

Pending

## Review Focus

The state-machine pieces are the highest-risk surface and benefit most from careful review: `submit.ts` two-phase clear (`clearInput` resets UI synchronously; `confirmOwnerCleared` tears down the owner snapshot only on async success under the captured revision; `restoreInput` reads from the still-intact owner on failure), the `editor-input.ts` carry-hydration effect (pinned beats portable; `isHomepageDraftEmpty` considers prompt + context + images so chips and image attachments are never overwritten; `shouldReset` also clears the matching owner so user-initiated clears don't leave a stale snapshot), the `portable-draft.ts` + `pinned-draft.ts` owner singletons, and the `homepage-migration.ts` sentinel's failure semantics (fire-and-forget, sentinel only marked complete after the full adopt + remove cycle succeeds).

Design version implemented: v7. History capture happens via `addToHistory(currentPrompt, mode)` at submit start (before any clear), so portable owner clears never race history capture. Queue path is unreachable for portable/pinned (the existing `shouldQueue && !creatingNewSession` gate is route-only); ownership.kind is always `route` there. Multi-window migration uses a single-renderer assumption with soft idempotence — every step (`portable.record`, `removePersisted`, sentinel write) is independently idempotent. Resolved-mention schema: `displayText` + `resolvedPath` + `fingerprint` (checksum of 64-char window around the mention midpoint) + `start`/`end`; matching prefers range-equality and falls back to occurrence order; free-text mentions without metadata are dropped rather than re-resolved against the submit directory.

## Risk Notes

PR1 deliberately does NOT enumerate other workspaces' pre-v7 homepage drafts for migration; only the currently opened directory's draft is adopted into the portable owner. Other workspaces' drafts stay in their per-route stores and self-heal through portable mirroring on next edit. Documented as a scope simplification — full enumeration is a follow-up.

Portable owner is runtime-only and does not survive app restart by design. Concrete session drafts (route-scoped Persist) are unchanged and continue to persist.

Visible UI change is small: the external-absolute file chip now renders with `aria-disabled`, dimmed opacity, `cursor-not-allowed`, an "External" tooltip prefix, and a click that no-ops; the trash button still works. No snap target was added (no nearby snap fixture for the chip surface) and no manual screenshot was captured. The conditional UI checklist item is left unticked; reviewer should walk a homepage with a portable-carried chip in `bun run dev:desktop` to confirm the dimmed-disabled state.

Owner-level integration is heavily unit-tested but the full route-walk (homepage A → homepage B → session → back to homepage A; deep-link arrival with existing portable hidden; submit failure on portable preserves the draft) is left to CI E2E and manual verification before merge.

## How To Verify

```text
typecheck (turbo, whole repo):      8/8 tasks ok
packages/app bun test:              1299 pass / 0 fail / 3088 expects across 183 files
packages/opencode bun test:         2767 pass / 9 skip / 1 todo / 0 fail / 11994 expects across 217 files
shell-frame-contract.test.ts:       8 pass / 0 fail (migration storage extracted to non-shell module)
new unit suites:                    path-canonical (28), mention-metadata (15), portable-draft (17),
                                    pinned-draft (16), homepage-migration (12), submit-ownership (11),
                                    draft-isolation.integration (7), context-items (10), draft-carryover (4 v7)
i18n parity test:                   1 pass / 0 fail (en + zh-Hans key parity preserved)
E2E (playwright):                   not run locally; left to CI
dev:desktop walk:                   not run (autonomous session) — recommended before merge
```

## Screenshots or Recordings

Not captured in this autonomous run. Reviewer should verify the external-absolute chip's disabled-dimmed appearance in `bun run dev:desktop`: drag-create a chip whose path points outside `sdk.directory`, confirm hover cursor is `not-allowed`, click is a no-op, tooltip says "External · <path>", and the trash button still removes it.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for file mentions in comments via `@filename` syntax for context attachment
  * Introduced portable draft system for prompt persistence across workspace changes
  * Added pinned draft support for deep-linked sessions with embedded prompts
  * Implemented automatic migration of legacy homepage drafts

* **Improvements**
  * External files now display as disabled in context items with visual distinction
  * Prompt history is now scoped per workspace instead of global
  * Enhanced draft ownership detection and lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->