### PR TITLE
feat(prompt-input): collapse /<command> into inline pill

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -381,6 +381,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     },
     readFileDataUrl: platform.readFileDataUrl,
     readClipboardImage: platform.readClipboardImage,
+    // Path C dependencies (paste of `/<known-name> args` into empty input).
+    imageAttachments,
+    composing,
+    sync,
   })
 
   const accepting = createMemo(() => {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -271,6 +271,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setStore,
     prompt,
     sdk,
+    sync,
     imageAttachments,
     editorRef: () => editorRef,
     mirror,
@@ -322,6 +323,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     handleCompositionStart,
     handleCompositionEnd,
     handleInput,
+    handleCopy,
     addPart,
   } = editorInput
 
@@ -532,6 +534,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               // @ts-expect-error
               autocomplete="off"
               onInput={handleInput}
+              onCopy={handleCopy}
               onPaste={(event) => {
                 if (!actionReady()) {
                   event.preventDefault()

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -297,6 +297,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     clearEditor,
     setEditorText,
     focusEditorEnd,
+    renderEditorWithCursor,
   })
   popoversRef = popovers
 

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -4,11 +4,14 @@ import { pathBasename } from "@opencode-ai/util/file-extensions"
 import { showToast } from "@opencode-ai/ui/toast"
 import { usePrompt, type ContentPart, type ImageAttachmentPart } from "@/context/prompt"
 import { useLanguage } from "@/context/language"
+import type { useSync } from "@/context/sync"
 import { uuid } from "@/utils/uuid"
 import { getCursorPosition } from "./editor-dom"
 import { textMime } from "./files"
 import { normalizePaste, pasteMode } from "./paste"
 import { routeBrowserFile, routePickedPath, type AttachRoute, type ModelInputSupport } from "./attachment-routing"
+import { buildSlashRegistry } from "./command-text-part"
+import { tryPathCConversion } from "./command-paste"
 
 function dataUrlMimeCompatible(actual: string, expected: string) {
   if (actual === expected) return true
@@ -64,6 +67,12 @@ type PromptAttachmentsInput = {
   openModelSelector: () => void
   readFileDataUrl?: (path: string, mime: string) => Promise<string | null>
   readClipboardImage?: () => Promise<File | null>
+  // Path C (paste of `/<known-name> args` into structurally-empty input)
+  // dependencies. Default to empty/false so callers that do not need pill
+  // paste behaviour (e.g. legacy tests) can omit them.
+  imageAttachments?: () => readonly ImageAttachmentPart[]
+  composing?: () => boolean
+  sync?: ReturnType<typeof useSync>
 }
 
 export function createPromptAttachments(input: PromptAttachmentsInput) {
@@ -269,6 +278,26 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     }
 
     if (!plainText) return
+
+    // Path C: command-shaped paste into structurally-empty input.
+    // Runs against RAW clipboard text (NOT normalizePaste output) so command
+    // boundary semantics stay verbatim. On miss → falls through to existing
+    // text-insert path unchanged.
+    if (input.sync) {
+      const pathC = tryPathCConversion({
+        plainText,
+        currentPrompt: prompt.current(),
+        contextItems: prompt.context.items(),
+        imageAttachments: input.imageAttachments?.() ?? [],
+        registry: buildSlashRegistry(input.sync.data.command),
+        composing: input.composing?.() ?? false,
+      })
+      if (pathC) {
+        const marked = pathC[0]
+        prompt.set(pathC, "content" in marked ? marked.content.length : 0)
+        return
+      }
+    }
 
     const text = normalizePaste(plainText)
 

--- a/packages/app/src/components/prompt-input/command-backspace.test.ts
+++ b/packages/app/src/components/prompt-input/command-backspace.test.ts
@@ -1,0 +1,212 @@
+// Tests for the Backspace fallback ladder on a command-marked leading TextPart.
+// Spec reference: §E9 Backspace and IME, §Backspace fallback ladder (L469-479).
+//
+// Tests exercise the pure-function layer `computeCommandBackspaceResult`.
+// No DOM or reactive context required.
+
+import { describe, expect, test } from "bun:test"
+import type { Prompt, TextPart, FileAttachmentPart, AgentPart, ImageAttachmentPart } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+import { computeCommandBackspaceResult } from "./command-backspace"
+
+// Helpers -----------------------------------------------------------------
+
+function marked(name: string, args: string): TextPart & { command: NonNullable<TextPart["command"]> } {
+  const content = `/${name} ${args}`
+  return {
+    type: "text",
+    content,
+    start: 0,
+    end: content.length,
+    command: { name, source: "skill", icon: "command" },
+  }
+}
+
+function plainText(content: string): TextPart {
+  return { type: "text", content, start: 0, end: content.length }
+}
+
+function filePart(path: string): FileAttachmentPart {
+  return { type: "file", path, content: `@${path}`, start: 0, end: path.length + 1 }
+}
+
+function agentPart(name: string): AgentPart {
+  return { type: "agent", name, content: `@${name}`, start: 0, end: name.length + 1 }
+}
+
+function imagePart(id: string): ImageAttachmentPart {
+  return { type: "image", id, filename: `${id}.png`, mime: "image/png", dataUrl: `data:image/png,${id}` }
+}
+
+function prefix(name: string): string {
+  return `/${name} `
+}
+
+// Cases (a)-(g) from the plan --------------------------------------------
+
+describe("computeCommandBackspaceResult — fallback ladder", () => {
+  // (a) marked has args → strip prefix, drop metadata
+  test("(a) [marked('/cmd args')] → [Text('args')], metadata dropped", () => {
+    const cmd = marked("cmd", "args")
+    const parts: Prompt = [cmd]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(1)
+    const first = result[0] as TextPart
+    expect(first.type).toBe("text")
+    expect(first.content).toBe("args")
+    expect(first.command).toBeUndefined()
+  })
+
+  // (b) marked has no args, sole part → DEFAULT_PROMPT
+  test("(b) [marked('/cmd ')] sole part → DEFAULT_PROMPT", () => {
+    const cmd = marked("cmd", "")
+    const parts: Prompt = [cmd]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    // Should equal DEFAULT_PROMPT shape: single empty TextPart
+    expect(result.length).toBe(1)
+    const first = result[0] as TextPart
+    expect(first.type).toBe("text")
+    expect(first.content).toBe("")
+    expect(first.command).toBeUndefined()
+  })
+
+  // (b) also verify it is the exact DEFAULT_PROMPT reference
+  test("(b) collapse to DEFAULT_PROMPT returns the canonical constant", () => {
+    const cmd = marked("cmd", "")
+    const result = computeCommandBackspaceResult([cmd], cmd, prefix("cmd"))
+    expect(result).toBe(DEFAULT_PROMPT)
+  })
+
+  // (c) marked has no args, rest has FilePart → remove marked, keep rest
+  test("(c) [marked('/cmd '), File('@foo')] → [File('@foo')]", () => {
+    const cmd = marked("cmd", "")
+    const file = filePart("/workspace/foo.ts")
+    const parts: Prompt = [cmd, file]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(1)
+    expect(result[0]).toEqual(file)
+  })
+
+  // (d) marked has no args, rest has AgentPart → remove marked, keep rest
+  test("(d) [marked('/cmd '), Agent('@coder')] → [Agent('@coder')]", () => {
+    const cmd = marked("cmd", "")
+    const agent = agentPart("coder")
+    const parts: Prompt = [cmd, agent]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(1)
+    expect(result[0]).toEqual(agent)
+  })
+
+  // (e) marked has no args, rest is ImagePart → remove marked, keep ImagePart
+  test("(e) [marked('/cmd '), ImagePart] → [ImagePart]", () => {
+    const cmd = marked("cmd", "")
+    const img = imagePart("img-001")
+    const parts: Prompt = [cmd, img]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(1)
+    expect(result[0]).toEqual(img)
+  })
+
+  // (f) E1 follow-up layout: marked has no args, rest=[Text, File] → rest preserved
+  test("(f) [marked('/cmd '), Text('foo'), File('@bar')] → [Text('foo'), File('@bar')]", () => {
+    const cmd = marked("cmd", "")
+    const txt = plainText("foo")
+    const file = filePart("/bar.ts")
+    const parts: Prompt = [cmd, txt, file]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(2)
+    expect(result[0]).toEqual(txt)
+    expect(result[1]).toEqual(file)
+  })
+
+  // (g) marked has args + rest has FilePart → strip prefix on first, keep File
+  test("(g) [marked('/cmd hello '), File('@foo')] → [Text('hello '), File('@foo')]", () => {
+    const cmd = marked("cmd", "hello ")
+    const file = filePart("/foo.ts")
+    const parts: Prompt = [cmd, file]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(2)
+    const first = result[0] as TextPart
+    expect(first.type).toBe("text")
+    expect(first.content).toBe("hello ")
+    expect(first.command).toBeUndefined()
+    expect(result[1]).toEqual(file)
+  })
+})
+
+// No-mutation invariant --------------------------------------------------
+
+describe("computeCommandBackspaceResult — no mutation of context side-data", () => {
+  test("prompt.context.items snapshot (external array) is not modified", () => {
+    // context.items is managed outside of Prompt; this test confirms the ladder
+    // only touches the parts array and returns a new Prompt, never mutating
+    // any caller-held reference.
+    const contextItems = [{ type: "file" as const, path: "/ctx.ts", key: "file:/ctx.ts:::" }]
+    const contextItemsSnapshot = [...contextItems]
+
+    const cmd = marked("cmd", "args")
+    const parts: Prompt = [cmd]
+    computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    // Simulate: the function must not have touched contextItems
+    expect(contextItems).toEqual(contextItemsSnapshot)
+  })
+
+  test("imageAttachments snapshot is not modified", () => {
+    const imageAttachments = [imagePart("img-1")]
+    const imageAttachmentsSnapshot = [...imageAttachments]
+
+    const cmd = marked("cmd", "")
+    const parts: Prompt = [cmd]
+    computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(imageAttachments).toEqual(imageAttachmentsSnapshot)
+  })
+
+  test("original parts array is not mutated", () => {
+    const cmd = marked("cmd", "args")
+    const file = filePart("/a.ts")
+    const parts: Prompt = [cmd, file]
+    const originalLength = parts.length
+    const originalFirst = parts[0]
+
+    computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(parts.length).toBe(originalLength)
+    expect(parts[0]).toBe(originalFirst)
+  })
+})
+
+// Edge cases ------------------------------------------------------------
+
+describe("computeCommandBackspaceResult — edge cases", () => {
+  test("args with trailing space preserved verbatim", () => {
+    // /cmd trailing  → argsAfterPrefix = "trailing "
+    const cmd = marked("cmd", "trailing ")
+    const parts: Prompt = [cmd]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect((result[0] as TextPart).content).toBe("trailing ")
+  })
+
+  test("multipart rest is preserved in order", () => {
+    const cmd = marked("cmd", "")
+    const t1 = plainText("foo")
+    const t2 = plainText("bar")
+    const f1 = filePart("/a.ts")
+    const parts: Prompt = [cmd, t1, t2, f1]
+    const result = computeCommandBackspaceResult(parts, cmd, prefix("cmd"))
+
+    expect(result.length).toBe(3)
+    expect(result[0]).toEqual(t1)
+    expect(result[1]).toEqual(t2)
+    expect(result[2]).toEqual(f1)
+  })
+})

--- a/packages/app/src/components/prompt-input/command-backspace.ts
+++ b/packages/app/src/components/prompt-input/command-backspace.ts
@@ -1,0 +1,49 @@
+// Pure data-transform for the Backspace fallback ladder on a command-marked
+// leading TextPart. No DOM, no reactive context.
+//
+// The three cases (in order, first match wins):
+//   1. Marked content has args (length > prefix.length): strip "/<name> ", drop
+//      command metadata. Result: [Text(argsOnly), ...rest]. Caret at 0.
+//   2. Marked content is exactly "/<name> " AND rest.length > 0: remove only
+//      the marked TextPart. Result: [...rest]. Caret at 0.
+//   3. Marked content is exactly "/<name> " AND no rest: collapse to DEFAULT_PROMPT.
+
+import type { Prompt, TextPart } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+
+/**
+ * Compute the new Prompt after a Backspace that fires the command fallback
+ * ladder. Returns a fresh array; the caller must pass it to `prompt.set`.
+ *
+ * @param parts - prompt.current() snapshot at the moment Backspace fires
+ * @param first - parts[0] cast to a marked TextPart (caller must verify)
+ * @param prefix - `"/${first.command.name} "` (passed in to avoid recomputation)
+ */
+export function computeCommandBackspaceResult(
+  parts: Prompt,
+  first: TextPart & { command: NonNullable<TextPart["command"]> },
+  prefix: string,
+): Prompt {
+  const rest = parts.slice(1)
+  const argsAfterPrefix = first.content.slice(prefix.length)
+
+  if (argsAfterPrefix.length > 0) {
+    // Case 1: strip prefix, drop command metadata.
+    const newFirst: TextPart = {
+      type: "text",
+      content: argsAfterPrefix,
+      start: 0,
+      end: argsAfterPrefix.length,
+    }
+    return [newFirst, ...rest]
+  }
+
+  // No args (content === "/<name> ").
+  if (rest.length > 0) {
+    // Case 2: remove only the marked TextPart.
+    return rest
+  }
+
+  // Case 3: sole part — collapse to DEFAULT_PROMPT.
+  return DEFAULT_PROMPT
+}

--- a/packages/app/src/components/prompt-input/command-copy.test.ts
+++ b/packages/app/src/components/prompt-input/command-copy.test.ts
@@ -1,0 +1,142 @@
+// Tests for scoped command-copy clipboard rewrite.
+// Spec: §Pill DOM → Copy contract (L164-174).
+
+import { describe, expect, test } from "bun:test"
+import { rewriteRangeForCommandCopy, selectionTouchesCommandMark } from "./command-copy"
+
+function buildPill(name: string): HTMLSpanElement {
+  const span = document.createElement("span")
+  span.dataset.cmdMark = "true"
+  span.dataset.name = name
+  span.contentEditable = "false"
+  const icon = document.createElement("span")
+  icon.dataset.cmdIcon = "true"
+  span.appendChild(icon)
+  const label = document.createElement("span")
+  label.dataset.cmdLabel = "true"
+  label.textContent = name
+  span.appendChild(label)
+  return span
+}
+
+function mountEditor(builder: (editor: HTMLElement) => void): HTMLElement {
+  const editor = document.createElement("div")
+  editor.contentEditable = "true"
+  builder(editor)
+  document.body.appendChild(editor)
+  return editor
+}
+
+describe("rewriteRangeForCommandCopy", () => {
+  test("selecting only the pill yields '/<name>'", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("brainstorming"))
+      e.appendChild(document.createTextNode(" hello"))
+    })
+    try {
+      const range = document.createRange()
+      range.selectNode(editor.firstChild!)
+      expect(rewriteRangeForCommandCopy(range)).toBe("/brainstorming")
+    } finally { editor.remove() }
+  })
+
+  test("selecting pill + adjacent args yields '/<name> args'", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("brainstorming"))
+      e.appendChild(document.createTextNode(" hello"))
+    })
+    try {
+      const range = document.createRange()
+      range.setStartBefore(editor.firstChild!)
+      range.setEndAfter(editor.lastChild!)
+      expect(rewriteRangeForCommandCopy(range)).toBe("/brainstorming hello")
+    } finally { editor.remove() }
+  })
+
+  test("multiple pills in selection each rewrite to /<name>", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("a"))
+      e.appendChild(document.createTextNode(" "))
+      e.appendChild(buildPill("b"))
+    })
+    try {
+      const range = document.createRange()
+      range.selectNodeContents(editor)
+      expect(rewriteRangeForCommandCopy(range)).toBe("/a /b")
+    } finally { editor.remove() }
+  })
+
+  test("<br> inside range becomes \\n", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("cmd"))
+      e.appendChild(document.createTextNode(" line1"))
+      e.appendChild(document.createElement("br"))
+      e.appendChild(document.createTextNode("line2"))
+    })
+    try {
+      const range = document.createRange()
+      range.selectNodeContents(editor)
+      expect(rewriteRangeForCommandCopy(range)).toBe("/cmd line1\nline2")
+    } finally { editor.remove() }
+  })
+})
+
+describe("selectionTouchesCommandMark", () => {
+  test("selection touching pill → true", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("cmd"))
+      e.appendChild(document.createTextNode(" args"))
+    })
+    try {
+      const range = document.createRange()
+      range.selectNode(editor.firstChild!)
+      const sel = window.getSelection()!
+      sel.removeAllRanges()
+      sel.addRange(range)
+      expect(selectionTouchesCommandMark(editor)).toBe(true)
+    } finally { editor.remove() }
+  })
+
+  test("selection in text-only region (no pill) → false", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(document.createTextNode("hello world"))
+    })
+    try {
+      const range = document.createRange()
+      range.setStart(editor.firstChild!, 0)
+      range.setEnd(editor.firstChild!, 5)
+      const sel = window.getSelection()!
+      sel.removeAllRanges()
+      sel.addRange(range)
+      expect(selectionTouchesCommandMark(editor)).toBe(false)
+    } finally { editor.remove() }
+  })
+
+  test("@file pill (data-type=file) but no data-cmd-mark → false", () => {
+    const editor = mountEditor((e) => {
+      const filePill = document.createElement("span")
+      filePill.dataset.type = "file"
+      filePill.textContent = "@foo.ts"
+      e.appendChild(filePill)
+    })
+    try {
+      const range = document.createRange()
+      range.selectNode(editor.firstChild!)
+      const sel = window.getSelection()!
+      sel.removeAllRanges()
+      sel.addRange(range)
+      expect(selectionTouchesCommandMark(editor)).toBe(false)
+    } finally { editor.remove() }
+  })
+
+  test("no selection → false", () => {
+    const editor = mountEditor((e) => {
+      e.appendChild(buildPill("cmd"))
+    })
+    try {
+      const sel = window.getSelection()!
+      sel.removeAllRanges()
+      expect(selectionTouchesCommandMark(editor)).toBe(false)
+    } finally { editor.remove() }
+  })
+})

--- a/packages/app/src/components/prompt-input/command-copy.ts
+++ b/packages/app/src/components/prompt-input/command-copy.ts
@@ -1,0 +1,44 @@
+// Scoped copy handler logic for command pills.
+//
+// Browser default copy on a [data-cmd-mark] pill yields just the visible
+// textContent (the label `<name>`, no slash). The rest of the system —
+// Path C paste, command-line round-trip, cross-app paste — needs the slash
+// literal `/<name>` to recognise the command. The copy listener intercepts
+// when the selection touches any [data-cmd-mark] element and rewrites the
+// `text/plain` clipboard payload accordingly.
+
+/**
+ * Walk a Range's cloned fragment and produce the text/plain string that
+ * substitutes every [data-cmd-mark] with `/<dataset.name>` and every <br>
+ * with `\n`. Returns the rewritten string.
+ */
+export function rewriteRangeForCommandCopy(range: Range): string {
+  const fragment = range.cloneContents()
+  const tmp = document.createElement("div")
+  tmp.appendChild(fragment)
+  tmp.querySelectorAll("[data-cmd-mark]").forEach((el) => {
+    const name = (el as HTMLElement).dataset.name ?? ""
+    el.replaceWith(document.createTextNode(`/${name}`))
+  })
+  tmp.querySelectorAll("br").forEach((br) => br.replaceWith(document.createTextNode("\n")))
+  return tmp.textContent ?? ""
+}
+
+/**
+ * Whether the current selection intersects any [data-cmd-mark] descendant of
+ * `editor`. The listener should only intercept the copy event in this case;
+ * otherwise the browser default applies (untouched by the command-copy logic).
+ */
+export function selectionTouchesCommandMark(editor: HTMLElement): boolean {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return false
+  const range = sel.getRangeAt(0)
+  if (!editor.contains(range.startContainer) && !editor.contains(range.endContainer)) {
+    return false
+  }
+  const marks = editor.querySelectorAll("[data-cmd-mark]")
+  for (const mark of marks) {
+    if (range.intersectsNode(mark)) return true
+  }
+  return false
+}

