### PR TITLE
fix(opencode): materialize responses tool calls on arguments done

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -885,6 +885,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
+              enqueueFunctionToolCallParts(
+                controller,
+                functionToolCalls.failUnmaterialized("chunk parse or validation error"),
+              )
               finishReason = {
                 unified: "error",
                 raw: undefined,
@@ -1276,14 +1280,24 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   },
                 })
               }
+            } else if (isResponseFailedChunk(value)) {
+              enqueueFunctionToolCallParts(controller, functionToolCalls.failUnmaterialized("response.failed"))
+              finishReason = { unified: "error", raw: "response.failed" }
+              controller.enqueue({ type: "error", error: value.response.error ?? value })
             } else if (isResponseFinishedChunk(value)) {
-              finishReason = {
-                unified: mapOpenAIResponseFinishReason({
-                  finishReason: value.response.incomplete_details?.reason,
-                  hasFunctionCall,
-                }),
-                raw: value.response.incomplete_details?.reason ?? undefined,
-              }
+              const hadAssemblerError = enqueueFunctionToolCallParts(
+                controller,
+                functionToolCalls.failUnmaterialized(value.type),
+              )
+              finishReason = hadAssemblerError
+                ? { unified: "error", raw: value.type }
+                : {
+                    unified: mapOpenAIResponseFinishReason({
+                      finishReason: value.response.incomplete_details?.reason,
+                      hasFunctionCall,
+                    }),
+                    raw: value.response.incomplete_details?.reason ?? undefined,
+                  }
               usage.inputTokens = value.response.usage.input_tokens
               usage.outputTokens = value.response.usage.output_tokens
               usage.totalTokens = value.response.usage.input_tokens + value.response.usage.output_tokens
@@ -1312,11 +1326,15 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               }
             } else if (isErrorChunk(value)) {
+              enqueueFunctionToolCallParts(controller, functionToolCalls.failUnmaterialized("provider error chunk"))
+              finishReason = { unified: "error", raw: value.code }
               controller.enqueue({ type: "error", error: value })
             }
           },
 
           flush(controller) {
+            enqueueFunctionToolCallParts(controller, functionToolCalls.failUnmaterialized("stream flush"))
+
             // Close any dangling text part
             if (currentTextId) {
               controller.enqueue({ type: "text-end", id: currentTextId })
@@ -1401,6 +1419,22 @@ const responseFinishedChunkSchema = z.object({
     usage: usageSchema,
     service_tier: z.string().nullish(),
   }),
+})
+
+const responseFailedChunkSchema = z.object({
+  type: z.literal("response.failed"),
+  response: z
+    .object({
+      error: z
+        .object({
+          code: z.string().nullish(),
+          message: z.string().nullish(),
+        })
+        .nullish(),
+      usage: usageSchema.nullish(),
+      service_tier: z.string().nullish(),
+    })
+    .loose(),
 })
 
 const responseCreatedChunkSchema = z.object({
@@ -1581,6 +1615,7 @@ const responseReasoningSummaryTextDeltaSchema = z.object({
 const openaiResponsesChunkSchema = z.union([
   textDeltaChunkSchema,
   responseFinishedChunkSchema,
+  responseFailedChunkSchema,
   responseCreatedChunkSchema,
   responseOutputItemAddedSchema,
   responseOutputItemDoneSchema,
@@ -1622,6 +1657,12 @@ function isResponseFinishedChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,
 ): chunk is z.infer<typeof responseFinishedChunkSchema> {
   return chunk.type === "response.completed" || chunk.type === "response.incomplete"
+}
+
+function isResponseFailedChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof responseFailedChunkSchema> {
+  return chunk.type === "response.failed"
 }
 
 function isResponseCreatedChunk(

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -29,6 +29,7 @@ import { mapOpenAIResponseFinishReason } from "./map-openai-responses-finish-rea
 import type { OpenAIResponsesIncludeOptions, OpenAIResponsesIncludeValue } from "./openai-responses-api-types"
 import { prepareResponsesTools } from "./openai-responses-prepare-tools"
 import type { OpenAIResponsesModelId } from "./openai-responses-settings"
+import { ResponsesToolCallAssembler } from "./openai-responses-tool-call-assembler"
 import { localShellInputSchema } from "./tool/local-shell"
 
 const webSearchCallItem = z.object({
@@ -832,6 +833,23 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     // flag that checks if there have been client-side tool calls (not executed by openai)
     let hasFunctionCall = false
+    const functionToolCalls = new ResponsesToolCallAssembler()
+
+    const enqueueFunctionToolCallParts = (
+      controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+      parts: LanguageModelV3StreamPart[],
+    ) => {
+      let emittedError = false
+      for (const part of parts) {
+        if (part.type === "tool-call") hasFunctionCall = true
+        if (part.type === "error") {
+          emittedError = true
+          finishReason = { unified: "error", raw: undefined }
+        }
+        controller.enqueue(part)
+      }
+      return emittedError
+    }
 
     // Track reasoning by output_index instead of item_id
     // GitHub Copilot rotates encrypted item IDs on every event
@@ -879,16 +897,16 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
             if (isResponseOutputItemAddedChunk(value)) {
               if (value.item.type === "function_call") {
-                ongoingToolCalls[value.output_index] = {
-                  toolName: value.item.name,
-                  toolCallId: value.item.call_id,
-                }
-
-                controller.enqueue({
-                  type: "tool-input-start",
-                  id: value.item.call_id,
-                  toolName: value.item.name,
-                })
+                enqueueFunctionToolCallParts(
+                  controller,
+                  functionToolCalls.onFunctionCallAdded({
+                    outputIndex: value.output_index,
+                    itemId: value.item.id,
+                    callId: value.item.call_id,
+                    toolName: value.item.name,
+                    arguments: value.item.arguments,
+                  }),
+                )
               } else if (value.item.type === "web_search_call") {
                 ongoingToolCalls[value.output_index] = {
                   toolName: webSearchToolName ?? "web_search",
@@ -980,25 +998,16 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               }
             } else if (isResponseOutputItemDoneChunk(value)) {
               if (value.item.type === "function_call") {
-                ongoingToolCalls[value.output_index] = undefined
-                hasFunctionCall = true
-
-                controller.enqueue({
-                  type: "tool-input-end",
-                  id: value.item.call_id,
-                })
-
-                controller.enqueue({
-                  type: "tool-call",
-                  toolCallId: value.item.call_id,
-                  toolName: value.item.name,
-                  input: value.item.arguments,
-                  providerMetadata: {
-                    openai: {
-                      itemId: value.item.id,
-                    },
-                  },
-                })
+                enqueueFunctionToolCallParts(
+                  controller,
+                  functionToolCalls.onFunctionCallDone({
+                    outputIndex: value.output_index,
+                    itemId: value.item.id,
+                    callId: value.item.call_id,
+                    toolName: value.item.name,
+                    arguments: value.item.arguments,
+                  }),
+                )
               } else if (value.item.type === "web_search_call") {
                 ongoingToolCalls[value.output_index] = undefined
 
@@ -1136,15 +1145,24 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 }
               }
             } else if (isResponseFunctionCallArgumentsDeltaChunk(value)) {
-              const toolCall = ongoingToolCalls[value.output_index]
-
-              if (toolCall != null) {
-                controller.enqueue({
-                  type: "tool-input-delta",
-                  id: toolCall.toolCallId,
+              enqueueFunctionToolCallParts(
+                controller,
+                functionToolCalls.onFunctionCallArgumentsDelta({
+                  outputIndex: value.output_index,
+                  itemId: value.item_id,
                   delta: value.delta,
-                })
-              }
+                }),
+              )
+            } else if (isResponseFunctionCallArgumentsDoneChunk(value)) {
+              enqueueFunctionToolCallParts(
+                controller,
+                functionToolCalls.onFunctionCallArgumentsDone({
+                  outputIndex: value.output_index,
+                  itemId: value.item_id,
+                  toolName: value.name,
+                  arguments: value.arguments,
+                }),
+              )
             } else if (isResponseImageGenerationCallPartialImageChunk(value)) {
               controller.enqueue({
                 type: "tool-result",
@@ -1498,6 +1516,14 @@ const responseFunctionCallArgumentsDeltaSchema = z.object({
   delta: z.string(),
 })
 
+const responseFunctionCallArgumentsDoneSchema = z.object({
+  type: z.literal("response.function_call_arguments.done"),
+  item_id: z.string(),
+  output_index: z.number(),
+  name: z.string(),
+  arguments: z.string(),
+})
+
 const responseImageGenerationCallPartialImageSchema = z.object({
   type: z.literal("response.image_generation_call.partial_image"),
   item_id: z.string(),
@@ -1559,6 +1585,7 @@ const openaiResponsesChunkSchema = z.union([
   responseOutputItemAddedSchema,
   responseOutputItemDoneSchema,
   responseFunctionCallArgumentsDeltaSchema,
+  responseFunctionCallArgumentsDoneSchema,
   responseImageGenerationCallPartialImageSchema,
   responseCodeInterpreterCallCodeDeltaSchema,
   responseCodeInterpreterCallCodeDoneSchema,
@@ -1608,6 +1635,13 @@ function isResponseFunctionCallArgumentsDeltaChunk(
 ): chunk is z.infer<typeof responseFunctionCallArgumentsDeltaSchema> {
   return chunk.type === "response.function_call_arguments.delta"
 }
+
+function isResponseFunctionCallArgumentsDoneChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof responseFunctionCallArgumentsDoneSchema> {
+  return chunk.type === "response.function_call_arguments.done"
+}
+
 function isResponseImageGenerationCallPartialImageChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,
 ): chunk is z.infer<typeof responseImageGenerationCallPartialImageSchema> {

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -1289,15 +1289,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 controller,
                 functionToolCalls.failUnmaterialized(value.type),
               )
-              finishReason = hadAssemblerError
-                ? { unified: "error", raw: value.type }
-                : {
-                    unified: mapOpenAIResponseFinishReason({
-                      finishReason: value.response.incomplete_details?.reason,
-                      hasFunctionCall,
-                    }),
-                    raw: value.response.incomplete_details?.reason ?? undefined,
-                  }
+              if (hadAssemblerError) {
+                finishReason = { unified: "error", raw: value.type }
+              } else if (finishReason.unified !== "error") {
+                finishReason = {
+                  unified: mapOpenAIResponseFinishReason({
+                    finishReason: value.response.incomplete_details?.reason,
+                    hasFunctionCall,
+                  }),
+                  raw: value.response.incomplete_details?.reason ?? undefined,
+                }
+              }
               usage.inputTokens = value.response.usage.input_tokens
               usage.outputTokens = value.response.usage.output_tokens
               usage.totalTokens = value.response.usage.input_tokens + value.response.usage.output_tokens

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
@@ -95,7 +95,6 @@ export class ResponsesToolCallAssembler {
       return [this.error(message)]
     }
     if (state.value.materialized) {
-      this.remove(state.value)
       return []
     }
 

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
@@ -34,9 +34,6 @@ type ResponsesToolCallState = {
   itemId: string
   callId: string
   toolName: string
-  argumentDeltas: string[]
-  addedArguments: string
-  doneArguments?: string
   materialized: boolean
 }
 
@@ -55,8 +52,6 @@ export class ResponsesToolCallAssembler {
       itemId: input.itemId,
       callId: input.callId,
       toolName: input.toolName,
-      argumentDeltas: [],
-      addedArguments: input.arguments,
       materialized: false,
     }
     this.statesByItemId.set(input.itemId, state)
@@ -70,7 +65,6 @@ export class ResponsesToolCallAssembler {
     if (!state.ok) return [this.error(state.message)]
     if (state.value.materialized) return []
 
-    state.value.argumentDeltas.push(input.delta)
     return [{ type: "tool-input-delta", id: state.value.callId, delta: input.delta }]
   }
 
@@ -84,7 +78,6 @@ export class ResponsesToolCallAssembler {
     }
     if (state.value.materialized) return []
 
-    state.value.doneArguments = input.arguments
     return this.materialize(state.value, input.arguments)
   }
 

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
@@ -99,7 +99,7 @@ export class ResponsesToolCallAssembler {
       return []
     }
 
-    return this.materialize(state.value, input.arguments, { removeAfterMaterialize: true })
+    return this.materialize(state.value, input.arguments)
   }
 
   failUnmaterialized(reason: string): LanguageModelV3StreamPart[] {

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-tool-call-assembler.ts
@@ -1,0 +1,177 @@
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider"
+
+export type ResponsesFunctionCallAdded = {
+  outputIndex: number
+  itemId: string
+  callId: string
+  toolName: string
+  arguments: string
+}
+
+export type ResponsesFunctionCallArgumentsDelta = {
+  outputIndex: number
+  itemId: string
+  delta: string
+}
+
+export type ResponsesFunctionCallArgumentsDone = {
+  outputIndex: number
+  itemId: string
+  toolName: string
+  arguments: string
+}
+
+export type ResponsesFunctionCallDone = {
+  outputIndex: number
+  itemId: string
+  callId: string
+  toolName: string
+  arguments: string
+}
+
+type ResponsesToolCallState = {
+  outputIndex: number
+  itemId: string
+  callId: string
+  toolName: string
+  argumentDeltas: string[]
+  addedArguments: string
+  doneArguments?: string
+  materialized: boolean
+}
+
+export class ResponsesToolCallAssembler {
+  private readonly statesByItemId = new Map<string, ResponsesToolCallState>()
+  private readonly itemIdByOutputIndex = new Map<number, string>()
+
+  onFunctionCallAdded(input: ResponsesFunctionCallAdded): LanguageModelV3StreamPart[] {
+    const previousItemId = this.itemIdByOutputIndex.get(input.outputIndex)
+    if (previousItemId) {
+      this.statesByItemId.delete(previousItemId)
+    }
+
+    const state: ResponsesToolCallState = {
+      outputIndex: input.outputIndex,
+      itemId: input.itemId,
+      callId: input.callId,
+      toolName: input.toolName,
+      argumentDeltas: [],
+      addedArguments: input.arguments,
+      materialized: false,
+    }
+    this.statesByItemId.set(input.itemId, state)
+    this.itemIdByOutputIndex.set(input.outputIndex, input.itemId)
+
+    return [{ type: "tool-input-start", id: input.callId, toolName: input.toolName }]
+  }
+
+  onFunctionCallArgumentsDelta(input: ResponsesFunctionCallArgumentsDelta): LanguageModelV3StreamPart[] {
+    const state = this.lookup(input.itemId, input.outputIndex)
+    if (!state.ok) return [this.error(state.message)]
+    if (state.value.materialized) return []
+
+    state.value.argumentDeltas.push(input.delta)
+    return [{ type: "tool-input-delta", id: state.value.callId, delta: input.delta }]
+  }
+
+  onFunctionCallArgumentsDone(input: ResponsesFunctionCallArgumentsDone): LanguageModelV3StreamPart[] {
+    const state = this.lookup(input.itemId, input.outputIndex)
+    if (!state.ok) return [this.error(state.message)]
+    if (state.value.toolName !== input.toolName) {
+      const message = `OpenAI Responses function call name mismatch for item ${input.itemId}: started ${state.value.toolName}, completed ${input.toolName}`
+      this.remove(state.value)
+      return [this.error(message)]
+    }
+    if (state.value.materialized) return []
+
+    state.value.doneArguments = input.arguments
+    return this.materialize(state.value, input.arguments)
+  }
+
+  onFunctionCallDone(input: ResponsesFunctionCallDone): LanguageModelV3StreamPart[] {
+    const state = this.lookup(input.itemId, input.outputIndex)
+    if (!state.ok) return [this.error(state.message)]
+    if (state.value.callId !== input.callId) {
+      const message = `OpenAI Responses function call id mismatch for item ${input.itemId}: started ${state.value.callId}, completed ${input.callId}`
+      this.remove(state.value)
+      return [this.error(message)]
+    }
+    if (state.value.toolName !== input.toolName) {
+      const message = `OpenAI Responses function call name mismatch for item ${input.itemId}: started ${state.value.toolName}, completed ${input.toolName}`
+      this.remove(state.value)
+      return [this.error(message)]
+    }
+    if (state.value.materialized) {
+      this.remove(state.value)
+      return []
+    }
+
+    return this.materialize(state.value, input.arguments, { removeAfterMaterialize: true })
+  }
+
+  failUnmaterialized(reason: string): LanguageModelV3StreamPart[] {
+    const parts: LanguageModelV3StreamPart[] = []
+    for (const state of this.statesByItemId.values()) {
+      if (!state.materialized) {
+        parts.push(
+          this.error(
+            `OpenAI Responses function call input did not complete before ${reason}: ${state.toolName} (${state.callId})`,
+          ),
+        )
+      }
+    }
+    this.statesByItemId.clear()
+    this.itemIdByOutputIndex.clear()
+    return parts
+  }
+
+  private lookup(
+    itemId: string,
+    outputIndex: number,
+  ): { ok: true; value: ResponsesToolCallState } | { ok: false; message: string } {
+    const state = this.statesByItemId.get(itemId)
+    if (!state) {
+      return {
+        ok: false,
+        message: `OpenAI Responses function call state was missing for item ${itemId} at output index ${outputIndex}`,
+      }
+    }
+    if (state.outputIndex !== outputIndex) {
+      return {
+        ok: false,
+        message: `OpenAI Responses function call output index mismatch for item ${itemId}: started ${state.outputIndex}, received ${outputIndex}`,
+      }
+    }
+    return { ok: true, value: state }
+  }
+
+  private materialize(
+    state: ResponsesToolCallState,
+    input: string,
+    options: { removeAfterMaterialize?: boolean } = {},
+  ): LanguageModelV3StreamPart[] {
+    state.materialized = true
+    if (options.removeAfterMaterialize) this.remove(state)
+    return [
+      { type: "tool-input-end", id: state.callId },
+      {
+        type: "tool-call",
+        toolCallId: state.callId,
+        toolName: state.toolName,
+        input,
+        providerMetadata: { openai: { itemId: state.itemId } },
+      },
+    ]
+  }
+
+  private remove(state: ResponsesToolCallState) {
+    this.statesByItemId.delete(state.itemId)
+    if (this.itemIdByOutputIndex.get(state.outputIndex) === state.itemId) {
+      this.itemIdByOutputIndex.delete(state.outputIndex)
+    }
+  }
+
+  private error(message: string): LanguageModelV3StreamPart {
+    return { type: "error", error: new Error(message) }
+  }
+}

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -44,6 +44,7 @@ type Sse = {
   hang?: boolean
   error?: unknown
   reset?: boolean
+  passthrough?: boolean
 }
 
 type HttpError = {
@@ -611,6 +612,7 @@ export function raw(input: {
   hang?: boolean
   error?: unknown
   reset?: boolean
+  passthrough?: boolean
 }): Item {
   return {
     type: "sse",
@@ -621,6 +623,7 @@ export function raw(input: {
     hang: input.hang,
     error: input.error,
     reset: input.reset,
+    passthrough: input.passthrough,
   }
 }
 
@@ -746,7 +749,7 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
         hits = [...hits, current]
         yield* notify()
         if (next.type !== "sse") return fail(next)
-        if (mode === "responses") return send(responses(next, modelFrom(body)))
+        if (mode === "responses") return send(next.passthrough ? next : responses(next, modelFrom(body)))
         if (next.reset) {
           yield* reset(next)
           return HttpServerResponse.empty()

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -258,12 +258,13 @@ function responseToolArgs(id: string, text: string, seq: number) {
   }
 }
 
-function responseToolArgsDone(id: string, args: string, seq: number) {
+function responseToolArgsDone(id: string, name: string, args: string, seq: number) {
   return {
     type: "response.function_call_arguments.done",
     sequence_number: seq,
     output_index: 0,
     item_id: id,
+    name,
     arguments: args,
   }
 }
@@ -418,7 +419,7 @@ function responses(item: Sse, model: string) {
   }
   if (call && !item.hang && !item.error) {
     seq += 1
-    tail.push(responseToolArgsDone(call.item, call.args, seq))
+    tail.push(responseToolArgsDone(call.item, call.name, call.args, seq))
     seq += 1
     tail.push(responseToolDone(call, seq))
   }
@@ -436,11 +437,16 @@ function send(item: Sse) {
   for (const stage of segments) {
     const chunkStream = bytes(stage.chunks)
     const wait = stage.wait
-    const segment = wait ? Stream.fromEffect(Effect.promise(() => wait)).pipe(Stream.flatMap(() => chunkStream)) : chunkStream
+    const segment = wait
+      ? Stream.fromEffect(Effect.promise(() => wait)).pipe(Stream.flatMap(() => chunkStream))
+      : chunkStream
     body = Stream.concat(body, segment)
   }
   const wait = item.wait
-  body = Stream.concat(body, wait ? Stream.fromEffect(Effect.promise(() => wait)).pipe(Stream.flatMap(() => tail)) : tail)
+  body = Stream.concat(
+    body,
+    wait ? Stream.fromEffect(Effect.promise(() => wait)).pipe(Stream.flatMap(() => tail)) : tail,
+  )
 
   let end: Stream.Stream<Uint8Array, unknown> = empty
   if (item.error) end = Stream.concat(empty, Stream.fail(item.error))

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -1,0 +1,156 @@
+import { OpenAIResponsesLanguageModel } from "@/provider/sdk/copilot/responses/openai-responses-language-model"
+import type { LanguageModelV3Prompt, LanguageModelV3StreamPart } from "@ai-sdk/provider"
+import { describe, expect, mock, test } from "bun:test"
+
+const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Use a tool" }] }]
+
+type SseChunk = Record<string, unknown>
+
+async function collectStream<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const result: T[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result.push(value)
+  }
+  return result
+}
+
+function createEventStream(chunks: SseChunk[]) {
+  const lines = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`)
+  lines.push("data: [DONE]")
+  const payload = `${lines.join("\n\n")}\n\n`
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload))
+      controller.close()
+    },
+  })
+}
+
+async function streamParts(chunks: SseChunk[]) {
+  const fetch = mock(async () => {
+    return new Response(createEventStream(chunks), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    })
+  })
+  const model = new OpenAIResponsesLanguageModel("gpt-5.2", {
+    provider: "test.responses",
+    url: () => "https://example.test/v1/responses",
+    headers: () => ({ Authorization: "Bearer test" }),
+    fetch: fetch as never,
+  })
+  const { stream } = await model.doStream({ prompt: TEST_PROMPT, includeRawChunks: false })
+  return collectStream(stream)
+}
+
+function responseCreated(): SseChunk {
+  return {
+    type: "response.created",
+    sequence_number: 1,
+    response: {
+      id: "resp_test",
+      created_at: 1779358949,
+      model: "gpt-5.2",
+      service_tier: null,
+    },
+  }
+}
+
+function responseCompleted(seq = 4): SseChunk {
+  return {
+    type: "response.completed",
+    sequence_number: seq,
+    response: {
+      incomplete_details: null,
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: null },
+        output_tokens: 1,
+        output_tokens_details: { reasoning_tokens: null },
+      },
+      service_tier: null,
+    },
+  }
+}
+
+function functionCallAdded(
+  input: {
+    seq?: number
+    outputIndex?: number
+    itemId?: string
+    callId?: string
+    name?: string
+    args?: string
+  } = {},
+): SseChunk {
+  return {
+    type: "response.output_item.added",
+    sequence_number: input.seq ?? 2,
+    output_index: input.outputIndex ?? 0,
+    item: {
+      type: "function_call",
+      id: input.itemId ?? "fc_1",
+      call_id: input.callId ?? "call_1",
+      name: input.name ?? "enter-worktree",
+      arguments: input.args ?? "",
+      status: "in_progress",
+    },
+  }
+}
+
+function functionCallArgumentsDone(
+  input: {
+    seq?: number
+    outputIndex?: number
+    itemId?: string
+    name?: string
+    args?: string
+  } = {},
+): SseChunk {
+  return {
+    type: "response.function_call_arguments.done",
+    sequence_number: input.seq ?? 3,
+    output_index: input.outputIndex ?? 0,
+    item_id: input.itemId ?? "fc_1",
+    name: input.name ?? "enter-worktree",
+    arguments: input.args ?? "{}",
+  }
+}
+
+function toolLifecycleParts(parts: LanguageModelV3StreamPart[]) {
+  return parts.filter(
+    (part) => part.type === "tool-input-start" || part.type === "tool-input-end" || part.type === "tool-call",
+  )
+}
+
+function toolCalls(parts: LanguageModelV3StreamPart[]) {
+  return parts.filter((part) => part.type === "tool-call")
+}
+
+describe("OpenAIResponsesLanguageModel function call materialization", () => {
+  test("materializes no-arg client tool when arguments.done arrives without output_item.done", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDone({ args: "{}" }),
+      responseCompleted(),
+    ])
+
+    expect(toolLifecycleParts(parts)).toMatchObject([
+      { type: "tool-input-start", id: "call_1", toolName: "enter-worktree" },
+      { type: "tool-input-end", id: "call_1" },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "enter-worktree",
+        input: "{}",
+        providerMetadata: { openai: { itemId: "fc_1" } },
+      },
+    ])
+    expect(toolCalls(parts)).toHaveLength(1)
+  })
+})

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -225,6 +225,10 @@ function errors(parts: LanguageModelV3StreamPart[]) {
   return parts.filter((part) => part.type === "error")
 }
 
+function finish(parts: LanguageModelV3StreamPart[]) {
+  return parts.find((part) => part.type === "finish")
+}
+
 describe("OpenAIResponsesLanguageModel function call materialization", () => {
   test("materializes no-arg client tool when arguments.done arrives without output_item.done", async () => {
     const parts = await streamParts([
@@ -305,6 +309,18 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
     expect(toolCalls(parts)).toHaveLength(0)
     expect(errors(parts)).toHaveLength(1)
     expect(String((errors(parts)[0] as { error: unknown }).error)).toContain("function call name mismatch")
+  })
+
+  test("keeps error finish reason when response.completed follows a function call mismatch", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded({ name: "enter-worktree" }),
+      functionCallArgumentsDone({ name: "bash", args: "{}" }),
+      responseCompleted(),
+    ])
+
+    expect(errors(parts)).toHaveLength(1)
+    expect(finish(parts)).toMatchObject({ finishReason: { unified: "error" } })
   })
 
   test("ignores late argument delta after materialization without changing input", async () => {

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -285,6 +285,20 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
     expect(toolCalls(parts)).toHaveLength(1)
   })
 
+  test("ignores late argument delta after output_item.done fallback materializes", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallDone({ seq: 3, args: '{"path":"fallback"}' }),
+      functionCallArgumentsDelta({ seq: 4, delta: '{"path":"late"}' }),
+      responseCompleted(5),
+    ])
+
+    expect(errors(parts)).toHaveLength(0)
+    expect(toolCalls(parts)).toHaveLength(1)
+    expect(toolCalls(parts)[0]).toMatchObject({ input: '{"path":"fallback"}' })
+  })
+
   test("does not duplicate tool-call when arguments.done is followed by output_item.done", async () => {
     const parts = await streamParts([
       responseCreated(),

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -312,6 +312,22 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
     expect(toolCalls(parts)[0]).toMatchObject({ toolCallId: "call_1", input: "{}" })
   })
 
+  test("ignores late argument delta after arguments.done and output_item.done duplicate", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDone({ seq: 3, args: '{"path":"done"}' }),
+      functionCallDone({ seq: 4, args: '{"path":"done"}' }),
+      functionCallArgumentsDelta({ seq: 5, delta: '{"path":"late"}' }),
+      responseCompleted(6),
+    ])
+
+    expect(errors(parts)).toHaveLength(0)
+    expect(toolCalls(parts)).toHaveLength(1)
+    expect(toolCalls(parts)[0]).toMatchObject({ input: '{"path":"done"}' })
+    expect(finish(parts)).toMatchObject({ finishReason: { unified: "tool-calls" } })
+  })
+
   test("blocks materialization when arguments.done name does not match added function name", async () => {
     const parts = await streamParts([
       responseCreated(),

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -77,6 +77,52 @@ function responseCompleted(seq = 4): SseChunk {
   }
 }
 
+function responseFailed(seq = 3): SseChunk {
+  return {
+    type: "response.failed",
+    sequence_number: seq,
+    response: {
+      id: "resp_test",
+      created_at: 1779358950,
+      model: "gpt-5.2",
+      error: { code: "server_error", message: "response failed" },
+      incomplete_details: null,
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: null },
+        output_tokens: 0,
+        output_tokens_details: { reasoning_tokens: null },
+      },
+      service_tier: null,
+    },
+  }
+}
+
+async function streamPartsWithoutDone(chunks: SseChunk[]) {
+  const fetch = mock(async () => {
+    const lines = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`)
+    const payload = `${lines.join("\n\n")}\n\n`
+    const encoder = new TextEncoder()
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(payload))
+          controller.close()
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    )
+  })
+  const model = new OpenAIResponsesLanguageModel("gpt-5.2", {
+    provider: "test.responses",
+    url: () => "https://example.test/v1/responses",
+    headers: () => ({ Authorization: "Bearer test" }),
+    fetch: fetch as never,
+  })
+  const { stream } = await model.doStream({ prompt: TEST_PROMPT, includeRawChunks: false })
+  return collectStream(stream)
+}
+
 function functionCallAdded(
   input: {
     seq?: number
@@ -273,5 +319,25 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
     expect(errors(parts)).toHaveLength(0)
     expect(toolCalls(parts)).toHaveLength(1)
     expect(toolCalls(parts)[0]).toMatchObject({ input: '{"path":"stable"}' })
+  })
+
+  test("emits an explicit error when response.failed arrives after function_call added", async () => {
+    const parts = await streamParts([responseCreated(), functionCallAdded(), responseFailed()])
+
+    expect(toolCalls(parts)).toHaveLength(0)
+    expect(errors(parts).length).toBeGreaterThanOrEqual(1)
+    expect(
+      errors(parts).some((part) => String((part as { error: unknown }).error).includes("input did not complete")),
+    ).toBe(true)
+  })
+
+  test("emits an explicit error on flush when function_call input never completes", async () => {
+    const parts = await streamPartsWithoutDone([responseCreated(), functionCallAdded()])
+
+    expect(toolCalls(parts)).toHaveLength(0)
+    expect(errors(parts).length).toBeGreaterThanOrEqual(1)
+    expect(
+      errors(parts).some((part) => String((part as { error: unknown }).error).includes("input did not complete")),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -121,9 +121,53 @@ function functionCallArgumentsDone(
   }
 }
 
+function functionCallArgumentsDelta(input: {
+  seq?: number
+  outputIndex?: number
+  itemId?: string
+  delta: string
+}): SseChunk {
+  return {
+    type: "response.function_call_arguments.delta",
+    sequence_number: input.seq ?? 3,
+    output_index: input.outputIndex ?? 0,
+    item_id: input.itemId ?? "fc_1",
+    delta: input.delta,
+  }
+}
+
+function functionCallDone(
+  input: {
+    seq?: number
+    outputIndex?: number
+    itemId?: string
+    callId?: string
+    name?: string
+    args?: string
+  } = {},
+): SseChunk {
+  return {
+    type: "response.output_item.done",
+    sequence_number: input.seq ?? 4,
+    output_index: input.outputIndex ?? 0,
+    item: {
+      type: "function_call",
+      id: input.itemId ?? "fc_1",
+      call_id: input.callId ?? "call_1",
+      name: input.name ?? "enter-worktree",
+      arguments: input.args ?? "{}",
+      status: "completed",
+    },
+  }
+}
+
 function toolLifecycleParts(parts: LanguageModelV3StreamPart[]) {
   return parts.filter(
-    (part) => part.type === "tool-input-start" || part.type === "tool-input-end" || part.type === "tool-call",
+    (part) =>
+      part.type === "tool-input-start" ||
+      part.type === "tool-input-delta" ||
+      part.type === "tool-input-end" ||
+      part.type === "tool-call",
   )
 }
 
@@ -152,5 +196,51 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
       },
     ])
     expect(toolCalls(parts)).toHaveLength(1)
+  })
+
+  test("uses final arguments.done input after argument deltas", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDelta({ seq: 3, delta: '{"path":' }),
+      functionCallArgumentsDelta({ seq: 4, delta: '"draft"}' }),
+      functionCallArgumentsDone({ seq: 5, args: '{"path":"final"}' }),
+      responseCompleted(6),
+    ])
+
+    expect(toolCalls(parts)).toMatchObject([
+      { type: "tool-call", toolCallId: "call_1", toolName: "enter-worktree", input: '{"path":"final"}' },
+    ])
+  })
+
+  test("keeps output_item.done fallback when arguments.done is absent", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDelta({ seq: 3, delta: "{}" }),
+      functionCallDone({ seq: 4, args: "{}" }),
+      responseCompleted(5),
+    ])
+
+    expect(toolLifecycleParts(parts)).toMatchObject([
+      { type: "tool-input-start", id: "call_1", toolName: "enter-worktree" },
+      { type: "tool-input-delta", id: "call_1", delta: "{}" },
+      { type: "tool-input-end", id: "call_1" },
+      { type: "tool-call", toolCallId: "call_1", toolName: "enter-worktree", input: "{}" },
+    ])
+    expect(toolCalls(parts)).toHaveLength(1)
+  })
+
+  test("does not duplicate tool-call when arguments.done is followed by output_item.done", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDone({ seq: 3, args: "{}" }),
+      functionCallDone({ seq: 4, args: "{}" }),
+      responseCompleted(5),
+    ])
+
+    expect(toolCalls(parts)).toHaveLength(1)
+    expect(toolCalls(parts)[0]).toMatchObject({ toolCallId: "call_1", input: "{}" })
   })
 })

