### PR TITLE
fix(session): guard run incident tool cleanup

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -113,6 +113,12 @@ type ToolCall = {
 
 type ToolInterruptionPhase = "tool_input_generation" | "tool_call_materialized_without_execution" | "tool_execution"
 
+const TOOL_INTERRUPTION_ERRORS: Record<ToolInterruptionPhase, string> = {
+  tool_execution: "Tool execution aborted",
+  tool_call_materialized_without_execution: "Tool call was prepared, but the tool did not run before the interruption.",
+  tool_input_generation: "Tool call generation interrupted before the tool ran.",
+}
+
 type PendingLoopAction = {
   loopAction: "block" | "stop"
   tool: string
@@ -1000,11 +1006,7 @@ export const layer: Layer.Layer<
           const errorText =
             part.tool === "question"
               ? "Question cancelled before the user answered it."
-              : interruptionPhase === "tool_execution"
-                ? "Tool execution aborted"
-                : interruptionPhase === "tool_call_materialized_without_execution"
-                  ? "Tool call was prepared, but the tool did not run before the interruption."
-                  : "Tool call generation interrupted before the tool ran."
+              : TOOL_INTERRUPTION_ERRORS[interruptionPhase]
           yield* session.updatePart({
             ...part,
             state: {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -105,7 +105,13 @@ type ToolCall = {
   messageID: MessageV2.ToolPart["messageID"]
   sessionID: MessageV2.ToolPart["sessionID"]
   done: Deferred.Deferred<void>
+  attemptID?: RunObservability.AttemptID
+  inputStarted?: boolean
+  materialized?: boolean
+  executionStarted?: boolean
 }
+
+type ToolInterruptionPhase = "tool_input_generation" | "tool_call_materialized_without_execution" | "tool_execution"
 
 type PendingLoopAction = {
   loopAction: "block" | "stop"
@@ -254,7 +260,11 @@ export const layer: Layer.Layer<
         tool: string
         toolCallID: string
       }) {
-        void input.toolCallID
+        const call = ctx.toolcalls[input.toolCallID]
+        if (call) {
+          call.executionStarted = true
+          call.attemptID = ctx.currentAttemptID ?? call.attemptID
+        }
         if (!ctx.currentAttemptID) return
         ctx.runTrace.recordToolExecutionStarted({
           attemptID: ctx.currentAttemptID,
@@ -733,6 +743,8 @@ export const layer: Layer.Layer<
               partID: part.id,
               messageID: part.messageID,
               sessionID: part.sessionID,
+              attemptID: ctx.currentAttemptID,
+              inputStarted: true,
             }
             yield* applyPendingToolUpdates(value.id)
             return
@@ -746,6 +758,11 @@ export const layer: Layer.Layer<
           case "tool-call": {
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
+            }
+            const tracked = ctx.toolcalls[value.toolCallId]
+            if (tracked) {
+              tracked.materialized = true
+              tracked.attemptID = ctx.currentAttemptID ?? tracked.attemptID
             }
             let running = yield* updateToolCall(value.toolCallId, (match) => ({
               ...match,
@@ -969,6 +986,11 @@ export const layer: Layer.Layer<
           const part = match.part
           const end = Date.now()
           const metadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {}
+          const interruptionPhase: ToolInterruptionPhase = match.call.executionStarted
+            ? "tool_execution"
+            : match.call.materialized || part.state.status === "running"
+              ? "tool_call_materialized_without_execution"
+              : "tool_input_generation"
           // Question tool deserves a clearer post-cancel message: the LLM
           // reads this string as the tool result, and "Tool execution aborted"
           // is ambiguous between "user dismissed your question" and "the run
@@ -976,29 +998,43 @@ export const layer: Layer.Layer<
           // (cancelled before answered), don't claim whether the user saw it
           // — they may have. See issue #419.
           const errorText =
-            part.tool === "question" ? "Question cancelled before the user answered it." : "Tool execution aborted"
+            part.tool === "question"
+              ? "Question cancelled before the user answered it."
+              : interruptionPhase === "tool_execution"
+                ? "Tool execution aborted"
+                : interruptionPhase === "tool_call_materialized_without_execution"
+                  ? "Tool call was prepared, but the tool did not run before the interruption."
+                  : "Tool call generation interrupted before the tool ran."
           yield* session.updatePart({
             ...part,
             state: {
               ...part.state,
               status: "error",
               error: errorText,
-              metadata: { ...metadata, interrupted: true },
+              metadata: {
+                ...metadata,
+                interrupted: true,
+                interruption_phase: interruptionPhase,
+                tool_execution_started: match.call.executionStarted === true,
+              },
               time: { start: "time" in part.state ? part.state.time.start : end, end },
             },
           })
-          if (ctx.currentAttemptID) {
-            if (part.state.status === "running") {
+          const attemptID = match.call.attemptID ?? ctx.currentAttemptID
+          if (attemptID) {
+            if (match.call.executionStarted) {
               ctx.runTrace.recordToolInterrupted({
-                attemptID: ctx.currentAttemptID,
+                attemptID,
                 at: end,
                 monotonicMs: performance.now(),
               })
             } else {
               ctx.runTrace.recordPendingToolPartInterrupted({
-                attemptID: ctx.currentAttemptID,
+                attemptID,
                 at: end,
                 monotonicMs: performance.now(),
+                interruptionPhase,
+                toolExecutionStarted: false,
               })
             }
           }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -106,7 +106,6 @@ type ToolCall = {
   sessionID: MessageV2.ToolPart["sessionID"]
   done: Deferred.Deferred<void>
   attemptID?: RunObservability.AttemptID
-  inputStarted?: boolean
   materialized?: boolean
   executionStarted?: boolean
 }
@@ -750,7 +749,6 @@ export const layer: Layer.Layer<
               messageID: part.messageID,
               sessionID: part.sessionID,
               attemptID: ctx.currentAttemptID,
-              inputStarted: true,
             }
             yield* applyPendingToolUpdates(value.id)
             return

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -37,7 +37,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
   const terminalFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id) : facts
   const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts })
   const summary = userSummary({ cause: terminal.cause, recovery })
-  const missingProvenance = input.missingProvenance ?? []
+  const missingProvenance = [...(input.missingProvenance ?? []), ...diagnosticGaps(input, terminal, facts)]
   return sanitizeIncident({
     schema_version: RUN_INCIDENT_SCHEMA_VERSION,
     incident_id: `incident:${input.messageID}`,
@@ -72,6 +72,19 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
     missing_provenance: missingProvenance.length ? missingProvenance : undefined,
     diagnostics_complete: missingProvenance.length === 0,
   })
+}
+
+function diagnosticGaps(
+  input: DeriveIncidentInput & { evidence: IncidentEvidenceEvent[] },
+  terminal: IncidentEvidenceEvent,
+  facts: IncidentFacts,
+) {
+  const gaps: string[] = []
+  if (!input.sideEffectFactsComplete) gaps.push("side_effect.boundary_unknown")
+  if (terminal.monotonic_ms === undefined) gaps.push("evidence.ordering_missing")
+  if (facts.tool_execution_started && !facts.tool_call_materialized) gaps.push("tool.materialization_missing")
+  if (facts.tool_input_completed && !facts.tool_input_started) gaps.push("tool_input.start_missing")
+  return Array.from(new Set(gaps))
 }
 
 function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvidenceEvent) {

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -40,6 +40,8 @@ export type IncidentEvidenceEvent = {
   tool_effect_kind?: ToolEffectKind
   tool_effect_unsafe?: boolean
   tool_effect_complete?: boolean
+  interruption_phase?: "tool_input_generation" | "tool_call_materialized_without_execution" | "tool_execution"
+  tool_execution_started?: boolean
 }
 
 export type IncidentEvidenceSummary = Omit<IncidentEvidenceEvent, "cause">

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -289,6 +289,25 @@ export function createRecorder(input: RecorderInput): Recorder {
       rememberEvent(next.monotonicMs)
     },
     recordToolInterrupted(next) {
+      const attempt = getAttempt(next.attemptID)
+      if (!attempt?.tool_execution_started) {
+        pendingToolPartsInterrupted++
+        appendEvidence({
+          monotonic_ms: next.monotonicMs,
+          source: "processor",
+          attempt_id: next.attemptID,
+          event_type: "pending_tool_part_interrupted",
+          terminal_candidate: false,
+          confidence: "medium",
+          redactions: ["raw_tool_input"],
+          interruption_phase: attempt?.tool_call_materialized
+            ? "tool_call_materialized_without_execution"
+            : "tool_input_generation",
+          tool_execution_started: false,
+        })
+        rememberEvent(next.monotonicMs)
+        return
+      }
       failure ??= { type: "tool", at: next.at, monotonicMs: next.monotonicMs, attemptID: next.attemptID }
       appendEvidence({
         monotonic_ms: next.monotonicMs,
@@ -297,6 +316,8 @@ export function createRecorder(input: RecorderInput): Recorder {
         event_type: "tool_execution_interrupted",
         terminal_candidate: true,
         confidence: "medium",
+        interruption_phase: "tool_execution",
+        tool_execution_started: true,
         cause: { category: "tool_execution_interrupted", confidence: "medium" },
       })
       rememberEvent(next.monotonicMs)
@@ -311,6 +332,8 @@ export function createRecorder(input: RecorderInput): Recorder {
         terminal_candidate: false,
         confidence: "medium",
         redactions: ["raw_tool_input"],
+        interruption_phase: next.interruptionPhase,
+        tool_execution_started: next.toolExecutionStarted,
       })
       rememberEvent(next.monotonicMs)
     },

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -174,7 +174,13 @@ export type Recorder = {
   recordToolCompleted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordToolFailed(input: { attemptID: AttemptID; at: number; monotonicMs: number; error?: unknown }): void
   recordToolInterrupted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
-  recordPendingToolPartInterrupted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
+  recordPendingToolPartInterrupted(input: {
+    attemptID: AttemptID
+    at: number
+    monotonicMs: number
+    interruptionPhase?: RunIncident.EvidenceEvent["interruption_phase"]
+    toolExecutionStarted?: boolean
+  }): void
   recordTransportFailure(input: {
     attemptID?: AttemptID
     at: number

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -1824,6 +1824,8 @@ describe("redactPart", () => {
           terminal_candidate: false,
           confidence: "medium",
           redactions: ["raw_tool_input", "/Users/secret/project", "sk-private"],
+          interruption_phase: "tool_input_generation",
+          tool_execution_started: false,
         },
       ],
       user_summary: {
@@ -1905,6 +1907,8 @@ describe("redactPart", () => {
       "pending_tool_part_interrupted",
     ])
     const serialized = JSON.stringify(sanitized.diagnostics.run_incidents)
+    expect(serialized).toContain("tool_input_generation")
+    expect(serialized).toContain("tool_execution_started")
     expect(serialized).toContain("raw_tool_input")
     expect(serialized).not.toContain("/Users/secret")
     expect(serialized).not.toContain("sk-private")

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -770,11 +770,24 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
           expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
         }
         expect(yield* llm.calls).toBe(1)
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+
         expect(call?.state.status).toBe("error")
         if (call?.state.status === "error") {
-          expect(call.state.error).toBe("Tool execution aborted")
+          expect(call.state.error).toBe("Tool call generation interrupted before the tool ran.")
           expect(call.state.metadata?.interrupted).toBe(true)
+          expect(call.state.metadata?.interruption_phase).toBe("tool_input_generation")
+          expect(call.state.metadata?.tool_execution_started).toBe(false)
           expect(call.state.time.end).toBeDefined()
+        }
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          const observability = stored.info.diagnostics?.run_observability
+          expect(observability?.tool_execution_started).toBe(false)
+          expect(observability?.pending_tool_parts_interrupted).toBe(1)
+          expect(observability?.incident?.terminal_cause.category).not.toBe("tool_execution_interrupted")
         }
       }),
     { git: true, config: (url) => providerCfg(url) },
@@ -852,6 +865,8 @@ it.live("session.processor effect tests rewrite aborted question tool error to f
         if (call?.state.status === "error") {
           expect(call.state.error).toBe("Question cancelled before the user answered it.")
           expect(call.state.metadata?.interrupted).toBe(true)
+          expect(call.state.metadata?.interruption_phase).toBe("tool_input_generation")
+          expect(call.state.metadata?.tool_execution_started).toBe(false)
         }
       }),
     { git: true, config: (url) => providerCfg(url) },

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,7 +1,9 @@
 import { NodeFileSystem } from "@effect/platform-node"
+import { tool } from "ai"
 import { expect } from "bun:test"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
+import z from "zod"
 import type { Agent } from "../../src/agent/agent"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
@@ -781,6 +783,137 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
           expect(call.state.metadata?.interruption_phase).toBe("tool_input_generation")
           expect(call.state.metadata?.tool_execution_started).toBe(false)
           expect(call.state.time.end).toBeDefined()
+        }
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          const observability = stored.info.diagnostics?.run_observability
+          expect(observability?.tool_execution_started).toBe(false)
+          expect(observability?.pending_tool_parts_interrupted).toBe(1)
+          expect(observability?.incident?.terminal_cause.category).not.toBe("tool_execution_interrupted")
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests mark materialized tools as prepared but not run on cleanup", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: "call_materialized_without_execution",
+                          type: "function",
+                          function: { name: "bash", arguments: "" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          function: { arguments: JSON.stringify({ cmd: "pwd" }) },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "tool_calls" }],
+              },
+            ],
+            hang: true,
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "materialized tool abort")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+              tools: { bash: true },
+            } satisfies MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "materialized tool abort" }],
+            tools: {
+              bash: tool({
+                description: "Run a shell command",
+                inputSchema: z.object({ cmd: z.string() }),
+              }),
+            },
+          })
+          .pipe(Effect.forkChild)
+
+        yield* llm.wait(1)
+        yield* Effect.promise(async () => {
+          const end = Date.now() + 500
+          while (Date.now() < end) {
+            const parts = await MessageV2.parts(msg.id)
+            if (parts.some((part) => part.type === "tool" && part.state.status === "running")) return
+            await Bun.sleep(10)
+          }
+        })
+        yield* Fiber.interrupt(run)
+
+        const exit = yield* Fiber.await(run)
+        const parts = MessageV2.parts(msg.id)
+        const call = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        expect(call?.state.status).toBe("error")
+        if (call?.state.status === "error") {
+          expect(call.state.error).toBe("Tool call was prepared, but the tool did not run before the interruption.")
+          expect(call.state.metadata?.interrupted).toBe(true)
+          expect(call.state.metadata?.interruption_phase).toBe("tool_call_materialized_without_execution")
+          expect(call.state.metadata?.tool_execution_started).toBe(false)
         }
         expect(stored?.info.role).toBe("assistant")
         if (stored?.info.role === "assistant") {

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -253,6 +253,135 @@ describe("RunObservability", () => {
     ])
   })
 
