### PR TITLE
fix(session): preserve worktree context after compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -14,7 +14,6 @@ import { Config } from "@/config"
 import { Storage } from "@/storage/storage"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect, Layer, Context, Schema } from "effect"
-import { InstanceState } from "@/effect"
 import { isOverflow as overflow, usable } from "./overflow"
 import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
@@ -110,9 +109,7 @@ function completedCompactions(messages: MessageV2.WithParts[]) {
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i]
     if (msg.info.role !== "user") continue
-    const compactionPart = msg.parts.find(
-      (part): part is MessageV2.CompactionPart => part.type === "compaction",
-    )
+    const compactionPart = msg.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
     if (!compactionPart) continue
     users.set(msg.info.id, { index: i, tailStartId: compactionPart.tail_start_id })
   }
@@ -444,7 +441,8 @@ export const layer: Layer.Layer<
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
       })
-      const ctx = yield* InstanceState.context
+      const currentSession = yield* session.get(input.sessionID)
+      const exec = currentSession.executionContext
       const msg: MessageV2.Assistant = {
         id: MessageID.ascending(),
         role: "assistant",
@@ -455,8 +453,8 @@ export const layer: Layer.Layer<
         variant: userMessage.model.variant,
         summary: true,
         path: {
-          cwd: ctx.directory,
-          root: ctx.worktree,
+          cwd: exec.activeDirectory,
+          root: exec.ownerDirectory,
         },
         cost: 0,
         tokens: {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -200,6 +200,7 @@ export interface Interface {
     sessionID: SessionID
     auto: boolean
     overflow?: boolean
+    executionContext?: Session.Info["executionContext"]
   }) => Effect.Effect<"continue" | "stop">
   readonly create: (input: {
     sessionID: SessionID
@@ -360,6 +361,7 @@ export const layer: Layer.Layer<
       sessionID: SessionID
       auto: boolean
       overflow?: boolean
+      executionContext?: Session.Info["executionContext"]
     }) {
       const parent = input.messages.findLast((m) => m.info.id === input.parentID)
       if (!parent || parent.info.role !== "user") {
@@ -441,8 +443,8 @@ export const layer: Layer.Layer<
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
       })
-      const currentSession = yield* session.get(input.sessionID)
-      const exec = currentSession.executionContext
+      let exec = input.executionContext
+      if (!exec) exec = (yield* session.get(input.sessionID)).executionContext
       const msg: MessageV2.Assistant = {
         id: MessageID.ascending(),
         role: "assistant",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1976,6 +1976,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID,
               auto: task.auto,
               overflow: task.overflow,
+              executionContext: session.executionContext,
             })
             if (result === "stop") break
             continue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2090,7 +2090,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
-              Effect.sync(() => sys.environment(model, lastUser.locale)),
+              Effect.sync(() =>
+                sys.environment({
+                  model,
+                  locale: lastUser.locale,
+                  executionContext: execLive,
+                }),
+              ),
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -3,6 +3,7 @@ import { Context, Effect, Layer } from "effect"
 import { Instance } from "../project/instance"
 
 import PROMPT_PAWWORK from "./prompt/pawwork.txt"