--- a/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-responses-language-model.test.ts
@@ -175,6 +175,10 @@ function toolCalls(parts: LanguageModelV3StreamPart[]) {
   return parts.filter((part) => part.type === "tool-call")
 }
 
+function errors(parts: LanguageModelV3StreamPart[]) {
+  return parts.filter((part) => part.type === "error")
+}
+
 describe("OpenAIResponsesLanguageModel function call materialization", () => {
   test("materializes no-arg client tool when arguments.done arrives without output_item.done", async () => {
     const parts = await streamParts([
@@ -242,5 +246,32 @@ describe("OpenAIResponsesLanguageModel function call materialization", () => {
 
     expect(toolCalls(parts)).toHaveLength(1)
     expect(toolCalls(parts)[0]).toMatchObject({ toolCallId: "call_1", input: "{}" })
+  })
+
+  test("blocks materialization when arguments.done name does not match added function name", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded({ name: "enter-worktree" }),
+      functionCallArgumentsDone({ name: "bash", args: "{}" }),
+      responseCompleted(),
+    ])
+
+    expect(toolCalls(parts)).toHaveLength(0)
+    expect(errors(parts)).toHaveLength(1)
+    expect(String((errors(parts)[0] as { error: unknown }).error)).toContain("function call name mismatch")
+  })
+
+  test("ignores late argument delta after materialization without changing input", async () => {
+    const parts = await streamParts([
+      responseCreated(),
+      functionCallAdded(),
+      functionCallArgumentsDone({ seq: 3, args: '{"path":"stable"}' }),
+      functionCallArgumentsDelta({ seq: 4, delta: '{"path":"late"}' }),
+      responseCompleted(5),
+    ])
+
+    expect(errors(parts)).toHaveLength(0)
+    expect(toolCalls(parts)).toHaveLength(1)
+    expect(toolCalls(parts)[0]).toMatchObject({ input: '{"path":"stable"}' })
   })
 })

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -45,6 +45,11 @@ const ref = {
   modelID: ModelID.make("test-model"),
 }
 
+const copilotResponsesRef = {
+  providerID: ProviderID.make("github-copilot"),
+  modelID: ModelID.make("gpt-5.2"),
+}
+
 const cfg = {
   provider: {
     test: {
@@ -86,6 +91,90 @@ function providerCfg(url: string) {
           baseURL: url,
         },
       },
+    },
+  }
+}
+
+function copilotResponsesProviderCfg(url: string) {
+  return {
+    provider: {
+      "github-copilot": {
+        name: "GitHub Copilot",
+        id: "github-copilot",
+        env: ["GITHUB_COPILOT_TOKEN"],
+        npm: "@ai-sdk/github-copilot",
+        api: "https://api.githubcopilot.com/v1",
+        models: {
+          "gpt-5.2": {
+            id: "gpt-5.2",
+            name: "GPT 5.2",
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: true,
+            release_date: "2025-01-01",
+            limit: { context: 100000, output: 10000 },
+            cost: { input: 0, output: 0 },
+            options: {},
+          },
+        },
+        options: {
+          apiKey: "test-copilot-key",
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+function responseCreated(model = "gpt-5.2") {
+  return {
+    type: "response.created",
+    sequence_number: 1,
+    response: { id: "resp_test", created_at: 1779358949, model, service_tier: null },
+  }
+}
+
+function responseFunctionCallAdded() {
+  return {
+    type: "response.output_item.added",
+    sequence_number: 2,
+    output_index: 0,
+    item: {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_responses_args_done_only",
+      name: "noop",
+      arguments: "",
+      status: "in_progress",
+    },
+  }
+}
+
+function responseFunctionCallArgumentsDone() {
+  return {
+    type: "response.function_call_arguments.done",
+    sequence_number: 3,
+    output_index: 0,
+    item_id: "fc_1",
+    name: "noop",
+    arguments: "{}",
+  }
+}
+
+function responseCompleted() {
+  return {
+    type: "response.completed",
+    sequence_number: 4,
+    response: {
+      incomplete_details: null,
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: null },
+        output_tokens: 1,
+        output_tokens_details: { reasoning_tokens: null },
+      },
+      service_tier: null,
     },
   }
 }
@@ -924,6 +1013,92 @@ it.live("session.processor effect tests mark materialized tools as prepared but 
         }
       }),
     { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests execute Responses args-done-only tool calls", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const previousToken = process.env.GITHUB_COPILOT_TOKEN
+        process.env.GITHUB_COPILOT_TOKEN = "test-copilot-token"
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            if (previousToken === undefined) delete process.env.GITHUB_COPILOT_TOKEN
+            else process.env.GITHUB_COPILOT_TOKEN = previousToken
+          }),
+        )
+        const { processors, session, provider } = yield* boot()
+        let executions = 0
+
+        yield* llm.push(
+          raw({
+            head: [
+              responseCreated(),
+              responseFunctionCallAdded(),
+              responseFunctionCallArgumentsDone(),
+              responseCompleted(),
+            ],
+            passthrough: true,
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "responses args done tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(copilotResponsesRef.providerID, copilotResponsesRef.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: copilotResponsesRef.providerID, modelID: copilotResponsesRef.modelID },
+            tools: { noop: true },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "responses args done tool" }],
+          tools: {
+            noop: tool({
+              description: "No-op tool",
+              inputSchema: z.object({}),
+              execute: async () => {
+                executions += 1
+                return { output: "ok" }
+              },
+            }),
+          },
+        })
+
+        yield* Effect.promise(async () => {
+          const end = Date.now() + 500
+          while (Date.now() < end) {
+            if (executions > 0) return
+            await Bun.sleep(10)
+          }
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const call = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+        const hits = yield* llm.hits
+
+        expect(hits[0]?.url.pathname).toBe("/v1/responses")
+        expect(call).toBeDefined()
+        expect(executions).toBe(1)
+        expect(call?.state.status).not.toBe("pending")
+        expect(call?.state.status).not.toBe("running")
+      }),
+    { git: true, config: (url) => copilotResponsesProviderCfg(url) },
   ),
 )
 


