### PR TITLE
fix(app): add timeline scroll command sink

### DIFF
--- a/packages/app/src/pages/session/session-auto-scroll.test.ts
+++ b/packages/app/src/pages/session/session-auto-scroll.test.ts
@@ -42,4 +42,49 @@ describe("session auto scroll", () => {
       dispose()
     })
   })
+
+  test("routes timeline bottom-follow writes through the optional command executor", () => {
+    createRoot((dispose) => {
+      const el = document.createElement("div")
+      let top = 500
+      const commands: Array<{ top: number; reason: string; method: string; anchor: string }> = []
+
+      Object.defineProperties(el, {
+        clientHeight: { value: 100, configurable: true },
+        scrollHeight: { value: 1000, configurable: true },
+        scrollTop: {
+          configurable: true,
+          get: () => top,
+          set: (value) => {
+            top = value
+          },
+        },
+      })
+
+      const autoScroll = createAutoScroll({
+        working: () => true,
+        overflowAnchor: "dynamic",
+        executeScrollCommand: (command) => {
+          commands.push({
+            top: command.top,
+            reason: command.reason,
+            method: command.method,
+            anchor: command.element.style.overflowAnchor,
+          })
+          command.element.scrollTop = command.top
+        },
+      })
+
+      autoScroll.scrollRef(el)
+      autoScroll.pause()
+      el.style.overflowAnchor = "auto"
+
+      autoScroll.forceScrollToBottom("force-bottom")
+
+      expect(commands).toEqual([{ top: 1000, reason: "force-bottom", method: "set-scroll-top", anchor: "none" }])
+      expect(top).toBe(1000)
+
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/pages/session/session-timeline-scroll-anchors.test.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-anchors.test.ts
@@ -4,6 +4,7 @@ import {
   restoreTimelineSafePosition,
   sampleTimelineSafePosition,
 } from "./session-timeline-scroll-anchors"
+import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 
 type RectInput = {
   top: number
@@ -163,14 +164,25 @@ describe("session timeline scroll anchors", () => {
       clientHeight: 400,
       scrollHeight: 1000,
     })
+    const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 200 })
 
     expect(
       restoreTimelineSafePosition({
         viewport: scroller.viewport,
         position: { kind: "latest", messageID: "msg_latest" },
+        scrollCommandSink,
       }),
     ).toEqual({ ok: true, restoredTo: { kind: "latest", messageID: "msg_latest" } })
     expect(scroller.scrollTop).toBe(600)
+    expect(scrollCommandSink.records()).toEqual([
+      expect.objectContaining({
+        monotonicMs: 200,
+        type: "anchor-restore",
+        source: "session-timeline-scroll-anchors/restoreLatest",
+        reason: "scroll-height-bottom",
+        top: 600,
+      }),
+    ])
   })
 
   test("restores reading anchor to its previous viewport offset", () => {

--- a/packages/app/src/pages/session/session-timeline-scroll-anchors.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-anchors.ts
@@ -1,4 +1,9 @@
-import type { TimelineSafePosition, TimelineScrollMetrics, TimelineScrollMode } from "./session-timeline-scroll-controller"
+import type {
+  TimelineSafePosition,
+  TimelineScrollMetrics,
+  TimelineScrollMode,
+} from "./session-timeline-scroll-controller"
+import { createTimelineScrollCommandSink, type TimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 
 export type TimelineAnchorRestoreResult =
   | { ok: true; restoredTo: TimelineSafePosition }
@@ -21,6 +26,24 @@ function firstVisibleMessage(viewport: HTMLElement) {
     if (rect.bottom > viewportRect.top && rect.top < viewportRect.bottom) return { el, rect }
   }
   return undefined
+}
+
+const fallbackTimelineScrollCommandSink = createTimelineScrollCommandSink()
+
+function setTimelineScrollTop(input: {
+  viewport: HTMLElement
+  top: number
+  sink: TimelineScrollCommandSink
+  source: string
+  reason: string
+}) {
+  input.sink.setScrollTop({
+    element: input.viewport,
+    top: Math.max(0, input.top),
+    type: "anchor-restore",
+    source: input.source,
+    reason: input.reason,
+  })
 }
 
 export function collectTimelineScrollMetrics(viewport: HTMLElement): TimelineScrollMetrics {
@@ -69,26 +92,56 @@ export function sampleTimelineSafePosition(args: {
   }
 }
 
-function restoreLatest(viewport: HTMLElement, bottomSentinel?: HTMLElement | null) {
+function restoreLatest(
+  viewport: HTMLElement,
+  bottomSentinel: HTMLElement | null | undefined,
+  sink: TimelineScrollCommandSink,
+) {
   if (bottomSentinel) {
     const viewportRect = viewport.getBoundingClientRect()
     const sentinelRect = bottomSentinel.getBoundingClientRect()
-    viewport.scrollTop = Math.max(0, viewport.scrollTop + sentinelRect.bottom - viewportRect.bottom)
+    setTimelineScrollTop({
+      viewport,
+      sink,
+      top: viewport.scrollTop + sentinelRect.bottom - viewportRect.bottom,
+      source: "session-timeline-scroll-anchors/restoreLatest",
+      reason: "bottom-sentinel",
+    })
     return
   }
-  viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+  setTimelineScrollTop({
+    viewport,
+    sink,
+    top: viewport.scrollHeight - viewport.clientHeight,
+    source: "session-timeline-scroll-anchors/restoreLatest",
+    reason: "scroll-height-bottom",
+  })
 }
 
-function restoreReading(viewport: HTMLElement, position: Extract<TimelineSafePosition, { kind: "reading" }>) {
+function restoreReading(
+  viewport: HTMLElement,
+  position: Extract<TimelineSafePosition, { kind: "reading" }>,
+  sink: TimelineScrollCommandSink,
+) {
   const anchor = messageElementByID(viewport, position.anchorMessageID)
   if (!anchor) return false
   const viewportRect = viewport.getBoundingClientRect()
   const anchorRect = anchor.getBoundingClientRect()
-  viewport.scrollTop = Math.max(0, viewport.scrollTop + anchorRect.top - viewportRect.top - position.offsetFromViewportTop)
+  setTimelineScrollTop({
+    viewport,
+    sink,
+    top: viewport.scrollTop + anchorRect.top - viewportRect.top - position.offsetFromViewportTop,
+    source: "session-timeline-scroll-anchors/restoreReading",
+    reason: "reading-anchor",
+  })
   return true
 }
 
-function restoreTarget(viewport: HTMLElement, position: Extract<TimelineSafePosition, { kind: "target_message" }>) {
+function restoreTarget(
+  viewport: HTMLElement,
+  position: Extract<TimelineSafePosition, { kind: "target_message" }>,
+  sink: TimelineScrollCommandSink,
+) {
   const target = messageElementByID(viewport, position.messageID)
   if (!target) return false
 
@@ -97,30 +150,57 @@ function restoreTarget(viewport: HTMLElement, position: Extract<TimelineSafePosi
   const offset = position.offsetFromViewportTop
 
   if (typeof offset === "number") {
-    viewport.scrollTop = Math.max(0, viewport.scrollTop + targetRect.top - viewportRect.top - offset)
+    setTimelineScrollTop({
+      viewport,
+      sink,
+      top: viewport.scrollTop + targetRect.top - viewportRect.top - offset,
+      source: "session-timeline-scroll-anchors/restoreTarget",
+      reason: "target-offset",
+    })
     return true
   }
 
   if (position.align === "nearest") {
     if (targetRect.top >= viewportRect.top && targetRect.bottom <= viewportRect.bottom) return true
     if (targetRect.top < viewportRect.top) {
-      viewport.scrollTop = Math.max(0, viewport.scrollTop + targetRect.top - viewportRect.top)
+      setTimelineScrollTop({
+        viewport,
+        sink,
+        top: viewport.scrollTop + targetRect.top - viewportRect.top,
+        source: "session-timeline-scroll-anchors/restoreTarget",
+        reason: "target-nearest-top",
+      })
       return true
     }
-    viewport.scrollTop = Math.max(0, viewport.scrollTop + targetRect.bottom - viewportRect.bottom)
+    setTimelineScrollTop({
+      viewport,
+      sink,
+      top: viewport.scrollTop + targetRect.bottom - viewportRect.bottom,
+      source: "session-timeline-scroll-anchors/restoreTarget",
+      reason: "target-nearest-bottom",
+    })
     return true
   }
 
   if (position.align === "center") {
     const targetHeight = Math.max(0, targetRect.bottom - targetRect.top)
-    viewport.scrollTop = Math.max(
-      0,
-      viewport.scrollTop + targetRect.top - viewportRect.top - (viewport.clientHeight - targetHeight) / 2,
-    )
+    setTimelineScrollTop({
+      viewport,
+      sink,
+      top: viewport.scrollTop + targetRect.top - viewportRect.top - (viewport.clientHeight - targetHeight) / 2,
+      source: "session-timeline-scroll-anchors/restoreTarget",
+      reason: "target-center",
+    })
     return true
   }
 
-  viewport.scrollTop = Math.max(0, viewport.scrollTop + targetRect.top - viewportRect.top)
+  setTimelineScrollTop({
+    viewport,
+    sink,
+    top: viewport.scrollTop + targetRect.top - viewportRect.top,
+    source: "session-timeline-scroll-anchors/restoreTarget",
+    reason: "target-start",
+  })
   return true
 }
 
@@ -128,23 +208,25 @@ export function restoreTimelineSafePosition(args: {
   viewport: HTMLElement | undefined
   position: TimelineSafePosition
   bottomSentinel?: HTMLElement | null
+  scrollCommandSink?: TimelineScrollCommandSink
 }): TimelineAnchorRestoreResult {
   if (!args.viewport) return { ok: false, reason: "viewport_missing" }
+  const sink = args.scrollCommandSink ?? fallbackTimelineScrollCommandSink
 
   if (args.position.kind === "latest") {
-    restoreLatest(args.viewport, args.bottomSentinel)
+    restoreLatest(args.viewport, args.bottomSentinel, sink)
     return { ok: true, restoredTo: args.position }
   }
 
   if (args.position.kind === "reading") {
     if (!args.position.anchorMessageID) return { ok: false, reason: "invalid_anchor" }
-    return restoreReading(args.viewport, args.position)
+    return restoreReading(args.viewport, args.position, sink)
       ? { ok: true, restoredTo: args.position }
       : { ok: false, reason: "anchor_not_mounted" }
   }
 
   if (!args.position.messageID) return { ok: false, reason: "invalid_anchor" }
-  return restoreTarget(args.viewport, args.position)
+  return restoreTarget(args.viewport, args.position, sink)
     ? { ok: true, restoredTo: args.position }
     : { ok: false, reason: "anchor_not_mounted" }
 }

--- a/packages/app/src/pages/session/timeline-scroll-command-allowlist.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-allowlist.ts
@@ -1,0 +1,32 @@
+import type { TimelineScrollOwnershipAllowlistEntry } from "./timeline-scroll-ownership-guard"
+
+export const timelineScrollCommandAllowlist: TimelineScrollOwnershipAllowlistEntry[] = [
+  {
+    filePath: "packages/app/src/pages/session/composer/session-question-dock.tsx",
+    symbol: "keepVisibleInQuestionOptions",
+    reason: "Question option list is a nested composer scroller, not the session timeline viewport.",
+    owner: "session composer",
+    removal: "Remove when nested composer option scrolling is routed through a dedicated non-timeline helper.",
+  },
+  {
+    filePath: "packages/app/src/pages/session/file-tabs.tsx",
+    symbol: "restore",
+    reason: "File tab restoration targets the file panel scroller, not the session timeline viewport.",
+    owner: "file tabs",
+    removal: "Remove when file panel scroll restoration is moved behind its own reviewed helper.",
+  },
+  {
+    filePath: "packages/app/src/pages/session/review-tab.tsx",
+    symbol: "doRestore",
+    reason: "Review tab restoration targets the review panel scroller, not the session timeline viewport.",
+    owner: "review panel",
+    removal: "Remove when review panel scroll restoration is moved behind its own reviewed helper.",
+  },
+  {
+    filePath: "packages/app/src/pages/session/review-panel-scroll.ts",
+    symbol: "scrollToReviewDiff",
+    reason: "Review diff navigation targets the review panel scroller, not the session timeline viewport.",
+    owner: "review panel",
+    removal: "Remove when review panel diff navigation is moved behind its own reviewed helper.",
+  },
+]

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
@@ -99,4 +99,26 @@ describe("TimelineScrollCommandSink", () => {
 
     expect(sink.records().map((record) => record.source)).toEqual(["two", "three"])
   })
+
+  test("keeps diagnostic failures out of the scroll path", async () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 0 })
+    const syncSink = createTimelineScrollCommandSink({
+      emitDiagnostic: () => {
+        throw new Error("diagnostic sync failure")
+      },
+    })
+    const asyncSink = createTimelineScrollCommandSink({
+      emitDiagnostic: () => Promise.reject(new Error("diagnostic async failure")),
+    })
+
+    expect(() => {
+      syncSink.setScrollTop({ element: scroller.el, top: 10, type: "bottom-follow", source: "sync" })
+    }).not.toThrow()
+
+    asyncSink.setScrollTop({ element: scroller.el, top: 20, type: "bottom-follow", source: "async" })
+    await Promise.resolve()
+
+    expect(syncSink.records()[0]?.source).toBe("sync")
+    expect(asyncSink.records()[0]?.source).toBe("async")
+  })
 })

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test"
+import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
+
+function makeScroller(input: { clientHeight: number; scrollHeight: number; scrollTop: number }) {
+  const el = document.createElement("div")
+  let top = input.scrollTop
+  const scrollToCalls: Array<{ top: number; behavior?: ScrollBehavior }> = []
+
+  Object.defineProperties(el, {
+    clientHeight: { value: input.clientHeight, configurable: true },
+    scrollHeight: { value: input.scrollHeight, configurable: true },
+    scrollTop: {
+      configurable: true,
+      get: () => top,
+      set: (value) => {
+        top = value
+      },
+    },
+    scrollTo: {
+      value: (options: ScrollToOptions) => {
+        scrollToCalls.push({ top: Number(options.top ?? 0), behavior: options.behavior })
+        top = Number(options.top ?? 0)
+      },
+      configurable: true,
+    },
+  })
+
+  return { el, scrollToCalls, top: () => top }
+}
+
+describe("TimelineScrollCommandSink", () => {
+  test("records and executes direct scrollTop commands", () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
+    const sink = createTimelineScrollCommandSink({ now: () => 123 })
+
+    sink.setScrollTop({
+      element: scroller.el,
+      top: 345,
+      type: "anchor-restore",
+      source: "session-timeline-scroll-anchors/restoreReading",
+      reason: "reading-anchor",
+    })
+
+    expect(scroller.top()).toBe(345)
+    expect(sink.records()).toEqual([
+      expect.objectContaining({
+        monotonicMs: 123,
+        type: "anchor-restore",
+        source: "session-timeline-scroll-anchors/restoreReading",
+        reason: "reading-anchor",
+        method: "set-scroll-top",
+        top: 345,
+      }),
+    ])
+  })
+
+  test("uses scrollTo when behavior must be preserved", () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
+    const sink = createTimelineScrollCommandSink()
+
+    sink.scrollTo({
+      element: scroller.el,
+      top: 200,
+      behavior: "smooth",
+      type: "hash-target",
+      source: "use-session-hash-scroll-core/scrollToElement",
+    })
+
+    expect(scroller.scrollToCalls).toEqual([{ top: 200, behavior: "smooth" }])
+    expect(scroller.top()).toBe(200)
+    expect(sink.records()[0]).toMatchObject({
+      method: "scroll-to",
+      behavior: "smooth",
+      type: "hash-target",
+    })
+  })
+
+  test("keeps full before and after metrics behind explicit enablement", () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
+    const cheap = createTimelineScrollCommandSink({ fullMetricsEnabled: () => false })
+    const full = createTimelineScrollCommandSink({ fullMetricsEnabled: () => true })
+
+    cheap.setScrollTop({ element: scroller.el, top: 300, type: "bottom-follow", source: "cheap" })
+    full.setScrollTop({ element: scroller.el, top: 400, type: "bottom-follow", source: "full" })
+
+    expect(cheap.records()[0]?.before).toBeUndefined()
+    expect(cheap.records()[0]?.after).toBeUndefined()
+    expect(full.records()[0]?.before).toMatchObject({ scrollTop: 300, clientHeight: 100, scrollHeight: 900 })
+    expect(full.records()[0]?.after).toMatchObject({ scrollTop: 400, clientHeight: 100, scrollHeight: 900 })
+  })
+
+  test("bounds retained command records", () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 0 })
+    const sink = createTimelineScrollCommandSink({ maxRecords: 2 })
+
+    sink.setScrollTop({ element: scroller.el, top: 1, type: "bottom-follow", source: "one" })
+    sink.setScrollTop({ element: scroller.el, top: 2, type: "bottom-follow", source: "two" })
+    sink.setScrollTop({ element: scroller.el, top: 3, type: "bottom-follow", source: "three" })
+
+    expect(sink.records().map((record) => record.source)).toEqual(["two", "three"])
+  })
+})

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.ts
@@ -77,25 +77,30 @@ export function createTimelineScrollCommandSink(input?: {
   const remember = (record: TimelineScrollCommandRecord) => {
     records.push(record)
     while (records.length > maxRecords) records.shift()
-    input?.emitDiagnostic?.({
-      name: "session.timeline.scroll_command",
-      route_session_id: record.routeSessionID,
-      visible_session_id: record.visibleSessionID,
-      timeline_session_id: record.timelineSessionID,
-      monotonic_ms: record.monotonicMs,
-      data: {
-        command_type: record.type,
-        command_method: record.method,
-        command_source: record.source,
-        command_reason: record.reason,
-        command_top: record.top,
-        command_behavior: record.behavior,
-        before_scroll_top: record.before?.scrollTop,
-        before_distance_from_bottom: record.before?.distanceFromBottom,
-        after_scroll_top: record.after?.scrollTop,
-        after_distance_from_bottom: record.after?.distanceFromBottom,
-      },
-    })
+    try {
+      const maybePromise = input?.emitDiagnostic?.({
+        name: "session.timeline.scroll_command",
+        route_session_id: record.routeSessionID,
+        visible_session_id: record.visibleSessionID,
+        timeline_session_id: record.timelineSessionID,
+        monotonic_ms: record.monotonicMs,
+        data: {
+          command_type: record.type,
+          command_method: record.method,
+          command_source: record.source,
+          command_reason: record.reason,
+          command_top: record.top,
+          command_behavior: record.behavior,
+          before_scroll_top: record.before?.scrollTop,
+          before_distance_from_bottom: record.before?.distanceFromBottom,
+          after_scroll_top: record.after?.scrollTop,
+          after_distance_from_bottom: record.after?.distanceFromBottom,
+        },
+      })
+      void maybePromise?.catch?.(() => {})
+    } catch {
+      // Diagnostics should never affect timeline scroll command execution.
+    }
     return record
   }
 

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.ts
@@ -1,0 +1,136 @@
+import type { RendererDiagnosticInput } from "@/context/platform"
+
+export type TimelineScrollCommandType =
+  | "anchor-restore"
+  | "bottom-follow"
+  | "content-resize-bottom-follow"
+  | "dock-resize-bottom-follow"
+  | "hash-target"
+  | "history-prepend-preserve"
+  | "target-message"
+
+export type TimelineScrollCommandMethod = "scroll-to" | "set-scroll-top"
+
+export type TimelineScrollCommandMetrics = {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  distanceFromBottom: number
+}
+
+export type TimelineScrollCommandContext = {
+  routeSessionID?: string
+  visibleSessionID?: string
+  timelineSessionID?: string
+}
+
+export type TimelineScrollCommandRecord = TimelineScrollCommandContext & {
+  monotonicMs: number
+  type: TimelineScrollCommandType
+  source: string
+  method: TimelineScrollCommandMethod
+  top: number
+  behavior?: ScrollBehavior
+  reason?: string
+  before?: TimelineScrollCommandMetrics
+  after?: TimelineScrollCommandMetrics
+}
+
+type TimelineScrollCommandBase = {
+  element: HTMLElement
+  top: number
+  type: TimelineScrollCommandType
+  source: string
+  reason?: string
+}
+
+export type TimelineSetScrollTopCommand = TimelineScrollCommandBase
+export type TimelineScrollToCommand = TimelineScrollCommandBase & { behavior?: ScrollBehavior }
+
+export type TimelineScrollCommandSink = {
+  setScrollTop: (command: TimelineSetScrollTopCommand) => TimelineScrollCommandRecord
+  scrollTo: (command: TimelineScrollToCommand) => TimelineScrollCommandRecord
+  records: () => TimelineScrollCommandRecord[]
+}
+
+export function collectTimelineScrollCommandMetrics(element: HTMLElement): TimelineScrollCommandMetrics {
+  const distanceFromBottom = Math.max(0, element.scrollHeight - element.clientHeight - element.scrollTop)
+  return {
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    distanceFromBottom,
+  }
+}
+
+export function createTimelineScrollCommandSink(input?: {
+  emitDiagnostic?: (event: RendererDiagnosticInput) => Promise<void> | void
+  fullMetricsEnabled?: () => boolean
+  getContext?: () => TimelineScrollCommandContext
+  maxRecords?: number
+  now?: () => number
+}): TimelineScrollCommandSink {
+  const maxRecords = Math.max(1, input?.maxRecords ?? 100)
+  const records: TimelineScrollCommandRecord[] = []
+  const now = input?.now ?? (() => performance.now())
+
+  const remember = (record: TimelineScrollCommandRecord) => {
+    records.push(record)
+    while (records.length > maxRecords) records.shift()
+    input?.emitDiagnostic?.({
+      name: "session.timeline.scroll_command",
+      route_session_id: record.routeSessionID,
+      visible_session_id: record.visibleSessionID,
+      timeline_session_id: record.timelineSessionID,
+      monotonic_ms: record.monotonicMs,
+      data: {
+        command_type: record.type,
+        command_method: record.method,
+        command_source: record.source,
+        command_reason: record.reason,
+        command_top: record.top,
+        command_behavior: record.behavior,
+        before_scroll_top: record.before?.scrollTop,
+        before_distance_from_bottom: record.before?.distanceFromBottom,
+        after_scroll_top: record.after?.scrollTop,
+        after_distance_from_bottom: record.after?.distanceFromBottom,
+      },
+    })
+    return record
+  }
+
+  const execute = (
+    command: TimelineSetScrollTopCommand | TimelineScrollToCommand,
+    method: TimelineScrollCommandMethod,
+    apply: () => void,
+  ) => {
+    const fullMetrics = input?.fullMetricsEnabled?.() ?? false
+    const before = fullMetrics ? collectTimelineScrollCommandMetrics(command.element) : undefined
+    apply()
+    const after = fullMetrics ? collectTimelineScrollCommandMetrics(command.element) : undefined
+    return remember({
+      ...(input?.getContext?.() ?? {}),
+      monotonicMs: now(),
+      type: command.type,
+      source: command.source,
+      method,
+      top: command.top,
+      behavior: "behavior" in command ? command.behavior : undefined,
+      reason: command.reason,
+      before,
+      after,
+    })
+  }
+
+  return {
+    setScrollTop: (command) =>
+      execute(command, "set-scroll-top", () => {
+        command.element.scrollTop = command.top
+      }),
+    scrollTo: (command) =>
+      execute(command, "scroll-to", () => {
+        command.element.scrollTo({ top: command.top, behavior: command.behavior })
+      }),
+    records: () => [...records],
+  }
+}

--- a/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
@@ -53,6 +53,12 @@ export const timelineScrollOwnershipFixtures = {
       sink.scrollTo({ top: 10 })
     }
   `,
+  fakeNestedSinkProperty: `
+    export function bypass(viewport: HTMLElement) {
+      const wrapper = { fake_scrollCommandSink: viewport }
+      wrapper.fake_scrollCommandSink.scrollTo({ top: 10 })
+    }
+  `,
   importedUtility: `
     import { scrollTimelineViewport } from "./scroll-utils"
     export function bypass(viewport: HTMLElement) {

--- a/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
@@ -14,6 +14,18 @@ export const timelineScrollOwnershipFixtures = {
       viewport.scroll({ top: 10 })
     }
   `,
+  directScrollShorthandTop: `
+    export function bypass(viewport: HTMLElement) {
+      const top = 10
+      viewport.scroll({ top })
+    }
+  `,
+  directScrollSpreadOptions: `
+    export function bypass(viewport: HTMLElement) {
+      const opts = { top: 10 }
+      viewport.scroll({ ...opts })
+    }
+  `,
   directScrollIntoView: `
     export function bypass(target: HTMLElement) {
       target.scrollIntoView({ block: "nearest" })

--- a/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
@@ -59,6 +59,12 @@ export const timelineScrollOwnershipFixtures = {
       wrapper.fake_scrollCommandSink.scrollTo({ top: 10 })
     }
   `,
+  fakeExactSinkProperty: `
+    export function bypass(viewport: HTMLElement) {
+      const wrapper = { scrollCommandSink: viewport }
+      wrapper.scrollCommandSink.scrollTo({ top: 10 })
+    }
+  `,
   importedUtility: `
     import { scrollTimelineViewport } from "./scroll-utils"
     export function bypass(viewport: HTMLElement) {

--- a/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-fixtures.ts
@@ -1,0 +1,68 @@
+export const timelineScrollOwnershipFixtures = {
+  directScrollTop: `
+    export function bypass(viewport: HTMLElement) {
+      viewport.scrollTop = 10
+    }
+  `,
+  directScrollTo: `
+    export function bypass(viewport: HTMLElement) {
+      viewport.scrollTo({ top: 10 })
+    }
+  `,
+  directScroll: `
+    export function bypass(viewport: HTMLElement) {
+      viewport.scroll({ top: 10 })
+    }
+  `,
+  directScrollIntoView: `
+    export function bypass(target: HTMLElement) {
+      target.scrollIntoView({ block: "nearest" })
+    }
+  `,
+  helperAlias: `
+    export function bypass(viewport: HTMLElement) {
+      const jump = viewport.scrollTo
+      jump({ top: 10 })
+    }
+  `,
+  computedScrollTop: `
+    export function bypass(viewport: HTMLElement) {
+      viewport["scrollTop"] = 10
+    }
+  `,
+  scrollTopIncrement: `
+    export function bypass(viewport: HTMLElement) {
+      viewport.scrollTop++
+    }
+  `,
+  fakeSinkAlias: `
+    export function bypass(viewport: HTMLElement) {
+      const sink = viewport
+      sink.scrollTo({ top: 10 })
+    }
+  `,
+  importedUtility: `
+    import { scrollTimelineViewport } from "./scroll-utils"
+    export function bypass(viewport: HTMLElement) {
+      scrollTimelineViewport(viewport, 10)
+    }
+  `,
+  virtualizerReveal: `
+    import { revealTimelineRow } from "./virtualizer"
+    export function bypass(row: string) {
+      revealTimelineRow(row)
+    }
+  `,
+  allowedSink: `
+    import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
+    export function ok(viewport: HTMLElement) {
+      const sink = createTimelineScrollCommandSink()
+      sink.setScrollTop({ element: viewport, top: 10, type: "anchor-restore", source: "fixture" })
+    }
+  `,
+  allowedNonTimeline: `
+    export function ok(panel: HTMLElement) {
+      panel.scrollTop = 10
+    }
+  `,
+} as const

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -22,6 +22,7 @@ describe("timeline scroll ownership guard", () => {
       timelineScrollOwnershipFixtures.computedScrollTop,
       timelineScrollOwnershipFixtures.scrollTopIncrement,
       timelineScrollOwnershipFixtures.fakeSinkAlias,
+      timelineScrollOwnershipFixtures.fakeNestedSinkProperty,
       timelineScrollOwnershipFixtures.importedUtility,
       timelineScrollOwnershipFixtures.virtualizerReveal,
     ]

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -15,6 +15,8 @@ describe("timeline scroll ownership guard", () => {
       timelineScrollOwnershipFixtures.directScrollTop,
       timelineScrollOwnershipFixtures.directScrollTo,
       timelineScrollOwnershipFixtures.directScroll,
+      timelineScrollOwnershipFixtures.directScrollShorthandTop,
+      timelineScrollOwnershipFixtures.directScrollSpreadOptions,
       timelineScrollOwnershipFixtures.directScrollIntoView,
       timelineScrollOwnershipFixtures.helperAlias,
       timelineScrollOwnershipFixtures.computedScrollTop,

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -23,6 +23,7 @@ describe("timeline scroll ownership guard", () => {
       timelineScrollOwnershipFixtures.scrollTopIncrement,
       timelineScrollOwnershipFixtures.fakeSinkAlias,
       timelineScrollOwnershipFixtures.fakeNestedSinkProperty,
+      timelineScrollOwnershipFixtures.fakeExactSinkProperty,
       timelineScrollOwnershipFixtures.importedUtility,
       timelineScrollOwnershipFixtures.virtualizerReveal,
     ]

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { timelineScrollCommandAllowlist } from "./timeline-scroll-command-allowlist"
+import { scanTimelineScrollOwnership, scanTimelineScrollOwnershipText } from "./timeline-scroll-ownership-guard"
+import { timelineScrollOwnershipFixtures } from "./timeline-scroll-ownership-fixtures"
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+describe("timeline scroll ownership guard", () => {
+  test("rejects direct and indirect timeline scroll bypasses", () => {
+    const forbidden = [
+      timelineScrollOwnershipFixtures.directScrollTop,
+      timelineScrollOwnershipFixtures.directScrollTo,
+      timelineScrollOwnershipFixtures.directScroll,
+      timelineScrollOwnershipFixtures.directScrollIntoView,
+      timelineScrollOwnershipFixtures.helperAlias,
+      timelineScrollOwnershipFixtures.computedScrollTop,
+      timelineScrollOwnershipFixtures.scrollTopIncrement,
+      timelineScrollOwnershipFixtures.fakeSinkAlias,
+      timelineScrollOwnershipFixtures.importedUtility,
+      timelineScrollOwnershipFixtures.virtualizerReveal,
+    ]
+
+    for (const [index, sourceText] of forbidden.entries()) {
+      const result = scanTimelineScrollOwnershipText({ filePath: `forbidden-${index}.ts`, sourceText })
+      expect(result.violations.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("allows sink execution and reviewed non-timeline exceptions", () => {
+    expect(
+      scanTimelineScrollOwnershipText({
+        filePath: "allowed-sink.ts",
+        sourceText: timelineScrollOwnershipFixtures.allowedSink,
+      }).violations,
+    ).toEqual([])
+
+    expect(
+      scanTimelineScrollOwnershipText({
+        filePath: "allowed-non-timeline.ts",
+        sourceText: timelineScrollOwnershipFixtures.allowedNonTimeline,
+        allowlist: [
+          {
+            filePath: "allowed-non-timeline.ts",
+            symbol: "ok",
+            reason: "fixture represents a non-session scroller",
+            owner: "test",
+            removal: "fixture only",
+          },
+        ],
+      }).violations,
+    ).toEqual([])
+  })
+
+  test("keeps production session timeline writes behind the command sink", async () => {
+    const result = await scanTimelineScrollOwnership({
+      roots: [here],
+      allowlist: timelineScrollCommandAllowlist,
+      exclude: [
+        /\.test\.tsx?$/,
+        /timeline-scroll-command-sink\.ts$/,
+        /timeline-scroll-command-allowlist\.ts$/,
+        /timeline-scroll-ownership-guard\.ts$/,
+        /timeline-scroll-ownership-fixtures\.ts$/,
+        /file-tab-scroll\.ts$/,
+      ],
+      include: [/\.tsx?$/],
+      rootLabel: join("packages", "app", "src", "pages", "session"),
+    })
+
+    expect(result.violations).toEqual([])
+  })
+
+  test("scans newly added session timeline files without a manual file list", async () => {
+    const root = await mkdtemp(join(tmpdir(), "timeline-scroll-ownership-"))
+    try {
+      await writeFile(
+        join(root, "new-session-timeline-writer.ts"),
+        `
+          export function bypass(viewport: HTMLElement) {
+            viewport.scrollTop = 10
+          }
+        `,
+      )
+
+      const result = await scanTimelineScrollOwnership({
+        roots: [root],
+        allowlist: [],
+        include: [/\.tsx?$/],
+        rootLabel: join("packages", "app", "src", "pages", "session"),
+      })
+
+      expect(result.violations).toEqual([
+        expect.objectContaining({
+          filePath: join("packages", "app", "src", "pages", "session", "new-session-timeline-writer.ts"),
+          symbol: "bypass",
+          reason: "direct scrollTop write bypasses TimelineScrollCommandSink",
+        }),
+      ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -108,6 +108,8 @@ function isDomScrollCall(node: ts.CallExpression, prop: string | undefined) {
   if (ts.isNumericLiteral(firstArgument)) return true
   if (!ts.isObjectLiteralExpression(firstArgument)) return false
   return firstArgument.properties.some((property) => {
+    if (ts.isShorthandPropertyAssignment(property)) return property.name.text === "top" || property.name.text === "left"
+    if (ts.isSpreadAssignment(property)) return true
     if (!ts.isPropertyAssignment(property)) return false
     const name = property.name
     if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text === "top" || name.text === "left"

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -123,13 +123,6 @@ function isTimelineScrollCommandSinkCall(node: ts.CallExpression, sinkIdentifier
   if (method !== "scrollTo" && method !== "setScrollTop") return false
   const receiver = node.expression.expression
   if (ts.isIdentifier(receiver)) return sinkIdentifiers.has(receiver.text)
-  if (ts.isPropertyAccessExpression(receiver)) return receiver.name.text === "scrollCommandSink"
-  if (ts.isElementAccessExpression(receiver)) {
-    const argument = receiver.argumentExpression
-    if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) {
-      return argument.text === "scrollCommandSink"
-    }
-  }
   if (ts.isCallExpression(receiver) && ts.isIdentifier(receiver.expression)) {
     return receiver.expression.text === "scrollCommandSink"
   }

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -1,0 +1,244 @@
+import { lstat, readdir, readFile } from "node:fs/promises"
+import { join, relative } from "node:path"
+import ts from "typescript"
+
+export type TimelineScrollOwnershipAllowlistEntry = {
+  filePath: string
+  symbol: string
+  reason: string
+  owner: string
+  removal: string
+}
+
+export type TimelineScrollOwnershipViolation = {
+  filePath: string
+  symbol: string
+  line: number
+  column: number
+  reason: string
+  snippet: string
+}
+
+type ScanTextInput = {
+  filePath: string
+  sourceText: string
+  allowlist?: TimelineScrollOwnershipAllowlistEntry[]
+}
+
+type ScanInput = {
+  files?: string[]
+  roots: string[]
+  allowlist?: TimelineScrollOwnershipAllowlistEntry[]
+  exclude?: RegExp[]
+  include?: RegExp[]
+  rootLabel?: string
+}
+
+const forbiddenPropertyCalls = new Set(["scrollTo", "scrollIntoView", "scrollToIndex"])
+const forbiddenImportedHelpers = new Set([
+  "forceScrollToBottom",
+  "revealTimelineRow",
+  "scrollTimelineViewport",
+  "scrollToTimelineViewport",
+  "scrollVirtualTimelineRow",
+])
+
+const assignmentOperators = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+])
+
+function lineSnippet(sourceText: string, line: number) {
+  return sourceText.split(/\r?\n/)[line - 1]?.trim() ?? ""
+}
+
+function location(source: ts.SourceFile, node: ts.Node) {
+  const pos = source.getLineAndCharacterOfPosition(node.getStart(source))
+  return { line: pos.line + 1, column: pos.character + 1 }
+}
+
+function nearestSymbol(node: ts.Node) {
+  let current: ts.Node | undefined = node
+  while (current) {
+    if ((ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current)) && current.name)
+      return current.name.text
+    if (ts.isMethodDeclaration(current) && ts.isIdentifier(current.name)) return current.name.text
+    if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) return current.name.text
+    current = current.parent
+  }
+  return "<module>"
+}
+
+function isAllowed(filePath: string, symbol: string, allowlist: TimelineScrollOwnershipAllowlistEntry[]) {
+  return allowlist.some((entry) => entry.filePath === filePath && entry.symbol === symbol)
+}
+
+function propertyName(node: ts.Expression) {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text
+  if (ts.isElementAccessExpression(node)) {
+    const argument = node.argumentExpression
+    if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) return argument.text
+  }
+  return undefined
+}
+
+function isScrollTopMutation(node: ts.Node) {
+  if (ts.isBinaryExpression(node) && assignmentOperators.has(node.operatorToken.kind)) {
+    return propertyName(node.left) === "scrollTop"
+  }
+  if (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) {
+    const operator = node.operator
+    return (
+      (operator === ts.SyntaxKind.PlusPlusToken || operator === ts.SyntaxKind.MinusMinusToken) &&
+      propertyName(node.operand) === "scrollTop"
+    )
+  }
+  return false
+}
+
+function isDomScrollCall(node: ts.CallExpression, prop: string | undefined) {
+  if (prop !== "scroll") return false
+  if (node.arguments.length >= 2) return true
+  const [firstArgument] = node.arguments
+  if (!firstArgument) return false
+  if (ts.isNumericLiteral(firstArgument)) return true
+  if (!ts.isObjectLiteralExpression(firstArgument)) return false
+  return firstArgument.properties.some((property) => {
+    if (!ts.isPropertyAssignment(property)) return false
+    const name = property.name
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text === "top" || name.text === "left"
+    return false
+  })
+}
+
+function isTimelineScrollCommandSinkCall(node: ts.CallExpression, sinkIdentifiers: ReadonlySet<string>) {
+  if (!ts.isPropertyAccessExpression(node.expression)) return false
+  const method = node.expression.name.text
+  if (method !== "scrollTo" && method !== "setScrollTop") return false
+  const receiver = node.expression.expression
+  if (ts.isIdentifier(receiver)) return sinkIdentifiers.has(receiver.text)
+  const receiverText = receiver.getText()
+  return receiverText.includes("scrollCommandSink") || receiverText.includes("TimelineScrollCommandSink")
+}
+
+export function scanTimelineScrollOwnershipText(input: ScanTextInput) {
+  const source = ts.createSourceFile(input.filePath, input.sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const allowlist = input.allowlist ?? []
+  const forbiddenIdentifiers = new Set<string>()
+  const sinkIdentifiers = new Set<string>()
+  const violations: TimelineScrollOwnershipViolation[] = []
+
+  const addViolation = (node: ts.Node, reason: string) => {
+    const symbol = nearestSymbol(node)
+    if (isAllowed(input.filePath, symbol, allowlist)) return
+    const pos = location(source, node)
+    violations.push({
+      filePath: input.filePath,
+      symbol,
+      line: pos.line,
+      column: pos.column,
+      reason,
+      snippet: lineSnippet(input.sourceText, pos.line),
+    })
+  }
+
+  const visit = (node: ts.Node) => {
+    if (ts.isImportSpecifier(node)) {
+      const local = node.name.text
+      const imported = node.propertyName?.text ?? local
+      if (forbiddenImportedHelpers.has(imported)) forbiddenIdentifiers.add(local)
+    }
+
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      if (
+        ts.isCallExpression(node.initializer) &&
+        ts.isIdentifier(node.initializer.expression) &&
+        node.initializer.expression.text === "createTimelineScrollCommandSink"
+      ) {
+        sinkIdentifiers.add(node.name.text)
+      }
+      const prop = propertyName(node.initializer)
+      if (prop && forbiddenPropertyCalls.has(prop)) forbiddenIdentifiers.add(node.name.text)
+      if (ts.isIdentifier(node.initializer) && forbiddenIdentifiers.has(node.initializer.text)) {
+        forbiddenIdentifiers.add(node.name.text)
+      }
+    }
+
+    if (isScrollTopMutation(node)) {
+      addViolation(node, "direct scrollTop write bypasses TimelineScrollCommandSink")
+    }
+
+    if (ts.isCallExpression(node)) {
+      if (isTimelineScrollCommandSinkCall(node, sinkIdentifiers)) {
+        ts.forEachChild(node, visit)
+        return
+      }
+      const prop = propertyName(node.expression)
+      if (isDomScrollCall(node, prop)) {
+        addViolation(node, "direct scroll call bypasses TimelineScrollCommandSink")
+      } else if (prop && forbiddenPropertyCalls.has(prop)) {
+        addViolation(node, `direct ${prop} call bypasses TimelineScrollCommandSink`)
+      } else if (ts.isIdentifier(node.expression) && forbiddenIdentifiers.has(node.expression.text)) {
+        addViolation(node, `indirect ${node.expression.text} call bypasses TimelineScrollCommandSink`)
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(source)
+  return { violations }
+}
+
+async function listFiles(root: string, input: Required<Pick<ScanInput, "exclude" | "include">>) {
+  const out: string[] = []
+  const walk = async (dir: string) => {
+    const stat = await lstat(dir)
+    if (!stat.isDirectory()) {
+      if (input.include.some((pattern) => pattern.test(dir)) && !input.exclude.some((pattern) => pattern.test(dir))) {
+        out.push(dir)
+      }
+      return
+    }
+    const entries = await readdir(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(path)
+        continue
+      }
+      if (!input.include.some((pattern) => pattern.test(path))) continue
+      if (input.exclude.some((pattern) => pattern.test(path))) continue
+      out.push(path)
+    }
+  }
+  await walk(root)
+  return out
+}
+
+export async function scanTimelineScrollOwnership(input: ScanInput) {
+  const violations: TimelineScrollOwnershipViolation[] = []
+  const include = input.include ?? [/\.tsx?$/]
+  const exclude = input.exclude ?? []
+  for (const root of input.roots) {
+    const files = input.files?.length
+      ? input.files.map((file) => join(root, file))
+      : await listFiles(root, { include, exclude })
+    for (const file of files) {
+      const filePath = input.rootLabel ? join(input.rootLabel, relative(root, file)) : file
+      const sourceText = await readFile(file, "utf8")
+      violations.push(
+        ...scanTimelineScrollOwnershipText({
+          filePath,
+          sourceText,
+          allowlist: input.allowlist,
+        }).violations,
+      )
+    }
+  }
+  return { violations }
+}

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -123,8 +123,17 @@ function isTimelineScrollCommandSinkCall(node: ts.CallExpression, sinkIdentifier
   if (method !== "scrollTo" && method !== "setScrollTop") return false
   const receiver = node.expression.expression
   if (ts.isIdentifier(receiver)) return sinkIdentifiers.has(receiver.text)
-  const receiverText = receiver.getText()
-  return receiverText.includes("scrollCommandSink") || receiverText.includes("TimelineScrollCommandSink")
+  if (ts.isPropertyAccessExpression(receiver)) return receiver.name.text === "scrollCommandSink"
+  if (ts.isElementAccessExpression(receiver)) {
+    const argument = receiver.argumentExpression
+    if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) {
+      return argument.text === "scrollCommandSink"
+    }
+  }
+  if (ts.isCallExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+    return receiver.expression.text === "scrollCommandSink"
+  }
+  return false
 }
 
 export function scanTimelineScrollOwnershipText(input: ScanTextInput) {

--- a/packages/app/src/pages/session/use-session-hash-scroll-core.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll-core.ts
@@ -1,6 +1,7 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { messageIdFromHash } from "./message-id-from-hash"
+import { createTimelineScrollCommandSink, type TimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 
 export type SessionHashScrollInput = {
   sessionKey: () => string
@@ -23,6 +24,7 @@ export type SessionHashScrollInput = {
   consumePendingMessage: (key: string) => string | undefined
   onMessageNavigation?: (messageID: string) => void
   onMessageHashCleared?: () => void
+  scrollCommandSink?: TimelineScrollCommandSink
 }
 
 type SessionHashScrollLocation = { hash: string; pathname: string; search: string }
@@ -33,6 +35,8 @@ export const createSessionHashScroll = (
   location: SessionHashScrollLocation,
   navigate: SessionHashScrollNavigate,
 ) => {
+  const fallbackTimelineScrollCommandSink = createTimelineScrollCommandSink()
+  const scrollCommandSink = () => input.scrollCommandSink ?? fallbackTimelineScrollCommandSink
   const visibleUserMessages = createMemo(() => input.visibleUserMessages())
   const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
   const messageIndex = createMemo(() => new Map(visibleUserMessages().map((m, i) => [m.id, i])))
@@ -80,7 +84,14 @@ export const createSessionHashScroll = (
     const sticky = root.querySelector("[data-session-title]")
     const inset = sticky instanceof HTMLElement ? sticky.offsetHeight : 0
     const top = Math.max(0, a.top - b.top + root.scrollTop - inset)
-    root.scrollTo({ top, behavior })
+    scrollCommandSink().scrollTo({
+      element: root,
+      top,
+      behavior,
+      type: "hash-target",
+      source: "use-session-hash-scroll-core/scrollToElement",
+      reason: "hash-target",
+    })
     return true
   }
 

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { createSessionHashScroll } from "./use-session-hash-scroll-core"
 import { messageIdFromHash } from "./message-id-from-hash"
+import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 
 describe("messageIdFromHash", () => {
   test("parses hash with leading #", () => {
@@ -53,6 +54,7 @@ describe("useSessionHashScroll", () => {
     const navigationCalls: string[] = []
     const activeMessages: string[] = []
     const markedTargets: number[] = []
+    const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 300 })
 
     root.id = "session-root"
     target.id = "message-msg_2"
@@ -111,6 +113,7 @@ describe("useSessionHashScroll", () => {
           anchor: (id) => `message-${id}`,
           scheduleScrollState: () => undefined,
           consumePendingMessage: () => undefined,
+          scrollCommandSink,
           onMessageNavigation: (messageID) => navigationCalls.push(messageID),
         },
         { hash: "#message-msg_2", pathname: "/session/ses_1", search: "" },
@@ -122,6 +125,15 @@ describe("useSessionHashScroll", () => {
     })
 
     expect(scrollPositions).toEqual([{ top: 160, behavior: "auto" }])
+    expect(scrollCommandSink.records()).toEqual([
+      expect.objectContaining({
+        monotonicMs: 300,
+        type: "hash-target",
+        source: "use-session-hash-scroll-core/scrollToElement",
+        method: "scroll-to",
+        top: 160,
+      }),
+    ])
     expect(activeMessages).toEqual(["msg_2"])
     expect(markedTargets).toEqual([1])
     expect(navigationCalls).toEqual(["msg_2"])

--- a/packages/app/src/pages/session/use-session-history-window.test.ts
+++ b/packages/app/src/pages/session/use-session-history-window.test.ts
@@ -6,6 +6,7 @@ import {
   resolveClearedHashTarget,
   resolveHistoryTurnStart,
 } from "./use-session-history-window"
+import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 
 const userMessage = (id: number) =>
   ({
@@ -16,6 +17,38 @@ const userMessage = (id: number) =>
 
 const userMessages = (count: number) => Array.from({ length: count }, (_, index) => userMessage(index))
 const ids = (start: number, end: number) => Array.from({ length: end - start }, (_, index) => `msg_${start + index}`)
+
+function makeScroller(input: { clientHeight: number; scrollHeight: number; scrollTop: number }) {
+  const el = document.createElement("div") as HTMLDivElement
+  let top = input.scrollTop
+  let height = input.scrollHeight
+
+  Object.defineProperties(el, {
+    clientHeight: { value: input.clientHeight, configurable: true },
+    scrollHeight: {
+      configurable: true,
+      get: () => height,
+      set: (value) => {
+        height = value
+      },
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => top,
+      set: (value) => {
+        top = value
+      },
+    },
+  })
+
+  return {
+    el,
+    setScrollHeight: (value: number) => {
+      height = value
+    },
+    top: () => top,
+  }
+}
 
 const createHarness = (input: { count: number; userScrolled?: boolean; atBottom?: boolean; historyMore?: boolean }) => {
   const [state, setState] = createSignal({
@@ -192,6 +225,47 @@ describe("session history window extraction", () => {
           expect(
             resolveHistoryTurnStart({ mode: "reading", storedTurnStart: 0, length: 40, userScrolled: false }),
           ).toBe(0)
+          dispose()
+          resolve()
+        })
+      })
+    })
+  })
+
+  test("records history prepend scroll preservation through the command sink", async () => {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1000, scrollTop: 120 })
+        const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 500 })
+
+        const history = createSessionHistoryWindow({
+          sessionID: () => "ses_1",
+          messagesReady: () => true,
+          loaded: () => 30,
+          visibleUserMessages: () => userMessages(30),
+          historyMore: () => false,
+          historyLoading: () => false,
+          loadMore: async () => undefined,
+          userScrolled: () => true,
+          isAtBottom: () => false,
+          scroller: () => scroller.el,
+          scrollCommandSink,
+        })
+
+        history.expandForReading(10)
+        history.onScrollerScroll()
+        scroller.setScrollHeight(1120)
+
+        requestAnimationFrame(() => {
+          expect(scroller.top()).toBe(240)
+          expect(scrollCommandSink.records()).toEqual([
+            expect.objectContaining({
+              monotonicMs: 500,
+              type: "history-prepend-preserve",
+              source: "use-session-history-window/preserveScroll",
+              top: 240,
+            }),
+          ])
           dispose()
           resolve()
         })

--- a/packages/app/src/pages/session/use-session-history-window.ts
+++ b/packages/app/src/pages/session/use-session-history-window.ts
@@ -2,6 +2,10 @@ import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { createEffect, createMemo, on } from "solid-js"
 import { createStore } from "solid-js/store"
 import { emptyUserMessages } from "@/pages/session/session-messages"
+import {
+  createTimelineScrollCommandSink,
+  type TimelineScrollCommandSink,
+} from "@/pages/session/timeline-scroll-command-sink"
 import { same } from "@/utils/same"
 
 export type SessionHistoryWindowInput = {
@@ -15,6 +19,7 @@ export type SessionHistoryWindowInput = {
   userScrolled: () => boolean
   isAtBottom: () => boolean
   scroller: () => HTMLDivElement | undefined
+  scrollCommandSink?: TimelineScrollCommandSink
 }
 
 type HistoryWindowMode = "bottom" | "reading" | "hash"
@@ -61,6 +66,8 @@ export function resolveClearedHashTarget(input: {
  * small batches while scrolling upward, and prefetches older history near top.
  */
 export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
+  const fallbackTimelineScrollCommandSink = createTimelineScrollCommandSink()
+  const scrollCommandSink = () => input.scrollCommandSink ?? fallbackTimelineScrollCommandSink
   const turnInit = 10
   const turnBatch = 8
   const turnScrollThreshold = 200
@@ -157,7 +164,13 @@ export function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
     requestAnimationFrame(() => {
       const delta = el.scrollHeight - beforeHeight
       if (!delta) return
-      el.scrollTop = beforeTop + delta
+      scrollCommandSink().setScrollTop({
+        element: el,
+        top: beforeTop + delta,
+        type: "history-prepend-preserve",
+        source: "use-session-history-window/preserveScroll",
+        reason: "preserve-scroll-after-backfill",
+      })
     })
   }
 

--- a/packages/app/src/pages/session/use-session-scroll-dock.test.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
+import { createTimelineScrollCommandSink } from "./timeline-scroll-command-sink"
 import {
   calculateSessionScrollState,
   createSessionScrollDock,
@@ -252,12 +253,14 @@ describe("session scroll dock", () => {
           scrollHeight: 1000,
           scrollTop: 600,
         })
+        const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 400 })
 
         try {
           const scrollDock = createSessionScrollDock({
             clearMessageHash: () => undefined,
             clearActiveMessage: () => undefined,
             fill: () => undefined,
+            scrollCommandSink,
             onDockHeightChange: (event) => events.push(event),
           })
 
@@ -293,6 +296,54 @@ describe("session scroll dock", () => {
         }
       })
     })
+  })
+
+  test("records a dock-resize bottom-follow command when resize needs a scroll write", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const previousDockHeight = document.documentElement.style.getPropertyValue("--composer-dock-height")
+        const promptDock = makeMeasuredDiv(120)
+        const scroller = makeScroller({
+          clientHeight: 400,
+          scrollHeight: 1000,
+          scrollTop: 500,
+        })
+        const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 450 })
+
+        try {
+          const scrollDock = createSessionScrollDock({
+            clearMessageHash: () => undefined,
+            clearActiveMessage: () => undefined,
+            fill: () => undefined,
+            scrollCommandSink,
+          })
+
+          scrollDock.setScrollRef(scroller.el)
+          scrollDock.setPromptDockRef(promptDock.el)
+          triggerResize(promptDock.el)
+
+          expect(scrollCommandSink.records()).toEqual([
+            expect.objectContaining({
+              monotonicMs: 450,
+              type: "dock-resize-bottom-follow",
+              reason: "dock-resize",
+              top: 1000,
+            }),
+          ])
+        } finally {
+          dispose()
+          if (previousDockHeight)
+            document.documentElement.style.setProperty("--composer-dock-height", previousDockHeight)
+          else document.documentElement.style.removeProperty("--composer-dock-height")
+        }
+      })
+    })
+  })
+
+  test("tags the auto-scroll ResizeObserver path as content resize", async () => {
+    const source = await Bun.file(new URL("../../../../ui/src/hooks/create-auto-scroll.tsx", import.meta.url)).text()
+
+    expect(source).toContain('scrollToBottom(false, "content-resize")')
   })
 
   test("restores a submit-time browser reset while bottom follow is locked", () => {

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -1,6 +1,11 @@
 import { createAutoScroll } from "@opencode-ai/ui/hooks"
 import { createEffect, createSignal, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
+import {
+  createTimelineScrollCommandSink,
+  type TimelineScrollCommandSink,
+  type TimelineScrollCommandType,
+} from "./timeline-scroll-command-sink"
 
 export type SessionScrollState = {
   overflow: boolean
@@ -89,14 +94,35 @@ export function createSessionScrollDock(input: {
     scrollTop?: number
     distanceFromBottom?: number
   }) => void
-  onContentResize?: (event: {
-    scrollTop?: number
-    distanceFromBottom?: number
-  }) => void
+  onContentResize?: (event: { scrollTop?: number; distanceFromBottom?: number }) => void
+  scrollCommandSink?: TimelineScrollCommandSink
 }) {
+  const fallbackTimelineScrollCommandSink = createTimelineScrollCommandSink()
+  const scrollCommandSink = () => input.scrollCommandSink ?? fallbackTimelineScrollCommandSink
   const autoScroll = createAutoScroll({
     working: () => true,
     overflowAnchor: "dynamic",
+    executeScrollCommand: (command) => {
+      const type: TimelineScrollCommandType =
+        command.reason === "content-resize"
+          ? "content-resize-bottom-follow"
+          : command.reason === "dock-resize"
+            ? "dock-resize-bottom-follow"
+            : "bottom-follow"
+      const source = `use-session-scroll-dock/createAutoScroll:${command.reason}`
+      const next = {
+        element: command.element,
+        top: command.top,
+        type,
+        source,
+        reason: command.reason,
+      }
+      if (command.method === "scroll-to") {
+        scrollCommandSink().scrollTo({ ...next, behavior: command.behavior })
+        return
+      }
+      scrollCommandSink().setScrollTop(next)
+    },
   })
 
   const [scroll, setScroll] = createStore<SessionScrollState>({
@@ -140,7 +166,7 @@ export function createSessionScrollDock(input: {
 
   const followBottom = () => {
     input.clearActiveMessage()
-    autoScroll.forceScrollToBottom()
+    autoScroll.forceScrollToBottom("force-bottom")
     input.clearMessageHash()
   }
 
@@ -210,9 +236,7 @@ export function createSessionScrollDock(input: {
     contentObserver = new ResizeObserver(() => {
       input.onContentResize?.({
         scrollTop: scroller?.scrollTop,
-        distanceFromBottom: scroller
-          ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
-          : undefined,
+        distanceFromBottom: scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined,
       })
       if (scroller) scheduleScrollState(scroller)
       input.fill()
@@ -225,16 +249,14 @@ export function createSessionScrollDock(input: {
     const previousDockHeight = dockHeight
     const dockKind = promptDockKind()
     const scrollTop = scroller?.scrollTop
-    const distanceFromBottom = scroller
-      ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
-      : undefined
+    const distanceFromBottom = scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined
     dockHeight = syncComposerDockHeight({
       el: scroller,
       previousDockHeight,
       nextDockHeight: next,
       userScrolled: autoScroll.userScrolled(),
       setCssHeight: (value) => document.documentElement.style.setProperty("--composer-dock-height", `${value}px`),
-      forceScrollToBottom: autoScroll.forceScrollToBottom,
+      forceScrollToBottom: () => autoScroll.forceScrollToBottom("dock-resize"),
       scheduleScrollState,
       fill: input.fill,
     })

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -18,6 +18,7 @@ import {
   type TimelineScrollIntent,
   type TimelineScrollObservation,
 } from "@/pages/session/session-timeline-scroll-controller"
+import { createTimelineScrollCommandSink } from "@/pages/session/timeline-scroll-command-sink"
 
 export function createSessionTimelineInteraction(input: {
   routeSessionID: () => string | undefined
@@ -48,6 +49,21 @@ export function createSessionTimelineInteraction(input: {
       },
     })
   let scrollController = createScrollController()
+  const scrollCommandSink = createTimelineScrollCommandSink({
+    emitDiagnostic: (event) => {
+      void emitRendererDiagnostic(event).catch(() => {})
+    },
+    fullMetricsEnabled: () => {
+      const value = (globalThis as typeof globalThis & { __PW_TIMELINE_SCROLL_FULL_METRICS__?: boolean })
+        .__PW_TIMELINE_SCROLL_FULL_METRICS__
+      return value === true
+    },
+    getContext: () => ({
+      routeSessionID: input.routeSessionID(),
+      visibleSessionID: input.sessionID(),
+      timelineSessionID: input.sessionID(),
+    }),
+  })
 
   const cancelRecoveryFrame = () => {
     if (recoveryFrame === undefined) return
@@ -85,6 +101,7 @@ export function createSessionTimelineInteraction(input: {
     clearMessageHash: () => clearMessageHash(),
     clearActiveMessage: () => activeMessage?.clearActiveMessage(),
     fill: () => historyBackfill?.fill(),
+    scrollCommandSink,
     onContentResize: () => {
       const viewport = scrollDock.scroller()
       if (!viewport) return
@@ -144,6 +161,7 @@ export function createSessionTimelineInteraction(input: {
     userScrolled: userScrolledForHistory,
     isAtBottom: () => scrollDock.scroll.bottom,
     scroller: scrollDock.scroller,
+    scrollCommandSink,
   })
 
   const resumeLatest = () => {
@@ -205,6 +223,7 @@ export function createSessionTimelineInteraction(input: {
       const restored = restoreTimelineSafePosition({
         viewport,
         position: recovery.anchor,
+        scrollCommandSink,
       })
       if (restored.ok && viewport) scrollDock.scheduleScrollState(viewport)
     })
@@ -283,6 +302,7 @@ export function createSessionTimelineInteraction(input: {
     anchor,
     scheduleScrollState: scrollDock.scheduleScrollState,
     consumePendingMessage: input.consumePendingMessage,
+    scrollCommandSink,
     onMessageNavigation: (messageID) => {
       scrollDock.cancelBottomFollowLock()
       onTimelineScrollIntent({

--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -8,7 +8,24 @@ export interface AutoScrollOptions {
   onUserInteracted?: () => void
   overflowAnchor?: "none" | "auto" | "dynamic"
   bottomThreshold?: number
+  executeScrollCommand?: (command: AutoScrollCommand) => void
 }
+
+export type AutoScrollCommand = {
+  element: HTMLElement
+  top: number
+  behavior: ScrollBehavior
+  method: "scroll-to" | "set-scroll-top"
+  reason: AutoScrollReason
+}
+
+export type AutoScrollReason =
+  | "content-resize"
+  | "dock-resize"
+  | "force-bottom"
+  | "follow-bottom"
+  | "resume"
+  | "working-start"
 
 export function createAutoScroll(options: AutoScrollOptions) {
   let settling = false
@@ -79,20 +96,34 @@ export function createAutoScroll(options: AutoScrollOptions) {
     return Math.abs(el.scrollTop - a.top) < 2
   }
 
-  const scrollToBottomNow = (behavior: ScrollBehavior) => {
+  const executeScrollCommand = (command: AutoScrollCommand) => {
+    if (options.executeScrollCommand) {
+      options.executeScrollCommand(command)
+      return
+    }
+
+    if (command.method === "scroll-to") {
+      command.element.scrollTo({ top: command.top, behavior: command.behavior })
+      return
+    }
+
+    command.element.scrollTop = command.top
+  }
+
+  const scrollToBottomNow = (behavior: ScrollBehavior, reason: AutoScrollReason) => {
     const el = store.scrollRef
     if (!el) return
     markAuto(el)
     if (behavior === "smooth") {
-      el.scrollTo({ top: el.scrollHeight, behavior })
+      executeScrollCommand({ element: el, top: el.scrollHeight, behavior, method: "scroll-to", reason })
       return
     }
 
     // `scrollTop` assignment bypasses any CSS `scroll-behavior: smooth`.
-    el.scrollTop = el.scrollHeight
+    executeScrollCommand({ element: el, top: el.scrollHeight, behavior, method: "set-scroll-top", reason })
   }
 
-  const scrollToBottom = (force: boolean) => {
+  const scrollToBottom = (force: boolean, reason: AutoScrollReason = force ? "force-bottom" : "follow-bottom") => {
     if (!force && !active()) return
 
     const el = store.scrollRef
@@ -114,7 +145,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // For auto-following content we prefer immediate updates to avoid
     // visible "catch up" animations while content is still settling.
-    scrollToBottomNow("auto")
+    scrollToBottomNow("auto", reason)
   }
 
   const stop = () => {
@@ -158,7 +189,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // Ignore scroll events triggered by our own scrollToBottom calls.
     if (!store.userScrolled && isAuto(el)) {
-      scrollToBottom(false)
+      scrollToBottom(false, "content-resize")
       return
     }
 
@@ -186,7 +217,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
       // ResizeObserver fires after layout, before paint.
       // Keep the bottom locked in the same frame to avoid visible
       // "jump up then catch up" artifacts while streaming content.
-      scrollToBottom(false)
+      scrollToBottom(false, "content-resize")
     },
   )
 
@@ -197,7 +228,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
       settleTimer = undefined
 
       if (working) {
-        if (!store.userScrolled) scrollToBottom(true)
+        if (!store.userScrolled) scrollToBottom(true, "working-start")
         return
       }
 
@@ -232,10 +263,10 @@ export function createAutoScroll(options: AutoScrollOptions) {
     pause: stop,
     resume: () => {
       if (store.userScrolled) setStore("userScrolled", false)
-      scrollToBottom(true)
+      scrollToBottom(true, "resume")
     },
-    scrollToBottom: () => scrollToBottom(false),
-    forceScrollToBottom: () => scrollToBottom(true),
+    scrollToBottom: (reason?: AutoScrollReason) => scrollToBottom(false, reason),
+    forceScrollToBottom: (reason?: AutoScrollReason) => scrollToBottom(true, reason),
     userScrolled: () => store.userScrolled,
   }
 }


### PR DESCRIPTION
## Summary

Adds the PR0 scroll ownership boundary for #747: session timeline scroll writes now route through a `TimelineScrollCommandSink`, and an AST-based guard prevents new timeline scroll bypasses.

This PR does not claim #747 is fixed; it makes scroll ownership observable before row virtualization or layout transactions.

## Why

#747's architecture path has converged on scroll ownership first, then row-level virtualization, then layout transactions. PR0 creates the imperative boundary needed before later PRs change measurement timing.

## Related Issue

Refs #747

## Human Review Status

Pending

## Review Focus

- Whether the PR0 boundary stays narrow: no virtualization, no layout transactions, no `TimelineLayoutEngine` migration.
- Whether `TimelineScrollCommandSink` records enough ownership metadata without adding unconditional full layout reads.
- Whether the AST guard catches direct and indirect timeline scroll writes without hiding production timeline exceptions.

## Risk Notes

- PR0 changes scroll write call sites but is intended to preserve existing behavior.
- The generic `createAutoScroll` hook keeps its direct DOM-scroll fallback for non-timeline callers; the session timeline path passes an executor that routes through the sink.
- Full before/after scroll metrics are off by default and require the explicit `__PW_TIMELINE_SCROLL_FULL_METRICS__` test/debug flag.
- No visible UI or copy changed; screenshots/recordings were not taken.
- No platform, packaging, updater, signing, shell, or permission surface was touched.
- Local-only plan / STATUS notes were updated outside the PR and were not staged.

## How To Verify

```text
bun install --frozen-lockfile: completed in the fresh worktree.
Targeted PR0 unit tests: 52 passed.
App unit suite: 1310 passed.
bun run typecheck: 8 successful tasks.
bun run lint: passed with no ESLint output.
bun test:e2e -- e2e/session/session-scroll-position.spec.ts: 4 passed.
PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_SCENARIOS=session-scroll-reading-long bun test:e2e -- e2e/perf/perf-probe.spec.ts -g "session-scroll-reading-long": 1 passed.
git diff --check: passed with no whitespace errors.
Focused pre-PR code review: no critical findings; two important findings fixed in follow-up commit 8b1c24ec.
```

## Screenshots or Recordings

Not required: no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scroll tracking system that records scroll operations with detailed context, including reason and source information for diagnostics.
  * Auto-scroll now supports external execution of scroll commands with configurable behavior.

* **Refactor**
  * Unified scroll command handling across timeline restoration, history window, hash navigation, and dock operations through a centralized system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->