+import type { SessionExecutionContext } from "./execution-context"
 import type { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
@@ -12,12 +13,53 @@ export function provider(_model: Provider.Model) {
   return [PROMPT_PAWWORK]
 }
 
+export type SessionEnvironmentContext = Pick<
+  SessionExecutionContext,
+  "ownerDirectory" | "activeDirectory" | "activeWorktree"
+>
+
+export type EnvironmentInput = {
+  model: Provider.Model
+  locale?: string
+  executionContext?: SessionEnvironmentContext
+}
+
 export interface Interface {
-  readonly environment: (model: Provider.Model, locale?: string) => string[]
+  readonly environment: (input: EnvironmentInput) => string[]
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SystemPrompt") {}
+
+export function renderSessionEnvironment(input: {
+  model: Provider.Model
+  locale?: string
+  project: { vcs?: string }
+  executionContext: SessionEnvironmentContext
+}) {
+  const env = [
+    `You are powered by the model named ${input.model.api.id}. The exact model ID is ${input.model.providerID}/${input.model.api.id}`,
+    `Here is some useful information about the environment you are running in:`,
+    `<env>`,
+    `  Working directory: ${input.executionContext.activeDirectory}`,
+    `  Workspace root folder: ${input.executionContext.ownerDirectory}`,
+    `  Is directory a git repo: ${input.project.vcs === "git" ? "yes" : "no"}`,
+    `  Platform: ${process.platform}`,
+    `  Today's date: ${new Date().toDateString()}`,
+  ]
+
+  if (input.locale) env.push(`  User locale: ${input.locale}`)
+
+  env.push(`</env>`)
+  return [env.join("\n")]
+}
+
+function ambientExecutionContext(): SessionEnvironmentContext {
+  return {
+    ownerDirectory: Instance.worktree,
+    activeDirectory: Instance.directory,
+  }
+}
 
 export const layer = Layer.effect(
   Service,
@@ -25,23 +67,14 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
 
     return Service.of({
-      environment(model, locale) {
+      environment(input) {
         const project = Instance.project
-        const env = [
-          `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
-          `Here is some useful information about the environment you are running in:`,
-          `<env>`,
-          `  Working directory: ${Instance.directory}`,
-          `  Workspace root folder: ${Instance.worktree}`,
-          `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
-          `  Platform: ${process.platform}`,
-          `  Today's date: ${new Date().toDateString()}`,
-        ]
-
-        if (locale) env.push(`  User locale: ${locale}`)
-
-        env.push(`</env>`)
-        return [env.join("\n")]
+        return renderSessionEnvironment({
+          model: input.model,
+          locale: input.locale,
+          project,
+          executionContext: input.executionContext ?? ambientExecutionContext(),
+        })
       },
 
       skills: Effect.fn("SystemPrompt.skills")(function* (agent: Agent.Info) {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -535,7 +535,7 @@ it.live("provider env matches assistant path for an active worktree", () =>
         yield* llm.text("done")
 
         const result = yield* prompt.loop({ sessionID: session.id })
-        expect(result.info.role).toBe("assistant")
+        if (result.info.role !== "assistant") throw new Error("Expected assistant message")
 
         const requestText = requestTextContaining(yield* llm.inputs, "check execution context snapshot")
         expect(envValue(requestText, "Working directory")).toBe(result.info.path.cwd)
@@ -546,7 +546,6 @@ it.live("provider env matches assistant path for an active worktree", () =>
     { git: true, config: providerCfg },
   ),
 )
-
 
 it.live("post-compaction auto-continue keeps env in the active worktree", () =>
   provideTmpdirServer(
@@ -632,7 +631,7 @@ it.live("post-compaction auto-continue keeps env in the active worktree", () =>
 
         yield* llm.text("continued after compaction")
         const result = yield* prompt.loop({ sessionID: session.id })
-        expect(result.info.role).toBe("assistant")
+        if (result.info.role !== "assistant") throw new Error("Expected assistant message")
 
         const requestText = requestTextContaining(yield* llm.inputs, "Continue if you have next steps")
         expect(envValue(requestText, "Working directory")).toBe(activeDirectory)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -620,6 +620,16 @@ it.live("post-compaction auto-continue keeps env in the active worktree", () =>
         })
         expect(compacted).toBe("continue")
 
+        const messagesAfterCompaction = yield* sessions.messages({ sessionID: session.id })
+        const summaryMessage = messagesAfterCompaction.find(
+          (message) => message.info.role === "assistant" && message.info.summary === true,
+        )
+        if (!summaryMessage || summaryMessage.info.role !== "assistant") {
+          throw new Error("Missing compaction summary assistant message")
+        }
+        expect(summaryMessage.info.path.cwd).toBe(activeDirectory)
+        expect(summaryMessage.info.path.root).toBe(dir)
+
         yield* llm.text("continued after compaction")
         const result = yield* prompt.loop({ sessionID: session.id })
         expect(result.info.role).toBe("assistant")

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -547,6 +547,93 @@ it.live("provider env matches assistant path for an active worktree", () =>
   ),
 )
 
+
+it.live("post-compaction auto-continue keeps env in the active worktree", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const compact = yield* SessionCompaction.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Compaction execution context",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const activeDirectory = path.join(dir, ".worktrees", "pawwork", "ctx-compact")
+        yield* Effect.promise(() => fs.mkdir(activeDirectory, { recursive: true }))
+        yield* sessions.updateExecutionContext({
+          sessionID: session.id,
+          activeWorktree: {
+            directory: activeDirectory,
+            name: "ctx-compact",
+            branch: "pawwork/ctx-compact",
+            source: "created",
+          },
+        })
+
+        const priorUser = yield* user(session.id, "work before compaction")
+        const priorAssistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: priorUser.id,
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          cost: 0,
+          path: { cwd: activeDirectory, root: dir },
+          tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: priorAssistant.id,
+          sessionID: session.id,
+          type: "text",
+          text: "finished work before compaction",
+        })
+
+        const compactionParent = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          time: { created: Date.now() },
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: compactionParent.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+        })
+
+        yield* llm.text("## Goal\n- Continue from compacted worktree context")
+        const compacted = yield* compact.process({
+          parentID: compactionParent.id,
+          messages: yield* MessageV2.filterCompactedEffect(session.id),
+          sessionID: session.id,
+          auto: true,
+        })
+        expect(compacted).toBe("continue")
+
+        yield* llm.text("continued after compaction")
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const requestText = requestTextContaining(yield* llm.inputs, "Continue if you have next steps")
+        expect(envValue(requestText, "Working directory")).toBe(activeDirectory)
+        expect(envValue(requestText, "Workspace root folder")).toBe(dir)
+        expect(result.info.path.cwd).toBe(activeDirectory)
+        expect(result.info.path.root).toBe(dir)
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("static loop returns assistant text through local provider", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -120,6 +120,37 @@ function errorTool(parts: MessageV2.Part[]) {
   return part?.state.status === "error" ? (part as ErrorToolPart) : undefined
 }
 
+function flattenRequestText(input: Record<string, unknown>) {
+  const messages = (input as { messages?: unknown[] }).messages ?? []
+  return messages
+    .flatMap((message) => {
+      const content = (message as { content?: unknown }).content
+      if (typeof content === "string") return [content]
+      if (Array.isArray(content)) {
+        return content.flatMap((part) => {
+          if (typeof part === "string") return [part]
+          if (part && typeof part === "object" && "text" in part) return [String((part as { text: unknown }).text)]
+          return []
+        })
+      }
+      return []
+    })
+    .join("\n")
+}
+
+function requestTextContaining(inputs: Record<string, unknown>[], needle: string) {
+  const match = inputs.find((input) => flattenRequestText(input).includes(needle))
+  if (!match) throw new Error(`Missing provider request containing: ${needle}`)
+  return flattenRequestText(match)
+}
+
+function envValue(text: string, label: string) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const match = text.match(new RegExp(`^  ${escaped}: (.+)$`, "m"))
+  if (!match) throw new Error(`Missing env field: ${label}`)
+  return match[1]
+}
+
 describe("title generation diagnostics helpers", () => {
   test("maps abort-time title generation states", () => {
     expect(titleGenerationStateAtAbort(undefined, 10)).toBe("not_started")
@@ -468,6 +499,50 @@ it.live("loop calls LLM and returns assistant message", () =>
       expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
       expect(yield* llm.hits).toHaveLength(1)
     }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+
+it.live("provider env matches assistant path for an active worktree", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "Execution context snapshot",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const activeDirectory = path.join(dir, ".worktrees", "pawwork", "ctx-snapshot")
+        yield* Effect.promise(() => fs.mkdir(activeDirectory, { recursive: true }))
+        yield* sessions.updateExecutionContext({
+          sessionID: session.id,
+          activeWorktree: {
+            directory: activeDirectory,
+            name: "ctx-snapshot",
+            branch: "pawwork/ctx-snapshot",
+            source: "created",
+          },
+        })
+
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "check execution context snapshot" }],
+        })
+        yield* llm.text("done")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+
+        const requestText = requestTextContaining(yield* llm.inputs, "check execution context snapshot")
+        expect(envValue(requestText, "Working directory")).toBe(result.info.path.cwd)
+        expect(envValue(requestText, "Workspace root folder")).toBe(result.info.path.root)
+        expect(result.info.path.cwd).toBe(activeDirectory)
+        expect(result.info.path.root).toBe(dir)
+      }),
     { git: true, config: providerCfg },
   ),
 )

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { readdir, readFile } from "fs/promises"
+import { mkdir, readdir, readFile } from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
 import { Agent } from "../../src/agent/agent"
@@ -99,16 +99,58 @@ describe("session.system", () => {
 
         const envWithLocale = await Effect.gen(function* () {
           const svc = yield* SystemPrompt.Service
-          return svc.environment(model, "zh-Hans").join("\n")
+          return svc.environment({ model, locale: "zh-Hans" }).join("\n")
         }).pipe(Effect.provide(SystemPrompt.defaultLayer), Effect.runPromise)
 
         const envWithoutLocale = await Effect.gen(function* () {
           const svc = yield* SystemPrompt.Service
-          return svc.environment(model).join("\n")
+          return svc.environment({ model }).join("\n")
         }).pipe(Effect.provide(SystemPrompt.defaultLayer), Effect.runPromise)
 
         expect(envWithLocale).toContain("User locale: zh-Hans")
         expect(envWithoutLocale).not.toContain("User locale:")
+      },
+    })
+  })
+
+  test("environment uses explicit session execution context over ambient instance", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const activeDirectory = path.join(tmp.path, ".worktrees", "pawwork", "ctx-env")
+    await mkdir(activeDirectory, { recursive: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = {
+          providerID: "openai",
+          api: { id: "gpt-5.2" },
+        } as any
+
+        const env = await Effect.gen(function* () {
+          const svc = yield* SystemPrompt.Service
+          return svc
+            .environment({
+              model,
+              locale: "zh-Hans",
+              executionContext: {
+                ownerDirectory: tmp.path,
+                activeDirectory,
+                activeWorktree: {
+                  directory: activeDirectory,
+                  name: "ctx-env",
+                  branch: "pawwork/ctx-env",
+                  source: "created",
+                },
+              },
+            })
+            .join("\n")
+        }).pipe(Effect.provide(SystemPrompt.defaultLayer), Effect.runPromise)
+
+        expect(env).toContain(`Working directory: ${activeDirectory}`)
+        expect(env).toContain(`Workspace root folder: ${tmp.path}`)
+        expect(env).toContain("User locale: zh-Hans")
+        expect(env).not.toContain(`Working directory: ${tmp.path}\n`)
+        expect(env).not.toContain("Active worktree:")
       },
     })
   })


### PR DESCRIPTION
## Summary
- Render session prompt env cwd/root from live `session.executionContext` instead of ambient `Instance` state.
- Use one provider-request execution-context snapshot for assistant `path` and system env.
- Store compaction summary `path.cwd/root` from the session execution context and cover post-compaction auto-continue.

## Verification
- `bun --cwd packages/opencode test test/session/system.test.ts test/session/prompt-effect.test.ts --timeout 30000`
- `bun run typecheck`
- `git diff --check`

## Notes
- Closes #821.
- `EnterWorktree` idempotent `reused` behavior is unchanged.
- First pass intentionally does not add an `Active worktree` prompt line.