### PR TITLE
perf(app): virtualize session timeline rows

### DIFF
--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -15,6 +15,7 @@ import type { createSdk } from "../utils"
 import { composerEvent, type ComposerDriverState, type ComposerWindow } from "../../src/testing/session-composer"
 import { installPerfProbe, resetPerfProbe, snapshotPerfProbe, summarizeScenarioRuns } from "./probe"
 import { applyPerfProfile, readPerfProfile, shouldRunScenario, type PerfScenarioName } from "./profiles"
+import { readTimelineDomBudget, shouldAssertTimelineVirtualization } from "./timeline-dom-budget"
 import {
   TIMELINE_RECOMPUTE_SEED_TURN_COUNT,
   buildHeterogeneousScrollSeedText,
@@ -55,8 +56,6 @@ const inputLagText = [
 ].join(" ")
 
 const longScrollSeedTurns = 104
-const sessionVirtualizerSelector = '[data-component="session-timeline-virtualizer"]'
-const sessionVirtualRowSelector = '[data-component="session-virtual-row"]'
 const longScrollMinimumAvailableRows = 80
 const longScrollMaximumMountedMessages = 48
 const longScrollCoverageRatio = 0.95
@@ -217,33 +216,6 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
   await expect
     .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 30_000 })
     .toBeGreaterThanOrEqual(expectedCount)
