### PR TITLE
fix(app): group sidebar sessions by opened directory

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1654,7 +1654,7 @@ export default function Layout(props: ParentProps) {
   }
 
   function syncSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    for (const key of pawworkSessionRouteUnhideKeys(directory, root)) {
+    for (const key of pawworkSessionRouteUnhideKeys(directory)) {
       if (!store.pawworkProjectHidden[key]) continue
       unhideProject(key)
     }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -89,6 +89,7 @@ import { createInlineEditorController } from "./layout/inline-editor"
 import {
   buildPawworkSidebarSessionRows,
   pawworkSessionDirectories,
+  resolvePawworkProjectRenameTarget,
   resolvePawworkSessionProjectKey,
   resolvePawworkSessionProjectLabel,
   sortPawworkSidebarSessions,
@@ -1226,24 +1227,18 @@ export default function Layout(props: ParentProps) {
   }
 
   async function handleRenameProject(projectKey: string, next: string) {
-    const projects = layout.projects.list()
-    const project =
-      projects.find((p) => workspaceKey(p.worktree) === projectKey) ||
-      projects.find((p) => p.sandboxes?.some((s) => workspaceKey(s) === projectKey))
-    if (project) {
-      await renameProject(project, next)
+    const target = resolvePawworkProjectRenameTarget(projectKey, {
+      projects: layout.projects.list(),
+      sessions: pawworkSessionWindow().sessions,
+    })
+    if (!target) return
+
+    if (target.type === "project") {
+      await renameProject(target.project, next)
       return
     }
 
-    const session = pawworkSessionWindow().sessions.find((s) => workspaceKey(s.directory) === projectKey)
-    if (!session) return
-
-    const sessionKey = workspaceKey(session.directory)
-    const localProject =
-      projects.find((p) => workspaceKey(p.worktree) === sessionKey) ||
-      projects.find((p) => p.sandboxes?.some((s) => workspaceKey(s) === sessionKey))
-    if (localProject) await renameProject(localProject, next)
-    else setWorkspaceName(session.directory, next)
+    setWorkspaceName(target.directory, next)
   }
 
   function expandPawworkProjectGroup(label: string | undefined) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -88,6 +88,7 @@ import {
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
   buildPawworkSidebarSessionRows,
+  pawworkSessionRouteUnhideKeys,
   pawworkSessionDirectories,
   resolvePawworkProjectRenameTarget,
   resolvePawworkSessionProjectKey,
@@ -1653,8 +1654,8 @@ export default function Layout(props: ParentProps) {
   }
 
   function syncSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    const key = workspaceKey(root)
-    if (store.pawworkProjectHidden[key]) {
+    for (const key of pawworkSessionRouteUnhideKeys(directory, root)) {
+      if (!store.pawworkProjectHidden[key]) continue
       unhideProject(key)
     }
     notification.session.markViewed(id)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -89,6 +89,8 @@ import { createInlineEditorController } from "./layout/inline-editor"
 import {
   buildPawworkSidebarSessionRows,
   pawworkSessionDirectories,
+  resolvePawworkSessionProjectKey,
+  resolvePawworkSessionProjectLabel,
   sortPawworkSidebarSessions,
 } from "./layout/pawwork-session-source"
 import {
@@ -622,21 +624,14 @@ export default function Layout(props: ParentProps) {
   }
 
   const projectKeyForSession = (session: Session | GlobalSession) => {
-    const project = "project" in session ? session.project : undefined
-    if (project?.worktree) return workspaceKey(project.worktree)
-    return workspaceKey(session.directory)
+    return resolvePawworkSessionProjectKey(session)
   }
 
   const projectLabelForSession = (session: Session | GlobalSession) => {
-    const project = "project" in session ? session.project : undefined
-    if (project?.worktree) {
-      const localProject = layout.projects.list().find((item) => workspaceKey(item.worktree) === workspaceKey(project.worktree))
-      if (localProject) return displayName(localProject)
-    }
-    const localProject = layout.projects.list().find((item) => workspaceKey(item.worktree) === workspaceKey(session.directory))
-    if (localProject) return displayName(localProject)
-    if (project?.name) return project.name
-    return getFilename(session.directory)
+    return resolvePawworkSessionProjectLabel(session, {
+      projects: layout.projects.list(),
+      workspaceName,
+    })
   }
 
   const pawworkSessionWindow = createMemo(() =>
@@ -1248,6 +1243,7 @@ export default function Layout(props: ParentProps) {
       projects.find((p) => workspaceKey(p.worktree) === sessionKey) ||
       projects.find((p) => p.sandboxes?.some((s) => workspaceKey(s) === sessionKey))
     if (localProject) await renameProject(localProject, next)
+    else setWorkspaceName(session.directory, next)
   }
 
   function expandPawworkProjectGroup(label: string | undefined) {
@@ -1694,7 +1690,7 @@ export default function Layout(props: ParentProps) {
 
   function openPawworkHome(directory?: string) {
     if (directory) {
-      const key = workspaceKey(projectRoot(directory))
+      const key = workspaceKey(directory)
       if (store.pawworkProjectHidden[key]) {
         unhideProject(key)
       }

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -124,6 +124,13 @@ export function resolvePawworkProjectRenameTarget<TProject extends ProjectLike, 
   return undefined
 }
 
+export function pawworkSessionRouteUnhideKeys(directory: string, root: string) {
+  const keys = [workspaceKey(directory)]
+  const rootKey = workspaceKey(root)
+  if (!keys.includes(rootKey)) keys.push(rootKey)
+  return keys
+}
+
 const isActivityEligibleUserMessage = (parts: PartTimeLike[] | undefined) => {
   if (!parts) return false
   if (parts.some((part) => part.type === "compaction")) return false

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -4,8 +4,15 @@ import { Worktree as WorktreeState } from "@/utils/worktree"
 import { effectiveWorkspaceOrder, workspaceKey } from "./helpers"
 
 type ProjectLike = {
+  id?: string
   name?: string
   worktree: string
+}
+
+type SessionProjectLike = {
+  id?: string
+  name?: string
+  worktree?: string
 }
 
 type SessionLike = {
@@ -38,6 +45,7 @@ type PartTimeLike = {
 type SidebarRowSessionLike = SessionTimeLike & {
   id: string
   directory: string
+  project?: SessionProjectLike | null
 }
 
 const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value)
@@ -72,6 +80,31 @@ export function sortPawworkSidebarSessions<T extends SessionLike>(sessions: T[])
     if (project !== 0) return project
     return a.id.localeCompare(b.id)
   })
+}
+
+export function resolvePawworkSessionProjectKey(session: { directory: string }) {
+  return workspaceKey(session.directory)
+}
+
+export function resolvePawworkSessionProjectLabel<T extends { directory: string; project?: SessionProjectLike | null }>(
+  session: T,
+  input: {
+    projects: ProjectLike[]
+    workspaceName?: (directory: string, projectId?: string, branch?: string) => string | undefined
+  },
+) {
+  const directName = input.workspaceName?.(session.directory)
+  if (directName) return directName
+
+  const sessionKey = workspaceKey(session.directory)
+  const localProject = input.projects.find((project) => workspaceKey(project.worktree) === sessionKey)
+  if (localProject) return localProject.name || getFilename(localProject.worktree)
+
+  if (session.project?.worktree && workspaceKey(session.project.worktree) === sessionKey) {
+    return session.project.name || getFilename(session.project.worktree)
+  }
+
+  return getFilename(session.directory)
 }
 
 const isActivityEligibleUserMessage = (parts: PartTimeLike[] | undefined) => {

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -124,11 +124,8 @@ export function resolvePawworkProjectRenameTarget<TProject extends ProjectLike, 
   return undefined
 }
 
-export function pawworkSessionRouteUnhideKeys(directory: string, root: string) {
-  const keys = [workspaceKey(directory)]
-  const rootKey = workspaceKey(root)
-  if (!keys.includes(rootKey)) keys.push(rootKey)
-  return keys
+export function pawworkSessionRouteUnhideKeys(directory: string) {
+  return [workspaceKey(directory)]
 }
 
 const isActivityEligibleUserMessage = (parts: PartTimeLike[] | undefined) => {

--- a/packages/app/src/pages/layout/pawwork-session-source.ts
+++ b/packages/app/src/pages/layout/pawwork-session-source.ts
@@ -7,6 +7,7 @@ type ProjectLike = {
   id?: string
   name?: string
   worktree: string
+  sandboxes?: string[]
 }
 
 type SessionProjectLike = {
@@ -105,6 +106,22 @@ export function resolvePawworkSessionProjectLabel<T extends { directory: string;
   }
 
   return getFilename(session.directory)
+}
+
+export function resolvePawworkProjectRenameTarget<TProject extends ProjectLike, TSession extends { directory: string }>(
+  projectKey: string,
+  input: {
+    projects: TProject[]
+    sessions: TSession[]
+  },
+): { type: "project"; project: TProject } | { type: "workspace"; directory: string } | undefined {
+  const project = input.projects.find((item) => workspaceKey(item.worktree) === projectKey)
+  if (project) return { type: "project", project }
+
+  const session = input.sessions.find((item) => workspaceKey(item.directory) === projectKey)
+  if (session) return { type: "workspace", directory: session.directory }
+
+  return undefined
 }
 
 const isActivityEligibleUserMessage = (parts: PartTimeLike[] | undefined) => {

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -1,8 +1,49 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, test } from "bun:test"
-import { buildPawworkSidebarSessionRows } from "./pawwork-session-source"
+import {
+  buildPawworkSidebarSessionRows,
+  resolvePawworkSessionProjectKey,
+  resolvePawworkSessionProjectLabel,
+} from "./pawwork-session-source"
 
 describe("buildPawworkSidebarSessionRows", () => {
+  test("groups git subfolder sessions by the opened directory instead of the repo root", () => {
+    const session = {
+      id: "session-subfolder",
+      directory: "/repo/packages/app",
+      project: { id: "proj_repo", name: "Repo", worktree: "/repo" },
+      time: { created: 100, updated: 100 },
+    }
+    const projects = [{ id: "proj_repo", name: "Repo", worktree: "/repo" }]
+
+    const result = buildPawworkSidebarSessionRows([session], {
+      slugForDirectory: (directory) => `slug:${directory}`,
+      projectKeyForSession: (item) => resolvePawworkSessionProjectKey(item),
+      projectLabelForSession: (item) => resolvePawworkSessionProjectLabel(item, { projects }),
+    })
+
+    expect(result[0].projectKey).toBe("/repo/packages/app")
+    expect(result[0].projectLabel).toBe("app")
+  })
+
+  test("keeps project names for sessions opened at the project root", () => {
+    const session = {
+      id: "session-root",
+      directory: "/repo",
+      project: { id: "proj_repo", name: "Repo", worktree: "/repo" },
+      time: { created: 100, updated: 100 },
+    }
+
+    const result = buildPawworkSidebarSessionRows([session], {
+      slugForDirectory: (directory) => `slug:${directory}`,
+      projectKeyForSession: (item) => resolvePawworkSessionProjectKey(item),
+      projectLabelForSession: (item) => resolvePawworkSessionProjectLabel(item, { projects: [] }),
+    })
+
+    expect(result[0].projectKey).toBe("/repo")
+    expect(result[0].projectLabel).toBe("Repo")
+  })
+
   test("uses API activity time before loaded message cache for sidebar rows", () => {
     const result = buildPawworkSidebarSessionRows(
       [

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -9,14 +9,14 @@ import {
 } from "./pawwork-session-source"
 
 describe("buildPawworkSidebarSessionRows", () => {
-  test("unhides the opened directory group when syncing a subfolder session route", () => {
+  test("keeps the parent root group hidden when syncing a subfolder session route", () => {
     const hidden: Record<string, boolean> = { "/repo/packages/app": true, "/repo": true }
 
-    for (const key of pawworkSessionRouteUnhideKeys("/repo/packages/app", "/repo")) {
+    for (const key of pawworkSessionRouteUnhideKeys("/repo/packages/app")) {
       delete hidden[key]
     }
 
-    expect(hidden).toEqual({})
+    expect(hidden).toEqual({ "/repo": true })
   })
 
   test("renames sandbox session groups as local workspace labels", () => {

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -2,11 +2,41 @@ import { readFileSync } from "node:fs"
 import { describe, expect, test } from "bun:test"
 import {
   buildPawworkSidebarSessionRows,
+  resolvePawworkProjectRenameTarget,
   resolvePawworkSessionProjectKey,
   resolvePawworkSessionProjectLabel,
 } from "./pawwork-session-source"
 
 describe("buildPawworkSidebarSessionRows", () => {
+  test("renames sandbox session groups as local workspace labels", () => {
+    const project = { id: "proj_repo", name: "Repo", worktree: "/repo", sandboxes: ["/repo-feature"] }
+
+    const target = resolvePawworkProjectRenameTarget("/repo-feature", {
+      projects: [project],
+      sessions: [
+        {
+          id: "session-sandbox",
+          directory: "/repo-feature",
+          project: { id: "proj_repo", name: "Repo", worktree: "/repo" },
+          time: { created: 100, updated: 100 },
+        },
+      ],
+    })
+
+    expect(target).toEqual({ type: "workspace", directory: "/repo-feature" })
+  })
+
+  test("renames root project groups as projects", () => {
+    const project = { id: "proj_repo", name: "Repo", worktree: "/repo", sandboxes: ["/repo-feature"] }
+
+    const target = resolvePawworkProjectRenameTarget("/repo", {
+      projects: [project],
+      sessions: [],
+    })
+
+    expect(target).toEqual({ type: "project", project })
+  })
+
   test("groups git subfolder sessions by the opened directory instead of the repo root", () => {
     const session = {
       id: "session-subfolder",

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -9,21 +9,27 @@ import {
 
 describe("buildPawworkSidebarSessionRows", () => {
   test("renames sandbox session groups as local workspace labels", () => {
-    const project = { id: "proj_repo", name: "Repo", worktree: "/repo", sandboxes: ["/repo-feature"] }
+    const project = { id: "proj_repo", name: "Repo", worktree: "/repo", sandboxes: ["/repo-worktree"] }
+    let renamedProject: typeof project | undefined
+    const workspaceName: Record<string, string> = {}
 
-    const target = resolvePawworkProjectRenameTarget("/repo-feature", {
+    const target = resolvePawworkProjectRenameTarget("/repo-worktree", {
       projects: [project],
       sessions: [
         {
           id: "session-sandbox",
-          directory: "/repo-feature",
+          directory: "/repo-worktree",
           project: { id: "proj_repo", name: "Repo", worktree: "/repo" },
           time: { created: 100, updated: 100 },
         },
       ],
     })
 
-    expect(target).toEqual({ type: "workspace", directory: "/repo-feature" })
+    if (target?.type === "project") renamedProject = target.project
+    if (target?.type === "workspace") workspaceName[target.directory] = "Feature"
+
+    expect(renamedProject).toBeUndefined()
+    expect(workspaceName).toEqual({ "/repo-worktree": "Feature" })
   })
 
   test("renames root project groups as projects", () => {

--- a/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-session-rows.test.ts
@@ -2,12 +2,23 @@ import { readFileSync } from "node:fs"
 import { describe, expect, test } from "bun:test"
 import {
   buildPawworkSidebarSessionRows,
+  pawworkSessionRouteUnhideKeys,
   resolvePawworkProjectRenameTarget,
   resolvePawworkSessionProjectKey,
   resolvePawworkSessionProjectLabel,
 } from "./pawwork-session-source"
 
 describe("buildPawworkSidebarSessionRows", () => {
+  test("unhides the opened directory group when syncing a subfolder session route", () => {
+    const hidden: Record<string, boolean> = { "/repo/packages/app": true, "/repo": true }
+
+    for (const key of pawworkSessionRouteUnhideKeys("/repo/packages/app", "/repo")) {
+      delete hidden[key]
+    }
+
+    expect(hidden).toEqual({})
+  })
+
   test("renames sandbox session groups as local workspace labels", () => {
     const project = { id: "proj_repo", name: "Repo", worktree: "/repo", sandboxes: ["/repo-worktree"] }
     let renamedProject: typeof project | undefined


### PR DESCRIPTION
## Summary

- Group PawWork sidebar sessions by the opened session directory instead of the parent Git worktree.
- Preserve project-root labels for root sessions while showing subfolder sessions by their opened folder name.
- Keep subfolder and sandbox session group renames local to the opened directory label instead of renaming the parent Git project.
- Review follow-up: sandbox/session-directory group renames now stay local while root project groups still rename the project.
- Review follow-up: Direct routed subfolder sessions now unhide only the opened directory group so the active session remains visible without restoring a hidden parent root group.

## Why

Git subfolder sessions currently appear under the parent repository in the PawWork sidebar, even though the user opened the subfolder as the working directory. This keeps Git root metadata available for technical Git behavior while aligning the sidebar with the user's selected workspace.

## Related Issue

Closes #806

## Human Review Status

Approved by @Astro-Han

## Review Focus

Please check that root project sessions still keep their project names, while Git subfolder sessions use the opened directory as their group identity.

## Risk Notes

- Platform impact is limited to path key normalization already handled by `workspaceKey`; no native shell, packaging, updater, or permission code changed.
- No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file changes are included.

## How To Verify

```text
Focused layout tests: 126 passed, 0 failed (`bun test src/pages/layout/`)
App typecheck: passed (`bun run typecheck` in packages/app)
Whitespace check: passed (`git diff --check`)
Visual snap: passed; reviewed `docs/design/preview/screenshots/sidebar.png` from `bun run snap sidebar`
```

## Screenshots or Recordings

Visual check: `bun run snap sidebar` generated and reviewed `docs/design/preview/screenshots/sidebar.png`.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced session sidebar organization with improved project naming and labeling accuracy
  * Refined project rename handling to better determine rename targets

* **Tests**
  * Expanded test coverage for sidebar session grouping and labeling functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