### PR DESCRIPTION
## Summary

- Add a small OpenAI Responses function-call assembler so `response.function_call_arguments.done` materializes client-side tools exactly once.
- Preserve `response.output_item.done` as fallback and block mismatched or late event sequences with explicit diagnostics.
- Cover args-done materialization, duplicate completion, output-item fallback, name mismatch, late deltas, `response.failed`, and stream flush cleanup.

## Why

Issue #829 showed a tool part stuck in `pending`: the client saw `response.output_item.added` and created `tool-input-start`, but never materialized a `tool-call` when the Responses stream completed arguments through `response.function_call_arguments.done`.

## Related Issue

Refs #829

## Human Review Status

- `Pending` — waiting for a human reviewer to approve.

## Review Focus

Please focus on the assembler state transitions and the terminal cleanup behavior: args-done-only should execute, output-item-done should remain a fallback, and added-but-unfinished streams should produce explicit errors rather than fake tool calls.

## Risk Notes

No visible UI changes. The main behavior risk is Responses stream ordering compatibility; tests cover args-done-only, deltas, output-item fallback, duplicate completion, mismatch, late deltas, response.failed, and flush cleanup. The existing LLM service test file still passes; processor materialization coverage is exercised by the existing focused processor test. No platform/packaging surface was touched.

## How To Verify

- Provider adapter tests: `bun test test/provider/copilot/openai-responses-language-model.test.ts --timeout 30000` — 8 passed.
- LLM tests: `bun test test/session/llm.test.ts --timeout 30000` — 19 passed.
- Processor materialization focused test: `bun test test/session/processor-effect.test.ts -t "mark materialized tools" --timeout 30000` — 1 passed.
- Typecheck: `bun run typecheck` — 8 packages successful.
- Diff check: `git diff --check` — no whitespace errors.

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.