### PR TITLE
fix(session): guard compaction control flow

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -517,7 +517,7 @@ export const layer: Layer.Layer<
         })
       }
 
-      if (result === "continue" && input.auto) {
+      if (result === "continue" && input.auto && input.overflow) {
         if (replay) {
           const original = replay.info
           const replayMsg = yield* session.updateMessage({

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -430,10 +430,9 @@ export const layer: Layer.Layer<
         cfg,
         model,
       })
+      const previousTailStartId = compactionPart?.tail_start_id ?? latestPrior?.tailStartId
       const stalledTailBoundary =
-        input.auto &&
-        compactionPart?.tail_start_id !== undefined &&
-        compactionPart.tail_start_id === selected.tail_start_id
+        input.auto && previousTailStartId !== undefined && previousTailStartId === selected.tail_start_id
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -430,6 +430,10 @@ export const layer: Layer.Layer<
         cfg,
         model,
       })
+      const stalledTailBoundary =
+        input.auto &&
+        compactionPart?.tail_start_id !== undefined &&
+        compactionPart.tail_start_id === selected.tail_start_id
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
@@ -472,6 +476,14 @@ export const layer: Layer.Layer<
         },
       }
       yield* session.updateMessage(msg)
+      if (stalledTailBoundary) {
+        msg.error = new MessageV2.ContextOverflowError({
+          message: `Auto compaction could not make progress: retained tail boundary did not advance (${selected.tail_start_id})`,
+        }).toObject()
+        msg.finish = "error"
+        yield* session.updateMessage(msg)
+        return "stop"
+      }
       const processor = yield* processors.create({
         assistantMessage: msg,
         sessionID: input.sessionID,

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -434,7 +434,8 @@ export const layer: Layer.Layer<
       const stalledTailBoundary =
         input.auto &&
         previousTailStartId !== undefined &&
-        (selected.tail_start_id === undefined || selected.tail_start_id <= previousTailStartId)
+        selected.tail_start_id !== undefined &&
+        selected.tail_start_id <= previousTailStartId
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -432,7 +432,9 @@ export const layer: Layer.Layer<
       })
       const previousTailStartId = compactionPart?.tail_start_id ?? latestPrior?.tailStartId
       const stalledTailBoundary =
-        input.auto && previousTailStartId !== undefined && previousTailStartId === selected.tail_start_id
+        input.auto &&
+        previousTailStartId !== undefined &&
+        (selected.tail_start_id === undefined || selected.tail_start_id <= previousTailStartId)
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1948,6 +1948,28 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             !hasToolCalls &&
             lastUser.id < lastAssistant.id
           ) {
+            const tokens = lastFinished?.tokens
+            const hasTokenUsage =
+              tokens !== undefined &&
+              ((tokens.total ?? 0) > 0 ||
+                tokens.input > 0 ||
+                tokens.output > 0 ||
+                tokens.reasoning > 0 ||
+                tokens.cache.read > 0 ||
+                tokens.cache.write > 0)
+            if (lastFinished && lastFinished.summary !== true && hasTokenUsage) {
+              const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+              if (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model })) {
+                yield* compaction.create({
+                  sessionID,
+                  agent: lastUser.agent,
+                  model: lastUser.model,
+                  auto: true,
+                  overflow: true,
+                })
+                continue
+              }
+            }
             yield* slog.info("exiting loop")
             break
           }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1914,17 +1914,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           yield* status.set(sessionID, { type: "busy" })
           yield* slog.info("loop", { step })
 
-          const rawMsgs = yield* sessions.messages({ sessionID })
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
           let lastUser: MessageV2.User | undefined
           let lastAssistant: MessageV2.Assistant | undefined
