### PR TITLE
fix(ui): stabilize turn change diff expansion

### DIFF
--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "../fixtures"
+import { routeTurnChangeDiff, TURN_CHANGE_DIFF_FILE_PATH } from "./turn-change-diff-fixture"
+
+test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await page.addInitScript(() => {
+    const state = { total: 0 }
+    Object.defineProperty(window, "__turnChangeCls", { value: state })
+    if (typeof PerformanceObserver === "undefined") return
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries() as Array<
+          PerformanceEntry & { value?: number; hadRecentInput?: boolean }
+        >) {
+          if (entry.hadRecentInput || typeof entry.value !== "number") continue
+          state.total += entry.value
+        }
+      })
+      observer.observe({ type: "layout-shift", buffered: true })
+    } catch {}
+  })
+
+  await project.open()
+  await routeTurnChangeDiff(page, { sessionID: "e2e-session" })
+
+  await llm.text("seeded turn-change diff")
+  await project.prompt(`seed turn-change diff ${Date.now()}`)
+
+  const card = page.locator('[data-slot="session-turn-changes"]').last()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  const row = card
+    .locator('[data-slot="session-turn-change-row"]')
+    .filter({ hasText: TURN_CHANGE_DIFF_FILE_PATH })
+    .first()
+  await expect(row).toBeVisible()
+
+  await page.evaluate(() => {
+    const state = (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls
+    if (state) state.total = 0
+  })
+
+  for (const _ of [0, 1, 2]) {
+    await row.click()
+    const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+    await expect(diff).toBeVisible()
+    await expect
+      .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0)
+    await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
+    await row.click()
+    await expect(diff).toHaveCount(0)
+  }
+
+  const cls = await page.evaluate(
+    () => (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls?.total ?? 0,
+  )
+  expect(cls).toBeLessThan(0.1)
+})

