### PR TITLE
feat(session): add lifecycle causality diagnostics

### DIFF
--- a/packages/app/src/components/dialog-connect-provider-source.test.ts
+++ b/packages/app/src/components/dialog-connect-provider-source.test.ts
@@ -22,24 +22,24 @@ describe("dialog-connect-provider source boundary", () => {
   })
 
   test("preserves provider auth copy and action wiring after extraction", () => {
-    for (const key of [
-      "provider.connect.apiKey.required",
-      "provider.connect.oauth.code.required",
-    ]) {
+    for (const key of ["provider.connect.apiKey.required", "provider.connect.oauth.code.required"]) {
       expect(authViewsSource).toContain(key)
     }
 
-    for (const key of [
-      "provider.connect.oauth.auto.confirmationCode",
-      "provider.connect.status.waiting",
-    ]) {
+    for (const key of ["provider.connect.oauth.auto.confirmationCode", "provider.connect.status.waiting"]) {
       expect(autoViewSource).toContain(key)
     }
 
     expect(promptViewSource).toContain("prompt.when")
     expect(dialogSource).toContain("globalSDK.client.provider.oauth")
     expect(dialogSource).toContain(".authorize(")
-    expect(dialogSource).toContain("globalSDK.client.global.dispose")
+    expect(dialogSource).toContain("actionClient.global.dispose")
+  })
+
+  test("tags provider connect lifecycle dispose calls with client action headers", () => {
+    expect(dialogSource).toContain("clientActionHeaders")
+    expect(dialogSource).toContain('kind: "settings.provider.connect"')
+    expect(dialogSource).toContain("actionClient.global.dispose")
   })
 
   test("formats nested provider auth errors without losing fallback behavior", () => {

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -13,6 +13,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
+import { clientActionHeaders } from "@/utils/server"
 import {
   ProviderApiAuthView,
   ProviderOAuthCodeView,
@@ -198,7 +199,11 @@ export function DialogConnectProvider(props: { provider: string }) {
   })
 
   async function complete() {
-    await globalSDK.client.global.dispose()
+    const actionClient = globalSDK.createClient({
+      headers: clientActionHeaders({ kind: "settings.provider.connect" }),
+      throwOnError: true,
+    })
+    await actionClient.global.dispose()
     dialog.close()
     showToast({
       variant: "success",

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -8,6 +8,7 @@ import { createMemo, type Component, For, Show } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
+import { clientActionHeaders } from "@/utils/server"
 import { DialogConnectProvider } from "./dialog-connect-provider"
 import { DialogSelectProvider } from "./dialog-select-provider"
 import { DialogCustomProvider } from "./dialog-custom-provider"
@@ -105,15 +106,19 @@ export const SettingsProviders: Component = () => {
   }
 
   const disconnect = async (providerID: string, name: string) => {
+    const actionClient = globalSDK.createClient({
+      headers: clientActionHeaders({ kind: "settings.provider.disconnect" }),
+      throwOnError: true,
+    })
     if (isConfigCustom(providerID)) {
-      await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
+      await actionClient.auth.remove({ providerID }).catch(() => undefined)
       await disableProvider(providerID, name)
       return
     }
-    await globalSDK.client.auth
+    await actionClient.auth
       .remove({ providerID })
       .then(async () => {
-        await globalSDK.client.global.dispose()
+        await actionClient.global.dispose()
         showToast({
           variant: "success",
           icon: "circle-check",

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -13,6 +13,7 @@ import { createContext, getOwner, onCleanup, onMount, type ParentProps, untrack,
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useLanguage } from "@/context/language"
 import { Persist, persisted } from "@/utils/persist"
+import { clientActionHeaders } from "@/utils/server"
 import type { InitError } from "../pages/error"
 import { useGlobalSDK } from "./global-sdk"
 import { bootstrapDirectory, bootstrapGlobal, clearProviderRev } from "./global-sync/bootstrap"
@@ -493,7 +494,11 @@ function createGlobalSync() {
 
   const updateConfig = async (config: Config) => {
     setGlobalStore("reload", "pending")
-    return globalSDK.client.global.config
+    const actionClient = globalSDK.createClient({
+      headers: clientActionHeaders({ kind: "global.config.update" }),
+      throwOnError: true,
+    })
+    return actionClient.global.config
       .update({ config })
       .then(bootstrap)
       .then(() => {

--- a/packages/app/src/context/global-sync/client-action-source.test.ts
+++ b/packages/app/src/context/global-sync/client-action-source.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const globalSyncSource = readFileSync(new URL("../global-sync.tsx", import.meta.url), "utf8")
+const settingsProvidersSource = readFileSync(
+  new URL("../../components/settings-providers.tsx", import.meta.url),
+  "utf8",
+)
+const layoutSource = readFileSync(new URL("../../pages/layout.tsx", import.meta.url), "utf8")
+
+describe("global sync client action provenance wiring", () => {
+  test("tags global config updates with client action headers", () => {
+    expect(globalSyncSource).toContain("clientActionHeaders")
+    expect(globalSyncSource).toContain('kind: "global.config.update"')
+    expect(globalSyncSource).toContain("actionClient.global.config")
+    expect(globalSyncSource).toContain(".update({ config })")
+  })
+
+  test("tags provider disconnect lifecycle dispose calls with client action headers", () => {
+    expect(settingsProvidersSource).toContain("clientActionHeaders")
+    expect(settingsProvidersSource).toContain('kind: "settings.provider.disconnect"')
+    expect(settingsProvidersSource).toContain("actionClient.global.dispose")
+  })
+
+  test("tags workspace reset instance disposal with client action headers", () => {
+    expect(layoutSource).toContain("clientActionHeaders")
+    expect(layoutSource).toContain('kind: "workspace.reset"')
+    expect(layoutSource).toContain("actionClient.instance.dispose")
+  })
+})

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -32,6 +32,7 @@ import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
 import { showToast, Toast, toaster } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
+import { clientActionHeaders } from "@/utils/server"
 import { LayoutPageContext } from "@/context/layout-page"
 import { ShellSurfaceContext } from "@/context/shell-surface"
 import { clearWorkspaceTerminals, isTerminalGoneError } from "@/context/terminal"
@@ -1970,7 +1971,11 @@ export default function Layout(props: ParentProps) {
       sessions.map((s) => s.id),
       platform,
     )
-    await globalSDK.client.instance.dispose({ directory }).catch(() => undefined)
+    const actionClient = globalSDK.createClient({
+      headers: clientActionHeaders({ kind: "workspace.reset" }),
+      throwOnError: true,
+    })
+    await actionClient.instance.dispose({ directory }).catch(() => undefined)
 
     const result = await globalSDK.client.worktree
       .reset({ directory: root, worktreeResetInput: { directory } })

--- a/packages/app/src/utils/server.test.ts
+++ b/packages/app/src/utils/server.test.ts
@@ -36,6 +36,9 @@ describe("clientActionHeaders", () => {
       "x-pawwork-route-session-id": "ses_route",
       "x-pawwork-visible-session-id": "ses_visible",
     })
-    expect(JSON.stringify(headers)).not.toContain("/Users/")
+    const serialized = JSON.stringify(headers)
+    expect(serialized).not.toContain("/Users/")
+    expect(serialized).not.toContain("/home/")
+    expect(serialized).not.toMatch(/[A-Z]:[\\/]/i)
   })
 })

--- a/packages/app/src/utils/server.test.ts
+++ b/packages/app/src/utils/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { authFromToken, authTokenFromCredentials } from "./server"
+import { authFromToken, authTokenFromCredentials, clientActionHeaders } from "./server"
 
 describe("authFromToken", () => {
   test("decodes basic auth credentials from auth_token", () => {
@@ -19,5 +19,23 @@ describe("authFromToken", () => {
 describe("authTokenFromCredentials", () => {
   test("encodes credentials with the default username", () => {
     expect(authTokenFromCredentials({ password: "secret" })).toBe(btoa("opencode:secret"))
+  })
+})
+
+describe("clientActionHeaders", () => {
+  test("creates safe renderer action headers without paths or prompt bodies", () => {
+    const headers = clientActionHeaders({
+      kind: "settings.provider.disconnect",
+      routeSessionID: "ses_route",
+      visibleSessionID: "ses_visible",
+    })
+
+    expect(headers["x-pawwork-client-action-id"]).toStartWith("client:")
+    expect(headers).toMatchObject({
+      "x-pawwork-client-action-kind": "settings.provider.disconnect",
+      "x-pawwork-route-session-id": "ses_route",
+      "x-pawwork-visible-session-id": "ses_visible",
+    })
+    expect(JSON.stringify(headers)).not.toContain("/Users/")
   })
 })

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -17,6 +17,20 @@ export function authFromToken(token: string | null) {
   }
 }
 
+export function clientActionHeaders(input: {
+  kind: string
+  routeSessionID?: string
+  visibleSessionID?: string
+}): Record<string, string> {
+  const actionID = `client:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`
+  return {
+    "x-pawwork-client-action-id": actionID,
+    "x-pawwork-client-action-kind": input.kind,
+    ...(input.routeSessionID ? { "x-pawwork-route-session-id": input.routeSessionID } : {}),
+    ...(input.visibleSessionID ? { "x-pawwork-visible-session-id": input.visibleSessionID } : {}),
+  }
+}
+
 export function createSdkForServer({
   server,
   ...config

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -49,6 +49,7 @@ import { Npm } from "@opencode-ai/core/npm"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@/util/flock"
 import { Installation } from "@/installation"
+import { withLifecycleOrigin } from "@/session/lifecycle-provenance"
 import { Runtime } from "@opencode-ai/core/runtime"
 
 const log = Log.create({ service: "config" })
@@ -1144,12 +1145,18 @@ const rawLayer = Layer.effect(
       // Only tear down running instances if config actually changed on disk.
       // No-op writes from UI mounts (see upstream PR #25114) would otherwise
       // abort any in-flight assistant turn.
-      if (changed) yield* Effect.promise(() => Instance.dispose())
+      if (changed)
+        yield* Effect.promise(() =>
+          withLifecycleOrigin(
+            { source: "config", operation: "config.update", reason: "config.update" },
+            () => Instance.dispose(),
+          ),
+        )
     })
 
-    const invalidate = Effect.fn("Config.invalidate")(function* (wait?: boolean) {
+    const invalidate = Effect.fn("Config.invalidate")(function* (wait?: boolean, operation = "config.invalidate") {
       yield* invalidateGlobal
-      const task = Instance.disposeAll()
+      const task = withLifecycleOrigin({ source: "config", operation, reason: operation }, () => Instance.disposeAll())
         .catch(() => undefined)
         .finally(() =>
           GlobalBus.emit("event", {
@@ -1223,7 +1230,7 @@ const rawLayer = Layer.effect(
       // Only invalidate (which calls Instance.disposeAll) if config actually
       // changed on disk. No-op writes from UI mounts would otherwise abort
       // any in-flight assistant turn across all instances.
-      if (changed) yield* invalidate()
+      if (changed) yield* invalidate(undefined, "config.updateGlobal")
       return next
     })
 

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -1,4 +1,5 @@
 import { Cause, Deferred, Effect, Exit, Fiber, Ref, Schema, Scope, SynchronizedRef } from "effect"
+import type { LifecycleRequest } from "@/session/lifecycle-provenance"
 
 export interface Runner<A, E = never> {
   readonly state: State<A, E>
@@ -38,6 +39,11 @@ export interface InterruptMeta {
   reason?: string
   lifecycleActionID?: string
   lifecycleKind?: string
+  lifecycleInitiatedAt?: number
+  lifecycleInitiatedMonotonicMs?: number
+  lifecycleAffectedDirectoryKeys?: string[]
+  lifecycleOrigin?: { source: string; operation?: string; reason?: string }
+  lifecycleRequest?: LifecycleRequest
   // Reserved for future paths that originate from a tool or model ctx.abort signal instead of
   // an explicit session.cancel call.
   viaCtxAbort?: boolean
@@ -81,8 +87,7 @@ export const make = <A, E = never>(
     source: "runner.interrupt_without_meta",
     reason: "fiber_interrupt_without_meta",
   }
-  const getInterruptFallback = () =>
-    typeof interruptFallback === "function" ? interruptFallback() : interruptFallback
+  const getInterruptFallback = () => (typeof interruptFallback === "function" ? interruptFallback() : interruptFallback)
 
   const complete = (done: Deferred.Deferred<A, E | Cancelled>, exit: Exit.Exit<A, E>) =>
     Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)
@@ -128,8 +133,9 @@ export const make = <A, E = never>(
 
   const awaitRun = (run: Pick<RunHandle<A, E>, "done" | "interruptMeta"> | PendingHandle<A, E>) =>
     Deferred.await(run.done).pipe(
-      Effect.catch((e): Effect.Effect<A, E> =>
-        e instanceof Cancelled ? resolveInterrupt(run.interruptMeta) : Effect.fail(e as E),
+      Effect.catch(
+        (e): Effect.Effect<A, E> =>
+          e instanceof Cancelled ? resolveInterrupt(run.interruptMeta) : Effect.fail(e as E),
       ),
     )
 
@@ -201,9 +207,7 @@ export const make = <A, E = never>(
         const cancelled = yield* Deferred.make<void>()
         const ready =
           options?.ready ??
-          (yield* Deferred.make<void>().pipe(
-            Effect.tap((ready) => Deferred.succeed(ready, undefined)),
-          ))
+          (yield* Deferred.make<void>().pipe(Effect.tap((ready) => Deferred.succeed(ready, undefined))))
         const fiber = yield* work.pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
         const interruptMeta = yield* Ref.make<InterruptMeta | undefined>(undefined)
         const shell = { id, ready, cancelled, interruptMeta, fiber } satisfies ShellHandle<A, E>

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -10,15 +10,24 @@ import { Project } from "./project"
 import { State } from "./state"
 import {
   createLifecycleCloseAction,
+  currentLifecycleOrigin,
   type LifecycleCloseAction,
   withLifecycleCloseAction,
 } from "@/session/lifecycle-provenance"
+import { currentRequestContext } from "@/server/request-context"
 
 export interface LoadInput {
   directory: string
   worktree?: string | undefined
   project?: Project.Info | undefined
 }
+
+type ContextMismatchReason =
+  | "worktree_mismatch"
+  | "project_id_mismatch"
+  | "project_row_missing"
+  | "explicit_context_changed"
+  | "unknown_context_mismatch"
 
 export interface Interface {
   readonly load: (input: LoadInput) => Effect.Effect<InstanceContext, unknown>
@@ -51,9 +60,14 @@ function validateExplicitContext(input: LoadInput) {
   }
 }
 
-function contextMatches(ctx: InstanceContext, input: LoadInput) {
-  if (!hasExplicitContext(input)) return true
-  return ctx.worktree === input.worktree && ctx.project.id === input.project?.id
+function contextMismatchReason(ctx: InstanceContext, input: LoadInput): ContextMismatchReason | undefined {
+  if (!hasExplicitContext(input)) return undefined
+  const worktreeChanged = ctx.worktree !== input.worktree
+  const projectChanged = ctx.project.id !== input.project?.id
+  if (worktreeChanged && projectChanged) return "explicit_context_changed"
+  if (worktreeChanged) return "worktree_mismatch"
+  if (projectChanged) return "project_id_mismatch"
+  return undefined
 }
 
 export const layer = Layer.effect(
@@ -116,10 +130,27 @@ export const layer = Layer.effect(
         }),
       )
 
+    const lifecycleContext = (operation: string, reason: string) => {
+      const request = currentRequestContext()
+      const explicitOrigin = currentLifecycleOrigin()
+      if (explicitOrigin) return { origin: explicitOrigin, ...(request ? { request } : {}) }
+      return request
+        ? {
+            origin: { source: "server_handler" as const, operation, reason: request.client_action?.kind ?? reason },
+            request,
+          }
+        : { origin: { source: "runtime" as const, operation, reason } }
+    }
+
     const disposeContext = (ctx: InstanceContext, action?: LifecycleCloseAction) =>
       Effect.gen(function* () {
         yield* Effect.promise(async () => {
-          const closeAction = action ?? createLifecycleCloseAction("instance_dispose")
+          const closeAction =
+            action ??
+            createLifecycleCloseAction("instance_dispose", {
+              affectedDirectories: [ctx.directory],
+              ...lifecycleContext("instance.dispose", "dispose_context"),
+            })
           await withLifecycleCloseAction([ctx.directory], closeAction, async () => {
             await State.dispose(ctx.directory)
             await runDisposers(ctx.directory)
@@ -137,7 +168,10 @@ export const layer = Layer.effect(
         return true
       })
 
-    const reload = (input: LoadInput): Effect.Effect<InstanceContext, unknown> => {
+    const reload = (
+      input: LoadInput,
+      reason: ContextMismatchReason | "reload" = "reload",
+    ): Effect.Effect<InstanceContext, unknown> => {
       const directory = Filesystem.resolve(input.directory)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
@@ -148,7 +182,14 @@ export const layer = Layer.effect(
           yield* Effect.gen(function* () {
             if (previous) {
               const exit = yield* Deferred.await(previous.deferred).pipe(Effect.exit)
-              if (Exit.isSuccess(exit)) yield* disposeContext(exit.value, createLifecycleCloseAction("instance_reload"))
+              if (Exit.isSuccess(exit))
+                yield* disposeContext(
+                  exit.value,
+                  createLifecycleCloseAction("instance_reload", {
+                    affectedDirectories: [exit.value.directory],
+                    ...lifecycleContext("instance.reload", reason),
+                  }),
+                )
               else yield* removeEntry(directory, previous)
             }
             yield* completeLoad(directory, input, entry)
@@ -166,11 +207,16 @@ export const layer = Layer.effect(
           const existing = entries.get(directory)
           if (existing) {
             const exit = yield* restore(Deferred.await(existing.deferred)).pipe(Effect.exit)
-            if (Exit.isSuccess(exit) && contextMatches(exit.value, input)) {
-              const row = yield* project.get(exit.value.project.id)
-              if (row) return exit.value
+            if (Exit.isSuccess(exit)) {
+              const mismatchReason = contextMismatchReason(exit.value, input)
+              if (!mismatchReason) {
+                const row = yield* project.get(exit.value.project.id)
+                if (row) return exit.value
+                return yield* reload(input, "project_row_missing")
+              }
+              return yield* reload(input, mismatchReason)
             }
-            return yield* reload(input)
+            return yield* reload(input, "unknown_context_mismatch")
           }
 
           const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext, unknown>() }
@@ -192,7 +238,15 @@ export const layer = Layer.effect(
         const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
         if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
         if (exit.value !== ctx) return
-        yield* disposeEntry(directory, entry, ctx, createLifecycleCloseAction("instance_dispose")).pipe(Effect.asVoid)
+        yield* disposeEntry(
+          directory,
+          entry,
+          ctx,
+          createLifecycleCloseAction("instance_dispose", {
+            affectedDirectories: [ctx.directory],
+            ...lifecycleContext("instance.dispose", "dispose"),
+          }),
+        ).pipe(Effect.asVoid)
       })
 
     const disposeDirectory = (inputDirectory: string) =>
@@ -203,13 +257,23 @@ export const layer = Layer.effect(
 
         const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
         if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
-        yield* disposeEntry(directory, entry, exit.value, createLifecycleCloseAction("instance_dispose_directory")).pipe(
-          Effect.asVoid,
-        )
+        yield* disposeEntry(
+          directory,
+          entry,
+          exit.value,
+          createLifecycleCloseAction("instance_dispose_directory", {
+            affectedDirectories: [exit.value.directory],
+            ...lifecycleContext("instance.disposeDirectory", "dispose_directory"),
+          }),
+        ).pipe(Effect.asVoid)
       })
 
     const disposeAllOnce = Effect.gen(function* () {
-      const action = createLifecycleCloseAction("instance_dispose_all")
+      const activeDirectories = [...entries.keys()]
+      const action = createLifecycleCloseAction("instance_dispose_all", {
+        affectedDirectories: activeDirectories,
+        ...lifecycleContext("instance.disposeAll", "dispose_all"),
+      })
       yield* Effect.forEach(
         [...entries.entries()],
         ([directory, entry]) =>
@@ -247,7 +311,8 @@ export const layer = Layer.effect(
       dispose,
       disposeDirectory,
       disposeAll,
-      provide: (input, effect) => load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx)))),
+      provide: (input, effect) =>
+        load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx)))),
     }
   }),
 )

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -15,6 +15,7 @@ import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { EventReplayStore, type GlobalEventEnvelope, type ReplayRecord } from "../event-replay"
+import { requestContextFromHono, withRequestContext } from "@/server/request-context"
 
 const log = Log.create({ service: "server" })
 
@@ -234,6 +235,7 @@ export async function streamGlobalEvents(
 
 export const GlobalRoutes = lazy(() =>
   new Hono()
+    .use((c, next) => withRequestContext(requestContextFromHono(c, {}), () => next()))
     .get(
       "/health",
       describeRoute({

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -13,6 +13,7 @@ import { SessionID } from "@/session/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Global } from "@/global"
 import { Runtime } from "@opencode-ai/core/runtime"
+import { requestContextFromHono, withRequestContext } from "@/server/request-context"
 
 type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
 
@@ -84,12 +85,15 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
         }
       }
 
-      return Instance.provide({
-        directory,
-        async fn() {
-          return next()
-        },
-      })
+      const snapshot = requestContextFromHono(c, { directory })
+      return withRequestContext(snapshot, () =>
+        Instance.provide({
+          directory,
+          async fn() {
+            return next()
+          },
+        }),
+      )
     }
 
     const workspace = await Workspace.record(WorkspaceID.make(workspaceID))
@@ -122,15 +126,18 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const target = await adaptor.target(workspace)
 
     if (target.type === "local") {
+      const snapshot = requestContextFromHono(c, { directory: target.directory, workspaceID })
       return WorkspaceContext.provide({
         workspaceID: WorkspaceID.make(workspaceID),
         fn: () =>
-          Instance.provide({
-            directory: target.directory,
-            async fn() {
-              return next()
-            },
-          }),
+          withRequestContext(snapshot, () =>
+            Instance.provide({
+              directory: target.directory,
+              async fn() {
+                return next()
+              },
+            }),
+          ),
       })
     }
 

--- a/packages/opencode/src/server/request-context.ts
+++ b/packages/opencode/src/server/request-context.ts
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+import type { Context } from "hono"
+import { directoryKey, type LifecycleClientAction, type LifecycleRequest } from "@/session/lifecycle-provenance"
+
+export type ClientActionSnapshot = LifecycleClientAction
+export type RequestContextSnapshot = LifecycleRequest
+
+const storage = new AsyncLocalStorage<RequestContextSnapshot>()
+
+export function currentRequestContext(): RequestContextSnapshot | undefined {
+  return storage.getStore()
+}
+
+export async function withRequestContext<T>(snapshot: RequestContextSnapshot, fn: () => Promise<T>): Promise<T> {
+  return storage.run(snapshot, fn)
+}
+
+export function requestContextFromHono(
+  c: Context,
+  input: { directory?: string; workspaceID?: string },
+): RequestContextSnapshot {
+  const clientActionID = safeHeaderToken(c.req.header("x-pawwork-client-action-id"))
+  const clientActionKind = safeHeaderToken(c.req.header("x-pawwork-client-action-kind"))
+  const routeSessionID = safeHeaderToken(c.req.header("x-pawwork-route-session-id"))
+  const visibleSessionID = safeHeaderToken(c.req.header("x-pawwork-visible-session-id"))
+  const client_action = clientActionID
+    ? {
+        id: clientActionID,
+        kind: clientActionKind ?? "unknown",
+        route_session_id: routeSessionID,
+        visible_session_id: visibleSessionID,
+      }
+    : undefined
+  return {
+    method: c.req.method,
+    path: c.req.path,
+    source: client_action ? "renderer" : "local_api",
+    directory_key: input.directory ? directoryKey(input.directory) : undefined,
+    workspace_id: input.workspaceID,
+    client_action,
+  }
+}
+
+function safeHeaderToken(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > 100) return "unknown"
+  if (/[/\\]|https?:\/\//i.test(trimmed)) return "unknown"
+  if (/token|secret|bearer|sk-|cookie|password/i.test(trimmed)) return "unknown"
+  if (!/^[a-zA-Z0-9_.:-]+$/.test(trimmed)) return "unknown"
+  return trimmed
+}

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -6,6 +6,7 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import type { WorkspaceID } from "@/control-plane/schema"
 import { Filesystem } from "@/util/filesystem"
 import { Instance } from "@/project/instance"
+import { requestContextFromHono, withRequestContext } from "@/server/request-context"
 
 export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler {
   return async (c, next) => {
@@ -29,11 +30,15 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
       }
     }
 
+    const snapshot = requestContextFromHono(c, { directory, workspaceID })
+
     const runInstance = () =>
-      Instance.provide({
-        directory,
-        fn: () => next(),
-      })
+      withRequestContext(snapshot, () =>
+        Instance.provide({
+          directory,
+          fn: () => next(),
+        }),
+      )
 
     if (!workspaceID) return runInstance()
 

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -161,6 +161,7 @@ export namespace Export {
       run_observability?: RunObservability.Summary[]
       run_incident_schema_version?: typeof RunIncident.SCHEMA_VERSION
       run_incidents?: RunIncident.Summary[]
+      incident_chains?: RunIncident.ExportIncidentChain[]
       aborts?: Array<{
         session_id: SessionID
         message_id: MessageID
@@ -215,6 +216,7 @@ export namespace Export {
     run_observability?: RunObservability.Summary[]
     run_incident_schema_version?: typeof RunIncident.SCHEMA_VERSION
     run_incidents?: RunIncident.Summary[]
+    incident_chains?: RunIncident.ExportIncidentChain[]
     aborts?: Array<{
       session_id: SessionID
       message_id: MessageID
@@ -301,6 +303,7 @@ export namespace Export {
     const llm_traces = collectLLMTraces(node)
     const run_observability = collectRunObservability(node)
     const run_incidents = collectRunIncidents(node)
+    const incident_chains = run_incidents.map(RunIncident.toExportChain)
     const aborts = collectAbortDiagnostics(node)
     const title_generations = collectTitleGenerations(node)
     return {
@@ -310,6 +313,7 @@ export namespace Export {
         ? { run_observability_schema_version: RunObservability.SCHEMA_VERSION, run_observability }
         : {}),
       ...(run_incidents.length ? { run_incident_schema_version: RunIncident.SCHEMA_VERSION, run_incidents } : {}),
+      ...(incident_chains.length ? { incident_chains } : {}),
       ...(aborts.length ? { aborts } : {}),
       ...(title_generations.length ? { title_generations } : {}),
     }
@@ -1031,6 +1035,29 @@ export namespace Export {
 
   function sanitizeDiagnostics(diagnostics: Snapshot["diagnostics"]): Snapshot["diagnostics"] {
     const last = diagnostics.loop?.last
+    const sanitizedIncidents = (
+      diagnostics.run_incidents ?? diagnostics.run_observability?.flatMap((summary) => summary.incident ?? [])
+    )?.map(RunIncident.sanitize)
+    const sanitizedChains =
+      sanitizedIncidents?.map(RunIncident.toExportChain) ??
+      diagnostics.incident_chains?.map((chain) => ({
+        ...chain,
+        plain_summary: redact("incident-chain-summary", chain.incident_id, chain.plain_summary),
+        nearest_origin: chain.nearest_origin
+          ? {
+              source: redact("incident-chain-origin-source", chain.incident_id, chain.nearest_origin.source),
+              operation:
+                chain.nearest_origin.operation === undefined
+                  ? undefined
+                  : redact("incident-chain-origin-operation", chain.incident_id, chain.nearest_origin.operation),
+              reason:
+                chain.nearest_origin.reason === undefined
+                  ? undefined
+                  : redact("incident-chain-origin-reason", chain.incident_id, chain.nearest_origin.reason),
+            }
+          : undefined,
+        nearest_request: chain.nearest_request ? RunIncident.sanitizeRequest(chain.nearest_request) : undefined,
+      }))
     return {
       ...diagnostics,
       ...(last
@@ -1065,9 +1092,8 @@ export namespace Export {
         (diagnostics.run_incidents?.length || diagnostics.run_observability?.some((summary) => summary.incident)
           ? RunIncident.SCHEMA_VERSION
           : undefined),
-      run_incidents: (
-        diagnostics.run_incidents ?? diagnostics.run_observability?.flatMap((summary) => summary.incident ?? [])
-      )?.map(RunIncident.sanitize),
+      run_incidents: sanitizedIncidents,
+      incident_chains: sanitizedChains,
     }
   }
 

--- a/packages/opencode/src/session/lifecycle-provenance.ts
+++ b/packages/opencode/src/session/lifecycle-provenance.ts
@@ -1,19 +1,92 @@
+import { createHash } from "node:crypto"
+import { AsyncLocalStorage } from "node:async_hooks"
 import type { LifecycleKind } from "./run-observability/types"
+
+export type LifecycleOrigin = {
+  source: "server_handler" | "config" | "cli" | "runtime" | "unknown"
+  operation?: string
+  reason?: string
+}
+
+export type LifecycleClientAction = {
+  id: string
+  kind?: string
+  route_session_id?: string
+  visible_session_id?: string
+}
+
+export type LifecycleRequest = {
+  method: string
+  path: string
+  source: "renderer" | "local_api" | "remote_forwarded" | "unknown"
+  directory_key?: string
+  workspace_id?: string
+  client_action?: LifecycleClientAction
+}
 
 export type LifecycleCloseAction = {
   actionID: string
   kind: LifecycleKind
+  initiatedAt: number
+  initiatedMonotonicMs: number
+  affectedDirectoryKeys: readonly string[]
+  origin?: Readonly<LifecycleOrigin>
+  request?: Readonly<LifecycleRequest>
+}
+
+export type CreateLifecycleCloseActionOptions = {
+  affectedDirectories?: string[]
+  origin?: LifecycleOrigin
+  request?: LifecycleRequest
 }
 
 let nextActionID = 0
 const activeByDirectory = new Map<string, LifecycleCloseAction[]>()
+const originContext = new AsyncLocalStorage<LifecycleOrigin>()
 
-export function createLifecycleCloseAction(kind: LifecycleKind): LifecycleCloseAction {
+export function directoryKey(directory: string): string {
+  const digest = createHash("sha256").update(directory).digest("hex").slice(0, 16)
+  return `dir:${digest}`
+}
+
+export function createLifecycleCloseAction(
+  kind: LifecycleKind,
+  options: CreateLifecycleCloseActionOptions = {},
+): LifecycleCloseAction {
   nextActionID += 1
   return {
     actionID: `lifecycle:${kind}:${Date.now().toString(36)}:${nextActionID.toString(36)}`,
     kind,
+    initiatedAt: Date.now(),
+    initiatedMonotonicMs: performance.now(),
+    affectedDirectoryKeys: Object.freeze([...new Set(options.affectedDirectories?.map(directoryKey) ?? [])]),
+    origin: options.origin ? Object.freeze({ ...options.origin }) : undefined,
+    request: options.request ? freezeRequest(options.request) : undefined,
   }
+}
+
+export function lifecycleCloseActionMeta(action: LifecycleCloseAction) {
+  return {
+    lifecycleActionID: action.actionID,
+    lifecycleKind: action.kind,
+    lifecycleInitiatedAt: action.initiatedAt,
+    lifecycleInitiatedMonotonicMs: action.initiatedMonotonicMs,
+    lifecycleAffectedDirectoryKeys: [...action.affectedDirectoryKeys],
+    lifecycleOrigin: action.origin ? { ...action.origin } : undefined,
+    lifecycleRequest: action.request ? cloneRequest(action.request) : undefined,
+  }
+}
+
+export function cloneRequest(request: Readonly<LifecycleRequest>): LifecycleRequest {
+  return {
+    ...request,
+    client_action: request.client_action ? { ...request.client_action } : undefined,
+  }
+}
+
+function freezeRequest(request: LifecycleRequest): Readonly<LifecycleRequest> {
+  const client_action = request.client_action ? Object.freeze({ ...request.client_action }) : undefined
+  return Object.freeze({ ...request, client_action })
 }
 
 export async function withLifecycleCloseAction<T>(
@@ -42,4 +115,13 @@ export async function withLifecycleCloseAction<T>(
 
 export function currentLifecycleCloseAction(directory: string): LifecycleCloseAction | undefined {
   return activeByDirectory.get(directory)?.at(-1)
+}
+
+export function currentLifecycleOrigin(): LifecycleOrigin | undefined {
+  const origin = originContext.getStore()
+  return origin ? { ...origin } : undefined
+}
+
+export async function withLifecycleOrigin<T>(origin: LifecycleOrigin, fn: () => Promise<T>): Promise<T> {
+  return originContext.run({ ...origin }, fn)
 }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -26,7 +26,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { TurnChange } from "./turn-change"
 import { LLMTrace } from "./llm-trace"
 import { RunObservability } from "./run-observability"
-import { currentLifecycleCloseAction } from "./lifecycle-provenance"
+import { currentLifecycleCloseAction, lifecycleCloseActionMeta } from "./lifecycle-provenance"
 
 const log = Log.create({ service: "session.processor" })
 const TOOL_CLEANUP_TIMEOUT_MS = 1_000
@@ -1154,8 +1154,7 @@ export const layer: Layer.Layer<
                   source: "session.processor.onInterrupt",
                   reason: "aborted",
                   propagationPoint: "session.processor.process.onInterrupt",
-                  lifecycleActionID: lifecycleAction?.actionID,
-                  lifecycleKind: lifecycleAction?.kind,
+                  ...(lifecycleAction ? lifecycleCloseActionMeta(lifecycleAction) : {}),
                 })
                 ctx.trace.recordAbortState({
                   provenanceSource: "session.processor.onInterrupt",

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -1,4 +1,5 @@
 import type { MessageID, SessionID } from "../schema"
+import type { LifecycleRequest } from "../lifecycle-provenance"
 import type { LifecycleKind, RunID, SafeErrorFingerprint, ToolEffectKind } from "../run-observability/types"
 import { recoveryFor } from "./policy"
 import { plainSummary, userSummary } from "./presentation"
@@ -24,7 +25,17 @@ export type DeriveIncidentInput = {
   unsafeSideEffectKinds: ToolEffectKind[]
   sideEffectFactsComplete: boolean
   materializedToolBoundaries?: MaterializedToolBoundary[]
-  lifecycle?: { action_id: string; kind: LifecycleKind; source?: string; reason?: string }
+  lifecycle?: {
+    action_id: string
+    kind: LifecycleKind
+    source?: string
+    reason?: string
+    initiated_at?: number
+    initiated_monotonic_ms?: number
+    affected_directory_keys: string[]
+    origin?: { source: string; operation?: string; reason?: string }
+    request?: LifecycleRequest
+  }
   missingProvenance?: string[]
 }
 
@@ -58,7 +69,11 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
               action_id: input.lifecycle.action_id,
               kind: input.lifecycle.kind,
               reason: input.lifecycle.reason,
-              affected_directory_keys: [],
+              initiated_at: input.lifecycle.initiated_at,
+              initiated_monotonic_ms: input.lifecycle.initiated_monotonic_ms,
+              affected_directory_keys: input.lifecycle.affected_directory_keys,
+              origin: input.lifecycle.origin,
+              request: input.lifecycle.request,
               completeness: "partial" as const,
             },
           }
@@ -82,6 +97,8 @@ function diagnosticGaps(
   const gaps: string[] = []
   if (!input.sideEffectFactsComplete) gaps.push("side_effect.boundary_unknown")
   if (terminal.monotonic_ms === undefined) gaps.push("evidence.ordering_missing")
+  if (input.lifecycle?.origin?.source === "server_handler" && !input.lifecycle.request)
+    gaps.push("lifecycle.request_context_missing")
   if (facts.tool_execution_started && !facts.tool_call_materialized) gaps.push("tool.materialization_missing")
   if (facts.tool_input_completed && !facts.tool_input_started) gaps.push("tool_input.start_missing")
   return Array.from(new Set(gaps))

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -68,6 +68,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
             lifecycle: {
               action_id: input.lifecycle.action_id,
               kind: input.lifecycle.kind,
+              source: input.lifecycle.source,
               reason: input.lifecycle.reason,
               initiated_at: input.lifecycle.initiated_at,
               initiated_monotonic_ms: input.lifecycle.initiated_monotonic_ms,

--- a/packages/opencode/src/session/run-incident/index.ts
+++ b/packages/opencode/src/session/run-incident/index.ts
@@ -1,9 +1,30 @@
 import { deriveIncident as deriveRunIncident, transportCause as providerTransportCause } from "./derive"
 import { recoveryFor as deriveRecovery } from "./policy"
 import { plainSummary as derivePlainSummary, userSummary as deriveUserSummary } from "./presentation"
-import { sanitizeIncident as sanitizeRunIncident } from "./sanitize"
+import { sanitizeIncident as sanitizeRunIncident, sanitizeLifecycleRequest } from "./sanitize"
 import { RUN_INCIDENT_SCHEMA_VERSION as VERSION } from "./types"
 import * as Types from "./types"
+
+function exportChain(incident: Types.RunIncident): Types.ExportIncidentChain {
+  return {
+    incident_id: incident.incident_id,
+    run_id: incident.run_id,
+    session_id: incident.session_id,
+    message_id: incident.message_id,
+    terminal_cause_category: incident.terminal_cause.category,
+    terminal_cause_subcategory:
+      "subcategory" in incident.terminal_cause ? String(incident.terminal_cause.subcategory) : undefined,
+    run_phase: incident.phase.run_phase,
+    stream_phase: incident.phase.stream_phase,
+    tool_phase: incident.phase.tool_phase,
+    recovery_recommendation: incident.recovery.recommendation,
+    nearest_origin: incident.provenance.lifecycle?.origin,
+    nearest_request: incident.provenance.lifecycle?.request,
+    missing_provenance: incident.missing_provenance,
+    diagnostics_complete: incident.diagnostics_complete,
+    plain_summary: incident.plain_summary,
+  }
+}
 
 export namespace RunIncident {
   export const SCHEMA_VERSION = VERSION
@@ -13,6 +34,8 @@ export namespace RunIncident {
   export const userSummary = deriveUserSummary
   export const plainSummary = derivePlainSummary
   export const sanitize = sanitizeRunIncident
+  export const sanitizeRequest = sanitizeLifecycleRequest
+  export const toExportChain = exportChain
 
   export type Summary = Types.RunIncident
   export type RunIncident = Types.RunIncident
@@ -23,4 +46,5 @@ export namespace RunIncident {
   export type Facts = Types.IncidentFacts
   export type Recovery = Types.RecoveryDecision
   export type MaterializedToolBoundary = Types.MaterializedToolBoundary
+  export type ExportIncidentChain = Types.ExportIncidentChain
 }

--- a/packages/opencode/src/session/run-incident/sanitize.ts
+++ b/packages/opencode/src/session/run-incident/sanitize.ts
@@ -1,12 +1,82 @@
 import type { IncidentEvidenceSummary, RunIncident } from "./types"
 
 const MAX_EXPORTED_EVIDENCE = 24
+type LifecycleProvenance = NonNullable<RunIncident["provenance"]["lifecycle"]>
 
 export function sanitizeIncident(incident: RunIncident): RunIncident {
   return {
     ...incident,
+    provenance: sanitizeProvenance(incident.provenance),
     evidence: boundEvidence(incident),
   }
+}
+
+function sanitizeProvenance(provenance: RunIncident["provenance"]): RunIncident["provenance"] {
+  return {
+    ...provenance,
+    lifecycle: provenance.lifecycle
+      ? {
+          ...provenance.lifecycle,
+          origin: provenance.lifecycle.origin ? sanitizeOrigin(provenance.lifecycle.origin) : undefined,
+          request: provenance.lifecycle.request ? sanitizeRequest(provenance.lifecycle.request) : undefined,
+        }
+      : undefined,
+  }
+}
+
+function sanitizeOrigin(origin: NonNullable<LifecycleProvenance["origin"]>) {
+  return {
+    source: safeToken(origin?.source, "unknown"),
+    operation: origin?.operation === undefined ? undefined : safeToken(origin.operation, "unknown"),
+    reason: origin?.reason === undefined ? undefined : safeToken(origin.reason, "unknown"),
+  }
+}
+
+function sanitizeRequest(request: NonNullable<LifecycleProvenance["request"]>) {
+  return {
+    method: safeMethod(request.method),
+    path: safeRoutePath(request.path),
+    source: safeToken(request.source, "unknown") as typeof request.source,
+    directory_key: request.directory_key === undefined ? undefined : safeToken(request.directory_key, "unknown"),
+    workspace_id: request.workspace_id === undefined ? undefined : safeToken(request.workspace_id, "unknown"),
+    client_action: request.client_action
+      ? {
+          id: safeToken(request.client_action.id, "unknown"),
+          kind: request.client_action.kind === undefined ? undefined : safeToken(request.client_action.kind, "unknown"),
+          route_session_id:
+            request.client_action.route_session_id === undefined
+              ? undefined
+              : safeToken(request.client_action.route_session_id, "unknown"),
+          visible_session_id:
+            request.client_action.visible_session_id === undefined
+              ? undefined
+              : safeToken(request.client_action.visible_session_id, "unknown"),
+        }
+      : undefined,
+  }
+}
+
+function safeMethod(value: string) {
+  const upper = value.toUpperCase()
+  return /^(GET|POST|PATCH|PUT|DELETE|OPTIONS|HEAD)$/.test(upper) ? upper : "UNKNOWN"
+}
+
+function safeRoutePath(value: string) {
+  const trimmed = value.trim().slice(0, 120)
+  if (!trimmed.startsWith("/")) return "unknown"
+  if (/\/Users\/|\/home\/|[/\\].*(token|secret|bearer|sk-|cookie|password)/i.test(trimmed)) return "unknown"
+  if (!/^\/[a-zA-Z0-9_./:-]*$/.test(trimmed)) return "unknown"
+  return trimmed
+}
+
+function safeToken(value: string | undefined, fallback: string) {
+  if (!value) return fallback
+  const trimmed = value.trim().slice(0, 100)
+  if (!trimmed) return fallback
+  if (/[/\\]|https?:\/\//i.test(trimmed)) return fallback
+  if (/token|secret|bearer|sk-|cookie|password/i.test(trimmed)) return fallback
+  if (!/^[a-zA-Z0-9_.:-]+$/.test(trimmed)) return fallback
+  return trimmed
 }
 
 function boundEvidence(incident: RunIncident): IncidentEvidenceSummary[] | undefined {

--- a/packages/opencode/src/session/run-incident/sanitize.ts
+++ b/packages/opencode/src/session/run-incident/sanitize.ts
@@ -32,7 +32,7 @@ function sanitizeOrigin(origin: NonNullable<LifecycleProvenance["origin"]>) {
   }
 }
 
-function sanitizeRequest(request: NonNullable<LifecycleProvenance["request"]>) {
+export function sanitizeLifecycleRequest(request: NonNullable<LifecycleProvenance["request"]>) {
   return {
     method: safeMethod(request.method),
     path: safeRoutePath(request.path),
@@ -55,6 +55,8 @@ function sanitizeRequest(request: NonNullable<LifecycleProvenance["request"]>) {
       : undefined,
   }
 }
+
+const sanitizeRequest = sanitizeLifecycleRequest
 
 function safeMethod(value: string) {
   const upper = value.toUpperCase()

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -139,6 +139,7 @@ export type IncidentProvenance = {
   lifecycle?: {
     action_id: string
     kind: LifecycleKind
+    source?: string
     reason?: string
     initiated_at?: number
     initiated_monotonic_ms?: number

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -8,6 +8,7 @@ import type {
   ToolEffect,
   ToolEffectKind,
 } from "../run-observability/types"
+import type { LifecycleRequest } from "../lifecycle-provenance"
 
 export const RUN_INCIDENT_SCHEMA_VERSION = 1
 
@@ -139,7 +140,11 @@ export type IncidentProvenance = {
     action_id: string
     kind: LifecycleKind
     reason?: string
+    initiated_at?: number
+    initiated_monotonic_ms?: number
     affected_directory_keys: string[]
+    origin?: { source: string; operation?: string; reason?: string }
+    request?: LifecycleRequest
     completeness: "complete" | "partial" | "unknown"
   }
   interrupt?: {
@@ -208,4 +213,22 @@ export type RunIncident = {
   plain_summary: string
   missing_provenance?: string[]
   diagnostics_complete: boolean
+}
+
+export type ExportIncidentChain = {
+  incident_id: string
+  run_id: RunID
+  session_id: SessionID
+  message_id: MessageID
+  terminal_cause_category: TerminalCause["category"]
+  terminal_cause_subcategory?: string
+  run_phase: IncidentPhase["run_phase"]
+  stream_phase?: IncidentPhase["stream_phase"]
+  tool_phase?: IncidentPhase["tool_phase"]
+  recovery_recommendation: RecoveryDecision["recommendation"]
+  nearest_origin?: { source: string; operation?: string; reason?: string }
+  nearest_request?: LifecycleRequest
+  missing_provenance?: string[]
+  diagnostics_complete: boolean
+  plain_summary: string
 }

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -14,6 +14,7 @@ import {
 } from "./types"
 import { safeErrorFingerprint } from "./sanitize"
 import { RunIncident } from "../run-incident"
+import { cloneRequest, type LifecycleRequest } from "../lifecycle-provenance"
 
 type AttemptMutable = AttemptSummary & { lastMonotonicMs: number }
 
@@ -28,8 +29,15 @@ type Failure =
       reason?: string
       lifecycleActionID?: string
       lifecycleKind?: LifecycleKind
+      lifecycleInitiatedAt?: number
+      lifecycleInitiatedMonotonicMs?: number
+      lifecycleAffectedDirectoryKeys?: string[]
+      lifecycleOrigin?: { source: string; operation?: string; reason?: string }
+      lifecycleRequest?: LifecycleRequest
     }
   | { type: "tool"; at: number; monotonicMs: number; error?: unknown; attemptID?: AttemptID }
+
+type ScopeClosedFailure = Extract<Failure, { type: "scope_closed" }>
 
 export function createRecorder(input: RecorderInput): Recorder {
   const attempts: AttemptMutable[] = []
@@ -48,6 +56,7 @@ export function createRecorder(input: RecorderInput): Recorder {
   const materializedToolBoundaries: RunIncident.MaterializedToolBoundary[] = []
   let lastEventMonotonicMs = input.monotonicStartMs
   let failure: Failure | undefined
+  let lifecycleFailure: ScopeClosedFailure | undefined
   let pendingToolPartsInterrupted = 0
   const evidence: RunIncident.EvidenceEvent[] = []
 
@@ -380,7 +389,8 @@ export function createRecorder(input: RecorderInput): Recorder {
       rememberEvent(next.monotonicMs)
     },
     recordScopeClosed(next) {
-      failure ??= {
+      const lifecycleCauseMonotonicMs = next.lifecycleInitiatedMonotonicMs ?? next.monotonicMs
+      const nextFailure: ScopeClosedFailure = {
         type: "scope_closed",
         at: next.at,
         monotonicMs: next.monotonicMs,
@@ -388,9 +398,18 @@ export function createRecorder(input: RecorderInput): Recorder {
         reason: next.reason,
         lifecycleActionID: next.lifecycleActionID,
         lifecycleKind: next.lifecycleKind,
+        lifecycleInitiatedAt: next.lifecycleInitiatedAt,
+        lifecycleInitiatedMonotonicMs: next.lifecycleInitiatedMonotonicMs,
+        lifecycleAffectedDirectoryKeys: next.lifecycleAffectedDirectoryKeys
+          ? [...next.lifecycleAffectedDirectoryKeys]
+          : undefined,
+        lifecycleOrigin: next.lifecycleOrigin ? { ...next.lifecycleOrigin } : undefined,
+        lifecycleRequest: next.lifecycleRequest ? cloneRequest(next.lifecycleRequest) : undefined,
       }
+      failure ??= nextFailure
+      lifecycleFailure = earlierLifecycleFailure(lifecycleFailure, nextFailure)
       appendEvidence({
-        monotonic_ms: next.monotonicMs,
+        monotonic_ms: lifecycleCauseMonotonicMs,
         source: "lifecycle",
         event_type: "lifecycle_close_seen",
         terminal_candidate: true,
@@ -401,9 +420,20 @@ export function createRecorder(input: RecorderInput): Recorder {
           confidence: next.lifecycleActionID ? "high" : "medium",
         },
       })
+      if (lifecycleCauseMonotonicMs !== next.monotonicMs) {
+        appendEvidence({
+          monotonic_ms: next.monotonicMs,
+          source: "lifecycle",
+          event_type: "lifecycle_close_propagated",
+          terminal_candidate: false,
+          confidence: next.lifecycleActionID ? "high" : "medium",
+        })
+      }
       rememberEvent(next.monotonicMs)
     },
     finalize(final) {
+      const lifecycle = lifecycleSummary(lifecycleFailure)
+      const incidentLifecycle = lifecycleSummary(lifecycleFailure)
       const incident = RunIncident.derive({
         runID: input.runID,
         traceID: input.traceID,
@@ -416,8 +446,8 @@ export function createRecorder(input: RecorderInput): Recorder {
         unsafeSideEffectKinds: unsafeKinds,
         sideEffectFactsComplete,
         materializedToolBoundaries,
-        lifecycle: lifecycleSummary(failure),
-        missingProvenance: classify(failure) === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined,
+        lifecycle: incidentLifecycle,
+        missingProvenance: lifecycleFailure && !lifecycle ? ["lifecycle.close_requested"] : undefined,
       })
       const classification = incident ? classificationForIncident(incident.terminal_cause) : classify(failure)
       const missingProvenance = classification === "unknown_scope_close" ? ["lifecycle.close_requested"] : undefined
@@ -466,7 +496,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         side_effect_facts_complete: sideEffectFactsComplete,
         pending_tool_parts_interrupted: pendingToolPartsInterrupted || undefined,
         incident,
-        lifecycle: lifecycleSummary(failure),
+        lifecycle,
         missing_provenance: missingProvenance,
         durations_ms: {
           total: duration(input.monotonicStartMs, final.monotonicMs),
@@ -574,7 +604,23 @@ function lifecycleSummary(failure: Failure | undefined): Summary["lifecycle"] {
     kind: failure.lifecycleKind,
     source: failure.source,
     reason: failure.reason,
+    initiated_at: failure.lifecycleInitiatedAt,
+    initiated_monotonic_ms: failure.lifecycleInitiatedMonotonicMs,
+    affected_directory_keys: [...(failure.lifecycleAffectedDirectoryKeys ?? [])],
+    origin: failure.lifecycleOrigin ? { ...failure.lifecycleOrigin } : undefined,
+    request: failure.lifecycleRequest ? cloneRequest(failure.lifecycleRequest) : undefined,
   }
+}
+
+function earlierLifecycleFailure(
+  current: ScopeClosedFailure | undefined,
+  next: ScopeClosedFailure,
+): ScopeClosedFailure {
+  if (!current) return next
+  const currentTime = current.lifecycleInitiatedMonotonicMs ?? current.monotonicMs
+  const nextTime = next.lifecycleInitiatedMonotonicMs ?? next.monotonicMs
+  if (nextTime < currentTime) return next
+  return current
 }
 
 export function isProviderProgressEvent(event: { type: string }) {

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -1,6 +1,7 @@
 import { MessageID, SessionID } from "../schema"
 import z from "zod"
 import type { RunIncident } from "../run-incident"
+import type { LifecycleRequest } from "../lifecycle-provenance"
 
 export const SCHEMA_VERSION = 1
 
@@ -113,6 +114,11 @@ export type Summary = {
     kind: LifecycleKind
     source?: string
     reason?: string
+    initiated_at?: number
+    initiated_monotonic_ms?: number
+    affected_directory_keys: string[]
+    origin?: { source: string; operation?: string; reason?: string }
+    request?: LifecycleRequest
   }
   missing_provenance?: string[]
   durations_ms: {
@@ -197,6 +203,11 @@ export type Recorder = {
     propagationPoint?: string
     lifecycleActionID?: string
     lifecycleKind?: LifecycleKind
+    lifecycleInitiatedAt?: number
+    lifecycleInitiatedMonotonicMs?: number
+    lifecycleAffectedDirectoryKeys?: string[]
+    lifecycleOrigin?: { source: string; operation?: string; reason?: string }
+    lifecycleRequest?: LifecycleRequest
   }): void
   finalize(input: { completedAt?: number; monotonicMs: number }): Summary
 }

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -5,7 +5,7 @@ import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
-import { currentLifecycleCloseAction } from "./lifecycle-provenance"
+import { currentLifecycleCloseAction, lifecycleCloseActionMeta } from "./lifecycle-provenance"
 
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
@@ -41,7 +41,7 @@ export const layer = Layer.effect(
           return {
             source: "session.run_state.scope",
             reason: "scope_closed_without_cancel_meta",
-            ...(action ? { lifecycleActionID: action.actionID, lifecycleKind: action.kind } : {}),
+            ...(action ? lifecycleCloseActionMeta(action) : {}),
           } satisfies InterruptMeta
         }
         yield* Effect.addFinalizer(
@@ -54,7 +54,7 @@ export const layer = Layer.effect(
                 runner.cancelWith({
                   source: "session.run_state.finalizer",
                   reason: "scope_finalizer",
-                  ...(action ? { lifecycleActionID: action.actionID, lifecycleKind: action.kind } : {}),
+                  ...(action ? lifecycleCloseActionMeta(action) : {}),
                 }),
               {
                 concurrency: "unbounded",

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -8,7 +8,9 @@ import { InstanceBootstrap } from "../../src/project/bootstrap-service"
 import { Instance } from "../../src/project/instance"
 import { InstanceStore } from "../../src/project/instance-store"
 import { Project } from "../../src/project/project"
-import { Database } from "../../src/storage/db"
+import { ProjectTable } from "../../src/project/project.sql"
+import { Database, eq } from "../../src/storage/db"
+import { currentLifecycleCloseAction } from "../../src/session/lifecycle-provenance"
 import { disposeAllInstances, tmpdir, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -92,6 +94,49 @@ describe("InstanceStore", () => {
       expect(second).not.toBe(first)
       expect(cached).toBe(second)
       expect(disposed).toEqual([dir])
+    }),
+  )
+
+  it.live("records worktree mismatch when load reloads an active instance", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const reasons: string[] = []
+      const off = registerDisposer(async (directory) => {
+        const action = currentLifecycleCloseAction(directory)
+        if (action?.origin?.reason) reasons.push(action.origin.reason)
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const first = yield* store.load({ directory: dir })
+      yield* store.load({
+        directory: dir,
+        worktree: `${first.worktree}-changed`,
+        project: first.project,
+      })
+
+      expect(reasons).toContain("worktree_mismatch")
+    }),
+  )
+
+  it.live("records project row missing when load reloads a stale active instance", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const reasons: string[] = []
+      const off = registerDisposer(async (directory) => {
+        const action = currentLifecycleCloseAction(directory)
+        if (action?.origin?.reason) reasons.push(action.origin.reason)
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const first = yield* store.load({ directory: dir })
+      yield* Effect.sync(() =>
+        Database.use((database) => database.delete(ProjectTable).where(eq(ProjectTable.id, first.project.id)).run()),
+      )
+      yield* store.load({ directory: dir })
+
+      expect(reasons).toContain("project_row_missing")
     }),
   )
 

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -3,7 +3,11 @@ import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { InvalidError, JsonError } from "../../src/config/error"
 import { ErrorMiddleware } from "../../src/server/middleware"
+import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
+import { InstanceMiddleware } from "../../src/server/routes/instance/middleware"
+import { currentRequestContext } from "../../src/server/request-context"
 import { NotFoundError } from "../../src/storage/db"
+import { tmpdir } from "../fixture/fixture"
 
 type ErrorLogCall = {
   message?: unknown
@@ -29,6 +33,84 @@ async function captureServerErrorLogs(fn: (calls: ErrorLogCall[]) => Promise<voi
 }
 
 describe("server error middleware", () => {
+  test("instance middleware records safe request context from headers", async () => {
+    const app = new Hono()
+    app.use(InstanceMiddleware())
+    app.get("/context", (c) => c.json(currentRequestContext()))
+
+    const response = await app.request("/context?directory=%2Ftmp%2Fpawwork-request-context", {
+      headers: {
+        "x-pawwork-client-action-id": "client-action-1",
+        "x-pawwork-client-action-kind": "settings.provider.disconnect",
+        "x-pawwork-route-session-id": "ses_route",
+      },
+    })
+    const body = await response.json()
+
+    expect(body).toMatchObject({
+      method: "GET",
+      path: "/context",
+      source: "renderer",
+      directory_key: expect.stringMatching(/^dir:/),
+      client_action: {
+        id: "client-action-1",
+        kind: "settings.provider.disconnect",
+        route_session_id: "ses_route",
+      },
+    })
+    expect(JSON.stringify(body)).not.toContain("/tmp/pawwork-request-context")
+  })
+
+  test("instance middleware normalizes unsafe client action headers", async () => {
+    const app = new Hono()
+    app.use(InstanceMiddleware())
+    app.get("/context", (c) => c.json(currentRequestContext()))
+
+    const response = await app.request("/context?directory=%2Ftmp%2Fpawwork-request-context", {
+      headers: {
+        "x-pawwork-client-action-id": "client-action-unsafe",
+        "x-pawwork-client-action-kind": "/Users/alice/project sk-secret",
+      },
+    })
+    const body = await response.json()
+
+    expect(body.client_action).toMatchObject({
+      id: "client-action-unsafe",
+      kind: "unknown",
+    })
+    expect(JSON.stringify(body)).not.toContain("/Users/alice")
+    expect(JSON.stringify(body)).not.toContain("sk-secret")
+  })
+
+  test("workspace router records safe request context on main instance routes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const app = new Hono()
+    app.use(WorkspaceRouterMiddleware(() => undefined as never))
+    app.get("/context", (c) => c.json(currentRequestContext()))
+
+    const response = await app.request(`/context?directory=${encodeURIComponent(tmp.path)}`, {
+      headers: {
+        "x-pawwork-client-action-id": "client-action-main-route",
+        "x-pawwork-client-action-kind": "project.git.init",
+      },
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body).toMatchObject({
+      method: "GET",
+      path: "/context",
+      source: "renderer",
+      directory_key: expect.stringMatching(/^dir:/),
+      client_action: {
+        id: "client-action-main-route",
+        kind: "project.git.init",
+      },
+    })
+    expect(JSON.stringify(body)).not.toContain("/tmp/pawwork-workspace-context")
+    expect(JSON.stringify(body)).not.toContain(tmp.path)
+  })
+
   test("serializes config named errors instead of wrapping them as unknown errors", async () => {
     const app = new Hono().get("/boom", () => {
       throw new JsonError({ path: "opencode.json", message: "bad json" })

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -1902,6 +1902,16 @@ describe("redactPart", () => {
 
     expect(sanitized.diagnostics.run_incident_schema_version).toBe(1)
     expect(sanitized.diagnostics.run_incidents?.[0]?.terminal_cause.category).toBe("provider_transport_disconnect")
+    expect(sanitized.diagnostics.incident_chains?.[0]).toMatchObject({
+      incident_id: "incident:msg_sanitize",
+      run_id: RunObservability.RunID.make("run_sanitize_incident"),
+      session_id: SessionID.make("ses_sanitize_incident"),
+      message_id: MessageID.make("msg_sanitize_incident"),
+      terminal_cause_category: "provider_transport_disconnect",
+      run_phase: "tool_generation",
+      recovery_recommendation: "offer_continue",
+      diagnostics_complete: true,
+    })
     expect(sanitized.diagnostics.run_incidents?.[0]?.evidence?.map((event) => event.event_type)).toEqual([
       "provider_transport_failure",
       "pending_tool_part_interrupted",
@@ -1912,6 +1922,153 @@ describe("redactPart", () => {
     expect(serialized).toContain("raw_tool_input")
     expect(serialized).not.toContain("/Users/secret")
     expect(serialized).not.toContain("sk-private")
+  })
+
+  test("sanitizes precomputed incident chains in snapshots", () => {
+    const sanitized = Export.sanitizeSnapshot({
+      schema_version: 1,
+      format: "pawwork-session-export",
+      exported_at: 1,
+      root_session_id: SessionID.make("ses_chain_sanitize"),
+      runtime_context: {
+        app_version: "test",
+        runtime_namespace: "pawwork",
+        platform: process.platform,
+        os_version: "test",
+        locale: "en-US",
+        timezone: "UTC",
+        instruction_sources: [],
+        model_refs: {},
+        stats: { session_count: 1, message_count: 0, part_count: 0, omitted_attachment_count: 0 },
+      },
+      diagnostics: {
+        incident_chains: [
+          {
+            incident_id: "incident:chain_sanitize",
+            run_id: RunObservability.RunID.make("run_chain_sanitize"),
+            session_id: SessionID.make("ses_chain_sanitize"),
+            message_id: MessageID.make("msg_chain_sanitize"),
+            terminal_cause_category: "local_lifecycle_close",
+            run_phase: "unknown",
+            recovery_recommendation: "do_not_retry",
+            nearest_origin: {
+              source: "server_handler",
+              operation: "/Users/alice/project/private-route",
+              reason: "sk-secret",
+            },
+            nearest_request: {
+              method: "POST",
+              path: "/Users/alice/project",
+              source: "renderer",
+              directory_key: "dir:safe",
+              workspace_id: "workspace/secret",
+              client_action: {
+                id: "client-action sk-secret",
+                kind: "/Users/alice/project sk-secret",
+              },
+            },
+            diagnostics_complete: false,
+            plain_summary: "secret path /Users/alice/project and token sk-secret",
+          },
+        ],
+      },
+      session: {
+        info: {
+          id: SessionID.make("ses_chain_sanitize"),
+          version: "0.0.0",
+          time: { created: 1, updated: 1 },
+          title: "x",
+          directory: "/tmp/project",
+        } as SessionNs.Info,
+        had_cloud_share: false,
+        diffs: [],
+        messages: [],
+        children: [],
+      },
+    })
+
+    const serialized = JSON.stringify(sanitized.diagnostics.incident_chains)
+    expect(serialized).toContain("[redacted:incident-chain-summary:incident:chain_sanitize]")
+    expect(serialized).toContain("incident-chain-origin-operation")
+    expect(serialized).toContain("unknown")
+    expect(serialized).not.toContain("/Users/alice")
+    expect(serialized).not.toContain("sk-secret")
+  })
+
+  test("sanitizes generated lifecycle incident provenance and chains", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_generated_chain_sanitize"),
+      traceID: MessageID.make("msg_generated_chain_sanitize"),
+      sessionID: SessionID.make("ses_generated_chain_sanitize"),
+      messageID: MessageID.make("msg_generated_chain_sanitize"),
+      providerID: "test",
+      modelID: "test-model",
+      createdAt: 1,
+      monotonicStartMs: 100,
+    })
+    recorder.recordScopeClosed({
+      at: 2,
+      monotonicMs: 120,
+      lifecycleActionID: "lifecycle:instance_reload:unsafe_request",
+      lifecycleKind: "instance_reload",
+      lifecycleAffectedDirectoryKeys: ["dir:safe"],
+      lifecycleOrigin: {
+        source: "server_handler",
+        operation: "instance.reload",
+        reason: "/Users/alice/project sk-secret",
+      },
+      lifecycleRequest: {
+        method: "POST",
+        path: "/project/git/init",
+        source: "renderer",
+        directory_key: "dir:safe",
+        client_action: {
+          id: "client-action-unsafe",
+          kind: "/Users/alice/project sk-secret",
+        },
+      },
+    })
+    const summary = recorder.finalize({ completedAt: 3, monotonicMs: 130 })
+
+    const sanitized = Export.sanitizeSnapshot({
+      schema_version: 1,
+      format: "pawwork-session-export",
+      exported_at: 1,
+      root_session_id: SessionID.make("ses_generated_chain_sanitize"),
+      runtime_context: {
+        app_version: "test",
+        runtime_namespace: "pawwork",
+        platform: process.platform,
+        os_version: "test",
+        locale: "en-US",
+        timezone: "UTC",
+        instruction_sources: [],
+        model_refs: {},
+        stats: { session_count: 1, message_count: 0, part_count: 0, omitted_attachment_count: 0 },
+      },
+      diagnostics: { run_observability_schema_version: 1, run_observability: [summary] },
+      session: {
+        info: {
+          id: SessionID.make("ses_generated_chain_sanitize"),
+          version: "0.0.0",
+          time: { created: 1, updated: 1 },
+          title: "x",
+          directory: "/tmp/project",
+        } as SessionNs.Info,
+        had_cloud_share: false,
+        diffs: [],
+        messages: [],
+        children: [],
+      },
+    })
+
+    const serialized = JSON.stringify({
+      run_incidents: sanitized.diagnostics.run_incidents,
+      incident_chains: sanitized.diagnostics.incident_chains,
+    })
+    expect(serialized).toContain("unknown")
+    expect(serialized).not.toContain("/Users/alice")
+    expect(serialized).not.toContain("sk-secret")
   })
 
   test("redacts data: url inside completed tool attachments", () => {

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1333,6 +1333,7 @@ describe("RunObservability", () => {
     expect(summary.incident?.provenance.lifecycle).toMatchObject({
       action_id: "lifecycle:instance_reload:abc123",
       kind: "instance_reload",
+      source: "session.run_state.finalizer",
       initiated_at: 18,
       initiated_monotonic_ms: 180,
       affected_directory_keys: ["dir:testreload"],

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { MessageID, SessionID } from "../../src/session/schema"
+import { RunIncident } from "../../src/session/run-incident"
 import { RunObservability } from "../../src/session/run-observability"
 
 describe("RunObservability", () => {
@@ -520,6 +521,133 @@ describe("RunObservability", () => {
     expect(lifecycleFirst.finalize({ completedAt: 14, monotonicMs: 140 }).incident?.terminal_cause).toMatchObject({
       category: "local_lifecycle_close",
       subcategory: "instance_reload",
+    })
+  })
+
+  test("orders lifecycle terminal causes by initiation time instead of finalizer time", () => {
+    const lifecycleBeforeProvider = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_initiated_first"),
+      traceID: MessageID.make("msg_lifecycle_initiated_first"),
+      sessionID: SessionID.make("ses_lifecycle_initiated_first"),
+      messageID: MessageID.make("msg_lifecycle_initiated_first"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const lifecycleBeforeAttempt = lifecycleBeforeProvider.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    lifecycleBeforeProvider.recordTransportFailure({
+      attemptID: lifecycleBeforeAttempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    lifecycleBeforeProvider.recordScopeClosed({
+      at: 14,
+      monotonicMs: 140,
+      lifecycleActionID: "lifecycle:instance_reload:initiated_before_provider",
+      lifecycleKind: "instance_reload",
+      lifecycleInitiatedMonotonicMs: 120,
+    })
+    expect(
+      lifecycleBeforeProvider.finalize({ completedAt: 15, monotonicMs: 150 }).incident?.terminal_cause,
+    ).toMatchObject({
+      category: "local_lifecycle_close",
+      subcategory: "instance_reload",
+    })
+
+    const providerBeforeLifecycle = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_provider_initiated_first"),
+      traceID: MessageID.make("msg_provider_initiated_first"),
+      sessionID: SessionID.make("ses_provider_initiated_first"),
+      messageID: MessageID.make("msg_provider_initiated_first"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const providerBeforeAttempt = providerBeforeLifecycle.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    providerBeforeLifecycle.recordTransportFailure({
+      attemptID: providerBeforeAttempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    providerBeforeLifecycle.recordScopeClosed({
+      at: 14,
+      monotonicMs: 140,
+      lifecycleActionID: "lifecycle:instance_reload:initiated_after_provider",
+      lifecycleKind: "instance_reload",
+      lifecycleInitiatedMonotonicMs: 130,
+    })
+    expect(
+      providerBeforeLifecycle.finalize({ completedAt: 15, monotonicMs: 150 }).incident?.terminal_cause.category,
+    ).toBe("provider_transport_disconnect")
+  })
+
+  test("keeps lifecycle provenance when provider failure records before earlier lifecycle close propagates", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_provenance_after_provider"),
+      traceID: MessageID.make("msg_lifecycle_provenance_after_provider"),
+      sessionID: SessionID.make("ses_lifecycle_provenance_after_provider"),
+      messageID: MessageID.make("msg_lifecycle_provenance_after_provider"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    recorder.recordScopeClosed({
+      at: 14,
+      monotonicMs: 140,
+      lifecycleActionID: "lifecycle:instance_reload:initiated_before_provider_with_request",
+      lifecycleKind: "instance_reload",
+      lifecycleInitiatedAt: 12,
+      lifecycleInitiatedMonotonicMs: 120,
+      lifecycleAffectedDirectoryKeys: ["dir:provenance"],
+      lifecycleOrigin: { source: "server_handler", operation: "instance.reload", reason: "project.git.init" },
+      lifecycleRequest: {
+        method: "POST",
+        path: "/project/git/init",
+        source: "renderer",
+        directory_key: "dir:provenance",
+        workspace_id: "workspace-provenance",
+        client_action: { id: "client-provenance", kind: "project.git.init" },
+      },
+    })
+
+    const incident = recorder.finalize({ completedAt: 15, monotonicMs: 150 }).incident
+    expect(incident?.terminal_cause).toMatchObject({
+      category: "local_lifecycle_close",
+      subcategory: "instance_reload",
+    })
+    expect(incident?.provenance.lifecycle).toMatchObject({
+      action_id: "lifecycle:instance_reload:initiated_before_provider_with_request",
+      kind: "instance_reload",
+      origin: { source: "server_handler", operation: "instance.reload", reason: "project.git.init" },
+      request: {
+        method: "POST",
+        path: "/project/git/init",
+        source: "renderer",
+        client_action: { id: "client-provenance", kind: "project.git.init" },
+      },
+    })
+    expect(RunIncident.toExportChain(incident!).nearest_origin).toMatchObject({
+      source: "server_handler",
+      operation: "instance.reload",
+      reason: "project.git.init",
+    })
+    expect(RunIncident.toExportChain(incident!).nearest_request).toMatchObject({
+      method: "POST",
+      path: "/project/git/init",
+      source: "renderer",
+      client_action: { id: "client-provenance", kind: "project.git.init" },
     })
   })
 
@@ -1183,6 +1311,10 @@ describe("RunObservability", () => {
       propagationPoint: "session.prompt.loop.onInterrupt",
       lifecycleActionID: "lifecycle:instance_reload:abc123",
       lifecycleKind: "instance_reload",
+      lifecycleInitiatedAt: 18,
+      lifecycleInitiatedMonotonicMs: 180,
+      lifecycleAffectedDirectoryKeys: ["dir:testreload"],
+      lifecycleOrigin: { source: "server_handler", operation: "instance.reload", reason: "route" },
     })
 
     const summary = recorder.finalize({ completedAt: 21, monotonicMs: 210 })
@@ -1193,8 +1325,101 @@ describe("RunObservability", () => {
       kind: "instance_reload",
       source: "session.run_state.finalizer",
       reason: "scope_finalizer",
+      initiated_at: 18,
+      initiated_monotonic_ms: 180,
+      affected_directory_keys: ["dir:testreload"],
+      origin: { source: "server_handler", operation: "instance.reload", reason: "route" },
+    })
+    expect(summary.incident?.provenance.lifecycle).toMatchObject({
+      action_id: "lifecycle:instance_reload:abc123",
+      kind: "instance_reload",
+      initiated_at: 18,
+      initiated_monotonic_ms: 180,
+      affected_directory_keys: ["dir:testreload"],
+      origin: { source: "server_handler", operation: "instance.reload", reason: "route" },
+      completeness: "partial",
     })
     expect(summary.missing_provenance).toBeUndefined()
+  })
+
+  test("exports structured lifecycle request initiator provenance", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_request"),
+      traceID: MessageID.make("msg_lifecycle_request"),
+      sessionID: SessionID.make("ses_lifecycle_request"),
+      messageID: MessageID.make("msg_lifecycle_request"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 1,
+      monotonicStartMs: 100,
+    })
+
+    recorder.recordScopeClosed({
+      at: 2,
+      monotonicMs: 120,
+      lifecycleActionID: "lifecycle:instance_reload:request",
+      lifecycleKind: "instance_reload",
+      lifecycleAffectedDirectoryKeys: ["dir:request"],
+      lifecycleOrigin: { source: "server_handler", operation: "instance.reload", reason: "project.git.init" },
+      lifecycleRequest: {
+        method: "POST",
+        path: "/project/git/init",
+        source: "renderer",
+        directory_key: "dir:request",
+        workspace_id: "workspace-request",
+        client_action: { id: "client-action-request", kind: "project.git.init" },
+      },
+    })
+
+    const incident = recorder.finalize({ completedAt: 3, monotonicMs: 130 }).incident
+    expect(incident?.provenance.lifecycle?.request).toMatchObject({
+      method: "POST",
+      path: "/project/git/init",
+      source: "renderer",
+      directory_key: "dir:request",
+      workspace_id: "workspace-request",
+      client_action: { id: "client-action-request", kind: "project.git.init" },
+    })
+    expect(RunIncident.toExportChain(incident!).nearest_request).toMatchObject({
+      method: "POST",
+      path: "/project/git/init",
+      source: "renderer",
+      client_action: { id: "client-action-request", kind: "project.git.init" },
+    })
+  })
+
+  test("clones lifecycle provenance before storing recorder summaries", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_clone"),
+      traceID: MessageID.make("msg_lifecycle_clone"),
+      sessionID: SessionID.make("ses_lifecycle_clone"),
+      messageID: MessageID.make("msg_lifecycle_clone"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const keys = ["dir:original"]
+    const origin = { source: "runtime", operation: "instance.dispose", reason: "original" }
+    recorder.recordScopeClosed({
+      at: 20,
+      monotonicMs: 200,
+      lifecycleActionID: "lifecycle:instance_dispose:clone",
+      lifecycleKind: "instance_dispose",
+      lifecycleAffectedDirectoryKeys: keys,
+      lifecycleOrigin: origin,
+    })
+
+    keys.push("dir:mutated")
+    origin.reason = "mutated"
+
+    const summary = recorder.finalize({ completedAt: 21, monotonicMs: 210 })
+    expect(summary.lifecycle?.affected_directory_keys).toEqual(["dir:original"])
+    expect(summary.lifecycle?.origin?.reason).toBe("original")
+    summary.lifecycle?.affected_directory_keys.push("dir:summary-mutated")
+    if (summary.lifecycle?.origin) summary.lifecycle.origin.reason = "summary-mutated"
+    expect(summary.incident?.provenance.lifecycle?.affected_directory_keys).toEqual(["dir:original"])
+    expect(summary.incident?.provenance.lifecycle?.origin?.reason).toBe("original")
   })
 
   test("records tool execution effect facts conservatively", () => {

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import { Effect, Exit, Fiber, Layer } from "effect"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Hono } from "hono"
 import { Instance } from "../../src/project/instance"
+import { GlobalRoutes } from "../../src/server/instance/global"
 import {
   createLifecycleCloseAction,
   currentLifecycleCloseAction,
@@ -124,6 +126,57 @@ describe("SessionRunState", () => {
           expect(second).toMatchObject({ lifecycleKind: "instance_dispose_all" })
           expect(first?.lifecycleActionID).toBe(second?.lifecycleActionID)
           expect(first?.lifecycleActionID).toStartWith("lifecycle:instance_dispose_all:")
+        }),
+      { git: true },
+    )
+  })
+
+  it.live("annotates global dispose interrupts with request origin", () => {
+    let captured:
+      | {
+          lifecycleKind?: string
+          lifecycleOrigin?: { source: string; operation?: string; reason?: string }
+        }
+      | undefined
+
+    return provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_global_dispose_origin"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Effect.never,
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(async () => {
+            const app = new Hono().route("/global", GlobalRoutes())
+            const response = await app.request("/global/dispose", {
+              method: "POST",
+              headers: {
+                "x-pawwork-client-action-id": "client-global-dispose",
+                "x-pawwork-client-action-kind": "global.dispose.button",
+              },
+            })
+            expect(response.status).toBe(200)
+          })
+
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          expect(captured).toMatchObject({
+            lifecycleKind: "instance_dispose_all",
+            lifecycleOrigin: {
+              source: "server_handler",
+              operation: "instance.disposeAll",
+              reason: "global.dispose.button",
+            },
+          })
         }),
       { git: true },
     )

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Exit, Fiber, Layer } from "effect"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Hono } from "hono"
+import { Config } from "../../src/config"
+import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { GlobalRoutes } from "../../src/server/instance/global"
 import {
   createLifecycleCloseAction,
   currentLifecycleCloseAction,
+  directoryKey,
+  lifecycleCloseActionMeta,
   withLifecycleCloseAction,
 } from "../../src/session/lifecycle-provenance"
 import { SessionRunState } from "../../src/session/run-state"
 import { SessionID } from "../../src/session/schema"
-import { provideTmpdirInstance } from "../fixture/fixture"
+import { provideTmpdirInstance, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, SessionRunState.defaultLayer))
@@ -44,6 +48,45 @@ describe("SessionRunState", () => {
     expect(currentLifecycleCloseAction(directory)).toBeUndefined()
   })
 
+  test("creates immutable lifecycle snapshots with safe affected directory keys", async () => {
+    const directory = "/tmp/pawwork-lifecycle-snapshot"
+    const action = createLifecycleCloseAction("instance_dispose_directory", {
+      affectedDirectories: [directory],
+      origin: {
+        source: "server_handler",
+        operation: "instance.dispose",
+        reason: "test_dispose",
+      },
+    })
+
+    expect(action.initiatedAt).toBeNumber()
+    expect(action.initiatedMonotonicMs).toBeNumber()
+    expect(action.origin).toEqual({
+      source: "server_handler",
+      operation: "instance.dispose",
+      reason: "test_dispose",
+    })
+    expect(Object.isFrozen(action.affectedDirectoryKeys)).toBe(true)
+    expect(Object.isFrozen(action.origin)).toBe(true)
+    expect(action.affectedDirectoryKeys).toHaveLength(1)
+    expect(action.affectedDirectoryKeys[0]).toStartWith("dir:")
+    expect(action.affectedDirectoryKeys[0]).not.toContain(directory)
+
+    const meta = lifecycleCloseActionMeta(action)
+    meta.lifecycleAffectedDirectoryKeys.push("dir:mutated")
+    if (meta.lifecycleOrigin) meta.lifecycleOrigin.reason = "mutated"
+    expect(action.affectedDirectoryKeys).toHaveLength(1)
+    expect(action.origin?.reason).toBe("test_dispose")
+
+    await withLifecycleCloseAction([directory], action, async () => {
+      expect(currentLifecycleCloseAction(directory)).toBe(action)
+    })
+
+    expect(currentLifecycleCloseAction(directory)).toBeUndefined()
+    expect(action.origin?.operation).toBe("instance.dispose")
+    expect(action.affectedDirectoryKeys).toHaveLength(1)
+  })
+
   it.live("annotates runner interrupts caused by instance disposal with lifecycle provenance", () => {
     let captured:
       | {
@@ -52,11 +95,15 @@ describe("SessionRunState", () => {
           recordedAt?: number
           lifecycleActionID?: string
           lifecycleKind?: string
+          lifecycleInitiatedAt?: number
+          lifecycleInitiatedMonotonicMs?: number
+          lifecycleAffectedDirectoryKeys?: string[]
+          lifecycleOrigin?: { source: string; operation?: string; reason?: string }
         }
       | undefined
 
     return provideTmpdirInstance(
-      () =>
+      (directory) =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
           const fiber = yield* run
@@ -83,6 +130,10 @@ describe("SessionRunState", () => {
             lifecycleKind: "instance_dispose",
           })
           expect(captured?.lifecycleActionID).toStartWith("lifecycle:instance_dispose:")
+          expect(captured?.lifecycleInitiatedAt).toBeNumber()
+          expect(captured?.lifecycleInitiatedMonotonicMs).toBeNumber()
+          expect(captured?.lifecycleAffectedDirectoryKeys).toEqual([directoryKey(directory)])
+          expect(captured?.lifecycleOrigin).toMatchObject({ source: "runtime", operation: "instance.dispose" })
           expect(typeof captured?.recordedAt).toBe("number")
         }),
       { git: true },
@@ -176,6 +227,123 @@ describe("SessionRunState", () => {
               operation: "instance.disposeAll",
               reason: "global.dispose.button",
             },
+            lifecycleRequest: {
+              method: "POST",
+              path: "/global/dispose",
+              source: "renderer",
+              client_action: {
+                id: "client-global-dispose",
+                kind: "global.dispose.button",
+              },
+            },
+          })
+        }),
+      { git: true },
+    )
+  })
+
+  it.live("annotates Config.update interrupts with config origin", () => {
+    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+
+    return provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_config_update_origin"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Effect.never,
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Config.update({ username: "config-update-origin" }))
+
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          expect(captured?.lifecycleOrigin).toMatchObject({
+            source: "config",
+            operation: "config.update",
+            reason: "config.update",
+          })
+        }),
+      { git: true },
+    )
+  })
+
+  it.live("annotates Config.invalidate interrupts with config origin", () => {
+    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+
+    return provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_config_invalidate_origin"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Effect.never,
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Config.invalidate(true))
+
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          expect(captured?.lifecycleOrigin).toMatchObject({
+            source: "config",
+            operation: "config.invalidate",
+            reason: "config.invalidate",
+          })
+        }),
+      { git: true },
+    )
+  })
+
+  it.live("annotates Config.updateGlobal interrupts with config origin", () => {
+    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+
+    return provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_config_update_global_origin"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Effect.never,
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(async () => {
+            await using globalTmp = await tmpdir()
+            const previous = Global.Path.config
+            ;(Global.Path as { config: string }).config = globalTmp.path
+            try {
+              await Config.updateGlobal({ username: "config-update-global-origin" })
+            } finally {
+              ;(Global.Path as { config: string }).config = previous
+            }
+          })
+
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          expect(captured?.lifecycleOrigin).toMatchObject({
+            source: "config",
+            operation: "config.updateGlobal",
+            reason: "config.updateGlobal",
           })
         }),
       { git: true },


### PR DESCRIPTION
## Summary

Adds lifecycle causality diagnostics for interrupted runs: immutable lifecycle close snapshots, request context provenance on real instance/global lifecycle routes, renderer client-action wiring for lifecycle-triggering UI calls, config-origin attribution, structured request/client-action provenance in run incidents and incident chains, explicit load→reload context-mismatch reasons, lifecycle initiation-time ordering, and sanitized export incident chains.

## Why

#802 asks for the local lifecycle causality slice of #808 so exported diagnostics can explain which local reload/dispose action interrupted a run and what provenance is complete or missing.

## Related Issue

Closes #802. Part of #808.

## Human Review Status

Pending

## Review Focus

Please focus on whether lifecycle close provenance stays diagnostic/export-only, does not change recovery behavior, preserves lifecycle-vs-provider terminal cause ordering while retaining lifecycle provenance, carries safe request/client-action initiator fields from real renderer call paths into exports, records explicit load→reload context mismatch/config origins, and avoids leaking raw local paths or secret-like strings.

## Risk Notes

Skipped conditional checks:
- Manual visible UI/copy check: no visible UI or copy changed.
- Docs/release/dependencies/permissions/generated content/local file changes: none of those surfaces were touched.

Platform impact was considered: the change hashes local paths before export and only adds diagnostic headers/snapshots, without changing runtime lifecycle behavior.

## How To Verify

```text
Baseline targeted tests: 86 passed before implementation from packages/opencode.
Opencode targeted tests after latest review fixes: 107 passed across instance-store, run-state, middleware, run-observability, and export.
App targeted tests after latest review fixes: 12 passed across server header helper and renderer client-action wiring source tests.
CodeRabbit follow-up verification: run-observability focused test passed 42 tests; server utils focused test passed 5 tests.
Typecheck: bun run typecheck completed successfully for 8 tasks.
Diff check: git diff --check completed with no whitespace errors.
Review fixes: real main-route/global request context coverage, lifecycle initiation-time terminal ordering, lifecycle provenance retention when provider failure records first, structured request/client-action initiator provenance, generated/precomputed-chain request sanitization, explicit load→reload context mismatch reasons, real renderer client-action wiring for global config update/provider connect/disconnect/workspace reset disposal calls, config update/invalidate/updateGlobal origin attribution, preserved lifecycle source provenance, broadened client-action header path leak assertions, Gemini path parsing, and CodeRabbit sanitization/immutability findings were fixed.
```

## Screenshots or Recordings

Not applicable — no visible UI or copy changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced incident diagnostics with incident chain tracking and lifecycle context.
  * Improved tracking of user-initiated operations (provider management, config updates, workspace actions).

* **Bug Fixes**
  * Better sanitization of sensitive data in incident reports to prevent information leakage.

* **Tests**
  * Extended test coverage for lifecycle provenance, request context, and incident export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
