### PR TITLE
fix(session): refine transport interruption phases

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1070,12 +1070,15 @@ export const layer: Layer.Layer<
         yield* turnChange.finalize({ sessionID: ctx.sessionID, messageID: ctx.assistantMessage.id })
       })
 
-      const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown) {
+      const halt = Effect.fn("SessionProcessor.halt")(function* (
+        e: unknown,
+        attemptID: RunObservability.AttemptID | undefined = ctx.currentAttemptID,
+      ) {
         slog.error("process", { error: errorMessage(e), stack: e instanceof Error ? e.stack : undefined })
         ctx.streamError = true
-        if (ctx.currentAttemptID) {
+        if (attemptID) {
           ctx.runTrace.recordTransportFailure({
-            attemptID: ctx.currentAttemptID,
+            attemptID,
             at: Date.now(),
             monotonicMs: performance.now(),
             error: e,
@@ -1117,6 +1120,7 @@ export const layer: Layer.Layer<
         slog.info("process")
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        let processAttemptID: RunObservability.AttemptID | undefined
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -1129,6 +1133,7 @@ export const layer: Layer.Layer<
               monotonicMs: performance.now(),
             })
             ctx.currentAttemptID = attempt.attemptID
+            processAttemptID = attempt.attemptID
             let stream: Stream.Stream<LLM.Event, unknown>
             try {
               stream = llm.stream({
@@ -1169,7 +1174,7 @@ export const layer: Layer.Layer<
                   provenanceRecordedAt: Date.now(),
                 })
                 if (!ctx.assistantMessage.error) {
-                  yield* halt(new DOMException("Aborted", "AbortError"))
+                  yield* halt(new DOMException("Aborted", "AbortError"), processAttemptID)
                 }
               }),
             ),
@@ -1192,7 +1197,7 @@ export const layer: Layer.Layer<
                 },
               }),
             ),
-            Effect.catch(halt),
+            Effect.catch((error) => halt(error, processAttemptID)),
             Effect.ensuring(cleanup()),
           )
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -261,18 +261,22 @@ export const layer: Layer.Layer<
         return { call, part }
       })
 