+          let lastAssistantMsg: MessageV2.WithParts | undefined
           let lastFinished: MessageV2.Assistant | undefined
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
-          for (let i = rawMsgs.length - 1; i >= 0; i--) {
-            const msg = rawMsgs[i]
+          for (const msg of MessageV2.stream(sessionID)) {
             if (!lastUser && msg.info.role === "user") lastUser = msg.info
-            if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
+            if (!lastAssistant && msg.info.role === "assistant") {
+              lastAssistant = msg.info
+              lastAssistantMsg = msg
+            }
             if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
             if (lastUser && lastFinished) break
             const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
@@ -1932,10 +1934,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-
-          const lastAssistantMsg = rawMsgs.findLast(
-            (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
-          )
           // Some providers return "stop" even when the assistant message contains tool calls.
           // Keep the loop running so tool results can be sent back to the model.
           // Skip provider-executed tool parts — those were fully handled within the

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1914,14 +1914,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           yield* status.set(sessionID, { type: "busy" })
           yield* slog.info("loop", { step })
 
+          const rawMsgs = yield* sessions.messages({ sessionID })
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
           let lastUser: MessageV2.User | undefined
           let lastAssistant: MessageV2.Assistant | undefined
           let lastFinished: MessageV2.Assistant | undefined
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
-          for (let i = msgs.length - 1; i >= 0; i--) {
-            const msg = msgs[i]
+          for (let i = rawMsgs.length - 1; i >= 0; i--) {
+            const msg = rawMsgs[i]
             if (!lastUser && msg.info.role === "user") lastUser = msg.info
             if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
             if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
@@ -1932,7 +1933,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
-          const lastAssistantMsg = msgs.findLast(
+          const lastAssistantMsg = rawMsgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
           )
           // Some providers return "stop" even when the assistant message contains tool calls.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1965,7 +1965,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   agent: lastUser.agent,
                   model: lastUser.model,
                   auto: true,
-                  overflow: true,
                 })
                 continue
               }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1069,7 +1069,7 @@ describe("session.compaction.process", () => {
     })
   })
 
-  test("adds synthetic continue prompt when auto is enabled", async () => {
+  test("waits for real user input after natural auto compaction", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
@@ -1094,15 +1094,17 @@ describe("session.compaction.process", () => {
           const last = all.at(-1)
 
           expect(result).toBe("continue")
-          expect(last?.info.role).toBe("user")
-          expect(last?.parts[0]).toMatchObject({
-            type: "text",
-            synthetic: true,
-            metadata: { compaction_continue: true },
-          })
-          if (last?.parts[0]?.type === "text") {
-            expect(last.parts[0].text).toContain("Continue if you have next steps")
-          }
+          expect(last?.info.role).toBe("assistant")
+          expect(
+            all.some(
+              (msg) =>
+                msg.info.role === "user" &&
+                msg.parts.some(
+                  (part) =>
+                    part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+                ),
+            ),
+          ).toBe(false)
         } finally {
           await rt.dispose()
         }
@@ -1146,6 +1148,48 @@ describe("session.compaction.process", () => {
                 ),
             ),
           ).toBe(false)
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("keeps overflow auto compaction continuation guidance", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const msg = await user(session.id, "hello")
+        const rt = runtime("continue", Plugin.defaultLayer, wide())
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: msg.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+                overflow: true,
+              }),
+            ),
+          )
+
+          const all = await svc.messages({ sessionID: session.id })
+          const last = all.at(-1)
+
+          expect(result).toBe("continue")
+          expect(last?.info.role).toBe("user")
+          expect(last?.parts[0]).toMatchObject({
+            type: "text",
+            synthetic: true,
+            metadata: { compaction_continue: true },
+          })
+          if (last?.parts[0]?.type === "text") {
+            expect(last.parts[0].text).toContain("previous request exceeded the provider's size limit")
+          }
         } finally {
           await rt.dispose()
         }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1197,6 +1197,74 @@ describe("session.compaction.process", () => {
     })
   })
 
