### PR TITLE
fix(app): tooltip content inherits color, fixing dark mode

### DIFF
--- a/packages/app/e2e/snap/worktree-tooltip.snap.ts
+++ b/packages/app/e2e/snap/worktree-tooltip.snap.ts
@@ -1,0 +1,85 @@
+import { test } from "../fixtures"
+import { applyDarkModeForTests } from "../utils"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 720, height: 360 }, deviceScaleFactor: 2 })
+
+// The badge tooltip only renders inside a session that's already bound to a
+// worktree. Standing up that backend state for a static color check costs more
+// than the fix it guards. Instead we navigate to the app root so the global
+// CSS (tooltip background/color + text utilities) loads, then inject the same
+// DOM the badge produces and snap it. The check is faithful because tooltip
+// surface color, text color, and the per-row classes are all global tokens —
+// no Solid component state involved.
+
+const TOOLTIP_HTML = `
+  <div style="display:flex;align-items:center;justify-content:center;min-height:300px;background:var(--bg-base);">
+    <div
+      data-component="tooltip"
+      data-expanded
+      style="position:static;opacity:1;animation:none;max-width:420px;"
+    >
+      <div data-component="pawwork-worktree-tooltip" class="grid min-w-0 gap-1.5 py-1 text-left">
+        <div class="grid min-w-0 grid-cols-[64px_minmax(0,1fr)] items-start gap-3">
+          <span class="text-caption">Worktree</span>
+          <span class="text-h3 min-w-0 break-all leading-[1.45]">fix-tooltip-dark-mode</span>
+        </div>
+        <div class="grid min-w-0 grid-cols-[64px_minmax(0,1fr)] items-start gap-3">
+          <span class="text-caption">Branch</span>
+          <span class="text-body min-w-0 break-all leading-[1.45]">claude/fix-tooltip-dark-mode</span>
+        </div>
+        <div class="grid min-w-0 grid-cols-[64px_minmax(0,1fr)] items-start gap-3">
+          <span class="text-caption">Location</span>
+          <span class="text-body min-w-0 break-all leading-[1.45]">/Users/yuhan/workspace/dev/pawwork/.claude/worktrees/fix-tooltip-dark-mode</span>
+        </div>
+      </div>
+    </div>
+  </div>
+`
+
+async function mountTooltip(page: import("@playwright/test").Page): Promise<void> {
+  // Replace the app shell while keeping the head (stylesheets, theme <style id="oc-theme">).
+  await page.evaluate((html) => {
+    document.body.innerHTML = html
+  }, TOOLTIP_HTML)
+  await page.locator('[data-component="tooltip"][data-expanded]').waitFor({ state: "visible", timeout: 10_000 })
+}
+
+async function waitForThemeBoot(page: import("@playwright/test").Page): Promise<void> {
+  // Theme tokens are injected at runtime by applyThemeCss(); waiting for one
+  // of them confirms the CSS pipeline finished, not just the bundle.
+  await page.waitForFunction(
+    () => {
+      const value = getComputedStyle(document.documentElement).getPropertyValue("--bg-base").trim()
+      return value.length > 0
+    },
+    null,
+    { timeout: 30_000 },
+  )
+}
+
+test("worktree-tooltip", async ({ page }) => {
+  test.setTimeout(120_000)
+
+  // Light mode first — direct navigation is fine, we don't depend on app state.
+  await page.goto("/")
+  await waitForThemeBoot(page)
+  await mountTooltip(page)
+  const lightShot: Shot = {
+    name: "light",
+    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+  }
+
+  // Dark mode — use the same storage + reload path the real app uses.
+  await applyDarkModeForTests(page)
+  await waitForThemeBoot(page)
+  await mountTooltip(page)
+  const darkShot: Shot = {
+    name: "dark",
+    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+  }
+
+  const out = snapOutputPath("worktree-tooltip")
+  await composeGrid([lightShot, darkShot], out)
+  process.stdout.write(`\n[snap] worktree-tooltip grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/worktree-tooltip.snap.ts
+++ b/packages/app/e2e/snap/worktree-tooltip.snap.ts
@@ -30,7 +30,7 @@ const TOOLTIP_HTML = `
         </div>
         <div class="grid min-w-0 grid-cols-[64px_minmax(0,1fr)] items-start gap-3">
           <span class="text-caption">Location</span>
-          <span class="text-body min-w-0 break-all leading-[1.45]">/Users/yuhan/workspace/dev/pawwork/.claude/worktrees/fix-tooltip-dark-mode</span>
+          <span class="text-body min-w-0 break-all leading-[1.45]">~/pawwork/.claude/worktrees/fix-tooltip-dark-mode</span>
         </div>
       </div>
     </div>

--- a/packages/app/src/components/model-picker-hotfix.test.ts
+++ b/packages/app/src/components/model-picker-hotfix.test.ts
@@ -10,6 +10,15 @@ describe("model picker visual regression guard", () => {
     expect(source).not.toContain("text-fg-on-brand")
   })
 
+  test.each([
+    "packages/app/src/pages/layout/pawwork-worktree-badge.tsx",
+    "packages/app/src/components/prompt-input/context-items.tsx",
+    "packages/app/src/components/server/server-row.tsx",
+  ])("tooltip content inherits the tooltip text color: %s", async (path) => {
+    const source = await read(path)
+    expect(source).not.toContain("fg-on-brand")
+  })
+
   test("model list active row uses a visible hover surface (picker contract)", async () => {
     const list = await read("packages/ui/src/components/list.css")
     const listSrc = await read("packages/ui/src/components/list.tsx")

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -40,18 +40,18 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 value={
                   <span class="flex flex-col gap-0.5 max-w-[300px]">
                     <Show when={external}>
-                      <span class="text-fg-on-brand opacity-80 text-xs">
+                      <span class="opacity-80 text-xs">
                         {props.t("prompt.context.externalFile")} · {item.path}
                       </span>
                     </Show>
                     <Show when={!external}>
                       <span class="flex">
-                        <span class="text-fg-on-brand truncate-start [unicode-bidi:plaintext] min-w-0">{directory}</span>
+                        <span class="truncate-start [unicode-bidi:plaintext] min-w-0">{directory}</span>
                         <span class="shrink-0">{filename}</span>
                       </span>
                     </Show>
                     <Show when={item.comment}>
-                      {(comment) => <span class="text-fg-on-brand opacity-80 break-words">{comment()}</span>}
+                      {(comment) => <span class="opacity-80 break-words">{comment()}</span>}
                     </Show>
                   </span>
                 }

--- a/packages/app/src/components/server/server-row.tsx
+++ b/packages/app/src/components/server/server-row.tsx
@@ -55,7 +55,7 @@ export function ServerRow(props: ServerRowProps) {
     <span class="flex items-center gap-2">
       <span>{serverName(props.conn, true)}</span>
       <Show when={props.status?.version}>
-        <span class="text-fg-on-brand">v{props.status?.version}</span>
+        <span class="opacity-80">v{props.status?.version}</span>
       </Show>
     </span>
   )

--- a/packages/app/src/pages/layout/pawwork-worktree-badge.tsx
+++ b/packages/app/src/pages/layout/pawwork-worktree-badge.tsx
@@ -5,11 +5,11 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 function WorktreeTooltipRow(props: { label: string; value?: string; emphasis?: boolean }) {
   return (
     <div class="grid min-w-0 grid-cols-[64px_minmax(0,1fr)] items-start gap-3">
-      <span class="text-caption [color:var(--fg-on-brand)]">{props.label}</span>
+      <span class="text-caption">{props.label}</span>
       <span
         classList={{
-          "text-h3 [color:var(--fg-on-brand)]": props.emphasis,
-          "text-body [color:var(--fg-on-brand)]": !props.emphasis,
+          "text-h3": props.emphasis,
+          "text-body": !props.emphasis,
         }}
         class="min-w-0 break-all leading-[1.45]"
       >


### PR DESCRIPTION
## Summary

Drop the `text-fg-on-brand` (white) overrides inside three tooltips so their text inherits the tooltip's default `--bg-cream`, which inverts correctly across light and dark modes. Extend the existing tooltip color-inheritance contract test to lock the affected files against regression and add a `worktree-tooltip` snap target that covers both color schemes.

## Why

The `Tooltip` component paints its surface with `--fg-strong` (dark in light mode, light cream in dark mode) and its text with `--bg-cream` (the inverse). Three callsites — the worktree badge in the session header, the prompt input context chip, and the server row — overrode the text color to `--fg-on-brand`, a token that is `#ffffff` in both modes and is intended for text on the brand-orange surface. In dark mode the tooltip surface became light cream while the text stayed white, which made the content unreadable. The same shape was already fixed once in `model-tooltip.tsx` and the existing `model-picker-hotfix.test.ts` was added specifically as a regression guard for it.

## Related Issue

No issue — direct user-reported visual bug in dark mode.

## Human Review Status

Pending

## Review Focus

- The token swap is the entire fix; confirm none of the three callsites actually wanted white text (they did not — none of them sits on a brand-orange surface).
- The contract test now uses `test.each` to lock three additional files against `fg-on-brand`. This is a substring check, same shape as the existing model-tooltip guard.
- The new snap target injects a static DOM after the app's global CSS loads instead of standing up a session with `executionContext.activeWorktree`. The check stays faithful because the tooltip surface/text colors and the row text utilities are global tokens, not Solid component state.

## Risk Notes

- Pure CSS-token swap on text color. No layout, no logic, no public API. The other two cleaned-up tooltips (context chip, server row) had the same root cause and would have failed the same way in dark mode; bundling them avoids a follow-up PR for an identical class of bug.

## How To Verify

```text
bun --cwd packages/app test src/pages/layout/pawwork-worktree-badge.test.tsx src/components/model-picker-hotfix.test.ts
  → 9 pass / 0 fail (worktree badge + contract guard, including the three new locked files)

bun --cwd packages/app run snap worktree-tooltip
  → 1 passed; grid written to docs/design/preview/screenshots/worktree-tooltip.png
  → light cell: dark surface + cream text (readable)
  → dark cell:  cream surface + dark text (readable; previously cream surface + white text → unreadable)
```

Broader checks (lint, typecheck, full app suite) left to PR CI.

## Screenshots or Recordings

Snap output at `docs/design/preview/screenshots/worktree-tooltip.png` (local-only path; regenerable with `bun --cwd packages/app run snap worktree-tooltip`). Two-cell grid: `light` and `dark`. The bug was that the dark cell rendered white text on a cream surface; after the fix the dark cell renders dark text on a cream surface.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
