### PR TITLE
fix(ui): RateLimitCard polish — token drift, copy ambiguity, alignment

### DIFF
--- a/packages/ui/src/components/card.css
+++ b/packages/ui/src/components/card.css
@@ -85,6 +85,7 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     word-break: break-word;
+    padding-left: var(--card-indent);
   }
 
   :where([data-card="actions"], [data-slot="card-actions"]) {

--- a/packages/ui/src/components/rate-limit-card.css
+++ b/packages/ui/src/components/rate-limit-card.css
@@ -1,66 +1,27 @@
-.rate-limit-card {
-  display: flex;
-  gap: 12px;
-  padding: 12px 12px 12px 14px;
-  border-left: 2px solid var(--warning);
-  background: transparent;
-  border-radius: 0;
-}
+[data-component="card"][data-kind="rate-limit-card"] {
+  [data-slot="card-actions"] {
+    display: flex;
+    gap: var(--space-lg);
+  }
 
-.rate-limit-card__icon {
-  display: inline-flex;
-  align-items: flex-start;
-  color: var(--warning);
-  padding-top: 1px;
-}
+  .rate-limit-card__action {
+    color: var(--fg-weak);
+    text-decoration: none;
+  }
 
-.rate-limit-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
+  .rate-limit-card__action:hover {
+    text-decoration: underline;
+  }
 
-.rate-limit-card__title {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--fg-strong);
-  line-height: 1.4;
-}
+  .rate-limit-card__action--primary {
+    color: var(--warning);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
 
-.rate-limit-card__description {
-  margin: 0;
-  font-size: var(--font-size-body);
-  font-weight: var(--font-weight-body);
-  color: var(--fg-base);
-}
-
-.rate-limit-card__actions {
-  display: flex;
-  gap: 20px;
-  margin-top: 4px;
-}
-
-.rate-limit-card__action {
-  font-size: var(--font-size-body);
-  font-weight: var(--font-weight-body);
-  color: var(--fg-muted);
-  text-decoration: none;
-}
-
-.rate-limit-card__action:hover {
-  text-decoration: underline;
-}
-
-.rate-limit-card__action--primary {
-  color: var(--warning);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.rate-limit-card__external {
-  font-size: 11px;
-  opacity: 0.8;
+  .rate-limit-card__external {
+    font-size: 11px;
+    opacity: 0.8;
+  }
 }

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -140,36 +140,43 @@ describe("RateLimitCard: CSS token contract", () => {
 
 describe("formatResetTime", () => {
   const EPOCH_UTC_MIDNIGHT = 1705276800000 // 2024-01-15T00:00:00Z
-  const SIX_HOURS = 6 * 60 * 60 * 1000
-  const ONE_DAY = 24 * 60 * 60 * 1000
+  const ONE_HOUR = 60 * 60 * 1000
+  const SIX_HOURS = 6 * ONE_HOUR
+  const ONE_DAY = 24 * ONE_HOUR
   const TWO_DAYS = 2 * ONE_DAY
+  // ±14h is the widest real local offset, so EPOCH + 6h stays on the same
+  // local calendar day in every IANA timezone.
+  const NOW = EPOCH_UTC_MIDNIGHT
 
   test("returns time string in HH:MM format", () => {
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.time).toMatch(/^\d{2}:\d{2}$/)
+    expect(formatResetTime(NOW + SIX_HOURS, NOW)?.time).toMatch(/^\d{2}:\d{2}$/)
   })
 
   test("different epochs produce different time strings", () => {
-    const t1 = formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.time
-    const t2 = formatResetTime(EPOCH_UTC_MIDNIGHT + SIX_HOURS, EPOCH_UTC_MIDNIGHT)?.time
+    const t1 = formatResetTime(NOW + ONE_HOUR, NOW)?.time
+    const t2 = formatResetTime(NOW + SIX_HOURS, NOW)?.time
     expect(t1).not.toEqual(t2)
   })
 
-  test("kind is 'today' when reset is on the same local calendar day as now", () => {
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.kind).toBe("today")
+  test("kind is 'today' when reset is later the same local calendar day", () => {
+    expect(formatResetTime(NOW + SIX_HOURS, NOW)?.kind).toBe("today")
   })
 
   test("kind is 'tomorrow' when reset is exactly one day ahead", () => {
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + ONE_DAY, EPOCH_UTC_MIDNIGHT)?.kind).toBe("tomorrow")
+    expect(formatResetTime(NOW + ONE_DAY, NOW)?.kind).toBe("tomorrow")
   })
 
-  test("returns undefined when resetAt is in the past", () => {
-    // Provider sent an HTTP-date that already elapsed (retry.ts clamps the
-    // wait to 0 but writes the parsed date into resetAt unchanged).
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT - TWO_DAYS, EPOCH_UTC_MIDNIGHT)).toBeUndefined()
+  test("returns undefined when resetAt is already past, even on the same local day", () => {
+    // Past on a previous day: provider sent an HTTP-date that already elapsed
+    // (retry.ts clamps the wait to 0 but writes the parsed date through).
+    expect(formatResetTime(NOW - TWO_DAYS, NOW)).toBeUndefined()
+    // Past within the same local day: the day-bucket check alone misses this,
+    // so the card would otherwise read "Resets around HH:MM today" for a time
+    // that has already gone by.
+    expect(formatResetTime(NOW, NOW + SIX_HOURS)).toBeUndefined()
   })
 
   test("returns undefined when resetAt is more than one local day ahead", () => {
-    // Avoid saying "tomorrow HH:MM" when the actual reset is +2 days out.
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + TWO_DAYS, EPOCH_UTC_MIDNIGHT)).toBeUndefined()
+    expect(formatResetTime(NOW + TWO_DAYS, NOW)).toBeUndefined()
   })
 })

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -136,6 +136,41 @@ describe("RateLimitCard: CSS token contract", () => {
   })
 })
 
