### PR TITLE
fix(app): add timeline layout transactions

### DIFF
--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -253,7 +253,6 @@ jobs:
           bun head/packages/app/script/compare-perf.ts
           --base "${PERF_ARTIFACT_DIR}/perf-base-confirm-combined.json"
           --head "${PERF_ARTIFACT_DIR}/perf-head-confirm-combined.json"
-          --failures-from "${PERF_ARTIFACT_DIR}/perf-compare.json"
           --output "${PERF_ARTIFACT_DIR}/perf-compare-confirm.json"
           --comment-output "${PERF_ARTIFACT_DIR}/perf-comment.md"
 

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -253,6 +253,7 @@ jobs:
           bun head/packages/app/script/compare-perf.ts
           --base "${PERF_ARTIFACT_DIR}/perf-base-confirm-combined.json"
           --head "${PERF_ARTIFACT_DIR}/perf-head-confirm-combined.json"
+          --failures-from "${PERF_ARTIFACT_DIR}/perf-compare.json"
           --output "${PERF_ARTIFACT_DIR}/perf-compare-confirm.json"
           --comment-output "${PERF_ARTIFACT_DIR}/perf-comment.md"
 

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -902,6 +902,7 @@ test.describe("PR0.1 perf probe baseline", () => {
         await expandLongScrollTodoDock(page)
 
         await hoverTimelineScrollLane(page)
+        await markTimelineWheelIntent(page, -2400)
         await scrollTimelineTo(page, 0)
         await settleFrames(page, 4)
         const atTop = await readTimelineMetrics(page)

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -13,6 +13,7 @@ import {
 import { sessionPath, terminalToggleKey } from "../utils"
 import type { createSdk } from "../utils"
 import { composerEvent, type ComposerDriverState, type ComposerWindow } from "../../src/testing/session-composer"
+import { timelineEvent } from "../../src/testing/timeline"
 import { installPerfProbe, resetPerfProbe, snapshotPerfProbe, summarizeScenarioRuns } from "./probe"
 import { applyPerfProfile, readPerfProfile, shouldRunScenario, type PerfScenarioName } from "./profiles"
 import { readTimelineDomBudget, shouldAssertTimelineVirtualization } from "./timeline-dom-budget"
@@ -230,13 +231,13 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
 }
 
 async function revealCachedSessionMessagesThroughDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
-  await page.evaluate(() => {
+  await page.evaluate((event) => {
     window.dispatchEvent(
-      new CustomEvent("opencode:e2e:timeline", {
+      new CustomEvent(event, {
         detail: { action: "reveal-cached" },
       }),
     )
-  })
+  }, timelineEvent)
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -213,7 +213,8 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)
     const loadEarlier = page.getByRole("button", { name: /Load earlier messages|加载更早的消息/i }).first()
-    if (await loadEarlier.isVisible()) await loadEarlier.click()
+    if (await loadEarlier.isVisible().catch(() => false))
+      await loadEarlier.click({ timeout: 1_000 }).catch(() => undefined)
     try {
       await expect
         .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_500 })

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -233,6 +233,20 @@ async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], t
   expect(found).toBe(true)
 }
 
+async function markTimelineWheelIntent(page: Parameters<typeof snapshotPerfProbe>[0], deltaY: number) {
+  const found = await page.evaluate(
+    ({ deltaY, scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY }))
+      return true
+    },
+    { deltaY, scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+  expect(found).toBe(true)
+}
+
 async function hoverTimelineScrollLane(page: Parameters<typeof snapshotPerfProbe>[0]) {
   const box = await page.locator(scrollViewportSelector).first().boundingBox()
   expect(box).toBeTruthy()
@@ -282,6 +296,7 @@ async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>
     const budget = await readTimelineDomBudget(page)
     if (budget.totalRows >= longScrollMinimumAvailableRows) return
     await page.mouse.wheel(0, -2400)
+    await markTimelineWheelIntent(page, -2400)
     await settleFrames(page, 2)
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -202,20 +202,40 @@ async function readPromptText(page: Parameters<typeof snapshotPerfProbe>[0]) {
 }
 
 async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfProbe>[0], expectedCount: number) {
-  const messages = page.locator(sessionMessageItemSelector)
-  if ((await messages.count()) < expectedCount) {
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const budget = await readTimelineDomBudget(page)
+    if (budget.totalRows >= expectedCount) return
+
     await page.locator(scrollViewportSelector).first().hover()
     await page.mouse.wheel(0, -2400)
+    await markTimelineWheelIntent(page, -2400)
     await settleFrames(page, 2)
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)
     const loadEarlier = page.getByRole("button", { name: /Load earlier messages|加载更早的消息/i }).first()
-    await expect(loadEarlier).toBeVisible({ timeout: 30_000 })
-    await loadEarlier.click()
+    if (await loadEarlier.isVisible()) await loadEarlier.click()
+    try {
+      await expect
+        .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_500 })
+        .toBeGreaterThanOrEqual(expectedCount)
+      return
+    } catch {
+      // Continue nudging the cached history window; final assertion below reports failure details.
+    }
   }
   await expect
     .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 30_000 })
     .toBeGreaterThanOrEqual(expectedCount)
+}
+
+async function revealCachedSessionMessagesThroughDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("opencode:e2e:timeline", {
+        detail: { action: "reveal-cached" },
+      }),
+    )
+  })
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {
@@ -320,6 +340,15 @@ async function installComposerPerfDriver(page: Parameters<typeof snapshotPerfPro
     const sessions = saved ? JSON.parse(saved) : {}
     win.__opencode_e2e = { ...win.__opencode_e2e, composer: { enabled: true, sessions } }
   })