--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -39,7 +39,7 @@ async function openTurnChangeCard(input: {
   await input.llm.text("seeded turn-change diff")
   await input.project.prompt(`seed turn-change diff ${Date.now()}`)
 
-  const card = input.page.locator('[data-slot="session-turn-changes"]').last()
+  const card = input.page.locator('[data-component="session-turn-changes"]').last()
   await expect(card).toBeVisible({ timeout: 30_000 })
   return card
 }
@@ -63,7 +63,7 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
   await installClsProbe(page)
   const card = await openTurnChangeCard({ page, llm, project })
   const row = card
-    .locator('[data-slot="session-turn-change-row"]')
+    .locator('[data-component="session-turn-change-row"]')
     .filter({ hasText: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
@@ -72,14 +72,14 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
 
   for (const _ of [0, 1, 2]) {
     await row.click()
-    const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+    const diff = card.locator('[data-component="session-turn-change-diff"]').first()
     await expect(diff).toBeVisible()
     await expect
       .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
         timeout: 10_000,
       })
       .toBeGreaterThanOrEqual(384)
-    await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
+    await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
     await row.click()
     await expect(diff).toHaveCount(0)
   }
@@ -93,15 +93,16 @@ test("small replacement diffs settle close to rendered content height", async ({
   await installClsProbe(page)
   const card = await openTurnChangeCard({ page, llm, project })
   const row = card
-    .locator('[data-slot="session-turn-change-row"]')
+    .locator('[data-component="session-turn-change-row"]')
     .filter({ hasText: TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
 
   await resetClsProbe(page)
   await row.click()
-  const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+  const diff = card.locator('[data-component="session-turn-change-diff"]').first()
   await expect(diff).toBeVisible()
+  await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
   const lines = diff.locator("[data-line]")
   await expect(lines.first()).toBeVisible({ timeout: 30_000 })
 

--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { routeTurnChangeDiff, TURN_CHANGE_DIFF_FILE_PATH } from "./turn-change-diff-fixture"
+import { routeTurnChangeDiff, TURN_CHANGE_MODIFIED_DIFF_FILE_PATH } from "./turn-change-diff-fixture"
 
 test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
   test.setTimeout(180_000)
@@ -31,7 +31,7 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
   await expect(card).toBeVisible({ timeout: 30_000 })
   const row = card
     .locator('[data-slot="session-turn-change-row"]')
-    .filter({ hasText: TURN_CHANGE_DIFF_FILE_PATH })
+    .filter({ hasText: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
 
@@ -48,7 +48,7 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
       .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
         timeout: 10_000,
       })
-      .toBeGreaterThan(0)
+      .toBeGreaterThanOrEqual(384)
     await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
     await row.click()
     await expect(diff).toHaveCount(0)

--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -1,9 +1,12 @@
+import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import { routeTurnChangeDiff, TURN_CHANGE_MODIFIED_DIFF_FILE_PATH } from "./turn-change-diff-fixture"
+import {
+  routeTurnChangeDiff,
+  TURN_CHANGE_MODIFIED_DIFF_FILE_PATH,
+  TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH,
+} from "./turn-change-diff-fixture"
 
-test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
-  test.setTimeout(180_000)
-
+async function installClsProbe(page: Page) {
   await page.addInitScript(() => {
     const state = { total: 0 }
     Object.defineProperty(window, "__turnChangeCls", { value: state })
@@ -20,25 +23,52 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
       observer.observe({ type: "layout-shift", buffered: true })
     } catch {}
   })
+}
 
-  await project.open()
-  await routeTurnChangeDiff(page, { sessionID: "e2e-session" })
+async function openTurnChangeCard(input: {
+  page: Page
+  llm: { text: (value: string) => Promise<void> }
+  project: {
+    open: () => Promise<void>
+    prompt: (value: string) => Promise<void>
+  }
+}) {
+  await input.project.open()
+  await routeTurnChangeDiff(input.page, { sessionID: "e2e-session" })
 
-  await llm.text("seeded turn-change diff")
-  await project.prompt(`seed turn-change diff ${Date.now()}`)
+  await input.llm.text("seeded turn-change diff")
+  await input.project.prompt(`seed turn-change diff ${Date.now()}`)
 
-  const card = page.locator('[data-slot="session-turn-changes"]').last()
+  const card = input.page.locator('[data-slot="session-turn-changes"]').last()
   await expect(card).toBeVisible({ timeout: 30_000 })
+  return card
+}
+
+async function resetClsProbe(page: Page) {
+  await page.evaluate(() => {
+    const state = (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls
+    if (state) state.total = 0
+  })
+}
+
+async function readClsProbe(page: Page) {
+  return await page.evaluate(
+    () => (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls?.total ?? 0,
+  )
+}
+
+test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await installClsProbe(page)
+  const card = await openTurnChangeCard({ page, llm, project })
   const row = card
     .locator('[data-slot="session-turn-change-row"]')
     .filter({ hasText: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
 
-  await page.evaluate(() => {
-    const state = (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls
-    if (state) state.total = 0
-  })
+  await resetClsProbe(page)
 
   for (const _ of [0, 1, 2]) {
     await row.click()
@@ -54,8 +84,37 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
     await expect(diff).toHaveCount(0)
   }
 
-  const cls = await page.evaluate(
-    () => (window as unknown as { __turnChangeCls?: { total: number } }).__turnChangeCls?.total ?? 0,
-  )
-  expect(cls).toBeLessThan(0.1)
+  expect(await readClsProbe(page)).toBeLessThan(0.1)
+})
+
+test("small replacement diffs settle close to rendered content height", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await installClsProbe(page)
+  const card = await openTurnChangeCard({ page, llm, project })
+  const row = card
+    .locator('[data-slot="session-turn-change-row"]')
+    .filter({ hasText: TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH })
+    .first()
+  await expect(row).toBeVisible()
+
+  await resetClsProbe(page)
+  await row.click()
+  const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+  await expect(diff).toBeVisible()
+  const lines = diff.locator("[data-line]")
+  await expect(lines.first()).toBeVisible({ timeout: 30_000 })
+
+  await expect
+    .poll(async () => {
+      const containerBox = await diff.boundingBox()
+      const firstLineBox = await lines.first().boundingBox()
+      const lastLineBox = await lines.last().boundingBox()
+      if (!containerBox || !firstLineBox || !lastLineBox) return Number.POSITIVE_INFINITY
+      const renderedContentHeight = lastLineBox.y + lastLineBox.height - firstLineBox.y
+      return containerBox.height - renderedContentHeight
+    })
+    .toBeLessThan(96)
+
+  expect(await readClsProbe(page)).toBeLessThan(0.1)
 })

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test"
 
 export const TURN_CHANGE_DIFF_FILE_PATH = "turn-change-cls-fixture.ts"
 export const TURN_CHANGE_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-replacement.ts"
+export const TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-small-replacement.ts"
 
 const turnChangeDiffPatch = [
   `diff --git a/${TURN_CHANGE_DIFF_FILE_PATH} b/${TURN_CHANGE_DIFF_FILE_PATH}`,
@@ -48,6 +49,24 @@ const turnChangeModifiedDiffPatch = [
   " ]",
 ].join("\n")
 
+const turnChangeSmallModifiedDiffPatch = [
+  `diff --git a/${TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH} b/${TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH}`,
+  "index 4444444..5555555 100644",
+  `--- a/${TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH}`,
+  `+++ b/${TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH}`,
+  "@@ -1,9 +1,9 @@",
+  " export const rows = [",
+  '   "alpha",',
+  '   "beta",',
+  '   "gamma",',
+  '-  "delta",',
+  '+  "delta replacement",',
+  '   "epsilon",',
+  '   "zeta",',
+  '   "eta",',
+  " ]",
+].join("\n")
+
 export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
   await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes$/, async (route) => {
     const url = new URL(route.request().url())
@@ -76,6 +95,14 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             additions: 8,
             deletions: 6,
             patch: turnChangeModifiedDiffPatch,
+            expandable: true,
+          },
+          {
+            path: TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH,
+            status: "modified",
+            additions: 1,
+            deletions: 1,
+            patch: turnChangeSmallModifiedDiffPatch,
             expandable: true,
           },
         ],

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -1,0 +1,52 @@
+import type { Page } from "@playwright/test"
+
+export const TURN_CHANGE_DIFF_FILE_PATH = "turn-change-cls-fixture.ts"
+
+const turnChangeDiffPatch = [
+  `diff --git a/${TURN_CHANGE_DIFF_FILE_PATH} b/${TURN_CHANGE_DIFF_FILE_PATH}`,
+  "new file mode 100644",
+  "index 0000000..1111111",
+  "--- /dev/null",
+  `+++ b/${TURN_CHANGE_DIFF_FILE_PATH}`,
+  "@@ -0,0 +1,12 @@",
+  "+export const rows = [",
+  '+  "alpha",',
+  '+  "beta",',
+  '+  "gamma",',
+  '+  "delta",',
+  '+  "epsilon",',
+  '+  "zeta",',
+  '+  "eta",',
+  '+  "theta",',
+  '+  "iota",',
+  '+  "kappa",',
+  "+]",
+].join("\n")
+
+export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
+  await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes$/, async (route) => {
+    const url = new URL(route.request().url())
+    const parts = url.pathname.split("/")
+    const turnID = parts.at(-2) ?? "turn"
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessionID: input.sessionID,
+        turnID,
+        messageID: turnID,
+        undoAvailable: true,
+        redoAvailable: false,
+        files: [
+          {
+            path: TURN_CHANGE_DIFF_FILE_PATH,
+            status: "added",
+            additions: 12,
+            deletions: 0,
+            patch: turnChangeDiffPatch,
+            expandable: true,
+          },
+        ],
+      }),
+    })
+  })
+}

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test"
 
 export const TURN_CHANGE_DIFF_FILE_PATH = "turn-change-cls-fixture.ts"
+export const TURN_CHANGE_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-replacement.ts"
 
 const turnChangeDiffPatch = [
   `diff --git a/${TURN_CHANGE_DIFF_FILE_PATH} b/${TURN_CHANGE_DIFF_FILE_PATH}`,
@@ -23,6 +24,30 @@ const turnChangeDiffPatch = [
   "+]",
 ].join("\n")
 
+const turnChangeModifiedDiffPatch = [
+  `diff --git a/${TURN_CHANGE_MODIFIED_DIFF_FILE_PATH} b/${TURN_CHANGE_MODIFIED_DIFF_FILE_PATH}`,
+  "index 2222222..3333333 100644",
+  `--- a/${TURN_CHANGE_MODIFIED_DIFF_FILE_PATH}`,
+  `+++ b/${TURN_CHANGE_MODIFIED_DIFF_FILE_PATH}`,
+  "@@ -1,8 +1,10 @@",
+  " export const rows = [",
+  '-  "alpha",',
+  '-  "beta",',
+  '-  "gamma",',
+  '-  "delta",',
+  '-  "epsilon",',
+  '-  "zeta",',
+  '+  "alpha replacement",',
+  '+  "beta replacement",',
+  '+  "gamma replacement",',
+  '+  "delta replacement",',
+  '+  "epsilon replacement",',
+  '+  "zeta replacement",',
+  '+  "eta replacement",',
+  '+  "theta replacement",',
+  " ]",
+].join("\n")
+
 export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
   await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes$/, async (route) => {
     const url = new URL(route.request().url())
@@ -43,6 +68,14 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             additions: 12,
             deletions: 0,
             patch: turnChangeDiffPatch,
+            expandable: true,
+          },
+          {
+            path: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH,
+            status: "modified",
+            additions: 8,
+            deletions: 6,
+            patch: turnChangeModifiedDiffPatch,
             expandable: true,
           },
         ],

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -68,7 +68,7 @@ const turnChangeSmallModifiedDiffPatch = [
 ].join("\n")
 
 export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
-  await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes$/, async (route) => {
+  await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes(?:\?.*)?$/, async (route) => {
     const url = new URL(route.request().url())
     const parts = url.pathname.split("/")
     const turnID = parts.at(-2) ?? "turn"

--- a/packages/app/e2e/snap/turn-change-diff.snap.ts
+++ b/packages/app/e2e/snap/turn-change-diff.snap.ts
@@ -13,10 +13,10 @@ test("turn-change-diff", async ({ page, llm, project }) => {
   await llm.text("seeded turn-change diff")
   await project.prompt("snap turn-change diff")
 
-  const card = page.locator('[data-slot="session-turn-changes"]').last()
+  const card = page.locator('[data-component="session-turn-changes"]').last()
   await expect(card).toBeVisible({ timeout: 30_000 })
   const row = card
-    .locator('[data-slot="session-turn-change-row"]')
+    .locator('[data-component="session-turn-change-row"]')
     .filter({ hasText: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
@@ -24,14 +24,14 @@ test("turn-change-diff", async ({ page, llm, project }) => {
   const shots: Shot[] = [{ name: "collapsed", buf: await card.screenshot() }]
 
   await row.click()
-  const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+  const diff = card.locator('[data-component="session-turn-change-diff"]').first()
   await expect(diff).toBeVisible()
   await expect
     .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
       timeout: 10_000,
     })
     .toBeGreaterThanOrEqual(384)
-  await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
+  await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
 
   shots.push({ name: "expanded-card", buf: await card.screenshot() })
 

--- a/packages/app/e2e/snap/turn-change-diff.snap.ts
+++ b/packages/app/e2e/snap/turn-change-diff.snap.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { routeTurnChangeDiff, TURN_CHANGE_DIFF_FILE_PATH } from "../session/turn-change-diff-fixture"
+import { routeTurnChangeDiff, TURN_CHANGE_MODIFIED_DIFF_FILE_PATH } from "../session/turn-change-diff-fixture"
 import { composeGrid, snapOutputPath, type Shot } from "./_compose"
 
 test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
@@ -17,7 +17,7 @@ test("turn-change-diff", async ({ page, llm, project }) => {
   await expect(card).toBeVisible({ timeout: 30_000 })
   const row = card
     .locator('[data-slot="session-turn-change-row"]')
-    .filter({ hasText: TURN_CHANGE_DIFF_FILE_PATH })
+    .filter({ hasText: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH })
     .first()
   await expect(row).toBeVisible()
 
@@ -30,7 +30,7 @@ test("turn-change-diff", async ({ page, llm, project }) => {
     .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
       timeout: 10_000,
     })
-    .toBeGreaterThan(0)
+    .toBeGreaterThanOrEqual(384)
   await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
 
   shots.push({ name: "expanded-card", buf: await card.screenshot() })

--- a/packages/app/e2e/snap/turn-change-diff.snap.ts
+++ b/packages/app/e2e/snap/turn-change-diff.snap.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "../fixtures"
+import { routeTurnChangeDiff, TURN_CHANGE_DIFF_FILE_PATH } from "../session/turn-change-diff-fixture"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+test("turn-change-diff", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+  await routeTurnChangeDiff(page, { sessionID: "snap-session" })
+
+  await llm.text("seeded turn-change diff")
+  await project.prompt("snap turn-change diff")
+
+  const card = page.locator('[data-slot="session-turn-changes"]').last()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  const row = card
+    .locator('[data-slot="session-turn-change-row"]')
+    .filter({ hasText: TURN_CHANGE_DIFF_FILE_PATH })
+    .first()
+  await expect(row).toBeVisible()
+
+  const shots: Shot[] = [{ name: "collapsed", buf: await card.screenshot() }]
+
+  await row.click()
+  const diff = card.locator('[data-slot="session-turn-change-diff"]').first()
+  await expect(diff).toBeVisible()
+  await expect
+    .poll(async () => await diff.evaluate((el) => Number.parseFloat(getComputedStyle(el).minHeight)), {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(0)
+  await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 30_000 })
+
+  shots.push({ name: "expanded-card", buf: await card.screenshot() })
+
+  const out = snapOutputPath("turn-change-diff")
+  await composeGrid(shots, out)
+  process.stdout.write(`\n[snap] turn-change-diff grid -> ${out}\n\n`)
+})

--- a/packages/ui/src/components/session-turn-change-diff-height.test.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.test.ts
@@ -14,8 +14,12 @@ const diff = (deletions: number, additions: number) => ({
 })
 
 describe("turn-change diff height reservation", () => {
-  test("estimates height from the larger side of the diff plus a small render buffer", () => {
-    expect(estimateTurnChangeDiffReservedHeight(diff(3, 8))).toBe(240)
+  test("estimates additions-only height plus a small render buffer", () => {
+    expect(estimateTurnChangeDiffReservedHeight(diff(0, 8))).toBe(240)
+  })
+
+  test("reserves both sides of a unified replacement hunk", () => {
+    expect(estimateTurnChangeDiffReservedHeight(diff(6, 8))).toBe(384)
   })
 
   test("caps reserved height at the existing inline diff max height", () => {

--- a/packages/ui/src/components/session-turn-change-diff-height.test.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.test.ts
@@ -13,6 +13,22 @@ const diff = (deletions: number, additions: number) => ({
   additionLines: Array.from({ length: additions }, (_, index) => `new ${index}`),
 })
 
+const replacementPatch = [
+  "diff --git a/file.ts b/file.ts",
+  "index 1111111..2222222 100644",
+  "--- a/file.ts",
+  "+++ b/file.ts",
+  "@@ -1,7 +1,7 @@",
+  " context one",
+  " context two",
+  " context three",
+  "-old value",
+  "+new value",
+  " context four",
+  " context five",
+  " context six",
+].join("\n")
+
 describe("turn-change diff height reservation", () => {
   test("estimates additions-only height plus a small render buffer", () => {
     expect(estimateTurnChangeDiffReservedHeight(diff(0, 8))).toBe(240)
@@ -20,6 +36,10 @@ describe("turn-change diff height reservation", () => {
 
   test("reserves both sides of a unified replacement hunk", () => {
     expect(estimateTurnChangeDiffReservedHeight(diff(6, 8))).toBe(384)
+  })
+
+  test("counts unified patch context once when the patch is available", () => {
+    expect(estimateTurnChangeDiffReservedHeight({ ...diff(7, 7), patch: replacementPatch })).toBe(240)
   })
 
   test("caps reserved height at the existing inline diff max height", () => {

--- a/packages/ui/src/components/session-turn-change-diff-height.test.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import {
+  clampTurnChangeDiffReservedHeight,
+  estimateTurnChangeDiffReservedHeight,
+} from "./session-turn-change-diff-height"
+
+const diff = (deletions: number, additions: number) => ({
+  deletionLines: Array.from({ length: deletions }, (_, index) => `old ${index}`),
+  additionLines: Array.from({ length: additions }, (_, index) => `new ${index}`),
+})
+
+describe("turn-change diff height reservation", () => {
+  test("estimates height from the larger side of the diff plus a small render buffer", () => {
+    expect(estimateTurnChangeDiffReservedHeight(diff(3, 8))).toBe(240)
+  })
+
+  test("caps reserved height at the existing inline diff max height", () => {
+    expect(estimateTurnChangeDiffReservedHeight(diff(50, 50))).toBe(420)
+  })
+
+  test("keeps a usable minimum for tiny diffs", () => {
+    expect(clampTurnChangeDiffReservedHeight(0)).toBe(48)
+    expect(estimateTurnChangeDiffReservedHeight(diff(0, 0))).toBe(72)
+  })
+})

--- a/packages/ui/src/components/session-turn-change-diff-height.test.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
 import {
   clampTurnChangeDiffReservedHeight,
   estimateTurnChangeDiffReservedHeight,
 } from "./session-turn-change-diff-height"
+
+const panelSource = readFileSync(new URL("./session-turn-changes-panel.tsx", import.meta.url), "utf8")
+const cssSource = readFileSync(new URL("./session-turn.css", import.meta.url), "utf8")
 
 const diff = (deletions: number, additions: number) => ({
   deletionLines: Array.from({ length: deletions }, (_, index) => `old ${index}`),
@@ -21,5 +25,20 @@ describe("turn-change diff height reservation", () => {
   test("keeps a usable minimum for tiny diffs", () => {
     expect(clampTurnChangeDiffReservedHeight(0)).toBe(48)
     expect(estimateTurnChangeDiffReservedHeight(diff(0, 0))).toBe(72)
+  })
+
+  test("wires the panel to reserve height and refresh the cached measurement after render", () => {
+    expect(panelSource).toContain("estimateTurnChangeDiffReservedHeight")
+    expect(panelSource).toContain("--turn-change-diff-reserved-height")
+    expect(panelSource).toContain("onRendered={handleDiffRendered}")
+  })
+
+  test("keeps the reservation scoped to turn-change diffs", () => {
+    expect(cssSource).toMatch(
+      /\[data-slot="session-turn-change-diff"\][\s\S]*?min-height:\s*var\(--turn-change-diff-reserved-height/,
+    )
+    expect(cssSource).toMatch(
+      /\[data-slot="session-turn-change-diff"\][\s\S]*?\[data-component="file"\][\s\S]*?content-visibility:\s*visible/,
+    )
   })
 })

--- a/packages/ui/src/components/session-turn-change-diff-height.test.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.test.ts
@@ -54,6 +54,9 @@ describe("turn-change diff height reservation", () => {
   test("wires the panel to reserve height and refresh the cached measurement after render", () => {
     expect(panelSource).toContain("estimateTurnChangeDiffReservedHeight")
     expect(panelSource).toContain("--turn-change-diff-reserved-height")
+    expect(panelSource).toContain("createEffect(() =>")
+    expect(panelSource).toContain("setMeasuredDiffHeight(undefined)")
+    expect(panelSource).toContain("const reservedDiffHeight = () =>")
     expect(panelSource).toContain("onRendered={handleDiffRendered}")
   })
 

--- a/packages/ui/src/components/session-turn-change-diff-height.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.ts
@@ -1,0 +1,21 @@
+import type { FileDiffMetadata } from "@pierre/diffs"
+
+export const TURN_CHANGE_DIFF_LINE_HEIGHT = 24
+export const TURN_CHANGE_DIFF_MAX_HEIGHT = 420
+export const TURN_CHANGE_DIFF_MIN_HEIGHT = 48
+
+const TURN_CHANGE_DIFF_RENDER_BUFFER_ROWS = 2
+
+type DiffHeightSource = Pick<FileDiffMetadata, "additionLines" | "deletionLines">
+
+export function clampTurnChangeDiffReservedHeight(height: number) {
+  if (!Number.isFinite(height)) return TURN_CHANGE_DIFF_MIN_HEIGHT
+  return Math.min(TURN_CHANGE_DIFF_MAX_HEIGHT, Math.max(TURN_CHANGE_DIFF_MIN_HEIGHT, Math.ceil(height)))
+}
+
+export function estimateTurnChangeDiffReservedHeight(diff: DiffHeightSource) {
+  const changedLines = Math.max(diff.deletionLines.length, diff.additionLines.length, 1)
+  return clampTurnChangeDiffReservedHeight(
+    (changedLines + TURN_CHANGE_DIFF_RENDER_BUFFER_ROWS) * TURN_CHANGE_DIFF_LINE_HEIGHT,
+  )
+}

--- a/packages/ui/src/components/session-turn-change-diff-height.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.ts
@@ -14,7 +14,7 @@ export function clampTurnChangeDiffReservedHeight(height: number) {
 }
 
 export function estimateTurnChangeDiffReservedHeight(diff: DiffHeightSource) {
-  const changedLines = Math.max(diff.deletionLines.length, diff.additionLines.length, 1)
+  const changedLines = Math.max(diff.deletionLines.length + diff.additionLines.length, 1)
   return clampTurnChangeDiffReservedHeight(
     (changedLines + TURN_CHANGE_DIFF_RENDER_BUFFER_ROWS) * TURN_CHANGE_DIFF_LINE_HEIGHT,
   )

--- a/packages/ui/src/components/session-turn-change-diff-height.ts
+++ b/packages/ui/src/components/session-turn-change-diff-height.ts
@@ -1,4 +1,5 @@
 import type { FileDiffMetadata } from "@pierre/diffs"
+import { parsePatch } from "diff"
 
 export const TURN_CHANGE_DIFF_LINE_HEIGHT = 24
 export const TURN_CHANGE_DIFF_MAX_HEIGHT = 420
@@ -6,7 +7,7 @@ export const TURN_CHANGE_DIFF_MIN_HEIGHT = 48
 
 const TURN_CHANGE_DIFF_RENDER_BUFFER_ROWS = 2
 
-type DiffHeightSource = Pick<FileDiffMetadata, "additionLines" | "deletionLines">
+type DiffHeightSource = Pick<FileDiffMetadata, "additionLines" | "deletionLines"> & { patch?: string }
 
 export function clampTurnChangeDiffReservedHeight(height: number) {
   if (!Number.isFinite(height)) return TURN_CHANGE_DIFF_MIN_HEIGHT
@@ -14,8 +15,24 @@ export function clampTurnChangeDiffReservedHeight(height: number) {
 }
 
 export function estimateTurnChangeDiffReservedHeight(diff: DiffHeightSource) {
-  const changedLines = Math.max(diff.deletionLines.length + diff.additionLines.length, 1)
+  const changedLines =
+    visibleUnifiedDiffLines(diff) ?? Math.max(diff.deletionLines.length + diff.additionLines.length, 1)
   return clampTurnChangeDiffReservedHeight(
     (changedLines + TURN_CHANGE_DIFF_RENDER_BUFFER_ROWS) * TURN_CHANGE_DIFF_LINE_HEIGHT,
   )
+}
+
+function visibleUnifiedDiffLines(diff: DiffHeightSource) {
+  if (!diff.patch) return
+
+  try {
+    const patches = parsePatch(diff.patch)
+    const visible = patches.reduce(
+      (total, filePatch) => total + filePatch.hunks.reduce((sum, hunk) => sum + hunk.lines.length, 0),
+      0,
+    )
+    return visible > 0 ? visible : undefined
+  } catch {
+    return
+  }
 }

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -166,6 +166,7 @@ export function SessionTurnChangesPanel(props: {
             return (
               <div data-slot="session-turn-change-item" data-expanded={expanded() || undefined}>
                 <div
+                  data-component="session-turn-change-row"
                   data-slot="session-turn-change-row"
                   data-expandable={file.expandable || undefined}
                   onClick={toggle}
@@ -222,6 +223,7 @@ export function SessionTurnChangesPanel(props: {
                   {(diff) => (
                     <div
                       ref={(el) => (diffRef = el)}
+                      data-component="session-turn-change-diff"
                       data-slot="session-turn-change-diff"
                       data-scrollable
                       style={{ "--turn-change-diff-reserved-height": `${reservedDiffHeight()}px` }}

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -8,6 +8,10 @@ import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
 import { normalize } from "./session-diff"
 import {
+  clampTurnChangeDiffReservedHeight,
+  estimateTurnChangeDiffReservedHeight,
+} from "./session-turn-change-diff-height"
+import {
   hasTurnChangeActionHandler,
   turnChangeAction,
   type TurnChangeActions,
@@ -62,7 +66,8 @@ export function SessionTurnChangesPanel(props: {
   const turnActionLabel = createMemo(() => {
     const action = turnChangeAction(props.turnChange)
     if (!action) return ""
-    const base = action === "undo" ? i18n.t("ui.sessionTurn.turnChanges.undo") : i18n.t("ui.sessionTurn.turnChanges.reapply")
+    const base =
+      action === "undo" ? i18n.t("ui.sessionTurn.turnChanges.undo") : i18n.t("ui.sessionTurn.turnChanges.reapply")
     return confirmAction() === action
       ? action === "undo"
         ? i18n.t("ui.sessionTurn.turnChanges.undoConfirm")
@@ -116,6 +121,8 @@ export function SessionTurnChangesPanel(props: {
         <For each={turnFiles()}>
           {(file) => {
             const expanded = createMemo(() => expandedPaths().includes(file.path))
+            const [measuredDiffHeight, setMeasuredDiffHeight] = createSignal<number>()
+            let diffRef: HTMLDivElement | undefined
             const toggle = () => {
               if (!file.expandable) return
               const current = expandedPaths()
@@ -134,6 +141,21 @@ export function SessionTurnChangesPanel(props: {
                   })
                 : undefined,
             )
+            const reservedDiffHeight = createMemo(() => {
+              const diff = view()
+              if (!diff) return 0
+              return Math.max(measuredDiffHeight() ?? 0, estimateTurnChangeDiffReservedHeight(diff.fileDiff))
+            })
+            const handleDiffRendered = () => {
+              const measure = () => {
+                if (!diffRef?.isConnected) return
+                const height = clampTurnChangeDiffReservedHeight(diffRef.scrollHeight)
+                setMeasuredDiffHeight((current) => (current === undefined ? height : Math.max(current, height)))
+              }
+
+              if (typeof requestAnimationFrame === "function") requestAnimationFrame(measure)
+              else measure()
+            }
             return (
               <div data-slot="session-turn-change-item" data-expanded={expanded() || undefined}>
                 <div
@@ -191,8 +213,18 @@ export function SessionTurnChangesPanel(props: {
                 </div>
                 <Show when={expanded() && view()}>
                   {(diff) => (
-                    <div data-slot="session-turn-change-diff" data-scrollable>
-                      <Dynamic component={fileComponent} mode="diff" fileDiff={diff().fileDiff} />
+                    <div
+                      ref={(el) => (diffRef = el)}
+                      data-slot="session-turn-change-diff"
+                      data-scrollable
+                      style={{ "--turn-change-diff-reserved-height": `${reservedDiffHeight()}px` }}
+                    >
+                      <Dynamic
+                        component={fileComponent}
+                        mode="diff"
+                        fileDiff={diff().fileDiff}
+                        onRendered={handleDiffRendered}
+                      />
                     </div>
                   )}
                 </Show>

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, For, onCleanup, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import { getDirectory } from "@opencode-ai/core/util/path"
 import { useFileComponent } from "../context/file"
@@ -141,13 +141,17 @@ export function SessionTurnChangesPanel(props: {
                   })
                 : undefined,
             )
-            const reservedDiffHeight = createMemo(() => {
+            createEffect(() => {
+              view()
+              setMeasuredDiffHeight(undefined)
+            })
+            const reservedDiffHeight = () => {
               const diff = view()
               if (!diff) return 0
               return (
                 measuredDiffHeight() ?? estimateTurnChangeDiffReservedHeight({ ...diff.fileDiff, patch: diff.patch })
               )
-            })
+            }
             const handleDiffRendered = () => {
               const measure = () => {
                 if (!diffRef?.isConnected) return

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -144,13 +144,16 @@ export function SessionTurnChangesPanel(props: {
             const reservedDiffHeight = createMemo(() => {
               const diff = view()
               if (!diff) return 0
-              return Math.max(measuredDiffHeight() ?? 0, estimateTurnChangeDiffReservedHeight(diff.fileDiff))
+              return (
+                measuredDiffHeight() ?? estimateTurnChangeDiffReservedHeight({ ...diff.fileDiff, patch: diff.patch })
+              )
             })
             const handleDiffRendered = () => {
               const measure = () => {
                 if (!diffRef?.isConnected) return
-                const height = clampTurnChangeDiffReservedHeight(diffRef.scrollHeight)
-                setMeasuredDiffHeight((current) => (current === undefined ? height : Math.max(current, height)))
+                const content = diffRef.querySelector<HTMLElement>('[data-component="file"]')
+                const height = clampTurnChangeDiffReservedHeight(content?.scrollHeight ?? diffRef.scrollHeight)
+                setMeasuredDiffHeight(height)
               }
 
               if (typeof requestAnimationFrame === "function") requestAnimationFrame(measure)

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -252,9 +252,14 @@
   }
 
   [data-slot="session-turn-change-diff"] {
+    min-height: var(--turn-change-diff-reserved-height, 0px);
     max-height: 420px;
     overflow: auto;
     background: var(--surface-sunken);
+
+    [data-component="file"] {
+      content-visibility: visible;
+    }
   }
 
   [data-slot="session-turn-changes-skipped-notice"] {


### PR DESCRIPTION
## Summary

- Reserve a capped height for expanded turn-change diffs before the async diff renderer paints.
- Cache the measured expanded height after render so repeated open/close cycles reuse a stable size.
- Add targeted unit, E2E, and snap coverage for the final turn-change card.

## Why

The final `N files changed` turn-change card could flicker and push visible content after a file row was expanded because the diff viewer mounted as an empty container and grew only after Pierre rendered the patch. That delayed growth was counted as non-input CLS in the debug/perf observers.

## Related Issue

Closes #805.

## Human Review Status

Pending

## Review Focus

- The height estimate and measurement cache in `SessionTurnChangesPanel` should remain scoped to the new turn-change panel.
- The nested `content-visibility: visible` override should not affect other diff surfaces.
- The E2E route fixture intentionally mocks only the turn-change endpoint so the test exercises the visible panel without relying on backend turn-change aggregation.

## Risk Notes

- This deliberately does not touch legacy `SessionTurnDiffs` or tool diff accordions; those remain PR2 candidates only if evidence shows the same issue there.
- Conditional checklist skipped: platform impact is not applicable; no platform, packaging, updater, signing, paths, shell, or permissions surface changed.
- Conditional checklist skipped: docs/release/dependencies/permissions/credentials/deletion behavior are not applicable; the local snap image is generated verification output and is not staged.

## How To Verify

```text
UI unit tests: bun test src/components/session-turn-change-diff-height.test.ts src/components/session-turn-parent.test.ts src/components/session-turn-turn-changes.test.ts — 12 pass, 0 fail
UI typecheck: bun run typecheck (packages/ui) — passed
App typecheck: bun run typecheck (packages/app) — passed
E2E: bun run test:e2e -- e2e/session/session-turn-change-diff.spec.ts --project=chromium --workers=1 --reporter=line — 1 passed
Visual snap: bun run snap turn-change-diff — 1 passed; reviewed docs/design/preview/screenshots/turn-change-diff.png
Diff check: git diff --check — no output
```

## Screenshots or Recordings

- Ran and reviewed `bun run snap turn-change-diff`; grid written to `docs/design/preview/screenshots/turn-change-diff.png` with collapsed and expanded turn-change card states.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented height reservation for turn-change diff containers to improve rendering stability and prevent layout shifts.

* **Tests**
  * Added end-to-end tests for turn-change diff rendering with layout stability verification.
  * Added snapshot tests for turn-change diff UI rendering.
  * Added unit tests for diff height calculation and reservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->