### PR TITLE
fix(app): stabilize sidebar session row identity

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -680,7 +680,6 @@ export default function Layout(props: ParentProps) {
       })),
       pinnedIDs: store.pawworkPinnedSessions,
       sortMode: store.pawworkSortMode,
-      currentSessionID: params.id,
     }),
   )
 

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -19,6 +19,7 @@ import {
   openProjectRoute,
   openSessionRoute,
   projectSessionRouteTarget,
+  pawworkSessionRowKey,
   sortedRootSessions,
   startupAutoselectDirectory,
   workspaceKey,
@@ -143,6 +144,17 @@ describe("layout workspace helpers", () => {
     expect(workspaceKey("C:\\")).toBe("C:/")
     expect(workspaceKey("C://")).toBe("C:/")
     expect(workspaceKey("C:///")).toBe("C:/")
+  })
+
+  test("builds stable session row keys from normalized workspace paths", () => {
+    expect(pawworkSessionRowKey({ directory: "/tmp/demo///", id: "ses_1" })).toBe("/tmp/demo\0ses_1")
+    expect(pawworkSessionRowKey({ directory: "C:\\tmp\\demo\\\\", id: "ses_1" })).toBe("C:/tmp/demo\0ses_1")
+  })
+
+  test("keeps identical session ids distinct across workspaces", () => {
+    expect(pawworkSessionRowKey({ directory: "/tmp/a", id: "same" })).not.toBe(
+      pawworkSessionRowKey({ directory: "/tmp/b", id: "same" }),
+    )
   })
 
   test("keeps local first while preserving known order", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -16,6 +16,9 @@ export const workspaceKey = (directory: string) => {
   return value.replace(/\/+$/, "")
 }
 
+export const pawworkSessionRowKey = (input: { directory: string; id: string }) =>
+  `${workspaceKey(input.directory)}\0${input.id}`
+
 const isRootVisibleSession = (session: Session, directory: string) =>
   workspaceKey(session.directory) === workspaceKey(directory) && !session.parentID && !session.time?.archived
 

--- a/packages/app/src/pages/layout/pawwork-session-nav.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-nav.test.ts
@@ -40,7 +40,6 @@ describe("buildPawworkSessionSections", () => {
       sessions,
       pinnedIDs: ["beta"],
       sortMode: "time",
-      currentSessionID: "alpha",
     })
 
     expect(result.pinned.map((item) => item.id)).toEqual(["beta"])
@@ -52,7 +51,6 @@ describe("buildPawworkSessionSections", () => {
       sessions,
       pinnedIDs: [],
       sortMode: "project",
-      currentSessionID: "alpha",
     })
 
     expect(result.groups.map((group) => group.label)).toEqual(["pawwork", "research"])

--- a/packages/app/src/pages/layout/pawwork-session-nav.ts
+++ b/packages/app/src/pages/layout/pawwork-session-nav.ts
@@ -19,7 +19,6 @@ export function buildPawworkSessionSections(input: {
   sessions: PawworkSessionItem[]
   pinnedIDs: string[]
   sortMode: PawworkSortMode
-  currentSessionID?: string
 }) {
   const pinnedSet = new Set(input.pinnedIDs)
   const pinned = input.pinnedIDs

--- a/packages/app/src/pages/layout/pawwork-sidebar-identity.test.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar-identity.test.tsx
@@ -1,0 +1,116 @@
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
+
+const browserCheck = String.raw`
+import { createMemo, createRenderEffect, createSignal, For } from "solid-js"
+import { createComponent, render } from "solid-js/web"
+import { buildPawworkSessionSections } from "./src/pages/layout/pawwork-session-nav.ts"
+import { buildPawworkSidebarCollections } from "./src/pages/layout/pawwork-sidebar-identity.ts"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const session = (input) => ({
+  slug: input.id,
+  projectKey: input.projectKey,
+  projectLabel: input.projectLabel,
+  created: input.created,
+  session: {
+    id: input.id,
+    title: input.title,
+    directory: input.directory,
+    version: "v2",
+    parentID: undefined,
+    messageCount: 0,
+    permissions: { session: {}, share: {} },
+    time: { created: input.created, updated: input.created, archived: undefined },
+  },
+})
+
+const makeSections = (sessions, sortMode) => buildPawworkSessionSections({
+  sessions: sessions.map((item) => ({
+    id: item.session.id,
+    title: item.session.title ?? "",
+    directory: item.session.directory,
+    projectKey: item.projectKey,
+    projectLabel: item.projectLabel,
+    created: item.created,
+  })),
+  pinnedIDs: [],
+  sortMode,
+})
+
+{
+  const root = document.createElement("div")
+  document.body.append(root)
+  const [rows, setRows] = createSignal([
+    session({ id: "alpha", title: "Alpha", directory: "/repo", projectKey: "pawwork", projectLabel: "PawWork", created: 300 }),
+    session({ id: "beta", title: "Beta", directory: "/repo", projectKey: "pawwork", projectLabel: "PawWork", created: 200 }),
+    session({ id: "gamma", title: "Gamma", directory: "/other", projectKey: "other", projectLabel: "Other", created: 100 }),
+  ])
+  const sections = createMemo(() => makeSections(rows(), "time"))
+  const model = createMemo(() => buildPawworkSidebarCollections({ sessions: rows(), sections: sections() }))
+
+  const dispose = render(() => createComponent(For, {
+    get each() { return model().recentRowKeys },
+    children: (rowKey) => {
+        const row = createMemo(() => model().rowByKey.get(rowKey))
+        const el = document.createElement("div")
+        el.setAttribute("data-session-id", row()?.session.id ?? "")
+        createRenderEffect(() => {
+          el.textContent = row()?.session.title ?? ""
+        })
+        return el
+    },
+  }), root)
+
+  const firstAlpha = root.querySelector('[data-session-id="alpha"]')
+  setRows((current) => current.map((item) => item.session.id === "alpha" ? { ...item, session: { ...item.session, title: "Alpha renamed" } } : item))
+  const secondAlpha = root.querySelector('[data-session-id="alpha"]')
+
+  assert(firstAlpha === secondAlpha, "time sort should keep unchanged row DOM nodes")
+  assert(secondAlpha?.textContent === "Alpha renamed", "row data should update under stable keys")
+  dispose()
+  root.remove()
+}
+
+{
+  const root = document.createElement("div")
+  document.body.append(root)
+  const [rows, setRows] = createSignal([
+    session({ id: "alpha", title: "Alpha", directory: "/repo", projectKey: "pawwork", projectLabel: "PawWork", created: 300 }),
+    session({ id: "beta", title: "Beta", directory: "/repo", projectKey: "pawwork", projectLabel: "PawWork", created: 200 }),
+    session({ id: "gamma", title: "Gamma", directory: "/other", projectKey: "other", projectLabel: "Other", created: 100 }),
+  ])
+  const sections = createMemo(() => makeSections(rows(), "project"))
+  const model = createMemo(() => buildPawworkSidebarCollections({ sessions: rows(), sections: sections() }))
+
+  const dispose = render(() => createComponent(For, {
+    get each() { return model().groupKeys },
+    children: (groupKey) => {
+        const group = createMemo(() => model().groupByKey.get(groupKey))
+        const el = document.createElement("section")
+        el.setAttribute("data-group-key", groupKey)
+        createRenderEffect(() => {
+          el.textContent = group()?.label ?? ""
+        })
+        return el
+    },
+  }), root)
+
+  const firstGroup = root.querySelector('[data-group-key="pawwork"]')
+  setRows((current) => current.map((item) => item.session.id === "alpha" ? { ...item, session: { ...item.session, title: "Alpha renamed" } } : item))
+  const secondGroup = root.querySelector('[data-group-key="pawwork"]')
+
+  assert(firstGroup === secondGroup, "project sort should keep unchanged group DOM nodes")
+  dispose()
+  root.remove()
+}
+`
+
+describe("pawwork sidebar identity", () => {
+  test("keeps row and group DOM nodes stable while row data updates", () => {
+    runBrowserCheck(browserCheck)
+  })
+})

--- a/packages/app/src/pages/layout/pawwork-sidebar-identity.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-identity.ts
@@ -16,18 +16,24 @@ export function buildPawworkSidebarCollections(input: {
   const rowByKey = new Map(input.sessions.map((item) => [rowKeyFor(item.session), item] as const))
   const pinnedRowKeys = input.sections.pinned.map(rowKeyFor).filter((key) => rowByKey.has(key))
   const recentRowKeys = input.sections.recent.map(rowKeyFor).filter((key) => rowByKey.has(key))
-  const groups = input.sections.groups.map((group) => ({
-    key: group.key,
-    label: group.label,
-    rowKeys: group.items.map(rowKeyFor).filter((key) => rowByKey.has(key)),
-  }))
-  const groupByKey = new Map(groups.map((group) => [group.key, group] as const))
+  const groupByKey = new Map<string, PawworkSidebarGroupCollection>()
+  const groupKeys: string[] = []
+
+  for (const group of input.sections.groups) {
+    const collection: PawworkSidebarGroupCollection = {
+      key: group.key,
+      label: group.label,
+      rowKeys: group.items.map(rowKeyFor).filter((key) => rowByKey.has(key)),
+    }
+    groupByKey.set(collection.key, collection)
+    groupKeys.push(collection.key)
+  }
 
   return {
     rowByKey,
     pinnedRowKeys,
     recentRowKeys,
-    groupKeys: groups.map((group) => group.key),
+    groupKeys,
     groupByKey,
   }
 }

--- a/packages/app/src/pages/layout/pawwork-sidebar-identity.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-identity.ts
@@ -1,0 +1,33 @@
+import { pawworkSessionRowKey } from "./helpers"
+import type { PawworkSessionSections } from "./pawwork-session-nav"
+import type { PawworkSidebarSession } from "./pawwork-sidebar"
+
+export type PawworkSidebarGroupCollection = {
+  key: string
+  label: string
+  rowKeys: string[]
+}
+
+export function buildPawworkSidebarCollections(input: {
+  sessions: PawworkSidebarSession[]
+  sections: PawworkSessionSections
+}) {
+  const rowKeyFor = (item: { directory: string; id: string }) => pawworkSessionRowKey(item)
+  const rowByKey = new Map(input.sessions.map((item) => [rowKeyFor(item.session), item] as const))
+  const pinnedRowKeys = input.sections.pinned.map(rowKeyFor).filter((key) => rowByKey.has(key))
+  const recentRowKeys = input.sections.recent.map(rowKeyFor).filter((key) => rowByKey.has(key))
+  const groups = input.sections.groups.map((group) => ({
+    key: group.key,
+    label: group.label,
+    rowKeys: group.items.map(rowKeyFor).filter((key) => rowByKey.has(key)),
+  }))
+  const groupByKey = new Map(groups.map((group) => [group.key, group] as const))
+
+  return {
+    rowByKey,
+    pinnedRowKeys,
+    recentRowKeys,
+    groupKeys: groups.map((group) => group.key),
+    groupByKey,
+  }
+}

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -175,60 +175,60 @@ export const PawworkSidebar = (props: {
     dialog.show(() => <DialogRemoveProject name={projectLabel} onConfirm={() => props.onRemoveProject(projectKey)} />)
   }
 
-  const renderSessionItem = (row: Accessor<PawworkSidebarSession | undefined>) => {
-    const menuLabels = () => ({
-      pin: language.t("sidebar.pawwork.pinSession"),
-      unpin: language.t("sidebar.pawwork.unpinSession"),
-      rename: language.t("common.rename"),
-      export: language.t("session.export.action.export"),
-      delete: language.t("common.delete"),
+  const menuLabels = () => ({
+    pin: language.t("sidebar.pawwork.pinSession"),
+    unpin: language.t("sidebar.pawwork.unpinSession"),
+    rename: language.t("common.rename"),
+    export: language.t("session.export.action.export"),
+    delete: language.t("common.delete"),
+  })
+  const menuActions = (target: Session, onRenameSession: (session: Session) => void) =>
+    buildSessionMenuActions({
+      session: target,
+      pinned: props.pinnedIDs().includes(target.id),
+      exportAvailable: props.exportSessionAvailable(),
+      labels: menuLabels(),
+      onTogglePinnedSession: props.onTogglePinnedSession,
+      onRenameSession,
+      onExportSession: props.onExportSession,
+      onDeleteSession: props.onDeleteSession,
     })
-    const menuActions = (target: Session, onRenameSession: (session: Session) => void) =>
-      buildSessionMenuActions({
-        session: target,
-        pinned: props.pinnedIDs().includes(target.id),
-        exportAvailable: props.exportSessionAvailable(),
-        labels: menuLabels(),
-        onTogglePinnedSession: props.onTogglePinnedSession,
-        onRenameSession,
-        onExportSession: props.onExportSession,
-        onDeleteSession: props.onDeleteSession,
-      })
-    const renderDropdownActions = (actions: SessionMenuAction[]) => (
-      <>
-        <For each={actions}>
-          {(action) => (
-            <>
-              <Show when={action.separatorBefore}>
-                <DropdownMenu.Separator />
-              </Show>
-              <DropdownMenu.Item onSelect={() => void action.run()}>
-                <Icon name={action.icon} class="text-icon-weak" />
-                <DropdownMenu.ItemLabel>{action.label}</DropdownMenu.ItemLabel>
-              </DropdownMenu.Item>
-            </>
-          )}
-        </For>
-      </>
-    )
-    const renderContextActions = (actions: SessionMenuAction[]) => (
-      <>
-        <For each={actions}>
-          {(action) => (
-            <>
-              <Show when={action.separatorBefore}>
-                <ContextMenu.Separator />
-              </Show>
-              <ContextMenu.Item onSelect={() => void action.run()}>
-                <Icon name={action.icon} class="text-icon-weak" />
-                <ContextMenu.ItemLabel>{action.label}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-            </>
-          )}
-        </For>
-      </>
-    )
+  const renderDropdownActions = (actions: SessionMenuAction[]) => (
+    <>
+      <For each={actions}>
+        {(action) => (
+          <>
+            <Show when={action.separatorBefore}>
+              <DropdownMenu.Separator />
+            </Show>
+            <DropdownMenu.Item onSelect={() => void action.run()}>
+              <Icon name={action.icon} class="text-icon-weak" />
+              <DropdownMenu.ItemLabel>{action.label}</DropdownMenu.ItemLabel>
+            </DropdownMenu.Item>
+          </>
+        )}
+      </For>
+    </>
+  )
+  const renderContextActions = (actions: SessionMenuAction[]) => (
+    <>
+      <For each={actions}>
+        {(action) => (
+          <>
+            <Show when={action.separatorBefore}>
+              <ContextMenu.Separator />
+            </Show>
+            <ContextMenu.Item onSelect={() => void action.run()}>
+              <Icon name={action.icon} class="text-icon-weak" />
+              <ContextMenu.ItemLabel>{action.label}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
+          </>
+        )}
+      </For>
+    </>
+  )
 
+  const renderSessionItem = (row: Accessor<PawworkSidebarSession | undefined>) => {
     return (
       <Show when={row()}>
         {(current) => (

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -13,6 +13,7 @@ import { DialogRenameSession } from "@/components/dialog-rename-session"
 import { DialogRenameProject } from "@/components/dialog-rename-project"
 import { DialogRemoveProject } from "@/components/dialog-remove-project"
 import { buildPawworkSessionSections, type PawworkSortMode } from "./pawwork-session-nav"
+import { buildPawworkSidebarCollections } from "./pawwork-sidebar-identity"
 import { buildSessionMenuActions, type SessionMenuAction } from "./session-menu-actions"
 import { SessionItem } from "./sidebar-items"
 import "./sidebar.css"
@@ -56,10 +57,7 @@ function ProjectGroupHeader(props: {
             onClick={props.onToggle}
             class="min-w-0 h-full flex-1 flex items-center gap-2 px-2.5 text-left focus:outline-none"
           >
-            <Icon
-              name={props.collapsed ? "folder" : "folder-open"}
-              class="shrink-0 text-icon-weak"
-            />
+            <Icon name={props.collapsed ? "folder" : "folder-open"} class="shrink-0 text-icon-weak" />
             <span class="min-w-0 flex-1 truncate">{props.label}</span>
           </button>
           <div class="pointer-events-none relative shrink-0 flex items-center justify-end h-[20px] min-w-[30px] pr-1">
@@ -143,7 +141,6 @@ export const PawworkSidebar = (props: {
   const dialog = useDialog()
   const navList = createMemo(() => props.sessions().map((item) => item.session))
   let scrollEl: HTMLDivElement | undefined
-  const byID = createMemo(() => new Map(props.sessions().map((item) => [item.session.id, item] as const)))
   const sections = createMemo(() =>
     buildPawworkSessionSections({
       sessions: props.sessions().map((item) => ({
@@ -156,58 +153,29 @@ export const PawworkSidebar = (props: {
       })),
       pinnedIDs: props.pinnedIDs(),
       sortMode: props.sortMode(),
-      currentSessionID: props.activeSessionID?.(),
     }),
   )
-  const rows = createMemo(() =>
-    sections()
-      .recent.map((item) => ({ item: byID().get(item.id) }))
-      .filter((entry): entry is { item: PawworkSidebarSession } => !!entry.item),
-  )
-  const pinnedRows = createMemo(() =>
-    sections()
-      .pinned.map((item) => ({ item: byID().get(item.id) }))
-      .filter((entry): entry is { item: PawworkSidebarSession } => !!entry.item),
-  )
-  const groupedRows = createMemo(() =>
-    sections().groups.map((group) => ({
-      key: group.key,
-      label: group.label,
-      items: group.items
-        .map((item) => byID().get(item.id))
-        .filter((item): item is PawworkSidebarSession => !!item),
-    })),
+  const sidebarCollections = createMemo(() =>
+    buildPawworkSidebarCollections({ sessions: props.sessions(), sections: sections() }),
   )
 
   const openRenameDialog = (target: Session) => {
     dialog.show(() => (
-      <DialogRenameSession
-        name={target.title ?? ""}
-        onConfirm={(next) => props.onRenameSession(target, next)}
-      />
+      <DialogRenameSession name={target.title ?? ""} onConfirm={(next) => props.onRenameSession(target, next)} />
     ))
   }
 
   const openRenameProjectDialog = (projectKey: string, currentLabel: string) => {
     dialog.show(() => (
-      <DialogRenameProject
-        name={currentLabel}
-        onConfirm={(next) => props.onRenameProject(projectKey, next)}
-      />
+      <DialogRenameProject name={currentLabel} onConfirm={(next) => props.onRenameProject(projectKey, next)} />
     ))
   }
 
   const openRemoveProjectDialog = (projectKey: string, projectLabel: string) => {
-    dialog.show(() => (
-      <DialogRemoveProject
-        name={projectLabel}
-        onConfirm={() => props.onRemoveProject(projectKey)}
-      />
-    ))
+    dialog.show(() => <DialogRemoveProject name={projectLabel} onConfirm={() => props.onRemoveProject(projectKey)} />)
   }
 
-  const renderSessionItem = (entry: { item: PawworkSidebarSession }) => {
-    const session = entry.item.session
+  const renderSessionItem = (row: Accessor<PawworkSidebarSession | undefined>) => {
     const menuLabels = () => ({
       pin: language.t("sidebar.pawwork.pinSession"),
       unpin: language.t("sidebar.pawwork.unpinSession"),
@@ -262,67 +230,67 @@ export const PawworkSidebar = (props: {
     )
 
     return (
-      <ContextMenu>
-        <ContextMenu.Trigger as="div" class="flex flex-col gap-1">
-          <SessionItem
-            session={session}
-            list={navList()}
-            navList={navList}
-            slug={entry.item.slug}
-            showChild
-            prefetchSession={props.prefetchSession}
-            hrefForSession={props.hrefForSession}
-            onOpenSession={props.onOpenSession}
-            timeText={() =>
-              entry.item.created > 0
-                ? getRelativeTime(new Date(entry.item.created).toISOString(), language.t)
-                : undefined
-            }
-            titleContent={({ title }) => (
-              <span
-                class="text-body text-fg-base [.active_&]:text-fg-strong [.active_&]:font-emphasis min-w-0 flex-1 truncate"
-                onDblClick={(e: MouseEvent) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  openRenameDialog(session)
-                }}
-              >
-                {title()}
-              </span>
-            )}
-            actionSlot={(rowSession) => (
-              <DropdownMenu>
-                <DropdownMenu.Trigger
-                  as={IconButton}
-                  icon="dot-grid"
-                  variant="ghost"
-                  class="h-[26px] w-[26px]"
-                  data-action="session-row-menu"
-                  aria-label={language.t("common.moreOptions")}
-                  onClick={(event: MouseEvent) => {
-                    event.preventDefault()
-                    event.stopPropagation()
-                  }}
-                />
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content>
-                    {renderDropdownActions(
-                      menuActions(rowSession, () => openRenameDialog(rowSession)),
-                    )}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu>
-            )}
-          />
-        </ContextMenu.Trigger>
-        <ContextMenu.Portal>
-          <ContextMenu.Content>
-            {renderContextActions(
-              menuActions(session, () => openRenameDialog(session)),
-            )}
-          </ContextMenu.Content>
-        </ContextMenu.Portal>
-      </ContextMenu>
+      <Show when={row()}>
+        {(current) => (
+          <ContextMenu>
+            <ContextMenu.Trigger as="div" class="flex flex-col gap-1">
+              <SessionItem
+                session={current().session}
+                list={navList()}
+                navList={navList}
+                slug={current().slug}
+                showChild
+                prefetchSession={props.prefetchSession}
+                hrefForSession={props.hrefForSession}
+                onOpenSession={props.onOpenSession}
+                timeText={() =>
+                  current().created > 0
+                    ? getRelativeTime(new Date(current().created).toISOString(), language.t)
+                    : undefined
+                }
+                titleContent={({ title }) => (
+                  <span
+                    class="text-body text-fg-base [.active_&]:text-fg-strong [.active_&]:font-emphasis min-w-0 flex-1 truncate"
+                    onDblClick={(e: MouseEvent) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      openRenameDialog(current().session)
+                    }}
+                  >
+                    {title()}
+                  </span>
+                )}
+                actionSlot={(rowSession) => (
+                  <DropdownMenu>
+                    <DropdownMenu.Trigger
+                      as={IconButton}
+                      icon="dot-grid"
+                      variant="ghost"
+                      class="h-[26px] w-[26px]"
+                      data-action="session-row-menu"
+                      aria-label={language.t("common.moreOptions")}
+                      onClick={(event: MouseEvent) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                      }}
+                    />
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.Content>
+                        {renderDropdownActions(menuActions(rowSession, () => openRenameDialog(rowSession)))}
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu>
+                )}
+              />
+            </ContextMenu.Trigger>
+            <ContextMenu.Portal>
+              <ContextMenu.Content>
+                {renderContextActions(menuActions(current().session, () => openRenameDialog(current().session)))}
+              </ContextMenu.Content>
+            </ContextMenu.Portal>
+          </ContextMenu>
+        )}
+      </Show>
     )
   }
 
@@ -422,13 +390,20 @@ export const PawworkSidebar = (props: {
         >
           <Show when={props.sessions().length > 0}>
             <nav class="flex flex-col">
-              <Show when={pinnedRows().length > 0}>
+              <Show when={sidebarCollections().pinnedRowKeys.length > 0}>
                 <section data-component="pawwork-sidebar-pinned" class="flex flex-col gap-0.5">
-                  <div class="mt-4 h-[30px] flex items-center px-2.5 text-body text-fg-weak">{language.t("sidebar.pawwork.pinned")}</div>
-                  <For each={pinnedRows()}>{(entry) => renderSessionItem(entry)}</For>
+                  <div class="mt-4 h-[30px] flex items-center px-2.5 text-body text-fg-weak">
+                    {language.t("sidebar.pawwork.pinned")}
+                  </div>
+                  <For each={sidebarCollections().pinnedRowKeys}>
+                    {(rowKey) => {
+                      const row = createMemo(() => sidebarCollections().rowByKey.get(rowKey))
+                      return renderSessionItem(row)
+                    }}
+                  </For>
                 </section>
               </Show>
-              <Show when={rows().length > 0 || groupedRows().length > 0}>
+              <Show when={sidebarCollections().recentRowKeys.length > 0 || sidebarCollections().groupKeys.length > 0}>
                 <div class="mt-4 h-[30px] flex items-center justify-between px-2.5">
                   <span class="text-body text-fg-weak">{language.t("sidebar.pawwork.all")}</span>
                   <DropdownMenu>
@@ -477,45 +452,60 @@ export const PawworkSidebar = (props: {
               </Show>
               <Show when={props.sortMode() === "time"}>
                 <div class="flex flex-col gap-0.5">
-                  <For each={rows()}>{(entry) => renderSessionItem(entry)}</For>
+                  <For each={sidebarCollections().recentRowKeys}>
+                    {(rowKey) => {
+                      const row = createMemo(() => sidebarCollections().rowByKey.get(rowKey))
+                      return renderSessionItem(row)
+                    }}
+                  </For>
                 </div>
               </Show>
               <Show when={props.sortMode() === "project"}>
-                <For each={groupedRows()}>
-                  {(group, index) => {
-                    const collapsed = createMemo(() => !!props.collapsedProjects()[group.key])
-                    const handleRename = () => openRenameProjectDialog(group.key, group.label)
-                    const handleRemove = () => openRemoveProjectDialog(group.key, group.label)
+                <For each={sidebarCollections().groupKeys}>
+                  {(groupKey, index) => {
+                    const group = createMemo(() => sidebarCollections().groupByKey.get(groupKey))
+                    const collapsed = createMemo(() => !!props.collapsedProjects()[groupKey])
+                    const handleRename = () => openRenameProjectDialog(groupKey, group()?.label ?? groupKey)
+                    const handleRemove = () => openRemoveProjectDialog(groupKey, group()?.label ?? groupKey)
 
                     return (
-                      <section class={`${index() > 0 ? "mt-0.5 " : ""}flex flex-col gap-0.5`}>
-                        <ProjectGroupHeader
-                          projectKey={group.key}
-                          label={group.label}
-                          collapsed={collapsed()}
-                          onToggle={() => props.onToggleProjectCollapsed(group.key)}
-                          onRename={handleRename}
-                          onRemove={handleRemove}
-                        />
-                        {/* grid-template-rows trick: 0fr → 1fr animates height without
-                          * touching layout-thrashing properties. Items stay mounted so
-                          * focus / scroll position survive the toggle; inert on the
-                          * inner wrapper takes them out of the tab order while collapsed. */}
-                        <div
-                          data-component="pawwork-group-content"
-                          data-collapsed={collapsed() ? "true" : undefined}
-                          class="grid transition-[grid-template-rows] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
-                          style={{ "grid-template-rows": collapsed() ? "0fr" : "1fr" }}
-                          aria-hidden={collapsed()}
-                        >
-                          <div
-                            class="min-h-0 overflow-hidden flex flex-col gap-0.5"
-                            inert={collapsed() ? true : undefined}
-                          >
-                            <For each={group.items}>{(item) => renderSessionItem({ item })}</For>
-                          </div>
-                        </div>
-                      </section>
+                      <Show when={group()}>
+                        {(current) => (
+                          <section class={`${index() > 0 ? "mt-0.5 " : ""}flex flex-col gap-0.5`}>
+                            <ProjectGroupHeader
+                              projectKey={groupKey}
+                              label={current().label}
+                              collapsed={collapsed()}
+                              onToggle={() => props.onToggleProjectCollapsed(groupKey)}
+                              onRename={handleRename}
+                              onRemove={handleRemove}
+                            />
+                            {/* grid-template-rows trick: 0fr → 1fr animates height without
+                             * touching layout-thrashing properties. Items stay mounted so
+                             * focus / scroll position survive the toggle; inert on the
+                             * inner wrapper takes them out of the tab order while collapsed. */}
+                            <div
+                              data-component="pawwork-group-content"
+                              data-collapsed={collapsed() ? "true" : undefined}
+                              class="grid transition-[grid-template-rows] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+                              style={{ "grid-template-rows": collapsed() ? "0fr" : "1fr" }}
+                              aria-hidden={collapsed()}
+                            >
+                              <div
+                                class="min-h-0 overflow-hidden flex flex-col gap-0.5"
+                                inert={collapsed() ? true : undefined}
+                              >
+                                <For each={current().rowKeys}>
+                                  {(rowKey) => {
+                                    const row = createMemo(() => sidebarCollections().rowByKey.get(rowKey))
+                                    return renderSessionItem(row)
+                                  }}
+                                </For>
+                              </div>
+                            </div>
+                          </section>
+                        )}
+                      </Show>
                     )
                   }}
                 </For>
@@ -546,15 +536,8 @@ export const PawworkSidebar = (props: {
         </div>
       </Show>
 
-      <div
-        data-component="pawwork-side-foot"
-        class="shrink-0 px-3 pt-4 pb-3"
-      >
-        <TooltipKeybind
-          placement="top"
-          title={props.settingsLabel()}
-          keybind={props.settingsKeybind() ?? ""}
-        >
+      <div data-component="pawwork-side-foot" class="shrink-0 px-3 pt-4 pb-3">
+        <TooltipKeybind placement="top" title={props.settingsLabel()} keybind={props.settingsKeybind() ?? ""}>
           <button
             type="button"
             data-action="pawwork-open-settings"


### PR DESCRIPTION
## Summary
- Stabilize PawWork sidebar row and project-group rendering around semantic row/group keys instead of fresh wrapper objects.
- Keep row/group data reactive through keyed lookup maps so titles, timestamps, labels, and membership can update without remounting unaffected DOM nodes.
- Remove the unused active-session input from section construction so selecting an already-visible session does not invalidate sidebar structure.

## Verification
- `bun test --preload ./happydom.ts src/pages/layout/helpers.test.ts src/pages/layout/pawwork-session-nav.test.ts src/pages/layout/pawwork-sidebar-identity.test.tsx` from `packages/app`
- `bun run typecheck` from `packages/app`
- `bun run snap sidebar`

## Links
- Closes #780
- V3 design note: https://github.com/Astro-Han/pawwork/issues/780#issuecomment-4495267828

## Risk
- Scope is limited to the PawWork sidebar session-list identity boundary.
- The session-window reload path is intentionally untouched; the new regression check covers stable row/group reuse plus reactive data updates first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session sidebar identity and key management for improved stability.

* **Tests**
  * Added tests validating session row key generation and sidebar identity behavior to ensure stable DOM element references during session updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->