### PR TITLE
fix(app): normalize timeline scroll guard paths

### DIFF
--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -59,6 +59,20 @@ describe("timeline scroll ownership guard", () => {
     ).toEqual([])
   })
 
+  test("matches reviewed exceptions when scanned file paths use Windows separators", () => {
+    expect(
+      scanTimelineScrollOwnershipText({
+        filePath: "packages\\app\\src\\pages\\session\\composer\\session-question-dock.tsx",
+        sourceText: `
+          function keepVisibleInQuestionOptions(scroller: HTMLElement) {
+            scroller.scrollTop += 1
+          }
+        `,
+        allowlist: timelineScrollCommandAllowlist,
+      }).violations,
+    ).toEqual([])
+  })
+
   test("keeps production session timeline writes behind the command sink", async () => {
     const result = await scanTimelineScrollOwnership({
       roots: [here],

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.ts
@@ -73,8 +73,13 @@ function nearestSymbol(node: ts.Node) {
   return "<module>"
 }
 
+function normalizeRepoPath(filePath: string) {
+  return filePath.replace(/\\/g, "/")
+}
+
 function isAllowed(filePath: string, symbol: string, allowlist: TimelineScrollOwnershipAllowlistEntry[]) {
-  return allowlist.some((entry) => entry.filePath === filePath && entry.symbol === symbol)
+  const normalizedFilePath = normalizeRepoPath(filePath)
+  return allowlist.some((entry) => normalizeRepoPath(entry.filePath) === normalizedFilePath && entry.symbol === symbol)
 }
 
 function propertyName(node: ts.Expression) {


### PR DESCRIPTION
## Summary

Fixes the merged `dev` Windows advisory failure by making the timeline scroll ownership guard compare allowlisted repo paths independent of the host path separator. No issue exists because this is direct merged-branch CI recovery.

## Why

`unit-windows-app` failed on merged `dev` because `scanTimelineScrollOwnership` builds scanned file paths with `node:path.join()`. On Windows that produces backslashes, while `timelineScrollCommandAllowlist` stores reviewed repo paths with forward slashes. The guard treated reviewed exceptions as new timeline scroll violations even though the source code had not regressed.

The latest merged `dev` Windows advisory run confirmed the other Windows jobs passed; the remaining stable failure was `unit-windows-app`.

## Related Issue

None. This PR fixes a merged `dev` CI regression directly.

## Human Review Status

Pending

## Review Focus

Confirm the fix stays limited to allowlist matching and does not change violation reporting or scanned path construction.

## Risk Notes

Low. This normalizes only the allowlist comparison path; violation output keeps the original scanned path. The touched surface is cross-platform path handling for a test guard, not product UI behavior.

No screenshots or recordings: no visible UI or copy changed.

## How To Verify

```text
bun test src/pages/session/timeline-scroll-ownership-guard.test.ts
Result: 5 pass, 0 fail, including Windows separator allowlist coverage.

bun run test:ci  # from packages/app
Result: 1447 pass, 0 fail.

bun run typecheck
Result: 8 successful package typecheck tasks.

git diff --check
Result: no whitespace errors.
```

## Screenshots or Recordings

Not applicable. No visible UI or copy changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cross-operating system compatibility by standardizing file path handling, ensuring the timeline scroll ownership verification feature operates consistently across Windows and Unix-style path formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->