+      const toolCallAttemptID = (toolCallID: string, fallbackAttemptID = ctx.currentAttemptID) =>
+        ctx.toolcalls[toolCallID]?.attemptID ?? fallbackAttemptID
+
       const recordToolExecutionStarted = Effect.fn("SessionProcessor.recordToolExecutionStarted")(function* (input: {
         tool: string
         toolCallID: string
       }) {
         const call = ctx.toolcalls[input.toolCallID]
+        const attemptID = toolCallAttemptID(input.toolCallID)
         if (call) {
           call.executionStarted = true
-          call.attemptID = ctx.currentAttemptID ?? call.attemptID
+          call.attemptID ??= ctx.currentAttemptID
         }
-        if (!ctx.currentAttemptID) return
+        if (!attemptID) return
         ctx.runTrace.recordToolExecutionStarted({
-          attemptID: ctx.currentAttemptID,
+          attemptID,
           at: Date.now(),
           monotonicMs: performance.now(),
           toolName: RunObservability.safeToolName(input.tool),
@@ -282,7 +286,7 @@ export const layer: Layer.Layer<
 
       const recordToolExecutionCompleted = Effect.fn("SessionProcessor.recordToolExecutionCompleted")(
         function* (input: { toolCallID: string }) {
-          const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID
+          const attemptID = toolCallAttemptID(input.toolCallID)
           if (!attemptID) return
           ctx.runTrace.recordToolCompleted({
             attemptID,
@@ -296,7 +300,7 @@ export const layer: Layer.Layer<
         toolCallID: string
         error?: unknown
       }) {
-        const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID
+        const attemptID = toolCallAttemptID(input.toolCallID)
         if (!attemptID) return
         ctx.runTrace.recordToolFailed({
           attemptID,
@@ -647,45 +651,47 @@ export const layer: Layer.Layer<
         return true
       })
 
-      const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
+      const handleEvent = Effect.fnUntraced(function* (value: StreamEvent, attemptID: RunObservability.AttemptID) {
         ctx.trace.observeEvent(value)
-        if (ctx.currentAttemptID) {
-          const now = Date.now()
-          const monotonicMs = performance.now()
-          if (RunObservability.isProviderProgressEvent(value)) {
-            ctx.runTrace.recordProviderProgress({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
-          }
-          if (value.type === "text-start" || value.type === "text-delta") {
-            ctx.runTrace.recordVisibleOutput({ attemptID: ctx.currentAttemptID, at: now, monotonicMs, kind: "text" })
-          }
-          if (value.type === "reasoning-start") {
-            ctx.runTrace.recordVisibleOutput({
-              attemptID: ctx.currentAttemptID,
-              at: now,
-              monotonicMs,
-              kind: "reasoning",
-            })
-          }
-          if (value.type === "tool-input-start") {
-            ctx.runTrace.recordToolInputStarted({
-              attemptID: ctx.currentAttemptID,
-              at: now,
-              monotonicMs,
-              providerExecuted: (value as { providerExecuted?: boolean }).providerExecuted,
-            })
-          }
-          if (value.type === "tool-input-end") {
-            ctx.runTrace.recordToolInputCompleted({ attemptID: ctx.currentAttemptID, at: now, monotonicMs })
-          }
-          if (value.type === "tool-call") {
-            ctx.runTrace.recordToolCallMaterialized({
-              attemptID: ctx.currentAttemptID,
-              at: now,
-              monotonicMs,
-              toolName: RunObservability.safeToolName(value.toolName),
-              effect: RunObservability.toolEffect(value.toolName),
-            })
-          }
+        const now = Date.now()
+        const monotonicMs = performance.now()
+        if (RunObservability.isProviderProgressEvent(value)) {
+          ctx.runTrace.recordProviderProgress({ attemptID, at: now, monotonicMs })
+        }
+        if (value.type === "text-start" || value.type === "text-delta") {
+          ctx.runTrace.recordVisibleOutput({ attemptID, at: now, monotonicMs, kind: "text" })
+        }
+        if (value.type === "reasoning-start") {
+          ctx.runTrace.recordVisibleOutput({
+            attemptID,
+            at: now,
+            monotonicMs,
+            kind: "reasoning",
+          })
+        }
+        if (value.type === "tool-input-start") {
+          ctx.runTrace.recordToolInputStarted({
+            attemptID,
+            at: now,
+            monotonicMs,
+            providerExecuted: (value as { providerExecuted?: boolean }).providerExecuted,
+          })
+        }
+        if (value.type === "tool-input-end") {
+          ctx.runTrace.recordToolInputCompleted({
+            attemptID: toolCallAttemptID(value.id, attemptID) ?? attemptID,
+            at: now,
+            monotonicMs,
+          })
+        }
+        if (value.type === "tool-call") {
+          ctx.runTrace.recordToolCallMaterialized({
+            attemptID: toolCallAttemptID(value.toolCallId, attemptID) ?? attemptID,
+            at: now,
+            monotonicMs,
+            toolName: RunObservability.safeToolName(value.toolName),
+            effect: RunObservability.toolEffect(value.toolName),
+          })
         }
         switch (value.type) {
           case "start":
@@ -748,7 +754,7 @@ export const layer: Layer.Layer<
               partID: part.id,
               messageID: part.messageID,
               sessionID: part.sessionID,
-              attemptID: ctx.currentAttemptID,
+              attemptID,
             }
             yield* applyPendingToolUpdates(value.id)
             return
@@ -766,7 +772,7 @@ export const layer: Layer.Layer<
             const tracked = ctx.toolcalls[value.toolCallId]
             if (tracked) {
               tracked.materialized = true
-              tracked.attemptID = ctx.currentAttemptID ?? tracked.attemptID
+              tracked.attemptID ??= attemptID
             }
             let running = yield* updateToolCall(value.toolCallId, (match) => ({
               ...match,
@@ -1136,7 +1142,7 @@ export const layer: Layer.Layer<
             }
 
             yield* stream.pipe(
-              Stream.tap((event) => handleEvent(event)),
+              Stream.tap((event) => handleEvent(event, attempt.attemptID)),
               // Stop draining the stream as soon as the loop gate fires a synthetic stop
               // (ctx.blocked) so any trailing model text after the synthetic stop tool-error
               // is dropped — the turn ends with the rendered Chinese summary alone.

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -282,10 +282,10 @@ export const layer: Layer.Layer<
 
       const recordToolExecutionCompleted = Effect.fn("SessionProcessor.recordToolExecutionCompleted")(
         function* (input: { toolCallID: string }) {
-          void input.toolCallID
-          if (!ctx.currentAttemptID) return
+          const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID
+          if (!attemptID) return
           ctx.runTrace.recordToolCompleted({
-            attemptID: ctx.currentAttemptID,
+            attemptID,
             at: Date.now(),
             monotonicMs: performance.now(),
           })
@@ -296,10 +296,10 @@ export const layer: Layer.Layer<
         toolCallID: string
         error?: unknown
       }) {
-        void input.toolCallID
-        if (!ctx.currentAttemptID) return
+        const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID
+        if (!attemptID) return
         ctx.runTrace.recordToolFailed({
-          attemptID: ctx.currentAttemptID,
+          attemptID,
           at: Date.now(),
           monotonicMs: performance.now(),
           error: input.error,

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -200,6 +200,7 @@ export function transportCause(input: {
   toolInputStarted: boolean
   toolInputCompleted: boolean
   toolCallMaterialized: boolean
+  toolExecutionStarted: boolean
 }): Extract<TerminalCause, { category: "provider_transport_disconnect" }> {
   const error = input.error
   const boundary = error?.cause_code === "UND_ERR_SOCKET" ? "sdk_transport" : "unknown"
@@ -210,11 +211,13 @@ export function transportCause(input: {
         ? "during_tool_input_generation"
         : input.toolInputCompleted && !input.toolCallMaterialized
           ? "unknown_stream_phase"
-          : input.toolCallMaterialized
-            ? "after_tool_call_before_execution"
-            : input.providerProgressSeen
-              ? "during_text_generation"
-              : "before_first_provider_progress",
+          : input.toolExecutionStarted
+            ? "unknown_stream_phase"
+            : input.toolCallMaterialized
+              ? "after_tool_call_before_execution"
+              : input.providerProgressSeen
+                ? "during_text_generation"
+                : "before_first_provider_progress",
     boundary,
     error,
     confidence: boundary === "sdk_transport" ? "high" : "medium",

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -155,7 +155,9 @@ function factsFromEvidence(
 
 function evidenceAtOrBefore(event: IncidentEvidenceEvent, terminal: IncidentEvidenceEvent) {
   if (event.monotonic_ms !== undefined && terminal.monotonic_ms !== undefined) {
-    return event.monotonic_ms < terminal.monotonic_ms || event.order <= terminal.order
+    if (event.monotonic_ms < terminal.monotonic_ms) return true
+    if (event.monotonic_ms > terminal.monotonic_ms) return false
+    return event.order <= terminal.order
   }
   return event.order <= terminal.order
 }

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -101,6 +101,8 @@ function diagnosticGaps(
   if (input.lifecycle?.origin?.source === "server_handler" && !input.lifecycle.request)
     gaps.push("lifecycle.request_context_missing")
   if (facts.tool_execution_started && !facts.tool_call_materialized) gaps.push("tool.materialization_missing")
+  if (facts.tool_execution_completed && !facts.tool_execution_started) gaps.push("tool_execution.start_missing")
+  if (facts.tool_execution_completed && !facts.tool_call_materialized) gaps.push("tool.materialization_missing")
   if (facts.tool_input_completed && !facts.tool_input_started) gaps.push("tool_input.start_missing")
   return Array.from(new Set(gaps))
 }
@@ -159,7 +161,8 @@ function phaseFor(input: {
   facts: IncidentFacts
   terminalAttemptID?: IncidentEvidenceEvent["attempt_id"]
 }): RunIncident["phase"] {
-  const toolPhase = input.facts.tool_execution_completed
+  const validToolExecutionCompleted = input.facts.tool_execution_completed && input.facts.tool_execution_started
+  const toolPhase = validToolExecutionCompleted
     ? "tool_execution_completed"
     : input.facts.tool_execution_started
       ? "tool_execution_started"
@@ -181,7 +184,7 @@ function phaseFor(input: {
           : input.facts.visible_output_seen || input.facts.provider_progress_seen
             ? "text_generation"
             : "before_first_provider_progress"
-  const runPhase = input.facts.tool_execution_completed
+  const runPhase = validToolExecutionCompleted
     ? "post_tool"
     : input.facts.tool_execution_started
       ? "tool_execution"
@@ -216,15 +219,17 @@ export function transportCause(input: {
         ? "during_tool_input_generation"
         : input.toolInputCompleted && !input.toolCallMaterialized
           ? "unknown_stream_phase"
-          : input.toolExecutionCompleted
-            ? "after_tool_result"
-            : input.toolExecutionStarted
-              ? "unknown_stream_phase"
-              : input.toolCallMaterialized
-                ? "after_tool_call_before_execution"
-                : input.providerProgressSeen
-                  ? "during_text_generation"
-                  : "before_first_provider_progress",
+          : input.toolExecutionCompleted && (!input.toolExecutionStarted || !input.toolCallMaterialized)
+            ? "unknown_stream_phase"
+            : input.toolExecutionCompleted && input.toolExecutionStarted && input.toolCallMaterialized
+              ? "after_tool_result"
+              : input.toolExecutionStarted
+                ? "unknown_stream_phase"
+                : input.toolCallMaterialized
+                  ? "after_tool_call_before_execution"
+                  : input.providerProgressSeen
+                    ? "during_text_generation"
+                    : "before_first_provider_progress",
     boundary,
     error,
     confidence: boundary === "sdk_transport" ? "high" : "medium",

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -46,7 +46,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
   if (!terminal?.cause) return undefined
   const facts = factsFromEvidence(input)
   const terminalFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id) : facts
-  const terminalPhaseFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id, terminal) : facts
+  const terminalPhaseFacts = factsFromEvidence(input, terminal.attempt_id, terminal)
   const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts })
   const summary = userSummary({ cause: terminal.cause, recovery })
   const missingProvenance = [...(input.missingProvenance ?? []), ...diagnosticGaps(input, terminal, facts)]

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -155,7 +155,7 @@ function factsFromEvidence(
 
 function evidenceAtOrBefore(event: IncidentEvidenceEvent, terminal: IncidentEvidenceEvent) {
   if (event.monotonic_ms !== undefined && terminal.monotonic_ms !== undefined) {
-    return event.monotonic_ms <= terminal.monotonic_ms
+    return event.monotonic_ms < terminal.monotonic_ms || event.order <= terminal.order
   }
   return event.order <= terminal.order
 }

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -46,6 +46,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
   if (!terminal?.cause) return undefined
   const facts = factsFromEvidence(input)
   const terminalFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id) : facts
+  const terminalPhaseFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id, terminal) : facts
   const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts })
   const summary = userSummary({ cause: terminal.cause, recovery })
   const missingProvenance = [...(input.missingProvenance ?? []), ...diagnosticGaps(input, terminal, facts)]
@@ -60,7 +61,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
     created_at: input.createdAt,
     completed_at: input.completedAt,
     terminal_cause: terminal.cause,
-    phase: phaseFor({ facts: terminalFacts, terminalAttemptID: terminal.attempt_id }),
+    phase: phaseFor({ facts: terminalPhaseFacts, terminalAttemptID: terminal.attempt_id }),
     facts,
     provenance: {
       ...(input.lifecycle
@@ -114,8 +115,16 @@ function compareTerminalEvents(left: IncidentEvidenceEvent, right: IncidentEvide
   return left.order - right.order
 }
 
-function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvidenceEvent["attempt_id"]): IncidentFacts {
-  const scopedEvidence = attemptID ? input.evidence.filter((event) => event.attempt_id === attemptID) : input.evidence
+function factsFromEvidence(
+  input: DeriveIncidentInput,
+  attemptID?: IncidentEvidenceEvent["attempt_id"],
+  terminal?: IncidentEvidenceEvent,
+): IncidentFacts {
+  const scopedEvidence = input.evidence.filter((event) => {
+    if (attemptID && event.attempt_id !== attemptID) return false
+    if (!terminal) return true
+    return evidenceAtOrBefore(event, terminal)
+  })
   const materializedToolBoundary = summarizeMaterializedToolBoundaries(input.materializedToolBoundaries, attemptID)
   const has = (eventType: string) => scopedEvidence.some((event) => event.event_type === eventType)
   const count = (eventType: string) => scopedEvidence.filter((event) => event.event_type === eventType).length
@@ -142,6 +151,13 @@ function factsFromEvidence(input: DeriveIncidentInput, attemptID?: IncidentEvide
     watchdog_fired: has("watchdog_fired"),
     pending_tool_parts_interrupted: count("pending_tool_part_interrupted") || undefined,
   }
+}
+
+function evidenceAtOrBefore(event: IncidentEvidenceEvent, terminal: IncidentEvidenceEvent) {
+  if (event.monotonic_ms !== undefined && terminal.monotonic_ms !== undefined) {
+    return event.monotonic_ms <= terminal.monotonic_ms
+  }
+  return event.order <= terminal.order
 }
 
 function summarizeMaterializedToolBoundaries(

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -159,15 +159,17 @@ function phaseFor(input: {
   facts: IncidentFacts
   terminalAttemptID?: IncidentEvidenceEvent["attempt_id"]
 }): RunIncident["phase"] {
-  const toolPhase = input.facts.tool_execution_started
-    ? "tool_execution_started"
-    : input.facts.tool_call_materialized
-      ? "tool_call_materialized"
-      : input.facts.tool_input_completed
-        ? "tool_input_completed"
-        : input.facts.tool_input_started
-          ? "tool_input_started"
-          : "none"
+  const toolPhase = input.facts.tool_execution_completed
+    ? "tool_execution_completed"
+    : input.facts.tool_execution_started
+      ? "tool_execution_started"
+      : input.facts.tool_call_materialized
+        ? "tool_call_materialized"
+        : input.facts.tool_input_completed
+          ? "tool_input_completed"
+          : input.facts.tool_input_started
+            ? "tool_input_started"
+            : "none"
   const streamPhase = input.facts.tool_call_materialized
     ? "after_tool_call"
     : input.facts.tool_input_completed
@@ -179,13 +181,15 @@ function phaseFor(input: {
           : input.facts.visible_output_seen || input.facts.provider_progress_seen
             ? "text_generation"
             : "before_first_provider_progress"
-  const runPhase = input.facts.tool_execution_started
-    ? "tool_execution"
-    : input.facts.tool_input_started || input.facts.tool_call_materialized
-      ? "tool_generation"
-      : input.facts.provider_progress_seen || input.facts.visible_output_seen
-        ? "streaming"
-        : "unknown"
+  const runPhase = input.facts.tool_execution_completed
+    ? "post_tool"
+    : input.facts.tool_execution_started
+      ? "tool_execution"
+      : input.facts.tool_input_started || input.facts.tool_call_materialized
+        ? "tool_generation"
+        : input.facts.provider_progress_seen || input.facts.visible_output_seen
+          ? "streaming"
+          : "unknown"
   return {
     run_phase: runPhase,
     stream_phase: streamPhase,
@@ -201,6 +205,7 @@ export function transportCause(input: {
   toolInputCompleted: boolean
   toolCallMaterialized: boolean
   toolExecutionStarted: boolean
+  toolExecutionCompleted: boolean
 }): Extract<TerminalCause, { category: "provider_transport_disconnect" }> {
   const error = input.error
   const boundary = error?.cause_code === "UND_ERR_SOCKET" ? "sdk_transport" : "unknown"
@@ -211,13 +216,15 @@ export function transportCause(input: {
         ? "during_tool_input_generation"
         : input.toolInputCompleted && !input.toolCallMaterialized
           ? "unknown_stream_phase"
-          : input.toolExecutionStarted
-            ? "unknown_stream_phase"
-            : input.toolCallMaterialized
-              ? "after_tool_call_before_execution"
-              : input.providerProgressSeen
-                ? "during_text_generation"
-                : "before_first_provider_progress",
+          : input.toolExecutionCompleted
+            ? "after_tool_result"
+            : input.toolExecutionStarted
+              ? "unknown_stream_phase"
+              : input.toolCallMaterialized
+                ? "after_tool_call_before_execution"
+                : input.providerProgressSeen
+                  ? "during_text_generation"
+                  : "before_first_provider_progress",
     boundary,
     error,
     confidence: boundary === "sdk_transport" ? "high" : "medium",

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -91,6 +91,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         tool_input_completed: false,
         tool_call_materialized: false,
         tool_execution_started: false,
+        tool_execution_completed: false,
         unsafe_side_effect_started: false,
         lastMonotonicMs: next.monotonicMs,
       })
@@ -264,6 +265,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       toolExecutionCompleted = true
       updateAttempt(next.attemptID, (attempt) => {
         attempt.last_tool_completed_at = next.at
+        attempt.tool_execution_completed = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
       appendEvidence({
@@ -371,6 +373,7 @@ export function createRecorder(input: RecorderInput): Recorder {
           toolInputCompleted: getAttempt(next.attemptID)?.tool_input_completed ?? toolInputCompleted,
           toolCallMaterialized: getAttempt(next.attemptID)?.tool_call_materialized ?? toolCallMaterialized,
           toolExecutionStarted: getAttempt(next.attemptID)?.tool_execution_started ?? toolExecutionStarted,
+          toolExecutionCompleted: getAttempt(next.attemptID)?.tool_execution_completed ?? toolExecutionCompleted,
         }),
       })
       rememberEvent(next.monotonicMs)

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -370,6 +370,7 @@ export function createRecorder(input: RecorderInput): Recorder {
           toolInputStarted: getAttempt(next.attemptID)?.tool_input_started ?? toolInputStarted,
           toolInputCompleted: getAttempt(next.attemptID)?.tool_input_completed ?? toolInputCompleted,
           toolCallMaterialized: getAttempt(next.attemptID)?.tool_call_materialized ?? toolCallMaterialized,
+          toolExecutionStarted: getAttempt(next.attemptID)?.tool_execution_started ?? toolExecutionStarted,
         }),
       })
       rememberEvent(next.monotonicMs)

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -76,6 +76,23 @@ export function createRecorder(input: RecorderInput): Recorder {
       event_id: `incident:${input.messageID}:evidence:${order}`,
     })
   }
+  const evidenceAtOrBefore = (event: RunIncident.EvidenceEvent, monotonicMs: number) =>
+    event.monotonic_ms === undefined || event.monotonic_ms <= monotonicMs
+  const transportFactsAt = (attemptID: AttemptID | undefined, monotonicMs: number) => {
+    const scopedEvidence = evidence.filter(
+      (event) => (!attemptID || event.attempt_id === attemptID) && evidenceAtOrBefore(event, monotonicMs),
+    )
+    const has = (eventType: RunIncident.EvidenceEvent["event_type"]) =>
+      scopedEvidence.some((event) => event.event_type === eventType)
+    return {
+      providerProgressSeen: has("provider_progress_seen") || (!attemptID && providerProgressSeen),
+      toolInputStarted: has("tool_input_started"),
+      toolInputCompleted: has("tool_input_completed"),
+      toolCallMaterialized: has("tool_call_materialized"),
+      toolExecutionStarted: has("tool_execution_started"),
+      toolExecutionCompleted: has("tool_execution_completed"),
+    }
+  }
 
   return {
     beginAttempt(next) {
@@ -350,6 +367,7 @@ export function createRecorder(input: RecorderInput): Recorder {
     },
     recordTransportFailure(next) {
       const error = safeErrorFingerprint(next.error)
+      const factsAtFailure = transportFactsAt(next.attemptID, next.monotonicMs)
       failure ??= {
         type: "transport",
         at: next.at,
@@ -368,12 +386,12 @@ export function createRecorder(input: RecorderInput): Recorder {
         error,
         cause: RunIncident.transportCause({
           error,
-          providerProgressSeen: getAttempt(next.attemptID)?.provider_progress_seen ?? providerProgressSeen,
-          toolInputStarted: getAttempt(next.attemptID)?.tool_input_started ?? toolInputStarted,
-          toolInputCompleted: getAttempt(next.attemptID)?.tool_input_completed ?? toolInputCompleted,
-          toolCallMaterialized: getAttempt(next.attemptID)?.tool_call_materialized ?? toolCallMaterialized,
-          toolExecutionStarted: getAttempt(next.attemptID)?.tool_execution_started ?? toolExecutionStarted,
-          toolExecutionCompleted: getAttempt(next.attemptID)?.tool_execution_completed ?? toolExecutionCompleted,
+          providerProgressSeen: factsAtFailure.providerProgressSeen,
+          toolInputStarted: factsAtFailure.toolInputStarted,
+          toolInputCompleted: factsAtFailure.toolInputCompleted,
+          toolCallMaterialized: factsAtFailure.toolCallMaterialized,
+          toolExecutionStarted: factsAtFailure.toolExecutionStarted,
+          toolExecutionCompleted: factsAtFailure.toolExecutionCompleted,
         }),
       })
       rememberEvent(next.monotonicMs)

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -77,6 +77,7 @@ export type AttemptSummary = {
   tool_input_completed: boolean
   tool_call_materialized: boolean
   tool_execution_started: boolean
+  tool_execution_completed: boolean
   unsafe_side_effect_started: boolean
 }
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { tool } from "ai"
-import { expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
 import z from "zod"
@@ -267,6 +267,14 @@ const env = Layer.mergeAll(
 )
 
 const it = testEffect(env)
+
+test("session.processor records completed and failed tools against the bound tool-call attempt first", async () => {
+  const source = await Bun.file("src/session/processor.ts").text()
+
+  expect(source).toContain("const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID")
+  expect(source).toContain("recordToolCompleted({\n            attemptID,")
+  expect(source).toContain("recordToolFailed({\n          attemptID,")
+})
 
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { tool } from "ai"
-import { expect, test } from "bun:test"
+import { expect } from "bun:test"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
 import z from "zod"
@@ -268,14 +268,6 @@ const env = Layer.mergeAll(
 
 const it = testEffect(env)
 
-test("session.processor records completed and failed tools against the bound tool-call attempt first", async () => {
-  const source = await Bun.file("src/session/processor.ts").text()
-
-  expect(source).toContain("const attemptID = ctx.toolcalls[input.toolCallID]?.attemptID ?? ctx.currentAttemptID")
-  expect(source).toContain("recordToolCompleted({\n            attemptID,")
-  expect(source).toContain("recordToolFailed({\n          attemptID,")
-})
-
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
   const session = yield* Session.Service
@@ -286,6 +278,156 @@ const boot = Effect.fn("test.boot")(function* () {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+it.live("session.processor keeps late tool execution diagnostics on the bound tool-call attempt", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const gate = defer<void>()
+        const { processors, session, provider } = yield* boot()
+        let executions = 0
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-bound-attempt",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-bound-attempt",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: "call_bound_attempt",
+                          type: "function",
+                          function: { name: "noop", arguments: "" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+            stages: [
+              {
+                wait: gate.promise,
+                chunks: [
+                  {
+                    id: "chatcmpl-bound-attempt",
+                    object: "chat.completion.chunk",
+                    choices: [
+                      {
+                        delta: {
+                          tool_calls: [
+                            {
+                              index: 0,
+                              function: { arguments: "{}" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    id: "chatcmpl-bound-attempt",
+                    object: "chat.completion.chunk",
+                    choices: [{ delta: {}, finish_reason: "tool_calls" }],
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        yield* llm.hang
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "late tool attempt binding")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+        const input = {
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+            tools: { noop: true },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "late tool attempt binding" }],
+          tools: {
+            noop: tool({
+              description: "No-op tool",
+              inputSchema: z.object({}),
+              execute: async () => {
+                executions += 1
+                return { output: "ok" }
+              },
+            }),
+          },
+        } satisfies LLM.StreamInput
+
+        const first = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        yield* Effect.promise(async () => {
+          const end = Date.now() + 500
+          while (Date.now() < end) {
+            const toolCallStarted = MessageV2.parts(msg.id).some(
+              (part) => part.type === "tool" && part.callID === "call_bound_attempt",
+            )
+            if (toolCallStarted) {
+              return
+            }
+            await Bun.sleep(10)
+          }
+        })
+        const second = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* llm.wait(2)
+        expect(handle.recordToolExecutionStarted).toBeDefined()
+        expect(handle.recordToolExecutionCompleted).toBeDefined()
+        yield* handle.recordToolExecutionStarted!({ tool: "noop", toolCallID: "call_bound_attempt" })
+        yield* handle.recordToolExecutionCompleted!({ toolCallID: "call_bound_attempt" })
+        gate.resolve()
+        yield* Fiber.join(first)
+
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+        expect(executions).toBe(1)
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          const attempts = stored.info.diagnostics?.run_observability?.attempts
+          expect(attempts?.[0]).toMatchObject({
+            attempt_index: 1,
+            tool_execution_started: true,
+            tool_execution_completed: true,
+          })
+          expect(attempts?.[1]).toMatchObject({
+            attempt_index: 2,
+            tool_execution_started: false,
+            tool_execution_completed: false,
+          })
+        }
+        yield* Fiber.interrupt(second)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
 
 it.live("session.processor effect tests capture llm input cleanly", () =>
   provideTmpdirServer(

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -429,6 +429,133 @@ it.live("session.processor keeps late tool execution diagnostics on the bound to
   ),
 )
 
+it.live("session.processor records late transport failures against the failing stream attempt", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const gate = defer<void>()
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-late-transport",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-late-transport",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: "call_late_transport",
+                          type: "function",
+                          function: { name: "noop", arguments: "" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+            stages: [
+              {
+                wait: gate.promise,
+                chunks: [
+                  {
+                    error: {
+                      message: "stream terminated",
+                      type: "invalid_request_error",
+                      code: "stream_terminated",
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        yield* llm.hang
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "late transport attempt binding")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+        const input = {
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+            tools: { noop: true },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "late transport attempt binding" }],
+          tools: {
+            noop: tool({
+              description: "No-op tool",
+              inputSchema: z.object({}),
+              execute: async () => ({ output: "ok" }),
+            }),
+          },
+        } satisfies LLM.StreamInput
+
+        const first = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        yield* Effect.promise(async () => {
+          const end = Date.now() + 500
+          while (Date.now() < end) {
+            const toolInputStarted = MessageV2.parts(msg.id).some(
+              (part) => part.type === "tool" && part.callID === "call_late_transport",
+            )
+            if (toolInputStarted) return
+            await Bun.sleep(10)
+          }
+        })
+        const second = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* llm.wait(2)
+        gate.resolve()
+        yield* Fiber.join(first)
+
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          const observability = stored.info.diagnostics?.run_observability
+          const firstAttemptID = observability?.attempts[0]?.attempt_id
+          expect(observability?.terminal_attempt_id).toBe(firstAttemptID)
+          expect(observability?.incident?.phase.terminal_attempt_id).toBe(firstAttemptID)
+          expect(observability?.incident?.phase).toMatchObject({
+            run_phase: "tool_generation",
+            stream_phase: "tool_input_generation",
+            tool_phase: "tool_input_started",
+          })
+          expect(observability?.incident?.terminal_cause).toMatchObject({
+            category: "provider_transport_disconnect",
+            subcategory: "during_tool_input_generation",
+          })
+        }
+        yield* Fiber.interrupt(second)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests capture llm input cleanly", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1592,6 +1592,64 @@ describe("RunObservability", () => {
     expect(summary.retry_safety.recommendation).toBe("do_not_auto_retry")
   })
 
+  test("lifecycle close phase ignores later tool completion without terminal attempt id", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_lifecycle_close_late_tool_completion"),
+      traceID: MessageID.make("msg_lifecycle_close_late_tool_completion"),
+      sessionID: SessionID.make("ses_lifecycle_close_late_tool_completion"),
+      messageID: MessageID.make("msg_lifecycle_close_late_tool_completion"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordScopeClosed({
+      at: 16,
+      monotonicMs: 160,
+      source: "session.run_state.finalizer",
+      reason: "scope_finalizer",
+      propagationPoint: "session.prompt.loop.onInterrupt",
+      lifecycleActionID: "lifecycle:instance_reload:late-tool",
+      lifecycleKind: "instance_reload",
+      lifecycleInitiatedAt: 16,
+      lifecycleInitiatedMonotonicMs: 160,
+      lifecycleAffectedDirectoryKeys: ["dir:testreload"],
+    })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 17, monotonicMs: 170 })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "local_lifecycle_close",
+      subcategory: "instance_reload",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_execution",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_started",
+    })
+    expect(summary.incident?.phase).not.toMatchObject({
+      run_phase: "post_tool",
+      tool_phase: "tool_execution_completed",
+    })
+  })
+
   test("classifies known instance reload lifecycle closes with parent provenance", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_instance_reload"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -949,6 +949,43 @@ describe("RunObservability", () => {
     })
   })
 
+  test("tool completion without start or materialization does not overclaim after-tool-result phase", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_completion_without_execution_boundary"),
+      traceID: MessageID.make("msg_completion_without_execution_boundary"),
+      sessionID: SessionID.make("ses_completion_without_execution_boundary"),
+      messageID: MessageID.make("msg_completion_without_execution_boundary"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 13,
+      monotonicMs: 130,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
+    expect(summary.incident?.diagnostics_complete).toBe(false)
+    expect(summary.incident?.missing_provenance).toContain("tool_execution.start_missing")
+    expect(summary.incident?.missing_provenance).toContain("tool.materialization_missing")
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "unknown_stream_phase",
+    })
+    expect(summary.incident?.terminal_cause).not.toMatchObject({
+      subcategory: "after_tool_result",
+    })
+    expect(summary.incident?.phase).not.toMatchObject({
+      run_phase: "post_tool",
+      tool_phase: "tool_execution_completed",
+    })
+  })
+
   test("safe materialized tool call without execution can offer continue", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_safe_materialized_tool"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1057,6 +1057,58 @@ describe("RunObservability", () => {
     })
   })
 
+  test("transport failure phase ignores earlier-order tool completion with later monotonic time", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_transport_earlier_order_late_monotonic_completion"),
+      traceID: MessageID.make("msg_transport_earlier_order_late_monotonic_completion"),
+      sessionID: SessionID.make("ses_transport_earlier_order_late_monotonic_completion"),
+      messageID: MessageID.make("msg_transport_earlier_order_late_monotonic_completion"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 17, monotonicMs: 170 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 16,
+      monotonicMs: 160,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "unknown_stream_phase",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_execution",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_started",
+    })
+    expect(summary.incident?.phase).not.toMatchObject({
+      run_phase: "post_tool",
+      tool_phase: "tool_execution_completed",
+    })
+  })
+
   test("tool completion without start or materialization does not overclaim after-tool-result phase", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_completion_without_execution_boundary"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -900,6 +900,55 @@ describe("RunObservability", () => {
     })
   })
 
+  test("transport failure after tool execution completes is classified after tool result", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_transport_after_tool_execution_completed"),
+      traceID: MessageID.make("msg_transport_after_tool_execution_completed"),
+      sessionID: SessionID.make("ses_transport_after_tool_execution_completed"),
+      messageID: MessageID.make("msg_transport_after_tool_execution_completed"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 16, monotonicMs: 160 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 17,
+      monotonicMs: 170,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.incident?.facts.tool_execution_completed).toBe(true)
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "after_tool_result",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "post_tool",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_completed",
+    })
+  })
+
   test("safe materialized tool call without execution can offer continue", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_safe_materialized_tool"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1009,6 +1009,54 @@ describe("RunObservability", () => {
     })
   })
 
+  test("transport failure phase ignores later same-timestamp tool completion evidence", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_transport_same_timestamp_late_completion"),
+      traceID: MessageID.make("msg_transport_same_timestamp_late_completion"),
+      sessionID: SessionID.make("ses_transport_same_timestamp_late_completion"),
+      messageID: MessageID.make("msg_transport_same_timestamp_late_completion"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 16,
+      monotonicMs: 160,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 17, monotonicMs: 160 })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_execution",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_started",
+    })
+    expect(summary.incident?.phase).not.toMatchObject({
+      run_phase: "post_tool",
+      tool_phase: "tool_execution_completed",
+    })
+  })
+
   test("tool completion without start or materialization does not overclaim after-tool-result phase", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_completion_without_execution_boundary"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -846,6 +846,60 @@ describe("RunObservability", () => {
     })
   })
 
+  test("transport failure after tool execution starts is not classified as before execution", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_transport_after_tool_execution_started"),
+      traceID: MessageID.make("msg_transport_after_tool_execution_started"),
+      sessionID: SessionID.make("ses_transport_after_tool_execution_started"),
+      messageID: MessageID.make("msg_transport_after_tool_execution_started"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 16,
+      monotonicMs: 160,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 17, monotonicMs: 170 })
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "unknown_stream_phase",
+    })
+    expect(summary.incident?.terminal_cause).not.toMatchObject({
+      subcategory: "after_tool_call_before_execution",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_execution",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_started",
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_execution_started",
+    })
+  })
+
   test("safe materialized tool call without execution can offer continue", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_safe_materialized_tool"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -949,6 +949,66 @@ describe("RunObservability", () => {
     })
   })
 
+  test("transport failure phase ignores later tool completion evidence", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_transport_before_late_tool_completion"),
+      traceID: MessageID.make("msg_transport_before_late_tool_completion"),
+      sessionID: SessionID.make("ses_transport_before_late_tool_completion"),
+      messageID: MessageID.make("msg_transport_before_late_tool_completion"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordToolInputStarted({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordToolInputCompleted({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordToolCallMaterialized({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordToolExecutionStarted({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      toolName: RunObservability.safeToolName("grep"),
+      effect: RunObservability.toolEffect("grep"),
+    })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 16,
+      monotonicMs: 160,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+    recorder.recordToolCompleted({ attemptID: attempt.attemptID, at: 17, monotonicMs: 170 })
+
+    const summary = recorder.finalize({ completedAt: 18, monotonicMs: 180 })
+    expect(summary.incident?.facts.tool_execution_completed).toBe(true)
+    expect(summary.incident?.terminal_cause).toMatchObject({
+      category: "provider_transport_disconnect",
+      subcategory: "unknown_stream_phase",
+    })
+    expect(summary.incident?.terminal_cause).not.toMatchObject({
+      subcategory: "after_tool_result",
+    })
+    expect(summary.incident?.phase).toMatchObject({
+      run_phase: "tool_execution",
+      stream_phase: "after_tool_call",
+      tool_phase: "tool_execution_started",
+    })
+    expect(summary.incident?.phase).not.toMatchObject({
+      run_phase: "post_tool",
+      tool_phase: "tool_execution_completed",
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "tool_execution_started",
+    })
+  })
+
   test("tool completion without start or materialization does not overclaim after-tool-result phase", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_completion_without_execution_boundary"),


### PR DESCRIPTION
## Summary

- Refines RunIncident provider transport diagnostics when streaming interrupts after tool execution has started.
- Tracks attempt-level tool execution completion so transport disconnects after a tool result derive `after_tool_result` and `post_tool` instead of a pre-execution phase.
- Adds regression coverage for post-materialization transport failures without changing recovery UX/API behavior.

## Why

Issue #803 requires provider/transport streaming interruptions to distinguish tool-call generation from tool execution. The landed Run Incident Framework already fixed partial tool-input disconnects; this follow-up closes the remaining phase gap where a transport failure after tool execution could still look like `after_tool_call_before_execution`.

## Related Issue

Closes #803.
Part of #808.

## Human Review Status

Pending

## Review Focus

- Whether transport failures after `tool_execution_started` no longer report a pre-execution provider phase.
- Whether `tool_execution_completed` is tracked at attempt scope and only upgrades completed-tool transport failures to `after_tool_result` / `post_tool`.
- Whether the change remains diagnostic-only and does not alter #804 recovery UX/API/idempotency behavior.

## Risk Notes

Latest review fix: terminal phase derivation now ignores same-attempt evidence recorded after the terminal event, and processor stream/tool execution diagnostics stay bound to the stream event or tool-call attempt instead of a later current attempt.

Latest follow-up review fix: halt/interrupt transport failures now record against the process-local failing attempt instead of mutable currentAttemptID, and same-monotonic phase truncation uses evidence order as a tie-breaker.

Latest tie-break review fix: terminal phase ordering now treats monotonic time as primary, uses evidence order only when monotonic times are equal, and transport cause facts are derived at the failure timestamp.

Latest lifecycle terminal review fix: terminal phase derivation now applies terminal-time evidence truncation even when the terminal event has no attempt_id, so lifecycle closes cannot be upgraded by later tool completion evidence.

- Diagnostic-only change: no recovery card, Continue/Resume API, auto-retry, provider SDK behavior, or user-visible recovery copy changed.
- Privacy posture is unchanged: no raw prompt, raw tool input, raw provider payload, local paths, or secrets are added to incidents or exports.
- No visible UI changed, so no snap/manual UI check was run.
- Platform impact is limited to diagnostic classification data in opencode session observability.

## How To Verify

```text
Red/green TDD:
- New regression for transport failure after tool execution start failed first because it was classified as after_tool_call_before_execution, then passed after the fix.
- New regression for transport failure after tool execution completion failed first because it was classified as unknown_stream_phase, then passed after the fix.

Final targeted checks:
- bun test test/session/run-observability.test.ts test/session/processor-effect.test.ts --timeout 30000 → 68 pass, 0 fail
- bun run typecheck from packages/opencode → passed
- git diff --check → passed
```

## Screenshots or Recordings

Not applicable — no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.