### PR TITLE
feat(app): show brand-orange unread dot in sidebar session row

### DIFF
--- a/packages/app/e2e/snap/sidebar-unread.snap.ts
+++ b/packages/app/e2e/snap/sidebar-unread.snap.ts
@@ -1,0 +1,64 @@
+import { test } from "../fixtures"
+import { openSidebar, withSession } from "../actions"
+import { pawworkSidebarSelector } from "../selectors"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test("sidebar-unread", async ({ page, sdk, directory, gotoSession }) => {
+  test.setTimeout(120_000)
+
+  await withSession(sdk, "snap sidebar unread a", async (a) => {
+    await withSession(sdk, "snap sidebar unread b", async (b) => {
+      // Land the user on session B so session A is the one that "finished
+      // a turn while the user was elsewhere". markViewed only fires for the
+      // current session, so A keeps its unseen state intact.
+      await gotoSession(b.id)
+
+      // Inject a turn-complete notification for session A directly into the
+      // persisted notification store. The notification context rebuilds its
+      // unseen index from this list on load, so the sidebar's statusKind
+      // memo will see unseenCount(a.id) > 0 and render the unread dot.
+      // Persist key derivation: Persist.global("notification") uses storage
+      // prefix "pawwork.global.dat" and key "notification" — see
+      // packages/app/src/utils/persist.ts and persist-local-storage.ts.
+      await page.evaluate(
+        ({ sessionId, dir }) => {
+          const stored = JSON.stringify({
+            list: [
+              {
+                type: "turn-complete",
+                time: Date.now(),
+                viewed: false,
+                session: sessionId,
+                directory: dir,
+              },
+            ],
+          })
+          window.localStorage.setItem("pawwork.global.dat:notification", stored)
+        },
+        { sessionId: a.id, dir: directory },
+      )
+
+      // Reload so NotificationProvider hydrates from the seeded localStorage.
+      await page.reload()
+      await openSidebar(page)
+
+      const sidebar = page.locator(pawworkSidebarSelector)
+      // Wait for the unread dot on session A's row. The Show-when-no-level
+      // status slot renders one of the five status indicators; we anchor on
+      // the dot's aria-label/role so this stays robust against unrelated
+      // layout tweaks.
+      await sidebar
+        .locator(`[data-session-id="${a.id}"] [role="img"][aria-label]`)
+        .first()
+        .waitFor({ state: "visible", timeout: 30_000 })
+
+      const shots: Shot[] = [{ name: "unread", buf: await sidebar.screenshot() }]
+
+      const out = snapOutputPath("sidebar-unread")
+      await composeGrid(shots, out)
+      process.stdout.write(`\n[snap] sidebar-unread grid -> ${out}\n\n`)
+    })
+  })
+})

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -797,6 +797,7 @@ export const dict = {
   "sidebar.pawwork.sort.optionByTime": "By time",
   "sidebar.pawwork.sort.optionByProject": "By project",
   "sidebar.pawwork.searchHistory": "Use Search for older sessions",
+  "sidebar.session.unread": "Has unread messages",
 
   "debugBar.ariaLabel": "Development performance diagnostics",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -708,6 +708,7 @@ export const dict = {
   "sidebar.pawwork.sort.optionByTime": "按时间",
   "sidebar.pawwork.sort.optionByProject": "按项目",
   "sidebar.pawwork.searchHistory": "搜索历史会话",
+  "sidebar.session.unread": "有未读消息",
 
   "app.name.desktop": "爪印",
 

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -110,7 +110,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     const asking = isAsking()
     const busy = !asking && !!sessionRunning()
     const error = !asking && !busy && hasError()
-    return sidebarStatusKind({ asking, busy, error })
+    const unread = !asking && !busy && !error && notification.session.unseenCount(props.session.id) > 0
+    return sidebarStatusKind({ asking, busy, error, unread })
   })
 
   const statusContent = (): JSX.Element => {
@@ -127,6 +128,14 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
         )
       case "error":
         return <Icon name="circle-x" class="text-error" />
+      case "unread":
+        return (
+          <span
+            aria-label={language.t("sidebar.session.unread")}
+            role="img"
+            class="block size-2 rounded-full bg-brand-primary"
+          />
+        )
       case "time": {
         const t = props.timeText?.(props.session)
         return t ? <span class="text-caption text-fg-weaker whitespace-nowrap">{t}</span> : null

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -106,13 +106,14 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     return childSessionOnPath(sessionStore.session, props.session.id, params.id)
   })
 