+// ── Live invalidation at resetAt ───────────────────────────────────────────
+//
+// rate_limit_blocked is a sticky terminal state (see session/status.ts), so
+// the card outlives resetAt unless the user submits a new turn. The component
+// schedules a one-shot tick at resetAt that flips its internal `now` signal,
+// forcing formatResetTime to fall through to the no-time subtitle.
+
+describe("RateLimitCard: invalidates copy at resetAt", () => {
+  test("imports onMount, createSignal, and onCleanup from solid-js", () => {
+    expect(src).toMatch(/from\s+["']solid-js["']/)
+    expect(src).toContain("onMount")
+    expect(src).toContain("createSignal")
+    expect(src).toContain("onCleanup")
+  })
+
+  test("schedules a setTimeout whose delay is derived from resetAt minus Date.now()", () => {
+    expect(src).toContain("setTimeout")
+    // Delay is computed from resetAt; we don't pin the exact arithmetic but do
+    // require both pieces appear in the same function so the relation is local.
+    expect(src).toMatch(/resetAt\s*-\s*Date\.now\(\)/)
+  })
+
+  test("clears the scheduled timer on unmount", () => {
+    expect(src).toContain("clearTimeout")
+    expect(src).toMatch(/onCleanup\(\s*\(\s*\)\s*=>\s*clearTimeout/)
+  })
+
+  test("skips scheduling when resetAt is undefined or already past", () => {
+    // The guard keeps the timer cost at zero for the no-time fallback path and
+    // avoids a setTimeout(_, 0) thrash when the provider sent a past HTTP-date.
+    expect(src).toMatch(/if\s*\(\s*resetAt\s*===\s*undefined\s*\)\s*return/)
+    expect(src).toMatch(/if\s*\(\s*remaining\s*<=\s*0\s*\)\s*return/)
+  })
+})
+
 // ── formatResetTime pure helper ────────────────────────────────────────────
 
 describe("formatResetTime", () => {

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -141,26 +141,35 @@ describe("RateLimitCard: CSS token contract", () => {
 describe("formatResetTime", () => {
   const EPOCH_UTC_MIDNIGHT = 1705276800000 // 2024-01-15T00:00:00Z
   const SIX_HOURS = 6 * 60 * 60 * 1000
-  const TWO_DAYS = 2 * 24 * 60 * 60 * 1000
+  const ONE_DAY = 24 * 60 * 60 * 1000
+  const TWO_DAYS = 2 * ONE_DAY
 
   test("returns time string in HH:MM format", () => {
-    // HH:MM with hour12: false — must match pattern like "08:00" or "19:00"
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT).time).toMatch(/^\d{2}:\d{2}$/)
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.time).toMatch(/^\d{2}:\d{2}$/)
   })
 
   test("different epochs produce different time strings", () => {
-    const t1 = formatResetTime(EPOCH_UTC_MIDNIGHT).time
-    const t2 = formatResetTime(EPOCH_UTC_MIDNIGHT + SIX_HOURS).time
+    const t1 = formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.time
+    const t2 = formatResetTime(EPOCH_UTC_MIDNIGHT + SIX_HOURS, EPOCH_UTC_MIDNIGHT)?.time
     expect(t1).not.toEqual(t2)
   })
 
-  test("dayOffset is 0 when reset is on the same local calendar day as now", () => {
-    // Same instant for both reset and now → identical local date components.
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT).dayOffset).toBe(0)
+  test("kind is 'today' when reset is on the same local calendar day as now", () => {
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT)?.kind).toBe("today")
   })
 
-  test("dayOffset is 1 when reset is past the local day boundary", () => {
-    // Two days ahead is comfortably past midnight in any local timezone.
-    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + TWO_DAYS, EPOCH_UTC_MIDNIGHT).dayOffset).toBe(1)
+  test("kind is 'tomorrow' when reset is exactly one day ahead", () => {
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + ONE_DAY, EPOCH_UTC_MIDNIGHT)?.kind).toBe("tomorrow")
+  })
+
+  test("returns undefined when resetAt is in the past", () => {
+    // Provider sent an HTTP-date that already elapsed (retry.ts clamps the
+    // wait to 0 but writes the parsed date into resetAt unchanged).
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT - TWO_DAYS, EPOCH_UTC_MIDNIGHT)).toBeUndefined()
+  })
+
+  test("returns undefined when resetAt is more than one local day ahead", () => {
+    // Avoid saying "tomorrow HH:MM" when the actual reset is +2 days out.
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + TWO_DAYS, EPOCH_UTC_MIDNIGHT)).toBeUndefined()
   })
 })

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -4,10 +4,9 @@
  * Two-layer test strategy:
  * 1. Source-analysis: verify DOM slots, CSS class contracts, and no-go rules
  *    (no buttons, no app imports) by reading the source file as text.