+  test("stops with a context overflow error when auto compaction cannot advance the retained tail", async () => {
+    await using tmp = await tmpdir()
+    const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create()
+        const first = await user(session.id, "first request")
+        await assistant(session.id, first.id, tmp.path)
+        const second = await user(session.id, "second request")
+        await assistant(session.id, second.id, tmp.path)
+        const previousCompaction = await user(session.id, "compact once")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: previousCompaction.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+          tail_start_id: second.id,
+        })
+        await assistant(session.id, previousCompaction.id, tmp.path)
+        const compact = await user(session.id, "compact again")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: compact.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+          tail_start_id: second.id,
+        })
+
+        const fakeLLM = llm()
+        fakeLLM.push(reply("new summary"))
+        const live = liveRuntime(
+          fakeLLM.layer,
+          ProviderTest.fake({ model }),
+          cfg({ tail_turns: 1, preserve_recent_tokens: 6_000 }),
+        )
+        try {
+          const beforeCompaction = await svc.messages({ sessionID: session.id })
+          const result = await live.runPromise(
+            SessionCompaction.Service.use((compaction) =>
+              compaction.process({
+                parentID: compact.id,
+                messages: beforeCompaction,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+
+          const summary = (await svc.messages({ sessionID: session.id })).findLast(
+            (message) => message.info.role === "assistant" && message.info.summary === true,
+          )
+
+          expect(result).toBe("stop")
+          expect(summary?.info.role).toBe("assistant")
+          if (summary?.info.role === "assistant") {
+            expect(summary.info.finish).toBe("error")
+            expect(summary.info.error?.name).toBe("ContextOverflowError")
+          }
+        } finally {
+          await live.dispose()
+        }
+      },
+    })
+  })
+
   test("replays the prior user turn on overflow when earlier context exists", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1197,7 +1197,7 @@ describe("session.compaction.process", () => {
     })
   })
 
