### PR TITLE
feat(session): add run incident diagnostics

### DIFF
--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -27,6 +27,7 @@ import { safeToolFailureMetadata } from "./tool-failure"
 import { LLMTrace } from "./llm-trace"
 import { safeErrorFingerprint, safeProviderCorrelation } from "./llm-trace/stream-diagnostics"
 import { RunObservability } from "./run-observability"
+import { RunIncident } from "./run-incident"
 
 export function getRuntimeNamespace(): "pawwork" | "opencode" {
   return Runtime.isPawWork() ? "pawwork" : "opencode"
@@ -158,6 +159,8 @@ export namespace Export {
       llm_traces?: LLMTrace.Summary[]
       run_observability_schema_version?: typeof RunObservability.SCHEMA_VERSION
       run_observability?: RunObservability.Summary[]
+      run_incident_schema_version?: typeof RunIncident.SCHEMA_VERSION
+      run_incidents?: RunIncident.Summary[]
       aborts?: Array<{
         session_id: SessionID
         message_id: MessageID
@@ -210,6 +213,8 @@ export namespace Export {
     llm_traces?: LLMTrace.Summary[]
     run_observability_schema_version?: typeof RunObservability.SCHEMA_VERSION
     run_observability?: RunObservability.Summary[]
+    run_incident_schema_version?: typeof RunIncident.SCHEMA_VERSION
+    run_incidents?: RunIncident.Summary[]
     aborts?: Array<{
       session_id: SessionID
       message_id: MessageID
@@ -295,6 +300,7 @@ export namespace Export {
     walk(node)
     const llm_traces = collectLLMTraces(node)
     const run_observability = collectRunObservability(node)
+    const run_incidents = collectRunIncidents(node)
     const aborts = collectAbortDiagnostics(node)
     const title_generations = collectTitleGenerations(node)
     return {
@@ -303,6 +309,7 @@ export namespace Export {
       ...(run_observability.length
         ? { run_observability_schema_version: RunObservability.SCHEMA_VERSION, run_observability }
         : {}),
+      ...(run_incidents.length ? { run_incident_schema_version: RunIncident.SCHEMA_VERSION, run_incidents } : {}),
       ...(aborts.length ? { aborts } : {}),
       ...(title_generations.length ? { title_generations } : {}),
     }
@@ -337,6 +344,23 @@ export namespace Export {
     }
     walk(node)
     return traces.sort((a, b) => {
+      if (a.session_id !== b.session_id) return a.session_id.localeCompare(b.session_id)
+      return a.message_id.localeCompare(b.message_id)
+    })
+  }
+
+  function collectRunIncidents(node: Tree) {
+    const incidents: RunIncident.Summary[] = []
+    const walk = (t: Tree) => {
+      for (const message of t.messages ?? []) {
+        if (message.info.role !== "assistant") continue
+        const incident = message.info.diagnostics?.run_observability?.incident
+        if (incident) incidents.push(incident)
+      }
+      for (const child of t.children ?? []) walk(child)
+    }
+    walk(node)
+    return incidents.sort((a, b) => {
       if (a.session_id !== b.session_id) return a.session_id.localeCompare(b.session_id)
       return a.message_id.localeCompare(b.message_id)
     })
@@ -1028,12 +1052,21 @@ export namespace Export {
       })),
       llm_traces: diagnostics.llm_traces?.map(sanitizeLLMTrace),
       run_observability: diagnostics.run_observability?.map(sanitizeRunObservability),
+      run_incident_schema_version:
+        diagnostics.run_incident_schema_version ??
+        (diagnostics.run_incidents?.length || diagnostics.run_observability?.some((summary) => summary.incident)
+          ? RunIncident.SCHEMA_VERSION
+          : undefined),
+      run_incidents: (
+        diagnostics.run_incidents ?? diagnostics.run_observability?.flatMap((summary) => summary.incident ?? [])
+      )?.map(RunIncident.sanitize),
     }
   }
 
   function sanitizeRunObservability(summary: RunObservability.Summary): RunObservability.Summary {
     return {
       ...summary,
+      incident: summary.incident ? RunIncident.sanitize(summary.incident) : undefined,
       error: summary.error,
     }
   }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -663,7 +663,13 @@ export const layer: Layer.Layer<
             ctx.runTrace.recordToolInputCompleted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
           }
           if (value.type === "tool-call") {
-            ctx.runTrace.recordToolCallMaterialized({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+            ctx.runTrace.recordToolCallMaterialized({
+              attemptID: ctx.currentAttemptID,
+              at: now,
+              monotonicMs,
+              toolName: RunObservability.safeToolName(value.toolName),
+              effect: RunObservability.toolEffect(value.toolName),
+            })
           }
         }
         switch (value.type) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -640,11 +640,25 @@ export const layer: Layer.Layer<
           if (RunObservability.isProviderProgressEvent(value)) {
             ctx.runTrace.recordProviderProgress({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
           }
-          if (value.type === "text-start" || value.type === "text-delta" || value.type === "reasoning-start") {
-            ctx.runTrace.recordVisibleOutput({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+          if (value.type === "text-start" || value.type === "text-delta") {
+            ctx.runTrace.recordVisibleOutput({ attemptID: ctx.currentAttemptID, at: now, monotonicMs, kind: "text" })
           }
-          if (value.type === "tool-input-start" || value.type === "tool-call") {
-            ctx.runTrace.recordToolCall({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+          if (value.type === "reasoning-start") {
+            ctx.runTrace.recordVisibleOutput({
+              attemptID: ctx.currentAttemptID,
+              at: now,
+              monotonicMs,
+              kind: "reasoning",
+            })
+          }
+          if (value.type === "tool-input-start") {
+            ctx.runTrace.recordToolInputStarted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+          }
+          if (value.type === "tool-input-end") {
+            ctx.runTrace.recordToolInputCompleted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+          }
+          if (value.type === "tool-call") {
+            ctx.runTrace.recordToolCallMaterialized({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
           }
         }
         switch (value.type) {
@@ -963,11 +977,19 @@ export const layer: Layer.Layer<
             },
           })
           if (ctx.currentAttemptID) {
-            ctx.runTrace.recordToolInterrupted({
-              attemptID: ctx.currentAttemptID,
-              at: end,
-              monotonicMs: performance.now(),
-            })
+            if (part.state.status === "running") {
+              ctx.runTrace.recordToolInterrupted({
+                attemptID: ctx.currentAttemptID,
+                at: end,
+                monotonicMs: performance.now(),
+              })
+            } else {
+              ctx.runTrace.recordPendingToolPartInterrupted({
+                attemptID: ctx.currentAttemptID,
+                at: end,
+                monotonicMs: performance.now(),
+              })
+            }
           }
         }
         ctx.toolcalls = {}

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -652,7 +652,12 @@ export const layer: Layer.Layer<
             })
           }
           if (value.type === "tool-input-start") {
-            ctx.runTrace.recordToolInputStarted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
+            ctx.runTrace.recordToolInputStarted({
+              attemptID: ctx.currentAttemptID,
+              at: now,
+              monotonicMs,
+              providerExecuted: (value as { providerExecuted?: boolean }).providerExecuted,
+            })
           }
           if (value.type === "tool-input-end") {
             ctx.runTrace.recordToolInputCompleted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -1,0 +1,165 @@
+import type { MessageID, SessionID } from "../schema"
+import type { LifecycleKind, RunID, SafeErrorFingerprint, ToolEffectKind } from "../run-observability/types"
+import { recoveryFor } from "./policy"
+import { plainSummary, userSummary } from "./presentation"
+import {
+  RUN_INCIDENT_SCHEMA_VERSION,
+  type IncidentEvidenceEvent,
+  type IncidentFacts,
+  type RunIncident,
+  type TerminalCause,
+} from "./types"
+import { sanitizeIncident } from "./sanitize"
+
+export type DeriveIncidentInput = {
+  runID: RunID
+  traceID: MessageID
+  sessionID: SessionID
+  messageID: MessageID
+  parentMessageID?: MessageID
+  createdAt: number
+  completedAt?: number
+  evidence: IncidentEvidenceEvent[]
+  unsafeSideEffectKinds: ToolEffectKind[]
+  sideEffectFactsComplete: boolean
+  lifecycle?: { action_id: string; kind: LifecycleKind; source?: string; reason?: string }
+  missingProvenance?: string[]
+}
+
+export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefined {
+  const terminal = input.evidence
+    .filter((event) => event.terminal_candidate && event.cause)
+    .sort(compareTerminalEvents)[0]
+  if (!terminal?.cause) return undefined
+  const facts = factsFromEvidence(input)
+  const recovery = recoveryFor({ cause: terminal.cause, facts })
+  const summary = userSummary({ cause: terminal.cause, recovery })
+  const missingProvenance = input.missingProvenance ?? []
+  return sanitizeIncident({
+    schema_version: RUN_INCIDENT_SCHEMA_VERSION,
+    incident_id: `incident:${input.messageID}`,
+    run_id: input.runID,
+    trace_id: input.traceID,
+    session_id: input.sessionID,
+    message_id: input.messageID,
+    parent_message_id: input.parentMessageID,
+    created_at: input.createdAt,
+    completed_at: input.completedAt,
+    terminal_cause: terminal.cause,
+    phase: phaseFor({ facts, terminalAttemptID: terminal.attempt_id }),
+    facts,
+    provenance: {
+      ...(input.lifecycle
+        ? {
+            lifecycle: {
+              action_id: input.lifecycle.action_id,
+              kind: input.lifecycle.kind,
+              reason: input.lifecycle.reason,
+              affected_directory_keys: [],
+              completeness: "partial" as const,
+            },
+          }
+        : {}),
+      completeness: missingProvenance.length ? "partial" : input.lifecycle ? "partial" : "unknown",
+    },
+    recovery,
+    evidence: input.evidence.map(({ cause, tool_name, ...event }) => event),
+    user_summary: summary,
+    plain_summary: plainSummary({ cause: terminal.cause, facts }),
+    missing_provenance: missingProvenance.length ? missingProvenance : undefined,
+    diagnostics_complete: missingProvenance.length === 0,
+  })
+}
+
+function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvidenceEvent) {
+  const leftTime = left.monotonic_ms ?? Number.POSITIVE_INFINITY
+  const rightTime = right.monotonic_ms ?? Number.POSITIVE_INFINITY
+  if (leftTime !== rightTime) return leftTime - rightTime
+  return left.order - right.order
+}
+
+function factsFromEvidence(input: DeriveIncidentInput): IncidentFacts {
+  const has = (eventType: string) => input.evidence.some((event) => event.event_type === eventType)
+  const count = (eventType: string) => input.evidence.filter((event) => event.event_type === eventType).length
+  return {
+    provider_progress_seen: has("provider_progress_seen"),
+    visible_output_seen: has("visible_output_seen"),
+    text_output_started: has("text_output_started"),
+    reasoning_output_started: has("reasoning_output_started"),
+    tool_input_started: has("tool_input_started"),
+    tool_input_completed: has("tool_input_completed"),
+    tool_call_materialized: has("tool_call_materialized"),
+    tool_execution_started: has("tool_execution_started"),
+    tool_execution_completed: has("tool_execution_completed"),
+    read_only_tool_started: has("read_only_tool_started"),
+    unsafe_side_effect_started: has("unsafe_side_effect_started"),
+    unsafe_side_effect_kinds: input.unsafeSideEffectKinds,
+    side_effect_facts_complete: input.sideEffectFactsComplete,
+    lifecycle_close_seen: has("lifecycle_close_seen"),
+    user_cancel_seen: has("user_cancel_seen"),
+    watchdog_fired: has("watchdog_fired"),
+    pending_tool_parts_interrupted: count("pending_tool_part_interrupted") || undefined,
+  }
+}
+
+function phaseFor(input: {
+  facts: IncidentFacts
+  terminalAttemptID?: IncidentEvidenceEvent["attempt_id"]
+}): RunIncident["phase"] {
+  const toolPhase = input.facts.tool_execution_started
+    ? "tool_execution_started"
+    : input.facts.tool_call_materialized
+      ? "tool_call_materialized"
+      : input.facts.tool_input_completed
+        ? "tool_input_completed"
+        : input.facts.tool_input_started
+          ? "tool_input_started"
+          : "none"
+  const streamPhase = input.facts.tool_call_materialized
+    ? "after_tool_call"
+    : input.facts.tool_input_started
+      ? "tool_input_generation"
+      : input.facts.visible_output_seen
+        ? "text_generation"
+        : input.facts.provider_progress_seen
+          ? "before_first_provider_progress"
+          : "unknown"
+  const runPhase = input.facts.tool_execution_started
+    ? "tool_execution"
+    : input.facts.tool_input_started || input.facts.tool_call_materialized
+      ? "tool_generation"
+      : input.facts.provider_progress_seen || input.facts.visible_output_seen
+        ? "streaming"
+        : "unknown"
+  return {
+    run_phase: runPhase,
+    stream_phase: streamPhase,
+    tool_phase: toolPhase,
+    terminal_attempt_id: input.terminalAttemptID,
+  }
+}
+
+export function transportCause(input: {
+  error?: SafeErrorFingerprint
+  providerProgressSeen: boolean
+  toolInputStarted: boolean
+  toolInputCompleted: boolean
+  toolCallMaterialized: boolean
+}): Extract<TerminalCause, { category: "provider_transport_disconnect" }> {
+  const error = input.error
+  const boundary = error?.cause_code === "UND_ERR_SOCKET" ? "sdk_transport" : "unknown"
+  return {
+    category: "provider_transport_disconnect",
+    subcategory:
+      input.toolInputStarted && !input.toolInputCompleted && !input.toolCallMaterialized
+        ? "during_tool_input_generation"
+        : input.toolCallMaterialized
+          ? "after_tool_call_before_execution"
+          : input.providerProgressSeen
+            ? "during_text_generation"
+            : "before_first_provider_progress",
+    boundary,
+    error,
+    confidence: boundary === "sdk_transport" ? "high" : "medium",
+  }
+}

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -145,11 +145,9 @@ function phaseFor(input: {
         ? "tool_input_generation"
         : input.facts.reasoning_output_started && !input.facts.text_output_started
           ? "reasoning_generation"
-          : input.facts.visible_output_seen
+          : input.facts.visible_output_seen || input.facts.provider_progress_seen
             ? "text_generation"
-            : input.facts.provider_progress_seen
-              ? "before_first_provider_progress"
-              : "unknown"
+            : "before_first_provider_progress"
   const runPhase = input.facts.tool_execution_started
     ? "tool_execution"
     : input.facts.tool_input_started || input.facts.tool_call_materialized

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -64,7 +64,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
       completeness: missingProvenance.length ? "partial" : input.lifecycle ? "partial" : "unknown",
     },
     recovery,
-    evidence: input.evidence.map(({ cause, tool_name, ...event }) => event),
+    evidence: input.evidence.map(({ cause, ...event }) => event),
     user_summary: summary,
     plain_summary: plainSummary({ cause: terminal.cause, facts }),
     missing_provenance: missingProvenance.length ? missingProvenance : undefined,

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -143,11 +143,13 @@ function phaseFor(input: {
       ? "after_tool_input_end"
       : input.facts.tool_input_started
         ? "tool_input_generation"
-        : input.facts.visible_output_seen
-          ? "text_generation"
-          : input.facts.provider_progress_seen
-            ? "before_first_provider_progress"
-            : "unknown"
+        : input.facts.reasoning_output_started && !input.facts.text_output_started
+          ? "reasoning_generation"
+          : input.facts.visible_output_seen
+            ? "text_generation"
+            : input.facts.provider_progress_seen
+              ? "before_first_provider_progress"
+              : "unknown"
   const runPhase = input.facts.tool_execution_started
     ? "tool_execution"
     : input.facts.tool_input_started || input.facts.tool_call_materialized

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -6,6 +6,7 @@ import {
   RUN_INCIDENT_SCHEMA_VERSION,
   type IncidentEvidenceEvent,
   type IncidentFacts,
+  type MaterializedToolBoundary,
   type RunIncident,
   type TerminalCause,
 } from "./types"
@@ -22,6 +23,7 @@ export type DeriveIncidentInput = {
   evidence: IncidentEvidenceEvent[]
   unsafeSideEffectKinds: ToolEffectKind[]
   sideEffectFactsComplete: boolean
+  materializedToolBoundary?: MaterializedToolBoundary
   lifecycle?: { action_id: string; kind: LifecycleKind; source?: string; reason?: string }
   missingProvenance?: string[]
 }
@@ -81,6 +83,8 @@ function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvide
 
 function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvidenceEvent["attempt_id"]): IncidentFacts {
   const scopedEvidence = attemptID ? input.evidence.filter((event) => event.attempt_id === attemptID) : input.evidence
+  const materializedToolBoundary =
+    attemptID && input.materializedToolBoundary?.attempt_id !== attemptID ? undefined : input.materializedToolBoundary
   const has = (eventType: string) => scopedEvidence.some((event) => event.event_type === eventType)
   const count = (eventType: string) => scopedEvidence.filter((event) => event.event_type === eventType).length
   return {
@@ -96,6 +100,10 @@ function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvide
     read_only_tool_started: has("read_only_tool_started"),
     unsafe_side_effect_started: has("unsafe_side_effect_started"),
     unsafe_side_effect_kinds: attemptID && !has("unsafe_side_effect_started") ? [] : input.unsafeSideEffectKinds,
+    materialized_tool_effect_kind: materializedToolBoundary?.effect.kind,
+    materialized_tool_requires_confirmation: materializedToolBoundary
+      ? materializedToolBoundary.effect.unsafe || !materializedToolBoundary.effect.complete
+      : undefined,
     side_effect_facts_complete: input.sideEffectFactsComplete,
     lifecycle_close_seen: has("lifecycle_close_seen"),
     user_cancel_seen: has("user_cancel_seen"),

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -23,7 +23,7 @@ export type DeriveIncidentInput = {
   evidence: IncidentEvidenceEvent[]
   unsafeSideEffectKinds: ToolEffectKind[]
   sideEffectFactsComplete: boolean
-  materializedToolBoundary?: MaterializedToolBoundary
+  materializedToolBoundaries?: MaterializedToolBoundary[]
   lifecycle?: { action_id: string; kind: LifecycleKind; source?: string; reason?: string }
   missingProvenance?: string[]
 }
@@ -83,8 +83,7 @@ function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvide
 
 function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvidenceEvent["attempt_id"]): IncidentFacts {
   const scopedEvidence = attemptID ? input.evidence.filter((event) => event.attempt_id === attemptID) : input.evidence
-  const materializedToolBoundary =
-    attemptID && input.materializedToolBoundary?.attempt_id !== attemptID ? undefined : input.materializedToolBoundary
+  const materializedToolBoundary = summarizeMaterializedToolBoundaries(input.materializedToolBoundaries, attemptID)
   const has = (eventType: string) => scopedEvidence.some((event) => event.event_type === eventType)
   const count = (eventType: string) => scopedEvidence.filter((event) => event.event_type === eventType).length
   return {
@@ -110,6 +109,19 @@ function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvide
     watchdog_fired: has("watchdog_fired"),
     pending_tool_parts_interrupted: count("pending_tool_part_interrupted") || undefined,
   }
+}
+
+function summarizeMaterializedToolBoundaries(
+  boundaries: MaterializedToolBoundary[] | undefined,
+  attemptID?: IncidentEvidenceEvent["attempt_id"],
+): MaterializedToolBoundary | undefined {
+  const scoped = boundaries?.filter((boundary) => !attemptID || boundary.attempt_id === attemptID) ?? []
+  if (!scoped.length) return undefined
+  return (
+    scoped.find((boundary) => !boundary.effect.complete) ??
+    scoped.find((boundary) => boundary.effect.unsafe) ??
+    scoped[scoped.length - 1]
+  )
 }
 
 function phaseFor(input: {

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -32,7 +32,8 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
     .sort(compareTerminalEvents)[0]
   if (!terminal?.cause) return undefined
   const facts = factsFromEvidence(input)
-  const recovery = recoveryFor({ cause: terminal.cause, facts })
+  const terminalFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id) : facts
+  const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts })
   const summary = userSummary({ cause: terminal.cause, recovery })
   const missingProvenance = input.missingProvenance ?? []
   return sanitizeIncident({
@@ -46,7 +47,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
     created_at: input.createdAt,
     completed_at: input.completedAt,
     terminal_cause: terminal.cause,
-    phase: phaseFor({ facts, terminalAttemptID: terminal.attempt_id }),
+    phase: phaseFor({ facts: terminalFacts, terminalAttemptID: terminal.attempt_id }),
     facts,
     provenance: {
       ...(input.lifecycle
@@ -78,9 +79,10 @@ function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvide
   return left.order - right.order
 }
 
-function factsFromEvidence(input: DeriveIncidentInput): IncidentFacts {
-  const has = (eventType: string) => input.evidence.some((event) => event.event_type === eventType)
-  const count = (eventType: string) => input.evidence.filter((event) => event.event_type === eventType).length
+function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvidenceEvent["attempt_id"]): IncidentFacts {
+  const scopedEvidence = attemptID ? input.evidence.filter((event) => event.attempt_id === attemptID) : input.evidence
+  const has = (eventType: string) => scopedEvidence.some((event) => event.event_type === eventType)
+  const count = (eventType: string) => scopedEvidence.filter((event) => event.event_type === eventType).length
   return {
     provider_progress_seen: has("provider_progress_seen"),
     visible_output_seen: has("visible_output_seen"),
@@ -93,7 +95,7 @@ function factsFromEvidence(input: DeriveIncidentInput): IncidentFacts {
     tool_execution_completed: has("tool_execution_completed"),
     read_only_tool_started: has("read_only_tool_started"),
     unsafe_side_effect_started: has("unsafe_side_effect_started"),
-    unsafe_side_effect_kinds: input.unsafeSideEffectKinds,
+    unsafe_side_effect_kinds: attemptID && !has("unsafe_side_effect_started") ? [] : input.unsafeSideEffectKinds,
     side_effect_facts_complete: input.sideEffectFactsComplete,
     lifecycle_close_seen: has("lifecycle_close_seen"),
     user_cancel_seen: has("user_cancel_seen"),
@@ -117,13 +119,15 @@ function phaseFor(input: {
           : "none"
   const streamPhase = input.facts.tool_call_materialized
     ? "after_tool_call"
-    : input.facts.tool_input_started
-      ? "tool_input_generation"
-      : input.facts.visible_output_seen
-        ? "text_generation"
-        : input.facts.provider_progress_seen
-          ? "before_first_provider_progress"
-          : "unknown"
+    : input.facts.tool_input_completed
+      ? "after_tool_input_end"
+      : input.facts.tool_input_started
+        ? "tool_input_generation"
+        : input.facts.visible_output_seen
+          ? "text_generation"
+          : input.facts.provider_progress_seen
+            ? "before_first_provider_progress"
+            : "unknown"
   const runPhase = input.facts.tool_execution_started
     ? "tool_execution"
     : input.facts.tool_input_started || input.facts.tool_call_materialized
@@ -153,11 +157,13 @@ export function transportCause(input: {
     subcategory:
       input.toolInputStarted && !input.toolInputCompleted && !input.toolCallMaterialized
         ? "during_tool_input_generation"
-        : input.toolCallMaterialized
-          ? "after_tool_call_before_execution"
-          : input.providerProgressSeen
-            ? "during_text_generation"
-            : "before_first_provider_progress",
+        : input.toolInputCompleted && !input.toolCallMaterialized
+          ? "unknown_stream_phase"
+          : input.toolCallMaterialized
+            ? "after_tool_call_before_execution"
+            : input.providerProgressSeen
+              ? "during_text_generation"
+              : "before_first_provider_progress",
     boundary,
     error,
     confidence: boundary === "sdk_transport" ? "high" : "medium",

--- a/packages/opencode/src/session/run-incident/index.ts
+++ b/packages/opencode/src/session/run-incident/index.ts
@@ -1,0 +1,25 @@
+import { deriveIncident as deriveRunIncident, transportCause as providerTransportCause } from "./derive"
+import { recoveryFor as deriveRecovery } from "./policy"
+import { plainSummary as derivePlainSummary, userSummary as deriveUserSummary } from "./presentation"
+import { sanitizeIncident as sanitizeRunIncident } from "./sanitize"
+import { RUN_INCIDENT_SCHEMA_VERSION as VERSION } from "./types"
+import * as Types from "./types"
+
+export namespace RunIncident {
+  export const SCHEMA_VERSION = VERSION
+  export const derive = deriveRunIncident
+  export const transportCause = providerTransportCause
+  export const recoveryFor = deriveRecovery
+  export const userSummary = deriveUserSummary
+  export const plainSummary = derivePlainSummary
+  export const sanitize = sanitizeRunIncident
+
+  export type Summary = Types.RunIncident
+  export type RunIncident = Types.RunIncident
+  export type EvidenceEvent = Types.IncidentEvidenceEvent
+  export type EvidenceSummary = Types.IncidentEvidenceSummary
+  export type TerminalCause = Types.TerminalCause
+  export type Phase = Types.IncidentPhase
+  export type Facts = Types.IncidentFacts
+  export type Recovery = Types.RecoveryDecision
+}

--- a/packages/opencode/src/session/run-incident/index.ts
+++ b/packages/opencode/src/session/run-incident/index.ts
@@ -22,4 +22,5 @@ export namespace RunIncident {
   export type Phase = Types.IncidentPhase
   export type Facts = Types.IncidentFacts
   export type Recovery = Types.RecoveryDecision
+  export type MaterializedToolBoundary = Types.MaterializedToolBoundary
 }

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -1,7 +1,12 @@
 import type { IncidentFacts, RecoveryDecision, TerminalCause } from "./types"
 
-export function recoveryFor(input: { cause: TerminalCause; facts: IncidentFacts }): RecoveryDecision {
+export function recoveryFor(input: {
+  cause: TerminalCause
+  facts: IncidentFacts
+  terminalFacts?: IncidentFacts
+}): RecoveryDecision {
   const base = { safety_scope: "visible_output_and_tool_side_effects" as const }
+  const terminalFacts = input.terminalFacts ?? input.facts
   if (input.cause.category === "user_cancel") {
     return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
   }
@@ -32,7 +37,7 @@ export function recoveryFor(input: { cause: TerminalCause; facts: IncidentFacts 
   if (input.facts.tool_execution_started) {
     return { ...base, recommendation: "ask_user_before_retry", confidence: "medium", reason: "tool_execution_started" }
   }
-  if (input.facts.tool_call_materialized) {
+  if (terminalFacts.tool_call_materialized) {
     return {
       ...base,
       recommendation: "offer_continue",
@@ -40,7 +45,7 @@ export function recoveryFor(input: { cause: TerminalCause; facts: IncidentFacts 
       reason: "tool_call_materialized_without_execution",
     }
   }
-  if (input.facts.tool_input_started && !input.facts.tool_input_completed) {
+  if (terminalFacts.tool_input_started && !terminalFacts.tool_input_completed) {
     return {
       ...base,
       recommendation: "offer_continue",
@@ -51,7 +56,7 @@ export function recoveryFor(input: { cause: TerminalCause; facts: IncidentFacts 
   if (input.facts.visible_output_seen) {
     return {
       ...base,
-      recommendation: "offer_continue",
+      recommendation: "ask_user_before_retry",
       confidence: "high",
       reason: "visible_output_without_tool_execution",
     }

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -1,0 +1,69 @@
+import type { IncidentFacts, RecoveryDecision, TerminalCause } from "./types"
+
+export function recoveryFor(input: { cause: TerminalCause; facts: IncidentFacts }): RecoveryDecision {
+  const base = { safety_scope: "visible_output_and_tool_side_effects" as const }
+  if (input.cause.category === "user_cancel") {
+    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
+  }
+  if (input.cause.category === "local_lifecycle_close") {
+    return {
+      ...base,
+      recommendation: "do_not_retry",
+      confidence: input.cause.confidence,
+      reason: "local_lifecycle_close",
+    }
+  }
+  if (!input.facts.side_effect_facts_complete) {
+    return {
+      ...base,
+      recommendation: "ask_user_before_retry",
+      confidence: "high",
+      reason: "side_effect_facts_incomplete",
+    }
+  }
+  if (input.facts.unsafe_side_effect_started) {
+    return {
+      ...base,
+      recommendation: "ask_user_before_retry",
+      confidence: "high",
+      reason: "unsafe_side_effect_started",
+    }
+  }
+  if (input.facts.tool_execution_started) {
+    return { ...base, recommendation: "ask_user_before_retry", confidence: "medium", reason: "tool_execution_started" }
+  }
+  if (input.facts.tool_call_materialized) {
+    return {
+      ...base,
+      recommendation: "offer_continue",
+      confidence: "high",
+      reason: "tool_call_materialized_without_execution",
+    }
+  }
+  if (input.facts.tool_input_started && !input.facts.tool_input_completed) {
+    return {
+      ...base,
+      recommendation: "offer_continue",
+      confidence: "high",
+      reason: "partial_tool_input_without_execution",
+    }
+  }
+  if (input.facts.visible_output_seen) {
+    return {
+      ...base,
+      recommendation: "offer_continue",
+      confidence: "high",
+      reason: "visible_output_without_tool_execution",
+    }
+  }
+  if (input.cause.category === "provider_transport_disconnect") {
+    return {
+      ...base,
+      recommendation: "auto_retry_once",
+      confidence: "medium",
+      reason: "no_visible_output_or_tool_execution",
+      auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
+    }
+  }
+  return { ...base, recommendation: "unknown", confidence: "low", reason: "unknown" }
+}

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -38,6 +38,22 @@ export function recoveryFor(input: {
     return { ...base, recommendation: "ask_user_before_retry", confidence: "medium", reason: "tool_execution_started" }
   }
   if (terminalFacts.tool_call_materialized) {
+    if (!terminalFacts.side_effect_facts_complete || terminalFacts.materialized_tool_effect_kind === "unknown") {
+      return {
+        ...base,
+        recommendation: "ask_user_before_retry",
+        confidence: "high",
+        reason: "side_effect_facts_incomplete",
+      }
+    }
+    if (terminalFacts.materialized_tool_requires_confirmation) {
+      return {
+        ...base,
+        recommendation: "ask_user_before_retry",
+        confidence: "high",
+        reason: "tool_call_materialized_without_execution",
+      }
+    }
     return {
       ...base,
       recommendation: "offer_continue",
@@ -56,7 +72,7 @@ export function recoveryFor(input: {
   if (input.facts.visible_output_seen) {
     return {
       ...base,
-      recommendation: "ask_user_before_retry",
+      recommendation: "offer_continue",
       confidence: "high",
       reason: "visible_output_without_tool_execution",
     }

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -37,8 +37,8 @@ export function recoveryFor(input: {
   if (input.facts.tool_execution_started) {
     return { ...base, recommendation: "ask_user_before_retry", confidence: "medium", reason: "tool_execution_started" }
   }
-  if (terminalFacts.tool_call_materialized) {
-    if (!terminalFacts.side_effect_facts_complete || terminalFacts.materialized_tool_effect_kind === "unknown") {
+  if (input.facts.tool_call_materialized) {
+    if (!input.facts.side_effect_facts_complete || input.facts.materialized_tool_effect_kind === "unknown") {
       return {
         ...base,
         recommendation: "ask_user_before_retry",
@@ -46,7 +46,7 @@ export function recoveryFor(input: {
         reason: "side_effect_facts_incomplete",
       }
     }
-    if (terminalFacts.materialized_tool_requires_confirmation) {
+    if (input.facts.materialized_tool_requires_confirmation) {
       return {
         ...base,
         recommendation: "ask_user_before_retry",

--- a/packages/opencode/src/session/run-incident/presentation.ts
+++ b/packages/opencode/src/session/run-incident/presentation.ts
@@ -1,0 +1,45 @@
+import type { IncidentFacts, RecoveryDecision, TerminalCause } from "./types"
+
+export function userSummary(input: { cause: TerminalCause; recovery: RecoveryDecision }) {
+  const prefix = `run_incident.${input.cause.category}`
+  const subcategory = "subcategory" in input.cause ? input.cause.subcategory : "unknown"
+  return {
+    title_key: prefix,
+    body_key: `${prefix}.${subcategory}`,
+    action_key: actionKey(input.recovery),
+    severity: severity(input.cause),
+  }
+}
+
+export function plainSummary(input: { cause: TerminalCause; facts: IncidentFacts }) {
+  if (
+    input.cause.category === "provider_transport_disconnect" &&
+    input.cause.subcategory === "during_tool_input_generation" &&
+    !input.facts.tool_execution_started
+  ) {
+    return "The provider stream disconnected while PawWork was preparing a tool call. The tool did not run."
+  }
+  if (input.cause.category === "local_lifecycle_close") {
+    return "The active run was interrupted by a local lifecycle close."
+  }
+  if (input.cause.category === "user_cancel") return "The run was cancelled by the user."
+  if (input.cause.category === "watchdog_timeout")
+    return "The run stopped after PawWork waited too long for provider progress."
+  if (input.cause.category === "tool_execution_failure") return "A tool failed after execution started."
+  return "The run ended before PawWork could complete the assistant response."
+}
+
+function actionKey(recovery: RecoveryDecision) {
+  if (recovery.recommendation === "auto_retry_once") return "run_incident.action.retry"
+  if (recovery.recommendation === "offer_continue") return "run_incident.action.continue"
+  if (recovery.recommendation === "offer_resume_with_confirmation") return "run_incident.action.confirm_continue"
+  if (recovery.recommendation === "ask_user_before_retry") return "run_incident.action.confirm_retry"
+  return undefined
+}
+
+function severity(cause: TerminalCause) {
+  if (cause.category === "user_cancel") return "info" as const
+  if (cause.category === "unknown_interruption" || cause.category === "crash_or_restart_incomplete")
+    return "error" as const
+  return "warning" as const
+}

--- a/packages/opencode/src/session/run-incident/sanitize.ts
+++ b/packages/opencode/src/session/run-incident/sanitize.ts
@@ -24,10 +24,9 @@ function boundEvidence(incident: RunIncident): IncidentEvidenceSummary[] | undef
     }
   }
 
-  const selectedEvents = evidence
-    .filter((event) => selected.has(event.order))
-    .sort((left, right) => left.order - right.order)
-    .slice(0, MAX_EXPORTED_EVIDENCE - 1)
+  const selectedEvents = capSelectedEvents(
+    evidence.filter((event) => selected.has(event.order)).sort((left, right) => left.order - right.order),
+  )
   const selectedOrders = new Set(selectedEvents.map((event) => event.order))
   const omitted = evidence.filter((event) => !selectedOrders.has(event.order))
   if (!omitted.length) return selectedEvents
@@ -45,6 +44,20 @@ function boundEvidence(incident: RunIncident): IncidentEvidenceSummary[] | undef
   }
 
   return [...selectedEvents, marker].sort((left, right) => left.order - right.order)
+}
+
+function capSelectedEvents(events: IncidentEvidenceSummary[]) {
+  const maxEventsBeforeMarker = MAX_EXPORTED_EVIDENCE - 1
+  if (events.length <= maxEventsBeforeMarker) return events
+
+  const anchorEvents = events.filter((event) => event.terminal_candidate || isCleanupEvidence(event.event_type))
+  const nonAnchorEvents = events.filter((event) => !event.terminal_candidate && !isCleanupEvidence(event.event_type))
+  const keptAnchors = anchorEvents.slice(-maxEventsBeforeMarker)
+  const remaining = Math.max(0, maxEventsBeforeMarker - keptAnchors.length)
+  const keptNonAnchors = remaining ? nonAnchorEvents.slice(-remaining) : []
+  const kept = new Map<number, IncidentEvidenceSummary>()
+  for (const event of [...keptNonAnchors, ...keptAnchors]) kept.set(event.order, event)
+  return [...kept.values()].sort((left, right) => left.order - right.order)
 }
 
 function isCleanupEvidence(eventType: string) {

--- a/packages/opencode/src/session/run-incident/sanitize.ts
+++ b/packages/opencode/src/session/run-incident/sanitize.ts
@@ -1,0 +1,25 @@
+import type { IncidentEvidenceSummary, RunIncident } from "./types"
+
+const MAX_EXPORTED_EVIDENCE = 24
+
+export function sanitizeIncident(incident: RunIncident): RunIncident {
+  return {
+    ...incident,
+    evidence: incident.evidence?.slice(0, MAX_EXPORTED_EVIDENCE).map(sanitizeEvidence),
+  }
+}
+
+export function sanitizeEvidence(event: IncidentEvidenceSummary): IncidentEvidenceSummary {
+  return {
+    ...event,
+    redactions: event.redactions?.map(safeRedactionMarker),
+  }
+}
+
+function safeRedactionMarker(value: string) {
+  const trimmed = value.trim().slice(0, 80)
+  if (!trimmed) return "redacted"
+  if (/[/\\]|https?:\/\//i.test(trimmed)) return "redacted"
+  if (/token|secret|bearer|sk-|cookie|password/i.test(trimmed)) return "redacted"
+  return trimmed.replace(/[^a-zA-Z0-9_.:-]/g, "_") || "redacted"
+}

--- a/packages/opencode/src/session/run-incident/sanitize.ts
+++ b/packages/opencode/src/session/run-incident/sanitize.ts
@@ -5,8 +5,50 @@ const MAX_EXPORTED_EVIDENCE = 24
 export function sanitizeIncident(incident: RunIncident): RunIncident {
   return {
     ...incident,
-    evidence: incident.evidence?.slice(0, MAX_EXPORTED_EVIDENCE).map(sanitizeEvidence),
+    evidence: boundEvidence(incident),
   }
+}
+
+function boundEvidence(incident: RunIncident): IncidentEvidenceSummary[] | undefined {
+  const evidence = incident.evidence?.map(sanitizeEvidence)
+  if (!evidence || evidence.length <= MAX_EXPORTED_EVIDENCE) return evidence
+
+  const selected = new Set<number>()
+  for (const event of evidence.slice(0, 8)) selected.add(event.order)
+  for (const event of evidence.slice(-5)) selected.add(event.order)
+  for (const event of evidence) {
+    if (event.terminal_candidate || isCleanupEvidence(event.event_type)) {
+      selected.add(event.order)
+      selected.add(event.order - 1)
+      selected.add(event.order + 1)
+    }
+  }
+
+  const selectedEvents = evidence
+    .filter((event) => selected.has(event.order))
+    .sort((left, right) => left.order - right.order)
+    .slice(0, MAX_EXPORTED_EVIDENCE - 1)
+  const selectedOrders = new Set(selectedEvents.map((event) => event.order))
+  const omitted = evidence.filter((event) => !selectedOrders.has(event.order))
+  if (!omitted.length) return selectedEvents
+
+  const firstOmitted = omitted[0]
+  const marker: IncidentEvidenceSummary = {
+    event_id: `${incident.incident_id}:evidence:omitted:${omitted.length}`,
+    order: firstOmitted.order - 0.1,
+    omitted_events: omitted.length,
+    monotonic_ms: firstOmitted.monotonic_ms,
+    source: "processor",
+    event_type: "evidence_omitted",
+    terminal_candidate: false,
+    confidence: "medium",
+  }
+
+  return [...selectedEvents, marker].sort((left, right) => left.order - right.order)
+}
+
+function isCleanupEvidence(eventType: string) {
+  return eventType === "pending_tool_part_interrupted" || eventType === "lifecycle_close_seen"
 }
 
 export function sanitizeEvidence(event: IncidentEvidenceSummary): IncidentEvidenceSummary {

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -25,6 +25,7 @@ export type IncidentEvidenceSource =
 export type IncidentEvidenceEvent = {
   event_id: string
   order: number
+  omitted_events?: number
   monotonic_ms?: number
   source: IncidentEvidenceSource
   attempt_id?: AttemptID

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -5,6 +5,7 @@ import type {
   RunID,
   SafeErrorFingerprint,
   SafeToolName,
+  ToolEffect,
   ToolEffectKind,
 } from "../run-observability/types"
 
@@ -36,6 +37,9 @@ export type IncidentEvidenceEvent = {
   redactions?: string[]
   cause?: TerminalCause
   tool_name?: SafeToolName
+  tool_effect_kind?: ToolEffectKind
+  tool_effect_unsafe?: boolean
+  tool_effect_complete?: boolean
 }
 
 export type IncidentEvidenceSummary = Omit<IncidentEvidenceEvent, "cause">
@@ -119,6 +123,8 @@ export type IncidentFacts = {
   read_only_tool_started: boolean
   unsafe_side_effect_started: boolean
   unsafe_side_effect_kinds: ToolEffectKind[]
+  materialized_tool_effect_kind?: ToolEffectKind
+  materialized_tool_requires_confirmation?: boolean
   side_effect_facts_complete: boolean
   lifecycle_close_seen: boolean
   user_cancel_seen: boolean
@@ -141,6 +147,12 @@ export type IncidentProvenance = {
     recorded_at?: number
   }
   completeness: "complete" | "partial" | "unknown"
+}
+
+export type MaterializedToolBoundary = {
+  attempt_id?: AttemptID
+  tool?: SafeToolName
+  effect: ToolEffect
 }
 
 export type RecoveryDecision = {

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -1,0 +1,196 @@
+import type { MessageID, SessionID } from "../schema"
+import type {
+  AttemptID,
+  LifecycleKind,
+  RunID,
+  SafeErrorFingerprint,
+  SafeToolName,
+  ToolEffectKind,
+} from "../run-observability/types"
+
+export const RUN_INCIDENT_SCHEMA_VERSION = 1
+
+export type Confidence = "low" | "medium" | "high"
+
+export type IncidentEvidenceSource =
+  | "provider_stream"
+  | "processor"
+  | "tool_runner"
+  | "lifecycle"
+  | "watchdog"
+  | "user_action"
+  | "recovery"
+  | "unknown"
+
+export type IncidentEvidenceEvent = {
+  event_id: string
+  order: number
+  monotonic_ms?: number
+  source: IncidentEvidenceSource
+  attempt_id?: AttemptID
+  event_type: string
+  terminal_candidate: boolean
+  confidence: Confidence
+  error?: SafeErrorFingerprint
+  redactions?: string[]
+  cause?: TerminalCause
+  tool_name?: SafeToolName
+}
+
+export type IncidentEvidenceSummary = Omit<IncidentEvidenceEvent, "cause" | "tool_name">
+
+export type TerminalCause =
+  | {
+      category: "provider_transport_disconnect"
+      subcategory:
+        | "before_first_provider_progress"
+        | "during_text_generation"
+        | "during_tool_input_generation"
+        | "after_tool_call_before_execution"
+        | "after_tool_result"
+        | "unknown_stream_phase"
+      boundary?: "sdk_transport" | "provider" | "network" | "unknown"
+      error?: SafeErrorFingerprint
+      confidence: Confidence
+    }
+  | {
+      category: "local_lifecycle_close"
+      subcategory: LifecycleKind | "unknown_lifecycle_close"
+      confidence: "medium" | "high"
+    }
+  | { category: "user_cancel"; confidence: "medium" | "high" }
+  | {
+      category: "watchdog_timeout"
+      subcategory: "connect" | "silent_stream" | "unknown"
+      confidence: "medium" | "high"
+    }
+  | { category: "request_setup_failure"; error?: SafeErrorFingerprint; confidence: "medium" | "high" }
+  | {
+      category: "tool_execution_failure"
+      tool?: SafeToolName
+      error?: SafeErrorFingerprint
+      confidence: "medium" | "high"
+    }
+  | { category: "tool_execution_interrupted"; tool?: SafeToolName; confidence: "medium" | "high" }
+  | { category: "crash_or_restart_incomplete"; confidence: Confidence }
+  | { category: "unknown_interruption"; confidence: "low" }
+
+export type IncidentPhase = {
+  run_phase:
+    | "before_provider_stream"
+    | "streaming"
+    | "tool_generation"
+    | "tool_execution"
+    | "post_tool"
+    | "finalizing"
+    | "unknown"
+  stream_phase?:
+    | "before_first_event"
+    | "before_first_provider_progress"
+    | "text_generation"
+    | "reasoning_generation"
+    | "tool_input_generation"
+    | "after_tool_input_end"
+    | "after_tool_call"
+    | "completed"
+    | "unknown"
+  tool_phase?:
+    | "none"
+    | "tool_input_started"
+    | "tool_input_completed"
+    | "tool_call_materialized"
+    | "tool_execution_started"
+    | "tool_execution_completed"
+    | "unknown"
+  terminal_attempt_id?: AttemptID
+}
+
+export type IncidentFacts = {
+  provider_progress_seen: boolean
+  visible_output_seen: boolean
+  text_output_started: boolean
+  reasoning_output_started: boolean
+  tool_input_started: boolean
+  tool_input_completed: boolean
+  tool_call_materialized: boolean
+  tool_execution_started: boolean
+  tool_execution_completed: boolean
+  read_only_tool_started: boolean
+  unsafe_side_effect_started: boolean
+  unsafe_side_effect_kinds: ToolEffectKind[]
+  side_effect_facts_complete: boolean
+  lifecycle_close_seen: boolean
+  user_cancel_seen: boolean
+  watchdog_fired: boolean
+  pending_tool_parts_interrupted?: number
+}
+
+export type IncidentProvenance = {
+  lifecycle?: {
+    action_id: string
+    kind: LifecycleKind
+    reason?: string
+    affected_directory_keys: string[]
+    completeness: "complete" | "partial" | "unknown"
+  }
+  interrupt?: {
+    source?: string
+    reason?: string
+    propagation_point?: string
+    recorded_at?: number
+  }
+  completeness: "complete" | "partial" | "unknown"
+}
+
+export type RecoveryDecision = {
+  recommendation:
+    | "auto_retry_once"
+    | "offer_continue"
+    | "offer_resume_with_confirmation"
+    | "ask_user_before_retry"
+    | "do_not_retry"
+    | "unknown"
+  confidence: Confidence
+  reason:
+    | "no_visible_output_or_tool_execution"
+    | "visible_output_without_tool_execution"
+    | "partial_tool_input_without_execution"
+    | "tool_call_materialized_without_execution"
+    | "read_only_tool_completed"
+    | "tool_execution_started"
+    | "unsafe_side_effect_started"
+    | "side_effect_facts_incomplete"
+    | "local_lifecycle_close"
+    | "user_cancel"
+    | "unknown"
+  auto_retry?: { max_attempts: 1; backoff_ms: number; attempted_at?: number }
+  user_action?: { kind: "continue" | "resume" | "retry" | "confirm_continue" | "dismiss"; idempotency_key: string }
+  safety_scope: "visible_output_and_tool_side_effects"
+}
+
+export type RunIncident = {
+  schema_version: typeof RUN_INCIDENT_SCHEMA_VERSION
+  incident_id: string
+  run_id: RunID
+  trace_id: MessageID
+  session_id: SessionID
+  message_id: MessageID
+  parent_message_id?: MessageID
+  created_at: number
+  completed_at?: number
+  terminal_cause: TerminalCause
+  phase: IncidentPhase
+  facts: IncidentFacts
+  provenance: IncidentProvenance
+  recovery: RecoveryDecision
+  evidence?: IncidentEvidenceSummary[]
+  user_summary: {
+    title_key: string
+    body_key: string
+    action_key?: string
+    severity: "info" | "warning" | "error"
+  }
+  plain_summary: string
+  missing_provenance?: string[]
+  diagnostics_complete: boolean
+}

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -38,7 +38,7 @@ export type IncidentEvidenceEvent = {
   tool_name?: SafeToolName
 }
 
-export type IncidentEvidenceSummary = Omit<IncidentEvidenceEvent, "cause" | "tool_name">
+export type IncidentEvidenceSummary = Omit<IncidentEvidenceEvent, "cause">
 
 export type TerminalCause =
   | {

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -45,7 +45,7 @@ export function createRecorder(input: RecorderInput): Recorder {
   let readOnlyToolStarted = false
   let unsafeSideEffectStarted = false
   let sideEffectFactsComplete = true
-  let materializedToolBoundary: RunIncident.MaterializedToolBoundary | undefined
+  const materializedToolBoundaries: RunIncident.MaterializedToolBoundary[] = []
   let lastEventMonotonicMs = input.monotonicStartMs
   let failure: Failure | undefined
   let pendingToolPartsInterrupted = 0
@@ -183,7 +183,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       toolCallSeen = true
       toolCallMaterialized = true
       if (next.effect) {
-        materializedToolBoundary = { attempt_id: next.attemptID, tool: next.toolName, effect: next.effect }
+        materializedToolBoundaries.push({ attempt_id: next.attemptID, tool: next.toolName, effect: next.effect })
         if (next.providerExecuted || !next.effect.complete) sideEffectFactsComplete = false
       }
       updateAttempt(next.attemptID, (attempt) => {
@@ -393,7 +393,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         evidence,
         unsafeSideEffectKinds: unsafeKinds,
         sideEffectFactsComplete,
-        materializedToolBoundary,
+        materializedToolBoundaries,
         lifecycle: lifecycleSummary(failure),
         missingProvenance: classify(failure) === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined,
       })

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -182,10 +182,9 @@ export function createRecorder(input: RecorderInput): Recorder {
     recordToolCallMaterialized(next) {
       toolCallSeen = true
       toolCallMaterialized = true
-      if (next.effect) {
-        materializedToolBoundaries.push({ attempt_id: next.attemptID, tool: next.toolName, effect: next.effect })
-        if (next.providerExecuted || !next.effect.complete) sideEffectFactsComplete = false
-      }
+      const effect = next.effect ?? { kind: "unknown", unsafe: true, complete: false as const }
+      materializedToolBoundaries.push({ attempt_id: next.attemptID, tool: next.toolName, effect })
+      if (next.providerExecuted || !effect.complete) sideEffectFactsComplete = false
       updateAttempt(next.attemptID, (attempt) => {
         attempt.tool_call_seen = true
         attempt.tool_call_materialized = true
@@ -199,9 +198,9 @@ export function createRecorder(input: RecorderInput): Recorder {
         terminal_candidate: false,
         confidence: "high",
         tool_name: next.toolName,
-        tool_effect_kind: next.effect?.kind,
-        tool_effect_unsafe: next.effect?.unsafe,
-        tool_effect_complete: next.effect?.complete,
+        tool_effect_kind: effect.kind,
+        tool_effect_unsafe: effect.unsafe,
+        tool_effect_complete: effect.complete,
       })
       rememberEvent(next.monotonicMs)
     },

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -13,6 +13,7 @@ import {
   type ToolEffectKind,
 } from "./types"
 import { safeErrorFingerprint } from "./sanitize"
+import { RunIncident } from "../run-incident"
 
 type AttemptMutable = AttemptSummary & { lastMonotonicMs: number }
 
@@ -36,12 +37,18 @@ export function createRecorder(input: RecorderInput): Recorder {
   let providerProgressSeen = false
   let visibleOutputSeen = false
   let toolCallSeen = false
+  let toolInputStarted = false
+  let toolInputCompleted = false
+  let toolCallMaterialized = false
   let toolExecutionStarted = false
+  let toolExecutionCompleted = false
   let readOnlyToolStarted = false
   let unsafeSideEffectStarted = false
   let sideEffectFactsComplete = true
   let lastEventMonotonicMs = input.monotonicStartMs
   let failure: Failure | undefined
+  let pendingToolPartsInterrupted = 0
+  const evidence: RunIncident.EvidenceEvent[] = []
 
   const rememberEvent = (monotonicMs: number) => {
     lastEventMonotonicMs = Math.max(lastEventMonotonicMs, monotonicMs)
@@ -50,6 +57,14 @@ export function createRecorder(input: RecorderInput): Recorder {
   const updateAttempt = (attemptID: AttemptID | undefined, fn: (attempt: AttemptMutable) => void) => {
     const attempt = getAttempt(attemptID)
     if (attempt) fn(attempt)
+  }
+  const appendEvidence = (next: Omit<RunIncident.EvidenceEvent, "event_id" | "order">) => {
+    const order = evidence.length + 1
+    evidence.push({
+      ...next,
+      order,
+      event_id: `incident:${input.messageID}:evidence:${order}`,
+    })
   }
 
   return {
@@ -62,9 +77,20 @@ export function createRecorder(input: RecorderInput): Recorder {
         provider_progress_seen: false,
         visible_output_seen: false,
         tool_call_seen: false,
+        tool_input_started: false,
+        tool_input_completed: false,
+        tool_call_materialized: false,
         tool_execution_started: false,
         unsafe_side_effect_started: false,
         lastMonotonicMs: next.monotonicMs,
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "processor",
+        attempt_id: attemptID,
+        event_type: "attempt_started",
+        terminal_candidate: false,
+        confidence: "high",
       })
       rememberEvent(next.monotonicMs)
       return { attemptID }
@@ -75,6 +101,14 @@ export function createRecorder(input: RecorderInput): Recorder {
         attempt.provider_progress_seen = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "provider_progress_seen",
+        terminal_candidate: false,
+        confidence: "high",
+      })
       rememberEvent(next.monotonicMs)
     },
     recordVisibleOutput(next) {
@@ -83,13 +117,87 @@ export function createRecorder(input: RecorderInput): Recorder {
         attempt.visible_output_seen = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: next.kind === "reasoning" ? "reasoning_output_started" : "text_output_started",
+        terminal_candidate: false,
+        confidence: "high",
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "visible_output_seen",
+        terminal_candidate: false,
+        confidence: "high",
+      })
+      rememberEvent(next.monotonicMs)
+    },
+    recordToolInputStarted(next) {
+      toolInputStarted = true
+      updateAttempt(next.attemptID, (attempt) => {
+        attempt.tool_input_started = true
+        attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "tool_input_started",
+        terminal_candidate: false,
+        confidence: "high",
+      })
+      rememberEvent(next.monotonicMs)
+    },
+    recordToolInputCompleted(next) {
+      toolInputCompleted = true
+      updateAttempt(next.attemptID, (attempt) => {
+        attempt.tool_input_completed = true
+        attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "tool_input_completed",
+        terminal_candidate: false,
+        confidence: "high",
+      })
       rememberEvent(next.monotonicMs)
     },
     recordToolCall(next) {
+      toolInputStarted = true
+      updateAttempt(next.attemptID, (attempt) => {
+        attempt.tool_input_started = true
+        attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "tool_input_started",
+        terminal_candidate: false,
+        confidence: "high",
+      })
+      rememberEvent(next.monotonicMs)
+    },
+    recordToolCallMaterialized(next) {
       toolCallSeen = true
+      toolCallMaterialized = true
       updateAttempt(next.attemptID, (attempt) => {
         attempt.tool_call_seen = true
+        attempt.tool_call_materialized = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
+      })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "tool_call_materialized",
+        terminal_candidate: false,
+        confidence: "high",
       })
       rememberEvent(next.monotonicMs)
     },
@@ -107,17 +215,56 @@ export function createRecorder(input: RecorderInput): Recorder {
         attempt.unsafe_side_effect_started ||= next.effect.unsafe
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "tool_runner",
+        attempt_id: next.attemptID,
+        event_type: "tool_execution_started",
+        terminal_candidate: false,
+        confidence: "high",
+        tool_name: next.toolName,
+      })
+      if (next.effect.kind === "read_only") {
+        appendEvidence({
+          monotonic_ms: next.monotonicMs,
+          source: "tool_runner",
+          attempt_id: next.attemptID,
+          event_type: "read_only_tool_started",
+          terminal_candidate: false,
+          confidence: "high",
+          tool_name: next.toolName,
+        })
+      }
+      if (next.effect.unsafe) {
+        appendEvidence({
+          monotonic_ms: next.monotonicMs,
+          source: "tool_runner",
+          attempt_id: next.attemptID,
+          event_type: "unsafe_side_effect_started",
+          terminal_candidate: false,
+          confidence: next.effect.complete ? "high" : "medium",
+          tool_name: next.toolName,
+        })
+      }
       rememberEvent(next.monotonicMs)
     },
     recordToolCompleted(next) {
+      toolExecutionCompleted = true
       updateAttempt(next.attemptID, (attempt) => {
         attempt.last_tool_completed_at = next.at
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "tool_runner",
+        attempt_id: next.attemptID,
+        event_type: "tool_execution_completed",
+        terminal_candidate: false,
+        confidence: "high",
+      })
       rememberEvent(next.monotonicMs)
     },
     recordToolFailed(next) {
-      if (failure?.type === "setup" || failure?.type === "scope_closed") return
       failure = {
         type: "tool",
         at: next.at,
@@ -125,15 +272,47 @@ export function createRecorder(input: RecorderInput): Recorder {
         error: next.error,
         attemptID: next.attemptID,
       }
+      const error = safeErrorFingerprint(next.error)
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "tool_runner",
+        attempt_id: next.attemptID,
+        event_type: "tool_execution_failure",
+        terminal_candidate: true,
+        confidence: "high",
+        error,
+        cause: { category: "tool_execution_failure", error, confidence: "high" },
+      })
       rememberEvent(next.monotonicMs)
     },
     recordToolInterrupted(next) {
-      if (failure?.type === "setup" || failure?.type === "scope_closed") return
       failure = { type: "tool", at: next.at, monotonicMs: next.monotonicMs, attemptID: next.attemptID }
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "tool_runner",
+        attempt_id: next.attemptID,
+        event_type: "tool_execution_interrupted",
+        terminal_candidate: true,
+        confidence: "medium",
+        cause: { category: "tool_execution_interrupted", confidence: "medium" },
+      })
+      rememberEvent(next.monotonicMs)
+    },
+    recordPendingToolPartInterrupted(next) {
+      pendingToolPartsInterrupted++
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "processor",
+        attempt_id: next.attemptID,
+        event_type: "pending_tool_part_interrupted",
+        terminal_candidate: false,
+        confidence: "medium",
+        redactions: ["raw_tool_input"],
+      })
       rememberEvent(next.monotonicMs)
     },
     recordTransportFailure(next) {
-      if (failure?.type === "scope_closed" || failure?.type === "setup" || failure?.type === "tool") return
+      const error = safeErrorFingerprint(next.error)
       failure = {
         type: "transport",
         at: next.at,
@@ -142,11 +321,36 @@ export function createRecorder(input: RecorderInput): Recorder {
         evidence: next.evidence ?? [],
         attemptID: next.attemptID,
       }
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "provider_stream",
+        attempt_id: next.attemptID,
+        event_type: "provider_transport_failure",
+        terminal_candidate: true,
+        confidence: error.cause_code === "UND_ERR_SOCKET" ? "high" : "medium",
+        error,
+        cause: RunIncident.transportCause({
+          error,
+          providerProgressSeen,
+          toolInputStarted,
+          toolInputCompleted,
+          toolCallMaterialized,
+        }),
+      })
       rememberEvent(next.monotonicMs)
     },
     recordSetupFailure(next) {
-      if (failure?.type === "scope_closed") return
       failure = { type: "setup", at: next.at, monotonicMs: next.monotonicMs, error: next.error }
+      const error = safeErrorFingerprint(next.error)
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "processor",
+        event_type: "request_setup_failure",
+        terminal_candidate: true,
+        confidence: "high",
+        error,
+        cause: { category: "request_setup_failure", error, confidence: "high" },
+      })
       rememberEvent(next.monotonicMs)
     },
     recordScopeClosed(next) {
@@ -159,12 +363,43 @@ export function createRecorder(input: RecorderInput): Recorder {
         lifecycleActionID: next.lifecycleActionID,
         lifecycleKind: next.lifecycleKind,
       }
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "lifecycle",
+        event_type: "lifecycle_close_seen",
+        terminal_candidate: true,
+        confidence: next.lifecycleActionID ? "high" : "medium",
+        cause: {
+          category: "local_lifecycle_close",
+          subcategory: next.lifecycleKind ?? "unknown_lifecycle_close",
+          confidence: next.lifecycleActionID ? "high" : "medium",
+        },
+      })
       rememberEvent(next.monotonicMs)
     },
     finalize(final) {
-      const classification = classify(failure)
+      const incident = RunIncident.derive({
+        runID: input.runID,
+        traceID: input.traceID,
+        sessionID: input.sessionID,
+        messageID: input.messageID,
+        parentMessageID: input.parentMessageID,
+        createdAt: input.createdAt,
+        completedAt: final.completedAt,
+        evidence,
+        unsafeSideEffectKinds: unsafeKinds,
+        sideEffectFactsComplete,
+        lifecycle: lifecycleSummary(failure),
+        missingProvenance: classify(failure) === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined,
+      })
+      const classification = incident ? classificationForIncident(incident.terminal_cause) : classify(failure)
       const missingProvenance = classification === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined
-      const summaryKey = summaryKeyFor(classification, summarySuffix({ failure, providerProgressSeen }))
+      const summaryKey = summaryKeyFor(
+        classification,
+        incident
+          ? summarySuffixForIncident(incident.terminal_cause, { providerProgressSeen })
+          : summarySuffix({ failure, providerProgressSeen }),
+      )
       const retrySafety = retrySafetyFor({
         classification,
         visibleOutputSeen,
@@ -194,11 +429,16 @@ export function createRecorder(input: RecorderInput): Recorder {
         provider_progress_seen: providerProgressSeen,
         visible_output_seen: visibleOutputSeen,
         tool_call_seen: toolCallSeen,
+        tool_input_started: toolInputStarted,
+        tool_input_completed: toolInputCompleted,
+        tool_call_materialized: toolCallMaterialized,
         tool_execution_started: toolExecutionStarted,
         read_only_tool_started: readOnlyToolStarted,
         unsafe_side_effect_started: unsafeSideEffectStarted,
         unsafe_side_effect_kinds: unsafeKinds,
         side_effect_facts_complete: sideEffectFactsComplete,
+        pending_tool_parts_interrupted: pendingToolPartsInterrupted || undefined,
+        incident,
         lifecycle: lifecycleSummary(failure),
         missing_provenance: missingProvenance,
         durations_ms: {
@@ -235,6 +475,48 @@ function classify(failure: Failure | undefined): Classification {
   }
   if (failure.type === "transport") return "external_stream_disconnect"
   return "unknown_failure"
+}
+
+function classificationForIncident(cause: RunIncident.TerminalCause): Classification {
+  switch (cause.category) {
+    case "provider_transport_disconnect":
+      return "external_stream_disconnect"
+    case "local_lifecycle_close":
+      if (cause.subcategory === "unknown_lifecycle_close") return "unknown_scope_close"
+      if (cause.subcategory === "instance_reload") return "local_instance_reload"
+      if (
+        cause.subcategory === "instance_dispose" ||
+        cause.subcategory === "instance_dispose_directory" ||
+        cause.subcategory === "instance_dispose_all"
+      )
+        return "local_instance_dispose"
+      return "known_lifecycle_close"
+    case "request_setup_failure":
+      return "request_setup_failure"
+    case "tool_execution_failure":
+    case "tool_execution_interrupted":
+      return "tool_failure"
+    default:
+      return "unknown_failure"
+  }
+}
+
+function summarySuffixForIncident(cause: RunIncident.TerminalCause, input: { providerProgressSeen: boolean }) {
+  if (cause.category === "provider_transport_disconnect") {
+    if (!input.providerProgressSeen) return "transport_failure"
+    if (cause.subcategory === "during_tool_input_generation") return "provider_progress_tool_input_disconnect"
+    if (cause.boundary === "sdk_transport" && cause.error?.cause_code === "UND_ERR_SOCKET")
+      return "provider_progress_socket_closed"
+    return "transport_failure"
+  }
+  if (cause.category === "local_lifecycle_close") {
+    if (cause.subcategory === "unknown_lifecycle_close") return "missing_lifecycle_provenance"
+    return "lifecycle_close"
+  }
+  if (cause.category === "request_setup_failure") return "request_setup_failed"
+  if (cause.category === "tool_execution_failure" || cause.category === "tool_execution_interrupted")
+    return "tool_execution_failed"
+  return "unknown"
 }
 
 function summarySuffix(input: { failure: Failure | undefined; providerProgressSeen: boolean }) {

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -137,6 +137,7 @@ export function createRecorder(input: RecorderInput): Recorder {
     },
     recordToolInputStarted(next) {
       toolInputStarted = true
+      if (next.providerExecuted) sideEffectFactsComplete = false
       updateAttempt(next.attemptID, (attempt) => {
         attempt.tool_input_started = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
@@ -149,6 +150,16 @@ export function createRecorder(input: RecorderInput): Recorder {
         terminal_candidate: false,
         confidence: "high",
       })
+      if (next.providerExecuted) {
+        appendEvidence({
+          monotonic_ms: next.monotonicMs,
+          source: "provider_stream",
+          attempt_id: next.attemptID,
+          event_type: "provider_executed_tool_boundary",
+          terminal_candidate: false,
+          confidence: "medium",
+        })
+      }
       rememberEvent(next.monotonicMs)
     },
     recordToolInputCompleted(next) {
@@ -162,22 +173,6 @@ export function createRecorder(input: RecorderInput): Recorder {
         source: "provider_stream",
         attempt_id: next.attemptID,
         event_type: "tool_input_completed",
-        terminal_candidate: false,
-        confidence: "high",
-      })
-      rememberEvent(next.monotonicMs)
-    },
-    recordToolCall(next) {
-      toolInputStarted = true
-      updateAttempt(next.attemptID, (attempt) => {
-        attempt.tool_input_started = true
-        attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
-      })
-      appendEvidence({
-        monotonic_ms: next.monotonicMs,
-        source: "provider_stream",
-        attempt_id: next.attemptID,
-        event_type: "tool_input_started",
         terminal_candidate: false,
         confidence: "high",
       })
@@ -265,7 +260,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       rememberEvent(next.monotonicMs)
     },
     recordToolFailed(next) {
-      failure = {
+      failure ??= {
         type: "tool",
         at: next.at,
         monotonicMs: next.monotonicMs,
@@ -286,7 +281,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       rememberEvent(next.monotonicMs)
     },
     recordToolInterrupted(next) {
-      failure = { type: "tool", at: next.at, monotonicMs: next.monotonicMs, attemptID: next.attemptID }
+      failure ??= { type: "tool", at: next.at, monotonicMs: next.monotonicMs, attemptID: next.attemptID }
       appendEvidence({
         monotonic_ms: next.monotonicMs,
         source: "tool_runner",
@@ -313,7 +308,7 @@ export function createRecorder(input: RecorderInput): Recorder {
     },
     recordTransportFailure(next) {
       const error = safeErrorFingerprint(next.error)
-      failure = {
+      failure ??= {
         type: "transport",
         at: next.at,
         monotonicMs: next.monotonicMs,
@@ -331,16 +326,16 @@ export function createRecorder(input: RecorderInput): Recorder {
         error,
         cause: RunIncident.transportCause({
           error,
-          providerProgressSeen,
-          toolInputStarted,
-          toolInputCompleted,
-          toolCallMaterialized,
+          providerProgressSeen: getAttempt(next.attemptID)?.provider_progress_seen ?? providerProgressSeen,
+          toolInputStarted: getAttempt(next.attemptID)?.tool_input_started ?? toolInputStarted,
+          toolInputCompleted: getAttempt(next.attemptID)?.tool_input_completed ?? toolInputCompleted,
+          toolCallMaterialized: getAttempt(next.attemptID)?.tool_call_materialized ?? toolCallMaterialized,
         }),
       })
       rememberEvent(next.monotonicMs)
     },
     recordSetupFailure(next) {
-      failure = { type: "setup", at: next.at, monotonicMs: next.monotonicMs, error: next.error }
+      failure ??= { type: "setup", at: next.at, monotonicMs: next.monotonicMs, error: next.error }
       const error = safeErrorFingerprint(next.error)
       appendEvidence({
         monotonic_ms: next.monotonicMs,
@@ -354,7 +349,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       rememberEvent(next.monotonicMs)
     },
     recordScopeClosed(next) {
-      failure = {
+      failure ??= {
         type: "scope_closed",
         at: next.at,
         monotonicMs: next.monotonicMs,

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -45,6 +45,7 @@ export function createRecorder(input: RecorderInput): Recorder {
   let readOnlyToolStarted = false
   let unsafeSideEffectStarted = false
   let sideEffectFactsComplete = true
+  let materializedToolBoundary: RunIncident.MaterializedToolBoundary | undefined
   let lastEventMonotonicMs = input.monotonicStartMs
   let failure: Failure | undefined
   let pendingToolPartsInterrupted = 0
@@ -181,6 +182,10 @@ export function createRecorder(input: RecorderInput): Recorder {
     recordToolCallMaterialized(next) {
       toolCallSeen = true
       toolCallMaterialized = true
+      if (next.effect) {
+        materializedToolBoundary = { attempt_id: next.attemptID, tool: next.toolName, effect: next.effect }
+        if (next.providerExecuted || !next.effect.complete) sideEffectFactsComplete = false
+      }
       updateAttempt(next.attemptID, (attempt) => {
         attempt.tool_call_seen = true
         attempt.tool_call_materialized = true
@@ -193,6 +198,10 @@ export function createRecorder(input: RecorderInput): Recorder {
         event_type: "tool_call_materialized",
         terminal_candidate: false,
         confidence: "high",
+        tool_name: next.toolName,
+        tool_effect_kind: next.effect?.kind,
+        tool_effect_unsafe: next.effect?.unsafe,
+        tool_effect_complete: next.effect?.complete,
       })
       rememberEvent(next.monotonicMs)
     },
@@ -384,6 +393,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         evidence,
         unsafeSideEffectKinds: unsafeKinds,
         sideEffectFactsComplete,
+        materializedToolBoundary,
         lifecycle: lifecycleSummary(failure),
         missingProvenance: classify(failure) === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined,
       })

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -156,7 +156,14 @@ export type Recorder = {
     providerExecuted?: boolean
   }): void
   recordToolInputCompleted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
-  recordToolCallMaterialized(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordToolCallMaterialized(input: {
+    attemptID: AttemptID
+    at: number
+    monotonicMs: number
+    toolName?: SafeToolName
+    effect?: ToolEffect
+    providerExecuted?: boolean
+  }): void
   recordToolExecutionStarted(input: {
     attemptID: AttemptID
     at: number

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -1,5 +1,6 @@
 import { MessageID, SessionID } from "../schema"
 import z from "zod"
+import type { RunIncident } from "../run-incident"
 
 export const SCHEMA_VERSION = 1
 
@@ -50,7 +51,11 @@ export type SafeErrorFingerprint = {
   cause_code?: string
 }
 
-export type LifecycleKind = "instance_reload" | "instance_dispose" | "instance_dispose_directory" | "instance_dispose_all"
+export type LifecycleKind =
+  | "instance_reload"
+  | "instance_dispose"
+  | "instance_dispose_directory"
+  | "instance_dispose_all"
 
 export type ToolEffectKind = "read_only" | "local_file_write" | "local_process" | "unknown"
 export type ToolEffect = {
@@ -67,6 +72,9 @@ export type AttemptSummary = {
   provider_progress_seen: boolean
   visible_output_seen: boolean
   tool_call_seen: boolean
+  tool_input_started: boolean
+  tool_input_completed: boolean
+  tool_call_materialized: boolean
   tool_execution_started: boolean
   unsafe_side_effect_started: boolean
 }
@@ -90,11 +98,16 @@ export type Summary = {
   provider_progress_seen: boolean
   visible_output_seen: boolean
   tool_call_seen: boolean
+  tool_input_started: boolean
+  tool_input_completed: boolean
+  tool_call_materialized: boolean
   tool_execution_started: boolean
   read_only_tool_started: boolean
   unsafe_side_effect_started: boolean
   unsafe_side_effect_kinds: ToolEffectKind[]
   side_effect_facts_complete: boolean
+  pending_tool_parts_interrupted?: number
+  incident?: RunIncident.Summary
   lifecycle?: {
     action_id: string
     kind: LifecycleKind
@@ -130,8 +143,16 @@ export type BeginAttemptInput = {
 export type Recorder = {
   beginAttempt(input: BeginAttemptInput): { attemptID: AttemptID }
   recordProviderProgress(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
-  recordVisibleOutput(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordVisibleOutput(input: {
+    attemptID: AttemptID
+    at: number
+    monotonicMs: number
+    kind?: "text" | "reasoning"
+  }): void
+  recordToolInputStarted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordToolInputCompleted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolCall(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordToolCallMaterialized(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolExecutionStarted(input: {
     attemptID: AttemptID
     at: number
@@ -142,6 +163,7 @@ export type Recorder = {
   recordToolCompleted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolFailed(input: { attemptID: AttemptID; at: number; monotonicMs: number; error?: unknown }): void
   recordToolInterrupted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordPendingToolPartInterrupted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordTransportFailure(input: {
     attemptID?: AttemptID
     at: number

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -149,9 +149,13 @@ export type Recorder = {
     monotonicMs: number
     kind?: "text" | "reasoning"
   }): void
-  recordToolInputStarted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordToolInputStarted(input: {
+    attemptID: AttemptID
+    at: number
+    monotonicMs: number
+    providerExecuted?: boolean
+  }): void
   recordToolInputCompleted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
-  recordToolCall(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolCallMaterialized(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolExecutionStarted(input: {
     attemptID: AttemptID

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -720,6 +720,9 @@ describe("Export.session", () => {
           provider_progress_seen: true,
           visible_output_seen: false,
           tool_call_seen: false,
+          tool_input_started: false,
+          tool_input_completed: false,
+          tool_call_materialized: false,
           tool_execution_started: false,
           read_only_tool_started: false,
           unsafe_side_effect_started: false,
@@ -1680,6 +1683,9 @@ describe("redactPart", () => {
       provider_progress_seen: true,
       visible_output_seen: false,
       tool_call_seen: false,
+      tool_input_started: false,
+      tool_input_completed: false,
+      tool_call_materialized: false,
       tool_execution_started: false,
       read_only_tool_started: false,
       unsafe_side_effect_started: false,
@@ -1748,6 +1754,160 @@ describe("redactPart", () => {
     ).toBe("UND_ERR_SOCKET")
     expect(JSON.stringify(sanitized)).not.toContain("/Users/")
     expect(JSON.stringify(sanitized)).not.toContain("sk-")
+  })
+
+  test("exports sanitized run incidents as authoritative diagnostics", () => {
+    const incident = {
+      schema_version: 1,
+      incident_id: "incident:msg_sanitize",
+      run_id: RunObservability.RunID.make("run_sanitize_incident"),
+      trace_id: MessageID.make("msg_sanitize_incident"),
+      session_id: SessionID.make("ses_sanitize_incident"),
+      message_id: MessageID.make("msg_sanitize_incident"),
+      created_at: 1,
+      completed_at: 2,
+      terminal_cause: {
+        category: "provider_transport_disconnect",
+        subcategory: "during_tool_input_generation",
+        boundary: "sdk_transport",
+        confidence: "high",
+        error: { name: "TypeError", message: "terminated", cause_code: "UND_ERR_SOCKET" },
+      },
+      phase: {
+        run_phase: "tool_generation",
+        stream_phase: "tool_input_generation",
+        tool_phase: "tool_input_started",
+      },
+      facts: {
+        provider_progress_seen: true,
+        visible_output_seen: true,
+        text_output_started: true,
+        reasoning_output_started: false,
+        tool_input_started: true,
+        tool_input_completed: false,
+        tool_call_materialized: false,
+        tool_execution_started: false,
+        tool_execution_completed: false,
+        read_only_tool_started: false,
+        unsafe_side_effect_started: false,
+        unsafe_side_effect_kinds: [],
+        side_effect_facts_complete: true,
+        lifecycle_close_seen: true,
+        user_cancel_seen: false,
+        watchdog_fired: false,
+        pending_tool_parts_interrupted: 1,
+      },
+      provenance: { completeness: "partial" },
+      recovery: {
+        recommendation: "offer_continue",
+        confidence: "high",
+        reason: "partial_tool_input_without_execution",
+        safety_scope: "visible_output_and_tool_side_effects",
+      },
+      evidence: [
+        {
+          event_id: "incident:msg_sanitize:evidence:1",
+          order: 1,
+          monotonic_ms: 100,
+          source: "provider_stream",
+          event_type: "provider_transport_failure",
+          terminal_candidate: true,
+          confidence: "high",
+          error: { message: "terminated", cause_code: "UND_ERR_SOCKET" },
+        },
+        {
+          event_id: "incident:msg_sanitize:evidence:2",
+          order: 2,
+          monotonic_ms: 110,
+          source: "processor",
+          event_type: "pending_tool_part_interrupted",
+          terminal_candidate: false,
+          confidence: "medium",
+          redactions: ["raw_tool_input", "/Users/secret/project", "sk-private"],
+        },
+      ],
+      user_summary: {
+        title_key: "run_incident.provider_transport_disconnect",
+        body_key: "run_incident.provider_transport_disconnect.during_tool_input_generation",
+        severity: "warning",
+      },
+      plain_summary: "The provider stream disconnected while PawWork was preparing a tool call. The tool did not run.",
+      diagnostics_complete: true,
+    }
+    const summary = {
+      schema_version: 1,
+      run_id: RunObservability.RunID.make("run_sanitize_incident"),
+      trace_id: MessageID.make("msg_sanitize_incident"),
+      session_id: SessionID.make("ses_sanitize_incident"),
+      message_id: MessageID.make("msg_sanitize_incident"),
+      provider: "test",
+      model: "test-model",
+      created_at: 1,
+      classification: "tool_failure",
+      summary_key: RunObservability.summaryKeyFor("tool_failure", "tool_execution_failed"),
+      retry_safety: {
+        recommendation: "unknown",
+        confidence: "low",
+        reason: "unknown",
+        safety_scope: "user_visible_and_tool_side_effects",
+      },
+      attempts: [],
+      provider_progress_seen: true,
+      visible_output_seen: true,
+      tool_call_seen: false,
+      tool_input_started: true,
+      tool_input_completed: false,
+      tool_call_materialized: false,
+      tool_execution_started: false,
+      read_only_tool_started: false,
+      unsafe_side_effect_started: false,
+      unsafe_side_effect_kinds: [],
+      side_effect_facts_complete: true,
+      durations_ms: {},
+      incident,
+    } as RunObservability.Summary
+    const sanitized = Export.sanitizeSnapshot({
+      schema_version: 1,
+      format: "pawwork-session-export",
+      exported_at: 1,
+      root_session_id: SessionID.make("ses_sanitize_incident"),
+      runtime_context: {
+        app_version: "test",
+        runtime_namespace: "pawwork",
+        platform: process.platform,
+        os_version: "test",
+        locale: "en-US",
+        timezone: "UTC",
+        instruction_sources: [],
+        model_refs: {},
+        stats: { session_count: 1, message_count: 1, part_count: 0, omitted_attachment_count: 0 },
+      },
+      diagnostics: { run_observability_schema_version: 1, run_observability: [summary] },
+      session: {
+        info: {
+          id: SessionID.make("ses_sanitize_incident"),
+          version: "0.0.0",
+          time: { created: 1, updated: 1 },
+          title: "x",
+          directory: "/tmp/project",
+        } as SessionNs.Info,
+        had_cloud_share: false,
+        diffs: [],
+        messages: [],
+        children: [],
+      },
+    })
+
+    expect(sanitized.diagnostics.run_incident_schema_version).toBe(1)
+    expect(sanitized.diagnostics.run_incidents?.[0]?.terminal_cause.category).toBe("provider_transport_disconnect")
+    expect(sanitized.diagnostics.run_incidents?.[0]?.evidence?.map((event) => event.event_type)).toEqual([
+      "provider_transport_failure",
+      "pending_tool_part_interrupted",
+    ])
+    const serialized = JSON.stringify(sanitized.diagnostics.run_incidents)
+    expect(serialized).toContain("raw_tool_input")
+    expect(serialized).not.toContain("/Users/secret")
+    expect(serialized).not.toContain("sk-private")
   })
 
   test("redacts data: url inside completed tool attachments", () => {

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -672,6 +672,139 @@ describe("RunObservability", () => {
     })
   })
 
+  test("materialized tool recovery keeps unsafe boundary even when a later safe tool materializes", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_unsafe_then_safe_materialized_tool"),
+      traceID: MessageID.make("msg_unsafe_then_safe_materialized_tool"),
+      sessionID: SessionID.make("ses_unsafe_then_safe_materialized_tool"),
+      messageID: MessageID.make("msg_unsafe_then_safe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_call_materialized_without_execution",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "local_process",
+      materialized_tool_requires_confirmation: true,
+    })
+  })
+
+  test("materialized tool recovery keeps unknown boundary even when a later safe tool materializes", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_unknown_then_safe_materialized_tool"),
+      traceID: MessageID.make("msg_unknown_then_safe_materialized_tool"),
+      sessionID: SessionID.make("ses_unknown_then_safe_materialized_tool"),
+      messageID: MessageID.make("msg_unknown_then_safe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("mcp_write"),
+      effect: RunObservability.toolEffect("mcp_write"),
+    })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "unknown",
+      materialized_tool_requires_confirmation: true,
+      side_effect_facts_complete: false,
+    })
+  })
+
+  test("materialized tool recovery keeps unsafe boundary when unsafe tool materializes last", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_safe_then_unsafe_materialized_tool"),
+      traceID: MessageID.make("msg_safe_then_unsafe_materialized_tool"),
+      sessionID: SessionID.make("ses_safe_then_unsafe_materialized_tool"),
+      messageID: MessageID.make("msg_safe_then_unsafe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_call_materialized_without_execution",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "local_process",
+      materialized_tool_requires_confirmation: true,
+    })
+  })
+
   test("classifies local scope close with missing lifecycle provenance separately from user cancel", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_scope_close"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -486,7 +486,7 @@ describe("RunObservability", () => {
       terminal_attempt_id: second.attemptID,
     })
     expect(summary.incident?.recovery).toMatchObject({
-      recommendation: "ask_user_before_retry",
+      recommendation: "offer_continue",
       reason: "visible_output_without_tool_execution",
     })
   })
@@ -550,6 +550,125 @@ describe("RunObservability", () => {
     expect(summary.incident?.phase).toMatchObject({
       stream_phase: "after_tool_input_end",
       tool_phase: "tool_input_completed",
+    })
+  })
+
+  test("safe materialized tool call without execution can offer continue", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_safe_materialized_tool"),
+      traceID: MessageID.make("msg_safe_materialized_tool"),
+      sessionID: SessionID.make("ses_safe_materialized_tool"),
+      messageID: MessageID.make("msg_safe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 16, monotonicMs: 160 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "offer_continue",
+      reason: "tool_call_materialized_without_execution",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "read_only",
+      materialized_tool_requires_confirmation: false,
+    })
+    expect(summary.incident?.evidence?.find((event) => event.event_type === "tool_call_materialized")).toMatchObject({
+      tool_name: RunObservability.safeToolName("read"),
+      tool_effect_kind: "read_only",
+      tool_effect_unsafe: false,
+      tool_effect_complete: true,
+    })
+  })
+
+  test("unsafe materialized tool call without execution requires confirmation", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_unsafe_materialized_tool"),
+      traceID: MessageID.make("msg_unsafe_materialized_tool"),
+      sessionID: SessionID.make("ses_unsafe_materialized_tool"),
+      messageID: MessageID.make("msg_unsafe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_call_materialized_without_execution",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "local_process",
+      materialized_tool_requires_confirmation: true,
+    })
+  })
+
+  test("unknown materialized tool call without execution requires confirmation", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_unknown_materialized_tool"),
+      traceID: MessageID.make("msg_unknown_materialized_tool"),
+      sessionID: SessionID.make("ses_unknown_materialized_tool"),
+      messageID: MessageID.make("msg_unknown_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("mcp_write"),
+      effect: RunObservability.toolEffect("mcp_write"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "unknown",
+      materialized_tool_requires_confirmation: true,
     })
   })
 

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -300,6 +300,42 @@ describe("RunObservability", () => {
     ])
   })
 
+  test("bounded incident evidence keeps newest terminal and cleanup anchors when anchors exceed cap", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_many_terminal_anchors"),
+      traceID: MessageID.make("msg_many_terminal_anchors"),
+      sessionID: SessionID.make("ses_many_terminal_anchors"),
+      messageID: MessageID.make("msg_many_terminal_anchors"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    for (let i = 0; i < 30; i++) {
+      recorder.recordToolFailed({
+        attemptID: attempt.attemptID,
+        at: 12 + i,
+        monotonicMs: 120 + i,
+        error: new Error(`tool failed ${i}`),
+      })
+    }
+    recorder.recordPendingToolPartInterrupted({ attemptID: attempt.attemptID, at: 50, monotonicMs: 500 })
+    recorder.recordScopeClosed({
+      at: 51,
+      monotonicMs: 510,
+      lifecycleActionID: "lifecycle:instance_reload:many-terminal-anchors",
+      lifecycleKind: "instance_reload",
+    })
+
+    const evidence = recorder.finalize({ completedAt: 52, monotonicMs: 520 }).incident?.evidence ?? []
+    expect(evidence.length).toBeLessThanOrEqual(24)
+    expect(evidence.some((event) => event.event_type === "evidence_omitted" && event.omitted_events)).toBe(true)
+    expect(evidence.map((event) => event.event_type)).toContain("pending_tool_part_interrupted")
+    expect(evidence.map((event) => event.event_type)).toContain("lifecycle_close_seen")
+    expect(evidence.at(-1)?.event_type).toBe("lifecycle_close_seen")
+  })
+
   test("orders terminal cause by initiating evidence time", () => {
     const providerFirst = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_provider_first"),
@@ -481,7 +517,7 @@ describe("RunObservability", () => {
       subcategory: "during_text_generation",
     })
     expect(summary.incident?.phase).toMatchObject({
-      stream_phase: "before_first_provider_progress",
+      stream_phase: "text_generation",
       tool_phase: "none",
       terminal_attempt_id: second.attemptID,
     })

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -805,6 +805,113 @@ describe("RunObservability", () => {
     })
   })
 
+  test("earlier attempt unsafe materialized tool prevents later auto retry", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_cross_attempt_unsafe_materialized_tool"),
+      traceID: MessageID.make("msg_cross_attempt_unsafe_materialized_tool"),
+      sessionID: SessionID.make("ses_cross_attempt_unsafe_materialized_tool"),
+      messageID: MessageID.make("msg_cross_attempt_unsafe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: first.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordTransportFailure({
+      attemptID: second.attemptID,
+      at: 21,
+      monotonicMs: 210,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 22, monotonicMs: 220 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "before_first_provider_progress",
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_call_materialized_without_execution",
+    })
+  })
+
+  test("earlier attempt safe materialized tool prevents later auto retry", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_cross_attempt_safe_materialized_tool"),
+      traceID: MessageID.make("msg_cross_attempt_safe_materialized_tool"),
+      sessionID: SessionID.make("ses_cross_attempt_safe_materialized_tool"),
+      messageID: MessageID.make("msg_cross_attempt_safe_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: first.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordTransportFailure({
+      attemptID: second.attemptID,
+      at: 21,
+      monotonicMs: 210,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 22, monotonicMs: 220 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "offer_continue",
+      reason: "tool_call_materialized_without_execution",
+    })
+  })
+
+  test("earlier attempt unknown materialized tool prevents later auto retry", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_cross_attempt_unknown_materialized_tool"),
+      traceID: MessageID.make("msg_cross_attempt_unknown_materialized_tool"),
+      sessionID: SessionID.make("ses_cross_attempt_unknown_materialized_tool"),
+      messageID: MessageID.make("msg_cross_attempt_unknown_materialized_tool"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({
+      attemptID: first.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("mcp_write"),
+      effect: RunObservability.toolEffect("mcp_write"),
+    })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordProviderProgress({ attemptID: second.attemptID, at: 21, monotonicMs: 210 })
+    recorder.recordTransportFailure({
+      attemptID: second.attemptID,
+      at: 22,
+      monotonicMs: 220,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 23, monotonicMs: 230 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+  })
+
   test("classifies local scope close with missing lifecycle provenance separately from user cancel", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_scope_close"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -672,6 +672,67 @@ describe("RunObservability", () => {
     })
   })
 
+  test("missing materialized tool effect requires confirmation", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_missing_materialized_effect"),
+      traceID: MessageID.make("msg_missing_materialized_effect"),
+      sessionID: SessionID.make("ses_missing_materialized_effect"),
+      messageID: MessageID.make("msg_missing_materialized_effect"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCallMaterialized({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+    expect(summary.incident?.facts).toMatchObject({
+      materialized_tool_effect_kind: "unknown",
+      materialized_tool_requires_confirmation: true,
+      side_effect_facts_complete: false,
+    })
+  })
+
+  test("reasoning-only transport failure uses reasoning generation phase", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_reasoning_only_disconnect"),
+      traceID: MessageID.make("msg_reasoning_only_disconnect"),
+      sessionID: SessionID.make("ses_reasoning_only_disconnect"),
+      messageID: MessageID.make("msg_reasoning_only_disconnect"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130, kind: "reasoning" })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.incident?.facts).toMatchObject({
+      reasoning_output_started: true,
+      text_output_started: false,
+    })
+    expect(summary.incident?.phase.stream_phase).toBe("reasoning_generation")
+  })
+
   test("materialized tool recovery keeps unsafe boundary even when a later safe tool materializes", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_unsafe_then_safe_materialized_tool"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -107,8 +107,8 @@ describe("RunObservability", () => {
       attemptID: attempt.attemptID,
       at: 12,
       monotonicMs: 120,
-      toolName: RunObservability.safeToolName("read"),
-      effect: RunObservability.toolEffect("read"),
+      toolName: RunObservability.safeToolName("bash /Users/alice/.ssh/id_rsa?token=secret"),
+      effect: RunObservability.toolEffect("bash"),
     })
     recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
 
@@ -641,6 +641,33 @@ describe("RunObservability", () => {
     expect(summary.side_effect_facts_complete).toBe(true)
     expect(JSON.stringify(summary)).not.toContain("/Users/alice")
     expect(JSON.stringify(summary)).not.toContain("secret")
+  })
+
+  test("keeps sanitized tool names in incident evidence", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_tool_name_evidence"),
+      traceID: MessageID.make("msg_tool_name_evidence"),
+      sessionID: SessionID.make("ses_tool_name_evidence"),
+      messageID: MessageID.make("msg_tool_name_evidence"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("read"),
+      effect: RunObservability.toolEffect("read"),
+    })
+    recorder.recordToolFailed({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130, error: new Error("failed") })
+
+    const evidence = recorder.finalize({ completedAt: 14, monotonicMs: 140 }).incident?.evidence ?? []
+    expect(String(evidence.find((event) => event.event_type === "tool_execution_started")?.tool_name)).toBe("read")
+    expect(JSON.stringify(evidence)).not.toContain("/Users/alice")
+    expect(JSON.stringify(evidence)).not.toContain("secret")
   })
 
   test("redacts arbitrary error messages to low-cardinality values", () => {

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -253,6 +253,53 @@ describe("RunObservability", () => {
     ])
   })
 
+  test("bounded incident evidence keeps terminal and cleanup basis after long output", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_long_output_disconnect"),
+      traceID: MessageID.make("msg_long_output_disconnect"),
+      sessionID: SessionID.make("ses_long_output_disconnect"),
+      messageID: MessageID.make("msg_long_output_disconnect"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    for (let i = 0; i < 20; i++) {
+      recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12 + i, monotonicMs: 120 + i * 10 })
+      recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 12 + i, monotonicMs: 121 + i * 10 })
+    }
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 40,
+      monotonicMs: 400,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      evidence: ["iterator_error"],
+    })
+    recorder.recordPendingToolPartInterrupted({ attemptID: attempt.attemptID, at: 41, monotonicMs: 410 })
+    recorder.recordScopeClosed({
+      at: 42,
+      monotonicMs: 420,
+      source: "session.run_state.finalizer",
+      reason: "scope_finalizer",
+      lifecycleActionID: "lifecycle:instance_reload:long-output",
+      lifecycleKind: "instance_reload",
+    })
+
+    const evidence = recorder.finalize({ completedAt: 43, monotonicMs: 430 }).incident?.evidence ?? []
+    expect(evidence.length).toBeLessThanOrEqual(24)
+    expect(evidence.some((event) => event.event_type === "evidence_omitted" && event.omitted_events)).toBe(true)
+    expect(evidence.map((event) => event.event_type)).toContain("provider_transport_failure")
+    expect(evidence.map((event) => event.event_type)).toContain("pending_tool_part_interrupted")
+    expect(evidence.map((event) => event.event_type)).toContain("lifecycle_close_seen")
+    expect(evidence.map((event) => event.event_type).slice(-3)).toEqual([
+      "provider_transport_failure",
+      "pending_tool_part_interrupted",
+      "lifecycle_close_seen",
+    ])
+  })
+
   test("orders terminal cause by initiating evidence time", () => {
     const providerFirst = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_provider_first"),
@@ -311,6 +358,70 @@ describe("RunObservability", () => {
     })
   })
 
+  test("cleanup events do not overwrite earlier lifecycle provenance", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_then_cleanup"),
+      traceID: MessageID.make("msg_lifecycle_then_cleanup"),
+      sessionID: SessionID.make("ses_lifecycle_then_cleanup"),
+      messageID: MessageID.make("msg_lifecycle_then_cleanup"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordScopeClosed({
+      at: 12,
+      monotonicMs: 120,
+      source: "session.run_state.scope",
+      reason: "scope_closed_without_cancel_meta",
+    })
+    recorder.recordToolInterrupted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "AbortError", message: "aborted" },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.classification).toBe("unknown_scope_close")
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "local_lifecycle_close",
+      subcategory: "unknown_lifecycle_close",
+    })
+    expect(summary.missing_provenance).toEqual(["lifecycle.close_requested"])
+    expect(summary.incident?.missing_provenance).toEqual(["lifecycle.close_requested"])
+    expect(summary.incident?.diagnostics_complete).toBe(false)
+  })
+
+  test("cleanup events do not overwrite earlier setup failures", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_setup_then_cleanup"),
+      traceID: MessageID.make("msg_setup_then_cleanup"),
+      sessionID: SessionID.make("ses_setup_then_cleanup"),
+      messageID: MessageID.make("msg_setup_then_cleanup"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordSetupFailure({ at: 12, monotonicMs: 120, error: new Error("setup failed") })
+    recorder.recordToolFailed({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130, error: new Error("cleanup") })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "AbortError", message: "aborted" },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.classification).toBe("request_setup_failure")
+    expect(summary.incident?.terminal_cause.category).toBe("request_setup_failure")
+    expect(summary.error?.message).toBe("redacted")
+  })
+
   test("retry safety is denied when any earlier attempt emitted visible output", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_retry_aggregate"),
@@ -339,6 +450,107 @@ describe("RunObservability", () => {
     expect(summary.visible_output_seen).toBe(true)
     expect(summary.retry_safety.recommendation).toBe("do_not_auto_retry")
     expect(summary.retry_safety.reason).toBe("visible_output_seen")
+  })
+
+  test("terminal attempt facts drive transport cause while run facts drive recovery safety", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_attempt_scoped_terminal"),
+      traceID: MessageID.make("msg_attempt_scoped_terminal"),
+      sessionID: SessionID.make("ses_attempt_scoped_terminal"),
+      messageID: MessageID.make("msg_attempt_scoped_terminal"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordVisibleOutput({ attemptID: first.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputStarted({ attemptID: first.attemptID, at: 13, monotonicMs: 130 })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordProviderProgress({ attemptID: second.attemptID, at: 21, monotonicMs: 210 })
+    recorder.recordTransportFailure({
+      attemptID: second.attemptID,
+      at: 22,
+      monotonicMs: 220,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 23, monotonicMs: 230 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "during_text_generation",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      stream_phase: "before_first_provider_progress",
+      tool_phase: "none",
+      terminal_attempt_id: second.attemptID,
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "visible_output_without_tool_execution",
+    })
+  })
+
+  test("provider-executed tool boundaries make recovery conservative", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_provider_executed_boundary"),
+      traceID: MessageID.make("msg_provider_executed_boundary"),
+      sessionID: SessionID.make("ses_provider_executed_boundary"),
+      messageID: MessageID.make("msg_provider_executed_boundary"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120, providerExecuted: true })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.side_effect_facts_complete).toBe(false)
+    expect(summary.incident?.facts.side_effect_facts_complete).toBe(false)
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+    expect(summary.incident?.evidence?.map((event) => event.event_type)).toContain("provider_executed_tool_boundary")
+  })
+
+  test("transport failure after tool input end is not classified as text generation", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_after_tool_input_end"),
+      traceID: MessageID.make("msg_after_tool_input_end"),
+      sessionID: SessionID.make("ses_after_tool_input_end"),
+      messageID: MessageID.make("msg_after_tool_input_end"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "unknown_stream_phase",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      stream_phase: "after_tool_input_end",
+      tool_phase: "tool_input_completed",
+    })
   })
 
   test("classifies local scope close with missing lifecycle provenance separately from user cancel", () => {

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -181,6 +181,136 @@ describe("RunObservability", () => {
     expect(summary.durations_ms.last_event_to_failure).toBe(130)
   })
 
+  test("derives provider transport incident during partial tool input instead of tool failure", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_partial_tool_input_disconnect"),
+      traceID: MessageID.make("msg_partial_tool_input_disconnect"),
+      sessionID: SessionID.make("ses_partial_tool_input_disconnect"),
+      messageID: MessageID.make("msg_partial_tool_input_disconnect"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 14, monotonicMs: 140 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      error: {
+        name: "TypeError",
+        message: "terminated",
+        cause: { name: "SocketError", message: "other side closed", code: "UND_ERR_SOCKET" },
+      },
+      evidence: ["iterator_error"],
+    })
+    recorder.recordPendingToolPartInterrupted({ attemptID: attempt.attemptID, at: 16, monotonicMs: 160 })
+    recorder.recordScopeClosed({
+      at: 17,
+      monotonicMs: 170,
+      source: "session.run_state.finalizer",
+      reason: "scope_finalizer",
+      lifecycleActionID: "lifecycle:instance_reload:late",
+      lifecycleKind: "instance_reload",
+    })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.classification).not.toBe("tool_failure")
+    expect(summary.tool_input_started).toBe(true)
+    expect(summary.tool_input_completed).toBe(false)
+    expect(summary.tool_call_materialized).toBe(false)
+    expect(summary.tool_execution_started).toBe(false)
+    expect(summary.pending_tool_parts_interrupted).toBe(1)
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "during_tool_input_generation",
+      boundary: "sdk_transport",
+      confidence: "high",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_generation",
+      stream_phase: "tool_input_generation",
+      tool_phase: "tool_input_started",
+      terminal_attempt_id: attempt.attemptID,
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "offer_continue",
+      reason: "partial_tool_input_without_execution",
+    })
+    expect(summary.incident?.evidence?.map((event) => event.event_type)).toEqual([
+      "attempt_started",
+      "provider_progress_seen",
+      "text_output_started",
+      "visible_output_seen",
+      "tool_input_started",
+      "provider_transport_failure",
+      "pending_tool_part_interrupted",
+      "lifecycle_close_seen",
+    ])
+  })
+
+  test("orders terminal cause by initiating evidence time", () => {
+    const providerFirst = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_provider_first"),
+      traceID: MessageID.make("msg_provider_first"),
+      sessionID: SessionID.make("ses_provider_first"),
+      messageID: MessageID.make("msg_provider_first"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const providerAttempt = providerFirst.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    providerFirst.recordProviderProgress({ attemptID: providerAttempt.attemptID, at: 12, monotonicMs: 120 })
+    providerFirst.recordTransportFailure({
+      attemptID: providerAttempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    providerFirst.recordScopeClosed({
+      at: 14,
+      monotonicMs: 140,
+      lifecycleActionID: "lifecycle:instance_reload:after_provider",
+      lifecycleKind: "instance_reload",
+    })
+    expect(providerFirst.finalize({ completedAt: 15, monotonicMs: 150 }).incident?.terminal_cause.category).toBe(
+      "provider_transport_disconnect",
+    )
+
+    const lifecycleFirst = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_first"),
+      traceID: MessageID.make("msg_lifecycle_first"),
+      sessionID: SessionID.make("ses_lifecycle_first"),
+      messageID: MessageID.make("msg_lifecycle_first"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const lifecycleAttempt = lifecycleFirst.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    lifecycleFirst.recordScopeClosed({
+      at: 12,
+      monotonicMs: 120,
+      lifecycleActionID: "lifecycle:instance_reload:before_provider_abort",
+      lifecycleKind: "instance_reload",
+    })
+    lifecycleFirst.recordTransportFailure({
+      attemptID: lifecycleAttempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "AbortError", message: "aborted" },
+    })
+    expect(lifecycleFirst.finalize({ completedAt: 14, monotonicMs: 140 }).incident?.terminal_cause).toMatchObject({
+      category: "local_lifecycle_close",
+      subcategory: "instance_reload",
+    })
+  })
+
   test("retry safety is denied when any earlier attempt emitted visible output", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_retry_aggregate"),


### PR DESCRIPTION
## Summary

Adds PR1 for #808's Run Incident Framework: a structured `run-incident` model, append-only evidence derivation, and sanitized incident export beside existing run observability diagnostics.

## Why

#803 showed a concrete misclassification: a provider transport disconnect during partial tool-input generation could be summarized as `tool_failure.tool_execution_failed` even though no tool execution started. This PR separates tool-call generation from execution and derives the terminal cause from ordered evidence so later cleanup/finalizer records cannot overwrite the initiating failure.

## Related Issue

Part of #808 Phase 1 / PR1 and directly addresses #803. Builds on #788 and #794. Does not implement #802's full lifecycle causal spine or #804 recovery UX.

## Human Review Status

Pending

## Review Focus

- Whether `RunIncident` fields stay derived from append-only evidence rather than mutable summary overwrites.
- Whether partial tool-input transport failures classify as `provider_transport_disconnect` and not tool execution failure.
- Whether exported evidence is bounded and sanitized, with raw tool input/private paths/secrets omitted.
- Whether PR scope stays diagnostic/export-only with no recovery UI or retry behavior change.

## Risk Notes

- Diagnostic/export-only change: no automatic retry, no Continue/Resume API, no recovery card, and no provider SDK behavior change.
- Legacy `classification`, `summary_key`, and `retry_safety` remain for compatibility; new export surfaces `run_incidents` as the authoritative structured path when present.
- Lifecycle origin remains the #794 level in this PR; immutable lifecycle snapshots and full #802 causal chain are follow-ups.
- Visible UI/copy check skipped: no visible UI changed.
- Platform/packaging check skipped: no macOS/Windows packaging, updater, signing, shell, or permission surface changed.

## How To Verify

```text
Red test first: bun test test/session/run-observability.test.ts test/session/export.test.ts --timeout 30000 — failed on missing RunIncident fields/API and missing run_incidents export
Run observability + export tests: bun test test/session/run-observability.test.ts test/session/export.test.ts --timeout 30000 — 54 pass, 0 fail
Typecheck: bun run typecheck from packages/opencode — passed
Whitespace check: git diff --check — passed
```

## Screenshots or Recordings

Not applicable — no visible UI changes.

## Checklist

> **How to use this checklist:**
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Comprehensive incident diagnostics with detailed evidence tracking, cause analysis, and recovery recommendations to help understand and address execution failures
  - Enhanced tool execution observability with improved phase tracking and state transition visibility
  - More actionable diagnostic information providing guidance on failure recovery and safety considerations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->