- * 2. Pure helper: verify formatResetTime produces correct HH:MM strings and
- *    the system timezone via mocking Intl.DateTimeFormat.
+ * 2. Pure helper: verify formatResetTime produces correct HH:MM strings.
  */
-import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { readFileSync } from "node:fs"
 import { formatResetTime } from "./rate-limit-card"
 
@@ -85,61 +84,83 @@ describe("RateLimitCard: callback props", () => {
   })
 })
 
-// ── CSS: warning left-border rule ──────────────────────────────────────────
+// ── Architecture: composes the canonical Card primitive ───────────────────
+//
+// PR #775 originally hand-rolled every visual rule (left border, title weight,
+// description color, body gap) instead of leaning on `<Card variant="warning">`.
+// That bypassed the project token system and led to off-grid spacing, an
+// undefined `--fg-muted` token, and a line-height that matched no type token.
+// These tests pin the architecture so the same drift cannot reappear.
+
+describe("RateLimitCard: composes Card primitive", () => {
+  test("imports Card / CardTitle / CardDescription / CardActions from ./card", () => {
+    expect(src).toMatch(/from\s+['"]\.\/card['"]/)
+    expect(src).toContain("Card")
+    expect(src).toContain("CardTitle")
+    expect(src).toContain("CardDescription")
+    expect(src).toContain("CardActions")
+  })
+
+  test("renders <Card variant=\"warning\"> so the 2px rule and accent come from the primitive", () => {
+    expect(src).toMatch(/<Card\b[^>]*variant=["']warning["']/)
+  })
+
+  test("scoped CSS targets the data-kind hook, not the bare component name", () => {
+    // Mirrors the tool-error-card pattern: `[data-component="card"][data-kind="..."]`.
+    expect(css).toContain('[data-component="card"][data-kind="rate-limit-card"]')
+  })
+
+  test("does not redefine container styles already owned by Card primitive", () => {
+    // The left rule, title color, and description font live in card.css now.
+    // Catching them here would mean RateLimitCard drifted off the system again.
+    expect(css).not.toContain("border-left")
+    expect(css).not.toContain("--fg-strong")
+    expect(css).not.toContain("--font-size-body")
+  })
+})
+
+// ── CSS: action-link specifics still live in this file ────────────────────
 
 describe("RateLimitCard: CSS token contract", () => {
-  test("left border uses var(--warning)", () => {
-    expect(css).toContain("border-left: 2px solid var(--warning)")
-  })
-
-  test("icon color uses var(--warning)", () => {
-    expect(css).toContain("color: var(--warning)")
-  })
-
   test("primary action color uses var(--warning)", () => {
-    // rate-limit-card__action--primary must override to warning color.
     expect(css).toMatch(/\.rate-limit-card__action--primary[\s\S]*?color:\s*var\(--warning\)/)
   })
 
-  test("title color uses var(--fg-strong)", () => {
-    expect(css).toContain("color: var(--fg-strong)")
+  test("secondary action color uses var(--fg-weak), not the undefined --fg-muted", () => {
+    expect(css).toContain("var(--fg-weak)")
+    expect(css).not.toContain("--fg-muted")
   })
 
-  test("description font uses body typography tokens", () => {
-    expect(css).toContain("font-size: var(--font-size-body)")
-    expect(css).toContain("font-weight: var(--font-weight-body)")
-  })
-
-  test("actions gap is 20px", () => {
-    expect(css).toMatch(/\.rate-limit-card__actions[\s\S]*?gap:\s*20px/)
+  test("actions row uses an on-grid horizontal gap via --space-* token", () => {
+    expect(css).toMatch(/\[data-slot="card-actions"\][\s\S]*?gap:\s*var\(--space-/)
   })
 })
 
 // ── formatResetTime pure helper ────────────────────────────────────────────
 
 describe("formatResetTime", () => {
-  // 2024-01-15 UTC midnight = 1705276800000 ms
-  // Asia/Shanghai is UTC+8 → 08:00
-  // America/New_York is UTC-5 (EST in January) → 19:00 previous day, but
-  // the displayed time for the same epoch varies by TZ.
   const EPOCH_UTC_MIDNIGHT = 1705276800000 // 2024-01-15T00:00:00Z
+  const SIX_HOURS = 6 * 60 * 60 * 1000
+  const TWO_DAYS = 2 * 24 * 60 * 60 * 1000
 
   test("returns time string in HH:MM format", () => {
-    const { time } = formatResetTime(EPOCH_UTC_MIDNIGHT)
     // HH:MM with hour12: false — must match pattern like "08:00" or "19:00"
-    expect(time).toMatch(/^\d{2}:\d{2}$/)
-  })
-
-  test("returns non-empty timezone string from Intl", () => {
-    const { tz } = formatResetTime(EPOCH_UTC_MIDNIGHT)
-    expect(typeof tz).toBe("string")
-    expect(tz.length).toBeGreaterThan(0)
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT).time).toMatch(/^\d{2}:\d{2}$/)
   })
 
   test("different epochs produce different time strings", () => {
-    const { time: t1 } = formatResetTime(EPOCH_UTC_MIDNIGHT)
-    // 6 hours later
-    const { time: t2 } = formatResetTime(EPOCH_UTC_MIDNIGHT + 6 * 60 * 60 * 1000)
+    const t1 = formatResetTime(EPOCH_UTC_MIDNIGHT).time
+    const t2 = formatResetTime(EPOCH_UTC_MIDNIGHT + SIX_HOURS).time
     expect(t1).not.toEqual(t2)
+  })
+
+  test("dayOffset is 0 when reset is on the same local calendar day as now", () => {
+    // Same instant for both reset and now → identical local date components.
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT, EPOCH_UTC_MIDNIGHT).dayOffset).toBe(0)
+  })
+
+  test("dayOffset is 1 when reset is past the local day boundary", () => {
+    // Two days ahead is comfortably past midnight in any local timezone.
+    expect(formatResetTime(EPOCH_UTC_MIDNIGHT + TWO_DAYS, EPOCH_UTC_MIDNIGHT).dayOffset).toBe(1)
   })
 })

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -1,6 +1,7 @@
 import { Show } from "solid-js"
 import type { RetryClassification } from "@opencode-ai/sdk/v2/client"
 import { useI18n } from "../context/i18n"
+import { Card, CardActions, CardDescription, CardTitle } from "./card"
 import "./rate-limit-card.css"
 
 export interface RateLimitCardProps {
@@ -9,77 +10,66 @@ export interface RateLimitCardProps {
   onUseOwnModelClick: () => void
 }
 
-// Exported for unit testing.
-export function formatResetTime(resetAt: number): { time: string; tz: string } {
-  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+// Exported for unit testing. `dayOffset` is clamped to 0 | 1: anything past
+// the next local-calendar day is treated as 1 (rare for daily-reset quotas).
+export function formatResetTime(resetAt: number, now: number = Date.now()): { time: string; dayOffset: 0 | 1 } {
   const time = new Intl.DateTimeFormat(undefined, {
     hour: "2-digit",
     minute: "2-digit",
-    timeZone: tz,
     hour12: false,
   }).format(new Date(resetAt))
-  return { time, tz }
+  const reset = new Date(resetAt)
+  const today = new Date(now)
+  const sameLocalDay =
+    reset.getFullYear() === today.getFullYear() &&
+    reset.getMonth() === today.getMonth() &&
+    reset.getDate() === today.getDate()
+  return { time, dayOffset: sameLocalDay ? 0 : 1 }
 }
 
 export function RateLimitCard(props: RateLimitCardProps) {
   const i18n = useI18n()
   return (
-    <div data-slot="rate-limit-card" class="rate-limit-card">
-      <span class="rate-limit-card__icon" aria-hidden="true">
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+    <Card variant="warning" data-slot="rate-limit-card" data-kind="rate-limit-card">
+      <CardTitle variant="warning">{i18n.t("ui.rateLimitCard.title")}</CardTitle>
+      <CardDescription>
+        <Show
+          when={props.classification.resetAt !== undefined}
+          fallback={i18n.t("ui.rateLimitCard.subtitleNoTime")}
         >
-          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
-          <line x1="12" y1="9" x2="12" y2="13" />
-          <line x1="12" y1="17" x2="12.01" y2="17" />
-        </svg>
-      </span>
-      <div class="rate-limit-card__body">
-        <h3 class="rate-limit-card__title">{i18n.t("ui.rateLimitCard.title")}</h3>
-        <p class="rate-limit-card__description">
-          <Show
-            when={props.classification.resetAt !== undefined}
-            fallback={i18n.t("ui.rateLimitCard.subtitleNoTime")}
-          >
-            {(() => {
-              const { time, tz } = formatResetTime(props.classification.resetAt!)
-              return i18n.t("ui.rateLimitCard.subtitleWithTime", { time, tz })
-            })()}
-          </Show>
-        </p>
-        <div class="rate-limit-card__actions">
-          <a
-            class="rate-limit-card__action rate-limit-card__action--primary"
-            href="#"
-            data-slot="rate-limit-card-subscribe"
-            onClick={(e) => {
-              e.preventDefault()
-              props.onSubscribeClick()
-            }}
-          >
-            {i18n.t("ui.rateLimitCard.actionSubscribe")}
-            <span class="rate-limit-card__external" aria-hidden="true">↗</span>
-          </a>
-          <a
-            class="rate-limit-card__action"
-            href="#"
-            data-slot="rate-limit-card-byo"
-            onClick={(e) => {
-              e.preventDefault()
-              props.onUseOwnModelClick()
-            }}
-          >
-            {i18n.t("ui.rateLimitCard.actionBYO")}
-          </a>
-        </div>
-      </div>
-    </div>
+          {(() => {
+            const { time, dayOffset } = formatResetTime(props.classification.resetAt!)
+            const key =
+              dayOffset === 0 ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
+            return i18n.t(key, { time })
+          })()}
+        </Show>
+      </CardDescription>
+      <CardActions>
+        <a
+          class="rate-limit-card__action rate-limit-card__action--primary"
+          href="#"
+          data-slot="rate-limit-card-subscribe"
+          onClick={(e) => {
+            e.preventDefault()
+            props.onSubscribeClick()
+          }}
+        >
+          {i18n.t("ui.rateLimitCard.actionSubscribe")}
+          <span class="rate-limit-card__external" aria-hidden="true">↗</span>
+        </a>
+        <a
+          class="rate-limit-card__action"
+          href="#"
+          data-slot="rate-limit-card-byo"
+          onClick={(e) => {
+            e.preventDefault()
+            props.onUseOwnModelClick()
+          }}
+        >
+          {i18n.t("ui.rateLimitCard.actionBYO")}
+        </a>
+      </CardActions>
+    </Card>
   )
 }

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -1,4 +1,4 @@
-import { Show } from "solid-js"
+import { createSignal, onCleanup, onMount, Show } from "solid-js"
 import type { RetryClassification } from "@opencode-ai/sdk/v2/client"
 import { useI18n } from "../context/i18n"
 import { Card, CardActions, CardDescription, CardTitle } from "./card"
@@ -34,8 +34,23 @@ export function formatResetTime(
 
 export function RateLimitCard(props: RateLimitCardProps) {
   const i18n = useI18n()
-  const formatted = () =>
-    props.classification.resetAt === undefined ? undefined : formatResetTime(props.classification.resetAt)
+  // rate_limit_blocked is a sticky terminal state (see session/status.ts), so
+  // the card stays mounted past resetAt unless the user starts a new turn.
+  // Tick `now` once at resetAt so the "today"/"tomorrow" copy falls through to
+  // the no-time subtitle instead of pointing at an already-elapsed time.
+  const [now, setNow] = createSignal(Date.now())
+  onMount(() => {
+    const resetAt = props.classification.resetAt
+    if (resetAt === undefined) return
+    const remaining = resetAt - Date.now()
+    if (remaining <= 0) return
+    const timer = setTimeout(() => setNow(Date.now()), remaining + 1000)
+    onCleanup(() => clearTimeout(timer))
+  })
+  const formatted = () => {
+    const resetAt = props.classification.resetAt
+    return resetAt === undefined ? undefined : formatResetTime(resetAt, now())
+  }
   return (
     <Card variant="warning" data-slot="rate-limit-card" data-kind="rate-limit-card">
       <CardTitle variant="warning">{i18n.t("ui.rateLimitCard.title")}</CardTitle>

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -10,39 +10,42 @@ export interface RateLimitCardProps {
   onUseOwnModelClick: () => void
 }
 
-// Exported for unit testing. `dayOffset` is clamped to 0 | 1: anything past
-// the next local-calendar day is treated as 1 (rare for daily-reset quotas).
-export function formatResetTime(resetAt: number, now: number = Date.now()): { time: string; dayOffset: 0 | 1 } {
+// Exported for unit testing. Returns undefined when resetAt is in the past or
+// more than one local calendar day away — those cases would yield misleading
+// "today"/"tomorrow" copy, so the caller falls back to the no-time subtitle.
+export function formatResetTime(
+  resetAt: number,
+  now: number = Date.now(),
+): { time: string; kind: "today" | "tomorrow" } | undefined {
+  const reset = new Date(resetAt)
+  const today = new Date(now)
+  const resetMidnight = new Date(reset.getFullYear(), reset.getMonth(), reset.getDate()).getTime()
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime()
+  const diffDays = Math.round((resetMidnight - todayMidnight) / 86_400_000)
+  if (diffDays !== 0 && diffDays !== 1) return undefined
   const time = new Intl.DateTimeFormat(undefined, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
-  }).format(new Date(resetAt))
-  const reset = new Date(resetAt)
-  const today = new Date(now)
-  const sameLocalDay =
-    reset.getFullYear() === today.getFullYear() &&
-    reset.getMonth() === today.getMonth() &&
-    reset.getDate() === today.getDate()
-  return { time, dayOffset: sameLocalDay ? 0 : 1 }
+  }).format(reset)
+  return { time, kind: diffDays === 0 ? "today" : "tomorrow" }
 }
 
 export function RateLimitCard(props: RateLimitCardProps) {
   const i18n = useI18n()
+  const formatted = () =>
+    props.classification.resetAt === undefined ? undefined : formatResetTime(props.classification.resetAt)
   return (
     <Card variant="warning" data-slot="rate-limit-card" data-kind="rate-limit-card">
       <CardTitle variant="warning">{i18n.t("ui.rateLimitCard.title")}</CardTitle>
       <CardDescription>
-        <Show
-          when={props.classification.resetAt !== undefined}
-          fallback={i18n.t("ui.rateLimitCard.subtitleNoTime")}
-        >
-          {(() => {
-            const { time, dayOffset } = formatResetTime(props.classification.resetAt!)
+        <Show when={formatted()} fallback={i18n.t("ui.rateLimitCard.subtitleNoTime")}>
+          {(result) => {
+            const r = result()
             const key =
-              dayOffset === 0 ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
-            return i18n.t(key, { time })
-          })()}
+              r.kind === "today" ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
+            return i18n.t(key, { time: r.time })
+          }}
         </Show>
       </CardDescription>
       <CardActions>

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -17,6 +17,7 @@ export function formatResetTime(
   resetAt: number,
   now: number = Date.now(),
 ): { time: string; kind: "today" | "tomorrow" } | undefined {
+  if (resetAt <= now) return undefined
   const reset = new Date(resetAt)
   const today = new Date(now)
   const resetMidnight = new Date(reset.getFullYear(), reset.getMonth(), reset.getDate()).getTime()

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -217,8 +217,9 @@ export const dict: Record<string, string> = {
   "ui.question.singleHint": "Pick 1",
   "ui.question.custom.placeholder": "Type your answer...",
   "ui.rateLimitCard.title": "Today's free quota is used up",
-  "ui.rateLimitCard.subtitleWithTime": "Resets around {{time}} ({{tz}}), based on the UTC daily reset.",
-  "ui.rateLimitCard.subtitleNoTime": "Resets on the next UTC day.",
+  "ui.rateLimitCard.subtitleResetToday": "Resets around {{time}} today.",
+  "ui.rateLimitCard.subtitleResetTomorrow": "Resets around {{time}} tomorrow.",
+  "ui.rateLimitCard.subtitleNoTime": "Try again later.",
   "ui.rateLimitCard.actionSubscribe": "Subscribe to OpenCode Go",
   "ui.rateLimitCard.actionBYO": "Use your own model",
 }

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -209,8 +209,9 @@ export const dict = {
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
   "ui.rateLimitCard.title": "今天的免费额度用完了",
-  "ui.rateLimitCard.subtitleWithTime": "约 {{time}}（{{tz}}）恢复，按 UTC 每日重置推导",
-  "ui.rateLimitCard.subtitleNoTime": "明日重置后恢复",
+  "ui.rateLimitCard.subtitleResetToday": "约今天 {{time}} 恢复",
+  "ui.rateLimitCard.subtitleResetTomorrow": "约明天 {{time}} 恢复",
+  "ui.rateLimitCard.subtitleNoTime": "稍后重试",
   "ui.rateLimitCard.actionSubscribe": "订阅 OpenCode Go",
   "ui.rateLimitCard.actionBYO": "使用自己的模型",
 } satisfies Partial<Record<Keys, string>>


### PR DESCRIPTION
## Summary

Follow-up to #775 that fixes four user-visible defects in the shipped RateLimitCard and disambiguates the reset-time copy:

- `--fg-muted` is not a defined token, so the secondary "use your own model" action fell back to `inherit` and rendered in body-black instead of weak.
- `padding-left: 14px`, `body gap: 6px`, and `icon padding-top: 1px` sit outside the 4pt spacing grid (DESIGN.md L225).
- `line-height: 1.4` on the title matches no type token.
- Title, description, and actions each had their own left padding, so the three rows did not share a left edge.
- The reset-time copy showed `约 08:00 恢复` with no today/tomorrow disambiguation; a user looking at the card in the evening could not tell whether `08:00` was today or tomorrow.

The fix replaces the bespoke JSX with the canonical Card primitive (`<Card variant="warning">` + CardTitle + CardDescription + CardActions), so the 2px rule, accent color, warning icon, title weight, description tone, and indent all come from one source. `formatResetTime` returns `{ time, kind: "today" | "tomorrow" } | undefined`; the render branch picks `subtitleResetToday` or `subtitleResetTomorrow` when defined, and falls back to `subtitleNoTime` ("Try again later" / "稍后重试") when the parsed `resetAt` is in the past (including same local day) or more than one calendar day out — avoiding a misleading "tomorrow HH:MM" for a +2-day reset or a "today HH:MM" for an already-elapsed timestamp.

Because `rate_limit_blocked` is a sticky terminal state in `session/status.ts` (the runner's onIdle hook intentionally cannot leave it), the card outlives `resetAt` whenever the user idles. `RateLimitCard` schedules a one-shot `setTimeout` in `onMount` that flips an internal `now` signal at `resetAt + 1s`, forcing the today/tomorrow copy to fall through to the no-time subtitle once the printed time has elapsed. The timer is cleared via `onCleanup`; `undefined` or already-past `resetAt` skip scheduling.

A second commit adds `padding-left: var(--card-indent)` to CardDescription in card.css so description and actions share the same left edge when the card has a title-icon; `--card-indent` is `0px` without a title-icon so tool-error-card is unaffected.

## Why

Pull #775 hand-rolled an entire card layout instead of composing the existing Card primitive. That bypassed the project token system and the spacing grid, and the failure was invisible to its test suite because the contract tests pinned the hand-rolled CSS strings (`expect(css).toContain("border-left: 2px solid var(--warning)")`) rather than the architecture. Contract tests in this PR are rewritten to lock the architecture: the source must import Card, must use `variant="warning"`, and must not redefine container styles. `--fg-muted` is explicitly forbidden by a test now.

## Related Issue

Follow-up to #775. No standalone issue — defects were discovered during free-quota walkthrough in dev:desktop on v2026.5.20.

## Human Review Status

Pending

## Review Focus

- card.css change (`padding-left: var(--card-indent)` on CardDescription) — only two production callers (tool-error-card without CardTitle → indent 0px; rate-limit-card with CardTitle → indent 24px). Verified locally.
- Architecture contract tests in `rate-limit-card.test.tsx` — they now ban hand-rolling. If a future RateLimitCard change wants to deviate from the Card primitive, these tests will fail and the deviation has to be justified.
- `formatResetTime` returns `undefined` for past or >24h-ahead `resetAt`, including same-local-day past, and the card falls back to the no-time subtitle. The component additionally schedules a one-shot `setTimeout` at `resetAt + 1s` so the same fallback applies live when the user idles past the printed time. This trades a possibly-still-useful "tomorrow HH:MM" for "Try again later" when the resetAt domain is uncertain, since the upstream retry classifier may receive arbitrary HTTP-date values.

## Risk Notes

- `card.css` adds `padding-left: var(--card-indent)` to CardDescription. Audited: only tool-error-card and rate-limit-card consume CardDescription in production. Tool-error-card does not use CardTitle so `--card-indent` is `0px` and behavior is unchanged.
- No platform / packaging / signing / updater surfaces touched.
- No new deps, no generated files, no permissions changes.

## How To Verify

```text
bun --cwd packages/ui test:                 594 pass / 4 fail (4 pre-existing unrelated)
bun turbo typecheck --filter @opencode-ai/ui: 3/3 successful
bun run snap rate-limit-card:               refreshed grid PNG
bun run dev:desktop walkthrough:            free-quota error triggered end-to-end on a real
                                            opencode/deepseek-v4-flash-free turn; card renders
                                            with aligned title/description/actions and the
                                            "约明天 08:00 恢复" copy in zh.
```

## Screenshots or Recordings

<img width="4488" height="1880" alt="rate-limit-card-en" src="https://github.com/user-attachments/assets/379fbe42-d2fc-47d0-97e4-cf70fd56e4fe" />
<img width="4488" height="1880" alt="rate-limit-card" src="https://github.com/user-attachments/assets/fdb78294-0e3f-4b0c-9958-996ce0a697d3" />

## Checklist

- [ ] **Type label** — bug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved card description alignment by applying consistent left padding with card indent.

* **Refactor**
  * Enhanced rate-limit card component with improved reset time messaging, now displaying "resets today" or "resets tomorrow" based on the actual reset moment.
  * Updated card-based structure for better visual consistency.

* **Documentation**
  * Updated English and Chinese translations for rate-limit card reset messaging to provide clearer user guidance on when rate limits will be restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->