### PR TITLE
test(opencode): relax compaction retry wait

### DIFF
--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1306,7 +1306,7 @@ describe("session.compaction.process", () => {
 
           await Promise.race([
             ready.promise,
-            wait(1000).then(() => {
+            wait(5_000).then(() => {
               throw new Error("timed out waiting for retry status")
             }),
           ])


### PR DESCRIPTION
## Summary

No related issue; this follows the failed merged `dev` CI run [`26183351655`](https://github.com/Astro-Han/pawwork/actions/runs/26183351655), where the Windows session shard timed out waiting for the compaction retry status.

This PR relaxes that focused test wait from 1 second to 5 seconds so slower Windows scheduling can observe the already expected retry state before the abort assertion runs.

## Why

The production code already delays retry backoff by 10 seconds. The test only used a 1 second polling race to notice the retry status before aborting. On Windows CI, that observation window was too tight and produced a merged-CI-only failure without evidence of a product regression.

## Related Issue

No separate issue. This is a direct merged CI repair after run `26183351655`.

## Human Review Status

Pending

## Review Focus

Confirm this stays at the test layer: it only gives the status observer more time and does not change compaction, retry, abort, or provider behavior.

## Risk Notes

Skipped visible UI/copy check: no UI or copy changed.
Skipped docs/release/dependency check: no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file outputs changed.

## How To Verify

```text
cd packages/opencode && bun test --timeout 30000 test/session/compaction.test.ts -t "stops quickly when aborted during retry backoff"
Result: 1 pass, 43 filtered, 0 fail, 3 expects, 1.303s

cd packages/opencode && bun test --timeout 30000 test/session test/plugin test/permission test/util test/skill test/index-runtime-namespace.test.ts test/permission-agent.test.ts test/permission-cleanup.test.ts
Result: 1097 pass, 4 skip, 1 todo, 0 fail, 6323 expects, 84.06s
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test timeout handling to enhance reliability of retry status validation during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->