### PR TITLE
feat(app): hint slash commands in prompt placeholder

### DIFF
--- a/packages/app/e2e/onboarding/home-suggestion-chips.spec.ts
+++ b/packages/app/e2e/onboarding/home-suggestion-chips.spec.ts
@@ -85,9 +85,9 @@ test("@smoke composer placeholder is the static home string", async ({ page, pro
   const label = await editor.getAttribute("aria-label")
   // i18n source: packages/app/src/i18n/{zh,en}.ts → prompt.placeholder.home
   if (locale === "zh") {
-    expect(label).toBe("输入你的任务，或 @ 引用文件")
+    expect(label).toBe("输入你的任务，@ 引用文件，/ 唤起命令")
   } else {
-    expect(label).toBe("Type your task, or @ to mention files")
+    expect(label).toBe("Type your task, @ to mention files, / for commands")
   }
 })
 

--- a/packages/app/e2e/snap/prompt-placeholder.snap.ts
+++ b/packages/app/e2e/snap/prompt-placeholder.snap.ts
@@ -12,9 +12,23 @@ async function snapComposer(page: import("@playwright/test").Page, name: string)
   return { name, buf: await prompt.screenshot() }
 }
 
+// Locale-independent right-panel toggle. The shared `openRightPanel` helper
+// looks up the button by English aria name and would not find it after the
+// snap switches the app to zh.
+async function ensureRightPanelOpen(page: import("@playwright/test").Page) {
+  const toggle = page.locator('[aria-controls="right-panel"]').first()
+  await toggle.waitFor({ state: "visible", timeout: 30_000 })
+  const expanded = await toggle.getAttribute("aria-expanded")
+  if (expanded === "true") return
+  await toggle.click()
+  await page.locator('#right-panel').waitFor({ state: "visible", timeout: 5_000 })
+}
+
 // 768px matches the Electron window minWidth from packages/desktop-electron/src/main/windows.ts.
 // The placeholder element has `truncate whitespace-nowrap`, so the narrow shot is the only
 // way to catch the `/ for commands` hint being clipped at the smallest supported window.
