### PR TITLE
test(opencode): stabilize middleware log assertions

### DIFF
--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -96,7 +96,7 @@ describe("server error middleware", () => {
 
     expect(response.status).toBe(404)
     expect(body.name).toBe("NotFoundError")
-    expect(calls.some((call) => call.message === "failed" && call.extra?.error instanceof NotFoundError)).toBe(false)
+    expect(calls).toEqual([])
   })
 
   test("still error-logs unexpected server failures", async () => {
@@ -112,6 +112,6 @@ describe("server error middleware", () => {
     })
 
     expect(response.status).toBe(500)
-    expect(calls.some((call) => call.message === "failed" && call.extra?.error === error)).toBe(true)
+    expect(calls).toEqual([{ message: "failed", extra: { error } }])
   })
 })

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -1,18 +1,31 @@
 import { describe, expect, test } from "bun:test"
-import { readFile } from "fs/promises"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { InvalidError, JsonError } from "../../src/config/error"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { NotFoundError } from "../../src/storage/db"
 
-async function readLogFile() {
-  for (let i = 0; i < 20; i++) {
-    const text = await readFile(Log.file(), "utf8").catch(() => "")
-    if (text.length > 0) return text
-    await Bun.sleep(10)
+type ErrorLogCall = {
+  message?: unknown
+  extra?: Record<string, unknown>
+}
+
+async function captureServerErrorLogs(fn: (calls: ErrorLogCall[]) => Promise<void>) {
+  const logger = Log.create({ service: "server" })
+  const original = logger.error
+  const calls: ErrorLogCall[] = []
+
+  logger.error = (message, extra) => {
+    calls.push({ message, extra })
   }
-  return readFile(Log.file(), "utf8").catch(() => "")
+
+  try {
+    await fn(calls)
+  } finally {
+    logger.error = original
+  }
+
+  return calls
 }
 
 describe("server error middleware", () => {
@@ -69,39 +82,36 @@ describe("server error middleware", () => {
   })
 
   test("does not error-log expected not found responses", async () => {
-    await Log.init({ print: false })
-    const before = await readLogFile()
     const app = new Hono().get("/missing", () => {
       throw new NotFoundError({ message: "Session not found: ses_missing" })
     })
     app.onError(ErrorMiddleware)
 
-    const response = await app.request("/missing")
-    const body = await response.json()
-    const after = await readLogFile()
-    const logs = after.slice(before.length)
+    let response!: Response
+    let body!: { name: string }
+    const calls = await captureServerErrorLogs(async () => {
+      response = await app.request("/missing")
+      body = await response.json()
+    })
 
     expect(response.status).toBe(404)
     expect(body.name).toBe("NotFoundError")
-    expect(logs).not.toContain("ERROR")
-    expect(logs).not.toContain("failed")
+    expect(calls.some((call) => call.message === "failed" && call.extra?.error instanceof NotFoundError)).toBe(false)
   })
 
   test("still error-logs unexpected server failures", async () => {
-    await Log.init({ print: false })
-    const before = await readLogFile()
+    const error = new Error("boom")
     const app = new Hono().get("/boom", () => {
-      throw new Error("boom")
+      throw error
     })
     app.onError(ErrorMiddleware)
 
-    const response = await app.request("/boom")
-    const after = await readLogFile()
-    const logs = after.slice(before.length)
+    let response!: Response
+    const calls = await captureServerErrorLogs(async () => {
+      response = await app.request("/boom")
+    })
 
     expect(response.status).toBe(500)
-    expect(logs).toContain("ERROR")
-    expect(logs).toContain("failed")
-    expect(logs).toContain("boom")
+    expect(calls.some((call) => call.message === "failed" && call.extra?.error === error)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Stabilize server error middleware log assertions by capturing the cached server logger directly.
- Remove file-log polling from the middleware tests so they do not depend on async log flush timing or concurrent `Log.init()` calls in other test files.

## Root cause
- The latest merged `dev` CI after PR #797 still failed in `windows-advisory` run 26180036670.
- The failing shard was `unit-windows-opencode-server-tools`.
- The failing test was `server error middleware > still error-logs unexpected server failures`.
- The test read the shared global log file immediately after `Log.error()`, but `Log.error()` writes through an async stream and many shard tests also call `Log.init()`. On Windows this can read before the expected log is visible.

## Verification
- `cd packages/opencode && bun test --timeout 30000 test/server/middleware.test.ts`
- `cd packages/opencode && bun test --timeout 30000 test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git test/storage test/provider test/pty test/share test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth`

## Risk
- Test-only change. It keeps the same behavior boundary: expected not-found errors are not error-logged, unexpected server failures are error-logged.

## Checklist
- [x] Targeted tests pass locally
- [x] Full affected shard passes locally
- [ ] PR CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced server error middleware test suite with improved logging capture and verification methods, enabling more reliable error scenario assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->