### PR TITLE
fix(app): use PawWork referral link for OpenCode Go

### DIFF
--- a/packages/app/src/components/rate-limit-card-wiring.test.ts
+++ b/packages/app/src/components/rate-limit-card-wiring.test.ts
@@ -4,5 +4,5 @@ import { test, expect } from "bun:test"
 const source = readFileSync(new URL("./rate-limit-card-wiring.tsx", import.meta.url), "utf8")
 
 test("OpenCode Go subscription opens PawWork referral link", () => {
-  expect(source).toContain('const SUBSCRIBE_URL = "https://opencode.ai/go?ref=V1WTSZKC69"')
+  expect(source).toMatch(/const\s+SUBSCRIBE_URL\s*=\s*["']https:\/\/opencode\.ai\/go\?ref=V1WTSZKC69["']/)
 })

--- a/packages/app/src/components/rate-limit-card-wiring.test.ts
+++ b/packages/app/src/components/rate-limit-card-wiring.test.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from "node:fs"
+import { test, expect } from "bun:test"
+
+const source = readFileSync(new URL("./rate-limit-card-wiring.tsx", import.meta.url), "utf8")
+
+test("OpenCode Go subscription opens PawWork referral link", () => {
+  expect(source).toContain('const SUBSCRIBE_URL = "https://opencode.ai/go?ref=V1WTSZKC69"')
+})

--- a/packages/app/src/components/rate-limit-card-wiring.tsx
+++ b/packages/app/src/components/rate-limit-card-wiring.tsx
@@ -3,7 +3,7 @@ import { RateLimitCard } from "@opencode-ai/ui/rate-limit-card"
 import { useShellSurface } from "../context/shell-surface"
 import { trackEvent } from "../utils/events"
 
-const SUBSCRIBE_URL = "https://opencode.ai/go"
+const SUBSCRIBE_URL = "https://opencode.ai/go?ref=V1WTSZKC69"
 
 // openLink is exposed by the desktop-electron preload (packages/desktop-electron/src/preload/types.ts:97).
 // The renderer-side window.api type in app.tsx declares only the subset of API the app actually uses;


### PR DESCRIPTION
## Summary

- Route the OpenCode Go subscription action to PawWork's referral URL instead of the default `https://opencode.ai/go`.
- Add a focused source-level guard so the referral URL does not regress back to the default link.
- No linked issue; this is a small user-requested referral routing update.

## Why

The rate-limit card sends users to OpenCode Go when the free quota is exhausted. Using PawWork's referral link preserves that conversion path while keeping the existing card UI and telemetry behavior unchanged.

## Related Issue

None — user-requested small routing change.

## Human Review Status

Pending

## Review Focus

Please check that the subscription target is the intended referral URL and that the source-level guard is sufficient for this narrow link change.

## Risk Notes

No behavior risk beyond changing the external URL opened by the subscribe action.

Skipped conditional checklist items:
- Visible UI/copy manual check: not applicable; no rendered UI or copy changed.
- Platform/packaging impact: not applicable; no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Docs/release/dependency/permission/generated/local-file note: not applicable; none of those surfaces changed.

## How To Verify

```text
Referral link test: bun test src/components/rate-limit-card-wiring.test.ts — 1 pass, 0 fail
App typecheck: bun run typecheck — completed successfully via tsgo -b
Final diff review: git diff dev...HEAD — only the referral URL and focused guard test changed
```

## Screenshots or Recordings

Not required — no visible UI or copy changed; only the external link target changes.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.