-  const statusKind = createMemo(() => {
-    const asking = isAsking()
-    const busy = !asking && !!sessionRunning()
-    const error = !asking && !busy && hasError()
-    const unread = !asking && !busy && !error && notification.session.unseenCount(props.session.id) > 0
-    return sidebarStatusKind({ asking, busy, error, unread })
-  })
+  const statusKind = createMemo(() =>
+    sidebarStatusKind({
+      asking: isAsking(),
+      busy: !!sessionRunning(),
+      error: hasError(),
+      unread: notification.session.unseenCount(props.session.id) > 0,
+    }),
+  )
 
   const statusContent = (): JSX.Element => {
     switch (statusKind()) {

--- a/packages/app/src/pages/layout/sidebar-status-kind.test.ts
+++ b/packages/app/src/pages/layout/sidebar-status-kind.test.ts
@@ -3,22 +3,50 @@ import { sidebarStatusKind } from "./sidebar-status-kind"
 
 describe("sidebarStatusKind", () => {
   test("returns time when nothing is happening", () => {
-    expect(sidebarStatusKind({ asking: false, busy: false, error: false })).toBe("time")
+    expect(sidebarStatusKind({ asking: false, busy: false, error: false, unread: false })).toBe("time")
   })
 
-  test("prefers asking over busy", () => {
-    expect(sidebarStatusKind({ asking: true, busy: true, error: false })).toBe("asking")
-  })
-
-  test("prefers asking over error", () => {
-    expect(sidebarStatusKind({ asking: true, busy: false, error: true })).toBe("asking")
-  })
-
-  test("prefers busy over error", () => {
-    expect(sidebarStatusKind({ asking: false, busy: true, error: true })).toBe("busy")
+  test("returns unread when only unread is true", () => {
+    expect(sidebarStatusKind({ asking: false, busy: false, error: false, unread: true })).toBe("unread")
   })
 
   test("returns error when only error is true", () => {
-    expect(sidebarStatusKind({ asking: false, busy: false, error: true })).toBe("error")
+    expect(sidebarStatusKind({ asking: false, busy: false, error: true, unread: false })).toBe("error")
+  })
+
+  test("prefers asking over busy", () => {
+    expect(sidebarStatusKind({ asking: true, busy: true, error: false, unread: false })).toBe("asking")
+  })
+
+  test("prefers asking over error", () => {
+    expect(sidebarStatusKind({ asking: true, busy: false, error: true, unread: false })).toBe("asking")
+  })
+
+  test("prefers asking over unread", () => {
+    expect(sidebarStatusKind({ asking: true, busy: false, error: false, unread: true })).toBe("asking")
+  })
+
+  test("prefers busy over error", () => {
+    expect(sidebarStatusKind({ asking: false, busy: true, error: true, unread: false })).toBe("busy")
+  })
+
+  test("prefers busy over unread (busy ring conveys 'wait' better than dot conveys 'come look')", () => {
+    expect(sidebarStatusKind({ asking: false, busy: true, error: false, unread: true })).toBe("busy")
+  })
+
+  test("prefers error over unread", () => {
+    expect(sidebarStatusKind({ asking: false, busy: false, error: true, unread: true })).toBe("error")
+  })
+
+  test("all four agent states true: asking wins (highest priority)", () => {
+    expect(sidebarStatusKind({ asking: true, busy: true, error: true, unread: true })).toBe("asking")
+  })
+
+  test("busy + error + unread (no asking): busy wins", () => {
+    expect(sidebarStatusKind({ asking: false, busy: true, error: true, unread: true })).toBe("busy")
+  })
+
+  test("error + unread (no asking/busy): error wins", () => {
+    expect(sidebarStatusKind({ asking: false, busy: false, error: true, unread: true })).toBe("error")
   })
 })

--- a/packages/app/src/pages/layout/sidebar-status-kind.ts
+++ b/packages/app/src/pages/layout/sidebar-status-kind.ts
@@ -1,22 +1,29 @@
-// 4-state right-slot status:
-//   asking → busy → error → time.
+// 5-state right-slot status:
+//   asking → busy → error → unread → time.
 // retry maps to busy upstream; interrupted falls through to time.
+// asking outranks busy/error/unread because it hard-blocks the user (the
+// agent is waiting for input). busy outranks unread because the spinning
+// ring already says "wait", while a dot would invite the user to click
+// into a still-running session. error outranks unread because errors
+// need active handling and unread is a neutral nudge.
 // Pinned sessions are signaled by their position in the "pinned"
 // section header, not by a per-row badge — adding one would say the
 // same thing twice.
 // Pure function so the row component stays declarative and the
 // priority order is unit-testable.
-export type SidebarStatusKind = "asking" | "busy" | "error" | "time"
+export type SidebarStatusKind = "asking" | "busy" | "error" | "unread" | "time"
 
 export interface SidebarStatusInput {
   asking: boolean
   busy: boolean
   error: boolean
+  unread: boolean
 }
 
 export function sidebarStatusKind(input: SidebarStatusInput): SidebarStatusKind {
   if (input.asking) return "asking"
   if (input.busy) return "busy"
   if (input.error) return "error"
+  if (input.unread) return "unread"
   return "time"
 }


### PR DESCRIPTION
## Summary

Add a 5th `unread` state to the sidebar session row right-slot status indicator, rendered as a brand-orange 8px solid dot. Wire it from the existing `useNotification().session.unseenCount(id)` boolean. No data-layer changes.

Priority chain extends from `asking > busy > error > time` to `asking > busy > error > unread > time`. `busy > unread` is deliberate: an actively-running session keeps showing the spinning ring instead of being shadowed by a static dot.

## Why

Before this change, a session row had no visual signal when its agent finished a turn while the user was elsewhere. A week-old idle session and a session that just finished replying looked identical. The notification context already tracked the data (turn-complete events, 30-day persisted, viewed boolean, `markViewed` on session enter), but the sidebar never read it.

This brings PawWork to parity with the same indicator pattern in ChatGPT, Claude Code (VS Code), Linear, iOS Mail, macOS Mail, and Slack. The brand-orange dot, paired with the existing brand-orange asking-bubble and brand-or-agent-tint busy spinner, also formalizes brand orange in the sidebar as the "agent activity" family color rather than a one-off CTA accent.

## Related Issue

No standalone issue tracker entry; the design discussion happened in the brainstorming session leading to this PR. Two preexisting follow-ups discovered during implementation: #789 (sidebar right-side controls shift toward sidebar edge), #790 (three-dot hover vs sort hover overlay mismatch). Neither is in scope here.

## Human Review Status

Pending

## Review Focus

- `packages/app/src/pages/layout/sidebar-status-kind.ts` — the priority chain. Specifically the `busy > unread` and `error > unread` placements. The accompanying 12-case truth-table test locks the contract.
- `packages/app/src/pages/layout/sidebar-items.tsx:109-115` — the `statusKind` memo guards each lower-priority state with `!higher`, so `sidebarStatusKind` always receives mutually-exclusive booleans. New `unread = !asking && !busy && !error && unseenCount > 0` line follows the existing pattern.
- `packages/app/src/pages/layout/sidebar-items.tsx:131-138` — the new `case "unread"` render. 8px brand-orange dot via Tailwind `size-2 rounded-full bg-brand-primary`; `role="img"` + `aria-label` for screen readers.
- The dot clears the moment the user enters that session via the existing `layout.tsx:1669 syncSessionRoute → markViewed`. No new clearing logic.

## Risk Notes

Low risk. Pure-function change behind one new boolean input; new render case behind `unseenCount > 0`. Existing `asking`/`busy`/`error`/`time` paths and existing notification data flow are untouched. `busy` ring color (`tint() ?? brand-primary`) is unchanged.

The new render only fires when `unseenCount > 0`, which is `0` by default and on any session the user has just entered, so existing sessions show the same as before.

## How To Verify

```text
# Unit truth-table (priority order, including busy > unread and error > unread)
cd packages/app && bun test src/pages/layout/sidebar-status-kind.test.ts
  -> 12 pass, 0 fail

# Full sidebar layout test surface (regression)
cd packages/app && bun test src/pages/layout/
  -> 121 pass, 0 fail

# i18n parity (new sidebar.session.unread key in en + zh)
cd packages/app && bun test src/i18n/
  -> 3 pass, 0 fail

# Typecheck
cd packages/app && bun run typecheck
  -> EXIT=0

# Visual regression on the default sidebar shot (no unread session in fixture)
cd packages/app && bun run snap sidebar
  -> 1 passed; default/sort-menu/closed grid unchanged

# Manual desktop walk (bun run dev:desktop), three paths:
#   1. Unread dot appears: send a prompt, switch away, observe brand-orange dot
#      on original session row when the agent replies.
#   2. Enter clears dot: click the row, dot disappears in the same frame.
#   3. Visual alignment with sort button center: confirmed.
# Busy outranks unread (path 3 in the spec) is not naturally reproducible in
# manual testing; coverage relies on the truth-table assertion above.
```

## Screenshots or Recordings

Screenshot of the brand-orange unread dot on a sidebar session row is attached to this PR via the GitHub editor (see body update after open).

<img width="392" height="934" alt="sidebar-unread" src="https://github.com/user-attachments/assets/4edeee2e-7024-468d-a726-ac6512c867cb" />

The default `bun run snap sidebar` grid is unchanged because the snap fixture has no unread session; adding a focused `sidebar-unread` snap target was considered and explicitly deferred to keep this PR focused.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions in the sidebar now display an unread indicator when they contain unread messages, making it easier to identify conversations needing attention. Support for English and Chinese localizations included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->