### PR TITLE
chore(release): bump desktop version to v2026.5.21

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.20",
+      "version": "2026.5.21",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.20",
+  "version": "2026.5.21",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the desktop Electron package version to `2026.5.21` for the next stable PawWork release.

No related issue: this is the release-version PR for the current `dev` baseline (`346472ea6`).

## Why

The stable GitHub release workflow reads `packages/desktop-electron/package.json` to derive the release tag, installer names, and updater metadata. This PR prepares `v2026.5.21` from the current `dev` branch.

## Related Issue

None. This is a release bump for the current stable release.

## Human Review Status

Not required: automated release-version bump only; no product logic or workflow behavior changed.

## Review Focus

Confirm the version bump is limited to the desktop package version and the matching workspace metadata in `bun.lock`.

## Risk Notes

No behavior risk from this PR itself. Release risk remains in the downstream signed/notarized artifact build and post-release verification.

Skipped checklist items:

- Manual visible UI/copy check: no visible UI or copy changed.

## How To Verify

```text
bun install: lockfile saved with desktop workspace version 2026.5.21
bun install --frozen-lockfile: passed, no changes
bun run --cwd packages/desktop-electron typecheck:release: passed
bun --cwd packages/desktop-electron test scripts/verify-release.test.ts scripts/release-workflow-contract.test.ts: 41 passed, 0 failed
git diff --check: passed
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