-  test("stops with a context overflow error when auto compaction cannot advance the retained tail", async () => {
+  test("allows auto compaction to clear the retained tail boundary", async () => {
     await using tmp = await tmpdir()
     const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
     await Instance.provide({
@@ -1228,6 +1228,95 @@ describe("session.compaction.process", () => {
         })
         const third = await user(session.id, "third request")
         await assistant(session.id, third.id, tmp.path)
+        const compact = await user(session.id, "compact and clear tail")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: compact.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+        })
+
+        const fakeLLM = llm()
+        fakeLLM.push(reply("new summary"))
+        const live = liveRuntime(
+          fakeLLM.layer,
+          ProviderTest.fake({ model }),
+          cfg({ tail_turns: 0, preserve_recent_tokens: 6_000 }),
+        )
+        try {
+          const beforeCompaction = await svc.messages({ sessionID: session.id })
+          const result = await live.runPromise(
+            SessionCompaction.Service.use((compaction) =>
+              compaction.process({
+                parentID: compact.id,
+                messages: beforeCompaction,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+
+          const messages = await svc.messages({ sessionID: session.id })
+          const currentPart = messages
+            .find((message) => message.info.id === compact.id)
+            ?.parts.find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+          const summary = messages.findLast(
+            (message) => message.info.role === "assistant" && message.info.parentID === compact.id,
+          )
+
+          expect(result).toBe("continue")
+          expect(currentPart?.tail_start_id).toBeUndefined()
+          expect(summary?.info.role).toBe("assistant")
+          if (summary?.info.role === "assistant") {
+            expect(summary.info.finish).not.toBe("error")
+            expect(summary.info.error).toBeUndefined()
+          }
+        } finally {
+          await live.dispose()
+        }
+      },
+    })
+  })
+
+  test("stops with a context overflow error when auto compaction cannot advance the retained tail", async () => {
+    await using tmp = await tmpdir()
+    const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create()
+        const first = await user(session.id, "first request")
+        await assistant(session.id, first.id, tmp.path)
+        const second = await user(session.id, "second request")
+        const secondReply = await assistant(session.id, second.id, tmp.path)
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: secondReply.id,
+          sessionID: session.id,
+          type: "text",
+          text: "x".repeat(40_000),
+        })
+        const previousCompaction = await user(session.id, "compact once")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: previousCompaction.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+          tail_start_id: second.id,
+        })
+        const previousSummary = await assistant(session.id, previousCompaction.id, tmp.path)
+        await svc.updateMessage({ ...previousSummary, summary: true })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: previousSummary.id,
+          sessionID: session.id,
+          type: "text",
+          text: "## Goal\n- Previous completed summary",
+        })
+        const third = await user(session.id, "third request")
+        await assistant(session.id, third.id, tmp.path)
         const compact = await user(session.id, "compact again")
         await svc.updatePart({
           id: PartID.ascending(),
@@ -1235,6 +1324,7 @@ describe("session.compaction.process", () => {
           sessionID: session.id,
           type: "compaction",
           auto: true,
+          tail_start_id: third.id,
         })
 
         const fakeLLM = llm()

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1217,7 +1217,8 @@ describe("session.compaction.process", () => {
           auto: true,
           tail_start_id: second.id,
         })
-        await assistant(session.id, previousCompaction.id, tmp.path)
+        const previousSummary = await assistant(session.id, previousCompaction.id, tmp.path)
+        await svc.updateMessage({ ...previousSummary, summary: true })
         const compact = await user(session.id, "compact again")
         await svc.updatePart({
           id: PartID.ascending(),
@@ -1225,7 +1226,6 @@ describe("session.compaction.process", () => {
           sessionID: session.id,
           type: "compaction",
           auto: true,
-          tail_start_id: second.id,
         })
 
         const fakeLLM = llm()

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1219,6 +1219,15 @@ describe("session.compaction.process", () => {
         })
         const previousSummary = await assistant(session.id, previousCompaction.id, tmp.path)
         await svc.updateMessage({ ...previousSummary, summary: true })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: previousSummary.id,
+          sessionID: session.id,
+          type: "text",
+          text: "## Goal\n- Previous completed summary",
+        })
+        const third = await user(session.id, "third request")
+        await assistant(session.id, third.id, tmp.path)
         const compact = await user(session.id, "compact again")
         await svc.updatePart({
           id: PartID.ascending(),
@@ -1233,7 +1242,7 @@ describe("session.compaction.process", () => {
         const live = liveRuntime(
           fakeLLM.layer,
           ProviderTest.fake({ model }),
-          cfg({ tail_turns: 1, preserve_recent_tokens: 6_000 }),
+          cfg({ tail_turns: 2, preserve_recent_tokens: 6_000 }),
         )
         try {
           const beforeCompaction = await svc.messages({ sessionID: session.id })

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -383,6 +383,16 @@ function providerCfg(url: string) {
   }
 }
 
+function retainedTailCfg(url: string) {
+  return {
+    ...providerCfg(url),
+    compaction: {
+      tail_turns: 1,
+      preserve_recent_tokens: 8_000,
+    },
+  }
+}
+
 const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
@@ -517,6 +527,94 @@ it.live("loop compacts a finished assistant turn before exiting when it overflow
         expect(yield* llm.calls).toBe(callsAfterCompaction)
       }),
     { git: true, config: providerCfg },
+  ),
+)
+
+it.live("finished compaction with retained tail does not compact that tail again", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Retained finished tail" })
+        const first = yield* user(chat.id, "first request")
+        const firstAssistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: first.id,
+          sessionID: chat.id,
+          mode: "build",
+          agent: "build",
+          cost: 0,
+          path: { cwd: dir, root: dir },
+          tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: firstAssistant.id,
+          sessionID: chat.id,
+          type: "text",
+          text: "first answer",
+        })
+        const second = yield* user(chat.id, "second request")
+        const secondAssistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: second.id,
+          sessionID: chat.id,
+          mode: "build",
+          agent: "build",
+          cost: 0,
+          path: { cwd: dir, root: dir },
+          tokens: { input: 95_000, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: secondAssistant.id,
+          sessionID: chat.id,
+          type: "text",
+          text: "second answer",
+        })
+        yield* llm.text("## Goal\n- Compacted first turn")
+        yield* llm.text("## Goal\n- Unexpected second compaction")
+
+        const result = yield* prompt.loop({ sessionID: chat.id })
+        const callsAfterFirstLoop = yield* llm.calls
+        const secondResult = yield* prompt.loop({ sessionID: chat.id })
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const filtered = yield* MessageV2.filterCompactedEffect(chat.id)
+        const compactionParts = messages.flatMap((message) => message.parts).filter((part) => part.type === "compaction")
+        const syntheticContinue = messages.find(
+          (message) =>
+            message.info.role === "user" &&
+            message.parts.some(
+              (part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+            ),
+        )
+
+        expect(result.info.role).toBe("assistant")
+        expect(secondResult.info.role).toBe("assistant")
+        expect(callsAfterFirstLoop).toBe(1)
+        expect(yield* llm.calls).toBe(1)
+        expect(compactionParts).toHaveLength(1)
+        expect(compactionParts[0]).toMatchObject({ tail_start_id: second.id })
+        expect(syntheticContinue).toBeUndefined()
+        expect(filtered.map((message) => message.info.id)).toEqual([
+          compactionParts[0]!.messageID,
+          result.info.id,
+          second.id,
+          secondAssistant.id,
+        ])
+      }),
+    { git: true, config: retainedTailCfg },
   ),
 )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -496,11 +496,25 @@ it.live("loop compacts a finished assistant turn before exiting when it overflow
           .flatMap((message) => message.parts)
           .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
         const summary = messages.find((message) => message.info.role === "assistant" && message.info.summary === true)
+        const syntheticContinue = messages.find(
+          (message) =>
+            message.info.role === "user" &&
+            message.parts.some(
+              (part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+            ),
+        )
 
         expect(yield* llm.calls).toBeGreaterThanOrEqual(1)
         expect(compactionPart).toBeDefined()
+        expect(compactionPart?.overflow).not.toBe(true)
         expect(summary?.info.role).toBe("assistant")
         expect(result.info.role).toBe("assistant")
+        expect(syntheticContinue).toBeUndefined()
+
+        const callsAfterCompaction = yield* llm.calls
+        const secondResult = yield* prompt.loop({ sessionID: chat.id })
+        expect(secondResult.info.role).toBe("assistant")
+        expect(yield* llm.calls).toBe(callsAfterCompaction)
       }),
     { git: true, config: providerCfg },
   ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -577,7 +577,7 @@ it.live("provider env matches assistant path for an active worktree", () =>
   ),
 )
 