+  test("does not promote pending tool cleanup to tool execution interruption without execution evidence", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_pending_tool_cleanup_guard"),
+      traceID: MessageID.make("msg_pending_tool_cleanup_guard"),
+      sessionID: SessionID.make("ses_pending_tool_cleanup_guard"),
+      messageID: MessageID.make("msg_pending_tool_cleanup_guard"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInterrupted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.classification).not.toBe("tool_failure")
+    expect(summary.tool_execution_started).toBe(false)
+    expect(summary.pending_tool_parts_interrupted).toBe(1)
+    expect(summary.incident).toBeUndefined()
+  })
+
+  test("keeps tool execution interruption when execution evidence exists", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_tool_execution_cleanup_guard"),
+      traceID: MessageID.make("msg_tool_execution_cleanup_guard"),
+      sessionID: SessionID.make("ses_tool_execution_cleanup_guard"),
+      messageID: MessageID.make("msg_tool_execution_cleanup_guard"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    recorder.recordToolInterrupted({ attemptID: attempt.attemptID, at: 16, monotonicMs: 160 })
+
+    const summary = recorder.finalize({ completedAt: 17, monotonicMs: 170 })
+    expect(summary.classification).toBe("tool_failure")
+    expect(summary.tool_execution_started).toBe(true)
+    expect(summary.incident?.terminal_cause.category).toBe("tool_execution_interrupted")
+  })
+
+  test("marks diagnostics incomplete for unknown side-effect and impossible tool evidence combinations", () => {
+    const unknownBoundary = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_unknown_boundary"),
+      traceID: MessageID.make("msg_unknown_boundary"),
+      sessionID: SessionID.make("ses_unknown_boundary"),
+      messageID: MessageID.make("msg_unknown_boundary"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const unknownAttempt = unknownBoundary.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    unknownBoundary.recordToolCallMaterialized({ attemptID: unknownAttempt.attemptID, at: 12, monotonicMs: 120 })
+    unknownBoundary.recordTransportFailure({
+      attemptID: unknownAttempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: new Error("boom"),
+    })
+    const unknownSummary = unknownBoundary.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(unknownSummary.incident?.diagnostics_complete).toBe(false)
+    expect(unknownSummary.incident?.missing_provenance).toContain("side_effect.boundary_unknown")
+
+    const executionWithoutCall = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_execution_without_call"),
+      traceID: MessageID.make("msg_execution_without_call"),
+      sessionID: SessionID.make("ses_execution_without_call"),
+      messageID: MessageID.make("msg_execution_without_call"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const executionAttempt = executionWithoutCall.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    executionWithoutCall.recordToolExecutionStarted({
+      attemptID: executionAttempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      toolName: RunObservability.safeToolName("bash"),
+      effect: RunObservability.toolEffect("bash"),
+    })
+    executionWithoutCall.recordToolInterrupted({ attemptID: executionAttempt.attemptID, at: 13, monotonicMs: 130 })
+    const executionSummary = executionWithoutCall.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(executionSummary.incident?.diagnostics_complete).toBe(false)
+    expect(executionSummary.incident?.missing_provenance).toContain("tool.materialization_missing")
+
+    const inputWithoutStart = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_input_without_start"),
+      traceID: MessageID.make("msg_input_without_start"),
+      sessionID: SessionID.make("ses_input_without_start"),
+      messageID: MessageID.make("msg_input_without_start"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const inputAttempt = inputWithoutStart.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    inputWithoutStart.recordToolInputCompleted({ attemptID: inputAttempt.attemptID, at: 12, monotonicMs: 120 })
+    inputWithoutStart.recordTransportFailure({
+      attemptID: inputAttempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: new Error("boom"),
+    })
+    const inputSummary = inputWithoutStart.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(inputSummary.incident?.diagnostics_complete).toBe(false)
+    expect(inputSummary.incident?.missing_provenance).toContain("tool_input.start_missing")
+  })
+
   test("bounded incident evidence keeps terminal and cleanup basis after long output", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_long_output_disconnect"),


### PR DESCRIPTION
## Summary

- Implements #808 Phase 2 / PR2 diagnostic guardrails for interrupted tool cleanup.
- Distinguishes tool input generation interruption, materialized-but-not-run cleanup, and actual tool execution interruption in safe evidence/metadata.
- Adds diagnostics completeness gaps for unknown side-effect boundaries and impossible evidence combinations.

## Why

PR #812 added the run incident diagnostic spine, but cleanup could still make a prepared or partial tool look like an executed tool interruption. This PR keeps PR2 diagnostic/export-only and prevents cleanup from overstating what actually happened.

## Related Issue

Part of #808.

## Human Review Status

Pending

## Review Focus

- Whether `processor.ts` now uses the tracked execution boundary rather than `part.state.status === "running"` to record interrupted execution.
- Whether `recordToolInterrupted` remains conservative when execution evidence is absent.
- Whether the new `diagnostics_complete=false` gaps are safe, non-secret, and useful for exports.

## Risk Notes

- No UI/API recovery behavior is changed; this is diagnostic/export-only.
- The cleanup copy stored on tool error parts changes for interrupted generated tool calls, but no visible UI surface was manually checked because this is persisted diagnostic/tool-result copy and not a frontend rendering change.
- No platform, packaging, dependencies, generated files, permissions, credentials, or deletion behavior touched.
- #802 lifecycle immutable snapshots and #804 recovery UX/API are intentionally out of scope.

## How To Verify

```text
Targeted tests: bun test test/session/run-observability.test.ts test/session/processor-effect.test.ts test/session/export.test.ts --timeout 30000 → 92 pass, 0 fail
Processor review follow-up: bun test test/session/processor-effect.test.ts --timeout 30000 → 16 pass, 0 fail
Typecheck: bun run typecheck in packages/opencode → passed
Diff check: git diff --check → no output / clean
```

## Screenshots or Recordings

Not applicable: no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.