### PR TITLE
test(opencode): reduce snapshot batch fixture sizes

### DIFF
--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -11,6 +11,9 @@ import { tmpdir } from "../fixture/fixture"
 // with path.join (which produces \ on Windows) then normalizes back to /.
 // This helper does the same for expected values so assertions match cross-platform.
 const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
+const SNAPSHOT_BATCH_BOUNDARY = 100
+const OVER_BATCH_COUNT = SNAPSHOT_BATCH_BOUNDARY + 1
+const MIXED_BATCH_GROUP_COUNT = Math.ceil(OVER_BATCH_COUNT / 4)
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -1098,7 +1101,7 @@ test("diffFull with a large interleaved mixed diff", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const ids = Array.from({ length: 60 }, (_, i) => i.toString().padStart(3, "0"))
+      const ids = Array.from({ length: MIXED_BATCH_GROUP_COUNT }, (_, i) => i.toString().padStart(3, "0"))
       const mod = ids.map((id) => fwd(tmp.path, "mix", `${id}-mod.txt`))
       const del = ids.map((id) => fwd(tmp.path, "mix", `${id}-del.txt`))
       const add = ids.map((id) => fwd(tmp.path, "mix", `${id}-add.txt`))
@@ -1161,7 +1164,7 @@ test("diffFull preserves git diff order across batch boundaries", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const ids = Array.from({ length: 140 }, (_, i) => i.toString().padStart(3, "0"))
+      const ids = Array.from({ length: OVER_BATCH_COUNT }, (_, i) => i.toString().padStart(3, "0"))
 
       await $`mkdir -p ${tmp.path}/order`.quiet()
       await Promise.all(ids.map((id) => Filesystem.write(`${tmp.path}/order/${id}.txt`, `before-${id}`)))
@@ -1471,8 +1474,8 @@ test("revert handles large mixed batches across chunk boundaries", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const base = Array.from({ length: 140 }, (_, i) => fwd(tmp.path, "batch", `${i}.txt`))
-      const fresh = Array.from({ length: 140 }, (_, i) => fwd(tmp.path, "fresh", `${i}.txt`))
+      const base = Array.from({ length: OVER_BATCH_COUNT }, (_, i) => fwd(tmp.path, "batch", `${i}.txt`))
+      const fresh = [fwd(tmp.path, "fresh", "0.txt")]
 
       await $`mkdir -p ${tmp.path}/batch ${tmp.path}/fresh`.quiet()
       await Promise.all(base.map((file, i) => Filesystem.write(file, `base-${i}`)))


### PR DESCRIPTION
## Summary

Reduce oversized snapshot batch fixtures so the tests still cross the 100-file batching boundary without pushing Windows CI into the 30s per-test timeout.

No issue: this follows the merged `dev` Windows advisory failure in run `26178604454`, where `unit-windows-opencode-server-tools` timed out on `diffFull with a large interleaved mixed diff`.

## Why

The merged CI rerun cleared the previous `unit-windows-app` path-guard failure, then exposed a separate Windows timeout in the snapshot stress fixture. The test only needs to verify behavior across the 100-file batch boundary, but it was generating 240 mixed diff rows and 280 revert rows.

## Related Issue

No issue. Merged CI repair follow-up.

## Human Review Status

Pending

## Review Focus

Confirm the reduced fixture sizes still cross the snapshot batching boundary and preserve the mixed add/delete/modify/binary coverage.

## Risk Notes

No product behavior change. Conditional UI/copy check skipped because this is test-only. Conditional docs/release/dependency check skipped because no docs, release notes, dependencies, generated files, or local-only files changed.

## How To Verify

```text
bun install --frozen-lockfile: ok
cd packages/opencode && bun test --timeout 30000 test/snapshot/snapshot.test.ts: 52 pass, 1 skip, 0 fail
cd packages/opencode && bun test --timeout 30000 test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git test/storage test/provider test/pty test/share test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth: 1340 pass, 2 skip, 0 fail
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
