### PR TITLE
test(opencode): avoid invalid branch worktree failure path

### DIFF
--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -162,15 +162,11 @@ describe("Worktree", () => {
     test("restores .gitignore when git worktree add fails", async () => {
       await using tmp = await tmpdir({ git: true })
       const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("bad-branch"))
+      await $`git branch ${info.branch}`.cwd(tmp.path).quiet()
 
-      await expect(
-        withInstance(tmp.path, () =>
-          Worktree.createFromInfo({
-            ...info,
-            branch: "bad branch name",
-          }),
-        ),
-      ).rejects.toThrow("WorktreeCreateFailedError")
+      await expect(withInstance(tmp.path, () => Worktree.createFromInfo(info))).rejects.toThrow(
+        "WorktreeCreateFailedError",
+      )
 
       await expect(Bun.file(path.join(tmp.path, ".gitignore")).text()).rejects.toThrow()
     })


### PR DESCRIPTION
## Summary

Stabilizes the worktree failure-path test that timed out in merged Windows advisory CI. There is no separate issue; this PR follows the failed `dev` push run for merge commit `0274c82988`.

## Why

`Worktree > create + remove lifecycle > restores .gitignore when git worktree add fails` forced `git worktree add` to fail by passing an invalid branch name. On Windows advisory CI that path timed out, which made the failure signal noisy. This keeps the same rollback coverage but triggers the failure by creating the branch first, so `git worktree add -b <existing-branch>` fails quickly and deterministically.

## Related Issue

No separate issue. Follow-up for merged CI failure in `windows-advisory` run `26181678477`.

## Human Review Status

Pending

## Review Focus

Confirm the test still covers `.gitignore` restoration after `Worktree.createFromInfo` fails during `git worktree add`, without relying on invalid branch-name behavior.

## Risk Notes

No product behavior changes. The only meaningful risk is test-surface coverage: this changes how the negative git path is induced, not the production worktree code.

## How To Verify

```text
Focused worktree test: cd packages/opencode && bun test --timeout 30000 test/project/worktree.test.ts -> 15 pass, 0 fail
Windows advisory config-project shard locally: cd packages/opencode && bun test --timeout 30000 test/config test/project test/worktree test/file test/github test/settings test/settings.test.ts -> 438 pass, 3 skip, 0 fail
Diff review: one test file changed; no production code, dependency, or generated-file changes
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