--- a/packages/app/src/components/prompt-input/command-paste.test.ts
+++ b/packages/app/src/components/prompt-input/command-paste.test.ts
@@ -1,0 +1,153 @@
+// Tests for Path C paste decision.
+// Spec: §Path C (L237-263).
+
+import { describe, expect, test } from "bun:test"
+import type {
+  CommandSource,
+  ContextItem,
+  FileAttachmentPart,
+  ImageAttachmentPart,
+  Prompt,
+} from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+import type { CommandDescriptor } from "./command-text-part"
+import { tryPathCConversion } from "./command-paste"
+
+const reg: CommandDescriptor[] = [
+  { name: "brainstorming", source: "skill" as CommandSource, icon: "command" },
+]
+
+const empty = (): Prompt => DEFAULT_PROMPT
+const file: FileAttachmentPart = {
+  type: "file", path: "foo.ts", content: "@foo.ts", start: 0, end: 7,
+}
+const image: ImageAttachmentPart = {
+  type: "image", id: "1", filename: "a.png", mime: "image/png", dataUrl: "data:img",
+}
+
+describe("tryPathCConversion", () => {
+  test("`/brainstorming hello world` into structurally-empty input → marked", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello world",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.length).toBe(1)
+    expect((result![0] as any).command.name).toBe("brainstorming")
+    expect((result![0] as any).content).toBe("/brainstorming hello world")
+  })
+
+  test("same string with existing text → null (fall back to plain paste)", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello",
+      currentPrompt: [{ type: "text", content: "hi", start: 0, end: 2 }],
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("with only file attachment present → null (attachment preserved)", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello",
+      currentPrompt: [file],
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("with only image attachment present → null", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [image],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("with context items present → null", () => {
+    const ctx: ContextItem[] = [{ type: "file", path: "foo.ts" }]
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello",
+      currentPrompt: empty(),
+      contextItems: ctx,
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("newline separator → null (regex requires single ASCII space)", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming\nargs",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("Codex-style markdown link → null (not a command shape)", () => {
+    const result = tryPathCConversion({
+      plainText: "[foo.ts](path/foo.ts)",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("composing=true → null even when structurally empty + valid command", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming hello",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: true,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("registry miss → null", () => {
+    const result = tryPathCConversion({
+      plainText: "/unknown args",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("`/brainstorming` (no args, no separator) into empty → marked with trailing space", () => {
+    const result = tryPathCConversion({
+      plainText: "/brainstorming",
+      currentPrompt: empty(),
+      contextItems: [],
+      imageAttachments: [],
+      registry: reg,
+      composing: false,
+    })
+    expect(result).not.toBeNull()
+    expect((result![0] as any).content).toBe("/brainstorming ")
+  })
+})

--- a/packages/app/src/components/prompt-input/command-paste.ts
+++ b/packages/app/src/components/prompt-input/command-paste.ts
@@ -1,0 +1,42 @@
+// Pure data-transform for Path C: paste of `/<known-name> <args>` into a
+// structurally-empty input produces a marked TextPart. Any non-empty existing
+// state (text, attachments, context items) declines — paste falls back to
+// the default text-insert path.
+//
+// Path C runs against the RAW clipboard text, NOT normalizePaste output —
+// normalizePaste strips trailing whitespace and collapses runs of blank lines,
+// which would change command-boundary semantics. The command regex needs
+// verbatim clipboard content.
+
+import type {
+  ContextItem,
+  ImageAttachmentPart,
+  Prompt,
+} from "@/context/prompt"
+import { isStructurallyEmpty } from "@/context/prompt"
+import type { CommandDescriptor } from "./command-text-part"
+import { tryParseLeadingCommandFromText } from "./command-text-part"
+
+export interface PathCInput {
+  plainText: string
+  currentPrompt: Prompt
+  contextItems: readonly ContextItem[]
+  imageAttachments: readonly ImageAttachmentPart[]
+  registry: ReadonlyArray<CommandDescriptor>
+  composing: boolean
+}
+
+/**
+ * Try to convert a paste into a marked TextPart. Returns the new Prompt on
+ * conversion, or null when Path C declines (any guard fails: IME composing,
+ * not structurally empty, regex miss, or registry miss).
+ */
+export function tryPathCConversion(input: PathCInput): Prompt | null {
+  if (input.composing) return null
+  if (!isStructurallyEmpty(input.currentPrompt, input.contextItems, input.imageAttachments)) {
+    return null
+  }
+  const marked = tryParseLeadingCommandFromText(input.plainText, input.registry)
+  if (!marked) return null
+  return [marked]
+}

--- a/packages/app/src/components/prompt-input/command-pill.css
+++ b/packages/app/src/components/prompt-input/command-pill.css
@@ -1,0 +1,21 @@
+/* Input-side command pill — visual parity with sent bubble.
+ * Source of truth: packages/ui/src/components/message-part.css
+ * (.user-message-command-prefix + .user-message-command-label).
+ * The icon span carries class="command-icon" so .command-icon rules from
+ * packages/ui/src/components/command-icon.css apply automatically.
+ */
+
+[data-cmd-mark] {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
+  color: var(--brand-primary);
+  user-select: text;
+  cursor: default;
+}
+
+[data-cmd-mark] [data-cmd-label] {
+  color: inherit;
+  font-weight: var(--font-weight-body);
+}

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -1,0 +1,190 @@
+// Tests for prependCommandMark — the pure helper that computes the new Prompt
+// when a custom slash command is selected from the popover.
+// Spec reference: §Path A (L200-222), §E1 variant (L209-222).
+//
+// No DOM or reactive context required.
+
+import { describe, expect, test } from "bun:test"
+import type { Prompt, TextPart, FileAttachmentPart, AgentPart, ImageAttachmentPart } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt"
+import type { CommandDescriptor } from "./command-text-part"
+import { prependCommandMark } from "./command-prepend"
+
+// Helpers -----------------------------------------------------------------
+
+function cmd(name: string, source: CommandDescriptor["source"] = "command"): CommandDescriptor {
+  return { name, source, icon: "command" }
+}
+
+function filePart(path: string): FileAttachmentPart {
+  return { type: "file", path, content: `@${path}`, start: 0, end: path.length + 1 }
+}
+
+function agentPart(name: string): AgentPart {
+  return { type: "agent", name, content: `@${name}`, start: 0, end: name.length + 1 }
+}
+
+function imagePart(id: string): ImageAttachmentPart {
+  return { type: "image", id, filename: `${id}.png`, mime: "image/png", dataUrl: `data:image/png,${id}` }
+}
+
+function plainText(content: string): TextPart {
+  return { type: "text", content, start: 0, end: content.length }
+}
+
+// Inspect the leading marked TextPart returned by prependCommandMark.
+function getMarked(result: Prompt): TextPart {
+  const first = result[0]
+  if (first.type !== "text") throw new Error("expected TextPart at index 0")
+  return first
+}
+
+// Empty prompt cases -------------------------------------------------------
+
+describe("prependCommandMark — empty prompt", () => {
+  test("empty prompt → [marked, ...images], ImagePart identity preserved", () => {
+    const img = imagePart("img-001")
+    const result = prependCommandMark(DEFAULT_PROMPT, [img], cmd("brainstorming"))
+
+    expect(result.length).toBe(2)
+
+    const marked = getMarked(result)
+    expect(marked.command?.name).toBe("brainstorming")
+    expect(marked.content).toBe("/brainstorming ")
+
+    // Reference identity — no cloning of incoming image parts.
+    expect(result[1]).toBe(img)
+  })
+
+  test("empty prompt + no images → [marked] only", () => {
+    const result = prependCommandMark(DEFAULT_PROMPT, [], cmd("review"))
+
+    expect(result.length).toBe(1)
+    const marked = getMarked(result)
+    expect(marked.command?.name).toBe("review")
+  })
+
+  test("cursor target = marked content length", () => {
+    const result = prependCommandMark(DEFAULT_PROMPT, [], cmd("x"))
+    const marked = getMarked(result)
+    // Content is "/x " (3 chars).
+    expect(marked.content.length).toBe(3)
+  })
+
+  test("marked TextPart has trailing space (createCommandTextPart contract)", () => {
+    const result = prependCommandMark(DEFAULT_PROMPT, [], cmd("do-it"))
+    const marked = getMarked(result)
+    expect(marked.content).toBe("/do-it ")
+    expect(marked.content.endsWith(" ")).toBe(true)
+  })
+
+  test("source and icon forwarded into command metadata", () => {
+    const descriptor: CommandDescriptor = { name: "scan", source: "skill", icon: "sparkles" }
+    const result = prependCommandMark(DEFAULT_PROMPT, [], descriptor)
+    const marked = getMarked(result)
+    expect(marked.command?.source).toBe("skill")
+    expect(marked.command?.icon).toBe("sparkles")
+  })
+
+  test("multiple image attachments → all images follow marked in order", () => {
+    const img1 = imagePart("img-001")
+    const img2 = imagePart("img-002")
+    const result = prependCommandMark(DEFAULT_PROMPT, [img1, img2], cmd("brainstorming"))
+
+    expect(result.length).toBe(3)
+    expect(result[1]).toBe(img1)
+    expect(result[2]).toBe(img2)
+  })
+})
+
+// Non-empty prompt cases (E1 variant) -------------------------------------
+
+describe("prependCommandMark — non-empty prompt (E1 variant)", () => {
+  test("non-empty prompt → [marked, ...current], original parts in original order", () => {
+    const file = filePart("/workspace/foo.ts")
+    const txt = plainText("some context")
+    const current: Prompt = [txt, file]
+    const result = prependCommandMark(current, [], cmd("review"))
+
+    expect(result.length).toBe(3)
+    const marked = getMarked(result)
+    expect(marked.command?.name).toBe("review")
+    // Original parts in original order and by reference.
+    expect(result[1]).toBe(txt)
+    expect(result[2]).toBe(file)
+  })
+
+  test("FilePart identity preserved (no clone)", () => {
+    const file = filePart("/src/main.ts")
+    const current: Prompt = [plainText(""), file]
+    const result = prependCommandMark(current, [], cmd("review"))
+    const fileInResult = result.find((p) => p.type === "file")
+    expect(fileInResult).toBe(file)
+  })
+
+  test("AgentPart identity preserved (no clone)", () => {
+    const agent = agentPart("coder")
+    const current: Prompt = [plainText(""), agent]
+    const result = prependCommandMark(current, [], cmd("refactor"))
+    const agentInResult = result.find((p) => p.type === "agent")
+    expect(agentInResult).toBe(agent)
+  })
+
+  test("cursor target = marked content.length", () => {
+    const current: Prompt = [plainText("existing text")]
+    const result = prependCommandMark(current, [], cmd("analyze"))
+    const marked = getMarked(result)
+    // "/analyze " = 9 chars
+    expect(marked.content.length).toBe("/analyze ".length)
+  })
+
+  test("images passed as second arg are ignored when prompt is non-empty (current already has them)", () => {
+    // E1: when current is non-empty, images arg is not used — caller passes
+    // imageAttachments() separately only for the empty-prompt case.
+    const img = imagePart("img-003")
+    const current: Prompt = [plainText("text"), img]
+    const result = prependCommandMark(current, [], cmd("summarize"))
+
+    // Result should be [marked, plainText, img] — the image comes from current,
+    // not from the images arg (which is empty here).
+    expect(result.length).toBe(3)
+    expect(result[2]).toBe(img)
+  })
+
+  test("interleaved File + Text parts all preserved by reference", () => {
+    const t1 = plainText("first chunk")
+    const f1 = filePart("/a.ts")
+    const t2 = plainText("second chunk")
+    const f2 = filePart("/b.ts")
+    const current: Prompt = [t1, f1, t2, f2]
+    const result = prependCommandMark(current, [], cmd("review"))
+
+    expect(result.length).toBe(5)
+    expect(result[1]).toBe(t1)
+    expect(result[2]).toBe(f1)
+    expect(result[3]).toBe(t2)
+    expect(result[4]).toBe(f2)
+  })
+})
+
+// No-mutation invariant ---------------------------------------------------
+
+describe("prependCommandMark — no mutation", () => {
+  test("original current array is not mutated", () => {
+    const file = filePart("/x.ts")
+    const current: Prompt = [plainText("hello"), file]
+    const snapshot = [...current]
+    prependCommandMark(current, [], cmd("review"))
+    expect(current.length).toBe(snapshot.length)
+    expect(current[0]).toBe(snapshot[0])
+    expect(current[1]).toBe(snapshot[1])
+  })
+
+  test("original images array is not mutated", () => {
+    const img = imagePart("img-001")
+    const images = [img]
+    prependCommandMark(DEFAULT_PROMPT, images, cmd("review"))
+    expect(images.length).toBe(1)
+    expect(images[0]).toBe(img)
+  })
+})

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -167,6 +167,60 @@ describe("prependCommandMark — non-empty prompt (E1 variant)", () => {
   })
 })
 
+// Slash-query replacement cases ------------------------------------------
+
+describe("prependCommandMark — slash-query state (user typed /<query>)", () => {
+  test("current=[Text('/')] → replace, NOT prepend", () => {
+    const current: Prompt = [plainText("/")]
+    const result = prependCommandMark(current, [], cmd("brainstorming"))
+    expect(result.length).toBe(1)
+    expect((result[0] as any).command?.name).toBe("brainstorming")
+    expect((result[0] as any).content).toBe("/brainstorming ")
+  })
+
+  test("current=[Text('/brain')] → replace, NOT prepend", () => {
+    const current: Prompt = [plainText("/brain")]
+    const result = prependCommandMark(current, [], cmd("brainstorming"))
+    expect(result.length).toBe(1)
+    expect((result[0] as any).command?.name).toBe("brainstorming")
+  })
+
+  test("slash-query state + images → [marked, ...images], typed slash consumed", () => {
+    const img = imagePart("a")
+    const current: Prompt = [plainText("/foo")]
+    const result = prependCommandMark(current, [img], cmd("review"))
+    expect(result.length).toBe(2)
+    expect((result[0] as any).command?.name).toBe("review")
+    expect(result[1]).toBe(img)
+  })
+
+  test("text containing slash mid-string is NOT slash-query state (E1)", () => {
+    const current: Prompt = [plainText("hi /foo")]
+    const result = prependCommandMark(current, [], cmd("review"))
+    // E1 branch fires: prepend
+    expect(result.length).toBe(2)
+    expect((result[1] as any).content).toBe("hi /foo")
+  })
+
+  test("multi-part prompt with leading /foo is NOT slash-query state (E1)", () => {
+    const current: Prompt = [plainText("/foo"), plainText("bar")]
+    const result = prependCommandMark(current, [], cmd("review"))
+    expect(result.length).toBe(3)
+  })
+
+  test("leading marked TextPart is NOT slash-query state (E1)", () => {
+    // current already has a marked pill; a second select should prepend (E1).
+    const markedAlready: Prompt = [{
+      type: "text", content: "/foo ", start: 0, end: 5,
+      command: { name: "foo", source: "skill", icon: "command" },
+    }]
+    const result = prependCommandMark(markedAlready, [], cmd("review"))
+    expect(result.length).toBe(2)
+    expect((result[0] as any).command?.name).toBe("review")
+    expect(result[1]).toBe(markedAlready[0])
+  })
+})
+
 // No-mutation invariant ---------------------------------------------------
 
 describe("prependCommandMark — no mutation", () => {

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -226,6 +226,27 @@ describe("prependCommandMark — slash-query state (user typed /<query>)", () =>
     expect(markedCount).toBe(1)
   })
 
+  test("leading marked TextPart with args → args are dropped on command switch", () => {
+    // Product decision: a pill is an atomic unit. Switching commands drops
+    // the old args because they carry the old command's semantics, which
+    // may not map to the new command (e.g. /summarize "the diff" → /translate).
+    // Carrying args across the switch would silently feed mismatched
+    // arguments into the new command.
+    const oldMarked: TextPart = {
+      type: "text", content: "/old hello world", start: 0, end: 16,
+      command: { name: "old", source: "skill", icon: "command" },
+    }
+    const result = prependCommandMark([oldMarked], [], cmd("new"))
+
+    expect(result.length).toBe(1)
+    const newMarked = result[0] as TextPart
+    expect(newMarked.command?.name).toBe("new")
+    // Empty args: content is just "/new " (slash + name + trailing space).
+    expect(newMarked.content).toBe("/new ")
+    // "hello world" is gone — not carried across the command switch.
+    expect(newMarked.content).not.toContain("hello")
+  })
+
   test("leading marked TextPart + tail parts → replace marked, preserve tail by identity", () => {
     // Args text after the pill, plus a file attachment, must survive identity.
     const oldMarked: TextPart = {

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -208,16 +208,41 @@ describe("prependCommandMark — slash-query state (user typed /<query>)", () =>
     expect(result.length).toBe(3)
   })
 
-  test("leading marked TextPart is NOT slash-query state (E1)", () => {
-    // current already has a marked pill; a second select should prepend (E1).
+  test("leading marked TextPart → replace old marked with new (at-most-one invariant)", () => {
+    // current already has a marked pill; picking a second command means the
+    // user is changing their mind. The result must contain exactly ONE marked
+    // TextPart at index 0 (spec invariant L538-546).
     const markedAlready: Prompt = [{
       type: "text", content: "/foo ", start: 0, end: 5,
       command: { name: "foo", source: "skill", icon: "command" },
     }]
     const result = prependCommandMark(markedAlready, [], cmd("review"))
+
+    expect(result.length).toBe(1)
+    expect((result[0] as any).command?.name).toBe("review")
+
+    // Exactly one marked TextPart in the whole result.
+    const markedCount = result.filter((p) => p.type === "text" && (p as TextPart).command).length
+    expect(markedCount).toBe(1)
+  })
+
+  test("leading marked TextPart + tail parts → replace marked, preserve tail by identity", () => {
+    // Args text after the pill, plus a file attachment, must survive identity.
+    const oldMarked: TextPart = {
+      type: "text", content: "/foo args", start: 0, end: 9,
+      command: { name: "foo", source: "skill", icon: "command" },
+    }
+    const file = filePart("/x.ts")
+    const markedAlready: Prompt = [oldMarked, file]
+    const result = prependCommandMark(markedAlready, [], cmd("review"))
+
     expect(result.length).toBe(2)
     expect((result[0] as any).command?.name).toBe("review")
-    expect(result[1]).toBe(markedAlready[0])
+    // Tail FilePart preserved by reference.
+    expect(result[1]).toBe(file)
+    // Old marked TextPart is gone (no duplicate command).
+    const markedCount = result.filter((p) => p.type === "text" && (p as TextPart).command).length
+    expect(markedCount).toBe(1)
   })
 })
 

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -226,12 +226,12 @@ describe("prependCommandMark — slash-query state (user typed /<query>)", () =>
     expect(markedCount).toBe(1)
   })
 
-  test("leading marked TextPart with args → args are dropped on command switch", () => {
-    // Product decision: a pill is an atomic unit. Switching commands drops
-    // the old args because they carry the old command's semantics, which
-    // may not map to the new command (e.g. /summarize "the diff" → /translate).
-    // Carrying args across the switch would silently feed mismatched
-    // arguments into the new command.
+  test("leading marked TextPart with args → args are preserved across command switch", () => {
+    // Product decision: switching commands keeps the args the user already
+    // typed. $ARGUMENTS is plain string substitution with no schema, so any
+    // text the user kept is still legitimate input. Silently deleting it
+    // would discard work the user invested time in. The user can see the
+    // args in the editor and remove them if they no longer fit.
     const oldMarked: TextPart = {
       type: "text", content: "/old hello world", start: 0, end: 16,
       command: { name: "old", source: "skill", icon: "command" },
@@ -241,10 +241,21 @@ describe("prependCommandMark — slash-query state (user typed /<query>)", () =>
     expect(result.length).toBe(1)
     const newMarked = result[0] as TextPart
     expect(newMarked.command?.name).toBe("new")
-    // Empty args: content is just "/new " (slash + name + trailing space).
-    expect(newMarked.content).toBe("/new ")
-    // "hello world" is gone — not carried across the command switch.
-    expect(newMarked.content).not.toContain("hello")
+    // Args carried over: content is "/new hello world".
+    expect(newMarked.content).toBe("/new hello world")
+  })
+
+  test("leading marked TextPart with empty args → result still has trailing space", () => {
+    // Old marked "/old " (empty args) → new marked "/new " (empty args).
+    // createCommandTextPart always emits trailing space after the name.
+    const oldMarked: TextPart = {
+      type: "text", content: "/old ", start: 0, end: 5,
+      command: { name: "old", source: "skill", icon: "command" },
+    }
+    const result = prependCommandMark([oldMarked], [], cmd("new"))
+
+    expect(result.length).toBe(1)
+    expect((result[0] as TextPart).content).toBe("/new ")
   })
 
   test("leading marked TextPart + tail parts → replace marked, preserve tail by identity", () => {

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -1,17 +1,34 @@
-// Pure data-transform: prepend a marked TextPart to a Prompt on slash-command
-// select. No DOM, no reactive context.
+// Pure data-transform: build the new Prompt after the user selects a slash
+// command from the popover. Three cases:
 //
-// Two cases:
-//   1. Empty prompt (equal to DEFAULT_PROMPT) with optional image attachments:
+//   1. Empty prompt (DEFAULT_PROMPT) with optional image attachments:
 //      result is [marked, ...images].
-//   2. Non-empty prompt: result is [marked, ...current].
+//   2. Slash-query state — the user opened the popover by typing /<query>;
+//      current is a single plain TextPart whose content matches `^/(\S*)$`.
+//      Per spec §Path A step 4, replace the entire slash-query match with
+//      the marked TextPart. Result: [marked, ...images].
+//   3. E1 mid-prompt — the popover was opened via the global command.trigger
+//      keybind while the editor already had unrelated content. Result:
+//      [marked, ...current], preserving original parts in order and identity.
 //
 // Non-text part identity (FilePart / AgentPart / ImagePart references) is
 // preserved exactly — no cloning of incoming parts.
 
-import type { ImageAttachmentPart, Prompt } from "@/context/prompt"
+import type { ImageAttachmentPart, Prompt, TextPart } from "@/context/prompt"
 import { DEFAULT_PROMPT, isPromptEqual } from "@/context/prompt"
 import { createCommandTextPart, type CommandDescriptor } from "./command-text-part"
+
+// Slash trigger regex — must match `editor-input.ts:261` exactly so the
+// "popover was opened by slash typing" detection here mirrors what opened it.
+const SLASH_QUERY_REGEX = /^\/(\S*)$/
+
+function isSlashQueryState(current: Prompt): boolean {
+  if (current.length !== 1) return false
+  const first = current[0] as TextPart
+  if (first.type !== "text") return false
+  if (first.command) return false // already a marked TextPart — not a query
+  return SLASH_QUERY_REGEX.test(first.content)
+}
 
 /**
  * Build the new Prompt after the user selects a custom slash command.
@@ -19,8 +36,9 @@ import { createCommandTextPart, type CommandDescriptor } from "./command-text-pa
  * @param current - snapshot of prompt.current() at the moment of selection
  * @param images  - imageAttachments() at the moment of selection
  * @param cmd     - descriptor forwarded from the SlashCommand entry
- * @returns new Prompt with the marked TextPart prepended; cursor target is
- *          `result[0].content.length` (end of the pill text)
+ * @returns new Prompt; cursor target is `result[0].content.length` (end of
+ *          the pill text, which is `/<name> ` per createCommandTextPart's
+ *          trailing-space invariant)
  */
 export function prependCommandMark(
   current: Prompt,
@@ -28,14 +46,15 @@ export function prependCommandMark(
   cmd: CommandDescriptor,
 ): Prompt {
   const marked = createCommandTextPart(cmd, "")
-  const isEmpty = isPromptEqual(current, DEFAULT_PROMPT)
 
-  if (isEmpty) {
-    // Preserve image attachment identity; omit the bare empty TextPart.
+  if (isPromptEqual(current, DEFAULT_PROMPT) || isSlashQueryState(current)) {
+    // Empty prompt OR slash-query state — replace the editor content with the
+    // marked TextPart. The slash literal the user typed (`/foo`) is consumed
+    // by the conversion. Image attachments survive.
     return [marked, ...images]
   }
 
-  // E1 variant: keep all existing parts (including any images already inside
-  // current) in original order and identity.
+  // E1 mid-prompt variant: keep all existing parts (including any images
+  // already inside current) in original order and identity.
   return [marked, ...current]
 }

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -1,0 +1,41 @@
+// Pure data-transform: prepend a marked TextPart to a Prompt on slash-command
+// select. No DOM, no reactive context.
+//
+// Two cases:
+//   1. Empty prompt (equal to DEFAULT_PROMPT) with optional image attachments:
+//      result is [marked, ...images].
+//   2. Non-empty prompt: result is [marked, ...current].
+//
+// Non-text part identity (FilePart / AgentPart / ImagePart references) is
+// preserved exactly — no cloning of incoming parts.
+
+import type { ImageAttachmentPart, Prompt } from "@/context/prompt"
+import { DEFAULT_PROMPT, isPromptEqual } from "@/context/prompt"
+import { createCommandTextPart, type CommandDescriptor } from "./command-text-part"
+
+/**
+ * Build the new Prompt after the user selects a custom slash command.
+ *
+ * @param current - snapshot of prompt.current() at the moment of selection
+ * @param images  - imageAttachments() at the moment of selection
+ * @param cmd     - descriptor forwarded from the SlashCommand entry
+ * @returns new Prompt with the marked TextPart prepended; cursor target is
+ *          `result[0].content.length` (end of the pill text)
+ */
+export function prependCommandMark(
+  current: Prompt,
+  images: ImageAttachmentPart[],
+  cmd: CommandDescriptor,
+): Prompt {
+  const marked = createCommandTextPart(cmd, "")
+  const isEmpty = isPromptEqual(current, DEFAULT_PROMPT)
+
+  if (isEmpty) {
+    // Preserve image attachment identity; omit the bare empty TextPart.
+    return [marked, ...images]
+  }
+
+  // E1 variant: keep all existing parts (including any images already inside
+  // current) in original order and identity.
+  return [marked, ...current]
+}

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -63,7 +63,11 @@ export function prependCommandMark(
     // Invariant: at most one marked TextPart per Prompt, always at index 0.
     // Re-opening the popover and picking a second command means the user is
     // changing their mind — replace the old marked TextPart with the new one
-    // and keep the rest of the prompt (args text, images, files, agents).
+    // and drop its args. A pill is an atomic unit: the args belong to the
+    // old command's semantics, which may not map to the new command at all
+    // (e.g. /summarize "the diff" → /translate). Carrying args across the
+    // switch would silently feed mismatched arguments into /new. Tail parts
+    // after the marked TextPart (files, agents, images) survive by identity.
     return [marked, ...current.slice(1)]
   }
 

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -35,6 +35,15 @@ function hasLeadingMarked(current: Prompt): boolean {
   return first?.type === "text" && !!first.command
 }
 
+// Extract the args portion from a leading marked TextPart. content always
+// starts with "/<name> " per createCommandTextPart's invariant, so slicing
+// off that prefix yields the user-typed args (possibly empty).
+function leadingArgs(current: Prompt): string {
+  const first = current[0] as TextPart & { command: NonNullable<TextPart["command"]> }
+  const prefix = `/${first.command.name} `
+  return first.content.slice(prefix.length)
+}
+
 /**
  * Build the new Prompt after the user selects a custom slash command.
  *
@@ -62,13 +71,17 @@ export function prependCommandMark(
   if (hasLeadingMarked(current)) {
     // Invariant: at most one marked TextPart per Prompt, always at index 0.
     // Re-opening the popover and picking a second command means the user is
-    // changing their mind — replace the old marked TextPart with the new one
-    // and drop its args. A pill is an atomic unit: the args belong to the
-    // old command's semantics, which may not map to the new command at all
-    // (e.g. /summarize "the diff" → /translate). Carrying args across the
-    // switch would silently feed mismatched arguments into /new. Tail parts
-    // after the marked TextPart (files, agents, images) survive by identity.
-    return [marked, ...current.slice(1)]
+    // changing their mind about the command name — swap the pill but keep
+    // the args the user already typed. $ARGUMENTS is a plain string
+    // substitution with no schema, so any text the user kept is still
+    // legitimate input for the new command; deciding otherwise would mean
+    // the system silently deletes work the user invested time in. If the
+    // args do not fit the new command, the user can see them in the editor
+    // and remove them. Tail parts (files, agents, images) survive by
+    // identity.
+    const carriedArgs = leadingArgs(current)
+    const markedWithArgs = createCommandTextPart(cmd, carriedArgs)
+    return [markedWithArgs, ...current.slice(1)]
   }
 
   // E1 mid-prompt variant: keep all existing parts (including any images

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -30,6 +30,11 @@ function isSlashQueryState(current: Prompt): boolean {
   return SLASH_QUERY_REGEX.test(first.content)
 }
 
+function hasLeadingMarked(current: Prompt): boolean {
+  const first = current[0]
+  return first?.type === "text" && !!first.command
+}
+
 /**
  * Build the new Prompt after the user selects a custom slash command.
  *
@@ -52,6 +57,14 @@ export function prependCommandMark(
     // marked TextPart. The slash literal the user typed (`/foo`) is consumed
     // by the conversion. Image attachments survive.
     return [marked, ...images]
+  }
+
+  if (hasLeadingMarked(current)) {
+    // Invariant: at most one marked TextPart per Prompt, always at index 0.
+    // Re-opening the popover and picking a second command means the user is
+    // changing their mind — replace the old marked TextPart with the new one
+    // and keep the rest of the prompt (args text, images, files, agents).
+    return [marked, ...current.slice(1)]
   }
 
   // E1 mid-prompt variant: keep all existing parts (including any images

--- a/packages/app/src/components/prompt-input/command-space-trigger.test.ts
+++ b/packages/app/src/components/prompt-input/command-space-trigger.test.ts
@@ -1,0 +1,121 @@
+// Tests for Path B Space-trigger detection logic.
+// Spec: §Path B (L224-235).
+
+import { describe, expect, test } from "bun:test"
+import type { CommandSource, ImageAttachmentPart } from "@/context/prompt"
+import type { CommandDescriptor } from "./command-text-part"
+import { tryPathBConversion } from "./command-space-trigger"
+
+const reg: CommandDescriptor[] = [
+  { name: "brainstorming", source: "skill" as CommandSource, icon: "command" },
+]
+
+const noImages: ImageAttachmentPart[] = []
+const image: ImageAttachmentPart = {
+  type: "image", id: "1", filename: "a.png", mime: "image/png", dataUrl: "data:img",
+}
+
+describe("tryPathBConversion", () => {
+  test("`/brainstorming ` + insertText space → marked TextPart returned", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/brainstorming ",
+      images: noImages, registry: reg,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.prompt.length).toBe(1)
+    const part = result!.prompt[0]
+    expect(part.type).toBe("text")
+    expect((part as any).command?.name).toBe("brainstorming")
+    expect((part as any).content).toBe("/brainstorming ")
+    expect(result!.cursor).toBe("/brainstorming ".length)
+  })
+
+  test("`/Brainstorming ` + space → canonical case in metadata", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/Brainstorming ",
+      images: noImages, registry: reg,
+    })
+    expect(result).not.toBeNull()
+    expect((result!.prompt[0] as any).command.name).toBe("brainstorming")
+  })
+
+  test("`/notcmd ` + space → null (registry miss)", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/notcmd ",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("non-insertText event (deleteContentBackward) → null", () => {
+    const result = tryPathBConversion({
+      inputType: "deleteContentBackward", data: null,
+      rawText: "/brainstorming ",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("insertText with data !== ' ' → null", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: "x",
+      rawText: "/brainstorming",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("insertCompositionText (IME commit) → null even if data is space", () => {
+    const result = tryPathBConversion({
+      inputType: "insertCompositionText", data: " ",
+      rawText: "/brainstorming ",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("buffer shape `/cmd args ` (space typed mid-args) → null", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/brainstorming hello ",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("buffer shape `/cmd` (no trailing space, but data was ' ') → null", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/brainstorming",
+      images: noImages, registry: reg,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("image preservation: [Text('/cmd'), Image] state + Space → [marked, image]", () => {
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/brainstorming ",
+      images: [image], registry: reg,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.prompt.length).toBe(2)
+    expect(result!.prompt[1]).toBe(image)
+  })
+
+  test("multi-image identity stable", () => {
+    const i2: ImageAttachmentPart = {
+      type: "image", id: "2", filename: "b.png", mime: "image/png", dataUrl: "data:b",
+    }
+    const result = tryPathBConversion({
+      inputType: "insertText", data: " ",
+      rawText: "/brainstorming ",
+      images: [image, i2], registry: reg,
+    })
+    expect(result!.prompt[1]).toBe(image)
+    expect(result!.prompt[2]).toBe(i2)
+  })
+})

--- a/packages/app/src/components/prompt-input/command-space-trigger.ts
+++ b/packages/app/src/components/prompt-input/command-space-trigger.ts
@@ -1,0 +1,45 @@
+// Pure data-transform for Path B: detect whether a Space-keystroke just typed
+// at the end of `/<known-name>` should materialise into a pill.
+//
+// Browser fires `input` events with `inputType === "insertText"` exclusively
+// when the user types a single character. This is naturally false on paste
+// (`insertFromPaste`), Backspace (`deleteContentBackward`), IME commit
+// (`insertCompositionText`), and programmatic mutations (no event). No flag
+// state machine needed.
+
+import type { ImageAttachmentPart, Prompt } from "@/context/prompt"
+import type { CommandDescriptor } from "./command-text-part"
+import { tryParseLeadingCommandFromText } from "./command-text-part"
+
+// Anchored Path B buffer check: leading slash, captured non-whitespace name,
+// exactly one trailing space, end of string. A space typed mid-args (buffer
+// like "/cmd args ") does NOT match — the args section already contains
+// whitespace, so `\S+` cannot bridge it.
+const SPACE_TRIGGER_REGEX = /^\/(\S+) $/
+
+export interface SpaceTriggerInput {
+  inputType?: string | null
+  data?: string | null
+  rawText: string
+  images: ImageAttachmentPart[]
+  registry: ReadonlyArray<CommandDescriptor>
+}
+
+/**
+ * Try to convert a Space-keystroke at `/<known-name>` into a marked TextPart.
+ * Returns the new Prompt and target cursor position on conversion, or null
+ * when Path B declines (event shape wrong, buffer shape wrong, or registry miss).
+ */
+export function tryPathBConversion(
+  input: SpaceTriggerInput,
+): { prompt: Prompt; cursor: number } | null {
+  if (input.inputType !== "insertText") return null
+  if (input.data !== " ") return null
+  if (!SPACE_TRIGGER_REGEX.test(input.rawText)) return null
+  const marked = tryParseLeadingCommandFromText(input.rawText, input.registry)
+  if (!marked) return null
+  return {
+    prompt: [marked, ...input.images],
+    cursor: marked.content.length,
+  }
+}

--- a/packages/app/src/components/prompt-input/command-text-part.test.ts
+++ b/packages/app/src/components/prompt-input/command-text-part.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import {
+  assertCommandTextPart,
+  createCommandTextPart,
+  tryParseLeadingCommandFromText,
+} from "./command-text-part"
+
+const reg = [
+  { name: "brainstorming", source: "skill" as const, icon: "command" },
+  { name: "帮助", source: "skill" as const, icon: "command" },
+]
+
+describe("createCommandTextPart", () => {
+  test("empty args produces content `/<name> ` with trailing space", () => {
+    const part = createCommandTextPart({ name: "brainstorming", source: "skill", icon: "command" }, "")
+    expect(part.type).toBe("text")
+    expect(part.content).toBe("/brainstorming ")
+    expect(part.start).toBe(0)
+    expect(part.end).toBe(part.content.length)
+    expect(part.command).toEqual({ name: "brainstorming", source: "skill", icon: "command" })
+  })
+
+  test("args preserved verbatim with single separator space", () => {
+    const part = createCommandTextPart({ name: "brainstorming", source: "skill", icon: "command" }, "hello world")
+    expect(part.content).toBe("/brainstorming hello world")
+  })
+
+  test("args with leading whitespace preserved verbatim — no further trim", () => {
+    const part = createCommandTextPart({ name: "x", source: "skill", icon: "command" }, "  indented")
+    expect(part.content).toBe("/x   indented")
+  })
+})
+
+describe("tryParseLeadingCommandFromText", () => {
+  test("registered name (case-insensitive ASCII) → canonical-cased TextPart", () => {
+    const part = tryParseLeadingCommandFromText("/Brainstorming hello", reg)
+    expect(part).not.toBeNull()
+    expect(part!.command!.name).toBe("brainstorming")
+    expect(part!.content).toBe("/brainstorming hello")
+  })
+
+  test("no args group → content is /<name> with trailing space", () => {
+    const part = tryParseLeadingCommandFromText("/brainstorming", reg)
+    expect(part).not.toBeNull()
+    expect(part!.content).toBe("/brainstorming ")
+  })
+
+  test("single trailing space → content is /<name> with one space (args empty)", () => {
+    const part = tryParseLeadingCommandFromText("/brainstorming ", reg)
+    expect(part!.content).toBe("/brainstorming ")
+  })
+
+  test("double space between name and args: first is separator, second is verbatim args char", () => {
+    const part = tryParseLeadingCommandFromText("/brainstorming  args", reg)
+    expect(part!.content).toBe("/brainstorming  args")
+  })
+
+  test("unknown name → null", () => {
+    expect(tryParseLeadingCommandFromText("/unknown hello", reg)).toBeNull()
+  })
+
+  test("newline separator → null", () => {
+    expect(tryParseLeadingCommandFromText("/brainstorming\nargs", reg)).toBeNull()
+  })
+
+  test("tab separator → null", () => {
+    expect(tryParseLeadingCommandFromText("/brainstorming\targs", reg)).toBeNull()
+  })
+
+  test("non-ASCII command name matches only byte-identically (no Unicode case-folding)", () => {
+    const part = tryParseLeadingCommandFromText("/帮助 hi", reg)
+    expect(part).not.toBeNull()
+    expect(part!.command!.name).toBe("帮助")
+  })
+
+  test("length-preserve invariant: result.command.name.length === inputName.length for every match", () => {
+    const inputs = ["/brainstorming", "/Brainstorming", "/BRAINSTORMING", "/帮助"]
+    for (const s of inputs) {
+      const part = tryParseLeadingCommandFromText(s, reg)
+      const inputName = s.split(" ")[0].slice(1)
+      expect(part).not.toBeNull()
+      expect(part!.command!.name.length).toBe(inputName.length)
+    }
+  })
+
+  test("empty name → null", () => {
+    expect(tryParseLeadingCommandFromText("/ args", reg)).toBeNull()
+  })
+})
+
+describe("assertCommandTextPart", () => {
+  test("valid marked TextPart does not throw", () => {
+    const part = createCommandTextPart({ name: "x", source: "skill", icon: "command" }, "args")
+    expect(() => assertCommandTextPart(part)).not.toThrow()
+  })
+
+  test("content not starting with /<name> throws synchronously", () => {
+    const bad = { type: "text" as const, content: "/wrong args", start: 0, end: 11,
+      command: { name: "right", source: "skill" as const, icon: "command" } }
+    expect(() => assertCommandTextPart(bad)).toThrow(/invariant/)
+  })
+
+  test("missing trailing space when args empty throws", () => {
+    const bad = { type: "text" as const, content: "/x", start: 0, end: 2,
+      command: { name: "x", source: "skill" as const, icon: "command" } }
+    expect(() => assertCommandTextPart(bad)).toThrow(/invariant/)
+  })
+})

--- a/packages/app/src/components/prompt-input/command-text-part.ts
+++ b/packages/app/src/components/prompt-input/command-text-part.ts
@@ -1,0 +1,94 @@
+import type { CommandSource, TextPart } from "@/context/prompt"
+
+export interface CommandDescriptor {
+  name: string
+  source: CommandSource
+  icon: string
+}
+
+// Regex: `/^\/(\S+)(?: ([\s\S]*))?$/` (no flags per spec).
+// Separator must be exactly one ASCII space. Tab/newline do NOT match.
+const COMMAND_REGEX = /^\/(\S+)(?: ([\s\S]*))?$/
+
+// Detect whether a string is pure ASCII (code points 0x00-0x7F).
+// Only pure-ASCII paths get case-insensitive matching to preserve
+// `command.name.length === inputName.length` byte-for-byte for caret math.
+function isAscii(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 127) return false
+  }
+  return true
+}
+
+// ASCII-only lowercase: replace A-Z with a-z without Unicode case-folding.
+function asciiLower(s: string): string {
+  return s.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32))
+}
+
+// Match a typed name against the registry.
+// Both sides must be pure ASCII for case-insensitive comparison; otherwise
+// exact byte match is required (no Unicode case-folding).
+function matchRegistry(
+  typedName: string,
+  registry: ReadonlyArray<CommandDescriptor>,
+): CommandDescriptor | null {
+  const typedAscii = isAscii(typedName)
+  for (const entry of registry) {
+    const entryAscii = isAscii(entry.name)
+    if (typedAscii && entryAscii) {
+      if (asciiLower(typedName) === asciiLower(entry.name)) return entry
+    } else {
+      if (typedName === entry.name) return entry
+    }
+  }
+  return null
+}
+
+// Create a marked TextPart for a command. Content is always `/<name> <args>`;
+// trailing space is present even when args is empty string.
+export function createCommandTextPart(cmd: CommandDescriptor, args: string): TextPart {
+  const content = `/${cmd.name} ${args}`
+  return {
+    type: "text",
+    content,
+    start: 0,
+    end: content.length,
+    command: { name: cmd.name, source: cmd.source, icon: cmd.icon },
+  }
+}
+
+// Try to parse rawText as a leading command from the registry.
+// Returns a marked TextPart using the registry's canonical casing, or null
+// when the text does not match the regex or the name is not registered.
+export function tryParseLeadingCommandFromText(
+  rawText: string,
+  registry: ReadonlyArray<CommandDescriptor>,
+): TextPart | null {
+  const match = rawText.match(COMMAND_REGEX)
+  if (!match) return null
+  const typedName = match[1]
+  // Regex requires \S+ so typedName can't be empty, but guard for safety.
+  if (!typedName) return null
+  const entry = matchRegistry(typedName, registry)
+  if (!entry) return null
+  // match[2] is the args group (everything after the single separator space).
+  // When there is no separator space in the input, match[2] is undefined → use "".
+  const args = match[2] ?? ""
+  return createCommandTextPart(entry, args)
+}
+
+// Synchronous invariant check. Throws when the marked TextPart violates the
+// content prefix contract (`/<name> ` must be the start of content).
+// Used by helper-level Bun tests; production renderer should use reportInvariantBreach.
+export function assertCommandTextPart(part: TextPart): void {
+  const cmd = part.command
+  if (!cmd) {
+    throw new Error("command-text-part invariant: missing command metadata")
+  }
+  const prefix = `/${cmd.name} `
+  if (!part.content.startsWith(prefix)) {
+    throw new Error(
+      `command-text-part invariant: content "${part.content}" does not start with "${prefix}"`,
+    )
+  }
+}

--- a/packages/app/src/components/prompt-input/command-text-part.ts
+++ b/packages/app/src/components/prompt-input/command-text-part.ts
@@ -77,6 +77,21 @@ export function tryParseLeadingCommandFromText(
   return createCommandTextPart(entry, args)
 }
 
+// Build a CommandDescriptor[] registry from sync.data.command entries.
+// sync.data.command provides {name, source?}; source defaults to "command"
+// when absent. icon always defaults to "command" (resolveCommandIconSvg
+// fallback). Built-in slash commands are NOT included — they dispatch
+// immediately, never rendered as pills.
+export function buildSlashRegistry(
+  commands: ReadonlyArray<{ name: string; source?: CommandSource }>,
+): CommandDescriptor[] {
+  return commands.map((c) => ({
+    name: c.name,
+    source: c.source ?? "command",
+    icon: "command",
+  }))
+}
+
 // Synchronous invariant check. Throws when the marked TextPart violates the
 // content prefix contract (`/<name> ` must be the start of content).
 // Used by helper-level Bun tests; production renderer should use reportInvariantBreach.

--- a/packages/app/src/components/prompt-input/editor-dom.test.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.test.ts
@@ -147,4 +147,51 @@ describe("prompt-input editor dom", () => {
 
     container.remove()
   })
+
+  test("getTextLength counts cmd-mark pill as 1 + name.length (NOT visible label)", () => {
+    // Pill DOM has label child whose textContent is name; logical length is
+    // 1 + name.length because the slash literal is NOT in the visible DOM.
+    // getCursorPosition feeds cloned ranges through getTextLength — if this
+    // reports the wrong length, caret math after a pill is off-by-one.
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "brainstorming"
+    const label = document.createElement("span")
+    label.dataset.cmdLabel = "true"
+    label.textContent = "brainstorming"
+    pill.appendChild(label)
+
+    expect(getTextLength(pill)).toBe(1 + "brainstorming".length)
+    // Confirm asymmetry vs the textContent walk that would happen without
+    // the cmd-mark branch.
+    expect(pill.textContent!.length).toBe("brainstorming".length)
+  })
+
+  test("getCursorPosition after pill + ' args' caret returns (1 + name.length) + 5", () => {
+    const container = document.createElement("div")
+    container.contentEditable = "true"
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "go"
+    const label = document.createElement("span")
+    label.dataset.cmdLabel = "true"
+    label.textContent = "go"
+    pill.appendChild(label)
+    container.appendChild(pill)
+    container.appendChild(document.createTextNode(" args"))
+    document.body.appendChild(container)
+
+    try {
+      const sel = window.getSelection()!
+      const r = document.createRange()
+      r.setStart(container.lastChild!, 5) // end of " args"
+      r.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(r)
+      // Expected: 1 (slash) + 2 ("go") + 5 (" args") = 8
+      expect(getCursorPosition(container)).toBe(8)
+    } finally {
+      container.remove()
+    }
+  })
 })

--- a/packages/app/src/components/prompt-input/editor-dom.test.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.test.ts
@@ -96,4 +96,55 @@ describe("prompt-input editor dom", () => {
 
     container.remove()
   })
+
+  test("getNodeLength returns 1 + name.length for a cmd-mark pill", () => {
+    // A slash-command pill has data-cmd-mark="true" and textContent equal to the command name.
+    // Logical length is 1 (for the slash trigger) + name.length, which is asymmetric to textContent.
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "summarize"
+    pill.textContent = "summarize"
+
+    expect(getNodeLength(pill)).toBe(1 + "summarize".length) // 10
+  })
+
+  test("getNodeLength cmd-mark branch fires BEFORE textContent fallback", () => {
+    // If the textContent fallback ran first it would return 9, not 10.
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "run"
+    pill.textContent = "run"
+
+    expect(getNodeLength(pill)).toBe(4) // 1 + 3
+    expect(pill.textContent!.length).toBe(3) // confirm asymmetry
+  })
+
+  test("setCursorPosition treats cmd-mark pill as a pill (cursor snaps around it)", () => {
+    // Layout: "ab" + [/go] + "cd"
+    // Logical offsets: a=0,b=1, pill occupies [2,4) (length 1+2=3? — "/go" name is "go" length 2 so 1+2=3)
+    // position 2 → before pill, position 4 (after pill) → after pill
+    const container = document.createElement("div")
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "go"
+    pill.textContent = "go"
+
+    container.appendChild(document.createTextNode("ab"))
+    container.appendChild(pill)
+    container.appendChild(document.createTextNode("cd"))
+    document.body.appendChild(container)
+
+    // Position 2 = just before the cmd-mark pill → cursor before pill node
+    setCursorPosition(container, 2)
+    const sel2 = window.getSelection()!
+    // The range should be positioned before the pill (startContainer is parent, offset = pill index)
+    expect(sel2.rangeCount).toBe(1)
+
+    // Position 5 (2 + 3) = just after the cmd-mark pill → cursor after pill node
+    setCursorPosition(container, 5)
+    const sel5 = window.getSelection()!
+    expect(sel5.rangeCount).toBe(1)
+
+    container.remove()
+  })
 })

--- a/packages/app/src/components/prompt-input/editor-dom.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.ts
@@ -29,6 +29,11 @@ export function createTextFragment(content: string): DocumentFragment {
 
 export function getNodeLength(node: Node): number {
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
+  // Slash-command pill: logical length is 1 (the slash trigger) + name length.
+  // This must run before the textContent fallback because textContent only holds the name (no slash).
+  if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.cmdMark === "true") {
+    return 1 + ((node as HTMLElement).dataset.name ?? "").length
+  }
   return (node.textContent ?? "").replace(/\u200B/g, "").length
 }
 
@@ -61,7 +66,9 @@ export function setCursorPosition(parent: HTMLElement, position: number) {
     const isText = node.nodeType === Node.TEXT_NODE
     const isPill =
       node.nodeType === Node.ELEMENT_NODE &&
-      ((node as HTMLElement).dataset.type === "file" || (node as HTMLElement).dataset.type === "agent")
+      ((node as HTMLElement).dataset.type === "file" ||
+        (node as HTMLElement).dataset.type === "agent" ||
+        (node as HTMLElement).dataset.cmdMark === "true")
     const isBreak = node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR"
 
     if (isText && remaining <= length) {
@@ -126,7 +133,9 @@ export function setRangeEdge(parent: HTMLElement, range: Range, edge: "start" | 
     const isText = node.nodeType === Node.TEXT_NODE
     const isPill =
       node.nodeType === Node.ELEMENT_NODE &&
-      ((node as HTMLElement).dataset.type === "file" || (node as HTMLElement).dataset.type === "agent")
+      ((node as HTMLElement).dataset.type === "file" ||
+        (node as HTMLElement).dataset.type === "agent" ||
+        (node as HTMLElement).dataset.cmdMark === "true")
     const isBreak = node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR"
 
     if (isText && remaining <= length) {

--- a/packages/app/src/components/prompt-input/editor-dom.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.ts
@@ -40,6 +40,13 @@ export function getNodeLength(node: Node): number {
 export function getTextLength(node: Node): number {
   if (node.nodeType === Node.TEXT_NODE) return (node.textContent ?? "").replace(/\u200B/g, "").length
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
+  // Command pill: logical length is "/<name>" (1 + name.length), NOT the visible
+  // label-only textContent which would be name.length. getCursorPosition feeds
+  // its cloned-range fragment through this function, so any data-cmd-mark inside
+  // the fragment must report its logical length or caret math goes off by one.
+  if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.cmdMark === "true") {
+    return 1 + ((node as HTMLElement).dataset.name ?? "").length
+  }
   let length = 0
   for (const child of Array.from(node.childNodes)) {
     length += getTextLength(child)

--- a/packages/app/src/components/prompt-input/editor-imperatives.ts
+++ b/packages/app/src/components/prompt-input/editor-imperatives.ts
@@ -23,7 +23,7 @@ export interface EditorImperatives {
   focusEditorEnd: () => void
   currentCursor: () => number | null
   restoreFocus: () => void
-  renderEditorWithCursor: (parts: Prompt) => void
+  renderEditorWithCursor: (parts: Prompt, cursor?: number) => void
   getCaretState: () => { collapsed: boolean; cursorPosition: number; textLength: number }
   escBlur: () => boolean
 }
@@ -111,11 +111,15 @@ export function createEditorImperatives(deps: EditorImperativesDeps): EditorImpe
     })
   }
 
-  const renderEditorWithCursor = (parts: Prompt) => {
+  const renderEditorWithCursor = (parts: Prompt, cursor?: number) => {
     const editor = editorRef()
-    const cursor = currentCursor()
+    // Caller-supplied cursor wins: Path B/C/Backspace know the target
+    // position before the DOM gets repainted. Falling back to currentCursor()
+    // would read the stale pre-repaint DOM selection (e.g. caret 0 in an
+    // empty editor when Path C just pasted "/cmd args").
+    const target = cursor ?? currentCursor() ?? undefined
     renderPartsToEditor(editor, parts)
-    if (cursor !== null) setCursorPosition(editor, cursor)
+    if (target !== undefined) setCursorPosition(editor, target)
   }
 
   const getCaretState = () => {

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -14,9 +14,13 @@ import {
   type usePrompt,
 } from "@/context/prompt"
 import type { useSDK } from "@/context/sdk"
+import type { useSync } from "@/context/sync"
 import { useParams } from "@solidjs/router"
 import { usePortableDraft } from "./portable-draft"
 import { usePinnedDraft } from "./pinned-draft"
+import { buildSlashRegistry } from "./command-text-part"
+import { tryPathBConversion } from "./command-space-trigger"
+import { rewriteRangeForCommandCopy, selectionTouchesCommandMark } from "./command-copy"
 import {
   createTextFragment,
   getCursorPosition,
@@ -41,6 +45,7 @@ export interface EditorInputDeps {
   setStore: SetStoreFunction<PromptStore>
   prompt: ReturnType<typeof usePrompt>
   sdk: ReturnType<typeof useSDK>
+  sync: ReturnType<typeof useSync>
   imageAttachments: Accessor<ImageAttachmentPart[]>
   editorRef: () => HTMLDivElement
   mirror: { input: boolean }
@@ -61,7 +66,8 @@ export interface EditorInput {
   handleBlur: () => void
   handleCompositionStart: () => void
   handleCompositionEnd: () => void
-  handleInput: () => void
+  handleInput: (event?: InputEvent) => void
+  handleCopy: (event: ClipboardEvent) => void
   addPart: (part: ContentPart) => boolean
 }
 
@@ -71,6 +77,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     setStore,
     prompt,
     sdk,
+    sync,
     imageAttachments,
     editorRef,
     mirror,
@@ -196,7 +203,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     ),
   )
 
-  const handleInput = () => {
+  const handleInput = (event?: InputEvent) => {
     const editor = editorRef()
     const rawParts = parseEditorToParts(editor)
     const images = imageAttachments()
@@ -205,6 +212,28 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
       rawParts.length === 1 && rawParts[0]?.type === "text"
         ? rawParts[0].content
         : rawParts.map((p) => ("content" in p ? p.content : "")).join("")
+
+    // Path B: Space-typed conversion of `/<known-name>` into a marked TextPart.
+    // The browser fires inputType="insertText" with data=" " only when the user
+    // types a single Space character — naturally false on paste, Backspace,
+    // IME commit, and programmatic mutations. No flag state machine needed.
+    if (!composing()) {
+      const registry = buildSlashRegistry(sync.data.command)
+      const pathB = tryPathBConversion({
+        inputType: event?.inputType,
+        data: event?.data,
+        rawText,
+        images,
+        registry,
+      })
+      if (pathB) {
+        closePopover()
+        resetHistoryNavigation()
+        mirror.input = true
+        prompt.set(pathB.prompt, pathB.cursor)
+        return
+      }
+    }
     const hasNonText = rawParts.some((part) => part.type !== "text")
     // Context chips (drag/drop, picker, hand-off draft, comment hydration) live
     // in prompt.context.items() and don't appear as editor parts, so we have to
@@ -394,6 +423,21 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     return true
   }
 
+  // Scoped copy handler: intercepts when selection touches any [data-cmd-mark]
+  // pill and rewrites text/plain to substitute the pill with `/<dataset.name>`.
+  // Browser default copies the visible textContent (just `<name>`, no slash),
+  // which would lose the slash for Path C paste / cross-app round-trip.
+  // Selections that do NOT touch a pill are untouched — default copy proceeds.
+  const handleCopy = (event: ClipboardEvent) => {
+    const editor = editorRef()
+    if (!selectionTouchesCommandMark(editor)) return
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) return
+    event.preventDefault()
+    const rewritten = rewriteRangeForCommandCopy(sel.getRangeAt(0))
+    event.clipboardData?.setData("text/plain", rewritten)
+  }
+
   return {
     composing,
     isImeComposing,
@@ -401,6 +445,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     handleCompositionStart,
     handleCompositionEnd,
     handleInput,
+    handleCopy,
     addPart,
   }
 }

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -178,8 +178,13 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
   // prompt to the snapshot's own contents) is a no-op and cannot loop.
   //
   // Session routes have no owner — guarded by params.id.
-  // IME composition is in-flight raw bytes, not a stable draft — skip and
-  // wait for compositionend to commit before recording.
+  // IME composition is in-flight raw bytes, not a stable draft — skip while
+  // composing() is true. composing() is in the tracked deps so the false→true
+  // and true→false transitions wake this effect. Most browsers fire an
+  // additional `inputType: "insertCompositionText"` input event after
+  // compositionend that would wake mirror via prompt.set in handleInput, but
+  // not all do; tracking composing directly guarantees a record on commit
+  // regardless of the post-compositionend input event.
   let lastSeenDir: string | undefined = sdk.directory
   let lastSeenSessionID: string | undefined = params.id
   createEffect(
@@ -191,9 +196,10 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           imageAttachments(),
           sdk.directory,
           params.id,
+          composing(),
         ] as const,
-      ([parts, contextItems, images, dir, sessionID]) => {
-        if (composing()) return
+      ([parts, contextItems, images, dir, sessionID, compose]) => {
+        if (compose) return
 
         // Scope change detection. Track sdk.directory and params.id so the
         // session swap in prompt.current() doesn't slip through unguarded.

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -4,6 +4,7 @@
 // reflects state into the prompt store.
 
 import { createEffect, createSignal, on, type Accessor } from "solid-js"
+import { createOwnerMirrorEffect } from "./owner-mirror"
 import type { SetStoreFunction } from "solid-js/store"
 import {
   type ContentPart,
@@ -36,7 +37,6 @@ import { promptLength } from "./history"
 import type { EditorImperatives } from "./editor-imperatives"
 import type { PopoverControllers } from "./popover-controllers"
 import type { PromptStore } from "./store-types"
-import type { ResolvedMention } from "./mention-metadata"
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
 
@@ -148,96 +148,18 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
   // recording. Runs as an effect on the prompt store so EVERY path that mutates
   // the prompt (normal text input, Path A popover select, Path B Space-trigger,
   // Path C paste, Backspace ladder, history navigation, attachment add/remove)
-  // automatically records into the active owner. Previously handleInput's
-  // tail-only mirror missed Path A/B/C and silently dropped the user's draft
-  // when they navigated away from the homepage and came back.
-  //
-  // Two layers of protection against firing with an empty payload at the
-  // wrong moment:
-  //
-  // 1. {defer: true} skips the initial mount-time invocation. At mount the
-  //    prompt is DEFAULT_PROMPT, which is an "empty payload" — without defer
-  //    this effect would call portable.record() / pinned.recordEdit() with
-  //    empty before the hydration effect below has a chance to consume the
-  //    snapshot or apply the pinned prefill.
-  //
-  // 2. lastSeenDir / lastSeenSessionID skip the first fire after the route
-  //    scope changes (homepage A → homepage B navigation, or session →
-  //    homepage). prompt.current() is session-keyed by {dir, id} in the
-  //    prompt binding, so when sdk.directory flips, prompt.current() flips
-  //    to the new session's value (typically DEFAULT_PROMPT for a fresh
-  //    homepage). That value change would otherwise wake this effect and
-  //    record an empty payload against the NEW directory, destroying the
-  //    portable snapshot held for the OLD directory before the hydration
-  //    effect can move it. Skipping the first fire after a scope change
-  //    lets hydration run; the next prompt change (carried content or user
-  //    keystroke) records normally.
-  //
-  // The portable/pinned record() implementations dedupe by deep-equal payload,
-  // so firing more often than strictly necessary (e.g. hydration setting the
-  // prompt to the snapshot's own contents) is a no-op and cannot loop.
-  //
-  // Session routes have no owner — guarded by params.id.
-  // IME composition is in-flight raw bytes, not a stable draft — skip while
-  // composing() is true. composing() is in the tracked deps so the false→true
-  // and true→false transitions wake this effect. Most browsers fire an
-  // additional `inputType: "insertCompositionText"` input event after
-  // compositionend that would wake mirror via prompt.set in handleInput, but
-  // not all do; tracking composing directly guarantees a record on commit
-  // regardless of the post-compositionend input event.
-  let lastSeenDir: string | undefined = sdk.directory
-  let lastSeenSessionID: string | undefined = params.id
-  createEffect(
-    on(
-      () =>
-        [
-          prompt.current(),
-          prompt.context.items(),
-          imageAttachments(),
-          sdk.directory,
-          params.id,
-          composing(),
-        ] as const,
-      ([parts, contextItems, images, dir, sessionID, compose]) => {
-        if (compose) return
-
-        // Scope change detection. Track sdk.directory and params.id so the
-        // session swap in prompt.current() doesn't slip through unguarded.
-        const scopeChanged = lastSeenDir !== dir || lastSeenSessionID !== sessionID
-        lastSeenDir = dir
-        lastSeenSessionID = sessionID
-        if (sessionID) return // session route, no owner mirror
-        if (scopeChanged) return // wait for hydration; next prompt change records
-
-        const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
-        for (const item of contextItems) {
-          if (item.type === "file" && item.resolvedMentions?.length) {
-            resolvedMentionsMap[item.key] = item.resolvedMentions
-          }
-        }
-
-        const currentPinnedSlot = pinned.current()
-        if (currentPinnedSlot && currentPinnedSlot.directory === dir) {
-          pinned.recordEdit({
-            directory: dir,
-            prompt: parts,
-            context: contextItems.slice(),
-            images: [...images],
-            resolvedMentions: resolvedMentionsMap,
-          })
-        } else {
-          portable.record({
-            sourceFilesystemDirectory: dir,
-            prompt: parts,
-            context: contextItems.slice(),
-            images: [...images],
-            resolvedMentions: resolvedMentionsMap,
-          })
-        }
-      },
-      { defer: true },
-    ),
-  )
+  // automatically records into the active owner. See owner-mirror.ts for the
+  // defer / scopeChanged / composing guard semantics.
+  createOwnerMirrorEffect({
+    prompt: () => prompt.current(),
+    contextItems: () => prompt.context.items(),
+    images: imageAttachments,
+    directory: () => sdk.directory,
+    sessionID: () => params.id,
+    composing,
+    portable,
+    pinned,
+  })
 
   // Centralized "is the homepage draft empty" check.
   // The prompt store, the context-item store, AND the imageAttachments accessor

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -102,14 +102,19 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
       mirror.input = false
       if (isNormalizedEditor(editor)) return
 
-      imperatives.renderEditorWithCursor(input)
+      imperatives.renderEditorWithCursor(input, prompt.cursor())
       return
     }
 
     const dom = parseEditorToParts(editor)
     if (isNormalizedEditor(editor) && isPromptEqual(input, dom)) return
 
-    imperatives.renderEditorWithCursor(input)
+    // Store-originated reconcile (Path B Space-trigger, Path C paste, Backspace
+    // ladder, popover select, history navigation): the prompt store already
+    // holds the target cursor. currentCursor() would read the pre-repaint DOM
+    // selection, which is stale whenever the editor has not yet caught up to
+    // the new prompt (e.g. Path C paste was preventDefault'd so DOM is empty).
+    imperatives.renderEditorWithCursor(input, prompt.cursor())
   }
 
   const handleBlur = () => {
@@ -229,7 +234,12 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
       if (pathB) {
         closePopover()
         resetHistoryNavigation()
-        mirror.input = true
+        // Do NOT set mirror.input=true here. The DOM still holds the raw
+        // "/<name> " text node; only the prompt store gets the marked
+        // TextPart. Letting reconcile run the non-mirror branch is what
+        // forces the editor to repaint into pill DOM. Marking as mirror
+        // would short-circuit on isNormalizedEditor() and leave raw text
+        // visible to the user (#778 main acceptance path).
         prompt.set(pathB.prompt, pathB.cursor)
         return
       }

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -152,32 +152,56 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
   // tail-only mirror missed Path A/B/C and silently dropped the user's draft
   // when they navigated away from the homepage and came back.
   //
-  // {defer: true} is load-bearing: at mount the prompt is DEFAULT_PROMPT,
-  // which is an "empty payload" for both owner implementations. Without
-  // defer this effect would fire immediately and call portable.record() /
-  // pinned.recordEdit() with an empty payload, which clears the portable
-  // snapshot and overwrites a pending pinned prefill — before the
-  // hydration effect below has a chance to consume them. Deferring means
-  // we wait for the first real prompt change. Hydration runs and replaces
-  // the empty default with the snapshot's content; that change is what
-  // wakes this effect up, at which point we record the hydrated payload
-  // (which dedupes against the owner's own snapshot, so it's a no-op).
-  // A fresh homepage with no owner data simply stays quiet until the
-  // user types.
+  // Two layers of protection against firing with an empty payload at the
+  // wrong moment:
+  //
+  // 1. {defer: true} skips the initial mount-time invocation. At mount the
+  //    prompt is DEFAULT_PROMPT, which is an "empty payload" — without defer
+  //    this effect would call portable.record() / pinned.recordEdit() with
+  //    empty before the hydration effect below has a chance to consume the
+  //    snapshot or apply the pinned prefill.
+  //
+  // 2. lastSeenDir / lastSeenSessionID skip the first fire after the route
+  //    scope changes (homepage A → homepage B navigation, or session →
+  //    homepage). prompt.current() is session-keyed by {dir, id} in the
+  //    prompt binding, so when sdk.directory flips, prompt.current() flips
+  //    to the new session's value (typically DEFAULT_PROMPT for a fresh
+  //    homepage). That value change would otherwise wake this effect and
+  //    record an empty payload against the NEW directory, destroying the
+  //    portable snapshot held for the OLD directory before the hydration
+  //    effect can move it. Skipping the first fire after a scope change
+  //    lets hydration run; the next prompt change (carried content or user
+  //    keystroke) records normally.
+  //
+  // The portable/pinned record() implementations dedupe by deep-equal payload,
+  // so firing more often than strictly necessary (e.g. hydration setting the
+  // prompt to the snapshot's own contents) is a no-op and cannot loop.
   //
   // Session routes have no owner — guarded by params.id.
   // IME composition is in-flight raw bytes, not a stable draft — skip and
   // wait for compositionend to commit before recording.
-  // The portable/pinned record() implementations both dedupe by deep-equal
-  // payload, so this effect firing more often than the old tail-only path
-  // (e.g. on hydration that sets the prompt to the snapshot's own contents)
-  // is a no-op and cannot loop.
+  let lastSeenDir: string | undefined = sdk.directory
+  let lastSeenSessionID: string | undefined = params.id
   createEffect(
     on(
-      () => [prompt.current(), prompt.context.items(), imageAttachments()] as const,
-      ([parts, contextItems, images]) => {
+      () =>
+        [
+          prompt.current(),
+          prompt.context.items(),
+          imageAttachments(),
+          sdk.directory,
+          params.id,
+        ] as const,
+      ([parts, contextItems, images, dir, sessionID]) => {
         if (composing()) return
-        if (params.id) return // session route, no owner mirror
+
+        // Scope change detection. Track sdk.directory and params.id so the
+        // session swap in prompt.current() doesn't slip through unguarded.
+        const scopeChanged = lastSeenDir !== dir || lastSeenSessionID !== sessionID
+        lastSeenDir = dir
+        lastSeenSessionID = sessionID
+        if (sessionID) return // session route, no owner mirror
+        if (scopeChanged) return // wait for hydration; next prompt change records
 
         const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
         for (const item of contextItems) {
@@ -187,9 +211,9 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         }
 
         const currentPinnedSlot = pinned.current()
-        if (currentPinnedSlot && currentPinnedSlot.directory === sdk.directory) {
+        if (currentPinnedSlot && currentPinnedSlot.directory === dir) {
           pinned.recordEdit({
-            directory: sdk.directory,
+            directory: dir,
             prompt: parts,
             context: contextItems.slice(),
             images: [...images],
@@ -197,7 +221,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           })
         } else {
           portable.record({
-            sourceFilesystemDirectory: sdk.directory,
+            sourceFilesystemDirectory: dir,
             prompt: parts,
             context: contextItems.slice(),
             images: [...images],

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -152,6 +152,19 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
   // tail-only mirror missed Path A/B/C and silently dropped the user's draft
   // when they navigated away from the homepage and came back.
   //
+  // {defer: true} is load-bearing: at mount the prompt is DEFAULT_PROMPT,
+  // which is an "empty payload" for both owner implementations. Without
+  // defer this effect would fire immediately and call portable.record() /
+  // pinned.recordEdit() with an empty payload, which clears the portable
+  // snapshot and overwrites a pending pinned prefill — before the
+  // hydration effect below has a chance to consume them. Deferring means
+  // we wait for the first real prompt change. Hydration runs and replaces
+  // the empty default with the snapshot's content; that change is what
+  // wakes this effect up, at which point we record the hydrated payload
+  // (which dedupes against the owner's own snapshot, so it's a no-op).
+  // A fresh homepage with no owner data simply stays quiet until the
+  // user types.
+  //
   // Session routes have no owner — guarded by params.id.
   // IME composition is in-flight raw bytes, not a stable draft — skip and
   // wait for compositionend to commit before recording.
@@ -192,6 +205,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
           })
         }
       },
+      { defer: true },
     ),
   )
 

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -144,6 +144,57 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     ),
   )
 
+  // Homepage owner mirror — single source of truth for portable/pinned draft
+  // recording. Runs as an effect on the prompt store so EVERY path that mutates
+  // the prompt (normal text input, Path A popover select, Path B Space-trigger,
+  // Path C paste, Backspace ladder, history navigation, attachment add/remove)
+  // automatically records into the active owner. Previously handleInput's
+  // tail-only mirror missed Path A/B/C and silently dropped the user's draft
+  // when they navigated away from the homepage and came back.
+  //
+  // Session routes have no owner — guarded by params.id.
+  // IME composition is in-flight raw bytes, not a stable draft — skip and
+  // wait for compositionend to commit before recording.
+  // The portable/pinned record() implementations both dedupe by deep-equal
+  // payload, so this effect firing more often than the old tail-only path
+  // (e.g. on hydration that sets the prompt to the snapshot's own contents)
+  // is a no-op and cannot loop.
+  createEffect(
+    on(
+      () => [prompt.current(), prompt.context.items(), imageAttachments()] as const,
+      ([parts, contextItems, images]) => {
+        if (composing()) return
+        if (params.id) return // session route, no owner mirror
+
+        const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
+        for (const item of contextItems) {
+          if (item.type === "file" && item.resolvedMentions?.length) {
+            resolvedMentionsMap[item.key] = item.resolvedMentions
+          }
+        }
+
+        const currentPinnedSlot = pinned.current()
+        if (currentPinnedSlot && currentPinnedSlot.directory === sdk.directory) {
+          pinned.recordEdit({
+            directory: sdk.directory,
+            prompt: parts,
+            context: contextItems.slice(),
+            images: [...images],
+            resolvedMentions: resolvedMentionsMap,
+          })
+        } else {
+          portable.record({
+            sourceFilesystemDirectory: sdk.directory,
+            prompt: parts,
+            context: contextItems.slice(),
+            images: [...images],
+            resolvedMentions: resolvedMentionsMap,
+          })
+        }
+      },
+    ),
+  )
+
   // Centralized "is the homepage draft empty" check.
   // The prompt store, the context-item store, AND the imageAttachments accessor
   // are three independent surfaces. A homepage with chips or images is NOT
@@ -261,35 +312,10 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
         prompt.set(DEFAULT_PROMPT, 0)
       }
       imperatives.queueScroll()
-
-      // Homepage route: clearing all input must also clear the active owner
-      // (Bug 3). Without this, navigating away later carries the stale
-      // snapshot — the user thinks they cleared the draft but the portable
-      // owner still has it.
-      if (!params.id) {
-        const pinnedSlot = pinned.current()
-        if (pinnedSlot && pinnedSlot.directory === sdk.directory) {
-          // Don't release the pinned binding. Recording an empty payload keeps
-          // the slot bound for future edits while signaling that the user
-          // cleared the prefill.
-          pinned.recordEdit({
-            directory: sdk.directory,
-            prompt: DEFAULT_PROMPT,
-            context: [],
-            images: [],
-            resolvedMentions: {},
-          })
-        } else {
-          // Portable owner: record({empty}) tears down the snapshot.
-          portable.record({
-            sourceFilesystemDirectory: sdk.directory,
-            prompt: DEFAULT_PROMPT,
-            context: [],
-            images: [],
-            resolvedMentions: {},
-          })
-        }
-      }
+      // Owner clear is handled by the homepage owner mirror effect above —
+      // setting prompt to DEFAULT_PROMPT with no context/images flips
+      // isPayloadEmpty=true, which makes portable.record() tear down the
+      // snapshot (Bug 3 still covered, just centralized).
       return
     }
 
@@ -316,38 +342,7 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
 
     mirror.input = true
     prompt.set([...rawParts, ...images], cursorPosition)
-    if (!params.id) {
-      // Homepage route: mirror edit into pinned or portable owner after prompt.set.
-      // Build resolvedMentions from current context items.
-      const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
-      for (const item of prompt.context.items()) {
-        if (item.type === "file" && item.resolvedMentions?.length) {
-          resolvedMentionsMap[item.key] = item.resolvedMentions
-        }
-      }
-      const currentPinnedSlot = pinned.current()
-      if (currentPinnedSlot && currentPinnedSlot.directory === sdk.directory) {
-        // Pinned scope is active for this directory: route edits to pinned owner.
-        // This ensures "clearing pinned prefill and typing fresh text remains pinned-scope".
-        pinned.recordEdit({
-          directory: sdk.directory,
-          prompt: prompt.current(),
-          context: prompt.context.items().slice(),
-          images: imageAttachments(),
-          resolvedMentions: resolvedMentionsMap,
-        })
-      } else {
-        // No active pinned slot for this directory: route edits to portable owner.
-        portable.record({
-          sourceFilesystemDirectory: sdk.directory,
-          prompt: prompt.current(),
-          context: prompt.context.items().slice(),
-          images: imageAttachments(),
-          resolvedMentions: resolvedMentionsMap,
-        })
-      }
-    }
-    // Session routes do not mirror into the portable owner.
+    // Owner mirror is handled by the homepage owner mirror effect above.
     imperatives.queueScroll()
   }
 

--- a/packages/app/src/components/prompt-input/editor-serialize.test.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { createCommandMark, parseEditorToParts, renderPartsToEditor } from "./editor-serialize"
+import { createCommandMark, isNormalizedEditor, parseEditorToParts, renderPartsToEditor } from "./editor-serialize"
 import type { TextPart } from "@/context/prompt"
 
 // Helper: build a leading-command TextPart
@@ -102,6 +102,39 @@ describe("renderPartsToEditor + parseEditorToParts round-trips", () => {
 
     const textPart = result[0] as TextPart
     expect(textPart.command).toEqual({ name: "brainstorming", source: "skill", icon: "command" })
+  })
+})
+
+describe("isNormalizedEditor command-pill position invariant", () => {
+  function buildPill(name: string): HTMLSpanElement {
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = name
+    pill.dataset.source = "skill"
+    pill.dataset.icon = "command"
+    pill.setAttribute("contenteditable", "false")
+    const label = document.createElement("span")
+    label.dataset.cmdLabel = "true"
+    label.textContent = name
+    pill.appendChild(label)
+    return pill
+  }
+
+  test("cmd-mark at index 0 is treated as normalized", () => {
+    const editor = document.createElement("div")
+    editor.appendChild(buildPill("go"))
+    editor.appendChild(document.createTextNode(" args"))
+    expect(isNormalizedEditor(editor)).toBe(true)
+  })
+
+  test("cmd-mark at non-zero index forces reconcile", () => {
+    // Invariant breach: marked TextPart must always be index 0. A mid-stream
+    // pill should make isNormalizedEditor return false so the reconcile pass
+    // rebuilds the editor from the canonical Prompt and self-heals.
+    const editor = document.createElement("div")
+    editor.appendChild(document.createTextNode("prefix "))
+    editor.appendChild(buildPill("go"))
+    expect(isNormalizedEditor(editor)).toBe(false)
   })
 })
 

--- a/packages/app/src/components/prompt-input/editor-serialize.test.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test"
+import { createCommandMark, parseEditorToParts, renderPartsToEditor } from "./editor-serialize"
+import type { TextPart } from "@/context/prompt"
+
+// Helper: build a leading-command TextPart
+function makeCommandPart(name: string, tail: string): TextPart {
+  return {
+    type: "text",
+    content: "/" + name + tail,
+    start: 0,
+    end: 1 + name.length + tail.length,
+    command: { name, source: "skill", icon: "command" },
+  }
+}
+
+describe("createCommandMark", () => {
+  test("outer span carries data-cmd-mark, data-name, data-source, data-icon, contenteditable=false", () => {
+    const part = makeCommandPart("summarize", " ")
+    const el = createCommandMark(part as TextPart & { command: NonNullable<TextPart["command"]> })
+
+    expect(el.dataset.cmdMark).toBe("true")
+    expect(el.dataset.name).toBe("summarize")
+    expect(el.dataset.source).toBe("skill")
+    expect(el.dataset.icon).toBe("command")
+    expect(el.getAttribute("contenteditable")).toBe("false")
+  })
+
+  test("visible textContent is the command name without a slash", () => {
+    const part = makeCommandPart("brainstorming", " ")
+    const el = createCommandMark(part as TextPart & { command: NonNullable<TextPart["command"]> })
+
+    // The label child carries the name; the icon child may add non-visible text
+    const label = el.querySelector("[data-cmd-label]") as HTMLElement
+    expect(label.textContent).toBe("brainstorming")
+    // Full textContent should NOT start with "/"
+    expect(el.textContent).not.toMatch(/^\//)
+  })
+
+  test("icon child has data-cmd-icon and class=command-icon", () => {
+    const part = makeCommandPart("go", " ")
+    const el = createCommandMark(part as TextPart & { command: NonNullable<TextPart["command"]> })
+
+    const icon = el.querySelector("[data-cmd-icon]") as HTMLElement
+    expect(icon).not.toBeNull()
+    expect(icon.getAttribute("aria-hidden")).toBe("true")
+    expect(icon.className).toBe("command-icon")
+  })
+})
+
+describe("renderPartsToEditor + parseEditorToParts round-trips", () => {
+  function roundTrip(parts: TextPart[]) {
+    const editor = document.createElement("div")
+    renderPartsToEditor(editor, parts)
+    return parseEditorToParts(editor)
+  }
+
+  test('"/cmd " round-trips byte-identical', () => {
+    const original = [makeCommandPart("cmd", " ")]
+    const result = roundTrip(original)
+
+    expect(result.length).toBe(1)
+    expect(result[0]!.type).toBe("text")
+    const textPart = result[0] as TextPart
+    expect(textPart.content).toBe("/cmd ")
+    expect(textPart.command).toEqual({ name: "cmd", source: "skill", icon: "command" })
+  })
+
+  test('"/cmd args" round-trips byte-identical', () => {
+    const original = [makeCommandPart("cmd", " args")]
+    const result = roundTrip(original)
+
+    const textPart = result[0] as TextPart
+    expect(textPart.content).toBe("/cmd args")
+    expect(textPart.command?.name).toBe("cmd")
+  })
+
+  test('"/cmd  args" (double-space) round-trips byte-identical', () => {
+    // First space is the separator, second is verbatim part of args
+    const original = [makeCommandPart("cmd", "  args")]
+    const result = roundTrip(original)
+
+    const textPart = result[0] as TextPart
+    expect(textPart.content).toBe("/cmd  args")
+    expect(textPart.command?.name).toBe("cmd")
+  })
+
+  test("pill DOM has no leading slash in visible label text", () => {
+    const original = [makeCommandPart("summarize", " ")]
+    const editor = document.createElement("div")
+    renderPartsToEditor(editor, original)
+
+    const pill = editor.querySelector("[data-cmd-mark]") as HTMLElement
+    expect(pill).not.toBeNull()
+    const label = pill.querySelector("[data-cmd-label]") as HTMLElement
+    expect(label.textContent).not.toMatch(/^\//)
+    expect(label.textContent).toBe("summarize")
+  })
+
+  test("parsed part carries command metadata with name, source, icon", () => {
+    const original = [makeCommandPart("brainstorming", " hello")]
+    const result = roundTrip(original)
+
+    const textPart = result[0] as TextPart
+    expect(textPart.command).toEqual({ name: "brainstorming", source: "skill", icon: "command" })
+  })
+})
+
+describe("self-heal: mid-stream data-cmd-mark → plain text, no command field", () => {
+  test("cmd-mark not at index 0 is parsed as plain text without command metadata", () => {
+    // Manually build an editor where the cmd-mark pill appears AFTER some text
+    const editor = document.createElement("div")
+    editor.appendChild(document.createTextNode("prefix "))
+
+    const pill = document.createElement("span")
+    pill.dataset.cmdMark = "true"
+    pill.dataset.name = "summarize"
+    pill.dataset.source = "skill"
+    pill.dataset.icon = "command"
+    pill.setAttribute("contenteditable", "false")
+
+    // Inner structure matching createCommandMark output
+    const label = document.createElement("span")
+    label.dataset.cmdLabel = "true"
+    label.textContent = "summarize"
+    pill.appendChild(label)
+
+    editor.appendChild(pill)
+    editor.appendChild(document.createTextNode(" suffix"))
+
+    const result = parseEditorToParts(editor)
+
+    // Should produce a single plain text part (no leading pill branch triggered)
+    expect(result.length).toBe(1)
+    const textPart = result[0] as TextPart
+    expect(textPart.type).toBe("text")
+    // No command metadata on a mid-stream pill
+    expect(textPart.command).toBeUndefined()
+    // The label text should appear in content (visit recurses into span children)
+    expect(textPart.content).toContain("summarize")
+  })
+})

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -53,7 +53,7 @@ export function createPill(part: FileAttachmentPart | AgentPart): HTMLSpanElemen
 }
 
 export function isNormalizedEditor(editor: HTMLElement): boolean {
-  return Array.from(editor.childNodes).every((node) => {
+  return Array.from(editor.childNodes).every((node, index) => {
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent ?? ""
       if (!text.includes("\u200B")) return true
@@ -68,10 +68,12 @@ export function isNormalizedEditor(editor: HTMLElement): boolean {
     const el = node as HTMLElement
     if (el.dataset.type === "file") return true
     if (el.dataset.type === "agent") return true
-    // Command pill at index 0 is a normal expected child; without this the
-    // reconcile pass forces a full DOM rebuild on every keystroke after a pill
-    // exists, which moves the caret and breaks IME / selections.
-    if (el.dataset.cmdMark === "true") return true
+    // Command pill is only valid at index 0 (spec invariant: at most one
+    // marked TextPart, always the leading part). A mid-stream cmd-mark means
+    // some path breached the invariant; returning false here forces the
+    // reconcile pass to rebuild the editor from the canonical Prompt and
+    // self-heal, instead of letting the malformed DOM persist.
+    if (el.dataset.cmdMark === "true") return index === 0
     return el.tagName === "BR"
   })
 }

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -68,6 +68,10 @@ export function isNormalizedEditor(editor: HTMLElement): boolean {
     const el = node as HTMLElement
     if (el.dataset.type === "file") return true
     if (el.dataset.type === "agent") return true
+    // Command pill at index 0 is a normal expected child; without this the
+    // reconcile pass forces a full DOM rebuild on every keystroke after a pill
+    // exists, which moves the caret and breaks IME / selections.
+    if (el.dataset.cmdMark === "true") return true
     return el.tagName === "BR"
   })
 }

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -3,11 +3,42 @@
 
 import {
   type AgentPart,
+  type CommandSource,
   type FileAttachmentPart,
+  type TextPart,
   type Prompt,
   DEFAULT_PROMPT,
 } from "@/context/prompt"
+import { resolveCommandIconSvg } from "@opencode-ai/ui/command-icon"
 import { createTextFragment } from "./editor-dom"
+import "./command-pill.css"
+
+/** Build the DOM node for a slash-command pill (contenteditable=false). */
+export function createCommandMark(part: TextPart & { command: NonNullable<TextPart["command"]> }): HTMLSpanElement {
+  const cmd = part.command
+  const outer = document.createElement("span")
+  outer.setAttribute("data-cmd-mark", "true")
+  outer.setAttribute("data-name", cmd.name)
+  outer.setAttribute("data-source", cmd.source)
+  outer.setAttribute("data-icon", cmd.icon)
+  outer.setAttribute("contenteditable", "false")
+
+  // Icon child — SVG injected via innerHTML; aria-hidden so screen-readers skip it
+  const iconSpan = document.createElement("span")
+  iconSpan.setAttribute("data-cmd-icon", "true")
+  iconSpan.setAttribute("aria-hidden", "true")
+  iconSpan.className = "command-icon"
+  iconSpan.innerHTML = resolveCommandIconSvg(cmd.icon)
+  outer.appendChild(iconSpan)
+
+  // Label child — name without slash, visible text
+  const labelSpan = document.createElement("span")
+  labelSpan.setAttribute("data-cmd-label", "true")
+  labelSpan.textContent = cmd.name
+  outer.appendChild(labelSpan)
+
+  return outer
+}
 
 export function createPill(part: FileAttachmentPart | AgentPart): HTMLSpanElement {
   const pill = document.createElement("span")
@@ -43,8 +74,22 @@ export function isNormalizedEditor(editor: HTMLElement): boolean {
 
 export function renderPartsToEditor(editor: HTMLElement, parts: Prompt): void {
   editor.replaceChildren()
-  for (const part of parts) {
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]!
     if (part.type === "text") {
+      // Leading text part with command metadata: render pill + tail separately.
+      // Only index 0 gets the pill treatment; subsequent text parts are plain.
+      if (i === 0 && part.command) {
+        const cmd = part.command
+        const pillPart = part as TextPart & { command: NonNullable<TextPart["command"]> }
+        // The content is "/<name><sep><args>" — strip the "/<name>" prefix so
+        // only the separator + args remain in the text fragment after the pill.
+        const prefixLen = 1 + cmd.name.length // slash + name
+        const tail = part.content.slice(prefixLen)
+        editor.appendChild(createCommandMark(pillPart))
+        if (tail) editor.appendChild(createTextFragment(tail))
+        continue
+      }
       editor.appendChild(createTextFragment(part.content))
       continue
     }
@@ -127,7 +172,69 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
   }
 
   const children = Array.from(editor.childNodes)
-  children.forEach((child, index) => {
+
+  // Leading-pill branch: if the very first child is a data-cmd-mark element,
+  // reconstruct the marked TextPart (Parser reconstruction rule, spec L538-546).
+  // content = "/" + dataset.name + followingTextRun, where followingTextRun is
+  // the verbatim concat of text/BR nodes immediately after the pill until next
+  // pill/file/agent/end.
+  let startIndex = 0
+  const firstChild = children[0]
+  if (
+    firstChild?.nodeType === Node.ELEMENT_NODE &&
+    (firstChild as HTMLElement).dataset.cmdMark === "true"
+  ) {
+    const pillEl = firstChild as HTMLElement
+    const name = pillEl.dataset.name ?? ""
+    const source = (pillEl.dataset.source ?? "skill") as CommandSource
+    const icon = pillEl.dataset.icon ?? "command"
+
+    // Collect following text run siblings (stop at next pill/file/agent boundary)
+    let followingTextRun = ""
+    let consumedSiblings = 0
+    for (let si = 1; si < children.length; si++) {
+      const sibling = children[si]!
+      if (sibling.nodeType === Node.TEXT_NODE) {
+        followingTextRun += sibling.textContent ?? ""
+        consumedSiblings++
+      } else if (sibling.nodeType === Node.ELEMENT_NODE) {
+        const sibEl = sibling as HTMLElement
+        // Stop at any pill-like boundary
+        if (sibEl.tagName === "BR") {
+          followingTextRun += "\n"
+          consumedSiblings++
+        } else if (sibEl.dataset.type === "file" || sibEl.dataset.type === "agent" || sibEl.dataset.cmdMark === "true") {
+          break
+        } else {
+          // Unknown inline element — recurse and collect text
+          followingTextRun += sibEl.textContent ?? ""
+          consumedSiblings++
+        }
+      } else {
+        break
+      }
+    }
+
+    // Strip zero-width space from collected run
+    followingTextRun = followingTextRun.replace(/​/g, "")
+
+    const content = "/" + name + followingTextRun
+    const cmdPart: TextPart = {
+      type: "text",
+      content,
+      start: position,
+      end: position + content.length,
+      command: { name, source, icon },
+    }
+    parts.push(cmdPart)
+    position += content.length
+
+    // Skip the pill + consumed siblings in the main loop below
+    startIndex = 1 + consumedSiblings
+  }
+
+  children.slice(startIndex).forEach((child, relIndex) => {
+    const index = startIndex + relIndex
     const isBlock =
       child.nodeType === Node.ELEMENT_NODE && ["DIV", "P"].includes((child as HTMLElement).tagName)
     visit(child)

--- a/packages/app/src/components/prompt-input/invariant.test.ts
+++ b/packages/app/src/components/prompt-input/invariant.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { reportInvariantBreach } from "./invariant"
+
+describe("reportInvariantBreach", () => {
+  let originalEnv: any
+  beforeEach(() => { originalEnv = (globalThis as any).__import_meta_env_dev })
+  afterEach(() => { (globalThis as any).__import_meta_env_dev = originalEnv })
+
+  test("non-dev env (import.meta.env undefined) does not throw synchronously", () => {
+    expect(() => reportInvariantBreach("test", { foo: "bar" })).not.toThrow()
+  })
+
+  // dev-throw path is exercised via assertCommandTextPart in command-text-part.test.ts.
+  // No need to fake import.meta.env in Bun — see spec L520.
+})

--- a/packages/app/src/components/prompt-input/invariant.ts
+++ b/packages/app/src/components/prompt-input/invariant.ts
@@ -1,0 +1,37 @@
+// Single source for invariant-breach reporting. Sync throw is exposed via
+// assertCommandTextPart for helpers; this reporter is the renderer/submit
+// boundary that may run inside a render pass where throwing would break UI.
+
+import { showToast } from "@opencode-ai/ui/toast"
+
+// Guard flag: only show the recovery toast once per app session so the user
+// is not spammed if the same invariant fires on every render.
+let prodToastShown = false
+
+function isDev(): boolean {
+  try {
+    return (import.meta as any).env?.DEV === true
+  } catch {
+    return false
+  }
+}
+
+export function reportInvariantBreach(message: string, context: unknown): void {
+  if (isDev()) {
+    // Re-raise asynchronously so the renderer pass does not crash; Vite's
+    // unhandled-rejection overlay and Bun's reporter both surface it.
+    queueMicrotask(() => {
+      throw new Error(`invariant breach: ${message} — context: ${JSON.stringify(context)}`)
+    })
+    return
+  }
+  // Prod: silently self-heal (caller continues with degraded state) and show
+  // a one-time non-blocking toast so users know something was recovered.
+  if (prodToastShown) return
+  prodToastShown = true
+  showToast({
+    title: "Command formatting recovered",
+    description: "Please report if this happens repeatedly.",
+    variant: "subtle",
+  })
+}

--- a/packages/app/src/components/prompt-input/keydown.ts
+++ b/packages/app/src/components/prompt-input/keydown.ts
@@ -4,11 +4,12 @@
 
 import type { Accessor } from "solid-js"
 import type { SetStoreFunction } from "solid-js/store"
-import type { ContentPart, usePrompt } from "@/context/prompt"
+import type { ContentPart, TextPart, usePrompt } from "@/context/prompt"
 import { canNavigateHistoryAtCursor } from "./history"
 import { getCursorPosition } from "./editor-dom"
 import { promptKeyActionReady } from "./readiness"
 import type { PromptStore } from "./store-types"
+import { computeCommandBackspaceResult } from "./command-backspace"
 
 export interface PromptKeydownDeps {
   store: PromptStore
@@ -89,6 +90,27 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
     if (event.key === "Backspace") {
       const selection = window.getSelection()
       if (selection && selection.isCollapsed) {
+        // Pre-check: if leading TextPart is command-marked and caret is inside
+        // or immediately after the "/<name> " prefix, apply the fallback ladder
+        // instead of the browser default delete.
+        const parts = prompt.current()
+        const first = parts[0]
+        if (first?.type === "text" && first.command) {
+          const prefix = `/${first.command.name} `
+          const cursorPos = getCursorPosition(editorRef())
+          // "Adjacent to pill": caret logical position <= prefix length covers
+          // caret-before-pill (0), caret-inside-pill, and caret-right-after-pill.
+          if (cursorPos <= prefix.length) {
+            event.preventDefault()
+            const markedFirst = first as TextPart & { command: NonNullable<TextPart["command"]> }
+            const newParts = computeCommandBackspaceResult(parts, markedFirst, prefix)
+            prompt.set(newParts, 0)
+            return
+          }
+        }
+
+        // Existing ZWSP cleanup: move caret to start of a ZWSP-only text node
+        // so the next keydown deletes the sentinel rather than real content.
         const node = selection.anchorNode
         const offset = selection.anchorOffset
         if (node && node.nodeType === Node.TEXT_NODE) {

--- a/packages/app/src/components/prompt-input/owner-mirror.test.ts
+++ b/packages/app/src/components/prompt-input/owner-mirror.test.ts
@@ -1,0 +1,332 @@
+// Tests for applyOwnerMirrorTick — the decision logic the owner mirror
+// effect runs on each fire. The effect itself wraps tick in
+// createEffect(on(..., {defer:true})) so the mount-time invocation is
+// skipped by the SolidJS framework; defer is not exercised here.
+//
+// What IS exercised: the three skip branches (composing, session route,
+// scope change) and the record routing (pinned vs portable). These pin
+// the regression scenarios called out in the PR review:
+//
+//   - homepage A → homepage B nav must not destroy the /repo-a snapshot
+//   - pinned prefill at mount must not be overwritten in place
+//   - IME compositionend must record the committed prompt without relying
+//     on a post-compose input event
+//
+// The tests drive tick directly with synthetic state, bypassing SolidJS
+// effect scheduling (which is gated by --conditions=browser in this repo
+// and not enabled for `bun test`).
+
+import { describe, expect, test } from "bun:test"
+import type { ContextItem, ImageAttachmentPart, Prompt } from "@/context/prompt"
+import {
+  applyOwnerMirrorTick,
+  type OwnerMirrorState,
+  type OwnerMirrorTickInputs,
+} from "./owner-mirror"
+import { createPortableDraftOwner } from "./portable-draft"
+import { createPinnedDraftOwner } from "./pinned-draft"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function textPrompt(text: string): Prompt {
+  return [{ type: "text", content: text, start: 0, end: text.length }]
+}
+
+function emptyPrompt(): Prompt {
+  return [{ type: "text", content: "", start: 0, end: 0 }]
+}
+
+function tickInputs(over: Partial<OwnerMirrorTickInputs> = {}): OwnerMirrorTickInputs {
+  return {
+    parts: emptyPrompt(),
+    contextItems: [],
+    images: [],
+    dir: "/repo-x",
+    sessionID: undefined,
+    compose: false,
+    ...over,
+  }
+}
+
+function makeState(initial: Partial<OwnerMirrorState> = {}): OwnerMirrorState {
+  return {
+    lastSeenDir: "/repo-x",
+    lastSeenSessionID: undefined,
+    ...initial,
+  }
+}
+
+function makeOwners() {
+  return {
+    portable: createPortableDraftOwner(),
+    pinned: createPinnedDraftOwner(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// composing guard
+// ---------------------------------------------------------------------------
+
+describe("applyOwnerMirrorTick — composing guard", () => {
+  test("intermediate IME prompt during composing=true returns skip-composing and does not record", () => {
+    const state = makeState()
+    const { portable, pinned } = makeOwners()
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("中"), compose: true }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("skip-composing")
+    expect(portable.snapshot()).toBeNull()
+    expect(pinned.current()).toBeNull()
+  })
+
+  test("compositionend (compose true→false) tick records the committed prompt", () => {
+    const state = makeState()
+    const { portable, pinned } = makeOwners()
+
+    // Tick 1: during composition (compose=true) — skipped.
+    applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("中文"), compose: true }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(portable.snapshot()).toBeNull()
+
+    // Tick 2: compositionend fires with the committed prompt (compose=false).
+    // The mirror effect tracks composing(), so this transition wakes it even
+    // without a post-compose input event.
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("中文"), compose: false }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("recorded-portable")
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "中文" })
+  })
+
+  test("composing=true does NOT update lastSeenDir/sessionID (next non-compose tick still sees current scope)", () => {
+    const state = makeState({ lastSeenDir: "/repo-x" })
+    const { portable, pinned } = makeOwners()
+    applyOwnerMirrorTick(
+      tickInputs({ dir: "/repo-x", compose: true }),
+      state,
+      pinned,
+      portable,
+    )
+    // State preserved — scope change is only consumed on non-composing ticks.
+    expect(state.lastSeenDir).toBe("/repo-x")
+    expect(state.lastSeenSessionID).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// session-route guard
+// ---------------------------------------------------------------------------
+
+describe("applyOwnerMirrorTick — session-route guard", () => {
+  test("sessionID set returns skip-session and does not record", () => {
+    const state = makeState()
+    const { portable, pinned } = makeOwners()
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("typed in session"), sessionID: "session-abc" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("skip-session")
+    expect(portable.snapshot()).toBeNull()
+    expect(pinned.current()).toBeNull()
+  })
+
+  test("session → homepage transition (sessionID undefined → string change) is treated as scope change", () => {
+    // Initial state: was on homepage /repo-x.
+    const state = makeState({ lastSeenDir: "/repo-x", lastSeenSessionID: undefined })
+    const { portable, pinned } = makeOwners()
+
+    // Enter session route.
+    const outcome1 = applyOwnerMirrorTick(
+      tickInputs({ sessionID: "session-abc" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome1).toBe("skip-session")
+    expect(state.lastSeenSessionID).toBe("session-abc")
+
+    // Leave session, return to homepage. First tick sees scope change.
+    const outcome2 = applyOwnerMirrorTick(
+      tickInputs({ parts: emptyPrompt(), sessionID: undefined }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome2).toBe("skip-scope")
+    expect(portable.snapshot()).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scope-change guard — the headline fix
+// ---------------------------------------------------------------------------
+
+describe("applyOwnerMirrorTick — scope-change guard", () => {
+  test("homepage A → homepage B (directory change) returns skip-scope without recording", () => {
+    // User typed on /repo-a; snapshot already recorded.
+    const { portable, pinned } = makeOwners()
+    portable.record({
+      sourceFilesystemDirectory: "/repo-a",
+      prompt: textPrompt("hello"),
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    // State reflects last-seen /repo-a.
+    const state = makeState({ lastSeenDir: "/repo-a" })
+
+    // Session swap fires the effect: dir is now /repo-b, prompt is empty
+    // (new session's DEFAULT_PROMPT).
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: emptyPrompt(), dir: "/repo-b" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("skip-scope")
+
+    // Snapshot for /repo-a is intact — empty record was not issued.
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/repo-a")
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "hello" })
+
+    // State updated so the next /repo-b tick passes the guard.
+    expect(state.lastSeenDir).toBe("/repo-b")
+  })
+
+  test("subsequent non-empty tick on the new dir records normally", () => {
+    const { portable, pinned } = makeOwners()
+    const state = makeState({ lastSeenDir: "/repo-a" })
+
+    // Scope-change tick.
+    applyOwnerMirrorTick(
+      tickInputs({ parts: emptyPrompt(), dir: "/repo-b" }),
+      state,
+      pinned,
+      portable,
+    )
+
+    // User types on /repo-b.
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("typed on b"), dir: "/repo-b" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("recorded-portable")
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/repo-b")
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "typed on b" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// record routing — pinned vs portable
+// ---------------------------------------------------------------------------
+
+describe("applyOwnerMirrorTick — record routing", () => {
+  test("pinned slot bound to current dir routes records to pinned (portable left untouched)", () => {
+    const { portable, pinned } = makeOwners()
+    pinned.adopt({ directory: "/repo-x", prompt: "prefill" })
+
+    const state = makeState({ lastSeenDir: "/repo-x" })
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("prefill plus edit"), dir: "/repo-x" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("recorded-pinned")
+    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "prefill plus edit" })
+    expect(portable.snapshot()).toBeNull()
+  })
+
+  test("pinned slot bound to a different dir routes records to portable", () => {
+    const { portable, pinned } = makeOwners()
+    pinned.adopt({ directory: "/repo-other", prompt: "other prefill" })
+
+    const state = makeState({ lastSeenDir: "/repo-x" })
+    const outcome = applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("hello"), dir: "/repo-x" }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(outcome).toBe("recorded-portable")
+    expect(portable.snapshot()?.sourceFilesystemDirectory).toBe("/repo-x")
+    // Pinned slot for /repo-other is untouched.
+    expect(pinned.current()?.directory).toBe("/repo-other")
+    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "other prefill" })
+  })
+
+  test("resolvedMentions on file context items are flattened into the recorded payload", () => {
+    const { portable, pinned } = makeOwners()
+    const state = makeState({ lastSeenDir: "/repo-x" })
+    const fileItem: ContextItem & { key: string } = {
+      type: "file",
+      path: "/repo-x/src/foo.ts",
+      key: "file:/repo-x/src/foo.ts",
+      resolvedMentions: [
+        {
+          displayText: "@src/bar.ts",
+          resolvedPath: "/repo-x/src/bar.ts",
+          fingerprint: "abc",
+          start: 0,
+          end: 11,
+        },
+      ],
+    }
+    applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("hello"), contextItems: [fileItem] }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(Object.keys(portable.snapshot()?.resolvedMentions ?? {})).toEqual([fileItem.key])
+  })
+
+  test("image attachments are copied into the recorded payload", () => {
+    const { portable, pinned } = makeOwners()
+    const state = makeState({ lastSeenDir: "/repo-x" })
+    const img: ImageAttachmentPart = {
+      type: "image",
+      id: "img-1",
+      filename: "img-1.png",
+      mime: "image/png",
+      dataUrl: "data:image/png,abc",
+    }
+    applyOwnerMirrorTick(
+      tickInputs({ parts: textPrompt("hi"), images: [img] }),
+      state,
+      pinned,
+      portable,
+    )
+    expect(portable.snapshot()?.images.length).toBe(1)
+    expect(portable.snapshot()?.images[0]?.id).toBe("img-1")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mount-defer regression note
+//
+// `{defer: true}` is part of the createEffect wiring in createOwnerMirrorEffect
+// and is NOT covered by these tests. It relies on SolidJS to skip the initial
+// invocation. If a future refactor strips defer, the editor-input.ts mount
+// sequence would fire applyOwnerMirrorTick with DEFAULT_PROMPT at mount and
+// clear any portable snapshot / overwrite any pinned prefill BEFORE hydration
+// applies. The pinned-draft.test.ts and portable-draft.test.ts hazard-pin
+// tests at the owner layer remain the canonical proof of why defer matters.
+// ---------------------------------------------------------------------------

--- a/packages/app/src/components/prompt-input/owner-mirror.ts
+++ b/packages/app/src/components/prompt-input/owner-mirror.ts
@@ -1,0 +1,143 @@
+// Owner mirror effect — single source of truth for portable/pinned draft
+// recording. Extracted from editor-input.ts so the decision logic can be
+// exercised end-to-end in isolation.
+//
+// The mirror folds three protections into one place:
+//
+// 1. {defer: true} skips the mount-time invocation. At mount the prompt is
+//    typically DEFAULT_PROMPT (empty payload) — without defer this would call
+//    portable.record() / pinned.recordEdit() with empty before the hydration
+//    logic in editor-input.ts has a chance to apply pinned prefill or consume
+//    a portable carry. defer is a SolidJS framework primitive; the unit test
+//    trusts SolidJS to honor it and only exercises applyOwnerMirrorTick.
+//
+// 2. lastSeenDir / lastSeenSessionID skip the first fire after a route scope
+//    change. prompt.current() in the binding is session-keyed by {dir, id};
+//    a homepage A → homepage B navigation flips it to the new session's
+//    empty default, which would otherwise wake this effect and record an
+//    empty payload against the NEW directory, destroying the snapshot held
+//    for the OLD directory before the hydration effect can move it.
+//
+// 3. composing() is tracked so the false→true and true→false transitions
+//    both wake the effect. Most browsers emit an additional input event
+//    after compositionend that would wake the mirror via handleInput's
+//    prompt.set, but not all do; tracking composing directly guarantees an
+//    owner record on IME commit regardless of the post-compositionend input
+//    event.
+
+import { createEffect, on } from "solid-js"
+import type { ContextItem, ImageAttachmentPart, Prompt } from "@/context/prompt"
+import type { ResolvedMention } from "./mention-metadata"
+import type { PinnedDraftOwner } from "./pinned-draft"
+import type { PortableDraftOwner } from "./portable-draft"
+
+export interface OwnerMirrorState {
+  lastSeenDir: string
+  lastSeenSessionID: string | undefined
+}
+
+export interface OwnerMirrorTickInputs {
+  parts: Prompt
+  contextItems: (ContextItem & { key: string })[]
+  images: ImageAttachmentPart[]
+  dir: string
+  sessionID: string | undefined
+  compose: boolean
+}
+
+export type OwnerMirrorTickOutcome =
+  | "recorded-pinned"
+  | "recorded-portable"
+  | "skip-composing"
+  | "skip-session"
+  | "skip-scope"
+
+/**
+ * One tick of the owner mirror state machine. Side effects: calls owner.record
+ * methods. Returns an outcome tag so tests can pin which branch ran.
+ *
+ * Mutates `state.lastSeenDir` / `state.lastSeenSessionID` even on skip-scope so
+ * a subsequent unchanged-scope tick passes the guard.
+ */
+export function applyOwnerMirrorTick(
+  inputs: OwnerMirrorTickInputs,
+  state: OwnerMirrorState,
+  pinned: PinnedDraftOwner,
+  portable: PortableDraftOwner,
+): OwnerMirrorTickOutcome {
+  if (inputs.compose) return "skip-composing"
+
+  const scopeChanged =
+    state.lastSeenDir !== inputs.dir || state.lastSeenSessionID !== inputs.sessionID
+  state.lastSeenDir = inputs.dir
+  state.lastSeenSessionID = inputs.sessionID
+  if (inputs.sessionID) return "skip-session"
+  if (scopeChanged) return "skip-scope"
+
+  const resolvedMentionsMap: Record<string, ResolvedMention[]> = {}
+  for (const item of inputs.contextItems) {
+    if (item.type === "file" && item.resolvedMentions?.length) {
+      resolvedMentionsMap[item.key] = item.resolvedMentions
+    }
+  }
+
+  const currentPinnedSlot = pinned.current()
+  if (currentPinnedSlot && currentPinnedSlot.directory === inputs.dir) {
+    pinned.recordEdit({
+      directory: inputs.dir,
+      prompt: inputs.parts,
+      context: inputs.contextItems.slice(),
+      images: [...inputs.images],
+      resolvedMentions: resolvedMentionsMap,
+    })
+    return "recorded-pinned"
+  }
+  portable.record({
+    sourceFilesystemDirectory: inputs.dir,
+    prompt: inputs.parts,
+    context: inputs.contextItems.slice(),
+    images: [...inputs.images],
+    resolvedMentions: resolvedMentionsMap,
+  })
+  return "recorded-portable"
+}
+
+export interface OwnerMirrorDeps {
+  prompt: () => Prompt
+  contextItems: () => (ContextItem & { key: string })[]
+  images: () => ImageAttachmentPart[]
+  directory: () => string
+  sessionID: () => string | undefined
+  composing: () => boolean
+  portable: PortableDraftOwner
+  pinned: PinnedDraftOwner
+}
+
+export function createOwnerMirrorEffect(deps: OwnerMirrorDeps): void {
+  const state: OwnerMirrorState = {
+    lastSeenDir: deps.directory(),
+    lastSeenSessionID: deps.sessionID(),
+  }
+  createEffect(
+    on(
+      () =>
+        [
+          deps.prompt(),
+          deps.contextItems(),
+          deps.images(),
+          deps.directory(),
+          deps.sessionID(),
+          deps.composing(),
+        ] as const,
+      ([parts, contextItems, images, dir, sessionID, compose]) => {
+        applyOwnerMirrorTick(
+          { parts, contextItems, images, dir, sessionID, compose },
+          state,
+          deps.pinned,
+          deps.portable,
+        )
+      },
+      { defer: true },
+    ),
+  )
+}

--- a/packages/app/src/components/prompt-input/path-b-integration.test.ts
+++ b/packages/app/src/components/prompt-input/path-b-integration.test.ts
@@ -1,0 +1,97 @@
+// Path B Space-trigger integration test.
+//
+// Regression guard for PR #785 review P1: setting `mirror.input = true` on
+// Path B hit short-circuited reconcile because the raw `/brainstorming ` DOM
+// looked "normalized" to isNormalizedEditor(). The store gained a marked
+// TextPart, but the editor never repainted into pill DOM, so the user kept
+// seeing raw slash text — #778 main acceptance path broken.
+//
+// This test pins the chain:
+//   1. Raw DOM + insertText Space input  ──►  tryPathBConversion returns marked
+//   2. Raw DOM is treated as normalized by isNormalizedEditor (would have
+//      caused the old short-circuit)
+//   3. Marked prompt vs parsed raw prompt are NOT equal, so the non-mirror
+//      reconcile branch fires renderPartsToEditor
+//   4. After repaint, DOM contains [data-cmd-mark] and visible label has no
+//      leading slash
+
+import { describe, expect, test } from "bun:test"
+import { isPromptEqual, type CommandSource } from "@/context/prompt"
+import { tryPathBConversion } from "./command-space-trigger"
+import {
+  isNormalizedEditor,
+  parseEditorToParts,
+  renderPartsToEditor,
+} from "./editor-serialize"
+import { setCursorPosition, getCursorPosition } from "./editor-dom"
+import type { CommandDescriptor } from "./command-text-part"
+
+const registry: CommandDescriptor[] = [
+  { name: "brainstorming", source: "skill" as CommandSource, icon: "command" },
+]
+
+describe("Path B integration: Space-trigger repaints DOM to pill", () => {
+  test("/brainstorming + Space → DOM gains [data-cmd-mark], raw slash gone", () => {
+    const editor = document.createElement("div")
+    editor.contentEditable = "true"
+    editor.appendChild(document.createTextNode("/brainstorming "))
+    document.body.appendChild(editor)
+
+    try {
+      const rawParts = parseEditorToParts(editor)
+      expect(rawParts.length).toBe(1)
+      expect(rawParts[0]?.type).toBe("text")
+      // Pre-conversion: no command metadata on the raw text part.
+      expect((rawParts[0] as any).command).toBeUndefined()
+
+      // (1) Path B conversion produces a marked Prompt.
+      const pathB = tryPathBConversion({
+        inputType: "insertText",
+        data: " ",
+        rawText: (rawParts[0] as any).content,
+        images: [],
+        registry,
+      })
+      expect(pathB).not.toBeNull()
+      expect((pathB!.prompt[0] as any).command?.name).toBe("brainstorming")
+
+      // (2) Raw DOM looks normalized. The OLD mirror.input=true short-circuit
+      // would have stopped here, leaving the user looking at raw slash text.
+      expect(isNormalizedEditor(editor)).toBe(true)
+
+      // (3) Marked Prompt is NOT equal to the parsed raw Prompt. The
+      // non-mirror reconcile branch detects this and forces a repaint.
+      expect(isPromptEqual(pathB!.prompt, rawParts)).toBe(false)
+
+      // (4) Repaint pushes pill DOM, raw "/brainstorming " text node is gone.
+      renderPartsToEditor(editor, pathB!.prompt)
+      setCursorPosition(editor, pathB!.cursor)
+
+      const pill = editor.querySelector("[data-cmd-mark]") as HTMLElement | null
+      expect(pill).not.toBeNull()
+      expect(pill!.dataset.name).toBe("brainstorming")
+      expect(pill!.getAttribute("contenteditable")).toBe("false")
+
+      // Visible label has no leading slash.
+      const label = pill!.querySelector("[data-cmd-label]") as HTMLElement
+      expect(label.textContent).toBe("brainstorming")
+      expect(label.textContent ?? "").not.toMatch(/^\//)
+
+      // Editor no longer contains a raw "/brainstorming " text run as a sibling
+      // of the pill (the slash now lives only in the marked TextPart content).
+      const directTextChildren = Array.from(editor.childNodes)
+        .filter((n) => n.nodeType === Node.TEXT_NODE)
+        .map((n) => n.textContent ?? "")
+      for (const t of directTextChildren) {
+        expect(t).not.toMatch(/^\/brainstorming/)
+      }
+
+      // Caret target reported by Path B matches the marked content length;
+      // after setCursorPosition the editor reports the same logical position.
+      expect(pathB!.cursor).toBe("/brainstorming ".length)
+      expect(getCursorPosition(editor)).toBe(pathB!.cursor)
+    } finally {
+      editor.remove()
+    }
+  })
+})

--- a/packages/app/src/components/prompt-input/pinned-draft.test.ts
+++ b/packages/app/src/components/prompt-input/pinned-draft.test.ts
@@ -232,3 +232,29 @@ describe("PinnedDraftOwner + PortableDraftOwner coexistence", () => {
     expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "portable still works" })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Mount-time hazard pin
+//
+// recordEdit() has no isEmpty short-circuit: an empty payload overwrites the
+// pinned prefill in place. The editor-input.ts homepage owner mirror effect
+// relies on {defer: true} to skip the mount-time fire so the prompt's default
+// empty state never reaches recordEdit() before the hydration effect runs.
+// Pinning this hazard explicitly so anyone reorganizing the mirror effect
+// stays aware of why defer is load-bearing.
+// ---------------------------------------------------------------------------
+
+describe("PinnedDraftOwner.recordEdit empty-payload hazard", () => {
+  test("empty payload overwrites a non-empty prefill in place", () => {
+    const owner = createPinnedDraftOwner()
+    owner.adopt({ directory: "/repo-x", prompt: "review this PR" })
+    expect(owner.current()?.prompt[0]).toMatchObject({ content: "review this PR" })
+
+    owner.recordEdit({ directory: "/repo-x", ...emptyPayload() })
+
+    // Prefill is gone. If the mirror effect ever fires at mount with the
+    // default empty prompt, this is what would happen to a pending pinned
+    // prefill. defer:true on the effect is what prevents it.
+    expect(owner.current()?.prompt[0]).toMatchObject({ content: "" })
+  })
+})

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -9,6 +9,7 @@ import {
   type ContentPart,
   DEFAULT_PROMPT,
   type ImageAttachmentPart,
+  type Prompt,
   type usePrompt,
 } from "@/context/prompt"
 import type { useCommand } from "@/context/command"
@@ -18,6 +19,7 @@ import type { useLanguage } from "@/context/language"
 import { promptEnabled, promptProbe } from "@/testing/prompt"
 import { type AtOption, type SlashCommand } from "./slash-popover"
 import type { PromptStore } from "./store-types"
+import { prependCommandMark } from "./command-prepend"
 
 export interface PopoverControllersDeps {
   store: PromptStore
@@ -38,6 +40,8 @@ export interface PopoverControllersDeps {
   clearEditor: () => void
   setEditorText: (text: string) => void
   focusEditorEnd: () => void
+  // renderEditorWithCursor is needed to push pill DOM for custom commands
+  renderEditorWithCursor: (parts: Prompt) => void
 }
 
 export interface PopoverControllers {
@@ -73,6 +77,7 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     clearEditor,
     setEditorText,
     focusEditorEnd,
+    renderEditorWithCursor,
   } = deps
 
   const handleAtSelect = (option: AtOption | undefined) => {
@@ -136,9 +141,20 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     const images = imageAttachments()
 
     if (cmd.type === "custom") {
-      const text = `/${cmd.trigger} `
-      setEditorText(text)
-      prompt.set([{ type: "text", content: text, start: 0, end: text.length }, ...images], text.length)
+      // Build a marked TextPart (pill) and prepend it to the current prompt.
+      // source is always present on custom commands (set in slashCommands memo).
+      // icon is not stored on SlashCommand; default to "command" per spec.
+      const descriptor = {
+        name: cmd.trigger,
+        source: cmd.source ?? "command",
+        icon: "command",
+      }
+      const newPrompt = prependCommandMark(prompt.current(), images, descriptor)
+      // prependCommandMark always places the marked TextPart at index 0.
+      const markedPart = newPrompt[0] as import("@/context/prompt").TextPart
+      prompt.set(newPrompt, markedPart.content.length)
+      // Explicitly push pill DOM: prompt.set alone does not re-render the editor.
+      renderEditorWithCursor(newPrompt)
       focusEditorEnd()
       return
     }

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -351,6 +351,40 @@ describe("PortableDraftOwner preserves command metadata on marked TextPart", () 
     expect((first as any).content).toBe("/brainstorming hello")
   })
 
+  test("regression guard: empty payload destroys an existing non-empty snapshot", () => {
+    // record() short-circuits empty payloads to setSnapshot(null). If the
+    // editor-input.ts homepage owner mirror effect ever fires at mount with
+    // DEFAULT_PROMPT (empty), this is what would happen to a portable
+    // snapshot from another homepage that hasn't been consumed yet —
+    // silently destroying the user's draft before hydration can move it.
+    // The mirror effect's {defer: true} option is what prevents this.
+    const owner = createPortableDraftOwner()
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: [{
+        type: "text",
+        content: "/brainstorming the failing test",
+        start: 0,
+        end: 31,
+        command: { name: "brainstorming", source: "skill", icon: "command" },
+      }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(owner.snapshot()).not.toBeNull()
+
+    // Empty payload — the shape the prompt has at mount.
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    expect(owner.snapshot()).toBeNull()
+  })
+
   test("consumeForHomepage round-trip preserves command field", () => {
     const owner = createPortableDraftOwner()
     owner.record({

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -311,3 +311,67 @@ describe("PortableDraftOwner canonicalizes file paths against the source directo
     expect(moved?.context[0]?.path).toBe("/repo-A/src/app.ts")
   })
 })
+
+// ---------------------------------------------------------------------------
+// Marked TextPart (command pill) round-trip through the owner.
+//
+// Path A/B/C all produce a Prompt whose leading TextPart carries a `command`
+// field. The homepage owner mirror effect records that Prompt verbatim; on
+// route-back hydration, the snapshot is replayed via prompt.set(snapshot.prompt).
+// This test pins that the `command` metadata survives intact through the
+// owner — otherwise the user's pill would silently degrade to raw slash text
+// after a route change.
+// ---------------------------------------------------------------------------
+
+describe("PortableDraftOwner preserves command metadata on marked TextPart", () => {
+  test("snapshot retains command field after record", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: [{
+        type: "text",
+        content: "/brainstorming hello",
+        start: 0,
+        end: 20,
+        command: { name: "brainstorming", source: "skill", icon: "command" },
+      }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    const snap = owner.snapshot()
+    expect(snap).not.toBeNull()
+    const first = snap!.prompt[0]
+    expect(first?.type).toBe("text")
+    expect((first as any).command).toEqual({
+      name: "brainstorming",
+      source: "skill",
+      icon: "command",
+    })
+    expect((first as any).content).toBe("/brainstorming hello")
+  })
+
+  test("consumeForHomepage round-trip preserves command field", () => {
+    const owner = createPortableDraftOwner()
+    owner.record({
+      sourceFilesystemDirectory: "/repo-A",
+      prompt: [{
+        type: "text",
+        content: "/review HEAD~3",
+        start: 0,
+        end: 14,
+        command: { name: "review", source: "command", icon: "command" },
+      }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    // Same-dir homepage navigation: snapshot restored via restore(), not consumed.
+    const restored = owner.restore()
+    expect((restored!.prompt[0] as any).command?.name).toBe("review")
+    // Different-dir move via consumeForHomepage: command still preserved.
+    const moved = owner.consumeForHomepage("/repo-B", true)
+    expect((moved!.prompt[0] as any).command?.name).toBe("review")
+    expect((moved!.prompt[0] as any).content).toBe("/review HEAD~3")
+  })
+})

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -796,3 +796,171 @@ describe("prompt submit worktree selection", () => {
     expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
   })
 })
+
+describe("Path D — marked TextPart routes through session.command", () => {
+  test("marked('/brainstorming ') alone → command call with arguments ''", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "brainstorming" })
+    promptValue = [{
+      type: "text", content: "/brainstorming ", start: 0, end: 15,
+      command: { name: "brainstorming", source: "skill", icon: "command" },
+    }]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => commandCalls.length > 0)
+
+    expect(commandCalls.at(-1)?.command).toBe("brainstorming")
+    expect(commandCalls.at(-1)?.arguments).toBe("")
+  })
+
+  test("marked + FilePart args projection → args includes file content", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "brainstorming" })
+    promptValue = [
+      { type: "text", content: "/brainstorming ", start: 0, end: 15,
+        command: { name: "brainstorming", source: "skill", icon: "command" } },
+      { type: "file", path: "foo.ts", content: "@foo.ts", start: 15, end: 22 } as any,
+    ]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => commandCalls.length > 0)
+
+    expect(commandCalls.at(-1)?.command).toBe("brainstorming")
+    expect(commandCalls.at(-1)?.arguments).toBe("@foo.ts")
+  })
+
+  test("invariant-violated marked TextPart falls through to plain-prompt path", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "brainstorming" })
+    const before = commandCalls.length
+    // content does NOT start with /<name> — invariant breach
+    promptValue = [{
+      type: "text", content: "WRONG", start: 0, end: 5,
+      command: { name: "brainstorming", source: "skill", icon: "command" },
+    }]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    // Invariant breach + content not starting with /<name> → falls through.
+    // The legacy fallback also won't fire (text "WRONG" doesn't start with /).
+    // So no NEW command call is made.
+    expect(commandCalls.length).toBe(before)
+  })
+})
+
+describe("Legacy fallback boundary (no marked TextPart)", () => {
+  test("[Text('/brainstorming'), File('@foo.ts')] → NOT a command (no separator space)", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "brainstorming" })
+    const before = commandCalls.length
+    promptValue = [
+      { type: "text", content: "/brainstorming", start: 0, end: 14 },
+      { type: "file", path: "foo.ts", content: "@foo.ts", start: 14, end: 21 } as any,
+    ]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    // flatText = "/brainstorming@foo.ts", head split-by-space = "/brainstorming@foo.ts",
+    // slice(1) = "brainstorming@foo.ts", registry miss → submits as plain prompt.
+    expect(commandCalls.length).toBe(before)
+  })
+
+  test("[Text('/brainstorming '), File('@foo.ts')] → command, args '@foo.ts'", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "brainstorming" })
+    promptValue = [
+      { type: "text", content: "/brainstorming ", start: 0, end: 15 },
+      { type: "file", path: "foo.ts", content: "@foo.ts", start: 15, end: 22 } as any,
+    ]
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => commandCalls.length > 0)
+
+    expect(commandCalls.at(-1)?.command).toBe("brainstorming")
+    expect(commandCalls.at(-1)?.arguments).toBe("@foo.ts")
+  })
+})

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -20,6 +20,7 @@ import { Worktree as WorktreeState } from "@/utils/worktree"
 import { rendererAbortDiagnosticSource, type RendererAbortSource } from "@/session/abort-source"
 import { buildRequestParts } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
+import { reportInvariantBreach } from "./invariant"
 import { formatServerError } from "@/utils/server-errors"
 import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
 import { type PromptRouteScope, promptScopeForSession } from "@/pages/session/prompt-route-scope"
@@ -123,6 +124,50 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
     const ok = await input.before?.()
     if (ok === false) return false
     return true
+  }
+
+  // Path D: first prompt part is a marked TextPart (command metadata present).
+  // flatText projects all content parts into a single string for argument slicing.
+  // If the content prefix invariant is violated, report and fall through to legacy.
+  const first = input.draft.prompt[0]
+  if (first?.type === "text" && first.command) {
+    const markedName = first.command.name
+    const prefix = `/${markedName} `
+    const flatText = input.draft.prompt
+      .map((p) => ("content" in p ? p.content : ""))
+      .join("")
+    if (!flatText.startsWith(prefix)) {
+      reportInvariantBreach("sendFollowupDraft: command content prefix mismatch", first)
+      // Fall through to the legacy command check below.
+    } else {
+      setBusy()
+      try {
+        if (!(await wait())) {
+          setIdle()
+          return false
+        }
+        await input.client.session.command({
+          sessionID: input.draft.sessionID,
+          command: markedName,
+          arguments: flatText.slice(prefix.length),
+          agent: input.draft.agent,
+          model: `${input.draft.model.providerID}/${input.draft.model.modelID}`,
+          locale: input.draft.locale,
+          variant: input.draft.variant,
+          parts: images.map((attachment) => ({
+            id: Identifier.ascending("part"),
+            type: "file" as const,
+            mime: attachment.mime,
+            url: attachment.dataUrl,
+            filename: attachment.filename,
+          })),
+        })
+        return true
+      } catch (err) {
+        setIdle()
+        throw err
+      }
+    }
   }
 
   const [head, ...tail] = text.split(" ")
@@ -670,6 +715,52 @@ export function createPromptSubmit(input: PromptSubmitInput) {
           restoreInput(ownership)
         })
       return
+    }
+
+    // Path D: first prompt part is a marked TextPart (command metadata present).
+    // flatText projects all content parts into a single string for argument slicing.
+    // If the content prefix invariant is violated, report and fall through to legacy.
+    const firstPart = currentPrompt[0]
+    if (firstPart?.type === "text" && firstPart.command) {
+      const markedName = firstPart.command.name
+      const markedPrefix = `/${markedName} `
+      const flatText = currentPrompt
+        .map((p) => ("content" in p ? p.content : ""))
+        .join("")
+      if (!flatText.startsWith(markedPrefix)) {
+        reportInvariantBreach("handleSubmit: command content prefix mismatch", firstPart)
+        // Fall through to the legacy slash-command check below.
+      } else {
+        clearInput(ownership)
+        client.session
+          .command({
+            sessionID: session.id,
+            command: markedName,
+            arguments: flatText.slice(markedPrefix.length),
+            agent,
+            model: `${model.providerID}/${model.modelID}`,
+            locale,
+            variant,
+            parts: images.map((attachment) => ({
+              id: Identifier.ascending("part"),
+              type: "file" as const,
+              mime: attachment.mime,
+              url: attachment.dataUrl,
+              filename: attachment.filename,
+            })),
+          })
+          .then(() => {
+            confirmOwnerCleared(ownership)
+          })
+          .catch((err) => {
+            showToast({
+              title: language.t("prompt.toast.commandSendFailed.title"),
+              description: formatServerError(err, language.t, language.t("common.requestFailed")),
+            })
+            restoreInput(ownership)
+          })
+        return
+      }
     }
 
     if (text.startsWith("/")) {

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -161,3 +161,25 @@ describe("isPartEqual with command field", () => {
   })
 })
 
+describe("isStructurallyEmpty", () => {
+  test("DEFAULT_PROMPT + no context + no images → true", () => {
+    expect(isStructurallyEmpty(DEFAULT_PROMPT, [], [])).toBe(true)
+  })
+  test("whitespace-only text → false", () => {
+    const p: Prompt = [{ type: "text", content: "   ", start: 0, end: 3 }]
+    expect(isStructurallyEmpty(p, [], [])).toBe(false)
+  })
+  test("attachments present → false", () => {
+    const file = { type: "file" as const, content: "@foo.ts", start: 0, end: 7, path: "foo.ts" }
+    expect(isStructurallyEmpty([file], [], [])).toBe(false)
+  })
+  test("context items present → false", () => {
+    const ctx: ContextItem[] = [{ type: "file", path: "foo.ts" }]
+    expect(isStructurallyEmpty(DEFAULT_PROMPT, ctx, [])).toBe(false)
+  })
+  test("image attachments present → false", () => {
+    const image: ImageAttachmentPart = { type: "image", id: "1", filename: "a.png", mime: "image/png", dataUrl: "data:" }
+    expect(isStructurallyEmpty(DEFAULT_PROMPT, [], [image])).toBe(false)
+  })
+})
+

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -1,8 +1,10 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test"
-import type { ContextItem, Prompt } from "./prompt"
+import type { ContextItem, ImageAttachmentPart, Prompt } from "./prompt"
 
 let createPromptBinding: typeof import("./prompt").createPromptBinding
 let DEFAULT_PROMPT: typeof import("./prompt").DEFAULT_PROMPT
+let isPromptEqual: typeof import("./prompt").isPromptEqual
+let isStructurallyEmpty: typeof import("./prompt").isStructurallyEmpty
 
 beforeAll(async () => {
   mock.module("@solidjs/router", () => ({
@@ -17,6 +19,8 @@ beforeAll(async () => {
   const mod = await import("./prompt")
   createPromptBinding = mod.createPromptBinding
   DEFAULT_PROMPT = mod.DEFAULT_PROMPT
+  isPromptEqual = mod.isPromptEqual
+  isStructurallyEmpty = mod.isStructurallyEmpty
 })
 
 function promptSession() {
@@ -130,3 +134,30 @@ describe("createPromptBinding", () => {
     expect(current.current()).toEqual([{ type: "text", content: "hello", start: 0, end: 5 }])
   })
 })
+
+// Task 1: isPartEqual with command field
+describe("isPartEqual with command field", () => {
+  test("two marked TextParts with same name+source+icon are equal", () => {
+    const a: Prompt = [{ type: "text", content: "/brainstorming ", start: 0, end: 15,
+      command: { name: "brainstorming", source: "skill", icon: "command" } }]
+    const b: Prompt = [{ type: "text", content: "/brainstorming ", start: 0, end: 15,
+      command: { name: "brainstorming", source: "skill", icon: "command" } }]
+    expect(isPromptEqual(a, b)).toBe(true)
+  })
+
+  test("marked vs plain TextPart with same content are NOT equal", () => {
+    const marked: Prompt = [{ type: "text", content: "/brainstorming ", start: 0, end: 15,
+      command: { name: "brainstorming", source: "skill", icon: "command" } }]
+    const plain: Prompt = [{ type: "text", content: "/brainstorming ", start: 0, end: 15 }]
+    expect(isPromptEqual(marked, plain)).toBe(false)
+  })
+
+  test("two marked TextParts with different command.name are NOT equal", () => {
+    const a: Prompt = [{ type: "text", content: "/a ", start: 0, end: 3,
+      command: { name: "a", source: "skill", icon: "command" } }]
+    const b: Prompt = [{ type: "text", content: "/a ", start: 0, end: 3,
+      command: { name: "b", source: "skill", icon: "command" } }]
+    expect(isPromptEqual(a, b)).toBe(false)
+  })
+})
+

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -101,6 +101,16 @@ export function isPromptEqual(promptA: Prompt, promptB: Prompt): boolean {
   return true
 }
 
+export function isStructurallyEmpty(
+  prompt: Prompt,
+  contextItems: readonly ContextItem[],
+  imageAttachments: readonly ImageAttachmentPart[],
+): boolean {
+  if (contextItems.length > 0) return false
+  if (imageAttachments.length > 0) return false
+  return isPromptEqual(prompt, DEFAULT_PROMPT)
+}
+
 function cloneSelection(selection?: FileSelection) {
   if (!selection) return undefined
   return { ...selection }

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -13,8 +13,15 @@ interface PartBase {
   end: number
 }
 
+export type CommandSource = "skill" | "mcp" | "command"
+
 export interface TextPart extends PartBase {
   type: "text"
+  command?: {
+    name: string
+    source: CommandSource
+    icon: string
+  }
 }
 
 export interface FileAttachmentPart extends PartBase {
@@ -63,10 +70,20 @@ function isSelectionEqual(a?: FileSelection, b?: FileSelection) {
   )
 }
 
+function isCommandMetaEqual(a: TextPart["command"], b: TextPart["command"]) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return a.name === b.name && a.source === b.source && a.icon === b.icon
+}
+
 function isPartEqual(partA: ContentPart, partB: ContentPart) {
   switch (partA.type) {
     case "text":
-      return partB.type === "text" && partA.content === partB.content
+      return (
+        partB.type === "text" &&
+        partA.content === partB.content &&
+        isCommandMetaEqual(partA.command, partB.command)
+      )
     case "file":
       return partB.type === "file" && partA.path === partB.path && isSelectionEqual(partA.selection, partB.selection)
     case "agent":

--- a/packages/app/src/utils/prompt.test.ts
+++ b/packages/app/src/utils/prompt.test.ts
@@ -186,7 +186,12 @@ describe("extractPromptFromParts", () => {
     const result = extractPromptFromParts(parts)
 
     expect(result).toHaveLength(2)
-    expect(result[0]).toMatchObject({ type: "text", content: "/brainstorming fold the bubble" })
+    // Must be a marked TextPart (command field present) for pill re-render.
+    expect(result[0]).toMatchObject({
+      type: "text",
+      content: "/brainstorming fold the bubble",
+      command: { name: "brainstorming", source: "command" },
+    })
     expect(result[1]).toMatchObject({
       type: "image",
       filename: "screenshot.png",
@@ -215,7 +220,12 @@ describe("extractPromptFromParts", () => {
     const result = extractPromptFromParts(parts)
 
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({ type: "text", content: "/brainstorming " })
+    // Marked TextPart: trailing space present, command metadata attached.
+    expect(result[0]).toMatchObject({
+      type: "text",
+      content: "/brainstorming ",
+      command: { name: "brainstorming", source: "command" },
+    })
   })
 
   test("command mode: suppresses commandTemplate-tagged file even when alone", () => {
@@ -248,6 +258,11 @@ describe("extractPromptFromParts", () => {
     const result = extractPromptFromParts(parts)
 
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({ type: "text", content: "/explain this" })
+    // Marked TextPart: template file suppressed, command metadata attached.
+    expect(result[0]).toMatchObject({
+      type: "text",
+      content: "/explain this",
+      command: { name: "explain", source: "command" },
+    })
   })
 })

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -1,5 +1,6 @@
 import type { FilePart, Part, TextPart } from "@opencode-ai/sdk/v2"
 import { deriveCommandInvocation } from "@opencode-ai/ui/lib/command-invocation"
+import { createCommandTextPart } from "@/components/prompt-input/command-text-part"
 import type { FileAttachmentPart, ImageAttachmentPart, Prompt } from "@/context/prompt"
 
 type Inline =
@@ -58,8 +59,12 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
   const attachmentName = opts?.attachmentName ?? "attachment"
   const invocation = deriveCommandInvocation(parts)
   if (invocation) {
-    const restoreText = invocation.restoreText
-    const out: Prompt = [{ type: "text", content: restoreText, start: 0, end: restoreText.length }]
+    // Restore as a marked TextPart so the editor can re-render it as a pill.
+    const commandPart = createCommandTextPart(
+      { name: invocation.name, source: invocation.source, icon: invocation.markIcon },
+      invocation.args,
+    )
+    const out: Prompt = [commandPart]
     for (const part of parts) {
       if (part.type !== "file") continue
       const filePart = part as FilePart

--- a/packages/ui/src/components/command-icon.test.ts
+++ b/packages/ui/src/components/command-icon.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { resolveCommandIconSvg } from "./command-icon"
+
+const CommandDefault = await Bun.file(
+  new URL("../assets/icons/command-default.svg", import.meta.url),
+).text()
+
+describe("resolveCommandIconSvg", () => {
+  test("returns the SVG string for a known icon key", () => {
+    const result = resolveCommandIconSvg("command")
+    expect(result).toBe(CommandDefault)
+    expect(result).toMatch(/<svg\b/)
+  })
+
+  test("falls back to the default command SVG for an unknown key", () => {
+    const result = resolveCommandIconSvg("nonexistent-icon-xyz")
+    expect(result).toBe(CommandDefault)
+  })
+
+  test("returns a string (not JSX or reactive)", () => {
+    const result = resolveCommandIconSvg("command")
+    expect(typeof result).toBe("string")
+  })
+
+  test("fallback matches what CommandIcon would render", () => {
+    // The fallback rule: REGISTRY[icon] ?? REGISTRY.command
+    // For unknown icons, both helpers must return the same thing.
+    const unknown = resolveCommandIconSvg("definitely-not-registered")
+    const known = resolveCommandIconSvg("command")
+    expect(unknown).toBe(known)
+  })
+})

--- a/packages/ui/src/components/command-icon.tsx
+++ b/packages/ui/src/components/command-icon.tsx
@@ -6,8 +6,14 @@ const REGISTRY: Record<string, string> = {
   command: CommandDefault,
 }
 
+/** Pure helper: resolves an icon key to its SVG string. No JSX or reactivity.
+ *  Used by both the SolidJS component and the DOM-side input pill serializer. */
+export function resolveCommandIconSvg(icon: string): string {
+  return REGISTRY[icon] ?? REGISTRY.command
+}
+
 export function CommandIcon(props: { icon: string }) {
-  const svg = () => REGISTRY[props.icon] ?? REGISTRY.command
+  const svg = () => resolveCommandIconSvg(props.icon)
   return (
     <Show when={svg()}>
       <span class="command-icon" data-slot="command-icon" innerHTML={svg()} aria-hidden="true" />


### PR DESCRIPTION
## Summary

Collapse `/<command> args` in the prompt input into the same inline pill (icon + brand-colored name) that PR #768 already renders in the sent bubble. Selecting from the slash popover, typing the command followed by Space, or pasting `/<known-name> args` into an empty input all materialise the leading `/<name>` into a `data-cmd-mark` element while the args remain plain text.

## Why

Fixes #778. The sent bubble shows the command name as a brand-colored pill, but until now the same text in the prompt input rendered as raw `/<name>`. Two surfaces, two visual treatments for the same concept. This PR aligns the editor side to the send-side model: a single optional `TextPart.command` field carries the metadata, content stays `/<name> <args>` end-to-end, and `metadata.commandInvocation` on the wire is unchanged.

## Related Issue

Fixes #778

## Human Review Status

Pending

## Review Focus

The marked-TextPart invariants. There is at most one per Prompt, always at index 0, and `content` always equals `/<name> <args>` with a single trailing space after the name. Most of the new code is the helpers (`command-text-part.ts`, `command-prepend.ts`, `command-space-trigger.ts`, `command-paste.ts`, `command-backspace.ts`) that enforce these invariants on the way into the store, plus the editor-side primitives (`editor-dom.ts`, `editor-serialize.ts`) that treat the pill as a unit of logical length `1 + name.length`. The contenteditable round-trip is the most fragile surface and has the largest test coverage.

Other things worth double-checking:

- ASCII-only case-insensitive matching in `command-text-part.ts:16-45`. Non-ASCII names fall back to exact byte match so caret math stays length-preserving.
- Path B trigger uses `inputType === "insertText" && data === " "`, which is naturally false on paste, Backspace, IME commit, and programmatic mutations. No flag state machine.
- Backspace ladder in `command-backspace.ts`: caret inside the prefix region of a marked TextPart degrades the pill back to plain text without dropping attachments.

## Risk Notes

- Path A (popover-select) and Path B (Space-trigger) preserve image attachments by passing `imageAttachments()` through to the new prompt, so the existing image flow is unchanged. Same for `prompt.context.items()`.
- E1 mid-prompt variant: when the popover is opened by the global trigger while the editor already has unrelated content, the marked TextPart is prepended and original parts keep both order and reference identity. No clone of incoming `FileAttachmentPart` / `AgentPart` / `ImagePart`.
- Legacy fallback boundary: the existing `text.split(" ")[0] === "/<known-name>"` codepath in `submit.ts` is kept as a safety net; the new path only fires when `part.command` metadata is present.
- Deferred follow-ups, none of which affect this PR's user-facing acceptance:
  - Homepage owner-mirror in Path A and Path C (Codex P2, narrow widening of an existing gap on Path A; new but narrow on Path C).
  - E2E snap target for the pill rendering. The unit tests at `editor-dom.test.ts` and `editor-serialize.test.ts` cover the DOM contract; a visual diff for the pill itself can be added in a small follow-up.
  - `dev:desktop` walkthrough of the IME + paste + Backspace paths on macOS/Windows. The unit and integration coverage exercises the same code paths.

## How To Verify

```text
bun --cwd packages/app test                  → 1405 pass, 0 fail
bun --cwd packages/app run typecheck         → 0 errors
gh pr diff (visual)                          → 17 commits, 1 P0 + 2 P1 from crosscheck addressed
manual: open slash popover, select brainstorming → pill renders, caret lands after the trailing space
manual: type `/brainstorming ` (with Space)  → buffer materialises into pill, popover closes
manual: Backspace just after pill            → pill collapses back to `/brainstorming ` plain text, attachments survive
manual: paste `/brainstorming hello` into empty input → pill + " hello" args
```

The 4 pre-existing icon-button test failures on `dev` (CSS 30x30 vs test expectation 24x24) are unrelated to this PR.

## Screenshots or Recordings

(To be attached by reviewer; pill visuals match PR #768 sent-bubble exactly, sharing `--brand-primary` and `--font-weight-body` via `command-pill.css`.)

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual command pills that display slash commands in the prompt editor with branded styling and icons.
  * Implemented copy/paste support for slash commands with proper clipboard handling and text rewriting.
  * Added keyboard interactions for command editing, including backspace handling to remove or modify command content.
  * Command icons now display with appropriate visual resolution and styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->