-it.live("post-compaction auto-continue keeps env in the active worktree", () =>
+it.live("post-compaction user continuation keeps env in the active worktree", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -659,11 +659,17 @@ it.live("post-compaction auto-continue keeps env in the active worktree", () =>
         expect(summaryMessage.info.path.cwd).toBe(activeDirectory)
         expect(summaryMessage.info.path.root).toBe(dir)
 
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "continue after compaction" }],
+        })
         yield* llm.text("continued after compaction")
         const result = yield* prompt.loop({ sessionID: session.id })
         if (result.info.role !== "assistant") throw new Error("Expected assistant message")
 
-        const requestText = requestTextContaining(yield* llm.inputs, "Continue if you have next steps")
+        const requestText = requestTextContaining(yield* llm.inputs, "continue after compaction")
         expect(envValue(requestText, "Working directory")).toBe(activeDirectory)
         expect(envValue(requestText, "Workspace root folder")).toBe(dir)
         expect(result.info.path.cwd).toBe(activeDirectory)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -476,6 +476,36 @@ it.live("loop exits immediately when last assistant has stop finish", () =>
   ),
 )
 
+it.live("loop compacts a finished assistant turn before exiting when it overflows", () =>
+  provideTmpdirServer(
+    ({ llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Overflowed finished turn" })
+        const seeded = yield* seed(chat.id, { finish: "stop" })
+        yield* sessions.updateMessage({
+          ...seeded.assistant,
+          tokens: { input: 95_000, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+        })
+        yield* llm.text("## Goal\n- Compacted finished overflow turn")
+
+        const result = yield* prompt.loop({ sessionID: chat.id })
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const compactionPart = messages
+          .flatMap((message) => message.parts)
+          .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+        const summary = messages.find((message) => message.info.role === "assistant" && message.info.summary === true)
+
+        expect(yield* llm.calls).toBeGreaterThanOrEqual(1)
+        expect(compactionPart).toBeDefined()
+        expect(summary?.info.role).toBe("assistant")
+        expect(result.info.role).toBe("assistant")
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop calls LLM and returns assistant message", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
## Summary

- Guard Core compaction control flow for #831 PR 1: finished overflowed turns now compact before loop exit, natural compactions wait for real user input, and stalled retained-tail boundaries stop with a terminal context-overflow summary.
- Keep overflow recovery continuation guidance intact while removing synthetic continuation from naturally completed auto compactions.
- Address review feedback by separating completed-turn token-threshold compaction from unfinished provider overflow recovery, reading latest loop-control state from raw newest-first transcript order, avoiding a second full raw transcript materialization per loop, and allowing auto compaction to clear a retained tail boundary when it fully summarizes the remaining tail.

## Why

#831 V2.3 final requires the first batch to be failure-driven over the existing message / part / summary / tail_start_id projection, without adding a new checkpoint subsystem.

## Related Issue

Refs #831

## Human Review Status

Pending

## Review Focus

- Whether the finished-turn overflow check is scoped narrowly enough and does not force provider model lookup for normal zero-token seeded sessions.
- Whether completed-turn token-threshold compaction stays on the natural compaction path instead of replaying old user requests or inserting synthetic continue prompts.
- Whether retained tail display reordering no longer makes `prompt.loop` treat old retained assistants as the latest finished turn.
- Whether the newest-first raw transcript scan is an acceptable low-overhead source for latest user / assistant / finished / pending task selection.
- Whether natural auto compaction correctly waits for real user input while overflow recovery still gets continuation guidance.
- Whether the stalled-boundary guard correctly stops auto compactions only when a concrete selected boundary is same/older than the latest retained boundary, while allowing successful clear-to-undefined full re-summaries.
- Whether PawWork question / permission / follow-up semantics remain unchanged outside overflow recovery.

## Risk Notes

- No visible UI changes; visual check not run.
- No platform, packaging, dependency, generated-file, permission, credential, or deletion surface touched.
- Loop context still uses `filterCompacted`; only loop-control latest user / assistant / pending task selection uses raw transcript order, and it now short-circuits while scanning newest-first.
- Commit history is split into review-sized commits: finished overflow turn compaction, natural compaction wait semantics, stalled boundary terminal error, completed-turn natural compaction review follow-up, retained-tail raw-transcript review follow-up, latest-state short-scan / realistic summary-fixture follow-up, and retained-tail clear-boundary follow-up.

## How To Verify

```text
Red checks before initial fix: 3 expected regression failures confirmed:
- finished overflowed assistant turn exited without compaction (`llm.calls` expected 1, received 0)
- natural auto compaction inserted synthetic continue user message
- repeated auto compaction reused same retained-tail boundary and returned continue

Red check for completed-turn overflow review follow-up:
bun --cwd packages/opencode test test/session/prompt-effect.test.ts --test-name-pattern "loop compacts a finished assistant turn"
Result before fix: failed because finished-turn compaction part had `overflow: true`

Red check for retained-tail review follow-up:
bun --cwd packages/opencode test test/session/prompt-effect.test.ts --test-name-pattern "finished compaction with retained tail"
Result before fix: failed because compaction LLM was called twice instead of once

Red check for clear-boundary review follow-up:
bun --cwd packages/opencode test test/session/compaction.test.ts --test-name-pattern "allows auto compaction to clear"
Result before fix: failed because clear-to-undefined selected tail returned terminal stop

Focused tests: bun --cwd packages/opencode test test/session/compaction.test.ts test/session/prompt-effect.test.ts
Result: 103 pass, 0 fail

Typecheck: bun run typecheck
Result: 8 successful, 8 total

Diff check: git diff --check
Result: no whitespace errors
```

## Screenshots or Recordings

Not applicable — no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.