+}
+
+async function installTimelinePerfDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const apply = () => {
+    const win = window as Window & { __opencode_e2e?: { timeline?: { enabled?: boolean } } }
+    win.__opencode_e2e = { ...win.__opencode_e2e, timeline: { enabled: true } }
+  }
+  await page.addInitScript(apply)
+  await page.evaluate(apply)
 }
 
 async function writeComposerDriver(
@@ -609,6 +638,7 @@ test.describe("PR0.1 perf probe baseline", () => {
   test("long-session-input-lag emits a 3-run JSON baseline", async ({ page, project }) => {
     skipUnlessScenario("long-session-input-lag")
     await installPerfProbe(page)
+    await installTimelinePerfDriver(page)
     await applyPerfProfile(page, PERF_PROFILE)
     await project.open()
 
@@ -619,6 +649,7 @@ test.describe("PR0.1 perf probe baseline", () => {
         await page.goto(sessionPath(project.directory, session.id))
         await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
         await expect(page.locator(promptSelector).first()).toBeVisible({ timeout: 30_000 })
+        await revealCachedSessionMessagesThroughDriver(page)
         await revealCachedSessionMessages(page, TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
 
         const prompt = page.locator(promptSelector).first()
@@ -847,6 +878,7 @@ test.describe("PR0.1 perf probe baseline", () => {
     test.setTimeout(180_000)
     await installComposerPerfDriver(page)
     await installPerfProbe(page)
+    await installTimelinePerfDriver(page)
     await applyPerfProfile(page, PERF_PROFILE)
     await project.open()
 
@@ -855,6 +887,8 @@ test.describe("PR0.1 perf probe baseline", () => {
       await withSession(project.sdk, `perf scroll long ${Date.now()}-${run}`, async (session) => {
         await seedLongScrollSession(project, session.id, run)
         await page.goto(sessionPath(project.directory, session.id))
+        await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
+        await revealCachedSessionMessagesThroughDriver(page)
         await revealLongScrollWindow(page)
         const budget = await readTimelineDomBudget(page)
         expect(budget.totalRows).toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
@@ -931,6 +965,7 @@ test.describe("PR0.1 perf probe baseline", () => {
   test("session-timeline-recompute emits a 3-run low-end JSON baseline", async ({ page, project }) => {
     skipUnlessScenario("session-timeline-recompute")
     await installPerfProbe(page)
+    await installTimelinePerfDriver(page)
     await applyPerfProfile(page, PERF_PROFILE)
     await project.open()
 
@@ -940,6 +975,8 @@ test.describe("PR0.1 perf probe baseline", () => {
         await seedTimelineRecomputeSession(project, session.id)
         await page.goto(sessionPath(project.directory, session.id))
         await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
+        await revealCachedSessionMessagesThroughDriver(page)
+        await revealCachedSessionMessages(page, TIMELINE_RECOMPUTE_SEED_TURN_COUNT)
         await expect.poll(async () => page.locator(sessionMessageItemSelector).count()).toBeGreaterThanOrEqual(8)
         await resetPerfProbe(page)
         await page.locator(scrollViewportSelector).first().hover()

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -285,9 +285,16 @@ async function revealLongScrollWindow(page: Parameters<typeof snapshotPerfProbe>
     await settleFrames(page, 2)
     await scrollTimelineTo(page, 0)
     await settleFrames(page, 2)
+    try {
+      await expect
+        .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_500 })
+        .toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
+    } catch {
+      // Continue nudging the history window; final assertion below reports failure details.
+    }
   }
   await expect
-    .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_000 })
+    .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 10_000 })
     .toBeGreaterThanOrEqual(longScrollMinimumAvailableRows)
 }
 

--- a/packages/app/e2e/perf/perf-probe.spec.ts
+++ b/packages/app/e2e/perf/perf-probe.spec.ts
@@ -13,7 +13,6 @@ import {
 import { sessionPath, terminalToggleKey } from "../utils"
 import type { createSdk } from "../utils"
 import { composerEvent, type ComposerDriverState, type ComposerWindow } from "../../src/testing/session-composer"
-import { timelineEvent } from "../../src/testing/timeline"
 import { installPerfProbe, resetPerfProbe, snapshotPerfProbe, summarizeScenarioRuns } from "./probe"
 import { applyPerfProfile, readPerfProfile, shouldRunScenario, type PerfScenarioName } from "./profiles"
 import { readTimelineDomBudget, shouldAssertTimelineVirtualization } from "./timeline-dom-budget"
@@ -231,13 +230,26 @@ async function revealCachedSessionMessages(page: Parameters<typeof snapshotPerfP
 }
 
 async function revealCachedSessionMessagesThroughDriver(page: Parameters<typeof snapshotPerfProbe>[0]) {
+  const event = await readTimelineDriverEvent()
   await page.evaluate((event) => {
     window.dispatchEvent(
       new CustomEvent(event, {
         detail: { action: "reveal-cached" },
       }),
     )
-  }, timelineEvent)
+  }, event)
+}
+
+async function readTimelineDriverEvent() {
+  try {
+    const timeline = await import("../../src/testing/timeline")
+    return timeline.timelineEvent
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    // The perf workflow copies this harness into the base checkout, where PR-only testing helpers may not exist yet.
+    if (message.includes("src/testing/timeline")) return "opencode:e2e:timeline"
+    throw error
+  }
 }
 
 async function scrollTimelineTo(page: Parameters<typeof snapshotPerfProbe>[0], top: number) {

--- a/packages/app/e2e/perf/runtime-cls-gate.spec.ts
+++ b/packages/app/e2e/perf/runtime-cls-gate.spec.ts
@@ -10,6 +10,7 @@ import {
   sessionTurnListSelector,
 } from "../selectors"
 import { sessionPath } from "../utils"
+import { timelineEvent, type TimelineWindow } from "../../src/testing/timeline"
 import { readTimelineDomBudget } from "./timeline-dom-budget"
 import {
   collectRuntimeClsFailures,
@@ -153,6 +154,15 @@ async function revealRuntimeClsRows(page: Page) {
     await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
   })
 
+  await page.evaluate((eventName) => {
+    window.dispatchEvent(
+      new CustomEvent(eventName, {
+        detail: { action: "reveal-cached" },
+      }),
+    )
+  }, timelineEvent)
+  await settleFrames(page, 4)
+
   for (let attempt = 0; attempt < 24; attempt += 1) {
     const budget = await readTimelineDomBudget(page)
     if (budget.totalRows >= RUNTIME_CLS_MINIMUM_ROWS) return budget
@@ -202,7 +212,17 @@ async function centerVisibleMessageID(page: Page) {
   return target!
 }
 
+async function installTimelineRuntimeClsDriver(page: Page) {
+  const apply = () => {
+    const win = window as TimelineWindow
+    win.__opencode_e2e = { ...win.__opencode_e2e, timeline: { enabled: true } }
+  }
+  await page.addInitScript(apply)
+  await page.evaluate(apply)
+}
+
 async function prepareRuntimeClsWindow(page: Page, project: RuntimeClsProject, sessionID: string) {
+  await installTimelineRuntimeClsDriver(page)
   await test.step("navigate to runtime CLS session", async () => {
     await page.goto(sessionPath(project.directory, sessionID))
   })

--- a/packages/app/e2e/perf/runtime-cls-gate.spec.ts
+++ b/packages/app/e2e/perf/runtime-cls-gate.spec.ts
@@ -130,6 +130,20 @@ async function moveMouseOverTimeline(page: Page) {
   await page.mouse.move(box.x + box.width / 2, box.y + Math.min(140, box.height * 0.25))
 }
 
+async function markTimelineWheelIntent(page: Page, deltaY: number) {
+  const found = await page.evaluate(
+    ({ deltaY, scrollViewportSelector, turnListSelector }) => {
+      const list = document.querySelector(turnListSelector)
+      const viewport = list?.closest(scrollViewportSelector)
+      if (!(viewport instanceof HTMLElement)) return false
+      viewport.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY }))
+      return true
+    },
+    { deltaY, scrollViewportSelector, turnListSelector: sessionTurnListSelector },
+  )
+  expect(found).toBe(true)
+}
+
 async function positionTimelineForMeasuredWindow(page: Page) {
   // A tiny real wheel gesture marks the timeline as user-scrolled. Without
   // that, the active question turn can briefly re-lock to bottom and the
@@ -181,6 +195,37 @@ async function revealRuntimeClsRows(page: Page) {
 
   await expect
     .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 1_000 })
+    .toBeGreaterThanOrEqual(RUNTIME_CLS_MINIMUM_ROWS)
+  return await readTimelineDomBudget(page)
+}
+
+async function revealRuntimeClsRowsNaturally(page: Page) {
+  await test.step("wait for first runtime CLS message", async () => {
+    await expect(page.locator(sessionMessageItemSelector).first()).toBeVisible({ timeout: 30_000 })
+  })
+
+  await moveMouseOverTimeline(page)
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    const budget = await readTimelineDomBudget(page)
+    if (budget.totalRows >= RUNTIME_CLS_MINIMUM_ROWS) return budget
+
+    await test.step(`naturally reveal runtime CLS rows attempt ${attempt + 1}`, async () => {
+      await page.mouse.wheel(0, -1200)
+      await markTimelineWheelIntent(page, -1200)
+      await settleFrames(page, 2)
+      await scrollTimelineToRatio(page, 0)
+      await settleFrames(page, 4)
+
+      const loadEarlier = page.getByRole("button", { name: /Load earlier messages|加载更早的消息/i }).first()
+      if (await loadEarlier.isVisible().catch(() => false)) {
+        await loadEarlier.click({ timeout: 1_000 }).catch(() => undefined)
+        await settleFrames(page, 4)
+      }
+    })
+  }
+
+  await expect
+    .poll(async () => (await readTimelineDomBudget(page)).totalRows, { timeout: 10_000 })
     .toBeGreaterThanOrEqual(RUNTIME_CLS_MINIMUM_ROWS)
   return await readTimelineDomBudget(page)
 }
@@ -404,6 +449,20 @@ test.describe("runtime CLS probe lifecycle", () => {
 
 test.describe("runtime CLS source gate", () => {
   test.setTimeout(180_000)
+
+  test("natural history reveal smoke reaches a virtualized runtime CLS window", async ({ page, project }) => {
+    await project.open()
+    await withSession(project.sdk, `runtime cls natural reveal ${Date.now()}`, async (session) => {
+      await seedRuntimeClsSession(project, session.id)
+      await page.goto(sessionPath(project.directory, session.id))
+
+      const budget = await revealRuntimeClsRowsNaturally(page)
+
+      expect(budget.totalRows).toBeGreaterThanOrEqual(RUNTIME_CLS_MINIMUM_ROWS)
+      expect(budget.hasVirtualizer).toBe(true)
+      expect(budget.mountedMessages).toBeLessThanOrEqual(RUNTIME_CLS_MAXIMUM_MOUNTED_MESSAGES)
+    })
+  })
 
   test("composer growth does not move visible timeline primary sources", async ({ page, project }) => {
     await installRuntimeClsProbe(page)

--- a/packages/app/e2e/perf/runtime-cls-probe.ts
+++ b/packages/app/e2e/perf/runtime-cls-probe.ts
@@ -18,6 +18,15 @@ export type RuntimeClsScrollMetrics = {
   maxScrollTop: number
 }
 
+export type RuntimeClsTransactionSnapshot = {
+  activeBefore?: boolean
+  activeAfter?: boolean
+  idBefore?: string
+  idAfter?: string
+  kindBefore?: string
+  kindAfter?: string
+}
+
 export type RuntimeClsSourceKind =
   | "primary-message-wrapper"
   | "primary-turn"
@@ -62,6 +71,7 @@ export type RuntimeClsSnapshot = {
   mountedRows?: number
   scrollBefore?: RuntimeClsScrollMetrics
   scrollAfter?: RuntimeClsScrollMetrics
+  transaction?: RuntimeClsTransactionSnapshot
 }
 
 export type RuntimeClsResult = {
@@ -277,6 +287,14 @@ export function formatRuntimeClsFailure(input: {
     })),
   }))
   const maxValue = Math.max(0, ...input.entries.map((entry) => entry.value))
+  const transactionSummary = input.snapshot.transaction
+    ? [
+        `transaction=${input.snapshot.transaction.idBefore ?? input.snapshot.transaction.idAfter ?? "<none>"}`,
+        `transactionKind=${input.snapshot.transaction.kindBefore ?? input.snapshot.transaction.kindAfter ?? "<none>"}`,
+        `transactionActiveBefore=${input.snapshot.transaction.activeBefore ?? false}`,
+        `transactionActiveAfter=${input.snapshot.transaction.activeAfter ?? false}`,
+      ].join(" ")
+    : "transaction=<none>"
   const sourceSummary = input.entries
     .flatMap((entry) =>
       entry.sources.map((source) =>
@@ -293,6 +311,7 @@ export function formatRuntimeClsFailure(input: {
   return [
     `Runtime CLS primary source gate failed during ${input.action}.`,
     `Threshold: single entry > ${RUNTIME_CLS_PRIMARY_SHIFT_THRESHOLD}; max primary entry: ${maxValue}.`,
+    transactionSummary,
     sourceSummary,
     JSON.stringify(
       {
@@ -352,6 +371,15 @@ function runtimeClsProbeInitScript(options?: RuntimeClsProbeInstallOptions) {
     maxScrollTop: number
   }
 
+  type RuntimeClsTransactionSnapshot = {
+    activeBefore?: boolean
+    activeAfter?: boolean
+    idBefore?: string
+    idAfter?: string
+    kindBefore?: string
+    kindAfter?: string
+  }
+
   type RuntimeClsSnapshot = {
     targetMessageID?: string
     targetBeforeRect?: RuntimeClsRect
@@ -361,6 +389,7 @@ function runtimeClsProbeInitScript(options?: RuntimeClsProbeInstallOptions) {
     mountedRows?: number
     scrollBefore?: RuntimeClsScrollMetrics
     scrollAfter?: RuntimeClsScrollMetrics
+    transaction?: RuntimeClsTransactionSnapshot
   }
 
   type RuntimeClsWindow = Window & {
@@ -564,6 +593,11 @@ function runtimeClsProbeInitScript(options?: RuntimeClsProbeInstallOptions) {
       totalRows: list?.dataset.totalRows ? Number(list.dataset.totalRows) : undefined,
       mountedRows: virtualRows > 0 ? virtualRows : messages,
       scrollAfter: readScrollMetrics(),
+      transaction: {
+        activeAfter: list?.dataset.layoutTransactionActive === "true",
+        idAfter: list?.dataset.layoutTransactionId || undefined,
+        kindAfter: list?.dataset.layoutTransactionKind || undefined,
+      },
     }
   }
 
@@ -630,6 +664,11 @@ function runtimeClsProbeInitScript(options?: RuntimeClsProbeInstallOptions) {
         totalRows: before.totalRows,
         mountedRows: before.mountedRows,
         scrollBefore: before.scrollAfter,
+        transaction: {
+          activeBefore: before.transaction?.activeAfter,
+          idBefore: before.transaction?.idAfter,
+          kindBefore: before.transaction?.kindAfter,
+        },
       }
     },
     stop() {
@@ -646,6 +685,12 @@ function runtimeClsProbeInitScript(options?: RuntimeClsProbeInstallOptions) {
           totalRows: after.totalRows ?? snapshotBefore.totalRows,
           mountedRows: after.mountedRows ?? snapshotBefore.mountedRows,
           scrollAfter: after.scrollAfter,
+          transaction: {
+            ...snapshotBefore.transaction,
+            activeAfter: after.transaction?.activeAfter,
+            idAfter: after.transaction?.idAfter,
+            kindAfter: after.transaction?.kindAfter,
+          },
         },
       }
       active = false

--- a/packages/app/e2e/perf/runtime-cls-probe.unit.ts
+++ b/packages/app/e2e/perf/runtime-cls-probe.unit.ts
@@ -171,6 +171,14 @@ describe("runtime CLS failure diagnostics", () => {
         mountedRows: 24,
         scrollBefore: { scrollTop: 1200, scrollHeight: 8000, clientHeight: 720, maxScrollTop: 7280 },
         scrollAfter: { scrollTop: 1236, scrollHeight: 8036, clientHeight: 720, maxScrollTop: 7316 },
+        transaction: {
+          activeBefore: true,
+          activeAfter: false,
+          idBefore: "timeline-layout-7",
+          kindBefore: "dock-resize",
+          idAfter: undefined,
+          kindAfter: undefined,
+        },
       },
     })
 
@@ -182,5 +190,7 @@ describe("runtime CLS failure diagnostics", () => {
     expect(message).toContain("scrollTop")
     expect(message).toContain("virtualized")
     expect(message).toContain("104")
+    expect(message).toContain("transaction=timeline-layout-7")
+    expect(message).toContain("transactionKind=dock-resize")
   })
 })

--- a/packages/app/script/compare-perf.ts
+++ b/packages/app/script/compare-perf.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises"
 import path from "node:path"
-import { comparePerfBaselines, renderPerfBaselineComment, type PerfScenarioSummary } from "../src/testing/perf-metrics"
+import {
+  comparePerfBaselines,
+  renderPerfBaselineComment,
+  type PerfBaselineComparison,
+  type PerfScenarioSummary,
+} from "../src/testing/perf-metrics"
 
 function readArg(flag: string) {
   const index = process.argv.indexOf(flag)
@@ -18,18 +23,35 @@ async function readPerfFile(filePath: string) {
   return payload
 }
 
+async function readFailureScenarioKeys(filePath: string) {
+  const payload = JSON.parse(await fs.readFile(filePath, "utf8")) as PerfBaselineComparison
+  if (!Array.isArray(payload.scenarios)) {
+    throw new Error(`Expected a perf comparison with scenarios in ${filePath}`)
+  }
+  return payload.scenarios
+    .filter((scenario) => scenario.failures.length > 0)
+    .map((scenario) => `${scenario.profile}:${scenario.scenario}`)
+}
+
 async function main() {
   const basePath = readArg("--base")
   const headPath = readArg("--head")
   const outputPath = readArg("--output")
   const commentOutputPath = readArg("--comment-output")
+  const failuresFromPath = readArg("--failures-from")
 
   if (!basePath || !headPath) {
-    throw new Error("Usage: bun script/compare-perf.ts --base <perf-base.json> --head <perf-head.json> [--output <path>]")
+    throw new Error(
+      "Usage: bun script/compare-perf.ts --base <perf-base.json> --head <perf-head.json> [--output <path>]",
+    )
   }
 
-  const [base, head] = await Promise.all([readPerfFile(basePath), readPerfFile(headPath)])
-  const comparison = comparePerfBaselines({ base, head })
+  const [base, head, scenarioKeys] = await Promise.all([
+    readPerfFile(basePath),
+    readPerfFile(headPath),
+    failuresFromPath ? readFailureScenarioKeys(failuresFromPath) : undefined,
+  ])
+  const comparison = comparePerfBaselines({ base, head, scenarioKeys })
 
   if (outputPath) {
     await fs.mkdir(path.dirname(outputPath), { recursive: true })

--- a/packages/app/script/compare-perf.ts
+++ b/packages/app/script/compare-perf.ts
@@ -33,6 +33,18 @@ async function readFailureScenarioKeys(filePath: string) {
     .map((scenario) => `${scenario.profile}:${scenario.scenario}`)
 }
 
+async function inferFailureScenarioSource(input: { outputPath?: string; failuresFromPath?: string }) {
+  if (input.failuresFromPath) return input.failuresFromPath
+  if (!input.outputPath || path.basename(input.outputPath) !== "perf-compare-confirm.json") return undefined
+  const candidate = path.join(path.dirname(input.outputPath), "perf-compare.json")
+  try {
+    await fs.access(candidate)
+    return candidate
+  } catch {
+    return undefined
+  }
+}
+
 async function main() {
   const basePath = readArg("--base")
   const headPath = readArg("--head")
@@ -46,10 +58,11 @@ async function main() {
     )
   }
 
+  const failuresSourcePath = await inferFailureScenarioSource({ outputPath, failuresFromPath })
   const [base, head, scenarioKeys] = await Promise.all([
     readPerfFile(basePath),
     readPerfFile(headPath),
-    failuresFromPath ? readFailureScenarioKeys(failuresFromPath) : undefined,
+    failuresSourcePath ? readFailureScenarioKeys(failuresSourcePath) : undefined,
   ])
   const comparison = comparePerfBaselines({ base, head, scenarioKeys })
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -488,6 +488,9 @@ export default function Page() {
       historyLoading={timelineHistoryLoading()}
       anchor={timelineInteraction.anchor}
       virtualizerBridge={timelineInteraction.virtualizerBridge}
+      layoutTransactionActive={timelineInteraction.layoutTransactionActive}
+      layoutTransactionID={timelineInteraction.layoutTransactionID}
+      layoutTransactionKind={timelineInteraction.layoutTransactionKind}
       onRetryOpenSession={retryOpenRouteSession}
       onOpenNewSession={openNewRouteSession}
       composerSession={renderComposerRegion()}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -94,6 +94,9 @@ export function MessageTimeline(props: {
   renderedUserMessages: UserMessage[]
   anchor: (id: string) => string
   virtualizerBridge: TimelineVirtualizerBridge
+  layoutTransactionActive: () => boolean
+  layoutTransactionID: () => string | undefined
+  layoutTransactionKind: () => string | undefined
 }) {
   let touchGesture: number | undefined
   let scrollSampleFrame: number | undefined
@@ -486,6 +489,9 @@ export function MessageTimeline(props: {
               data-slot="session-turn-list"
               data-render-mode={rowRenderMode()}
               data-total-rows={rowMutation().rows.length}
+              data-layout-transaction-active={props.layoutTransactionActive() ? "true" : "false"}
+              data-layout-transaction-id={props.layoutTransactionID()}
+              data-layout-transaction-kind={props.layoutTransactionKind()}
               class="transition-[margin]"
               classList={{
                 "w-full": true,
@@ -500,6 +506,7 @@ export function MessageTimeline(props: {
                 viewport={virtualizerViewport()}
                 virtualizerBridge={props.virtualizerBridge}
                 shift={rowMutation().mutation === "prepend"}
+                transactionActive={props.layoutTransactionActive()}
                 renderRow={renderTimelineRow}
               />
             </div>

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -1,4 +1,4 @@
-import { Match, onCleanup, onMount, Show, Switch, type ComponentProps, type JSX } from "solid-js"
+import { Match, Show, Switch, type ComponentProps, type JSX } from "solid-js"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import type { useLanguage } from "@/context/language"
@@ -10,7 +10,7 @@ import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
 import type { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
-import { bindTimelineDriver } from "@/testing/timeline"
+import { TimelineE2EDriverBoundary } from "@/testing/timeline"
 
 type TimelineProps = ComponentProps<typeof MessageTimeline>
 
@@ -62,15 +62,6 @@ export function SessionMainView(props: {
   files: ReturnType<typeof createSessionReviewState>["artifactFiles"]
   size: ReturnType<typeof createSizing>
 }) {
-  onMount(() => {
-    const cleanupTimelineDriver = bindTimelineDriver({
-      testRuntime: import.meta.env.DEV || import.meta.env.TEST,
-      timelineSessionID: () => props.timelineSessionID,
-      revealCached: () => props.historyWindow.expandForHash(0),
-    })
-    onCleanup(cleanupTimelineDriver)
-  })
-
   const showSessionOpeningState = () =>
     shouldShowSessionOpeningState({
       activeSessionID: props.activeSessionID,
@@ -81,6 +72,10 @@ export function SessionMainView(props: {
 
   return (
     <div class="relative size-full overflow-hidden flex flex-col">
+      <TimelineE2EDriverBoundary
+        timelineSessionID={() => props.timelineSessionID}
+        revealCached={() => props.historyWindow.expandForHash(0)}
+      />
       <SessionHeader />
       <div class="flex-1 min-h-0 flex flex-col md:flex-row">
         <Show when={!props.isDesktop && !!props.activeSessionID}>

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -63,8 +63,11 @@ export function SessionMainView(props: {
   size: ReturnType<typeof createSizing>
 }) {
   onMount(() => {
+    const timelineDriverTestRuntime = import.meta.env.DEV || import.meta.env.TEST
+    if (!timelineDriverTestRuntime) return
+
     const handleTimelineDriver = (event: Event) => {
-      if (!timelineDriverEnabled()) return
+      if (!timelineDriverEnabled({ testRuntime: timelineDriverTestRuntime })) return
       const detail = (event as TimelineDriverEvent).detail
       if (detail?.sessionID && detail.sessionID !== props.timelineSessionID) return
       if (detail?.action === "reveal-cached") props.historyWindow.expandForHash(0)

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -10,7 +10,7 @@ import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
 import type { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
-import { timelineDriverEnabled, timelineEvent, type TimelineDriverEvent } from "@/testing/timeline"
+import { bindTimelineDriver } from "@/testing/timeline"
 
 type TimelineProps = ComponentProps<typeof MessageTimeline>
 
@@ -63,17 +63,12 @@ export function SessionMainView(props: {
   size: ReturnType<typeof createSizing>
 }) {
   onMount(() => {
-    const timelineDriverTestRuntime = import.meta.env.DEV || import.meta.env.TEST
-    if (!timelineDriverTestRuntime) return
-
-    const handleTimelineDriver = (event: Event) => {
-      if (!timelineDriverEnabled({ testRuntime: timelineDriverTestRuntime })) return
-      const detail = (event as TimelineDriverEvent).detail
-      if (detail?.sessionID && detail.sessionID !== props.timelineSessionID) return
-      if (detail?.action === "reveal-cached") props.historyWindow.expandForHash(0)
-    }
-    window.addEventListener(timelineEvent, handleTimelineDriver)
-    onCleanup(() => window.removeEventListener(timelineEvent, handleTimelineDriver))
+    const cleanupTimelineDriver = bindTimelineDriver({
+      testRuntime: import.meta.env.DEV || import.meta.env.TEST,
+      timelineSessionID: () => props.timelineSessionID,
+      revealCached: () => props.historyWindow.expandForHash(0),
+    })
+    onCleanup(cleanupTimelineDriver)
   })
 
   const showSessionOpeningState = () =>

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -1,4 +1,4 @@
-import { Match, Show, Switch, type ComponentProps, type JSX } from "solid-js"
+import { Match, onCleanup, onMount, Show, Switch, type ComponentProps, type JSX } from "solid-js"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import type { useLanguage } from "@/context/language"
@@ -10,6 +10,7 @@ import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
 import type { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
+import { timelineDriverEnabled, timelineEvent, type TimelineDriverEvent } from "@/testing/timeline"
 
 type TimelineProps = ComponentProps<typeof MessageTimeline>
 
@@ -61,6 +62,17 @@ export function SessionMainView(props: {
   files: ReturnType<typeof createSessionReviewState>["artifactFiles"]
   size: ReturnType<typeof createSizing>
 }) {
+  onMount(() => {
+    const handleTimelineDriver = (event: Event) => {
+      if (!timelineDriverEnabled()) return
+      const detail = (event as TimelineDriverEvent).detail
+      if (detail?.sessionID && detail.sessionID !== props.timelineSessionID) return
+      if (detail?.action === "reveal-cached") props.historyWindow.expandForHash(0)
+    }
+    window.addEventListener(timelineEvent, handleTimelineDriver)
+    onCleanup(() => window.removeEventListener(timelineEvent, handleTimelineDriver))
+  })
+
   const showSessionOpeningState = () =>
     shouldShowSessionOpeningState({
       activeSessionID: props.activeSessionID,

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -46,6 +46,9 @@ export function SessionMainView(props: {
   historyLoading: boolean
   anchor: TimelineProps["anchor"]
   virtualizerBridge: TimelineProps["virtualizerBridge"]
+  layoutTransactionActive: TimelineProps["layoutTransactionActive"]
+  layoutTransactionID: TimelineProps["layoutTransactionID"]
+  layoutTransactionKind: TimelineProps["layoutTransactionKind"]
   onRetryOpenSession: () => void
   onOpenNewSession: () => void
   composerSession: JSX.Element
@@ -159,6 +162,9 @@ export function SessionMainView(props: {
                   renderedUserMessages={props.historyWindow.renderedUserMessages()}
                   anchor={props.anchor}
                   virtualizerBridge={props.virtualizerBridge}
+                  layoutTransactionActive={props.layoutTransactionActive}
+                  layoutTransactionID={props.layoutTransactionID}
+                  layoutTransactionKind={props.layoutTransactionKind}
                 />
               </Match>
               <Match when={!props.activeSessionID}>

--- a/packages/app/src/pages/session/session-timeline-scroll-controller.ts
+++ b/packages/app/src/pages/session/session-timeline-scroll-controller.ts
@@ -118,6 +118,7 @@ export type TimelineScrollObservation =
       previousDockHeight: number
       nextDockHeight: number
       metrics: TimelineScrollMetrics
+      layoutTransactionHandled?: boolean
     }
   | {
       type: "owner_detached"
@@ -283,7 +284,8 @@ export function createTimelineScrollControllerDiagnostic(input: {
 }
 
 function isExplicitTopIntent(intent: TimelineScrollIntent) {
-  if (intent.type === "keyboard_scroll") return intent.key === "ArrowUp" || intent.key === "Home" || intent.key === "PageUp"
+  if (intent.type === "keyboard_scroll")
+    return intent.key === "ArrowUp" || intent.key === "Home" || intent.key === "PageUp"
   if (intent.type === "wheel_scroll" || intent.type === "touch_scroll") {
     return intent.direction === "up" && !intent.nestedScrollable
   }
@@ -302,7 +304,10 @@ function updateSafePosition(state: TimelineScrollControllerState, safePosition: 
   if (safePosition) state.lastSafePosition = safePosition
 }
 
-function updateObservedSafePosition(state: TimelineScrollControllerState, safePosition: TimelineSafePosition | undefined) {
+function updateObservedSafePosition(
+  state: TimelineScrollControllerState,
+  safePosition: TimelineSafePosition | undefined,
+) {
   if (
     state.mode === "targeting_message" &&
     state.lastSafePosition.kind === "target_message" &&

--- a/packages/app/src/pages/session/timeline-layout-recovery-policy.ts
+++ b/packages/app/src/pages/session/timeline-layout-recovery-policy.ts
@@ -2,8 +2,11 @@ import type { TimelineScrollObservation } from "./session-timeline-scroll-contro
 
 export function shouldApplyTimelineRecoveryForObservation(input: {
   layoutTransactionActive: boolean
+  layoutTransactionHandled?: boolean
   observationType: TimelineScrollObservation["type"]
 }) {
+  const resizeObservation = input.observationType === "content_resize" || input.observationType === "dock_resize"
+  if (input.layoutTransactionHandled && resizeObservation) return false
   if (!input.layoutTransactionActive) return true
-  return input.observationType !== "content_resize" && input.observationType !== "dock_resize"
+  return !resizeObservation
 }

--- a/packages/app/src/pages/session/timeline-layout-recovery-policy.ts
+++ b/packages/app/src/pages/session/timeline-layout-recovery-policy.ts
@@ -1,0 +1,9 @@
+import type { TimelineScrollObservation } from "./session-timeline-scroll-controller"
+
+export function shouldApplyTimelineRecoveryForObservation(input: {
+  layoutTransactionActive: boolean
+  observationType: TimelineScrollObservation["type"]
+}) {
+  if (!input.layoutTransactionActive) return true
+  return input.observationType !== "content_resize" && input.observationType !== "dock_resize"
+}

--- a/packages/app/src/pages/session/timeline-layout-stable-band.test.ts
+++ b/packages/app/src/pages/session/timeline-layout-stable-band.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import {
+  chooseTimelineVirtualizerOverscan,
+  TIMELINE_BASE_OVERSCAN,
+  TIMELINE_TRANSACTION_OVERSCAN,
+} from "./timeline-layout-stable-band"
+
+describe("timeline layout stable band", () => {
+  test("keeps normal overscan small outside transactions", () => {
+    expect(chooseTimelineVirtualizerOverscan({ transactionActive: false })).toBe(TIMELINE_BASE_OVERSCAN)
+  })
+
+  test("widens overscan only during a layout transaction", () => {
+    expect(chooseTimelineVirtualizerOverscan({ transactionActive: true })).toBe(TIMELINE_TRANSACTION_OVERSCAN)
+    expect(TIMELINE_TRANSACTION_OVERSCAN).toBeGreaterThan(TIMELINE_BASE_OVERSCAN)
+  })
+})

--- a/packages/app/src/pages/session/timeline-layout-stable-band.ts
+++ b/packages/app/src/pages/session/timeline-layout-stable-band.ts
@@ -1,0 +1,6 @@
+export const TIMELINE_BASE_OVERSCAN = 8
+export const TIMELINE_TRANSACTION_OVERSCAN = 24
+
+export function chooseTimelineVirtualizerOverscan(input: { transactionActive: boolean }) {
+  return input.transactionActive ? TIMELINE_TRANSACTION_OVERSCAN : TIMELINE_BASE_OVERSCAN
+}

--- a/packages/app/src/pages/session/timeline-layout-transaction.test.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createTimelineLayoutTransactionCoordinator,
+  type TimelineLayoutTransactionDiagnostic,
+  type TimelineLayoutTransactionFrameScheduler,
+} from "./timeline-layout-transaction"
+import type { TimelineSafePosition, TimelineScrollMode } from "./session-timeline-scroll-controller"
+
+const readingAnchor: TimelineSafePosition = {
+  kind: "reading",
+  anchorMessageID: "msg-2",
+  offsetFromViewportTop: 96,
+  renderedStart: 0,
+  renderedCount: 12,
+}
+
+function immediateFrameScheduler(): TimelineLayoutTransactionFrameScheduler {
+  return (callback) => {
+    callback()
+    return 1
+  }
+}
+
+function makeCoordinator(input?: {
+  mode?: TimelineScrollMode
+  restoreResults?: boolean[]
+  diagnostics?: TimelineLayoutTransactionDiagnostic[]
+}) {
+  let restoreCalls = 0
+  let latestCalls = 0
+  let stableBand = false
+  const restoreResults = input?.restoreResults ?? [true]
+  const diagnostics = input?.diagnostics ?? []
+  const coordinator = createTimelineLayoutTransactionCoordinator({
+    now: () => 123 + diagnostics.length,
+    scheduleFrame: immediateFrameScheduler(),
+    cancelFrame: () => {},
+    readMode: () => input?.mode ?? "reading_history",
+    sampleAnchor: () => readingAnchor,
+    restoreAnchor: () => restoreResults[Math.min(restoreCalls++, restoreResults.length - 1)] ?? false,
+    restoreLatest: () => {
+      latestCalls += 1
+      return true
+    },
+    setStableBandActive: (active) => {
+      stableBand = active
+    },
+    emitDiagnostic: (event) => diagnostics.push(event),
+  })
+  return {
+    coordinator,
+    diagnostics,
+    restoreCalls: () => restoreCalls,
+    latestCalls: () => latestCalls,
+    stableBand: () => stableBand,
+  }
+}
+
+describe("timeline layout transaction coordinator", () => {
+  test("restores the sampled reading anchor before paint", () => {
+    const { coordinator, diagnostics, restoreCalls, stableBand } = makeCoordinator()
+    const mutations: string[] = []
+
+    const result = coordinator.run({
+      kind: "dock-resize",
+      source: "use-session-scroll-dock/updateDockHeight",
+      reason: "question-dock-close",
+      mutate: () => mutations.push("dock-height-applied"),
+    })
+
+    expect(mutations).toEqual(["dock-height-applied"])
+    expect(restoreCalls()).toBe(1)
+    expect(stableBand()).toBe(false)
+    expect(result.status).toBe("before-paint")
+    expect(result.anchor).toEqual(readingAnchor)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "settled"])
+  })
+
+  test("preserves latest instead of reading anchor when already following latest", () => {
+    const { coordinator, latestCalls, restoreCalls } = makeCoordinator({ mode: "following_latest" })
+
+    const result = coordinator.run({
+      kind: "dock-resize",
+      source: "use-session-scroll-dock/updateDockHeight",
+      reason: "composer-growth",
+      mutate: () => {},
+    })
+
+    expect(result.status).toBe("before-paint")
+    expect(result.anchor).toEqual({ kind: "latest" })
+    expect(latestCalls()).toBe(1)
+    expect(restoreCalls()).toBe(0)
+  })
+
+  test("uses a bounded two-frame fallback when the anchor is not immediately restorable", () => {
+    const { coordinator, diagnostics, restoreCalls } = makeCoordinator({ restoreResults: [false, true] })
+
+    const result = coordinator.run({
+      kind: "content-resize",
+      source: "use-session-scroll-dock/contentObserver",
+      reason: "streaming-content-resize",
+      mutate: () => {},
+    })
+
+    expect(result.status).toBe("fallback")
+    expect(result.fallbackFrames).toBe(1)
+    expect(restoreCalls()).toBe(2)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback", "settled"])
+  })
+
+  test("reports a violation after the two-frame fallback budget is exceeded", () => {
+    const { coordinator, diagnostics, restoreCalls } = makeCoordinator({ restoreResults: [false, false, false] })
+
+    const result = coordinator.run({
+      kind: "row-measurement",
+      source: "timeline-virtualizer-bridge/measurement",
+      reason: "virtual-row-height-change",
+      mutate: () => {},
+    })
+
+    expect(result.status).toBe("violation")
+    expect(result.violation).toBe("anchor_restore_exceeded_fallback_budget")
+    expect(result.fallbackFrames).toBe(2)
+    expect(restoreCalls()).toBe(3)
+    expect(diagnostics.at(-1)).toMatchObject({
+      phase: "violation",
+      violation: "anchor_restore_exceeded_fallback_budget",
+    })
+  })
+})

--- a/packages/app/src/pages/session/timeline-layout-transaction.test.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.test.ts
@@ -311,4 +311,41 @@ describe("timeline layout transaction coordinator", () => {
       { active: false },
     ])
   })
+
+  test("cancels pending fallback before stale frames can restore or violate", () => {
+    const frame = deferredFrameScheduler()
+    let restoreCalls = 0
+    let stableBand = false
+    const diagnostics: TimelineLayoutTransactionDiagnostic[] = []
+    const coordinator = createTimelineLayoutTransactionCoordinator({
+      now: () => 600 + diagnostics.length,
+      scheduleFrame: frame.scheduler,
+      cancelFrame: () => {},
+      readMode: () => "reading_history",
+      sampleAnchor: () => readingAnchor,
+      restoreAnchor: () => {
+        restoreCalls += 1
+        return false
+      },
+      restoreLatest: () => false,
+      setStableBandActive: (active) => {
+        stableBand = active
+      },
+      emitDiagnostic: (event) => diagnostics.push(event),
+    })
+
+    coordinator.run({
+      kind: "content-resize",
+      source: "use-session-scroll-dock/contentObserver",
+      reason: "streaming-content-resize",
+      mutate: () => {},
+    })
+
+    coordinator.cancel()
+    frame.flushNextFrame()
+
+    expect(restoreCalls).toBe(1)
+    expect(stableBand).toBe(false)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback"])
+  })
 })

--- a/packages/app/src/pages/session/timeline-layout-transaction.test.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.test.ts
@@ -21,6 +21,19 @@ function immediateFrameScheduler(): TimelineLayoutTransactionFrameScheduler {
   }
 }
 
+function deferredFrameScheduler() {
+  const callbacks: Array<() => void> = []
+  const scheduler: TimelineLayoutTransactionFrameScheduler = (callback) => {
+    callbacks.push(callback)
+    return callbacks.length
+  }
+  return {
+    scheduler,
+    pendingFrames: () => callbacks.length,
+    flushNextFrame: () => callbacks.shift()?.(),
+  }
+}
+
 function makeCoordinator(input?: {
   mode?: TimelineScrollMode
   restoreResults?: boolean[]
@@ -126,5 +139,176 @@ describe("timeline layout transaction coordinator", () => {
       phase: "violation",
       violation: "anchor_restore_exceeded_fallback_budget",
     })
+  })
+
+  test("keeps async fallback transactions active until a scheduled frame settles", () => {
+    const frame = deferredFrameScheduler()
+    let restoreCalls = 0
+    let stableBand = false
+    const diagnostics: TimelineLayoutTransactionDiagnostic[] = []
+    const coordinator = createTimelineLayoutTransactionCoordinator({
+      now: () => 200 + diagnostics.length,
+      scheduleFrame: frame.scheduler,
+      cancelFrame: () => {},
+      readMode: () => "reading_history",
+      sampleAnchor: () => readingAnchor,
+      restoreAnchor: () => {
+        restoreCalls += 1
+        return restoreCalls === 2
+      },
+      restoreLatest: () => false,
+      setStableBandActive: (active) => {
+        stableBand = active
+      },
+      emitDiagnostic: (event) => diagnostics.push(event),
+    })
+
+    const result = coordinator.run({
+      kind: "dock-resize",
+      source: "use-session-scroll-dock/updateDockHeight",
+      reason: "question-dock-open",
+      mutate: () => {},
+    })
+
+    expect(result.status).toBe("fallback")
+    expect(result.fallbackFrames).toBe(1)
+    expect(restoreCalls).toBe(1)
+    expect(stableBand).toBe(true)
+    expect(frame.pendingFrames()).toBe(1)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback"])
+
+    frame.flushNextFrame()
+
+    expect(restoreCalls).toBe(2)
+    expect(stableBand).toBe(false)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback", "settled"])
+  })
+
+  test("keeps async fallback transactions active until second-frame violation", () => {
+    const frame = deferredFrameScheduler()
+    let restoreCalls = 0
+    let stableBand = false
+    const diagnostics: TimelineLayoutTransactionDiagnostic[] = []
+    const coordinator = createTimelineLayoutTransactionCoordinator({
+      now: () => 300 + diagnostics.length,
+      scheduleFrame: frame.scheduler,
+      cancelFrame: () => {},
+      readMode: () => "reading_history",
+      sampleAnchor: () => readingAnchor,
+      restoreAnchor: () => {
+        restoreCalls += 1
+        return false
+      },
+      restoreLatest: () => false,
+      setStableBandActive: (active) => {
+        stableBand = active
+      },
+      emitDiagnostic: (event) => diagnostics.push(event),
+    })
+
+    coordinator.run({
+      kind: "content-resize",
+      source: "use-session-scroll-dock/contentObserver",
+      reason: "streaming-content-resize",
+      mutate: () => {},
+    })
+
+    expect(stableBand).toBe(true)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback"])
+
+    frame.flushNextFrame()
+
+    expect(stableBand).toBe(true)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback", "fallback"])
+
+    frame.flushNextFrame()
+
+    expect(restoreCalls).toBe(3)
+    expect(stableBand).toBe(false)
+    expect(diagnostics.map((event) => event.phase)).toEqual(["start", "fallback", "fallback", "violation"])
+    expect(diagnostics.at(-1)?.violation).toBe("anchor_restore_exceeded_fallback_budget")
+  })
+
+  test("cancels stale fallback frames when a newer transaction starts", () => {
+    const frame = deferredFrameScheduler()
+    const canceledHandles: number[] = []
+    const diagnostics: TimelineLayoutTransactionDiagnostic[] = []
+    let firstRestoreCalls = 0
+    const coordinator = createTimelineLayoutTransactionCoordinator({
+      now: () => 400 + diagnostics.length,
+      scheduleFrame: frame.scheduler,
+      cancelFrame: (handle) => canceledHandles.push(handle),
+      readMode: () => "reading_history",
+      sampleAnchor: () => readingAnchor,
+      restoreAnchor: () => {
+        firstRestoreCalls += 1
+        return firstRestoreCalls > 2
+      },
+      restoreLatest: () => false,
+      setStableBandActive: () => {},
+      emitDiagnostic: (event) => diagnostics.push(event),
+    })
+
+    const first = coordinator.run({
+      kind: "content-resize",
+      source: "use-session-scroll-dock/contentObserver",
+      reason: "streaming-content-resize",
+      mutate: () => {},
+    })
+    const second = coordinator.run({
+      kind: "dock-resize",
+      source: "use-session-scroll-dock/updateDockHeight",
+      reason: "question-dock-open",
+      mutate: () => {},
+    })
+
+    expect(first.status).toBe("fallback")
+    expect(second.status).toBe("fallback")
+    expect(canceledHandles).toEqual([1])
+
+    frame.flushNextFrame()
+    frame.flushNextFrame()
+
+    expect(diagnostics.map((event) => `${event.transactionID}:${event.phase}`)).toEqual([
+      "timeline-layout-1:start",
+      "timeline-layout-1:fallback",
+      "timeline-layout-2:start",
+      "timeline-layout-2:fallback",
+      "timeline-layout-2:settled",
+    ])
+  })
+
+  test("reports active transaction state explicitly instead of through diagnostics", () => {
+    const frame = deferredFrameScheduler()
+    const states: Array<{ active: boolean; transactionID?: string; kind?: string }> = []
+    const diagnostics: TimelineLayoutTransactionDiagnostic[] = []
+    const coordinator = createTimelineLayoutTransactionCoordinator({
+      now: () => 500 + diagnostics.length,
+      scheduleFrame: frame.scheduler,
+      cancelFrame: () => {},
+      readMode: () => "reading_history",
+      sampleAnchor: () => readingAnchor,
+      restoreAnchor: () => diagnostics.length > 1,
+      restoreLatest: () => false,
+      setStableBandActive: () => {},
+      setTransactionState: (state) => states.push(state),
+      emitDiagnostic: (event) => diagnostics.push(event),
+    })
+
+    coordinator.run({
+      kind: "dock-resize",
+      source: "use-session-scroll-dock/updateDockHeight",
+      reason: "composer-growth",
+      mutate: () => {},
+    })
+
+    expect(states).toEqual([{ active: true, transactionID: "timeline-layout-1", kind: "dock-resize" }])
+
+    frame.flushNextFrame()
+
+    expect(states).toEqual([
+      { active: true, transactionID: "timeline-layout-1", kind: "dock-resize" },
+      { active: false },
+    ])
   })
 })

--- a/packages/app/src/pages/session/timeline-layout-transaction.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.ts
@@ -75,6 +75,7 @@ export function createTimelineLayoutTransactionCoordinator(input: {
 }) {
   let sequence = 0
   let activeGeneration = 0
+  let transactionPending = false
   let pendingFrameHandles = new Set<number>()
   const now = input.now ?? (() => performance.now())
 
@@ -87,8 +88,17 @@ export function createTimelineLayoutTransactionCoordinator(input: {
     pendingFrameHandles = new Set()
   }
 
-  const run = (runInput: TimelineLayoutTransactionRunInput): TimelineLayoutTransactionResult => {
+  const cancel = () => {
+    if (!transactionPending && pendingFrameHandles.size <= 0) return
+    activeGeneration += 1
+    transactionPending = false
     clearPendingFrames()
+    input.setStableBandActive(false)
+    input.setTransactionState?.({ active: false })
+  }
+
+  const run = (runInput: TimelineLayoutTransactionRunInput): TimelineLayoutTransactionResult => {
+    cancel()
     sequence += 1
     activeGeneration += 1
     const generation = activeGeneration
@@ -124,6 +134,7 @@ export function createTimelineLayoutTransactionCoordinator(input: {
     ) => {
       if (generation !== activeGeneration || settled) return false
       settled = true
+      transactionPending = false
       input.setStableBandActive(false)
       input.setTransactionState?.({ active: false })
       if (violation) {
@@ -160,6 +171,7 @@ export function createTimelineLayoutTransactionCoordinator(input: {
     }
 
     input.setStableBandActive(true)
+    transactionPending = true
     input.setTransactionState?.({ active: true, transactionID, kind: runInput.kind })
     emit({ ...base, phase: "start", fallbackFrames: 0 })
 
@@ -175,11 +187,12 @@ export function createTimelineLayoutTransactionCoordinator(input: {
       return result
     } catch (error) {
       if (generation === activeGeneration) clearPendingFrames()
+      transactionPending = false
       input.setStableBandActive(false)
       input.setTransactionState?.({ active: false })
       throw error
     }
   }
 
-  return { run }
+  return { run, cancel }
 }

--- a/packages/app/src/pages/session/timeline-layout-transaction.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.ts
@@ -1,0 +1,133 @@
+import type { TimelineSafePosition, TimelineScrollMode } from "./session-timeline-scroll-controller"
+
+export type TimelineLayoutTransactionKind = "dock-resize" | "content-resize" | "row-measurement" | "end-of-turn-settle"
+export type TimelineLayoutTransactionPhase = "start" | "fallback" | "settled" | "violation"
+export type TimelineLayoutTransactionStatus = "before-paint" | "fallback" | "violation" | "no-op"
+export type TimelineLayoutTransactionViolation = "anchor_restore_exceeded_fallback_budget"
+
+export type TimelineLayoutTransactionFrameScheduler = (callback: () => void) => number
+
+export type TimelineLayoutTransactionDiagnostic = {
+  transactionID: string
+  kind: TimelineLayoutTransactionKind
+  phase: TimelineLayoutTransactionPhase
+  monotonicMs: number
+  mode: TimelineScrollMode
+  source: string
+  reason: string
+  anchorKind: TimelineSafePosition["kind"]
+  anchorMessageID?: string
+  fallbackFrames: number
+  violation?: TimelineLayoutTransactionViolation
+}
+
+export type TimelineLayoutTransactionResult = {
+  transactionID: string
+  kind: TimelineLayoutTransactionKind
+  status: TimelineLayoutTransactionStatus
+  anchor: TimelineSafePosition
+  fallbackFrames: number
+  violation?: TimelineLayoutTransactionViolation
+}
+
+export type TimelineLayoutTransactionRunInput = {
+  kind: TimelineLayoutTransactionKind
+  source: string
+  reason: string
+  mutate: () => void
+}
+
+function anchorMessageID(anchor: TimelineSafePosition) {
+  if (anchor.kind === "reading") return anchor.anchorMessageID
+  if (anchor.kind === "target_message") return anchor.messageID
+  return anchor.messageID
+}
+
+function latestAnchor(): TimelineSafePosition {
+  return { kind: "latest" }
+}
+
+export function createTimelineLayoutTransactionCoordinator(input: {
+  now?: () => number
+  scheduleFrame: TimelineLayoutTransactionFrameScheduler
+  cancelFrame: (handle: number) => void
+  readMode: () => TimelineScrollMode
+  sampleAnchor: () => TimelineSafePosition
+  restoreAnchor: (anchor: TimelineSafePosition, transactionID: string) => boolean
+  restoreLatest: (transactionID: string) => boolean
+  setStableBandActive: (active: boolean) => void
+  emitDiagnostic?: (event: TimelineLayoutTransactionDiagnostic) => void
+}) {
+  let sequence = 0
+  const now = input.now ?? (() => performance.now())
+
+  const emit = (event: Omit<TimelineLayoutTransactionDiagnostic, "monotonicMs">) => {
+    input.emitDiagnostic?.({ ...event, monotonicMs: now() })
+  }
+
+  const run = (runInput: TimelineLayoutTransactionRunInput): TimelineLayoutTransactionResult => {
+    sequence += 1
+    const transactionID = `timeline-layout-${sequence}`
+    const mode = input.readMode()
+    const anchor = mode === "following_latest" ? latestAnchor() : input.sampleAnchor()
+    const base = {
+      transactionID,
+      kind: runInput.kind,
+      mode,
+      source: runInput.source,
+      reason: runInput.reason,
+      anchorKind: anchor.kind,
+      anchorMessageID: anchorMessageID(anchor),
+    }
+
+    input.setStableBandActive(true)
+    emit({ ...base, phase: "start", fallbackFrames: 0 })
+
+    try {
+      runInput.mutate()
+
+      const restored =
+        anchor.kind === "latest" ? input.restoreLatest(transactionID) : input.restoreAnchor(anchor, transactionID)
+      if (restored) {
+        input.setStableBandActive(false)
+        emit({ ...base, phase: "settled", fallbackFrames: 0 })
+        return { transactionID, kind: runInput.kind, status: "before-paint", anchor, fallbackFrames: 0 }
+      }
+
+      for (let frame = 1; frame <= 2; frame += 1) {
+        emit({ ...base, phase: "fallback", fallbackFrames: frame })
+        let fallbackRestored = false
+        input.scheduleFrame(() => {
+          fallbackRestored =
+            anchor.kind === "latest" ? input.restoreLatest(transactionID) : input.restoreAnchor(anchor, transactionID)
+        })
+        if (fallbackRestored) {
+          input.setStableBandActive(false)
+          emit({ ...base, phase: "settled", fallbackFrames: frame })
+          return { transactionID, kind: runInput.kind, status: "fallback", anchor, fallbackFrames: frame }
+        }
+      }
+
+      input.setStableBandActive(false)
+      emit({
+        ...base,
+        phase: "violation",
+        fallbackFrames: 2,
+        violation: "anchor_restore_exceeded_fallback_budget",
+      })
+      return {
+        transactionID,
+        kind: runInput.kind,
+        status: "violation",
+        anchor,
+        fallbackFrames: 2,
+        violation: "anchor_restore_exceeded_fallback_budget",
+      }
+    } catch (error) {
+      input.setStableBandActive(false)
+      throw error
+    }
+  }
+
+  return { run }
+}

--- a/packages/app/src/pages/session/timeline-layout-transaction.ts
+++ b/packages/app/src/pages/session/timeline-layout-transaction.ts
@@ -35,7 +35,21 @@ export type TimelineLayoutTransactionRunInput = {
   source: string
   reason: string
   mutate: () => void
+  mode?: TimelineScrollMode
+  restoreLatest?: (transactionID: string) => boolean
 }
+
+export type TimelineLayoutTransactionState =
+  | {
+      active: true
+      transactionID: string
+      kind: TimelineLayoutTransactionKind
+    }
+  | {
+      active: false
+      transactionID?: undefined
+      kind?: undefined
+    }
 
 function anchorMessageID(anchor: TimelineSafePosition) {
   if (anchor.kind === "reading") return anchor.anchorMessageID
@@ -56,20 +70,32 @@ export function createTimelineLayoutTransactionCoordinator(input: {
   restoreAnchor: (anchor: TimelineSafePosition, transactionID: string) => boolean
   restoreLatest: (transactionID: string) => boolean
   setStableBandActive: (active: boolean) => void
+  setTransactionState?: (state: TimelineLayoutTransactionState) => void
   emitDiagnostic?: (event: TimelineLayoutTransactionDiagnostic) => void
 }) {
   let sequence = 0
+  let activeGeneration = 0
+  let pendingFrameHandles = new Set<number>()
   const now = input.now ?? (() => performance.now())
 
   const emit = (event: Omit<TimelineLayoutTransactionDiagnostic, "monotonicMs">) => {
     input.emitDiagnostic?.({ ...event, monotonicMs: now() })
   }
 
+  const clearPendingFrames = () => {
+    for (const handle of pendingFrameHandles) input.cancelFrame(handle)
+    pendingFrameHandles = new Set()
+  }
+
   const run = (runInput: TimelineLayoutTransactionRunInput): TimelineLayoutTransactionResult => {
+    clearPendingFrames()
     sequence += 1
+    activeGeneration += 1
+    const generation = activeGeneration
     const transactionID = `timeline-layout-${sequence}`
-    const mode = input.readMode()
+    const mode = runInput.mode ?? input.readMode()
     const anchor = mode === "following_latest" ? latestAnchor() : input.sampleAnchor()
+    const restoreLatestForTransaction = runInput.restoreLatest ?? input.restoreLatest
     const base = {
       transactionID,
       kind: runInput.kind,
@@ -79,52 +105,78 @@ export function createTimelineLayoutTransactionCoordinator(input: {
       anchorKind: anchor.kind,
       anchorMessageID: anchorMessageID(anchor),
     }
+    let settled = false
+    let result: TimelineLayoutTransactionResult = {
+      transactionID,
+      kind: runInput.kind,
+      status: "fallback",
+      anchor,
+      fallbackFrames: 1,
+    }
+
+    const restore = () =>
+      anchor.kind === "latest" ? restoreLatestForTransaction(transactionID) : input.restoreAnchor(anchor, transactionID)
+
+    const settle = (
+      status: TimelineLayoutTransactionStatus,
+      fallbackFrames: number,
+      violation?: TimelineLayoutTransactionViolation,
+    ) => {
+      if (generation !== activeGeneration || settled) return false
+      settled = true
+      input.setStableBandActive(false)
+      input.setTransactionState?.({ active: false })
+      if (violation) {
+        emit({ ...base, phase: "violation", fallbackFrames, violation })
+      } else {
+        emit({ ...base, phase: "settled", fallbackFrames })
+      }
+      result = { transactionID, kind: runInput.kind, status, anchor, fallbackFrames, violation }
+      return true
+    }
+
+    const attemptFallbackRestore = (frame: number) => {
+      if (generation !== activeGeneration || settled) return
+      if (restore()) {
+        settle("fallback", frame)
+        return
+      }
+      if (frame >= 2) {
+        settle("violation", frame, "anchor_restore_exceeded_fallback_budget")
+        return
+      }
+      scheduleFallback(frame + 1)
+    }
+
+    const scheduleFallback = (frame: number) => {
+      if (generation !== activeGeneration || settled) return
+      emit({ ...base, phase: "fallback", fallbackFrames: frame })
+      let handle: number | undefined
+      handle = input.scheduleFrame(() => {
+        if (handle !== undefined) pendingFrameHandles.delete(handle)
+        attemptFallbackRestore(frame)
+      })
+      if (!settled && generation === activeGeneration) pendingFrameHandles.add(handle)
+    }
 
     input.setStableBandActive(true)
+    input.setTransactionState?.({ active: true, transactionID, kind: runInput.kind })
     emit({ ...base, phase: "start", fallbackFrames: 0 })
 
     try {
       runInput.mutate()
 
-      const restored =
-        anchor.kind === "latest" ? input.restoreLatest(transactionID) : input.restoreAnchor(anchor, transactionID)
-      if (restored) {
-        input.setStableBandActive(false)
-        emit({ ...base, phase: "settled", fallbackFrames: 0 })
+      if (restore()) {
+        settle("before-paint", 0)
         return { transactionID, kind: runInput.kind, status: "before-paint", anchor, fallbackFrames: 0 }
       }
 
-      for (let frame = 1; frame <= 2; frame += 1) {
-        emit({ ...base, phase: "fallback", fallbackFrames: frame })
-        let fallbackRestored = false
-        input.scheduleFrame(() => {
-          fallbackRestored =
-            anchor.kind === "latest" ? input.restoreLatest(transactionID) : input.restoreAnchor(anchor, transactionID)
-        })
-        if (fallbackRestored) {
-          input.setStableBandActive(false)
-          emit({ ...base, phase: "settled", fallbackFrames: frame })
-          return { transactionID, kind: runInput.kind, status: "fallback", anchor, fallbackFrames: frame }
-        }
-      }
-
-      input.setStableBandActive(false)
-      emit({
-        ...base,
-        phase: "violation",
-        fallbackFrames: 2,
-        violation: "anchor_restore_exceeded_fallback_budget",
-      })
-      return {
-        transactionID,
-        kind: runInput.kind,
-        status: "violation",
-        anchor,
-        fallbackFrames: 2,
-        violation: "anchor_restore_exceeded_fallback_budget",
-      }
+      scheduleFallback(1)
+      return result
     } catch (error) {
+      if (generation === activeGeneration) clearPendingFrames()
       input.setStableBandActive(false)
+      input.setTransactionState?.({ active: false })
       throw error
     }
   }

--- a/packages/app/src/pages/session/timeline-row-renderer.tsx
+++ b/packages/app/src/pages/session/timeline-row-renderer.tsx
@@ -3,6 +3,7 @@ import { Virtualizer } from "virtua/solid"
 import type { TimelineVirtualizerBridge } from "./timeline-virtualizer-bridge"
 import type { TimelineVirtualRow } from "./timeline-virtual-rows"
 import type { TimelineRowRenderMode } from "./timeline-virtualization-strategy"
+import { chooseTimelineVirtualizerOverscan } from "./timeline-layout-stable-band"
 
 export function TimelineRowRenderer(props: {
   mode: TimelineRowRenderMode
@@ -10,6 +11,7 @@ export function TimelineRowRenderer(props: {
   viewport: HTMLDivElement | undefined
   virtualizerBridge: TimelineVirtualizerBridge
   shift: boolean
+  transactionActive: boolean
   renderRow: (row: TimelineVirtualRow) => JSX.Element
 }) {
   createEffect(() => {
@@ -33,6 +35,7 @@ function VirtualizedTimelineRows(props: {
   viewport: HTMLDivElement | undefined
   virtualizerBridge: TimelineVirtualizerBridge
   shift: boolean
+  transactionActive: boolean
   renderRow: (row: TimelineVirtualRow) => JSX.Element
 }) {
   return (
@@ -43,7 +46,7 @@ function VirtualizedTimelineRows(props: {
           data={props.rows}
           scrollRef={viewport()}
           shift={props.shift}
-          overscan={8}
+          overscan={chooseTimelineVirtualizerOverscan({ transactionActive: props.transactionActive })}
         >
           {props.renderRow}
         </Virtualizer>

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
@@ -100,6 +100,44 @@ describe("TimelineScrollCommandSink", () => {
     expect(sink.records().map((record) => record.source)).toEqual(["two", "three"])
   })
 
+  test("records transaction metadata on scoped commands", () => {
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
+    const sink = createTimelineScrollCommandSink({ now: () => 456 })
+    const scoped = sink.withTransaction({ transactionID: "tx-1", transactionKind: "dock-resize" })
+
+    scoped.setScrollTop({ element: scroller.el, top: 120, type: "anchor-restore", source: "transaction-test" })
+
+    expect(sink.records()[0]).toMatchObject({
+      transactionID: "tx-1",
+      transactionKind: "dock-resize",
+      type: "anchor-restore",
+      source: "transaction-test",
+    })
+  })
+
+  test("emits a transaction violation when an unscoped command runs during an active transaction", () => {
+    const events: unknown[] = []
+    const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
+    const sink = createTimelineScrollCommandSink({
+      activeTransaction: () => ({ transactionID: "tx-2", transactionKind: "content-resize" }),
+      emitDiagnostic: (event) => events.push(event),
+    })
+
+    sink.setScrollTop({ element: scroller.el, top: 220, type: "bottom-follow", source: "legacy-bottom-follow" })
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "session.timeline.layout_transaction_violation",
+        data: expect.objectContaining({
+          transaction_id: "tx-2",
+          transaction_kind: "content-resize",
+          violation: "scroll_command_outside_transaction",
+          command_source: "legacy-bottom-follow",
+        }),
+      }),
+    )
+  })
+
   test("keeps diagnostic failures out of the scroll path", async () => {
     const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 0 })
     const syncSink = createTimelineScrollCommandSink({

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.test.ts
@@ -120,7 +120,9 @@ describe("TimelineScrollCommandSink", () => {
     const scroller = makeScroller({ clientHeight: 100, scrollHeight: 900, scrollTop: 12 })
     const sink = createTimelineScrollCommandSink({
       activeTransaction: () => ({ transactionID: "tx-2", transactionKind: "content-resize" }),
-      emitDiagnostic: (event) => events.push(event),
+      emitDiagnostic: (event) => {
+        events.push(event)
+      },
     })
 
     sink.setScrollTop({ element: scroller.el, top: 220, type: "bottom-follow", source: "legacy-bottom-follow" })

--- a/packages/app/src/pages/session/timeline-scroll-command-sink.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-sink.ts
@@ -1,4 +1,5 @@
 import type { RendererDiagnosticInput } from "@/context/platform"
+import type { TimelineLayoutTransactionKind } from "./timeline-layout-transaction"
 
 export type TimelineScrollCommandType =
   | "anchor-restore"
@@ -24,17 +25,25 @@ export type TimelineScrollCommandContext = {
   timelineSessionID?: string
 }
 
-export type TimelineScrollCommandRecord = TimelineScrollCommandContext & {
-  monotonicMs: number
-  type: TimelineScrollCommandType
-  source: string
-  method: TimelineScrollCommandMethod
-  top: number
-  behavior?: ScrollBehavior
-  reason?: string
-  before?: TimelineScrollCommandMetrics
-  after?: TimelineScrollCommandMetrics
+export type TimelineScrollCommandTransaction = {
+  transactionID: string
+  transactionKind: TimelineLayoutTransactionKind
 }
+
+type TimelineScrollCommandTransactionPartial = Partial<TimelineScrollCommandTransaction>
+
+export type TimelineScrollCommandRecord = TimelineScrollCommandContext &
+  TimelineScrollCommandTransactionPartial & {
+    monotonicMs: number
+    type: TimelineScrollCommandType
+    source: string
+    method: TimelineScrollCommandMethod
+    top: number
+    behavior?: ScrollBehavior
+    reason?: string
+    before?: TimelineScrollCommandMetrics
+    after?: TimelineScrollCommandMetrics
+  }
 
 type TimelineScrollCommandBase = {
   element: HTMLElement
@@ -42,6 +51,7 @@ type TimelineScrollCommandBase = {
   type: TimelineScrollCommandType
   source: string
   reason?: string
+  transaction?: TimelineScrollCommandTransaction
 }
 
 export type TimelineSetScrollTopCommand = TimelineScrollCommandBase
@@ -51,6 +61,7 @@ export type TimelineScrollCommandSink = {
   setScrollTop: (command: TimelineSetScrollTopCommand) => TimelineScrollCommandRecord
   scrollTo: (command: TimelineScrollToCommand) => TimelineScrollCommandRecord
   records: () => TimelineScrollCommandRecord[]
+  withTransaction: (transaction: TimelineScrollCommandTransaction) => TimelineScrollCommandSink
 }
 
 export function collectTimelineScrollCommandMetrics(element: HTMLElement): TimelineScrollCommandMetrics {
@@ -64,43 +75,76 @@ export function collectTimelineScrollCommandMetrics(element: HTMLElement): Timel
 }
 
 export function createTimelineScrollCommandSink(input?: {
+  activeTransaction?: () => TimelineScrollCommandTransaction | undefined
   emitDiagnostic?: (event: RendererDiagnosticInput) => Promise<void> | void
   fullMetricsEnabled?: () => boolean
   getContext?: () => TimelineScrollCommandContext
   maxRecords?: number
   now?: () => number
+  transaction?: TimelineScrollCommandTransaction
 }): TimelineScrollCommandSink {
   const maxRecords = Math.max(1, input?.maxRecords ?? 100)
   const records: TimelineScrollCommandRecord[] = []
   const now = input?.now ?? (() => performance.now())
 
-  const remember = (record: TimelineScrollCommandRecord) => {
-    records.push(record)
-    while (records.length > maxRecords) records.shift()
+  const emitDiagnostic = (event: RendererDiagnosticInput) => {
     try {
-      const maybePromise = input?.emitDiagnostic?.({
-        name: "session.timeline.scroll_command",
-        route_session_id: record.routeSessionID,
-        visible_session_id: record.visibleSessionID,
-        timeline_session_id: record.timelineSessionID,
-        monotonic_ms: record.monotonicMs,
-        data: {
-          command_type: record.type,
-          command_method: record.method,
-          command_source: record.source,
-          command_reason: record.reason,
-          command_top: record.top,
-          command_behavior: record.behavior,
-          before_scroll_top: record.before?.scrollTop,
-          before_distance_from_bottom: record.before?.distanceFromBottom,
-          after_scroll_top: record.after?.scrollTop,
-          after_distance_from_bottom: record.after?.distanceFromBottom,
-        },
-      })
+      const maybePromise = input?.emitDiagnostic?.(event)
       void maybePromise?.catch?.(() => {})
     } catch {
       // Diagnostics should never affect timeline scroll command execution.
     }
+  }
+
+  const maybeEmitTransactionViolation = (record: TimelineScrollCommandRecord) => {
+    const activeTransaction = input?.activeTransaction?.()
+    if (!activeTransaction) return
+    if (record.transactionID === activeTransaction.transactionID) return
+    emitDiagnostic({
+      name: "session.timeline.layout_transaction_violation",
+      route_session_id: record.routeSessionID,
+      visible_session_id: record.visibleSessionID,
+      timeline_session_id: record.timelineSessionID,
+      monotonic_ms: record.monotonicMs,
+      data: {
+        transaction_id: activeTransaction.transactionID,
+        transaction_kind: activeTransaction.transactionKind,
+        command_transaction_id: record.transactionID,
+        command_transaction_kind: record.transactionKind,
+        violation: "scroll_command_outside_transaction",
+        command_type: record.type,
+        command_method: record.method,
+        command_source: record.source,
+        command_reason: record.reason,
+      },
+    })
+  }
+
+  const remember = (record: TimelineScrollCommandRecord) => {
+    records.push(record)
+    while (records.length > maxRecords) records.shift()
+    maybeEmitTransactionViolation(record)
+    emitDiagnostic({
+      name: "session.timeline.scroll_command",
+      route_session_id: record.routeSessionID,
+      visible_session_id: record.visibleSessionID,
+      timeline_session_id: record.timelineSessionID,
+      monotonic_ms: record.monotonicMs,
+      data: {
+        command_type: record.type,
+        command_method: record.method,
+        command_source: record.source,
+        command_reason: record.reason,
+        command_top: record.top,
+        command_behavior: record.behavior,
+        transaction_id: record.transactionID,
+        transaction_kind: record.transactionKind,
+        before_scroll_top: record.before?.scrollTop,
+        before_distance_from_bottom: record.before?.distanceFromBottom,
+        after_scroll_top: record.after?.scrollTop,
+        after_distance_from_bottom: record.after?.distanceFromBottom,
+      },
+    })
     return record
   }
 
@@ -108,13 +152,16 @@ export function createTimelineScrollCommandSink(input?: {
     command: TimelineSetScrollTopCommand | TimelineScrollToCommand,
     method: TimelineScrollCommandMethod,
     apply: () => void,
+    sinkTransaction?: TimelineScrollCommandTransaction,
   ) => {
     const fullMetrics = input?.fullMetricsEnabled?.() ?? false
     const before = fullMetrics ? collectTimelineScrollCommandMetrics(command.element) : undefined
     apply()
     const after = fullMetrics ? collectTimelineScrollCommandMetrics(command.element) : undefined
+    const transaction = command.transaction ?? sinkTransaction ?? input?.transaction
     return remember({
       ...(input?.getContext?.() ?? {}),
+      ...transaction,
       monotonicMs: now(),
       type: command.type,
       source: command.source,
@@ -127,15 +174,28 @@ export function createTimelineScrollCommandSink(input?: {
     })
   }
 
-  return {
+  const makeSink = (sinkTransaction?: TimelineScrollCommandTransaction): TimelineScrollCommandSink => ({
     setScrollTop: (command) =>
-      execute(command, "set-scroll-top", () => {
-        command.element.scrollTop = command.top
-      }),
+      execute(
+        command,
+        "set-scroll-top",
+        () => {
+          command.element.scrollTop = command.top
+        },
+        sinkTransaction,
+      ),
     scrollTo: (command) =>
-      execute(command, "scroll-to", () => {
-        command.element.scrollTo({ top: command.top, behavior: command.behavior })
-      }),
+      execute(
+        command,
+        "scroll-to",
+        () => {
+          command.element.scrollTo({ top: command.top, behavior: command.behavior })
+        },
+        sinkTransaction,
+      ),
     records: () => [...records],
-  }
+    withTransaction: (transaction) => makeSink(transaction),
+  })
+
+  return makeSink(input?.transaction)
 }

--- a/packages/app/src/pages/session/use-session-scroll-dock.test.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.test.ts
@@ -375,6 +375,73 @@ describe("session scroll dock", () => {
     })
   })
 
+  test("keeps dock resize bottom-follow recovery inside the active layout transaction", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const promptDock = makeMeasuredDiv(120)
+        const events: unknown[] = []
+        let activeTransaction: { transactionID: string; transactionKind: "dock-resize" | "content-resize" } | undefined
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1000, scrollTop: 600 })
+        const scrollCommandSink = createTimelineScrollCommandSink({
+          activeTransaction: () => activeTransaction,
+          emitDiagnostic: (event) => {
+            events.push(event)
+          },
+        })
+
+        try {
+          const scrollDock = createSessionScrollDock({
+            clearMessageHash: () => undefined,
+            clearActiveMessage: () => undefined,
+            fill: () => undefined,
+            scrollCommandSink,
+            runLayoutTransaction: (event) => {
+              activeTransaction = { transactionID: "tx-dock-locked", transactionKind: event.kind }
+              try {
+                event.mutate()
+                event.restoreLatest("tx-dock-locked")
+              } finally {
+                activeTransaction = undefined
+              }
+            },
+          })
+
+          scrollDock.setScrollRef(scroller.el)
+          scrollDock.setPromptDockRef(promptDock.el)
+          scrollDock.resumeScroll()
+          scroller.el.scrollTop = 0
+          promptDock.setHeight(220)
+          triggerResize(promptDock.el)
+
+          expect(scrollCommandSink.records().length).toBeGreaterThan(0)
+          expect(scrollCommandSink.records()).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: "dock-resize-bottom-follow",
+                transactionID: "tx-dock-locked",
+                transactionKind: "dock-resize",
+              }),
+            ]),
+          )
+          expect(scrollCommandSink.records()).toEqual(
+            scrollCommandSink.records().map((record) =>
+              expect.objectContaining({
+                transactionID: "tx-dock-locked",
+                transactionKind: "dock-resize",
+              }),
+            ),
+          )
+          expect(events).not.toContainEqual(
+            expect.objectContaining({ name: "session.timeline.layout_transaction_violation" }),
+          )
+        } finally {
+          dispose()
+          document.documentElement.style.removeProperty("--composer-dock-height")
+        }
+      })
+    })
+  })
+
   test("runs content resize through the layout transaction callback", () => {
     withResizeObserver((triggerResize) => {
       createRoot((dispose) => {
@@ -406,6 +473,71 @@ describe("session scroll dock", () => {
           "fill",
           "transaction:restore-anchor",
         ])
+        dispose()
+      })
+    })
+  })
+
+  test("keeps content resize bottom-follow recovery inside the active layout transaction", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const content = makeMeasuredDiv(600)
+        const events: unknown[] = []
+        let activeTransaction: { transactionID: string; transactionKind: "dock-resize" | "content-resize" } | undefined
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1200, scrollTop: 800 })
+        const scrollCommandSink = createTimelineScrollCommandSink({
+          activeTransaction: () => activeTransaction,
+          emitDiagnostic: (event) => {
+            events.push(event)
+          },
+        })
+
+        const scrollDock = createSessionScrollDock({
+          clearMessageHash: () => undefined,
+          clearActiveMessage: () => undefined,
+          fill: () => undefined,
+          scrollCommandSink,
+          onContentResize: () => undefined,
+          runLayoutTransaction: (event) => {
+            activeTransaction = { transactionID: "tx-content-locked", transactionKind: event.kind }
+            try {
+              event.mutate()
+              event.restoreLatest("tx-content-locked")
+            } finally {
+              activeTransaction = undefined
+            }
+          },
+        })
+
+        scrollDock.setScrollRef(scroller.el)
+        scrollDock.setContentRef(content.el)
+        scrollDock.resumeScroll()
+        scroller.el.scrollTop = 0
+        content.setHeight(720)
+        triggerResize(content.el)
+
+        expect(scrollCommandSink.records().length).toBeGreaterThan(0)
+        expect(scrollCommandSink.records()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "content-resize-bottom-follow",
+              transactionID: "tx-content-locked",
+              transactionKind: "content-resize",
+            }),
+          ]),
+        )
+        expect(scrollCommandSink.records()).toEqual(
+          scrollCommandSink.records().map((record) =>
+            expect.objectContaining({
+              transactionID: "tx-content-locked",
+              transactionKind: "content-resize",
+            }),
+          ),
+        )
+        expect(events).not.toContainEqual(
+          expect.objectContaining({ name: "session.timeline.layout_transaction_violation" }),
+        )
+
         dispose()
       })
     })

--- a/packages/app/src/pages/session/use-session-scroll-dock.test.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.test.ts
@@ -298,6 +298,119 @@ describe("session scroll dock", () => {
     })
   })
 
+  test("runs dock height changes through the layout transaction callback while reading history", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const previousDockHeight = document.documentElement.style.getPropertyValue("--composer-dock-height")
+        const promptDock = makeMeasuredDiv(120)
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1000, scrollTop: 200 })
+        const events: string[] = []
+
+        try {
+          const scrollDock = createSessionScrollDock({
+            clearMessageHash: () => undefined,
+            clearActiveMessage: () => undefined,
+            fill: () => events.push("fill"),
+            runLayoutTransaction: (event) => {
+              events.push(`transaction:start:${event.kind}`)
+              event.mutate()
+              events.push("transaction:restore-anchor")
+            },
+          })
+
+          scrollDock.setScrollRef(scroller.el)
+          scrollDock.setPromptDockRef(promptDock.el)
+          events.length = 0
+          promptDock.setHeight(180)
+          triggerResize(promptDock.el)
+
+          expect(events).toEqual(["transaction:start:dock-resize", "fill", "transaction:restore-anchor"])
+          expect(document.documentElement.style.getPropertyValue("--composer-dock-height")).toBe("180px")
+        } finally {
+          dispose()
+          if (previousDockHeight)
+            document.documentElement.style.setProperty("--composer-dock-height", previousDockHeight)
+          else document.documentElement.style.removeProperty("--composer-dock-height")
+        }
+      })
+    })
+  })
+
+  test("lets the transaction issue the final bottom-follow command when pinned to latest", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const promptDock = makeMeasuredDiv(120)
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1000, scrollTop: 600 })
+        const scrollCommandSink = createTimelineScrollCommandSink({ now: () => 600 })
+
+        try {
+          const scrollDock = createSessionScrollDock({
+            clearMessageHash: () => undefined,
+            clearActiveMessage: () => undefined,
+            fill: () => undefined,
+            scrollCommandSink,
+            runLayoutTransaction: (event) => {
+              event.mutate()
+              event.restoreLatest("tx-dock-latest")
+            },
+          })
+
+          scrollDock.setScrollRef(scroller.el)
+          scrollDock.setPromptDockRef(promptDock.el)
+          promptDock.setHeight(220)
+          triggerResize(promptDock.el)
+
+          expect(scrollCommandSink.records()).toContainEqual(
+            expect.objectContaining({
+              type: "dock-resize-bottom-follow",
+              transactionID: "tx-dock-latest",
+              transactionKind: "dock-resize",
+            }),
+          )
+        } finally {
+          dispose()
+          document.documentElement.style.removeProperty("--composer-dock-height")
+        }
+      })
+    })
+  })
+
+  test("runs content resize through the layout transaction callback", () => {
+    withResizeObserver((triggerResize) => {
+      createRoot((dispose) => {
+        const content = makeMeasuredDiv(600)
+        const scroller = makeScroller({ clientHeight: 400, scrollHeight: 1200, scrollTop: 240 })
+        const events: string[] = []
+
+        const scrollDock = createSessionScrollDock({
+          clearMessageHash: () => undefined,
+          clearActiveMessage: () => undefined,
+          fill: () => events.push("fill"),
+          onContentResize: () => events.push("content-observed"),
+          runLayoutTransaction: (event) => {
+            events.push(`transaction:start:${event.kind}`)
+            event.mutate()
+            events.push("transaction:restore-anchor")
+          },
+        })
+
+        scrollDock.setScrollRef(scroller.el)
+        scrollDock.setContentRef(content.el)
+        events.length = 0
+        content.setHeight(720)
+        triggerResize(content.el)
+
+        expect(events).toEqual([
+          "transaction:start:content-resize",
+          "content-observed",
+          "fill",
+          "transaction:restore-anchor",
+        ])
+        dispose()
+      })
+    })
+  })
+
   test("records a dock-resize bottom-follow command when resize needs a scroll write", () => {
     withResizeObserver((triggerResize) => {
       createRoot((dispose) => {

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -4,13 +4,24 @@ import { createStore } from "solid-js/store"
 import {
   createTimelineScrollCommandSink,
   type TimelineScrollCommandSink,
+  type TimelineScrollCommandTransaction,
   type TimelineScrollCommandType,
 } from "./timeline-scroll-command-sink"
+import type { TimelineLayoutTransactionKind } from "./timeline-layout-transaction"
 
 export type SessionScrollState = {
   overflow: boolean
   bottom: boolean
   jump: boolean
+}
+
+type SessionLayoutTransactionInput = {
+  kind: Extract<TimelineLayoutTransactionKind, "dock-resize" | "content-resize">
+  source: string
+  reason: string
+  stickToBottom: boolean
+  mutate: () => void
+  restoreLatest: (transactionID: string) => boolean
 }
 
 const BOTTOM_FOLLOW_LOCK_MS = 3_000
@@ -95,6 +106,7 @@ export function createSessionScrollDock(input: {
     distanceFromBottom?: number
   }) => void
   onContentResize?: (event: { scrollTop?: number; distanceFromBottom?: number }) => void
+  runLayoutTransaction?: (input: SessionLayoutTransactionInput) => void
   scrollCommandSink?: TimelineScrollCommandSink
 }) {
   const fallbackTimelineScrollCommandSink = createTimelineScrollCommandSink()
@@ -217,6 +229,24 @@ export function createSessionScrollDock(input: {
     return true
   }
 
+  const restoreLatestThroughSink = (input: {
+    transaction: TimelineScrollCommandTransaction
+    type: Extract<TimelineScrollCommandType, "content-resize-bottom-follow" | "dock-resize-bottom-follow">
+    source: string
+    reason: string
+  }) => {
+    if (!scroller) return false
+    scrollCommandSink().withTransaction(input.transaction).setScrollTop({
+      element: scroller,
+      top: scroller.scrollHeight,
+      type: input.type,
+      source: input.source,
+      reason: input.reason,
+    })
+    if (scroller) scheduleScrollState(scroller)
+    return true
+  }
+
   const setScrollRef = (el: HTMLDivElement | undefined) => {
     scroller = el
     autoScroll.scrollRef(el)
@@ -234,12 +264,34 @@ export function createSessionScrollDock(input: {
     if (el && scroller) scheduleScrollState(scroller)
     if (!el) return
     contentObserver = new ResizeObserver(() => {
-      input.onContentResize?.({
-        scrollTop: scroller?.scrollTop,
-        distanceFromBottom: scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined,
-      })
-      if (scroller) scheduleScrollState(scroller)
-      input.fill()
+      const runContentMutation = () => {
+        input.onContentResize?.({
+          scrollTop: scroller?.scrollTop,
+          distanceFromBottom: scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined,
+        })
+        if (scroller) scheduleScrollState(scroller)
+        input.fill()
+      }
+
+      if (input.runLayoutTransaction && scroller) {
+        input.runLayoutTransaction({
+          kind: "content-resize",
+          source: "use-session-scroll-dock/contentObserver",
+          reason: "content-resize",
+          stickToBottom: bottomFollowLockedFor(),
+          mutate: runContentMutation,
+          restoreLatest: (transactionID) =>
+            restoreLatestThroughSink({
+              transaction: { transactionID, transactionKind: "content-resize" },
+              type: "content-resize-bottom-follow",
+              source: "use-session-scroll-dock/layoutTransactionRestoreLatest",
+              reason: "content-resize",
+            }),
+        })
+        return
+      }
+
+      runContentMutation()
       restoreBottomIfLocked()
     })
     contentObserver.observe(el)
@@ -250,16 +302,45 @@ export function createSessionScrollDock(input: {
     const dockKind = promptDockKind()
     const scrollTop = scroller?.scrollTop
     const distanceFromBottom = scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined
-    dockHeight = syncComposerDockHeight({
-      el: scroller,
-      previousDockHeight,
-      nextDockHeight: next,
-      userScrolled: autoScroll.userScrolled(),
-      setCssHeight: (value) => document.documentElement.style.setProperty("--composer-dock-height", `${value}px`),
-      forceScrollToBottom: () => autoScroll.forceScrollToBottom("dock-resize"),
-      scheduleScrollState,
-      fill: input.fill,
-    })
+    const stickToBottom = scroller
+      ? shouldStickToBottomAfterDockResize({
+          el: scroller,
+          userScrolled: autoScroll.userScrolled(),
+          previousDockHeight,
+          nextDockHeight: next,
+        })
+      : false
+    const runDockMutation = (forceScrollToBottom: () => void) => {
+      dockHeight = syncComposerDockHeight({
+        el: scroller,
+        previousDockHeight,
+        nextDockHeight: next,
+        userScrolled: autoScroll.userScrolled(),
+        setCssHeight: (value) => document.documentElement.style.setProperty("--composer-dock-height", `${value}px`),
+        forceScrollToBottom,
+        scheduleScrollState,
+        fill: input.fill,
+      })
+    }
+
+    if (input.runLayoutTransaction && scroller && next !== previousDockHeight) {
+      input.runLayoutTransaction({
+        kind: "dock-resize",
+        source: "use-session-scroll-dock/updateDockHeight",
+        reason: dockKind,
+        stickToBottom,
+        mutate: () => runDockMutation(() => {}),
+        restoreLatest: (transactionID) =>
+          restoreLatestThroughSink({
+            transaction: { transactionID, transactionKind: "dock-resize" },
+            type: "dock-resize-bottom-follow",
+            source: "use-session-scroll-dock/layoutTransactionRestoreLatest",
+            reason: "dock-resize",
+          }),
+      })
+    } else {
+      runDockMutation(() => autoScroll.forceScrollToBottom("dock-resize"))
+    }
     if (dockHeight !== previousDockHeight) {
       try {
         input.onDockHeightChange?.({

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -102,6 +102,7 @@ export function createSessionScrollDock(input: {
     dockKind: "composer" | "question" | "permission" | "todo" | "followup" | "revert" | "prompt"
     composerHeight: number
     previousComposerHeight: number
+    layoutTransactionHandled?: boolean
     scrollTop?: number
     distanceFromBottom?: number
   }) => void
@@ -306,6 +307,7 @@ export function createSessionScrollDock(input: {
     const dockKind = promptDockKind()
     const scrollTop = scroller?.scrollTop
     const distanceFromBottom = scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined
+    let layoutTransactionHandled = false
     const stickToBottom = scroller
       ? shouldStickToBottomAfterDockResize({
           el: scroller,
@@ -331,6 +333,7 @@ export function createSessionScrollDock(input: {
     }
 
     if (input.runLayoutTransaction && scroller && next !== previousDockHeight) {
+      layoutTransactionHandled = true
       input.runLayoutTransaction({
         kind: "dock-resize",
         source: "use-session-scroll-dock/updateDockHeight",
@@ -357,6 +360,7 @@ export function createSessionScrollDock(input: {
           dockKind,
           composerHeight: dockHeight,
           previousComposerHeight: previousDockHeight,
+          layoutTransactionHandled: layoutTransactionHandled || undefined,
           scrollTop,
           distanceFromBottom,
         })

--- a/packages/app/src/pages/session/use-session-scroll-dock.ts
+++ b/packages/app/src/pages/session/use-session-scroll-dock.ts
@@ -193,8 +193,8 @@ export function createSessionScrollDock(input: {
     setScroll(next)
   }
 
-  const scheduleScrollState = (el: HTMLDivElement) => {
-    if (bottomFollowLocked()) {
+  const scheduleScrollState = (el: HTMLDivElement, options?: { recoverBottomLock?: boolean }) => {
+    if (options?.recoverBottomLock !== false && bottomFollowLocked()) {
       const next = calculateSessionScrollState({
         clientHeight: el.clientHeight,
         scrollHeight: el.scrollHeight,
@@ -215,6 +215,10 @@ export function createSessionScrollDock(input: {
       scrollStateTarget = undefined
       if (target) updateScrollState(target)
     })
+  }
+
+  const scheduleTransactionScrollState = (el: HTMLDivElement) => {
+    scheduleScrollState(el, { recoverBottomLock: false })
   }
 
   // A non-matching owner means the active lock belongs to an older session path.
@@ -264,12 +268,12 @@ export function createSessionScrollDock(input: {
     if (el && scroller) scheduleScrollState(scroller)
     if (!el) return
     contentObserver = new ResizeObserver(() => {
-      const runContentMutation = () => {
+      const runContentMutation = (scheduleState: (el: HTMLDivElement) => void) => {
         input.onContentResize?.({
           scrollTop: scroller?.scrollTop,
           distanceFromBottom: scroller ? scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop : undefined,
         })
-        if (scroller) scheduleScrollState(scroller)
+        if (scroller) scheduleState(scroller)
         input.fill()
       }
 
@@ -279,7 +283,7 @@ export function createSessionScrollDock(input: {
           source: "use-session-scroll-dock/contentObserver",
           reason: "content-resize",
           stickToBottom: bottomFollowLockedFor(),
-          mutate: runContentMutation,
+          mutate: () => runContentMutation(scheduleTransactionScrollState),
           restoreLatest: (transactionID) =>
             restoreLatestThroughSink({
               transaction: { transactionID, transactionKind: "content-resize" },
@@ -291,7 +295,7 @@ export function createSessionScrollDock(input: {
         return
       }
 
-      runContentMutation()
+      runContentMutation(scheduleScrollState)
       restoreBottomIfLocked()
     })
     contentObserver.observe(el)
@@ -310,15 +314,18 @@ export function createSessionScrollDock(input: {
           nextDockHeight: next,
         })
       : false
-    const runDockMutation = (forceScrollToBottom: () => void) => {
+    const runDockMutation = (options: {
+      forceScrollToBottom: () => void
+      scheduleState: (el: HTMLDivElement) => void
+    }) => {
       dockHeight = syncComposerDockHeight({
         el: scroller,
         previousDockHeight,
         nextDockHeight: next,
         userScrolled: autoScroll.userScrolled(),
         setCssHeight: (value) => document.documentElement.style.setProperty("--composer-dock-height", `${value}px`),
-        forceScrollToBottom,
-        scheduleScrollState,
+        forceScrollToBottom: options.forceScrollToBottom,
+        scheduleScrollState: options.scheduleState,
         fill: input.fill,
       })
     }
@@ -329,7 +336,7 @@ export function createSessionScrollDock(input: {
         source: "use-session-scroll-dock/updateDockHeight",
         reason: dockKind,
         stickToBottom,
-        mutate: () => runDockMutation(() => {}),
+        mutate: () => runDockMutation({ forceScrollToBottom: () => {}, scheduleState: scheduleTransactionScrollState }),
         restoreLatest: (transactionID) =>
           restoreLatestThroughSink({
             transaction: { transactionID, transactionKind: "dock-resize" },
@@ -339,7 +346,10 @@ export function createSessionScrollDock(input: {
           }),
       })
     } else {
-      runDockMutation(() => autoScroll.forceScrollToBottom("dock-resize"))
+      runDockMutation({
+        forceScrollToBottom: () => autoScroll.forceScrollToBottom("dock-resize"),
+        scheduleState: scheduleScrollState,
+      })
     }
     if (dockHeight !== previousDockHeight) {
       try {

--- a/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
@@ -17,6 +17,16 @@ describe("session timeline interaction layout recovery", () => {
     ).toBe(false)
   })
 
+  test("skips dock resize recovery after an immediate transaction restore has already settled", () => {
+    expect(
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: false,
+        layoutTransactionHandled: true,
+        observationType: "dock_resize",
+      }),
+    ).toBe(false)
+  })
+
   test("keeps non-transaction and non-resize recovery paths active", () => {
     expect(
       shouldApplyTimelineRecoveryForObservation({

--- a/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { shouldApplyTimelineRecoveryForObservation } from "./timeline-layout-recovery-policy"
+
+describe("session timeline interaction layout recovery", () => {
+  test("lets layout transactions own resize recovery while controller still observes resize", () => {
+    expect(
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: true,
+        observationType: "dock_resize",
+      }),
+    ).toBe(false)
+    expect(
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: true,
+        observationType: "content_resize",
+      }),
+    ).toBe(false)
+  })
+
+  test("keeps non-transaction and non-resize recovery paths active", () => {
+    expect(
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: false,
+        observationType: "dock_resize",
+      }),
+    ).toBe(true)
+    expect(
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: true,
+        observationType: "scroll_sample",
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -211,6 +211,7 @@ export function createSessionTimelineInteraction(input: {
           previousDockHeight: event.previousComposerHeight,
           nextDockHeight: event.composerHeight,
           metrics: collectTimelineScrollMetrics(viewport),
+          layoutTransactionHandled: event.layoutTransactionHandled,
         })
       }
       void emitRendererDiagnostic({
@@ -377,6 +378,8 @@ export function createSessionTimelineInteraction(input: {
     if (
       shouldApplyTimelineRecoveryForObservation({
         layoutTransactionActive: layoutTransactionState.active,
+        layoutTransactionHandled:
+          "layoutTransactionHandled" in observation ? observation.layoutTransactionHandled : undefined,
         observationType: observation.type,
       })
     ) {

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -1,5 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { createEffect, createMemo, on, onCleanup } from "solid-js"
+import { createStore } from "solid-js/store"
 import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import {
   collectTimelineScrollMetrics,
@@ -13,6 +14,10 @@ import { createSessionHistoryWindow } from "@/pages/session/use-session-history-
 import { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
 import { createTimelineVirtualRows } from "@/pages/session/timeline-virtual-rows"
 import { createTimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
+import {
+  createTimelineLayoutTransactionCoordinator,
+  type TimelineLayoutTransactionKind,
+} from "@/pages/session/timeline-layout-transaction"
 import {
   createSessionTimelineScrollController,
   type TimelineRecovery,
@@ -38,7 +43,15 @@ export function createSessionTimelineInteraction(input: {
   let clearMessageHash = () => {}
   let activeMessage!: ReturnType<typeof createSessionActiveMessage>
   let historyBackfill: ReturnType<typeof createSessionHistoryBackfill> | undefined
+  let historyWindow!: ReturnType<typeof createSessionHistoryWindow>
   let recoveryFrame: number | undefined
+  let activeTransactionRestoreLatest: ((transactionID: string) => boolean) | undefined
+  let activeTransactionStickToBottom = false
+  const [layoutTransactionState, setLayoutTransactionState] = createStore({
+    active: false,
+    transactionID: undefined as string | undefined,
+    kind: undefined as TimelineLayoutTransactionKind | undefined,
+  })
   const createScrollController = () =>
     createSessionTimelineScrollController({
       sessionOwner: input.sessionKey(),
@@ -52,6 +65,13 @@ export function createSessionTimelineInteraction(input: {
     })
   let scrollController = createScrollController()
   const scrollCommandSink = createTimelineScrollCommandSink({
+    activeTransaction: () =>
+      layoutTransactionState.active && layoutTransactionState.transactionID && layoutTransactionState.kind
+        ? {
+            transactionID: layoutTransactionState.transactionID,
+            transactionKind: layoutTransactionState.kind,
+          }
+        : undefined,
     emitDiagnostic: (event) => {
       void emitRendererDiagnostic(event).catch(() => {})
     },
@@ -65,6 +85,74 @@ export function createSessionTimelineInteraction(input: {
       visibleSessionID: input.sessionID(),
       timelineSessionID: input.sessionID(),
     }),
+  })
+
+  const layoutTransactionCoordinator = createTimelineLayoutTransactionCoordinator({
+    scheduleFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (handle) => cancelAnimationFrame(handle),
+    readMode: () => (activeTransactionStickToBottom ? "following_latest" : scrollController.state().mode),
+    sampleAnchor: () => {
+      const viewport = scrollDock.scroller()
+      const controllerState = scrollController.state()
+      const targetMessageID =
+        controllerState.lastSafePosition.kind === "target_message"
+          ? controllerState.lastSafePosition.messageID
+          : undefined
+      if (!viewport) return controllerState.lastSafePosition
+      return sampleTimelineSafePosition({
+        viewport,
+        mode: controllerState.mode,
+        renderedStart: historyWindow.turnStart(),
+        renderedCount: historyWindow.renderedUserMessages().length,
+        newestMessageID: input.visibleUserMessages().at(-1)?.id,
+        targetMessageID,
+      })
+    },
+    restoreAnchor: (position, transactionID) => {
+      const viewport = scrollDock.scroller()
+      const restored = restoreTimelineSafePosition({
+        viewport,
+        position,
+        scrollCommandSink: scrollCommandSink.withTransaction({
+          transactionID,
+          transactionKind: layoutTransactionState.kind ?? "content-resize",
+        }),
+      })
+      if (restored.ok && viewport) scrollDock.scheduleScrollState(viewport)
+      return restored.ok
+    },
+    restoreLatest: (transactionID) => activeTransactionRestoreLatest?.(transactionID) ?? false,
+    setStableBandActive: (active) => {
+      if (!active) setLayoutTransactionState({ active: false, transactionID: undefined, kind: undefined })
+    },
+    emitDiagnostic: (event) => {
+      if (event.phase === "start") {
+        setLayoutTransactionState({ active: true, transactionID: event.transactionID, kind: event.kind })
+      }
+      if (event.phase === "settled" || event.phase === "violation") {
+        setLayoutTransactionState({ active: false, transactionID: undefined, kind: undefined })
+      }
+      void emitRendererDiagnostic({
+        name: "session.timeline.layout_transaction",
+        route_session_id: input.routeSessionID(),
+        visible_session_id: input.sessionID(),
+        timeline_session_id: input.sessionID(),
+        monotonic_ms: event.monotonicMs,
+        data: {
+          transaction_id: event.transactionID,
+          transaction_kind: event.kind,
+          transaction_phase: event.phase,
+          transaction_status: event.violation ? "violation" : undefined,
+          mode: event.mode,
+          source: event.source,
+          reason: event.reason,
+          anchor_kind: event.anchorKind,
+          anchor_message_id: event.anchorMessageID,
+          fallback_frames: event.fallbackFrames,
+          violation: event.violation,
+        },
+      }).catch(() => {})
+    },
   })
 
   const cancelRecoveryFrame = () => {
@@ -137,6 +225,21 @@ export function createSessionTimelineInteraction(input: {
         },
       })
     },
+    runLayoutTransaction: (event) => {
+      activeTransactionRestoreLatest = event.restoreLatest
+      activeTransactionStickToBottom = event.stickToBottom
+      try {
+        layoutTransactionCoordinator.run({
+          kind: event.kind,
+          source: event.source,
+          reason: event.reason,
+          mutate: event.mutate,
+        })
+      } finally {
+        activeTransactionRestoreLatest = undefined
+        activeTransactionStickToBottom = false
+      }
+    },
   })
   const autoScroll = scrollDock.autoScroll
   const lockOwner = () => input.sessionKey()
@@ -152,7 +255,7 @@ export function createSessionTimelineInteraction(input: {
     pauseAutoScroll: autoScroll.pause,
   })
 
-  const historyWindow = createSessionHistoryWindow({
+  historyWindow = createSessionHistoryWindow({
     sessionID: input.sessionID,
     messagesReady: input.messagesReady,
     loaded: input.loadedMessages,
@@ -343,6 +446,9 @@ export function createSessionTimelineInteraction(input: {
     submitLatest,
     scheduleScrollState: scrollDock.scheduleScrollState,
     scrollDock,
+    layoutTransactionActive: () => layoutTransactionState.active,
+    layoutTransactionID: () => layoutTransactionState.transactionID,
+    layoutTransactionKind: () => layoutTransactionState.kind,
     setScrollRef: scrollDock.setScrollRef,
     markScrollGesture,
     navigateMessageByOffset,

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -164,6 +164,7 @@ export function createSessionTimelineInteraction(input: {
     on(
       () => [input.sessionKey(), input.sessionID()] as const,
       () => {
+        layoutTransactionCoordinator.cancel()
         cancelRecoveryFrame()
         const previous = scrollController.state()
         scrollController.detach({
@@ -177,6 +178,7 @@ export function createSessionTimelineInteraction(input: {
   )
 
   onCleanup(() => {
+    layoutTransactionCoordinator.cancel()
     cancelRecoveryFrame()
     const owner = scrollController.state()
     scrollController.detach({
@@ -290,6 +292,7 @@ export function createSessionTimelineInteraction(input: {
   })
 
   const markScrollGesture = (target?: EventTarget | null) => {
+    layoutTransactionCoordinator.cancel()
     scrollDock.cancelBottomFollowLock()
     activeMessage.markScrollGesture(target)
   }
@@ -306,6 +309,7 @@ export function createSessionTimelineInteraction(input: {
   }
 
   const navigateMessageByOffset = (offset: number) => {
+    layoutTransactionCoordinator.cancel()
     scrollDock.cancelBottomFollowLock()
     activeMessage.navigateMessageByOffset(offset)
   }
@@ -336,7 +340,10 @@ export function createSessionTimelineInteraction(input: {
   }
 
   const onTimelineScrollIntent = (intent: TimelineScrollIntent): TimelineScrollControllerResult => {
-    if (shouldCancelBottomFollowLockForIntent(intent)) scrollDock.cancelBottomFollowLock()
+    if (shouldCancelBottomFollowLockForIntent(intent)) {
+      layoutTransactionCoordinator.cancel()
+      scrollDock.cancelBottomFollowLock()
+    }
     const result = scrollController.intent(intent)
     applyTimelineRecovery(result.recovery)
     return result

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -18,6 +18,7 @@ import {
   createTimelineLayoutTransactionCoordinator,
   type TimelineLayoutTransactionKind,
 } from "@/pages/session/timeline-layout-transaction"
+import { shouldApplyTimelineRecoveryForObservation } from "@/pages/session/timeline-layout-recovery-policy"
 import {
   createSessionTimelineScrollController,
   type TimelineRecovery,
@@ -373,7 +374,14 @@ export function createSessionTimelineInteraction(input: {
       }
     }
     const result = scrollController.observe(next)
-    applyTimelineRecovery(result.recovery)
+    if (
+      shouldApplyTimelineRecoveryForObservation({
+        layoutTransactionActive: layoutTransactionState.active,
+        observationType: observation.type,
+      })
+    ) {
+      applyTimelineRecovery(result.recovery)
+    }
     return result
   }
 

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -45,8 +45,6 @@ export function createSessionTimelineInteraction(input: {
   let historyBackfill: ReturnType<typeof createSessionHistoryBackfill> | undefined
   let historyWindow!: ReturnType<typeof createSessionHistoryWindow>
   let recoveryFrame: number | undefined
-  let activeTransactionRestoreLatest: ((transactionID: string) => boolean) | undefined
-  let activeTransactionStickToBottom = false
   const [layoutTransactionState, setLayoutTransactionState] = createStore({
     active: false,
     transactionID: undefined as string | undefined,
@@ -90,7 +88,7 @@ export function createSessionTimelineInteraction(input: {
   const layoutTransactionCoordinator = createTimelineLayoutTransactionCoordinator({
     scheduleFrame: (callback) => requestAnimationFrame(callback),
     cancelFrame: (handle) => cancelAnimationFrame(handle),
-    readMode: () => (activeTransactionStickToBottom ? "following_latest" : scrollController.state().mode),
+    readMode: () => scrollController.state().mode,
     sampleAnchor: () => {
       const viewport = scrollDock.scroller()
       const controllerState = scrollController.state()
@@ -121,17 +119,18 @@ export function createSessionTimelineInteraction(input: {
       if (restored.ok && viewport) scrollDock.scheduleScrollState(viewport)
       return restored.ok
     },
-    restoreLatest: (transactionID) => activeTransactionRestoreLatest?.(transactionID) ?? false,
+    restoreLatest: () => false,
     setStableBandActive: (active) => {
       if (!active) setLayoutTransactionState({ active: false, transactionID: undefined, kind: undefined })
     },
+    setTransactionState: (state) => {
+      if (state.active) {
+        setLayoutTransactionState({ active: true, transactionID: state.transactionID, kind: state.kind })
+        return
+      }
+      setLayoutTransactionState({ active: false, transactionID: undefined, kind: undefined })
+    },
     emitDiagnostic: (event) => {
-      if (event.phase === "start") {
-        setLayoutTransactionState({ active: true, transactionID: event.transactionID, kind: event.kind })
-      }
-      if (event.phase === "settled" || event.phase === "violation") {
-        setLayoutTransactionState({ active: false, transactionID: undefined, kind: undefined })
-      }
       void emitRendererDiagnostic({
         name: "session.timeline.layout_transaction",
         route_session_id: input.routeSessionID(),
@@ -226,19 +225,14 @@ export function createSessionTimelineInteraction(input: {
       })
     },
     runLayoutTransaction: (event) => {
-      activeTransactionRestoreLatest = event.restoreLatest
-      activeTransactionStickToBottom = event.stickToBottom
-      try {
-        layoutTransactionCoordinator.run({
-          kind: event.kind,
-          source: event.source,
-          reason: event.reason,
-          mutate: event.mutate,
-        })
-      } finally {
-        activeTransactionRestoreLatest = undefined
-        activeTransactionStickToBottom = false
-      }
+      layoutTransactionCoordinator.run({
+        kind: event.kind,
+        source: event.source,
+        reason: event.reason,
+        mode: event.stickToBottom ? "following_latest" : undefined,
+        mutate: event.mutate,
+        restoreLatest: event.restoreLatest,
+      })
     },
   })
   const autoScroll = scrollDock.autoScroll

--- a/packages/app/src/testing/perf-metrics.test.ts
+++ b/packages/app/src/testing/perf-metrics.test.ts
@@ -386,10 +386,7 @@ describe("perf metrics", () => {
   })
 
   test("restricts confirmation comparisons to the originally failing scenarios", () => {
-    const base = [
-      scenario({ branch: "base", scenario: "session-scroll-reading", interaction: 32 }),
-      scenario({ branch: "base", scenario: "homepage-cold", frameMax: 116 }),
-    ]
+    const base = [scenario({ branch: "base", scenario: "session-scroll-reading", interaction: 32 })]
     const head = [
       scenario({ branch: "head", scenario: "session-scroll-reading", interaction: 40 }),
       scenario({ branch: "head", scenario: "homepage-cold", frameMax: 183 }),

--- a/packages/app/src/testing/perf-metrics.test.ts
+++ b/packages/app/src/testing/perf-metrics.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { aggregatePerfRuns, comparePerfBaselines, comparePerfScenarioSummaries, PERF_COMMENT_MARKER, renderPerfBaselineComment, summarizePerfRun } from "./perf-metrics"
+import {
+  aggregatePerfRuns,
+  comparePerfBaselines,
+  comparePerfScenarioSummaries,
+  PERF_COMMENT_MARKER,
+  renderPerfBaselineComment,
+  summarizePerfRun,
+} from "./perf-metrics"
 
 function scenario(input: {
   branch?: string
@@ -376,6 +383,25 @@ describe("perf metrics", () => {
 
     expect(result.pass).toBe(false)
     expect(result.failures).toContain("missing_head_scenario:low-end:session-timeline-recompute")
+  })
+
+  test("restricts confirmation comparisons to the originally failing scenarios", () => {
+    const base = [
+      scenario({ branch: "base", scenario: "session-scroll-reading", interaction: 32 }),
+      scenario({ branch: "base", scenario: "homepage-cold", frameMax: 116 }),
+    ]
+    const head = [
+      scenario({ branch: "head", scenario: "session-scroll-reading", interaction: 40 }),
+      scenario({ branch: "head", scenario: "homepage-cold", frameMax: 183 }),
+    ]
+
+    const result = comparePerfBaselines({ base, head, scenarioKeys: ["default:session-scroll-reading"] })
+
+    expect(result.pass).toBe(true)
+    expect(result.failures).toHaveLength(0)
+    expect(result.scenarios.map((entry) => `${entry.profile}:${entry.scenario}`)).toEqual([
+      "default:session-scroll-reading",
+    ])
   })
 
   test("keeps low-end moderate regressions warning-only", () => {

--- a/packages/app/src/testing/perf-metrics.ts
+++ b/packages/app/src/testing/perf-metrics.ts
@@ -451,6 +451,7 @@ export function comparePerfBaselines(input: {
 
   for (const headScenario of input.head) {
     const key = scenarioKey(headScenario)
+    if (requestedScenarioKeys && !requestedScenarioKeys.has(key)) continue
     if (!input.base.some((scenario) => scenarioKey(scenario) === key)) {
       failures.push(`missing_base_scenario:${key}`)
     }

--- a/packages/app/src/testing/perf-metrics.ts
+++ b/packages/app/src/testing/perf-metrics.ts
@@ -306,10 +306,14 @@ export function comparePerfScenarioSummaries(input: {
     if (interactionWorstRegressed) {
       warnings.push("interaction_ms_worst_delta")
     }
-    if (interactionWorstRegressed && input.head.interaction_ms_worst >= lowEndCatastrophicThresholds.interactionMsWorst) {
+    if (
+      interactionWorstRegressed &&
+      input.head.interaction_ms_worst >= lowEndCatastrophicThresholds.interactionMsWorst
+    ) {
       failures.push("interaction_ms_worst")
     }
-    const longTaskRegressed = input.head.long_task_max_ms > input.base.long_task_max_ms + lowEndWarningThresholds.longTaskMaxMs
+    const longTaskRegressed =
+      input.head.long_task_max_ms > input.base.long_task_max_ms + lowEndWarningThresholds.longTaskMaxMs
     if (longTaskRegressed) {
       warnings.push("long_task_max_ms_delta")
     }
@@ -322,7 +326,8 @@ export function comparePerfScenarioSummaries(input: {
     if (input.head.frame_gap_p95_ms > input.base.frame_gap_p95_ms + lowEndWarningThresholds.frameGapP95Ms) {
       warnings.push("frame_gap_p95_ms")
     }
-    const frameGapMaxRegressed = input.head.frame_gap_max_ms > input.base.frame_gap_max_ms + lowEndWarningThresholds.frameGapMaxMs
+    const frameGapMaxRegressed =
+      input.head.frame_gap_max_ms > input.base.frame_gap_max_ms + lowEndWarningThresholds.frameGapMaxMs
     if (frameGapMaxRegressed) {
       warnings.push("frame_gap_max_ms_delta")
     }
@@ -389,7 +394,12 @@ export function comparePerfScenarioSummaries(input: {
     failures.push("cls_delta")
   }
 
-  addAbsoluteWarning(warnings, "interaction_ms_worst", input.head.interaction_ms_worst, perfAbsoluteWarnings.interactionMsWorst)
+  addAbsoluteWarning(
+    warnings,
+    "interaction_ms_worst",
+    input.head.interaction_ms_worst,
+    perfAbsoluteWarnings.interactionMsWorst,
+  )
   addAbsoluteWarning(warnings, "tbt_ms", input.head.tbt_ms, perfAbsoluteWarnings.tbtMs)
   addAbsoluteWarning(warnings, "cls", input.head.cls, perfAbsoluteWarnings.cls)
   addAbsoluteWarning(warnings, "fcp_ms", input.head.fcp_ms, perfAbsoluteWarnings.fcpMs)
@@ -413,14 +423,17 @@ function scenarioKey(input: { profile?: PerfProfile; scenario: string }) {
 export function comparePerfBaselines(input: {
   base: PerfScenarioSummary[]
   head: PerfScenarioSummary[]
+  scenarioKeys?: string[]
 }): PerfBaselineComparison {
   const failures: string[] = []
   const warnings: string[] = []
   const scenarios: PerfScenarioComparison[] = []
   const headByScenario = new Map(input.head.map((scenario) => [scenarioKey(scenario), scenario]))
+  const requestedScenarioKeys = input.scenarioKeys ? new Set(input.scenarioKeys) : undefined
 
   for (const baseScenario of input.base) {
     const key = scenarioKey(baseScenario)
+    if (requestedScenarioKeys && !requestedScenarioKeys.has(key)) continue
     const headScenario = headByScenario.get(key)
     if (!headScenario) {
       failures.push(`missing_head_scenario:${key}`)

--- a/packages/app/src/testing/timeline.test.ts
+++ b/packages/app/src/testing/timeline.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { timelineDriverEnabled, type TimelineWindow } from "./timeline"
+
+describe("timeline e2e driver", () => {
+  test("stays disabled outside explicit test runtime even when the window flag is set", () => {
+    const win = { __opencode_e2e: { timeline: { enabled: true } } } as TimelineWindow
+
+    expect(timelineDriverEnabled({ testRuntime: false, windowRef: win })).toBe(false)
+  })
+
+  test("requires the window flag inside explicit test runtime", () => {
+    const win = { __opencode_e2e: { timeline: { enabled: true } } } as TimelineWindow
+
+    expect(timelineDriverEnabled({ testRuntime: true, windowRef: win })).toBe(true)
+    expect(timelineDriverEnabled({ testRuntime: true, windowRef: {} as TimelineWindow })).toBe(false)
+  })
+})

--- a/packages/app/src/testing/timeline.test.ts
+++ b/packages/app/src/testing/timeline.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { bindTimelineDriver, timelineEvent, timelineDriverEnabled, type TimelineWindow } from "./timeline"
+import {
+  bindTimelineDriver,
+  timelineDriverDefaultTestRuntime,
+  timelineEvent,
+  timelineDriverEnabled,
+  type TimelineWindow,
+} from "./timeline"
 
 describe("timeline e2e driver", () => {
   test("stays disabled outside explicit test runtime even when the window flag is set", () => {
@@ -13,6 +19,12 @@ describe("timeline e2e driver", () => {
 
     expect(timelineDriverEnabled({ testRuntime: true, windowRef: win })).toBe(true)
     expect(timelineDriverEnabled({ testRuntime: true, windowRef: {} as TimelineWindow })).toBe(false)
+  })
+
+  test("uses DEV or TEST as the default runtime guard", () => {
+    expect(timelineDriverDefaultTestRuntime({ DEV: false, TEST: false })).toBe(false)
+    expect(timelineDriverDefaultTestRuntime({ DEV: true, TEST: false })).toBe(true)
+    expect(timelineDriverDefaultTestRuntime({ DEV: false, TEST: true })).toBe(true)
   })
 
   test("binds the reveal listener inside the centralized test driver", () => {

--- a/packages/app/src/testing/timeline.test.ts
+++ b/packages/app/src/testing/timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { timelineDriverEnabled, type TimelineWindow } from "./timeline"
+import { bindTimelineDriver, timelineEvent, timelineDriverEnabled, type TimelineWindow } from "./timeline"
 
 describe("timeline e2e driver", () => {
   test("stays disabled outside explicit test runtime even when the window flag is set", () => {
@@ -13,5 +13,57 @@ describe("timeline e2e driver", () => {
 
     expect(timelineDriverEnabled({ testRuntime: true, windowRef: win })).toBe(true)
     expect(timelineDriverEnabled({ testRuntime: true, windowRef: {} as TimelineWindow })).toBe(false)
+  })
+
+  test("binds the reveal listener inside the centralized test driver", () => {
+    const listeners = new Map<string, (event: Event) => void>()
+    const win = {
+      __opencode_e2e: { timeline: { enabled: true } },
+      addEventListener(name: string, handler: EventListener) {
+        listeners.set(name, handler as (event: Event) => void)
+      },
+      removeEventListener(name: string, handler: EventListener) {
+        if (listeners.get(name) === handler) listeners.delete(name)
+      },
+    } as unknown as TimelineWindow
+    let reveals = 0
+
+    const cleanup = bindTimelineDriver({
+      testRuntime: true,
+      timelineSessionID: () => "session-1",
+      revealCached: () => {
+        reveals += 1
+      },
+      windowRef: win,
+    })
+
+    listeners.get(timelineEvent)?.(new CustomEvent(timelineEvent, { detail: { action: "reveal-cached" } }))
+    listeners.get(timelineEvent)?.(
+      new CustomEvent(timelineEvent, { detail: { action: "reveal-cached", sessionID: "other-session" } }),
+    )
+    cleanup()
+
+    expect(reveals).toBe(1)
+    expect(listeners.has(timelineEvent)).toBe(false)
+  })
+
+  test("does not bind the listener outside explicit test runtime", () => {
+    const listeners = new Map<string, EventListener>()
+    const win = {
+      __opencode_e2e: { timeline: { enabled: true } },
+      addEventListener(name: string, handler: EventListener) {
+        listeners.set(name, handler)
+      },
+      removeEventListener() {},
+    } as unknown as TimelineWindow
+
+    bindTimelineDriver({
+      testRuntime: false,
+      timelineSessionID: () => undefined,
+      revealCached: () => {},
+      windowRef: win,
+    })
+
+    expect(listeners.has(timelineEvent)).toBe(false)
   })
 })

--- a/packages/app/src/testing/timeline.ts
+++ b/packages/app/src/testing/timeline.ts
@@ -15,8 +15,32 @@ export type TimelineWindow = Window & {
   }
 }
 
+type TimelineEventTarget = Pick<Window, "addEventListener" | "removeEventListener">
+
 export const timelineDriverEnabled = (input?: { testRuntime?: boolean; windowRef?: TimelineWindow }) => {
   if (!input?.testRuntime) return false
   const win = input.windowRef ?? (typeof window === "undefined" ? undefined : (window as TimelineWindow))
   return win?.__opencode_e2e?.timeline?.enabled === true
+}
+
+export const bindTimelineDriver = (input: {
+  testRuntime?: boolean
+  timelineSessionID: () => string | undefined
+  revealCached: () => void
+  windowRef?: TimelineWindow & TimelineEventTarget
+}) => {
+  if (!input.testRuntime) return () => {}
+  const win =
+    input.windowRef ?? (typeof window === "undefined" ? undefined : (window as TimelineWindow & TimelineEventTarget))
+  if (!win) return () => {}
+
+  const handleTimelineDriver = (event: Event) => {
+    if (!timelineDriverEnabled({ testRuntime: input.testRuntime, windowRef: win })) return
+    const detail = (event as TimelineDriverEvent).detail
+    if (detail?.sessionID && detail.sessionID !== input.timelineSessionID()) return
+    if (detail?.action === "reveal-cached") input.revealCached()
+  }
+
+  win.addEventListener(timelineEvent, handleTimelineDriver)
+  return () => win.removeEventListener(timelineEvent, handleTimelineDriver)
 }

--- a/packages/app/src/testing/timeline.ts
+++ b/packages/app/src/testing/timeline.ts
@@ -15,7 +15,8 @@ export type TimelineWindow = Window & {
   }
 }
 
-export const timelineDriverEnabled = () => {
-  if (typeof window === "undefined") return false
-  return (window as TimelineWindow).__opencode_e2e?.timeline?.enabled === true
+export const timelineDriverEnabled = (input?: { testRuntime?: boolean; windowRef?: TimelineWindow }) => {
+  if (!input?.testRuntime) return false
+  const win = input.windowRef ?? (typeof window === "undefined" ? undefined : (window as TimelineWindow))
+  return win?.__opencode_e2e?.timeline?.enabled === true
 }

--- a/packages/app/src/testing/timeline.ts
+++ b/packages/app/src/testing/timeline.ts
@@ -1,0 +1,21 @@
+export const timelineEvent = "opencode:e2e:timeline"
+
+export type TimelineDriverAction = "reveal-cached"
+
+export type TimelineDriverEvent = CustomEvent<{
+  action: TimelineDriverAction
+  sessionID?: string
+}>
+
+export type TimelineWindow = Window & {
+  __opencode_e2e?: {
+    timeline?: {
+      enabled?: boolean
+    }
+  }
+}
+
+export const timelineDriverEnabled = () => {
+  if (typeof window === "undefined") return false
+  return (window as TimelineWindow).__opencode_e2e?.timeline?.enabled === true
+}

--- a/packages/app/src/testing/timeline.ts
+++ b/packages/app/src/testing/timeline.ts
@@ -1,3 +1,5 @@
+import { onCleanup, onMount } from "solid-js"
+
 export const timelineEvent = "opencode:e2e:timeline"
 
 export type TimelineDriverAction = "reveal-cached"
@@ -16,6 +18,9 @@ export type TimelineWindow = Window & {
 }
 
 type TimelineEventTarget = Pick<Window, "addEventListener" | "removeEventListener">
+
+export const timelineDriverDefaultTestRuntime = (env: { DEV?: boolean; TEST?: boolean } = import.meta.env) =>
+  env.DEV || env.TEST
 
 export const timelineDriverEnabled = (input?: { testRuntime?: boolean; windowRef?: TimelineWindow }) => {
   if (!input?.testRuntime) return false
@@ -43,4 +48,20 @@ export const bindTimelineDriver = (input: {
 
   win.addEventListener(timelineEvent, handleTimelineDriver)
   return () => win.removeEventListener(timelineEvent, handleTimelineDriver)
+}
+
+export function TimelineE2EDriverBoundary(props: {
+  timelineSessionID: () => string | undefined
+  revealCached: () => void
+}) {
+  onMount(() => {
+    const cleanupTimelineDriver = bindTimelineDriver({
+      testRuntime: timelineDriverDefaultTestRuntime(),
+      timelineSessionID: props.timelineSessionID,
+      revealCached: props.revealCached,
+    })
+    onCleanup(cleanupTimelineDriver)
+  })
+
+  return null
 }


### PR DESCRIPTION
## Summary

- Add a minimal timeline layout transaction coordinator for dock/content resize windows.
- Tag scroll-command diagnostics with transaction metadata and report transaction violations.
- Widen virtualized row overscan only while a transaction is active, then return to the normal long-session budget.

## Why

This PR lands #747 PR2's minimal layout transaction layer for controlled dock/content resize windows. It does not complete the later PR3+ `TimelineLayoutEngine` migration and does not retire all legacy scroll owners.

## Related Issue

Refs #747

## Human Review Status

- `Pending` — waiting for a human reviewer to approve.

## Review Focus

- Whether transaction-scoped restore paths keep scroll execution behind `TimelineScrollCommandSink`.
- Whether legacy bottom-follow behavior is preserved when the user is pinned to latest.
- Whether the temporary virtualizer overscan increase is narrowly scoped to active transactions.

## Risk Notes

This is #747 PR2 only. It does not complete the later TimelineLayoutEngine migration and does not retire every legacy scroll owner. The coordinator still delegates final scroll execution to TimelineScrollCommandSink.

Skipped checklist items:
- Manual visual check: no intended visual or copy change; the user-visible surface is scroll stability. Targeted E2E checks were attempted but currently fail before reaching the changed surface because `project.open()` lands on a 404 during `waitSession` in this worktree.
- Platform impact: no platform, packaging, updater, signing, shell, permission, or installer surface touched.
- Docs/release/dependencies/local files: no shipped docs, release notes, dependencies, permissions, credentials, generated files, deletion behavior, or staged local-only files included.

Content-resize E2E deferred because deterministic streaming resize seed is unavailable; coordinator unit tests cover fallback semantics and existing runtime gate covers dock resize windows.

## How To Verify

```text
Focused session/unit tests: PASS — 70 pass, 0 fail
Command: bun test --preload ./happydom.ts src/pages/session/timeline-layout-transaction.test.ts src/pages/session/timeline-layout-stable-band.test.ts src/pages/session/timeline-scroll-command-sink.test.ts src/pages/session/timeline-scroll-ownership-guard.test.ts src/pages/session/use-session-scroll-dock.test.ts src/pages/session/session-timeline-scroll-controller.test.ts src/pages/session/session-timeline-scroll-anchors.test.ts src/pages/session/timeline-virtualization-strategy.test.ts src/pages/session/timeline-row-layout.test.ts

Runtime CLS probe unit tests: PASS — 8 pass, 0 fail
Command: bun test ./e2e/perf/runtime-cls-probe.unit.ts

Typecheck: PASS — 8 successful, 8 total
Command: bun run typecheck

Whitespace: PASS — no output
Command: git diff --check

Runtime CLS E2E gate: ATTEMPTED, blocked before changed surface — 3/3 failed at project.open() / waitSession with 404 page snapshots
Command: bun test:e2e -- e2e/perf/runtime-cls-gate.spec.ts -g \"runtime CLS source gate\"

Session scroll E2E: ATTEMPTED, blocked before changed surface — 4/4 failed at project.open() / waitSession with 404 page snapshots
Command: bun test:e2e -- e2e/session/session-scroll-position.spec.ts

Low-end scroll perf smoke: ATTEMPTED, blocked before changed surface — failed at project.open() / waitSession with 404 page snapshot
Command: PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_SCENARIOS=session-scroll-reading-long bun test:e2e -- e2e/perf/perf-probe.spec.ts -g \"session-scroll-reading-long\"
```

## Screenshots or Recordings

Not applicable: no intended visual or copy change. Failed E2E attempts produced 404 screenshots under `packages/app/e2e/test-results/`, before reaching the changed timeline surface.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; \"not required\" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved timeline stability during interactive layout transactions (dock/content resize) with transaction-aware scroll handling and adaptive overscan.
  * Added a test-mode timeline driver to reliably reveal and drive cached timeline history during performance tests.
  * Enhanced diagnostics to include layout-transaction metadata for clearer performance failure summaries.

* **Tests**
  * Expanded unit and end-to-end coverage for timeline layout transactions, scroll-command behavior, and perf-comparison scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->