-}
-
-async function readTimelineDomBudget(page: Parameters<typeof snapshotPerfProbe>[0]) {
-  return page.evaluate(
-    ({ messageSelector, rowSelector, virtualizerSelector }) => {
-      const virtualizer = document.querySelector(virtualizerSelector)
-      const rows = Array.from(document.querySelectorAll(rowSelector))
-      const messages = Array.from(document.querySelectorAll(messageSelector))
-      const virtualizedTotalRows = Number((virtualizer as HTMLElement | null)?.dataset.totalRows ?? 0)
-      return {
-        hasVirtualizer: virtualizer instanceof HTMLElement,
-        totalRows: virtualizedTotalRows > 0 ? virtualizedTotalRows : messages.length,
-        mountedRows: rows.length,
-        mountedMessages: messages.length,
-        visibleRows: rows.filter((row) => {
-          if (!(row instanceof HTMLElement)) return false
-          const rect = row.getBoundingClientRect()
-          return rect.bottom > 0 && rect.top < window.innerHeight
-        }).length,
-      }
-    },
-    {
-      messageSelector: sessionMessageItemSelector,
-      rowSelector: sessionVirtualRowSelector,
-      virtualizerSelector: sessionVirtualizerSelector,
-    },
-  )
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {
@@ -864,7 +836,7 @@ test.describe("PR0.1 perf probe baseline", () => {
         await revealLongScrollWindow(page)
         const budget = await readTimelineDomBudget(page)
         expect(budget.totalRows).toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
-        if (perfBranch !== "base") {
+        if (shouldAssertTimelineVirtualization(perfBranch)) {
           expect(budget.hasVirtualizer).toBe(true)
           expect(budget.mountedMessages).toBeLessThanOrEqual(longScrollMaximumMountedMessages)
           expect(budget.mountedMessages).toBeLessThan(budget.totalRows)

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -225,8 +225,10 @@ async function readTimelineDomBudget(page: Parameters<typeof snapshotPerfProbe>[
       const virtualizer = document.querySelector(virtualizerSelector)
       const rows = Array.from(document.querySelectorAll(rowSelector))
       const messages = Array.from(document.querySelectorAll(messageSelector))
+      const virtualizedTotalRows = Number((virtualizer as HTMLElement | null)?.dataset.totalRows ?? 0)
       return {
-        totalRows: Number((virtualizer as HTMLElement | null)?.dataset.totalRows ?? 0),
+        hasVirtualizer: virtualizer instanceof HTMLElement,
+        totalRows: virtualizedTotalRows > 0 ? virtualizedTotalRows : messages.length,
         mountedRows: rows.length,
         mountedMessages: messages.length,
         visibleRows: rows.filter((row) => {
@@ -862,8 +864,11 @@ test.describe("PR0.1 perf probe baseline", () => {
         await revealLongScrollWindow(page)
         const budget = await readTimelineDomBudget(page)
         expect(budget.totalRows).toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
-        expect(budget.mountedMessages).toBeLessThanOrEqual(longScrollMaximumMountedMessages)
-        expect(budget.mountedMessages).toBeLessThan(budget.totalRows)
+        if (perfBranch !== "base") {
+          expect(budget.hasVirtualizer).toBe(true)
+          expect(budget.mountedMessages).toBeLessThanOrEqual(longScrollMaximumMountedMessages)
+          expect(budget.mountedMessages).toBeLessThan(budget.totalRows)
+        }
         await writeComposerDriver(page, session.id, longScrollTodoDriver(run, 0))
         await expandLongScrollTodoDock(page)
 

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -7,6 +7,8 @@ import {
   promptSelector,
   sessionMessageItemSelector,
   sessionTurnListSelector,
+  sessionVirtualizerSelector,
+  sessionVirtualRowSelector,
   scrollViewportSelector,
   terminalSelector,
 } from "../selectors"
@@ -22,7 +24,8 @@ import {
 } from "./timeline-fixture"
 import { CONCURRENT_SHIMMER_COUNT, buildConcurrentShimmerReply } from "./concurrent-shimmer-fixture"
 
-const outputPath = process.env.PAWWORK_PERF_OUTPUT ?? path.join(process.cwd(), "e2e", "perf-results", "pr0.1-baseline.json")
+const outputPath =
+  process.env.PAWWORK_PERF_OUTPUT ?? path.join(process.cwd(), "e2e", "perf-results", "pr0.1-baseline.json")
 const perfBranch = process.env.PAWWORK_PERF_BRANCH ?? "dev"
 const PERF_PROFILE = readPerfProfile()
 
@@ -54,7 +57,8 @@ const inputLagText = [
 ].join(" ")
 
 const longScrollSeedTurns = 104
-const longScrollMinimumRenderedMessages = 80
+const longScrollMinimumAvailableRows = 80
+const longScrollMaximumMountedMessages = 48
 const longScrollCoverageRatio = 0.95
 const longScrollMinimumProbeWindowMs = 15_000
 const longScrollMaxRouteDurationMs = 30_000
@@ -91,7 +95,10 @@ type WheelRouteResult = {
   final: TimelineMetrics
 }
 
-const chatChunk = (delta: Record<string, unknown>, input?: { finish?: string; usage?: { input: number; output: number } }) => ({
+const chatChunk = (
+  delta: Record<string, unknown>,
+  input?: { finish?: string; usage?: { input: number; output: number } },
+) => ({
   id: "chatcmpl-test",
   object: "chat.completion.chunk",
   choices: [
@@ -183,11 +190,16 @@ async function submitVisiblePrompt(page: Parameters<typeof snapshotPerfProbe>[0]
   await prompt.fill("")
   await page.keyboard.type(text)
   await page.keyboard.press("Enter")
-  await expect.poll(async () => (await readPromptSend(page)).started, { timeout: 10_000 }).toBeGreaterThan(previous.started)
+  await expect
+    .poll(async () => (await readPromptSend(page)).started, { timeout: 10_000 })
+    .toBeGreaterThan(previous.started)
 }
 
 async function readPromptText(page: Parameters<typeof snapshotPerfProbe>[0]) {
-  return page.locator(promptSelector).first().evaluate((el) => (el.textContent ?? "").replace(/\u200B/g, "").trim())
+  return page
+    .locator(promptSelector)
+    .first()
+    .evaluate((el) => (el.textContent ?? "").replace(/\u200B/g, "").trim())
 }
 
 async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfProbe>[0], expectedCount: number) {
@@ -203,6 +215,31 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
     await loadEarlier.click()
   }
   await expect(messages).toHaveCount(expectedCount, { timeout: 30_000 })
+}
+
+async function readTimelineDomBudget(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  return page.evaluate(
+    ({ messageSelector, rowSelector, virtualizerSelector }) => {
+      const virtualizer = document.querySelector(virtualizerSelector)
+      const rows = Array.from(document.querySelectorAll(rowSelector))
+      const messages = Array.from(document.querySelectorAll(messageSelector))
+      return {
+        totalRows: Number((virtualizer as HTMLElement | null)?.dataset.totalRows ?? 0),
+        mountedRows: rows.length,
+        mountedMessages: messages.length,
+        visibleRows: rows.filter((row) => {
+          if (!(row instanceof HTMLElement)) return false
+          const rect = row.getBoundingClientRect()
+          return rect.bottom > 0 && rect.top < window.innerHeight
+        }).length,
+      }
+    },
+    {
+      messageSelector: sessionMessageItemSelector,
+      rowSelector: sessionVirtualRowSelector,
+      virtualizerSelector: sessionVirtualizerSelector,
+    },
+  )
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {
@@ -266,13 +303,16 @@ async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>
   await expect(messages.first()).toBeVisible({ timeout: 30_000 })
   await hoverTimelineScrollLane(page)
   for (let attempt = 0; attempt < 24; attempt += 1) {
-    if ((await messages.count()) >= longScrollMinimumRenderedMessages) return
+    const budget = await readTimelineDomBudget(page)
+    if (budget.totalRows >= longScrollMinimumAvailableRows) return
     await page.mouse.wheel(0, -2400)
     await settleFrames(page, 2)
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)
   }
-  await expect.poll(async () => messages.count().catch(() => -1), { timeout: 1_000 }).toBeGreaterThanOrEqual(longScrollMinimumRenderedMessages)
+  await expect
+    .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_000 })
+    .toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
 }
 
 async function installComposerPerfDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
@@ -319,11 +359,7 @@ function longScrollTodoDriver(run: number, phase: number): ComposerDriverState {
   }
 }
 
-function longScrollTodoPulse(
-  page: Parameters<typeof snapshotPerfProbe>[0],
-  sessionID: string,
-  run: number,
-) {
+function longScrollTodoPulse(page: Parameters<typeof snapshotPerfProbe>[0], sessionID: string, run: number) {
   const checkpoints = [700, 1_600, 2_800, 4_200]
   let next = 0
   return async (elapsedMs: number) => {
@@ -492,11 +528,7 @@ async function enableShellToolPartsExpanded(page: Parameters<typeof snapshotPerf
   await page.evaluate(apply)
 }
 
-async function seedHeavyBashSession(input: {
-  project: PerfProject
-  llm: PerfLlm
-  run: number
-}) {
+async function seedHeavyBashSession(input: { project: PerfProject; llm: PerfLlm; run: number }) {
   const session = await input.project.sdk.session
     .create({
       title: `perf heavy bash ${Date.now()}-${input.run}`,
@@ -571,7 +603,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       if (run < 2) await cooldownAfterRun(page)
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "homepage-cold", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "homepage-cold", runs }),
+    )
   })
 
   test("long-session-input-lag emits a 3-run JSON baseline", async ({ page, project }) => {
@@ -602,7 +636,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       })
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "long-session-input-lag", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "long-session-input-lag", runs }),
+    )
   })
 
   test("session-streaming-long emits a 3-run JSON baseline", async ({ page, project, llm }) => {
@@ -616,7 +652,10 @@ test.describe("PR0.1 perf probe baseline", () => {
       const firstWave = deferred()
       const secondWave = deferred()
       const chunks = splitText(longMarkdown, 320)
-      const headChunks = [chatChunk({ role: "assistant" }), ...chunks.slice(0, 3).map((chunk) => chatChunk({ content: chunk }))]
+      const headChunks = [
+        chatChunk({ role: "assistant" }),
+        ...chunks.slice(0, 3).map((chunk) => chatChunk({ content: chunk })),
+      ]
       const stageOneChunks = chunks.slice(3, 9).map((chunk) => chatChunk({ content: chunk }))
       const stageTwoChunks = chunks.slice(9).map((chunk) => chatChunk({ content: chunk }))
 
@@ -634,7 +673,9 @@ test.describe("PR0.1 perf probe baseline", () => {
 
       const send = project.prompt(`Stream probe ${run + 1}`)
       await expect.poll(() => page.url(), { timeout: 30_000 }).toContain("/session/")
-      await expect(page.getByText("This stream exists to stress markdown rendering while the session remains interactive.")).toBeVisible({
+      await expect(
+        page.getByText("This stream exists to stress markdown rendering while the session remains interactive."),
+      ).toBeVisible({
         timeout: 30_000,
       })
 
@@ -649,7 +690,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       if (run < 2) await cooldownAfterRun(page)
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-streaming-long", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-streaming-long", runs }),
+    )
   })
 
   test("tool-call-expand emits a 3-run JSON baseline", async ({ page, project, llm }) => {
@@ -667,7 +710,10 @@ test.describe("PR0.1 perf probe baseline", () => {
       await llm.tool("enter-worktree", { path: created.directory })
       await llm.text(`tool call baseline ${run + 1}`)
       await project.prompt(`Create todos for perf probe run ${run + 1}.`)
-      const trigger = page.locator('[data-slot="collapsible-trigger"]').filter({ has: page.locator('[data-component="tool-trigger"]') }).first()
+      const trigger = page
+        .locator('[data-slot="collapsible-trigger"]')
+        .filter({ has: page.locator('[data-component="tool-trigger"]') })
+        .first()
       await expect(trigger).toBeVisible({ timeout: 30_000 })
       await resetPerfProbe(page)
       await trigger.click()
@@ -681,7 +727,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       if (run < 2) await cooldownAfterRun(page)
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "tool-call-expand", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "tool-call-expand", runs }),
+    )
   })
 
   test("tool-default-open-heavy-bash emits a 3-run JSON baseline", async ({ page, project, llm }) => {
@@ -696,7 +744,10 @@ test.describe("PR0.1 perf probe baseline", () => {
       const session = await seedHeavyBashSession({ project, llm, run })
       try {
         await page.goto(sessionPath(project.directory, session.id))
-        const trigger = page.locator('[data-slot="collapsible-trigger"]').filter({ has: page.locator('[data-component="tool-trigger"]') }).first()
+        const trigger = page
+          .locator('[data-slot="collapsible-trigger"]')
+          .filter({ has: page.locator('[data-component="tool-trigger"]') })
+          .first()
         await expect(trigger).toBeVisible({ timeout: 30_000 })
         await expect(trigger).toHaveAttribute("aria-expanded", "true")
         await settleFrames(page, 2)
@@ -708,7 +759,12 @@ test.describe("PR0.1 perf probe baseline", () => {
     }
 
     scenarioResults.push(
-      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "tool-default-open-heavy-bash", runs }),
+      summarizeScenarioRuns({
+        branch: perfBranch,
+        profile: PERF_PROFILE,
+        scenario: "tool-default-open-heavy-bash",
+        runs,
+      }),
     )
   })
 
@@ -738,7 +794,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       })
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "terminal-side-panel-open", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "terminal-side-panel-open", runs }),
+    )
   })
 
   test("session-scroll-reading emits a 3-run JSON baseline", async ({ page, project }) => {
@@ -779,7 +837,9 @@ test.describe("PR0.1 perf probe baseline", () => {
       })
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-scroll-reading", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-scroll-reading", runs }),
+    )
   })
 
   test("session-scroll-reading-long emits a low-end full-coverage JSON baseline", async ({ page, project }) => {
@@ -796,6 +856,10 @@ test.describe("PR0.1 perf probe baseline", () => {
         await seedLongScrollSession(project, session.id, run)
         await page.goto(sessionPath(project.directory, session.id))
         await revealLongScrollWindow(page)
+        const budget = await readTimelineDomBudget(page)
+        expect(budget.totalRows).toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
+        expect(budget.mountedMessages).toBeLessThanOrEqual(longScrollMaximumMountedMessages)
+        expect(budget.mountedMessages).toBeLessThan(budget.totalRows)
         await writeComposerDriver(page, session.id, longScrollTodoDriver(run, 0))
         await expandLongScrollTodoDock(page)
 
@@ -852,7 +916,12 @@ test.describe("PR0.1 perf probe baseline", () => {
     }
 
     scenarioResults.push(
-      summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-scroll-reading-long", runs }),
+      summarizeScenarioRuns({
+        branch: perfBranch,
+        profile: PERF_PROFILE,
+        scenario: "session-scroll-reading-long",
+        runs,
+      }),
     )
   })
 
@@ -882,7 +951,14 @@ test.describe("PR0.1 perf probe baseline", () => {
       })
     }
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "session-timeline-recompute", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({
+        branch: perfBranch,
+        profile: PERF_PROFILE,
+        scenario: "session-timeline-recompute",
+        runs,
+      }),
+    )
   })
 
   test("concurrent-shimmer-extreme emits a low-end JSON baseline", async ({ page, project, llm }) => {
@@ -911,9 +987,7 @@ test.describe("PR0.1 perf probe baseline", () => {
     // Guard against CI runners with reduced-motion forced on — text-shimmer.css
     // disables the animation entirely in that mode, which would silently mask
     // any regression.
-    const reducedMotion = await page.evaluate(
-      () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
-    )
+    const reducedMotion = await page.evaluate(() => window.matchMedia("(prefers-reduced-motion: reduce)").matches)
     expect(reducedMotion).toBe(false)
 
     // Sample idle-shimmer cost across at least 2 full 1800ms cycles so the
@@ -923,6 +997,13 @@ test.describe("PR0.1 perf probe baseline", () => {
     await settleFrames(page, 4)
     const runs = [await snapshotPerfProbe(page)]
 
-    scenarioResults.push(summarizeScenarioRuns({ branch: perfBranch, profile: PERF_PROFILE, scenario: "concurrent-shimmer-extreme", runs }))
+    scenarioResults.push(
+      summarizeScenarioRuns({
+        branch: perfBranch,
+        profile: PERF_PROFILE,
+        scenario: "concurrent-shimmer-extreme",
+        runs,
+      }),
+    )
   })
 })

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -214,7 +214,9 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
     await expect(loadEarlier).toBeVisible({ timeout: 30_000 })
     await loadEarlier.click()
   }
-  await expect(messages).toHaveCount(expectedCount, { timeout: 30_000 })
+  await expect
+    .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 30_000 })
+    .toBeGreaterThanOrEqual(expectedCount)
 }
 
 async function readTimelineDomBudget(page: Parameters<typeof snapshotPerfProbe>[0]) {
@@ -626,7 +628,9 @@ test.describe("PR0.1 perf probe baseline", () => {
         const prompt = page.locator(promptSelector).first()
         await prompt.click()
         await prompt.fill("")
-        await expect(page.locator(sessionMessageItemSelector)).toHaveCount(TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
+        await expect
+          .poll(async () => (await readTimelineDomBudget(page)).totalRows)
+          .toBeGreaterThanOrEqual(TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
         await resetPerfProbe(page)
         await page.keyboard.type(`${inputLagText} run ${run + 1}.`)
         await expect.poll(() => readPromptText(page)).toBe(`${inputLagText} run ${run + 1}.`)

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -7,8 +7,6 @@ import {
   promptSelector,
   sessionMessageItemSelector,
   sessionTurnListSelector,
-  sessionVirtualizerSelector,
-  sessionVirtualRowSelector,
   scrollViewportSelector,
   terminalSelector,
 } from "../selectors"
@@ -57,6 +55,8 @@ const inputLagText = [
 ].join(" ")
 
 const longScrollSeedTurns = 104
+const sessionVirtualizerSelector = '[data-component="session-timeline-virtualizer"]'
+const sessionVirtualRowSelector = '[data-component="session-virtual-row"]'
 const longScrollMinimumAvailableRows = 80
 const longScrollMaximumMountedMessages = 48
 const longScrollCoverageRatio = 0.95

--- a/packages/app/e2e/perf/timeline-dom-budget.ts
+++ b/packages/app/e2e/perf/timeline-dom-budget.ts
@@ -1,0 +1,44 @@
+import type { Page } from "@playwright/test"
+
+const timelineMessageSelector = "[data-message-id]"
+const timelineVirtualizerSelector = '[data-component="session-timeline-virtualizer"]'
+const timelineVirtualRowSelector = '[data-component="session-virtual-row"]'
+
+export type TimelineDomBudget = {
+  hasVirtualizer: boolean
+  totalRows: number
+  mountedRows: number
+  mountedMessages: number
+  visibleRows: number
+}
+
+export function shouldAssertTimelineVirtualization(perfBranch: string) {
+  return perfBranch !== "base"
+}
+
+export async function readTimelineDomBudget(page: Page): Promise<TimelineDomBudget> {
+  return page.evaluate(
+    ({ messageSelector, rowSelector, virtualizerSelector }) => {
+      const virtualizer = document.querySelector(virtualizerSelector)
+      const rows = Array.from(document.querySelectorAll(rowSelector))
+      const messages = Array.from(document.querySelectorAll(messageSelector))
+      const virtualizedTotalRows = Number((virtualizer as HTMLElement | null)?.dataset.totalRows ?? 0)
+      return {
+        hasVirtualizer: virtualizer instanceof HTMLElement,
+        totalRows: virtualizedTotalRows > 0 ? virtualizedTotalRows : messages.length,
+        mountedRows: rows.length,
+        mountedMessages: messages.length,
+        visibleRows: rows.filter((row) => {
+          if (!(row instanceof HTMLElement)) return false
+          const rect = row.getBoundingClientRect()
+          return rect.bottom > 0 && rect.top < window.innerHeight
+        }).length,
+      }
+    },
+    {
+      messageSelector: timelineMessageSelector,
+      rowSelector: timelineVirtualRowSelector,
+      virtualizerSelector: timelineVirtualizerSelector,
+    },
+  )
+}

--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -7,6 +7,8 @@ export const sessionComposerColumnSelector = '[data-component="session-composer-
 export const sessionTimelineColumnSelector = '[data-component="session-timeline-column"]'
 export const sessionTurnListSelector = '[data-slot="session-turn-list"]'
 export const sessionMessageItemSelector = "[data-message-id]"
+export const sessionVirtualizerSelector = '[data-component="session-timeline-virtualizer"]'
+export const sessionVirtualRowSelector = '[data-component="session-virtual-row"]'
 export const scrollViewSelector = '[data-component="scroll-view"]'
 export const scrollViewportSelector = '[data-component="scroll-viewport"]'
 export const scrollThumbSelector = '[data-component="scroll-thumb"]'

--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -248,11 +248,13 @@ async function expandRenderedTimeline(page: Page, target: number) {
   await expect
     .poll(
       async () => {
-        const count = await page.locator(sessionMessageItemSelector).count()
-        if (count >= target) return count
+        const total = Number(
+          (await page.locator(sessionVirtualizerSelector).first().getAttribute("data-total-rows")) ?? 0,
+        )
+        if (total >= target) return total
         await viewport.hover()
         await page.mouse.wheel(0, -2400)
-        return page.locator(sessionMessageItemSelector).count()
+        return Number((await page.locator(sessionVirtualizerSelector).first().getAttribute("data-total-rows")) ?? 0)
       },
       { timeout: 30_000 },
     )

--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -278,8 +278,15 @@ async function expectTimelineAvailableRows(page: Page, target: number) {
 }
 
 async function expectVirtualTimelineMounted(page: Page) {
-  const value = await page.locator(sessionVirtualizerSelector).first().getAttribute("data-total-rows")
-  expect(Number(value ?? 0)).toBeGreaterThan(0)
+  await expect
+    .poll(
+      async () => {
+        const value = await page.locator(sessionVirtualizerSelector).first().getAttribute("data-total-rows")
+        return Number(value ?? 0)
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0)
   await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeLessThanOrEqual(48)
 }
 
@@ -587,7 +594,8 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     const followupVisibleCounts = followupEvents
       .filter((event) => event.name === "session.timeline.visible")
       .map((event) => numberData(event, "rendered_count") ?? 0)
-    if (followupVisibleCounts.length > 0) expect(Math.max(...followupVisibleCounts)).toBeGreaterThan(0)
+    expect(followupVisibleCounts.length).toBeGreaterThan(0)
+    expect(Math.max(...followupVisibleCounts)).toBeGreaterThan(0)
 
     const followupScrollJumps = followupEvents.filter((event) => {
       if (event.name !== "session.scroll.sample") return false

--- a/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
+++ b/packages/app/e2e/session/session-renderer-diagnostics.spec.ts
@@ -8,6 +8,7 @@ import {
   scrollViewportSelector,
   sessionMessageItemSelector,
   sessionTurnListSelector,
+  sessionVirtualizerSelector,
 } from "../selectors"
 import { createSdk } from "../utils"
 
@@ -258,6 +259,28 @@ async function expandRenderedTimeline(page: Page, target: number) {
     .toBeGreaterThanOrEqual(target)
 }
 
+async function expectTimelineAvailableRows(page: Page, target: number) {
+  await expect
+    .poll(
+      async () => {
+        const value = await page
+          .locator(sessionVirtualizerSelector)
+          .first()
+          .getAttribute("data-total-rows")
+          .catch(() => null)
+        return Number(value ?? 0)
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThanOrEqual(target)
+}
+
+async function expectVirtualTimelineMounted(page: Page) {
+  const value = await page.locator(sessionVirtualizerSelector).first().getAttribute("data-total-rows")
+  expect(Number(value ?? 0)).toBeGreaterThan(0)
+  await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeLessThanOrEqual(48)
+}
+
 async function readPromptSent(page: Page) {
   return page.evaluate(() => {
     const win = window as typeof window & {
@@ -359,9 +382,9 @@ test("captures renderer diagnostics while guarding send scroll position", async 
       .filter((event) => event.name === "session.timeline.visible")
       .map((event) => numberData(event, "rendered_count") ?? 0)
     expect(Math.min(...visibleCounts)).toBeGreaterThan(0)
-    expect(
-      events.some((event) => event.name === "session.scroll.sample" && event.data?.user_scrolled === false),
-    ).toBe(true)
+    expect(events.some((event) => event.name === "session.scroll.sample" && event.data?.user_scrolled === false)).toBe(
+      true,
+    )
   })
 })
 
@@ -515,30 +538,25 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     await llm.tool("enter-worktree", { path: worktreeDirectory })
     await sendVisiblePrompt({ page, text: "enter diagnostics worktree" })
     await waitSessionActiveDirectory({ sdk, sessionID: session.id, directory: worktreeDirectory })
-    await expect
-      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
-      .toBeGreaterThanOrEqual(80)
+    await expectVirtualTimelineMounted(page)
 
     await llm.tool("exit-worktree", {})
     await sendVisiblePrompt({ page, text: "exit diagnostics worktree" })
     await waitSessionActiveDirectory({ sdk, sessionID: session.id, directory: project.directory })
-    await expect
-      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
-      .toBeGreaterThanOrEqual(80)
+    await expectVirtualTimelineMounted(page)
     await expect.poll(async () => (await expectTimelineMetrics(page)).top).toBeGreaterThan(20)
 
     const followupCheckpoint = (await readRendererDiagnostics(page)).length
-    const sentBeforeFollowup = await readPromptSent(page)
     const followupText = `worktree exit follow-up ${Date.now()}`
     await sendVisiblePrompt({ page, text: followupText })
-    await expect
-      .poll(async () => page.locator(sessionMessageItemSelector).count(), { timeout: 30_000 })
-      .toBeGreaterThanOrEqual(80)
+    await expectVirtualTimelineMounted(page)
 
     await expect
       .poll(
         async () => {
-          const messages = await sdk.session.messages({ sessionID: session.id, limit: 200 }).then((res) => res.data ?? [])
+          const messages = await sdk.session
+            .messages({ sessionID: session.id, limit: 200 })
+            .then((res) => res.data ?? [])
           return {
             count: messages.length,
             hasFollowup: messages.some((message) =>
@@ -554,7 +572,6 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     expect(messages.length).toBeGreaterThanOrEqual(91)
 
     const sent = await readPromptSent(page)
-    expect(sent.count).toBeGreaterThan(sentBeforeFollowup.count)
     expect(sent.sessionID).toBe(session.id)
     expect(sent.directory).toBe(project.directory)
 
@@ -568,7 +585,7 @@ test("keeps long timeline stable across worktree exit follow-up", async ({ page,
     const followupVisibleCounts = followupEvents
       .filter((event) => event.name === "session.timeline.visible")
       .map((event) => numberData(event, "rendered_count") ?? 0)
-    if (followupVisibleCounts.length > 0) expect(Math.max(...followupVisibleCounts)).toBeGreaterThanOrEqual(80)
+    if (followupVisibleCounts.length > 0) expect(Math.max(...followupVisibleCounts)).toBeGreaterThan(0)
 
     const followupScrollJumps = followupEvents.filter((event) => {
       if (event.name !== "session.scroll.sample") return false

--- a/packages/app/e2e/session/session-scroll-position.spec.ts
+++ b/packages/app/e2e/session/session-scroll-position.spec.ts
@@ -229,6 +229,10 @@ function collectPageErrors(page: Page) {
   }
 }
 
+function relevantPageErrors(errors: CapturedPageError[]) {
+  return errors.filter((error) => error.message !== "ResizeObserver loop completed with undelivered notifications.")
+}
+
 async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: number }) {
   for (let i = 0; i < input.count; i++) {
     await input.sdk.session.promptAsync({
@@ -572,7 +576,7 @@ test("renders the full initial session window when switching sessions", async ({
       const removedMountFrames = samples.filter((sample) => sample.removedComposerDock || sample.removedMessageList)
       const invalidComposerFrames = switched.filter((sample) => sample.composerDock !== 1 || sample.composerHeight <= 0)
       const invalidMessageListFrames = switched.filter((sample) => sample.messageList !== 1)
-      const pageErrors = await readPageErrorProbe(page)
+      const pageErrors = relevantPageErrors(await readPageErrorProbe(page))
 
       expect(switched.length).toBeGreaterThan(0)
       expect(rendered.every((id) => secondIDs.has(id))).toBe(true)
@@ -593,6 +597,6 @@ test("renders the full initial session window when switching sessions", async ({
       await page.goto(current.toString())
     })
   })
-  expect(pageErrorEvents.errors).toEqual([])
+  expect(relevantPageErrors(pageErrorEvents.errors)).toEqual([])
   pageErrorEvents.dispose()
 })

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -372,9 +372,7 @@ export default function Page() {
     ),
   )
 
-  const renderComposerRegion = (ctx?: {
-    onModeChange: (mode: "normal" | "shell") => void
-  }) => (
+  const renderComposerRegion = (ctx?: { onModeChange: (mode: "normal" | "shell") => void }) => (
     <SessionPageComposerRegion
       state={composer}
       ready={!deferRender() && sessionActionReady()}
@@ -427,9 +425,7 @@ export default function Page() {
     />
   )
 
-  const renderHomeComposerRegion = (ctx?: {
-    onModeChange: (mode: "normal" | "shell") => void
-  }) => (
+  const renderHomeComposerRegion = (ctx?: { onModeChange: (mode: "normal" | "shell") => void }) => (
     <HomeComposerRegion
       inputRef={(el) => {
         inputRef = el
@@ -491,6 +487,7 @@ export default function Page() {
       historyMore={timelineHistoryMore()}
       historyLoading={timelineHistoryLoading()}
       anchor={timelineInteraction.anchor}
+      virtualizerBridge={timelineInteraction.virtualizerBridge}
       onRetryOpenSession={retryOpenRouteSession}
       onOpenNewSession={openNewRouteSession}
       composerSession={renderComposerRegion()}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -29,6 +29,7 @@ import {
   type TimelineVirtualRow,
 } from "@/pages/session/timeline-virtual-rows"
 import { TimelineRowRenderer } from "@/pages/session/timeline-row-renderer"
+import { timelineMessageRowStyle } from "@/pages/session/timeline-row-layout"
 import type { TimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
 import { chooseTimelineRowRenderMode } from "@/pages/session/timeline-virtualization-strategy"
 import {
@@ -312,6 +313,7 @@ export function MessageTimeline(props: {
           "min-w-0 w-full max-w-full": true,
           "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
         }}
+        style={timelineMessageRowStyle({ mode: rowRenderMode(), active: active() })}
       >
         <SessionMessageComments comments={comments()} />
         <SessionTurn

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,5 @@
-import { For, createEffect, createMemo, on, onCleanup, onMount, Show, type JSX } from "solid-js"
+import { createEffect, createMemo, on, onCleanup, onMount, Show, type JSX } from "solid-js"
+import { Virtualizer } from "virtua/solid"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { SessionTurn } from "@opencode-ai/ui/session-turn"
@@ -22,6 +23,13 @@ import {
   shouldMarkTimelineBoundaryGesture,
 } from "@/pages/session/session-timeline-scroll-intents"
 import { createTimelineStaging } from "@/pages/session/session-timeline-staging"
+import {
+  createTimelineVirtualRows,
+  classifyTimelineRowMutation,
+  type TimelineRowMutation,
+  type TimelineVirtualRow,
+} from "@/pages/session/timeline-virtual-rows"
+import type { TimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
 import {
   areMessageCommentsEqual,
   extractMessageComments,
@@ -83,6 +91,7 @@ export function MessageTimeline(props: {
   onLoadEarlier: () => void
   renderedUserMessages: UserMessage[]
   anchor: (id: string) => string
+  virtualizerBridge: TimelineVirtualizerBridge
 }) {
   let touchGesture: number | undefined
   let scrollSampleFrame: number | undefined
@@ -253,6 +262,17 @@ export function MessageTimeline(props: {
     messages: () => props.renderedUserMessages,
     config: stageCfg,
   })
+  const rows = createMemo(() =>
+    createTimelineVirtualRows({
+      messages: props.renderedUserMessages,
+      historyMore: props.historyMore,
+      turnStart: props.turnStart,
+    }),
+  )
+  const rowMutation = createMemo<{ rows: readonly TimelineVirtualRow[]; mutation: TimelineRowMutation }>((previous) => {
+    const next = rows()
+    return { rows: next, mutation: classifyTimelineRowMutation({ previous: previous?.rows ?? [], next }) }
+  })
 
   return (
     <Show
@@ -264,8 +284,7 @@ export function MessageTimeline(props: {
           class="absolute left-1/2 -translate-x-1/2 bottom-[calc(var(--composer-dock-height,0px)+2.5rem)] z-[60] pointer-events-none transition-opacity duration-200 ease-out"
           classList={{
             "opacity-100": props.scroll.overflow && props.scroll.jump && !staging.isStaging(),
-            "opacity-0 pointer-events-none":
-              !props.scroll.overflow || !props.scroll.jump || staging.isStaging(),
+            "opacity-0 pointer-events-none": !props.scroll.overflow || !props.scroll.jump || staging.isStaging(),
           }}
         >
           {/* 偏离: W1 preview L267 锁 cursor:pointer，用户 2026-05-15 决定改回默认。preview/DESIGN 同步留 follow-up。 */}
@@ -387,9 +406,10 @@ export function MessageTimeline(props: {
           >
             <div
               role="log"
-              data-component="session-timeline-column"
+              data-component="session-timeline-virtualizer"
               data-slot="session-turn-list"
-              class="flex flex-col items-start justify-start pb-4 transition-[margin]"
+              data-total-rows={rows().length}
+              class="transition-[margin]"
               classList={{
                 "w-full": true,
                 "md:max-w-[800px] md:mx-auto 2xl:max-w-[1000px]": props.centered,
@@ -397,46 +417,57 @@ export function MessageTimeline(props: {
                 "mt-0": !props.centered,
               }}
             >
-              <Show when={props.turnStart > 0 || props.historyMore}>
-                <div class="w-full flex justify-center">
-                  <Button
-                    variant="ghost"
-                    size="large"
-                    class="text-h3 opacity-50"
-                    disabled={props.historyLoading}
-                    onClick={props.onLoadEarlier}
-                  >
-                    {props.historyLoading
-                      ? language.t("session.messages.loadingEarlier")
-                      : language.t("session.messages.loadEarlier")}
-                  </Button>
-                </div>
-              </Show>
-              <For each={rendered()}>
-                {(messageID, index) => {
-                  const userMessage = createMemo(() => props.renderedUserMessages[index()])
+              <Virtualizer
+                ref={(handle) => props.virtualizerBridge.setHandle(handle)}
+                data={rows()}
+                scrollRef={viewportRef}
+                shift={rowMutation().mutation === "prepend"}
+                overscan={8}
+              >
+                {(row) => {
+                  if (row.type === "load-earlier") {
+                    return (
+                      <div
+                        data-component="session-virtual-row"
+                        data-row-type="load-earlier"
+                        class="w-full flex justify-center"
+                      >
+                        <Button
+                          variant="ghost"
+                          size="large"
+                          class="text-h3 opacity-50"
+                          disabled={props.historyLoading}
+                          onClick={props.onLoadEarlier}
+                        >
+                          {props.historyLoading
+                            ? language.t("session.messages.loadingEarlier")
+                            : language.t("session.messages.loadEarlier")}
+                        </Button>
+                      </div>
+                    )
+                  }
+
+                  const messageID = row.messageID
                   const active = createMemo(() => activeMessageID() === messageID)
                   const comments = createMemo(() => extractMessageComments(sync.data.part[messageID] ?? []), [], {
                     equals: areMessageCommentsEqual,
                   })
                   return (
                     <div
+                      data-component="session-virtual-row"
                       id={props.anchor(messageID)}
+                      data-row-type="message"
                       data-message-id={messageID}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
                         "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
-                      }}
-                      style={{
-                        "content-visibility": active() ? undefined : "auto",
-                        "contain-intrinsic-size": active() ? undefined : "auto 500px",
                       }}
                     >
                       <SessionMessageComments comments={comments()} />
                       <SessionTurn
                         sessionID={sessionID() ?? ""}
                         messageID={messageID}
-                        message={userMessage()}
+                        message={row.message}
                         assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
                         messages={sessionMessages()}
                         actions={props.actions}
@@ -465,7 +496,7 @@ export function MessageTimeline(props: {
                     </div>
                   )
                 }}
-              </For>
+              </Virtualizer>
             </div>
           </div>
         </ScrollView>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,5 +1,4 @@
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, type JSX } from "solid-js"
-import { Virtualizer } from "virtua/solid"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { SessionTurn } from "@opencode-ai/ui/session-turn"
@@ -29,7 +28,9 @@ import {
   type TimelineRowMutation,
   type TimelineVirtualRow,
 } from "@/pages/session/timeline-virtual-rows"
+import { TimelineRowRenderer } from "@/pages/session/timeline-row-renderer"
 import type { TimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
+import { chooseTimelineRowRenderMode } from "@/pages/session/timeline-virtualization-strategy"
 import {
   areMessageCommentsEqual,
   extractMessageComments,
@@ -270,10 +271,81 @@ export function MessageTimeline(props: {
       turnStart: props.turnStart,
     }),
   )
-  const rowMutation = createMemo<{ rows: readonly TimelineVirtualRow[]; mutation: TimelineRowMutation }>((previous) => {
+  const rowMutation = createMemo<{ rows: TimelineVirtualRow[]; mutation: TimelineRowMutation }>((previous) => {
     const next = rows()
     return { rows: next, mutation: classifyTimelineRowMutation({ previous: previous?.rows ?? [], next }) }
   })
+  const rowRenderMode = createMemo(() => chooseTimelineRowRenderMode({ rowCount: rowMutation().rows.length }))
+
+  const renderTimelineRow = (row: TimelineVirtualRow): JSX.Element => {
+    if (row.type === "load-earlier") {
+      return (
+        <div data-component="session-virtual-row" data-row-type="load-earlier" class="w-full flex justify-center">
+          <Button
+            variant="ghost"
+            size="large"
+            class="text-h3 opacity-50"
+            disabled={props.historyLoading}
+            onClick={props.onLoadEarlier}
+          >
+            {props.historyLoading
+              ? language.t("session.messages.loadingEarlier")
+              : language.t("session.messages.loadEarlier")}
+          </Button>
+        </div>
+      )
+    }
+
+    const messageID = row.messageID
+    const active = createMemo(() => activeMessageID() === messageID)
+    const comments = createMemo(() => extractMessageComments(sync.data.part[messageID] ?? []), [], {
+      equals: areMessageCommentsEqual,
+    })
+
+    return (
+      <div
+        data-component="session-virtual-row"
+        id={props.anchor(messageID)}
+        data-row-type="message"
+        data-message-id={messageID}
+        classList={{
+          "min-w-0 w-full max-w-full": true,
+          "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
+        }}
+      >
+        <SessionMessageComments comments={comments()} />
+        <SessionTurn
+          sessionID={sessionID() ?? ""}
+          messageID={messageID}
+          message={row.message}
+          assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
+          messages={sessionMessages()}
+          actions={props.actions}
+          active={active()}
+          status={active() ? sessionStatus() : undefined}
+          rateLimitCardSlot={(classification) => <RateLimitCardWiring classification={classification} />}
+          showReasoningSummaries={settings.general.showReasoningSummaries()}
+          shellToolDefaultOpen={settings.general.shellToolPartsExpanded()}
+          editToolDefaultOpen={settings.general.editToolPartsExpanded()}
+          turnChanges={turnChangeController.turnChanges}
+          turnChangeActions={{
+            ...turnChangeController.actions,
+            openFile: (path) => {
+              void platform.openPath?.(path)
+            },
+            showInFolder: (path) => {
+              void platform.showItemInFolder?.(path)
+            },
+          }}
+          classes={{
+            root: "min-w-0 w-full relative",
+            content: "flex flex-col justify-between !overflow-visible",
+            container: "w-full px-4 md:px-5",
+          }}
+        />
+      </div>
+    )
+  }
 
   return (
     <Show
@@ -410,7 +482,8 @@ export function MessageTimeline(props: {
               role="log"
               data-component="session-timeline-virtualizer"
               data-slot="session-turn-list"
-              data-total-rows={rows().length}
+              data-render-mode={rowRenderMode()}
+              data-total-rows={rowMutation().rows.length}
               class="transition-[margin]"
               classList={{
                 "w-full": true,
@@ -419,92 +492,14 @@ export function MessageTimeline(props: {
                 "mt-0": !props.centered,
               }}
             >
-              <Show when={virtualizerViewport()}>
-                {(viewport) => (
-                  <Virtualizer
-                    ref={(handle) => props.virtualizerBridge.setHandle(handle)}
-                    data={rows()}
-                    scrollRef={viewport()}
-                    shift={rowMutation().mutation === "prepend"}
-                    overscan={8}
-                  >
-                    {(row) => {
-                      if (row.type === "load-earlier") {
-                        return (
-                          <div
-                            data-component="session-virtual-row"
-                            data-row-type="load-earlier"
-                            class="w-full flex justify-center"
-                          >
-                            <Button
-                              variant="ghost"
-                              size="large"
-                              class="text-h3 opacity-50"
-                              disabled={props.historyLoading}
-                              onClick={props.onLoadEarlier}
-                            >
-                              {props.historyLoading
-                                ? language.t("session.messages.loadingEarlier")
-                                : language.t("session.messages.loadEarlier")}
-                            </Button>
-                          </div>
-                        )
-                      }
-
-                      const messageID = row.messageID
-                      const active = createMemo(() => activeMessageID() === messageID)
-                      const comments = createMemo(() => extractMessageComments(sync.data.part[messageID] ?? []), [], {
-                        equals: areMessageCommentsEqual,
-                      })
-                      return (
-                        <div
-                          data-component="session-virtual-row"
-                          id={props.anchor(messageID)}
-                          data-row-type="message"
-                          data-message-id={messageID}
-                          classList={{
-                            "min-w-0 w-full max-w-full": true,
-                            "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
-                          }}
-                        >
-                          <SessionMessageComments comments={comments()} />
-                          <SessionTurn
-                            sessionID={sessionID() ?? ""}
-                            messageID={messageID}
-                            message={row.message}
-                            assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
-                            messages={sessionMessages()}
-                            actions={props.actions}
-                            active={active()}
-                            status={active() ? sessionStatus() : undefined}
-                            rateLimitCardSlot={(classification) => (
-                              <RateLimitCardWiring classification={classification} />
-                            )}
-                            showReasoningSummaries={settings.general.showReasoningSummaries()}
-                            shellToolDefaultOpen={settings.general.shellToolPartsExpanded()}
-                            editToolDefaultOpen={settings.general.editToolPartsExpanded()}
-                            turnChanges={turnChangeController.turnChanges}
-                            turnChangeActions={{
-                              ...turnChangeController.actions,
-                              openFile: (path) => {
-                                void platform.openPath?.(path)
-                              },
-                              showInFolder: (path) => {
-                                void platform.showItemInFolder?.(path)
-                              },
-                            }}
-                            classes={{
-                              root: "min-w-0 w-full relative",
-                              content: "flex flex-col justify-between !overflow-visible",
-                              container: "w-full px-4 md:px-5",
-                            }}
-                          />
-                        </div>
-                      )
-                    }}
-                  </Virtualizer>
-                )}
-              </Show>
+              <TimelineRowRenderer
+                mode={rowRenderMode()}
+                rows={rowMutation().rows}
+                viewport={virtualizerViewport()}
+                virtualizerBridge={props.virtualizerBridge}
+                shift={rowMutation().mutation === "prepend"}
+                renderRow={renderTimelineRow}
+              />
             </div>
           </div>
         </ScrollView>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, on, onCleanup, onMount, Show, type JSX } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, type JSX } from "solid-js"
 import { Virtualizer } from "virtua/solid"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -96,6 +96,7 @@ export function MessageTimeline(props: {
   let touchGesture: number | undefined
   let scrollSampleFrame: number | undefined
   let viewportRef: HTMLDivElement | undefined
+  const [virtualizerViewport, setVirtualizerViewport] = createSignal<HTMLDivElement>()
   let mounted = true
   let pendingScrollSample:
     | {
@@ -301,6 +302,7 @@ export function MessageTimeline(props: {
         <ScrollView
           viewportRef={(el) => {
             viewportRef = el
+            setVirtualizerViewport(el)
             props.setScrollRef(el)
           }}
           onScrollIntent={(intent) => {
@@ -417,86 +419,92 @@ export function MessageTimeline(props: {
                 "mt-0": !props.centered,
               }}
             >
-              <Virtualizer
-                ref={(handle) => props.virtualizerBridge.setHandle(handle)}
-                data={rows()}
-                scrollRef={viewportRef}
-                shift={rowMutation().mutation === "prepend"}
-                overscan={8}
-              >
-                {(row) => {
-                  if (row.type === "load-earlier") {
-                    return (
-                      <div
-                        data-component="session-virtual-row"
-                        data-row-type="load-earlier"
-                        class="w-full flex justify-center"
-                      >
-                        <Button
-                          variant="ghost"
-                          size="large"
-                          class="text-h3 opacity-50"
-                          disabled={props.historyLoading}
-                          onClick={props.onLoadEarlier}
-                        >
-                          {props.historyLoading
-                            ? language.t("session.messages.loadingEarlier")
-                            : language.t("session.messages.loadEarlier")}
-                        </Button>
-                      </div>
-                    )
-                  }
+              <Show when={virtualizerViewport()}>
+                {(viewport) => (
+                  <Virtualizer
+                    ref={(handle) => props.virtualizerBridge.setHandle(handle)}
+                    data={rows()}
+                    scrollRef={viewport()}
+                    shift={rowMutation().mutation === "prepend"}
+                    overscan={8}
+                  >
+                    {(row) => {
+                      if (row.type === "load-earlier") {
+                        return (
+                          <div
+                            data-component="session-virtual-row"
+                            data-row-type="load-earlier"
+                            class="w-full flex justify-center"
+                          >
+                            <Button
+                              variant="ghost"
+                              size="large"
+                              class="text-h3 opacity-50"
+                              disabled={props.historyLoading}
+                              onClick={props.onLoadEarlier}
+                            >
+                              {props.historyLoading
+                                ? language.t("session.messages.loadingEarlier")
+                                : language.t("session.messages.loadEarlier")}
+                            </Button>
+                          </div>
+                        )
+                      }
 
-                  const messageID = row.messageID
-                  const active = createMemo(() => activeMessageID() === messageID)
-                  const comments = createMemo(() => extractMessageComments(sync.data.part[messageID] ?? []), [], {
-                    equals: areMessageCommentsEqual,
-                  })
-                  return (
-                    <div
-                      data-component="session-virtual-row"
-                      id={props.anchor(messageID)}
-                      data-row-type="message"
-                      data-message-id={messageID}
-                      classList={{
-                        "min-w-0 w-full max-w-full": true,
-                        "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
-                      }}
-                    >
-                      <SessionMessageComments comments={comments()} />
-                      <SessionTurn
-                        sessionID={sessionID() ?? ""}
-                        messageID={messageID}
-                        message={row.message}
-                        assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
-                        messages={sessionMessages()}
-                        actions={props.actions}
-                        active={active()}
-                        status={active() ? sessionStatus() : undefined}
-                        rateLimitCardSlot={(classification) => <RateLimitCardWiring classification={classification} />}
-                        showReasoningSummaries={settings.general.showReasoningSummaries()}
-                        shellToolDefaultOpen={settings.general.shellToolPartsExpanded()}
-                        editToolDefaultOpen={settings.general.editToolPartsExpanded()}
-                        turnChanges={turnChangeController.turnChanges}
-                        turnChangeActions={{
-                          ...turnChangeController.actions,
-                          openFile: (path) => {
-                            void platform.openPath?.(path)
-                          },
-                          showInFolder: (path) => {
-                            void platform.showItemInFolder?.(path)
-                          },
-                        }}
-                        classes={{
-                          root: "min-w-0 w-full relative",
-                          content: "flex flex-col justify-between !overflow-visible",
-                          container: "w-full px-4 md:px-5",
-                        }}
-                      />
-                    </div>
-                  )
-                }}
-              </Virtualizer>
+                      const messageID = row.messageID
+                      const active = createMemo(() => activeMessageID() === messageID)
+                      const comments = createMemo(() => extractMessageComments(sync.data.part[messageID] ?? []), [], {
+                        equals: areMessageCommentsEqual,
+                      })
+                      return (
+                        <div
+                          data-component="session-virtual-row"
+                          id={props.anchor(messageID)}
+                          data-row-type="message"
+                          data-message-id={messageID}
+                          classList={{
+                            "min-w-0 w-full max-w-full": true,
+                            "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
+                          }}
+                        >
+                          <SessionMessageComments comments={comments()} />
+                          <SessionTurn
+                            sessionID={sessionID() ?? ""}
+                            messageID={messageID}
+                            message={row.message}
+                            assistantMessages={turnMessagesByUserID().get(messageID) ?? emptyAssistantMessages}
+                            messages={sessionMessages()}
+                            actions={props.actions}
+                            active={active()}
+                            status={active() ? sessionStatus() : undefined}
+                            rateLimitCardSlot={(classification) => (
+                              <RateLimitCardWiring classification={classification} />
+                            )}
+                            showReasoningSummaries={settings.general.showReasoningSummaries()}
+                            shellToolDefaultOpen={settings.general.shellToolPartsExpanded()}
+                            editToolDefaultOpen={settings.general.editToolPartsExpanded()}
+                            turnChanges={turnChangeController.turnChanges}
+                            turnChangeActions={{
+                              ...turnChangeController.actions,
+                              openFile: (path) => {
+                                void platform.openPath?.(path)
+                              },
+                              showInFolder: (path) => {
+                                void platform.showItemInFolder?.(path)
+                              },
+                            }}
+                            classes={{
+                              root: "min-w-0 w-full relative",
+                              content: "flex flex-col justify-between !overflow-visible",
+                              container: "w-full px-4 md:px-5",
+                            }}
+                          />
+                        </div>
+                      )
+                    }}
+                  </Virtualizer>
+                )}
+              </Show>
             </div>
           </div>
         </ScrollView>

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -45,12 +45,11 @@ export function SessionMainView(props: {
   historyMore: boolean
   historyLoading: boolean
   anchor: TimelineProps["anchor"]
+  virtualizerBridge: TimelineProps["virtualizerBridge"]
   onRetryOpenSession: () => void
   onOpenNewSession: () => void
   composerSession: JSX.Element
-  composerHome: (ctx: {
-    onModeChange: (mode: "normal" | "shell") => void
-  }) => JSX.Element
+  composerHome: (ctx: { onModeChange: (mode: "normal" | "shell") => void }) => JSX.Element
   canReview: () => boolean
   reviewDiffs: ReturnType<typeof createSessionReviewState>["reviewDiffs"]
   hasReview: ReturnType<typeof createSessionReviewState>["hasReview"]
@@ -129,11 +128,7 @@ export function SessionMainView(props: {
                   </div>
                 </div>
               </Match>
-              <Match
-                when={
-                  props.activeSessionID && props.timelineSessionID ? props.timelineSessionID : undefined
-                }
-              >
+              <Match when={props.activeSessionID && props.timelineSessionID ? props.timelineSessionID : undefined}>
                 <MessageTimeline
                   sessionID={props.timelineSessionID ?? ""}
                   sessionKey={props.timelineSessionKey}
@@ -163,6 +158,7 @@ export function SessionMainView(props: {
                   }}
                   renderedUserMessages={props.historyWindow.renderedUserMessages()}
                   anchor={props.anchor}
+                  virtualizerBridge={props.virtualizerBridge}
                 />
               </Match>
               <Match when={!props.activeSessionID}>
@@ -173,9 +169,7 @@ export function SessionMainView(props: {
               </Match>
             </Switch>
           </div>
-          <Show when={props.activeSessionID && !showSessionOpeningState()}>
-            {props.composerSession}
-          </Show>
+          <Show when={props.activeSessionID && !showSessionOpeningState()}>{props.composerSession}</Show>
         </div>
 
         <SessionSidePanel

--- a/packages/app/src/pages/session/timeline-row-layout.test.ts
+++ b/packages/app/src/pages/session/timeline-row-layout.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { timelineMessageRowStyle } from "./timeline-row-layout"
+
+describe("timeline row layout", () => {
+  test("keeps browser lazy layout on inactive plain rows", () => {
+    expect(timelineMessageRowStyle({ mode: "plain", active: false })).toEqual({
+      "content-visibility": "auto",
+      "contain-intrinsic-size": "auto 500px",
+    })
+  })
+
+  test("does not lazy-layout active plain rows", () => {
+    expect(timelineMessageRowStyle({ mode: "plain", active: true })).toBeUndefined()
+  })
+
+  test("leaves virtualized rows to the virtualizer measurement path", () => {
+    expect(timelineMessageRowStyle({ mode: "virtualized", active: false })).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/session/timeline-row-layout.ts
+++ b/packages/app/src/pages/session/timeline-row-layout.ts
@@ -1,0 +1,11 @@
+import type { TimelineRowRenderMode } from "./timeline-virtualization-strategy"
+
+const inactivePlainMessageRowStyle = {
+  "content-visibility": "auto",
+  "contain-intrinsic-size": "auto 500px",
+} as const
+
+export function timelineMessageRowStyle(input: { mode: TimelineRowRenderMode; active: boolean }) {
+  if (input.mode !== "plain") return undefined
+  return input.active ? undefined : inactivePlainMessageRowStyle
+}

--- a/packages/app/src/pages/session/timeline-row-renderer.tsx
+++ b/packages/app/src/pages/session/timeline-row-renderer.tsx
@@ -1,0 +1,53 @@
+import { createEffect, For, onCleanup, Show, type JSX } from "solid-js"
+import { Virtualizer } from "virtua/solid"
+import type { TimelineVirtualizerBridge } from "./timeline-virtualizer-bridge"
+import type { TimelineVirtualRow } from "./timeline-virtual-rows"
+import type { TimelineRowRenderMode } from "./timeline-virtualization-strategy"
+
+export function TimelineRowRenderer(props: {
+  mode: TimelineRowRenderMode
+  rows: TimelineVirtualRow[]
+  viewport: HTMLDivElement | undefined
+  virtualizerBridge: TimelineVirtualizerBridge
+  shift: boolean
+  renderRow: (row: TimelineVirtualRow) => JSX.Element
+}) {
+  createEffect(() => {
+    if (props.mode === "virtualized" && props.viewport) return
+    props.virtualizerBridge.setHandle(undefined)
+  })
+
+  onCleanup(() => {
+    props.virtualizerBridge.setHandle(undefined)
+  })
+
+  return (
+    <Show when={props.mode === "plain"} fallback={<VirtualizedTimelineRows {...props} />}>
+      <For each={props.rows}>{props.renderRow}</For>
+    </Show>
+  )
+}
+
+function VirtualizedTimelineRows(props: {
+  rows: TimelineVirtualRow[]
+  viewport: HTMLDivElement | undefined
+  virtualizerBridge: TimelineVirtualizerBridge
+  shift: boolean
+  renderRow: (row: TimelineVirtualRow) => JSX.Element
+}) {
+  return (
+    <Show when={props.viewport}>
+      {(viewport) => (
+        <Virtualizer
+          ref={(handle) => props.virtualizerBridge.setHandle(handle)}
+          data={props.rows}
+          scrollRef={viewport()}
+          shift={props.shift}
+          overscan={8}
+        >
+          {props.renderRow}
+        </Virtualizer>
+      )}
+    </Show>
+  )
+}

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -165,6 +165,9 @@ export function scanTimelineScrollOwnershipText(input: ScanTextInput) {
       ) {
         sinkIdentifiers.add(node.name.text)
       }
+      if (node.type?.getText(source) === "TimelineScrollCommandSink") {
+        sinkIdentifiers.add(node.name.text)
+      }
       const prop = propertyName(node.initializer)
       if (prop && forbiddenPropertyCalls.has(prop)) forbiddenIdentifiers.add(node.name.text)
       if (ts.isIdentifier(node.initializer) && forbiddenIdentifiers.has(node.initializer.text)) {

--- a/packages/app/src/pages/session/timeline-virtual-rows.test.ts
+++ b/packages/app/src/pages/session/timeline-virtual-rows.test.ts
@@ -1,0 +1,54 @@
+import type { UserMessage } from "@opencode-ai/sdk/v2"
+import { describe, expect, test } from "bun:test"
+import { classifyTimelineRowMutation, createTimelineVirtualRows } from "./timeline-virtual-rows"
+
+function userMessage(id: number): UserMessage {
+  return {
+    id: `msg_${id}`,
+    role: "user",
+    time: { created: id },
+  } as UserMessage
+}
+
+function userMessages(start: number, end: number) {
+  return Array.from({ length: end - start }, (_, index) => userMessage(start + index))
+}
+
+describe("timeline virtual rows", () => {
+  test("creates one stable message row per user message", () => {
+    const rows = createTimelineVirtualRows({ messages: userMessages(0, 3), historyMore: false, turnStart: 0 })
+
+    expect(rows).toEqual([
+      expect.objectContaining({ type: "message", key: "message:msg_0", messageID: "msg_0", messageIndex: 0 }),
+      expect.objectContaining({ type: "message", key: "message:msg_1", messageID: "msg_1", messageIndex: 1 }),
+      expect.objectContaining({ type: "message", key: "message:msg_2", messageID: "msg_2", messageIndex: 2 }),
+    ])
+  })
+
+  test("adds the load-earlier row when cached or remote history exists", () => {
+    expect(createTimelineVirtualRows({ messages: userMessages(0, 1), historyMore: false, turnStart: 2 })[0]).toEqual({
+      type: "load-earlier",
+      key: "history-load-earlier",
+    })
+    expect(createTimelineVirtualRows({ messages: userMessages(0, 1), historyMore: true, turnStart: 0 })[0]).toEqual({
+      type: "load-earlier",
+      key: "history-load-earlier",
+    })
+  })
+
+  test("classifies prepends and appends without using row indexes as identity", () => {
+    const previous = createTimelineVirtualRows({ messages: userMessages(5, 8), historyMore: false, turnStart: 0 })
+    const prepended = createTimelineVirtualRows({ messages: userMessages(2, 8), historyMore: false, turnStart: 0 })
+    const appended = createTimelineVirtualRows({ messages: userMessages(5, 10), historyMore: false, turnStart: 0 })
+
+    expect(classifyTimelineRowMutation({ previous, next: prepended })).toBe("prepend")
+    expect(classifyTimelineRowMutation({ previous, next: appended })).toBe("append")
+  })
+
+  test("classifies replacement when neither end remains stable", () => {
+    const previous = createTimelineVirtualRows({ messages: userMessages(5, 8), historyMore: false, turnStart: 0 })
+    const next = createTimelineVirtualRows({ messages: userMessages(20, 23), historyMore: false, turnStart: 0 })
+
+    expect(classifyTimelineRowMutation({ previous, next })).toBe("replace")
+  })
+})

--- a/packages/app/src/pages/session/timeline-virtual-rows.ts
+++ b/packages/app/src/pages/session/timeline-virtual-rows.ts
@@ -1,0 +1,69 @@
+import type { UserMessage } from "@opencode-ai/sdk/v2"
+
+export type TimelineVirtualMessageRow = {
+  type: "message"
+  key: `message:${string}`
+  messageID: string
+  message: UserMessage
+  messageIndex: number
+}
+
+export type TimelineVirtualLoadEarlierRow = {
+  type: "load-earlier"
+  key: "history-load-earlier"
+}
+
+export type TimelineVirtualRow = TimelineVirtualLoadEarlierRow | TimelineVirtualMessageRow
+
+export type TimelineRowMutation = "initial" | "same" | "prepend" | "append" | "replace"
+
+export function createTimelineVirtualRows(input: {
+  messages: readonly UserMessage[]
+  historyMore: boolean
+  turnStart: number
+}): TimelineVirtualRow[] {
+  const rows: TimelineVirtualRow[] = []
+
+  if (input.turnStart > 0 || input.historyMore) {
+    rows.push({ type: "load-earlier", key: "history-load-earlier" })
+  }
+
+  input.messages.forEach((message, messageIndex) => {
+    rows.push({
+      type: "message",
+      key: `message:${message.id}`,
+      messageID: message.id,
+      message,
+      messageIndex,
+    })
+  })
+
+  return rows
+}
+
+function messageRows(rows: readonly TimelineVirtualRow[]) {
+  return rows.filter((row): row is TimelineVirtualMessageRow => row.type === "message")
+}
+
+export function classifyTimelineRowMutation(input: {
+  previous: readonly TimelineVirtualRow[]
+  next: readonly TimelineVirtualRow[]
+}): TimelineRowMutation {
+  const previousMessages = messageRows(input.previous)
+  const nextMessages = messageRows(input.next)
+
+  if (previousMessages.length === 0) return nextMessages.length > 0 ? "initial" : "same"
+  if (nextMessages.length === 0) return "replace"
+
+  const previousFirst = previousMessages[0]?.messageID
+  const previousLast = previousMessages.at(-1)?.messageID
+  const nextFirst = nextMessages[0]?.messageID
+  const nextLast = nextMessages.at(-1)?.messageID
+
+  if (previousFirst === nextFirst && previousLast === nextLast && previousMessages.length === nextMessages.length) {
+    return "same"
+  }
+  if (previousLast === nextLast && previousFirst !== nextFirst) return "prepend"
+  if (previousFirst === nextFirst && previousLast !== nextLast) return "append"
+  return "replace"
+}

--- a/packages/app/src/pages/session/timeline-virtualization-strategy.test.ts
+++ b/packages/app/src/pages/session/timeline-virtualization-strategy.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test"
+import { chooseTimelineRowRenderMode, TIMELINE_PLAIN_RENDER_ROW_LIMIT } from "./timeline-virtualization-strategy"
+
+describe("timeline virtualization strategy", () => {
+  test("renders short timelines without the virtualizer overhead", () => {
+    expect(chooseTimelineRowRenderMode({ rowCount: 0 })).toBe("plain")
+    expect(chooseTimelineRowRenderMode({ rowCount: TIMELINE_PLAIN_RENDER_ROW_LIMIT })).toBe("plain")
+    expect(chooseTimelineRowRenderMode({ rowCount: TIMELINE_PLAIN_RENDER_ROW_LIMIT + 1 })).toBe("virtualized")
+  })
+})

--- a/packages/app/src/pages/session/timeline-virtualization-strategy.ts
+++ b/packages/app/src/pages/session/timeline-virtualization-strategy.ts
@@ -1,0 +1,7 @@
+export type TimelineRowRenderMode = "plain" | "virtualized"
+
+export const TIMELINE_PLAIN_RENDER_ROW_LIMIT = 48
+
+export function chooseTimelineRowRenderMode(input: { rowCount: number }): TimelineRowRenderMode {
+  return input.rowCount <= TIMELINE_PLAIN_RENDER_ROW_LIMIT ? "plain" : "virtualized"
+}

--- a/packages/app/src/pages/session/timeline-virtualizer-bridge.ts
+++ b/packages/app/src/pages/session/timeline-virtualizer-bridge.ts
@@ -1,0 +1,50 @@
+import type { Accessor } from "solid-js"
+import type { VirtualizerHandle } from "virtua/solid"
+import type { TimelineVirtualRow } from "./timeline-virtual-rows"
+import type { TimelineScrollCommandSink } from "./timeline-scroll-command-sink"
+
+export type TimelineVirtualizerBridge = {
+  setHandle: (handle: VirtualizerHandle | undefined) => void
+  rowIndexForMessage: (messageID: string) => number | undefined
+  scrollMessageNearTop: (input: {
+    messageID: string
+    viewport: HTMLElement | undefined
+    behavior: ScrollBehavior
+    sink: TimelineScrollCommandSink
+    source: string
+    reason: string
+  }) => boolean
+}
+
+export function createTimelineVirtualizerBridge(input: {
+  rows: Accessor<readonly TimelineVirtualRow[]>
+}): TimelineVirtualizerBridge {
+  let handle: VirtualizerHandle | undefined
+
+  const rowIndexForMessage = (messageID: string) => {
+    const index = input.rows().findIndex((row) => row.type === "message" && row.messageID === messageID)
+    return index >= 0 ? index : undefined
+  }
+
+  return {
+    setHandle: (next) => {
+      handle = next
+    },
+    rowIndexForMessage,
+    scrollMessageNearTop: (args) => {
+      if (!handle || !args.viewport) return false
+      const index = rowIndexForMessage(args.messageID)
+      if (index === undefined) return false
+      const sink: TimelineScrollCommandSink = args.sink
+      sink.scrollTo({
+        element: args.viewport,
+        top: Math.max(0, handle.getItemOffset(index)),
+        behavior: args.behavior,
+        type: "target-message",
+        source: args.source,
+        reason: args.reason,
+      })
+      return true
+    },
+  }
+}

--- a/packages/app/src/pages/session/use-session-hash-scroll-core.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll-core.ts
@@ -99,14 +99,13 @@ export const createSessionHashScroll = (
   const seek = (id: string, behavior: ScrollBehavior, left = 4): boolean => {
     const el = document.getElementById(input.anchor(id))
     if (el) return scrollToElement(el, behavior)
+    if (left <= 0) return false
     if (input.virtualizerReveal?.({ messageID: id, behavior })) {
-      if (left <= 0) return false
       queue(() => {
         seek(id, behavior, left - 1)
       })
       return false
     }
-    if (left <= 0) return false
     queue(() => {
       seek(id, behavior, left - 1)
     })

--- a/packages/app/src/pages/session/use-session-hash-scroll-core.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll-core.ts
@@ -24,6 +24,7 @@ export type SessionHashScrollInput = {
   consumePendingMessage: (key: string) => string | undefined
   onMessageNavigation?: (messageID: string) => void
   onMessageHashCleared?: () => void
+  virtualizerReveal?: (input: { messageID: string; behavior: ScrollBehavior }) => boolean
   scrollCommandSink?: TimelineScrollCommandSink
 }
 
@@ -98,6 +99,12 @@ export const createSessionHashScroll = (
   const seek = (id: string, behavior: ScrollBehavior, left = 4): boolean => {
     const el = document.getElementById(input.anchor(id))
     if (el) return scrollToElement(el, behavior)
+    if (input.virtualizerReveal?.({ messageID: id, behavior })) {
+      queue(() => {
+        seek(id, behavior, left - 1)
+      })
+      return false
+    }
     if (left <= 0) return false
     queue(() => {
       seek(id, behavior, left - 1)

--- a/packages/app/src/pages/session/use-session-hash-scroll-core.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll-core.ts
@@ -100,6 +100,7 @@ export const createSessionHashScroll = (
     const el = document.getElementById(input.anchor(id))
     if (el) return scrollToElement(el, behavior)
     if (input.virtualizerReveal?.({ messageID: id, behavior })) {
+      if (left <= 0) return false
       queue(() => {
         seek(id, behavior, left - 1)
       })

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -156,10 +156,11 @@ describe("useSessionHashScroll", () => {
     }) as typeof requestAnimationFrame
     globalThis.cancelAnimationFrame = (() => undefined) as typeof cancelAnimationFrame
 
+    let dispose: (() => void) | undefined
     try {
       document.body.append(root)
 
-      const dispose = createRoot((dispose) => {
+      dispose = createRoot((dispose) => {
         const hashScroll = createSessionHashScroll(
           {
             sessionKey: () => "ses_1:/repo",
@@ -201,9 +202,8 @@ describe("useSessionHashScroll", () => {
 
       expect(revealCalls).toEqual(["msg_2", "msg_2", "msg_2", "msg_2"])
       expect(frameCallbacks).toHaveLength(0)
-
-      dispose()
     } finally {
+      dispose?.()
       root.remove()
       globalThis.requestAnimationFrame = originalRequestAnimationFrame
       globalThis.cancelAnimationFrame = originalCancelAnimationFrame

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -141,4 +141,72 @@ describe("useSessionHashScroll", () => {
     dispose()
     root.remove()
   })
+
+  test("hash navigation bounds virtualizer reveal retries when the target never mounts", () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+    const frameCallbacks: FrameRequestCallback[] = []
+    let nextFrameId = 1
+    const revealCalls: string[] = []
+    const root = document.createElement("div")
+
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return nextFrameId++
+    }) as typeof requestAnimationFrame
+    globalThis.cancelAnimationFrame = (() => undefined) as typeof cancelAnimationFrame
+
+    try {
+      document.body.append(root)
+
+      const dispose = createRoot((dispose) => {
+        const hashScroll = createSessionHashScroll(
+          {
+            sessionKey: () => "ses_1:/repo",
+            sessionID: () => "ses_1",
+            messagesReady: () => true,
+            visibleUserMessages: () => [{ id: "msg_2" }] as any,
+            historyMore: () => false,
+            historyLoading: () => false,
+            loadMore: async () => undefined,
+            turnStart: () => 0,
+            currentMessageId: () => undefined,
+            pendingMessage: () => undefined,
+            setPendingMessage: () => undefined,
+            setActiveMessage: () => undefined,
+            markHashTarget: () => undefined,
+            autoScroll: { pause: () => undefined, forceScrollToBottom: () => undefined },
+            scroller: () => root,
+            anchor: (id) => `message-${id}`,
+            scheduleScrollState: () => undefined,
+            consumePendingMessage: () => undefined,
+            virtualizerReveal: ({ messageID }) => {
+              revealCalls.push(messageID)
+              return true
+            },
+          },
+          { hash: "#message-msg_2", pathname: "/session/ses_1", search: "" },
+          () => undefined,
+        )
+
+        hashScroll.applyHash("auto")
+        return dispose
+      })
+
+      for (let index = 0; index < 10; index += 1) {
+        const callback = frameCallbacks.shift()
+        if (!callback) break
+        callback(index)
+      }
+
+      expect(revealCalls).toEqual(["msg_2", "msg_2", "msg_2", "msg_2"])
+      expect(frameCallbacks).toHaveLength(0)
+
+      dispose()
+    } finally {
+      root.remove()
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    }
+  })
 })

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -224,7 +224,6 @@ export function createSessionTimelineInteraction(input: {
 
       if (recovery.type === "restore_latest") {
         if (current.mode !== "following_latest") return
-        historyWindow.resumeLatestWindow()
         resumeScroll()
         return
       }
@@ -279,7 +278,6 @@ export function createSessionTimelineInteraction(input: {
       type: "submit",
       originMode: scrollController.state().mode,
     })
-    historyWindow.resumeLatestWindow()
     applyTimelineRecovery(result.recovery)
   }
 

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -1,5 +1,5 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
-import { createEffect, on, onCleanup } from "solid-js"
+import { createEffect, createMemo, on, onCleanup } from "solid-js"
 import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import {
   collectTimelineScrollMetrics,
@@ -11,6 +11,8 @@ import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { createSessionHistoryBackfill } from "@/pages/session/use-session-history-backfill"
 import { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
+import { createTimelineVirtualRows } from "@/pages/session/timeline-virtual-rows"
+import { createTimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
 import {
   createSessionTimelineScrollController,
   type TimelineRecovery,
@@ -163,6 +165,14 @@ export function createSessionTimelineInteraction(input: {
     scroller: scrollDock.scroller,
     scrollCommandSink,
   })
+  const virtualRows = createMemo(() =>
+    createTimelineVirtualRows({
+      messages: historyWindow.renderedUserMessages(),
+      historyMore: input.historyMore(),
+      turnStart: historyWindow.turnStart(),
+    }),
+  )
+  const virtualizerBridge = createTimelineVirtualizerBridge({ rows: virtualRows })
 
   const resumeLatest = () => {
     const result = scrollController.intent({ type: "jump_latest", source: "button" })
@@ -303,6 +313,15 @@ export function createSessionTimelineInteraction(input: {
     scheduleScrollState: scrollDock.scheduleScrollState,
     consumePendingMessage: input.consumePendingMessage,
     scrollCommandSink,
+    virtualizerReveal: ({ messageID, behavior }) =>
+      virtualizerBridge.scrollMessageNearTop({
+        messageID,
+        behavior,
+        viewport: scrollDock.scroller(),
+        sink: scrollCommandSink,
+        source: "use-session-timeline-interaction/virtualizerReveal",
+        reason: "hash-target-not-mounted",
+      }),
     onMessageNavigation: (messageID) => {
       scrollDock.cancelBottomFollowLock()
       onTimelineScrollIntent({
@@ -321,6 +340,7 @@ export function createSessionTimelineInteraction(input: {
     autoScroll,
     anchor,
     historyWindow,
+    virtualizerBridge,
     resumeScroll: resumeLatest,
     submitLatest,
     scheduleScrollState: scrollDock.scheduleScrollState,

--- a/packages/ui/src/components/basic-tool-defer.test.ts
+++ b/packages/ui/src/components/basic-tool-defer.test.ts
@@ -134,3 +134,23 @@ test("closed tools start without mounted details", () => {
   expect(basicToolInitialReady({ defer: true })).toBe(false)
   expect(basicToolInitialReady({})).toBe(false)
 })
+
+test("row-local open state evicts the oldest stateKey while preserving recent keys", async () => {
+  const { mountBasicTool } = await loadFixture()
+  const prefix = `basic-tool-cap-${Date.now()}`
+
+  for (let index = 0; index <= 500; index++) {
+    const tool = mountBasicTool({ defaultOpen: false, stateKey: `${prefix}-${index}` })
+    tool.trigger()?.click()
+    await Promise.resolve()
+    tool.dispose()
+  }
+
+  const oldest = mountBasicTool({ defaultOpen: false, stateKey: `${prefix}-0` })
+  expect(oldest.details()).toBeNull()
+  oldest.dispose()
+
+  const recent = mountBasicTool({ defaultOpen: false, stateKey: `${prefix}-500` })
+  expect(recent.details()?.textContent).toBe("details")
+  recent.dispose()
+})

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -37,7 +37,10 @@ export interface BasicToolProps {
   onTriggerClick?: JSX.EventHandlerUnion<HTMLElement, MouseEvent>
   triggerHref?: string
   clickable?: boolean
+  stateKey?: string
 }
+
+const basicToolOpenState = new Map<string, boolean>()
 
 const SPRING = { type: "spring" as const, visualDuration: 0.35, bounce: 0 }
 
@@ -47,9 +50,12 @@ export function basicToolInitialReady(props: { defaultOpen?: boolean; defer?: bo
 }
 
 export function BasicTool(props: BasicToolProps) {
+  const initialOpen = props.stateKey
+    ? (basicToolOpenState.get(props.stateKey) ?? props.defaultOpen ?? false)
+    : (props.defaultOpen ?? false)
   const [state, setState] = createStore({
-    open: props.defaultOpen ?? false,
-    ready: basicToolInitialReady(props),
+    open: initialOpen,
+    ready: basicToolInitialReady({ defaultOpen: initialOpen, defer: props.defer }),
   })
   const open = () => state.open
   const ready = () => state.ready
@@ -74,7 +80,9 @@ export function BasicTool(props: BasicToolProps) {
   onCleanup(cancel)
 
   createEffect(() => {
-    if (props.forceOpen) setState("open", true)
+    if (!props.forceOpen) return
+    setState("open", true)
+    if (props.stateKey) basicToolOpenState.set(props.stateKey, true)
   })
 
   createEffect(() => {
@@ -97,7 +105,7 @@ export function BasicTool(props: BasicToolProps) {
   // Animated height for collapsible open/close
   let contentRef: HTMLDivElement | undefined
   let heightAnim: AnimationPlaybackControls | undefined
-  const initialOpen = open()
+  const animatedInitialOpen = open()
 
   createEffect(
     on(
@@ -134,6 +142,7 @@ export function BasicTool(props: BasicToolProps) {
     if (pending()) return
     if (props.locked && !value) return
     setState("open", value)
+    if (props.stateKey) basicToolOpenState.set(props.stateKey, value)
   }
 
   const triggerInfo = () => {
@@ -237,8 +246,8 @@ export function BasicTool(props: BasicToolProps) {
           data-slot="collapsible-content"
           data-animated
           style={{
-            height: initialOpen ? "auto" : "0px",
-            overflow: initialOpen ? "visible" : "hidden",
+            height: animatedInitialOpen ? "auto" : "0px",
+            overflow: animatedInitialOpen ? "visible" : "hidden",
             "pointer-events": closingAnimatedDetails() ? "none" : undefined,
           }}
           aria-hidden={closingAnimatedDetails() ? "true" : undefined}

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "../context/i18n"
 import { createStore } from "solid-js/store"
 import { Collapsible } from "./collapsible"
 import type { IconProps } from "./icon"
+import { createBoundedStateMap } from "./persisted-state-map"
 import { TextShimmer } from "./text-shimmer"
 
 export type TriggerTitle = {
@@ -40,7 +41,7 @@ export interface BasicToolProps {
   stateKey?: string
 }
 
-const basicToolOpenState = new Map<string, boolean>()
+const basicToolOpenState = createBoundedStateMap<boolean>()
 
 const SPRING = { type: "spring" as const, visualDuration: 0.35, bounce: 0 }
 

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -49,10 +49,14 @@ export function basicToolInitialReady(props: { defaultOpen?: boolean; defer?: bo
   return props.defaultOpen ?? false
 }
 
-export function BasicTool(props: BasicToolProps) {
-  const initialOpen = props.stateKey
+function basicToolInitialOpen(props: { stateKey?: string; defaultOpen?: boolean }) {
+  return props.stateKey
     ? (basicToolOpenState.get(props.stateKey) ?? props.defaultOpen ?? false)
     : (props.defaultOpen ?? false)
+}
+
+export function BasicTool(props: BasicToolProps) {
+  const initialOpen = basicToolInitialOpen(props)
   const [state, setState] = createStore({
     open: initialOpen,
     ready: basicToolInitialReady({ defaultOpen: initialOpen, defer: props.defer }),
@@ -78,6 +82,18 @@ export function BasicTool(props: BasicToolProps) {
   }
 
   onCleanup(cancel)
+
+  createEffect(
+    on(
+      () => props.stateKey,
+      () => {
+        const nextOpen = basicToolInitialOpen(props)
+        setState("open", nextOpen)
+        setState("ready", basicToolInitialReady({ defaultOpen: nextOpen, defer: props.defer }))
+      },
+      { defer: true },
+    ),
+  )
 
   createEffect(() => {
     if (!props.forceOpen) return

--- a/packages/ui/src/components/message-part/assistant-message-display.tsx
+++ b/packages/ui/src/components/message-part/assistant-message-display.tsx
@@ -70,6 +70,7 @@ export function AssistantMessageDisplay(props: {
                       part={stableItem()!}
                       message={props.message}
                       showAssistantCopyPartID={props.showAssistantCopyPartID}
+                      stateKey={`tool:${stableItem()!.id}`}
                     />
                   </Show>
                 )

--- a/packages/ui/src/components/message-part/assistant-parts.tsx
+++ b/packages/ui/src/components/message-part/assistant-parts.tsx
@@ -101,6 +101,7 @@ export function AssistantParts(props: {
                           props.shellToolDefaultOpen,
                           props.editToolDefaultOpen,
                         )}
+                        stateKey={`tool:${stableItem()!.id}`}
                       />
                     </Show>
                   </Show>

--- a/packages/ui/src/components/message-part/context-tool-group.tsx
+++ b/packages/ui/src/components/message-part/context-tool-group.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, For, Index, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, Index, on, Show } from "solid-js"
 import type { ToolPart } from "@opencode-ai/sdk/v2"
 import { useI18n } from "../../context/i18n"
 import { Collapsible } from "../collapsible"
@@ -13,6 +13,7 @@ export function ContextToolGroup(props: { parts: ToolPart[]; busy?: boolean }) {
   const i18n = useI18n()
   const stateKey = createMemo(() => props.parts.map((part) => part.id).join(":"))
   const [open, setOpen] = createSignal(contextToolGroupOpenState.get(stateKey()) ?? false)
+  createEffect(on(stateKey, (key) => setOpen(contextToolGroupOpenState.get(key) ?? false), { defer: true }))
   const setPersistentOpen = (value: boolean) => {
     setOpen(value)
     contextToolGroupOpenState.set(stateKey(), value)

--- a/packages/ui/src/components/message-part/context-tool-group.tsx
+++ b/packages/ui/src/components/message-part/context-tool-group.tsx
@@ -7,9 +7,16 @@ import { AnimatedCountList } from "../tool-count-summary"
 import { ToolStatusTitle } from "../tool-status-title"
 import { contextToolSummary, contextToolTrigger } from "./context-tool-helpers"
 
+const contextToolGroupOpenState = new Map<string, boolean>()
+
 export function ContextToolGroup(props: { parts: ToolPart[]; busy?: boolean }) {
   const i18n = useI18n()
-  const [open, setOpen] = createSignal(false)
+  const stateKey = createMemo(() => props.parts.map((part) => part.id).join(":"))
+  const [open, setOpen] = createSignal(contextToolGroupOpenState.get(stateKey()) ?? false)
+  const setPersistentOpen = (value: boolean) => {
+    setOpen(value)
+    contextToolGroupOpenState.set(stateKey(), value)
+  }
   const pending = createMemo(
     () =>
       !!props.busy || props.parts.some((part) => part.state.status === "pending" || part.state.status === "running"),
@@ -17,13 +24,10 @@ export function ContextToolGroup(props: { parts: ToolPart[]; busy?: boolean }) {
   const summary = createMemo(() => contextToolSummary(props.parts))
 
   return (
-    <Collapsible open={open()} onOpenChange={setOpen} variant="ghost" class="tool-collapsible">
+    <Collapsible open={open()} onOpenChange={setPersistentOpen} variant="ghost" class="tool-collapsible">
       <Collapsible.Trigger>
         <div data-component="context-tool-group-trigger">
-          <span
-            data-slot="context-tool-group-title"
-            class="min-w-0 flex items-center gap-2 text-h3 text-fg-strong"
-          >
+          <span data-slot="context-tool-group-title" class="min-w-0 flex items-center gap-2 text-h3 text-fg-strong">
             <span data-slot="context-tool-group-label" class="shrink-0">
               <ToolStatusTitle
                 active={pending()}

--- a/packages/ui/src/components/message-part/context-tool-group.tsx
+++ b/packages/ui/src/components/message-part/context-tool-group.tsx
@@ -2,12 +2,13 @@ import { createEffect, createMemo, createSignal, For, Index, on, Show } from "so
 import type { ToolPart } from "@opencode-ai/sdk/v2"
 import { useI18n } from "../../context/i18n"
 import { Collapsible } from "../collapsible"
+import { createBoundedStateMap } from "../persisted-state-map"
 import { TextShimmer } from "../text-shimmer"
 import { AnimatedCountList } from "../tool-count-summary"
 import { ToolStatusTitle } from "../tool-status-title"
 import { contextToolSummary, contextToolTrigger } from "./context-tool-helpers"
 
-const contextToolGroupOpenState = new Map<string, boolean>()
+const contextToolGroupOpenState = createBoundedStateMap<boolean>()
 
 export function ContextToolGroup(props: { parts: ToolPart[]; busy?: boolean }) {
   const i18n = useI18n()

--- a/packages/ui/src/components/message-part/message-router.tsx
+++ b/packages/ui/src/components/message-part/message-router.tsx
@@ -35,6 +35,7 @@ export function Part(props: MessagePartProps) {
         defaultOpen={props.defaultOpen}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         turnDurationMs={props.turnDurationMs}
+        stateKey={props.stateKey}
       />
     </Show>
   )

--- a/packages/ui/src/components/message-part/parts/tool.tsx
+++ b/packages/ui/src/components/message-part/parts/tool.tsx
@@ -41,9 +41,7 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
   // renders. Flag-on: render the thin marker (no hide).
   const hideQuestion = createMemo(() => isQuestionRunning() && !newQuestionPath())
   // Hide synthetic stop tool parts while keeping metadata available for exported diagnostics.
-  const hideSyntheticStop = createMemo(
-    () => partMetadata().diagnostics?.loop?.loopAction === "stop",
-  )
+  const hideSyntheticStop = createMemo(() => partMetadata().diagnostics?.loop?.loopAction === "stop")
   const taskId = createMemo(() => {
     if (part().tool !== TOOL_AGENT_LEGACY && part().tool !== TOOL_AGENT) return // agent-rename:legacy-render
     const value = partMetadata().sessionId
@@ -84,17 +82,9 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
               "completed", so this branch would otherwise be unreachable.
               `metadata.dismissed === true` is unique to the new path (the
               legacy dismiss flow routes through the error branch). */}
-          <Match
-            when={
-              isQuestion() &&
-              part().state.status === "completed" &&
-              partMetadata()?.dismissed === true
-            }
-          >
+          <Match when={isQuestion() && part().state.status === "completed" && partMetadata()?.dismissed === true}>
             <div style="width: 100%; display: flex; justify-content: flex-end;">
-              <span class="text-body text-fg-weak cursor-default">
-                {i18n.t("ui.messagePart.questions.dismissed")}
-              </span>
+              <span class="text-body text-fg-weak cursor-default">{i18n.t("ui.messagePart.questions.dismissed")}</span>
             </div>
           </Match>
           <Match when={part().state.status === "error" && toolStateError(part().state)}>
@@ -104,7 +94,7 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
               // fall through to the substring fallback below for back-compat.
               const reason =
                 part().state.status === "error" && "reason" in part().state
-                  ? ((part().state as { reason?: "aborted" | "shutdown" | "tool_failure" }).reason)
+                  ? (part().state as { reason?: "aborted" | "shutdown" | "tool_failure" }).reason
                   : undefined
               if (isQuestion() && (reason === "aborted" || reason === "shutdown")) {
                 return (
@@ -147,6 +137,7 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
                   tool={part().tool}
                   error={webSearchError?.error ?? error()}
                   defaultOpen={props.defaultOpen}
+                  stateKey={props.stateKey ? `${props.stateKey}:error` : undefined}
                   subtitle={webSearchError?.subtitle ?? taskSubtitle()}
                   href={taskHref()}
                 />
@@ -164,6 +155,7 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
               status={part().state.status}
               hideDetails={props.hideDetails}
               defaultOpen={props.defaultOpen}
+              stateKey={props.stateKey}
             />
           </Match>
         </Switch>

--- a/packages/ui/src/components/message-part/parts/tool.tsx
+++ b/packages/ui/src/components/message-part/parts/tool.tsx
@@ -41,10 +41,10 @@ registerPartComponent("tool", function ToolPartDisplay(props) {
   // renders. Flag-on: render the thin marker (no hide).
   const hideQuestion = createMemo(() => isQuestionRunning() && !newQuestionPath())
   // Hide synthetic stop tool parts while keeping metadata available for exported diagnostics.
-  const hideSyntheticStop = createMemo(() => partMetadata().diagnostics?.loop?.loopAction === "stop")
+  const hideSyntheticStop = createMemo(() => partMetadata()?.diagnostics?.loop?.loopAction === "stop")
   const taskId = createMemo(() => {
     if (part().tool !== TOOL_AGENT_LEGACY && part().tool !== TOOL_AGENT) return // agent-rename:legacy-render
-    const value = partMetadata().sessionId
+    const value = partMetadata()?.sessionId
     if (typeof value === "string" && value) return value
   })
   const taskHref = createMemo(() => {

--- a/packages/ui/src/components/message-part/registry.ts
+++ b/packages/ui/src/components/message-part/registry.ts
@@ -23,6 +23,7 @@ export interface MessagePartProps {
   defaultOpen?: boolean
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+  stateKey?: string
 }
 
 export type PartComponent = Component<MessagePartProps>
@@ -43,6 +44,7 @@ export interface ToolProps {
   defaultOpen?: boolean
   forceOpen?: boolean
   locked?: boolean
+  stateKey?: string
 }
 
 export type ToolComponent = Component<ToolProps>

--- a/packages/ui/src/components/message-part/tools/apply-patch.tsx
+++ b/packages/ui/src/components/message-part/tools/apply-patch.tsx
@@ -15,6 +15,8 @@ import { getDirectory } from "../markdown-render"
 import { ToolRegistry } from "../registry"
 import { ToolFileAccordion } from "./_file-accordion"
 
+const applyPatchExpandedState = new Map<string, string[]>()
+
 ToolRegistry.register({
   name: "apply_patch",
   render(props) {
@@ -27,7 +29,9 @@ ToolRegistry.register({
       if (list.length !== 1) return
       return list[0]
     })
-    const [expanded, setExpanded] = createSignal<string[]>([])
+    const [expanded, setExpanded] = createSignal<string[]>(
+      props.stateKey ? (applyPatchExpandedState.get(props.stateKey) ?? []) : [],
+    )
     let seeded = false
 
     createEffect(() => {
@@ -35,7 +39,9 @@ ToolRegistry.register({
       if (list.length === 0) return
       if (seeded) return
       seeded = true
-      setExpanded(list.filter((f) => f.type !== "delete").map((f) => f.filePath))
+      const next = list.filter((f) => f.type !== "delete").map((f) => f.filePath)
+      setExpanded(next)
+      if (props.stateKey) applyPatchExpandedState.set(props.stateKey, next)
     })
 
     const subtitle = createMemo(() => {
@@ -64,7 +70,11 @@ ToolRegistry.register({
                   data-scope="apply-patch"
                   style={{ "--sticky-accordion-offset": "calc(32px + var(--tool-content-gap))" }}
                   value={expanded()}
-                  onChange={(value) => setExpanded(Array.isArray(value) ? value : value ? [value] : [])}
+                  onChange={(value) => {
+                    const next = Array.isArray(value) ? value : value ? [value] : []
+                    setExpanded(next)
+                    if (props.stateKey) applyPatchExpandedState.set(props.stateKey, next)
+                  }}
                 >
                   <For each={files()}>
                     {(file) => {

--- a/packages/ui/src/components/message-part/tools/apply-patch.tsx
+++ b/packages/ui/src/components/message-part/tools/apply-patch.tsx
@@ -5,6 +5,7 @@ import { useFileComponent } from "../../../context/file"
 import { useI18n } from "../../../context/i18n"
 import { Accordion } from "../../accordion"
 import { BasicTool } from "../../basic-tool"
+import { createBoundedStateMap } from "../../persisted-state-map"
 import { DiffChanges } from "../../diff-changes"
 import { FileIcon } from "../../file-icon"
 import { Icon } from "../../icon"
@@ -15,7 +16,7 @@ import { getDirectory } from "../markdown-render"
 import { ToolRegistry } from "../registry"
 import { ToolFileAccordion } from "./_file-accordion"
 
-const applyPatchExpandedState = new Map<string, string[]>()
+const applyPatchExpandedState = createBoundedStateMap<string[]>()
 
 ToolRegistry.register({
   name: "apply_patch",
@@ -42,7 +43,6 @@ ToolRegistry.register({
       if (props.stateKey && applyPatchExpandedState.has(props.stateKey)) return
       const next = list.filter((f) => f.type !== "delete").map((f) => f.filePath)
       setExpanded(next)
-      if (props.stateKey) applyPatchExpandedState.set(props.stateKey, next)
     })
 
     const subtitle = createMemo(() => {

--- a/packages/ui/src/components/message-part/tools/apply-patch.tsx
+++ b/packages/ui/src/components/message-part/tools/apply-patch.tsx
@@ -39,6 +39,7 @@ ToolRegistry.register({
       if (list.length === 0) return
       if (seeded) return
       seeded = true
+      if (props.stateKey && applyPatchExpandedState.has(props.stateKey)) return
       const next = list.filter((f) => f.type !== "delete").map((f) => f.filePath)
       setExpanded(next)
       if (props.stateKey) applyPatchExpandedState.set(props.stateKey, next)

--- a/packages/ui/src/components/persisted-state-map.test.ts
+++ b/packages/ui/src/components/persisted-state-map.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { createBoundedStateMap } from "./persisted-state-map"
+
+test("bounded state map caps entries and evicts the least recently used key", () => {
+  const state = createBoundedStateMap<string>(2)
+
+  state.set("oldest", "old")
+  state.set("recent", "new")
+  expect(state.get("oldest")).toBe("old")
+
+  state.set("newest", "next")
+
+  expect(state.size).toBe(2)
+  expect(state.get("recent")).toBeUndefined()
+  expect(state.get("oldest")).toBe("old")
+  expect(state.get("newest")).toBe("next")
+})

--- a/packages/ui/src/components/persisted-state-map.ts
+++ b/packages/ui/src/components/persisted-state-map.ts
@@ -1,0 +1,40 @@
+export const ROW_LOCAL_PERSISTED_STATE_LIMIT = 500
+
+export type BoundedStateMap<Value> = {
+  readonly size: number
+  get(key: string): Value | undefined
+  has(key: string): boolean
+  set(key: string, value: Value): void
+}
+
+export function createBoundedStateMap<Value>(limit = ROW_LOCAL_PERSISTED_STATE_LIMIT): BoundedStateMap<Value> {
+  const entries = new Map<string, Value>()
+
+  return {
+    get size() {
+      return entries.size
+    },
+    get(key) {
+      if (!entries.has(key)) return undefined
+      const value = entries.get(key) as Value
+      entries.delete(key)
+      entries.set(key, value)
+      return value
+    },
+    has(key) {
+      return entries.has(key)
+    },
+    set(key, value) {
+      if (entries.has(key)) {
+        entries.delete(key)
+      } else {
+        while (entries.size >= limit) {
+          const oldest = entries.keys().next()
+          if (oldest.done) break
+          entries.delete(oldest.value)
+        }
+      }
+      entries.set(key, value)
+    },
+  }
+}

--- a/packages/ui/src/components/session-turn-diffs.tsx
+++ b/packages/ui/src/components/session-turn-diffs.tsx
@@ -12,7 +12,16 @@ import { normalize } from "./session-diff"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 
 const MAX_FILES = 10
+const MAX_PERSISTED_TURN_DIFF_STATES = 500
 const turnDiffState = new Map<string, { showAll: boolean; expanded: string[] }>()
+
+function setTurnDiffState(key: string, value: { showAll: boolean; expanded: string[] }) {
+  if (!turnDiffState.has(key) && turnDiffState.size >= MAX_PERSISTED_TURN_DIFF_STATES) {
+    const oldest = turnDiffState.keys().next().value
+    if (oldest) turnDiffState.delete(oldest)
+  }
+  turnDiffState.set(key, value)
+}
 
 export function SessionTurnDiffs(props: {
   diffs: SnapshotFileDiff[]
@@ -35,11 +44,11 @@ export function SessionTurnDiffs(props: {
     props.onShowAllToggle?.()
     const next = !showAll()
     setState("showAll", next)
-    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: next, expanded: expanded() })
+    if (props.stateKey) setTurnDiffState(props.stateKey, { showAll: next, expanded: expanded() })
   }
   const setExpandedPersistent = (value: string[]) => {
     setState("expanded", value)
-    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: showAll(), expanded: value })
+    if (props.stateKey) setTurnDiffState(props.stateKey, { showAll: showAll(), expanded: value })
   }
 
   return (

--- a/packages/ui/src/components/session-turn-diffs.tsx
+++ b/packages/ui/src/components/session-turn-diffs.tsx
@@ -8,20 +8,12 @@ import { useI18n } from "../context/i18n"
 import { Accordion } from "./accordion"
 import { DiffChanges } from "./diff-changes"
 import { Icon } from "./icon"
+import { createBoundedStateMap } from "./persisted-state-map"
 import { normalize } from "./session-diff"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 
 const MAX_FILES = 10
-const MAX_PERSISTED_TURN_DIFF_STATES = 500
-const turnDiffState = new Map<string, { showAll: boolean; expanded: string[] }>()
-
-function setTurnDiffState(key: string, value: { showAll: boolean; expanded: string[] }) {
-  if (!turnDiffState.has(key) && turnDiffState.size >= MAX_PERSISTED_TURN_DIFF_STATES) {
-    const oldest = turnDiffState.keys().next().value
-    if (oldest) turnDiffState.delete(oldest)
-  }
-  turnDiffState.set(key, value)
-}
+const turnDiffState = createBoundedStateMap<{ showAll: boolean; expanded: string[] }>()
 
 export function SessionTurnDiffs(props: {
   diffs: SnapshotFileDiff[]
@@ -44,11 +36,11 @@ export function SessionTurnDiffs(props: {
     props.onShowAllToggle?.()
     const next = !showAll()
     setState("showAll", next)
-    if (props.stateKey) setTurnDiffState(props.stateKey, { showAll: next, expanded: expanded() })
+    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: next, expanded: expanded() })
   }
   const setExpandedPersistent = (value: string[]) => {
     setState("expanded", value)
-    if (props.stateKey) setTurnDiffState(props.stateKey, { showAll: showAll(), expanded: value })
+    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: showAll(), expanded: value })
   }
 
   return (

--- a/packages/ui/src/components/session-turn-diffs.tsx
+++ b/packages/ui/src/components/session-turn-diffs.tsx
@@ -12,16 +12,19 @@ import { normalize } from "./session-diff"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 
 const MAX_FILES = 10
+const turnDiffState = new Map<string, { showAll: boolean; expanded: string[] }>()
 
 export function SessionTurnDiffs(props: {
   diffs: SnapshotFileDiff[]
   onShowAllToggle?: () => void
+  stateKey?: string
 }) {
   const i18n = useI18n()
   const fileComponent = useFileComponent()
+  const persisted = props.stateKey ? turnDiffState.get(props.stateKey) : undefined
   const [state, setState] = createStore({
-    showAll: false,
-    expanded: [] as string[],
+    showAll: persisted?.showAll ?? false,
+    expanded: persisted?.expanded ?? ([] as string[]),
   })
   const showAll = () => state.showAll
   const expanded = () => state.expanded
@@ -30,7 +33,13 @@ export function SessionTurnDiffs(props: {
   const visible = createMemo(() => (showAll() ? props.diffs : props.diffs.slice(0, MAX_FILES)))
   const toggleAll = () => {
     props.onShowAllToggle?.()
-    setState("showAll", !showAll())
+    const next = !showAll()
+    setState("showAll", next)
+    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: next, expanded: expanded() })
+  }
+  const setExpandedPersistent = (value: string[]) => {
+    setState("expanded", value)
+    if (props.stateKey) turnDiffState.set(props.stateKey, { showAll: showAll(), expanded: value })
   }
 
   return (
@@ -56,7 +65,7 @@ export function SessionTurnDiffs(props: {
           multiple
           style={{ "--sticky-accordion-offset": "44px" }}
           value={expanded()}
-          onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
+          onChange={(value) => setExpandedPersistent(Array.isArray(value) ? value : value ? [value] : [])}
         >
           <For each={visible()}>
             {(diff) => {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -440,7 +440,11 @@ export function SessionTurn(
                   )}
                 </Show>
                 <Show when={!hasVisibleTurnChanges(turnChange()) && diffs().length > 0 && !working()}>
-                  <SessionTurnDiffs diffs={diffs()} onShowAllToggle={() => autoScroll.pause()} />
+                  <SessionTurnDiffs
+                    diffs={diffs()}
+                    onShowAllToggle={() => autoScroll.pause()}
+                    stateKey={props.messageID}
+                  />
                 </Show>
                 <Show when={error()}>
                   <Card variant="error" class="error-card">

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -17,6 +17,15 @@ export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "c
 }
 
 const toolErrorOpenState = new Map<string, boolean>()
+const MAX_PERSISTED_TOOL_ERROR_STATES = 500
+
+function setToolErrorOpenState(key: string, value: boolean) {
+  if (!toolErrorOpenState.has(key) && toolErrorOpenState.size >= MAX_PERSISTED_TOOL_ERROR_STATES) {
+    const oldest = toolErrorOpenState.keys().next().value
+    if (oldest) toolErrorOpenState.delete(oldest)
+  }
+  toolErrorOpenState.set(key, value)
+}
 
 export function ToolErrorCard(props: ToolErrorCardProps) {
   const i18n = useI18n()
@@ -90,7 +99,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
         open={open()}
         onOpenChange={(value) => {
           setState("open", value)
-          if (split.stateKey) toolErrorOpenState.set(split.stateKey, value)
+          if (split.stateKey) setToolErrorOpenState(split.stateKey, value)
         }}
       >
         <Collapsible.Trigger>

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -13,17 +13,23 @@ export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "c
   defaultOpen?: boolean
   subtitle?: string
   href?: string
+  stateKey?: string
 }
+
+const toolErrorOpenState = new Map<string, boolean>()
 
 export function ToolErrorCard(props: ToolErrorCardProps) {
   const i18n = useI18n()
+  const initialOpen = props.stateKey
+    ? (toolErrorOpenState.get(props.stateKey) ?? props.defaultOpen ?? false)
+    : (props.defaultOpen ?? false)
   const [state, setState] = createStore({
-    open: props.defaultOpen ?? false,
+    open: initialOpen,
     copied: false,
   })
   const open = () => state.open
   const copied = () => state.copied
-  const [split, rest] = splitProps(props, ["tool", "error", "defaultOpen", "subtitle", "href"])
+  const [split, rest] = splitProps(props, ["tool", "error", "defaultOpen", "subtitle", "href", "stateKey"])
   const name = createMemo(() => {
     const map: Record<string, string> = {
       read: "ui.tool.read",
@@ -82,7 +88,10 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
         class="tool-collapsible"
         data-open={open() ? "true" : "false"}
         open={open()}
-        onOpenChange={(value) => setState("open", value)}
+        onOpenChange={(value) => {
+          setState("open", value)
+          if (split.stateKey) toolErrorOpenState.set(split.stateKey, value)
+        }}
       >
         <Collapsible.Trigger>
           <div data-component="tool-trigger">

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -4,6 +4,7 @@ import { Card, CardDescription } from "./card"
 import { Collapsible } from "./collapsible"
 import { Icon } from "./icon"
 import { IconButton } from "./icon-button"
+import { createBoundedStateMap } from "./persisted-state-map"
 import { Tooltip } from "./tooltip"
 import { useI18n } from "../context/i18n"
 
@@ -16,16 +17,7 @@ export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "c
   stateKey?: string
 }
 
-const toolErrorOpenState = new Map<string, boolean>()
-const MAX_PERSISTED_TOOL_ERROR_STATES = 500
-
-function setToolErrorOpenState(key: string, value: boolean) {
-  if (!toolErrorOpenState.has(key) && toolErrorOpenState.size >= MAX_PERSISTED_TOOL_ERROR_STATES) {
-    const oldest = toolErrorOpenState.keys().next().value
-    if (oldest) toolErrorOpenState.delete(oldest)
-  }
-  toolErrorOpenState.set(key, value)
-}
+const toolErrorOpenState = createBoundedStateMap<boolean>()
 
 export function ToolErrorCard(props: ToolErrorCardProps) {
   const i18n = useI18n()
@@ -99,7 +91,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
         open={open()}
         onOpenChange={(value) => {
           setState("open", value)
-          if (split.stateKey) setToolErrorOpenState(split.stateKey, value)
+          if (split.stateKey) toolErrorOpenState.set(split.stateKey, value)
         }}
       >
         <Collapsible.Trigger>

--- a/packages/ui/test/fixtures/basic-tool-render.fixture.tsx
+++ b/packages/ui/test/fixtures/basic-tool-render.fixture.tsx
@@ -6,7 +6,7 @@ function Details(props: { onRender: () => void }) {
   return <span data-testid="basic-tool-details">details</span>
 }
 
-export function mountBasicTool(props: { defaultOpen?: boolean; defer?: boolean }) {
+export function mountBasicTool(props: { defaultOpen?: boolean; defer?: boolean; stateKey?: string }) {
   let detailsRenderCount = 0
   const host = document.createElement("div")
   document.body.append(host)
@@ -18,6 +18,7 @@ export function mountBasicTool(props: { defaultOpen?: boolean; defer?: boolean }
         trigger={{ title: "Test tool" }}
         defaultOpen={props.defaultOpen}
         defer={props.defer}
+        stateKey={props.stateKey}
       >
         <Details onRender={() => detailsRenderCount++} />
       </BasicTool>


### PR DESCRIPTION
## Summary

- Adds row-level virtualization for the session timeline while keeping scroll/reveal execution behind `TimelineScrollCommandSink`.
- Adds perf guard semantics that distinguish total virtual rows from mounted message DOM rows.
- Persists row-local expansion state across virtual row remounts and adapts scroll/diagnostics E2E coverage for virtualized rows.

## Why

Long session timelines were still too expensive to keep mounted while preserving stable scroll behavior around old hash navigation and submit recovery. This PR is PR1 for the #747 follow-up plan: it reduces mounted timeline DOM and keeps scroll ownership centralized, but it does **not** claim to close #747. PR2 still owns the controlled runtime CLS gate.

## Related Issue

Related to #747. Does not close it; this is the row virtualization PR1 slice.

## Human Review Status

Pending

## Review Focus

- Confirm `virtua/solid` stays a measurement/mounting layer only; target reveal and submit recovery should continue through `TimelineScrollCommandSink`.
- Check the virtual row identity model and E2E perf assertions (`data-total-rows` vs mounted `[data-message-id]`).
- Review the minimal persisted expansion state keys for tool/diff rows across virtualization remounts.

## Risk Notes

- PR1 does not include the PR2 runtime CLS gate and does not close #747.
- Large patchless full-file diff CPU cost remains out of scope for this slice.
- The existing `virtua@0.42.3` package emits a Vite JSX import-source warning during web/E2E runs; tests pass with the warning.
- Platform/packaging surfaces were not touched, so the platform checklist item is left unticked.
- Docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, and local file surfaces were not touched, so that conditional checklist item is left unticked.

## How To Verify

```text
Typecheck: `bun run typecheck` → passed (`tsgo -b`).
Focused unit tests: `bun test --preload ./happydom.ts ./src/pages/session/timeline-virtual-rows.test.ts ./src/pages/session/use-session-history-window.test.ts ./src/pages/session/use-session-hash-scroll.test.ts ./src/pages/session/timeline-scroll-ownership-guard.test.ts` → 30 passed, 0 failed.
Scroll E2E: `bun run test:e2e -- e2e/session/session-scroll-position.spec.ts` → 4 passed.
Renderer diagnostics E2E: `bun run test:e2e -- e2e/session/session-renderer-diagnostics.spec.ts` → 4 passed.
Perf guard: `PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_SCENARIOS=session-scroll-reading-long bun run test:e2e:perf` → 1 passed, 9 skipped.
Perf guard: `PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_SCENARIOS=session-timeline-recompute bun run test:e2e:perf` → 1 passed, 9 skipped.
Perf guard: `PAWWORK_PERF_SCENARIOS=long-session-input-lag bun run test:e2e:perf` → 1 passed, 9 skipped.
Visual snap: `bun run snap message-command-inline` → 1 passed; reviewed generated grid PNG at `docs/design/preview/screenshots/message-command-inline.png`.
Final diff/status: reviewed `git diff dev...HEAD --stat`; branch was clean before push.
```

## Screenshots or Recordings

- Ran and reviewed `message-command-inline` snap: `docs/design/preview/screenshots/message-command-inline.png`.
- No existing snap target directly covers the full virtualized timeline surface; scroll and renderer behavior are covered by the targeted E2E runs above.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple UI components (conversation panels, tools, diffs, error cards) now persist their expanded/collapsed state across renders and navigation.
  * Timeline now uses virtualized row rendering for large sessions, improving responsiveness.

* **Performance**
  * Faster and more memory-efficient scrolling/rendering for long message histories; improved jump-to-message behavior with virtualization-aware seeks.

* **Tests**
  * Expanded E2E and unit tests to validate timeline virtualization, DOM-budget checks, and hash-scroll retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->