### PR TITLE
fix(app): prevent restored todo dock pop-out

### DIFF
--- a/packages/app/e2e/session/session-todo-dock-restore.spec.ts
+++ b/packages/app/e2e/session/session-todo-dock-restore.spec.ts
@@ -35,6 +35,42 @@ async function updateTodos(
   expect(response.status, await response.text()).toBe(204)
 }
 
+async function enableComposerStateProbe(page: { addInitScript: (script: () => void) => Promise<void> | void }) {
+  await page.addInitScript(() => {
+    const win = window as Window & {
+      __opencode_e2e?: {
+        composer?: {
+          enabled?: boolean
+          sessions?: Record<string, unknown>
+        }
+      }
+    }
+    win.__opencode_e2e = {
+      ...win.__opencode_e2e,
+      composer: {
+        enabled: true,
+        sessions: {},
+      },
+    }
+  })
+}
+
+async function readComposerState(
+  page: { evaluate: <T>(fn: (sessionID: string) => T, arg: string) => Promise<T> },
+  sessionID: string,
+) {
+  return page.evaluate((id) => {
+    const win = window as Window & {
+      __opencode_e2e?: {
+        composer?: {
+          sessions?: Record<string, { stateProbe?: { count: number; states: string[]; openingSamples?: boolean[] } }>
+        }
+      }
+    }
+    return win.__opencode_e2e?.composer?.sessions?.[id]?.stateProbe ?? null
+  }, sessionID)
+}
+
 test("todo dock restores without entrance animation on session entry", async ({ page, project }) => {
   let session: { id: string; title: string } | undefined
   await project.open({
@@ -68,4 +104,38 @@ test("todo dock restores without entrance animation on session entry", async ({ 
     return Number.parseFloat(el.style.maxHeight || getComputedStyle(el).maxHeight)
   })
   expect(restoredHeight).toBeGreaterThanOrEqual(35)
+})
+
+test("historical tool-parts todo restores without entrance animation on sidebar session switch", async ({
+  page,
+  llm,
+  project,
+}) => {
+  await enableComposerStateProbe(page)
+  await project.open()
+
+  await llm.tool("todowrite", {
+    todos: [{ content: "historical parts task", status: "in_progress", priority: "high" }],
+  })
+  await llm.text("todo started")
+  const sessionID = await project.prompt("Create a todo that should be historical after reload.")
+
+  const other = await project.sdk.session.create({ title: "e2e todo dock switch target" }).then((res) => res.data)
+  if (!other?.id) throw new Error("Session create did not return an id")
+  await seedSessionTurn({ sdk: project.sdk, sessionID: other.id })
+  project.trackSession(other.id)
+
+  await project.gotoSession(other.id)
+  await page.reload()
+  await project.gotoSession(other.id)
+
+  await openSidebar(page)
+  await page.locator(sessionItemSelector(sessionID)).click()
+
+  await expect
+    .poll(async () => readComposerState(page, sessionID), { timeout: 30_000 })
+    .toMatchObject({ count: 1, states: ["in_progress"] })
+
+  const state = await readComposerState(page, sessionID)
+  expect(state?.openingSamples ?? []).not.toContain(true)
 })

--- a/packages/app/src/pages/session/todos/todo-dock-machine.test.ts
+++ b/packages/app/src/pages/session/todos/todo-dock-machine.test.ts
@@ -221,6 +221,54 @@ describe("createTodoDockRestoreTracker", () => {
     ).toBe(false)
   })
 
+  test("marks timestamped historical tool-parts todos as restored after a known empty snapshot primes the session", () => {
+    const restored = createTodoDockRestoreTracker(() => 200)
+
+    expect(restored({ sessionID: "s", known: true, count: 0, phase: "empty" })).toBe(false)
+    expect(
+      restored({
+        sessionID: "s",
+        known: false,
+        count: 1,
+        phase: "active",
+        source: "primary-parts",
+        sourceUpdatedAt: 100,
+      }),
+    ).toBe(true)
+  })
+
+  test("shows timestamped historical tool-parts without opening after a known empty snapshot primes the session", () => {
+    const restored = createTodoDockRestoreTracker(() => 200)
+    let state = reduceTodoDockState(todoDockHiddenState(), {
+      type: "snapshot",
+      input: { sessionID: "s", count: 0, phase: "empty", lifecycleSignature: "[]" },
+    })
+
+    expect(restored({ sessionID: "s", known: true, count: 0, phase: "empty" })).toBe(false)
+
+    const restoredInput = restored({
+      sessionID: "s",
+      known: false,
+      count: 1,
+      phase: "active",
+      source: "primary-parts",
+      sourceUpdatedAt: 100,
+    })
+    state = reduceTodoDockState(state, {
+      type: "snapshot",
+      input: {
+        sessionID: "s",
+        count: 1,
+        phase: "active",
+        lifecycleSignature: "[pending]",
+        restored: restoredInput,
+      },
+    })
+
+    expect(restoredInput).toBe(true)
+    expect(state).toMatchObject({ dock: true, opening: false })
+  })
+
   test("does not mark live tool-parts todos as restored after a known empty snapshot primes the session", () => {
     const restored = createTodoDockRestoreTracker()
     const liveToolPartsSnapshot = {

--- a/packages/app/src/pages/session/todos/todo-dock-machine.test.ts
+++ b/packages/app/src/pages/session/todos/todo-dock-machine.test.ts
@@ -174,7 +174,54 @@ describe("createTodoDockRestoreTracker", () => {
     expect(restored({ sessionID: "s", known: true, count: 1, phase: "active" })).toBe(false)
   })
 
-  test("does not mark the first live tool-parts todo snapshot as restored", () => {
+  test("marks historical tool-parts todos as restored on session entry", () => {
+    const restored = createTodoDockRestoreTracker(() => 200)
+
+    expect(restored({ sessionID: "s", known: false, count: 0, phase: "empty" })).toBe(false)
+    expect(
+      restored({
+        sessionID: "s",
+        known: false,
+        count: 1,
+        phase: "active",
+        source: "primary-parts",
+        sourceUpdatedAt: 100,
+      }),
+    ).toBe(true)
+  })
+
+  test("marks first tool-parts todos without timestamps as restored on session entry", () => {
+    const restored = createTodoDockRestoreTracker(() => 200)
+
+    expect(restored({ sessionID: "s", known: false, count: 0, phase: "empty" })).toBe(false)
+    expect(
+      restored({
+        sessionID: "s",
+        known: false,
+        count: 1,
+        phase: "active",
+        source: "primary-parts",
+      }),
+    ).toBe(true)
+  })
+
+  test("does not mark newly observed tool-parts todos as restored after session entry", () => {
+    const restored = createTodoDockRestoreTracker(() => 200)
+
+    expect(restored({ sessionID: "s", known: false, count: 0, phase: "empty" })).toBe(false)
+    expect(
+      restored({
+        sessionID: "s",
+        known: true,
+        count: 1,
+        phase: "active",
+        source: "primary-parts",
+        sourceUpdatedAt: 250,
+      }),
+    ).toBe(false)
+  })
+
+  test("does not mark live tool-parts todos as restored after a known empty snapshot primes the session", () => {
     const restored = createTodoDockRestoreTracker()
     const liveToolPartsSnapshot = {
       sessionID: "s",
@@ -184,7 +231,7 @@ describe("createTodoDockRestoreTracker", () => {
       source: "primary-parts" as const,
     }
 
-    expect(restored({ sessionID: "s", known: false, count: 0, phase: "empty" })).toBe(false)
+    expect(restored({ sessionID: "s", known: true, count: 0, phase: "empty" })).toBe(false)
     expect(restored(liveToolPartsSnapshot)).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/todos/todo-dock-machine.ts
+++ b/packages/app/src/pages/session/todos/todo-dock-machine.ts
@@ -87,11 +87,17 @@ export function createTodoDockRestoreTracker(now: () => number = () => Date.now(
     }
 
     const active = input.count > 0 && input.phase === "active"
-    const historicalToolParts =
+    const timestampedHistoricalToolParts =
       isToolPartsSource(input.source) &&
       active &&
-      (input.sourceUpdatedAt === undefined || input.sourceUpdatedAt <= sessionEnteredAt)
-    const restored = !primed && active && (historicalToolParts || (input.known && !isToolPartsSource(input.source)))
+      input.sourceUpdatedAt !== undefined &&
+      input.sourceUpdatedAt <= sessionEnteredAt
+    const untimestampedInitialToolParts =
+      !primed && isToolPartsSource(input.source) && active && input.sourceUpdatedAt === undefined
+    const restored =
+      timestampedHistoricalToolParts ||
+      untimestampedInitialToolParts ||
+      (!primed && active && input.known && !isToolPartsSource(input.source))
     if (input.known) primed = true
     return restored
   }

--- a/packages/app/src/pages/session/todos/todo-dock-machine.ts
+++ b/packages/app/src/pages/session/todos/todo-dock-machine.ts
@@ -42,6 +42,7 @@ export type TodoDockInput = {
   count: number
   phase: TodoPhase
   lifecycleSignature: string
+  sourceUpdatedAt?: number
   dockEligible?: boolean
   restored?: boolean
   // Semantic flag from the source selector. The reducer primarily uses active
@@ -59,33 +60,38 @@ export type TodoDockRestoreTrackerInput = {
   sessionID?: string
   known: boolean
   source?: TodoSourceKind
+  sourceUpdatedAt?: number
   count: number
   phase: TodoPhase
 }
 
-export function createTodoDockRestoreTracker() {
+const isToolPartsSource = (source?: TodoSourceKind) => source === "primary-parts" || source === "fallback-parts"
+
+export function createTodoDockRestoreTracker(now: () => number = () => Date.now()) {
   let sessionID: string | undefined
+  let sessionEnteredAt = now()
   let primed = false
 
   return (input: TodoDockRestoreTrackerInput) => {
     if (!input.sessionID) {
       sessionID = undefined
+      sessionEnteredAt = now()
       primed = false
       return false
     }
 
     if (sessionID !== input.sessionID) {
       sessionID = input.sessionID
+      sessionEnteredAt = now()
       primed = false
     }
 
-    const restored =
-      input.known &&
-      !primed &&
-      input.count > 0 &&
-      input.phase === "active" &&
-      input.source !== "primary-parts" &&
-      input.source !== "fallback-parts"
+    const active = input.count > 0 && input.phase === "active"
+    const historicalToolParts =
+      isToolPartsSource(input.source) &&
+      active &&
+      (input.sourceUpdatedAt === undefined || input.sourceUpdatedAt <= sessionEnteredAt)
+    const restored = !primed && active && (historicalToolParts || (input.known && !isToolPartsSource(input.source)))
     if (input.known) primed = true
     return restored
   }

--- a/packages/app/src/pages/session/todos/todo-model.ts
+++ b/packages/app/src/pages/session/todos/todo-model.ts
@@ -11,6 +11,7 @@ export type TodoSnapshot = {
   source: TodoSourceKind
   items: SessionTodoItem[]
   phase: TodoPhase
+  sourceUpdatedAt?: number
   lifecycleSignature: string
   displaySignature: string
   dockEligible: boolean
@@ -40,6 +41,7 @@ export function todoSnapshot(input: {
   sessionID?: string
   source: TodoSourceKind
   items: SessionTodoItem[]
+  sourceUpdatedAt?: number
   dockEligible?: boolean
   historicalTerminal?: boolean
 }): TodoSnapshot {
@@ -49,6 +51,7 @@ export function todoSnapshot(input: {
     source: input.source,
     items: input.items,
     phase,
+    sourceUpdatedAt: input.sourceUpdatedAt,
     lifecycleSignature: todoLifecycleSignature(input.items),
     displaySignature: todoDisplaySignature(input.items),
     dockEligible: input.dockEligible ?? phase === "active",

--- a/packages/app/src/pages/session/todos/todo-source.ts
+++ b/packages/app/src/pages/session/todos/todo-source.ts
@@ -73,6 +73,7 @@ const sourceTodoSnapshot = (
       sessionID: input.sessionID,
       source: source.parts,
       items: sourceParts,
+      sourceUpdatedAt: latestTodoWriteTime(input.parts),
       dockEligible: phase === "active",
       historicalTerminal: phase === "terminal",
     })

--- a/packages/app/src/pages/session/todos/use-session-todos.test.ts
+++ b/packages/app/src/pages/session/todos/use-session-todos.test.ts
@@ -1,5 +1,63 @@
-import { describe, expect, test } from "bun:test"
-import { isTodoSnapshotKnownForRestore } from "./use-session-todos"
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import type { Part, ToolState } from "@opencode-ai/sdk/v2"
+import type { Message, Todo } from "@opencode-ai/sdk/v2/client"
+
+let createSessionTodoModel: typeof import("./use-session-todos").createSessionTodoModel
+let isTodoSnapshotKnownForRestore: typeof import("./use-session-todos").isTodoSnapshotKnownForRestore
+let syncData: {
+  message: Record<string, Message[] | undefined>
+  part: Record<string, Part[] | undefined>
+  todo: Record<string, Todo[] | undefined>
+}
+let globalSyncData: {
+  session_todo: Record<string, Todo[] | undefined>
+  session_todo_clear: Record<string, number | undefined>
+}
+
+const completedState = (
+  overrides: Partial<Extract<ToolState, { status: "completed" }>> = {},
+): Extract<ToolState, { status: "completed" }> => ({
+  status: "completed",
+  input: {},
+  output: "",
+  title: "",
+  metadata: {},
+  time: { start: 0, end: 0 },
+  ...overrides,
+})
+
+const todo = (content: string, status: Todo["status"] = "pending"): Todo =>
+  ({
+    content,
+    status,
+    priority: "medium",
+  }) as Todo
+
+const todoWritePart = (state: ToolState): Part =>
+  ({
+    id: "p1",
+    sessionID: "s",
+    messageID: "m1",
+    type: "tool",
+    callID: "c1",
+    tool: "todowrite",
+    state,
+  }) as Part
+
+beforeAll(async () => {
+  mock.module("@/context/sync", () => ({
+    useSync: () => ({ data: syncData }),
+  }))
+  mock.module("@/context/global-sync", () => ({
+    useGlobalSync: () => ({ data: globalSyncData }),
+  }))
+
+  const module = await import("./use-session-todos")
+  createSessionTodoModel = module.createSessionTodoModel
+  isTodoSnapshotKnownForRestore = module.isTodoSnapshotKnownForRestore
+})
 
 describe("isTodoSnapshotKnownForRestore", () => {
   test("does not treat a non-none todo source as known without a sync cache", () => {
@@ -44,5 +102,49 @@ describe("isTodoSnapshotKnownForRestore", () => {
         globalTodoKnown: true,
       }),
     ).toBe(true)
+  })
+})
+
+describe("createSessionTodoModel dock restore input", () => {
+  test("keeps the first live tool-parts todo opening when backend cache has not primed", () => {
+    const originalNow = Date.now
+    Date.now = () => 200
+
+    try {
+      createRoot((dispose) => {
+        const stores = createStore({
+          message: { s: [{ id: "m1", sessionID: "s" } as Message] },
+          part: {
+            m1: [
+              todoWritePart(
+                completedState({
+                  input: { todos: [todo("live task", "in_progress")] },
+                  time: { start: 250, end: 250 },
+                }),
+              ),
+            ],
+          } as Record<string, Part[] | undefined>,
+          todo: {} as Record<string, Todo[] | undefined>,
+        })
+        syncData = stores[0]
+        globalSyncData = {
+          session_todo: {},
+          session_todo_clear: {},
+        }
+
+        const model = createSessionTodoModel({ sessionID: () => "s" })
+
+        expect(model.snapshot()).toMatchObject({
+          source: "primary-parts",
+          sourceUpdatedAt: 250,
+          phase: "active",
+        })
+        expect(model.opening()).toBe(true)
+
+        dispose()
+      })
+    } finally {
+      Date.now = originalNow
+    }
   })
 })

--- a/packages/app/src/pages/session/todos/use-session-todos.ts
+++ b/packages/app/src/pages/session/todos/use-session-todos.ts
@@ -29,6 +29,7 @@ const dockInput = (snapshot: TodoSnapshot, sessionID?: string, restored?: boolea
   count: snapshot.items.length,
   phase: snapshot.phase,
   lifecycleSignature: snapshot.lifecycleSignature,
+  sourceUpdatedAt: snapshot.sourceUpdatedAt,
   dockEligible: snapshot.dockEligible,
   restored,
   historicalTerminal: snapshot.historicalTerminal,

--- a/packages/app/src/pages/session/todos/use-session-todos.ts
+++ b/packages/app/src/pages/session/todos/use-session-todos.ts
@@ -140,6 +140,7 @@ export function createSessionTodoModel(input: {
         source: current.source,
         count: current.items.length,
         phase: current.phase,
+        sourceUpdatedAt: current.sourceUpdatedAt,
       }),
     )
   }


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

- Treat active ToDos restored from historical tool parts as restored dock state instead of newly opened dock state.
- Carry the latest `todowrite` part time into ToDo snapshots so live ToDos created after session entry can still animate.
- Add regression coverage for sidebar switching into an existing active-ToDo session while preserving the live `todowrite` entrance path.

## Why

A user trace from the formal v2026.5.21 build showed that sidebar switching into an existing active-ToDo session can render historical `todowrite` message parts before `/session/:id/todo` cache returns. The previous restored-dock fix excluded `primary-parts`, so those historical active ToDos were misclassified as a new live dock and replayed the pop-out animation.

## Related Issue

No dedicated bug issue; this fixes a user-reported regression diagnosed from `docs/debug-trace/Trace-20260521T104612-tododock-popout.json.gz`. Related long-term design debt: #807.

## Human Review Status

Pending

## Review Focus

Please check the restored/live boundary in `createTodoDockRestoreTracker`: historical tool parts from before session entry should not animate, but a real `todowrite` created while viewing the session should still animate.

## Risk Notes

- The fix still preserves the short-term composer dock model; #807 tracks removing non-blocking dock surfaces from the composer area.
- Existing E2E output still prints the known `[e2e:pageerror] Object` and Node `DEP0205` warning noise; all assertions passed.
- Platform/packaging surfaces were not touched.
- Docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, and tracked local files were not touched.

## How To Verify

```text
bun test --preload ./happydom.ts ./src/pages/session/todos/todo-dock-machine.test.ts ./src/pages/session/todos/todo-source.test.ts ./src/pages/session/todos/todo-model.test.ts
Result: 50 pass, 0 fail.

bun run typecheck
Result: tsgo -b completed successfully.

bun run test:e2e -- e2e/session/session-todo-dock-restore.spec.ts
Result: 2 passed, covering restored backend ToDos and historical tool-parts ToDos on sidebar session switch.

bun run test:e2e -- e2e/session/session-composer-dock.spec.ts -g "todo dock appears from real todowrite tool parts"
Result: 1 passed, confirming live todowrite still triggers the entrance path.

bun run snap todo-dock-restored
Result: 1 passed; reviewed docs/design/preview/screenshots/todo-dock-restored.png.
```

## Screenshots or Recordings

- `bun run snap todo-dock-restored` generated `docs/design/preview/screenshots/todo-dock-restored.png`; reviewed the grid PNG.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.