+// The "squeezed" row also opens the right panel so the prompt width is realistically narrow
+// (window minWidth - sidebar - right panel) instead of just window minWidth.
 const NARROW_WIDTH = 768
 
 test("prompt-placeholder", async ({ page, project }) => {
@@ -26,7 +40,10 @@ test("prompt-placeholder", async ({ page, project }) => {
   await page.setViewportSize({ width: NARROW_WIDTH, height: 900 })
   const enNarrowShot = await snapComposer(page, "en-768")
 
-  // Client-side locale is sourced from localStorage. Set it, reload, re-snap both widths.
+  await ensureRightPanelOpen(page)
+  const enSqueezedShot = await snapComposer(page, "en-768+rightpanel")
+
+  // Client-side locale is sourced from localStorage. Set it, reload, re-snap all widths.
   await page.evaluate(() => {
     localStorage.setItem("pawwork.global.dat:language", JSON.stringify({ locale: "zh" }))
   })
@@ -37,7 +54,13 @@ test("prompt-placeholder", async ({ page, project }) => {
   await page.setViewportSize({ width: NARROW_WIDTH, height: 900 })
   const zhNarrowShot = await snapComposer(page, "zh-768")
 
+  await ensureRightPanelOpen(page)
+  const zhSqueezedShot = await snapComposer(page, "zh-768+rightpanel")
+
   const out = snapOutputPath("prompt-placeholder")
-  await composeGrid([enShot, enNarrowShot, zhShot, zhNarrowShot], out)
+  await composeGrid(
+    [enShot, enNarrowShot, enSqueezedShot, zhShot, zhNarrowShot, zhSqueezedShot],
+    out,
+  )
   process.stdout.write(`\n[snap] prompt-placeholder grid -> ${out}\n\n`)
 })

--- a/packages/app/e2e/snap/prompt-placeholder.snap.ts
+++ b/packages/app/e2e/snap/prompt-placeholder.snap.ts
@@ -12,20 +12,32 @@ async function snapComposer(page: import("@playwright/test").Page, name: string)
   return { name, buf: await prompt.screenshot() }
 }
 
+// 768px matches the Electron window minWidth from packages/desktop-electron/src/main/windows.ts.
+// The placeholder element has `truncate whitespace-nowrap`, so the narrow shot is the only
+// way to catch the `/ for commands` hint being clipped at the smallest supported window.
+const NARROW_WIDTH = 768
+
 test("prompt-placeholder", async ({ page, project }) => {
   test.setTimeout(180_000)
 
   await project.open()
-  const enShot = await snapComposer(page, "en")
+  const enShot = await snapComposer(page, "en-1440")
 
-  // Client-side locale is sourced from localStorage. Set it, reload, re-snap.
+  await page.setViewportSize({ width: NARROW_WIDTH, height: 900 })
+  const enNarrowShot = await snapComposer(page, "en-768")
+
+  // Client-side locale is sourced from localStorage. Set it, reload, re-snap both widths.
   await page.evaluate(() => {
     localStorage.setItem("pawwork.global.dat:language", JSON.stringify({ locale: "zh" }))
   })
+  await page.setViewportSize({ width: 1440, height: 900 })
   await page.reload()
-  const zhShot = await snapComposer(page, "zh")
+  const zhShot = await snapComposer(page, "zh-1440")
+
+  await page.setViewportSize({ width: NARROW_WIDTH, height: 900 })
+  const zhNarrowShot = await snapComposer(page, "zh-768")
 
   const out = snapOutputPath("prompt-placeholder")
-  await composeGrid([enShot, zhShot], out)
+  await composeGrid([enShot, enNarrowShot, zhShot, zhNarrowShot], out)
   process.stdout.write(`\n[snap] prompt-placeholder grid -> ${out}\n\n`)
 })

--- a/packages/app/e2e/snap/prompt-placeholder.snap.ts
+++ b/packages/app/e2e/snap/prompt-placeholder.snap.ts
@@ -1,0 +1,31 @@
+import { test } from "../fixtures"
+import { promptSelector } from "../selectors"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+async function snapComposer(page: import("@playwright/test").Page, name: string): Promise<Shot> {
+  const prompt = page.locator(promptSelector)
+  await prompt.waitFor({ state: "visible", timeout: 30_000 })
+  const placeholder = page.locator('[data-component="prompt-placeholder"]')
+  await placeholder.waitFor({ state: "visible", timeout: 30_000 })
+  return { name, buf: await prompt.screenshot() }
+}
+
+test("prompt-placeholder", async ({ page, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+  const enShot = await snapComposer(page, "en")
+
+  // Client-side locale is sourced from localStorage. Set it, reload, re-snap.
+  await page.evaluate(() => {
+    localStorage.setItem("pawwork.global.dat:language", JSON.stringify({ locale: "zh" }))
+  })
+  await page.reload()
+  const zhShot = await snapComposer(page, "zh")
+
+  const out = snapOutputPath("prompt-placeholder")
+  await composeGrid([enShot, zhShot], out)
+  process.stdout.write(`\n[snap] prompt-placeholder grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/prompt-placeholder.snap.ts
+++ b/packages/app/e2e/snap/prompt-placeholder.snap.ts
@@ -44,8 +44,12 @@ test("prompt-placeholder", async ({ page, project }) => {
   const enSqueezedShot = await snapComposer(page, "en-768+rightpanel")
 
   // Client-side locale is sourced from localStorage. Set it, reload, re-snap all widths.
+  // Also clear persisted layout state so the right panel returns to its default closed
+  // state for the zh baseline/narrow shots — opening it for the en squeezed shot writes
+  // `rightPanel.opened: true` into `pawwork.global.dat:layout`, which survives reload.
   await page.evaluate(() => {
     localStorage.setItem("pawwork.global.dat:language", JSON.stringify({ locale: "zh" }))
+    localStorage.removeItem("pawwork.global.dat:layout")
   })
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.reload()

--- a/packages/app/src/components/prompt-input/placeholder.test.ts
+++ b/packages/app/src/components/prompt-input/placeholder.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { dict as en } from "@/i18n/en"
+import { dict as zh } from "@/i18n/zh"
 import { promptPlaceholder } from "./placeholder"
 
 describe("promptPlaceholder", () => {
@@ -15,5 +17,19 @@ describe("promptPlaceholder", () => {
 
   test("returns static home placeholder for normal mode with no comments", () => {
     expect(promptPlaceholder({ mode: "normal", commentCount: 0, t })).toBe("prompt.placeholder.home")
+  })
+})
+
+describe("prompt.placeholder.home copy", () => {
+  test("hints at both @ for files and / for commands in English", () => {
+    const copy = en["prompt.placeholder.home"]
+    expect(copy).toContain("@")
+    expect(copy).toContain("/")
+  })
+
+  test("hints at both @ for files and / for commands in Chinese", () => {
+    const copy = zh["prompt.placeholder.home"]
+    expect(copy).toContain("@")
+    expect(copy).toContain("/")
   })
 })

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -258,7 +258,7 @@ export const dict = {
   "variant.max": "Max",
 
   "prompt.placeholder.shell": "Enter shell command...",
-  "prompt.placeholder.home": "Type your task, or @ to mention files",
+  "prompt.placeholder.home": "Type your task, @ to mention files, / for commands",
   "prompt.placeholder.summarizeComments": "Summarize comments…",
   "prompt.placeholder.summarizeComment": "Summarize comment…",
   "prompt.mode.shell": "Shell",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -276,7 +276,7 @@ export const dict = {
   "variant.max": "最高",
 
   "prompt.placeholder.shell": "输入 shell 命令...",
-  "prompt.placeholder.home": "输入你的任务，或 @ 引用文件",
+  "prompt.placeholder.home": "输入你的任务，@ 引用文件，/ 唤起命令",
   "prompt.placeholder.summarizeComments": "总结评论…",
   "prompt.placeholder.summarizeComment": "总结该评论…",
   "prompt.mode.shell": "Shell",


### PR DESCRIPTION
## Summary

Update the home composer placeholder so it lists all three inline affordances: type a task, `@` to mention files, `/` to invoke commands. Both English and Chinese copy updated.

## Why

The previous placeholder only hinted at `@` mentions. Non-technical users had no way to discover that `/` opens a command popover from within the input box. `/` is the only entry point that inserts a command pill into the current task (`Cmd+Shift+P` opens the global palette, a different browse-and-execute model).

## Related Issue

Closes #826.

## Human Review Status

Pending

## Review Focus

- Copy fits in the input bar at default desktop width without truncation or wrapping. Verified via the new `prompt-placeholder` snap target for both English and Chinese (see screenshot below).
- Test coverage for placeholder copy is now content-asserting, not just key-routing.

## Risk Notes

None. Pure copy change in two locales plus a non-blocking snap target. No layout, logic, or behavior change.

## How To Verify

```text
bun --cwd packages/app run typecheck            : tsgo -b ok, no errors
bun --cwd packages/app test                      : 1460 pass, 0 fail
bun --cwd packages/app run snap prompt-placeholder (PORT 3175): grid generated, en + zh both fit, no truncation
```

## Screenshots or Recordings
<img width="2560" height="262" alt="prompt-placeholder" src="https://github.com/user-attachments/assets/26ab3ea9-d629-4c28-9dc4-9aaa356bb645" />

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the home prompt placeholder text in English and Chinese to explicitly guide users on using `@` to mention files and `/` to trigger commands.

* **Tests**
  * Added visual regression tests for prompt placeholder across different locales and viewport sizes.
  * Added unit tests validating placeholder text content in both languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->