### PR TITLE
fix(ui): rework turn changes panel and lift assistant footer

### DIFF
--- a/packages/app/e2e/session/session-turn-footer.spec.ts
+++ b/packages/app/e2e/session/session-turn-footer.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
+import { bodyText } from "../prompt/mock"
+
+test("assistant footer is hover-only and copy writes response to clipboard", async ({
+  page,
+  context,
+  project,
+  llm,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"])
+  await project.open()
+
+  const reply = "Hello from assistant body for footer test."
+  await llm.text(reply)
+  await project.prompt("seed footer hover")
+
+  const container = page.locator('[data-slot="session-turn-message-container"]').last()
+  const footer = container.locator('[data-slot="assistant-turn-footer"]')
+  await expect(footer).toBeAttached({ timeout: 30_000 })
+
+  const opacityBeforeHover = await footer.evaluate((el) => getComputedStyle(el).opacity)
+  expect(Number(opacityBeforeHover)).toBe(0)
+
+  await container.hover()
+  await expect.poll(async () => footer.evaluate((el) => getComputedStyle(el).opacity), { timeout: 5_000 }).toBe("1")
+
+  const copy = footer.getByRole("button").first()
+  await copy.click()
+  const clip = await page.evaluate(() => navigator.clipboard.readText())
+  expect(clip).toBe(reply)
+})
+
+test("assistant footer renders below the turn changes panel in the same turn", async ({ page, project, llm }) => {
+  test.setTimeout(180_000)
+  await project.open()
+
+  const patchText = [
+    "*** Begin Patch",
+    "*** Add File: footer-order-fixture.txt",
+    "+seeded",
+    "*** End Patch",
+  ].join("\n")
+  const marker = "seed apply_patch then reply for footer ordering"
+
+  await withSession(project.sdk, "footer order with panel", async (session) => {
+    project.trackSession(session.id)
+    await llm.toolMatch((hit) => bodyText(hit).includes(marker), "apply_patch", { patchText })
+    await llm.text("Done patching.")
+    await project.sdk.session.prompt({
+      sessionID: session.id,
+      agent: "build",
+      system: [
+        "You are seeding deterministic e2e UI state.",
+        "Call apply_patch once with the provided JSON input, then send a short text reply.",
+        `Use this JSON input for apply_patch: ${JSON.stringify({ patchText })}`,
+      ].join("\n"),
+      parts: [{ type: "text", text: marker }],
+    })
+
+    await expect
+      .poll(
+        async () => {
+          const aggregate = await project.sdk.session.diff({ sessionID: session.id }).then((res) => res.data)
+          if (!aggregate || aggregate.kind === "empty" || aggregate.kind === "uncaptured") return 0
+          return aggregate.files.filter((file) => file.restoreState === "applied").length
+        },
+        { timeout: 120_000 },
+      )
+      .toBeGreaterThan(0)
+
+    await project.gotoSession(session.id)
+
+    const panel = page.locator('[data-component="session-turn-changes"]').first()
+    const footer = page.locator('[data-slot="assistant-turn-footer"]').first()
+    await expect(panel).toBeVisible({ timeout: 60_000 })
+    await expect(footer).toBeAttached({ timeout: 60_000 })
+
+    const panelBox = await panel.boundingBox()
+    const footerBox = await footer.boundingBox()
+    if (!panelBox || !footerBox) throw new Error("Failed to measure panel/footer position")
+    expect(footerBox.y).toBeGreaterThanOrEqual(panelBox.y + panelBox.height)
+  })
+})

--- a/packages/app/e2e/snap/session-turn-changes.snap.ts
+++ b/packages/app/e2e/snap/session-turn-changes.snap.ts
@@ -124,7 +124,7 @@ async function runCapturedPass(
     await expect(action).toBeVisible()
     await action.click()
     await action.click()
-    await expect(page.locator('[data-slot="session-turn-changes-undone"]').first()).toBeVisible()
+    await expect(page.locator('[data-slot="session-turn-changes-undone-summary"]').first()).toBeVisible()
     shots.push(await captureTurnChanges(page, `${label}-captured-undone`))
   })
 
@@ -132,7 +132,8 @@ async function runCapturedPass(
     project.trackSession(session.id)
     await uncapturedWithMock(llm, project.sdk, session.id, `snap-uncaptured-${label}.txt`)
     await project.gotoSession(session.id)
-    shots.push(await captureTurnChanges(page, `${label}-uncaptured`))
+    // Uncaptured-only turns intentionally render no panel; assert that and skip the shot.
+    await expect(page.locator('[data-component="session-turn-changes"]')).toHaveCount(0, { timeout: 10_000 })
   })
 }
 

--- a/packages/app/e2e/snap/session-turn-changes.snap.ts
+++ b/packages/app/e2e/snap/session-turn-changes.snap.ts
@@ -64,6 +64,37 @@ async function patchWithMock(
     .toBeGreaterThan(0)
 }
 
+async function mixedWithMock(
+  llm: Parameters<typeof test>[0]["llm"],
+  sdk: Parameters<typeof withSession>[0],
+  sessionID: string,
+  patchText: string,
+  shellFile: string,
+) {
+  const callsBefore = await llm.calls()
+  const command = `touch ${shellFile}`
+  await llm.tool("apply_patch", { patchText })
+  await llm.tool("bash", { command, description: "Writes a mixed snap fixture shell file" })
+  await llm.text("Done.")
+  await sdk.session.prompt({
+    sessionID,
+    agent: "build",
+    system: [
+      "You are seeding deterministic snap UI state.",
+      "Issue exactly two tool calls in order: first apply_patch, then bash.",
+      `Use this JSON for apply_patch: ${JSON.stringify({ patchText })}`,
+      `Use this JSON for bash: ${JSON.stringify({ command, description: "Writes a mixed snap fixture shell file" })}`,
+      "After both tools return, send a short text reply and stop.",
+    ].join("\n"),
+    parts: [{ type: "text", text: "Run apply_patch first, then bash, then reply." }],
+  })
+
+  await expect.poll(() => llm.calls().then((c) => c > callsBefore), { timeout: 30_000 }).toBe(true)
+  await expect
+    .poll(async () => sdk.session.diff({ sessionID }).then((res) => res.data?.kind), { timeout: 120_000 })
+    .toBe("mixed")
+}
+
 async function uncapturedWithMock(
   llm: Parameters<typeof test>[0]["llm"],
   sdk: Parameters<typeof withSession>[0],
@@ -134,6 +165,25 @@ async function runCapturedPass(
     await project.gotoSession(session.id)
     // Uncaptured-only turns intentionally render no panel; assert that and skip the shot.
     await expect(page.locator('[data-component="session-turn-changes"]')).toHaveCount(0, { timeout: 10_000 })
+  })
+
+  await withSession(project.sdk, `snap turn changes mixed ${label}`, async (session) => {
+    project.trackSession(session.id)
+    await mixedWithMock(
+      llm,
+      project.sdk,
+      session.id,
+      patch(`snap-mixed-${label}.txt`, `mixed-${label}`),
+      `snap-mixed-shell-${label}.txt`,
+    )
+    await project.gotoSession(session.id)
+    // Mixed turns render the captured-files panel only; the uncaptured diagnostic copy
+    // is intentionally suppressed (originally surfaced as "部分 shell 改动未逐个捕获").
+    const panel = page.locator('[data-component="session-turn-changes"]').first()
+    await expect(panel).toBeVisible({ timeout: 30_000 })
+    await expect(panel.locator('[data-slot="session-turn-changes-uncaptured"]')).toHaveCount(0)
+    await expect(panel.locator('[data-slot="session-turn-change-item"]')).toHaveCount(1)
+    shots.push(await captureTurnChanges(page, `${label}-mixed`))
   })
 }
 

--- a/packages/ui/src/components/assistant-turn-footer.tsx
+++ b/packages/ui/src/components/assistant-turn-footer.tsx
@@ -1,0 +1,90 @@
+import { createMemo, createSignal, Show } from "solid-js"
+import type { AssistantMessage } from "@opencode-ai/sdk/v2"
+import { useData } from "../context"
+import { useI18n } from "../context/i18n"
+import { IconButton } from "./icon-button"
+import { Tooltip } from "./tooltip"
+
+export function AssistantTurnFooter(props: {
+  text: string
+  message: AssistantMessage
+  turnDurationMs?: number
+}) {
+  const data = useData()
+  const i18n = useI18n()
+  const numfmt = createMemo(() => new Intl.NumberFormat(i18n.locale()))
+  const [copied, setCopied] = createSignal(false)
+
+  const interrupted = createMemo(() => props.message.error?.name === "MessageAbortedError")
+
+  const model = createMemo(() => {
+    const match = data.store.provider?.all?.find((p) => p.id === props.message.providerID)
+    return match?.models?.[props.message.modelID]?.name ?? props.message.modelID
+  })
+
+  const duration = createMemo(() => {
+    const completed = props.message.time.completed
+    const ms =
+      typeof props.turnDurationMs === "number"
+        ? props.turnDurationMs
+        : typeof completed === "number"
+          ? completed - props.message.time.created
+          : -1
+    if (!(ms >= 0)) return ""
+    const total = Math.round(ms / 1000)
+    if (total < 60) return i18n.t("ui.message.duration.seconds", { count: numfmt().format(total) })
+    const minutes = Math.floor(total / 60)
+    const seconds = total % 60
+    return i18n.t("ui.message.duration.minutesSeconds", {
+      minutes: numfmt().format(minutes),
+      seconds: numfmt().format(seconds),
+    })
+  })
+
+  const meta = createMemo(() => {
+    const agent = props.message.agent
+    const items = [
+      agent ? agent[0]?.toUpperCase() + agent.slice(1) : "",
+      model(),
+      duration(),
+      interrupted() ? i18n.t("ui.message.interrupted") : "",
+    ]
+    return items.filter((x) => !!x).join(" · ")
+  })
+
+  const handleCopy = async () => {
+    const content = props.text
+    if (!content) return
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div data-slot="assistant-turn-footer" data-interrupted={interrupted() ? "" : undefined}>
+      <Tooltip
+        value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+        placement="top"
+        gutter={4}
+      >
+        <IconButton
+          icon={copied() ? "check" : "copy"}
+          size="normal"
+          variant="ghost"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={handleCopy}
+          aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+        />
+      </Tooltip>
+      <Show when={meta()}>
+        <span data-slot="assistant-turn-footer-meta" class="text-body text-fg-weak cursor-default">
+          {meta()}
+        </span>
+      </Show>
+    </div>
+  )
+}

--- a/packages/ui/src/components/message-part-registry.test.ts
+++ b/packages/ui/src/components/message-part-registry.test.ts
@@ -42,6 +42,7 @@ function sourceFiles(dir: string): string[] {
 function readMessagePartSources() {
   return [
     readFileSync(join(COMPONENT_DIR, "message-part.tsx"), "utf8"),
+    readFileSync(join(COMPONENT_DIR, "assistant-turn-footer.tsx"), "utf8"),
     ...sourceFiles(MESSAGE_PART_DIR).map((file) => readFileSync(file, "utf8")),
   ].join("\n")
 }
@@ -135,7 +136,7 @@ test("review hardening keeps routing, clipboard, url, and write guards explicit"
 
   expect(source).toContain("return path.slice(prefix.length)")
   expect(source).toContain("path.search(/\\/session(?:\\/|$)/)")
-  expect([...source.matchAll(/try \{\n\s+await navigator\.clipboard\.writeText/g)].length).toBe(1)
+  expect([...source.matchAll(/try \{\n\s+await navigator\.clipboard\.writeText/g)].length).toBe(2)
   expect(source).toContain('if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return ""')
   expect(source).toContain("getDiagnostics(props.metadata?.diagnostics, props.input.filePath)")
   expect(source).toContain("props.input.content != null && path()")

--- a/packages/ui/src/components/message-part-registry.test.ts
+++ b/packages/ui/src/components/message-part-registry.test.ts
@@ -135,7 +135,7 @@ test("review hardening keeps routing, clipboard, url, and write guards explicit"
 
   expect(source).toContain("return path.slice(prefix.length)")
   expect(source).toContain("path.search(/\\/session(?:\\/|$)/)")
-  expect([...source.matchAll(/try \{\n\s+await navigator\.clipboard\.writeText/g)].length).toBe(2)
+  expect([...source.matchAll(/try \{\n\s+await navigator\.clipboard\.writeText/g)].length).toBe(1)
   expect(source).toContain('if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return ""')
   expect(source).toContain("getDiagnostics(props.metadata?.diagnostics, props.input.filePath)")
   expect(source).toContain("props.input.content != null && path()")

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -243,40 +243,6 @@
   [data-slot="text-part-body"] {
     margin-top: 0;
   }
-
-  [data-slot="text-part-copy-wrapper"] {
-    min-height: 30px;
-    margin-top: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 10px;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease;
-    will-change: opacity;
-
-    [data-component="tooltip-trigger"] {
-      display: inline-flex;
-      width: fit-content;
-    }
-  }
-
-  [data-slot="text-part-meta"] {
-    user-select: none;
-  }
-
-  [data-slot="text-part-copy-wrapper"][data-interrupted] {
-    width: 100%;
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
-  &:hover [data-slot="text-part-copy-wrapper"],
-  &:focus-within [data-slot="text-part-copy-wrapper"] {
-    opacity: 1;
-    pointer-events: auto;
-  }
 }
 
 [data-component="compaction-part"] {

--- a/packages/ui/src/components/message-part/assistant-message-display.tsx
+++ b/packages/ui/src/components/message-part/assistant-message-display.tsx
@@ -8,7 +8,6 @@ import { Part } from "./message-router"
 export function AssistantMessageDisplay(props: {
   message: AssistantMessage
   parts: PartType[]
-  showAssistantCopyPartID?: string | null
   showReasoningSummaries?: boolean
 }) {
   const emptyTools: ToolPart[] = []
@@ -69,7 +68,6 @@ export function AssistantMessageDisplay(props: {
                     <Part
                       part={stableItem()!}
                       message={props.message}
-                      showAssistantCopyPartID={props.showAssistantCopyPartID}
                       stateKey={`tool:${stableItem()!.id}`}
                     />
                   </Show>

--- a/packages/ui/src/components/message-part/assistant-parts.tsx
+++ b/packages/ui/src/components/message-part/assistant-parts.tsx
@@ -8,8 +8,6 @@ import { Part } from "./message-router"
 
 export function AssistantParts(props: {
   messages: AssistantMessage[]
-  showAssistantCopyPartID?: string | null
-  turnDurationMs?: number
   working?: boolean
   showReasoningSummaries?: boolean
   shellToolDefaultOpen?: boolean
@@ -94,8 +92,6 @@ export function AssistantParts(props: {
                       <Part
                         part={stableItem()!}
                         message={stableMessage()!}
-                        showAssistantCopyPartID={props.showAssistantCopyPartID}
-                        turnDurationMs={props.turnDurationMs}
                         defaultOpen={partDefaultOpen(
                           stableItem()!,
                           props.shellToolDefaultOpen,

--- a/packages/ui/src/components/message-part/message-router.tsx
+++ b/packages/ui/src/components/message-part/message-router.tsx
@@ -15,7 +15,6 @@ export function Message(props: MessageProps) {
         <AssistantMessageDisplay
           message={props.message as AssistantMessage}
           parts={props.parts}
-          showAssistantCopyPartID={props.showAssistantCopyPartID}
           showReasoningSummaries={props.showReasoningSummaries}
         />
       </Show>
@@ -33,8 +32,6 @@ export function Part(props: MessagePartProps) {
         message={props.message}
         hideDetails={props.hideDetails}
         defaultOpen={props.defaultOpen}
-        showAssistantCopyPartID={props.showAssistantCopyPartID}
-        turnDurationMs={props.turnDurationMs}
         stateKey={props.stateKey}
       />
     </Show>

--- a/packages/ui/src/components/message-part/parts/text.tsx
+++ b/packages/ui/src/components/message-part/parts/text.tsx
@@ -1,91 +1,14 @@
-import { createMemo, createSignal, Show } from "solid-js"
+import { createMemo, Show } from "solid-js"
 import type { AssistantMessage, TextPart } from "@opencode-ai/sdk/v2"
-import { useData } from "../../../context"
-import { useI18n } from "../../../context/i18n"
-import { IconButton } from "../../icon-button"
-import { Tooltip } from "../../tooltip"
 import { MessageMarkdown, PacedMarkdown } from "../markdown-render"
 import { registerPartComponent } from "../registry"
 
 registerPartComponent("text", function TextPartDisplay(props) {
-  const data = useData()
-  const i18n = useI18n()
-  const numfmt = createMemo(() => new Intl.NumberFormat(i18n.locale()))
   const part = () => props.part as TextPart
-  const interrupted = createMemo(
-    () =>
-      props.message.role === "assistant" && (props.message as AssistantMessage).error?.name === "MessageAbortedError",
-  )
-
-  const model = createMemo(() => {
-    if (props.message.role !== "assistant") return ""
-    const message = props.message as AssistantMessage
-    const match = data.store.provider?.all?.find((p) => p.id === message.providerID)
-    return match?.models?.[message.modelID]?.name ?? message.modelID
-  })
-
-  const duration = createMemo(() => {
-    if (props.message.role !== "assistant") return ""
-    const message = props.message as AssistantMessage
-    const completed = message.time.completed
-    const ms =
-      typeof props.turnDurationMs === "number"
-        ? props.turnDurationMs
-        : typeof completed === "number"
-          ? completed - message.time.created
-          : -1
-    if (!(ms >= 0)) return ""
-    const total = Math.round(ms / 1000)
-    if (total < 60) return i18n.t("ui.message.duration.seconds", { count: numfmt().format(total) })
-    const minutes = Math.floor(total / 60)
-    const seconds = total % 60
-    return i18n.t("ui.message.duration.minutesSeconds", {
-      minutes: numfmt().format(minutes),
-      seconds: numfmt().format(seconds),
-    })
-  })
-
-  const meta = createMemo(() => {
-    if (props.message.role !== "assistant") return ""
-    const agent = (props.message as AssistantMessage).agent
-    const items = [
-      agent ? agent[0]?.toUpperCase() + agent.slice(1) : "",
-      model(),
-      duration(),
-      interrupted() ? i18n.t("ui.message.interrupted") : "",
-    ]
-    return items.filter((x) => !!x).join(" \u00B7 ")
-  })
-
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
   const text = () => (part().text ?? "").trim()
-  const isLastTextPart = createMemo(() => {
-    const last = (data.store.part?.[props.message.id] ?? [])
-      .filter((item): item is TextPart => item?.type === "text" && !!item.text?.trim())
-      .at(-1)
-    return last?.id === part().id
-  })
-  const showCopy = createMemo(() => {
-    if (props.message.role !== "assistant") return isLastTextPart()
-    if (props.showAssistantCopyPartID === null) return false
-    if (typeof props.showAssistantCopyPartID === "string") return props.showAssistantCopyPartID === part().id
-    return isLastTextPart()
-  })
-  const [copied, setCopied] = createSignal(false)
-
-  const handleCopy = async () => {
-    const content = text()
-    if (!content) return
-    try {
-      await navigator.clipboard.writeText(content)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      setCopied(false)
-    }
-  }
 
   return (
     <Show when={text()}>
@@ -95,29 +18,6 @@ registerPartComponent("text", function TextPartDisplay(props) {
             <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
           </Show>
         </div>
-        <Show when={showCopy()}>
-          <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
-            <Tooltip
-              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              placement="top"
-              gutter={4}
-            >
-              <IconButton
-                icon={copied() ? "check" : "copy"}
-                size="normal"
-                variant="ghost"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={handleCopy}
-                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              />
-            </Tooltip>
-            <Show when={meta()}>
-              <span data-slot="text-part-meta" class="text-body text-fg-weak cursor-default">
-                {meta()}
-              </span>
-            </Show>
-          </div>
-        </Show>
       </div>
     </Show>
   )

--- a/packages/ui/src/components/message-part/registry.ts
+++ b/packages/ui/src/components/message-part/registry.ts
@@ -5,7 +5,6 @@ export interface MessageProps {
   message: MessageType
   parts: PartType[]
   actions?: UserActions
-  showAssistantCopyPartID?: string | null
   showReasoningSummaries?: boolean
 }
 
@@ -21,8 +20,6 @@ export interface MessagePartProps {
   message: MessageType
   hideDetails?: boolean
   defaultOpen?: boolean
-  showAssistantCopyPartID?: string | null
-  turnDurationMs?: number
   stateKey?: string
 }
 

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -91,26 +91,36 @@ export function SessionTurnChangesPanel(props: {
     <div data-slot="session-turn-changes" data-component="session-turn-changes">
       <div data-slot="session-turn-changes-header">
         <div data-slot="session-turn-changes-summary">
-          <span>
-            {i18n.t(
-              turnEdited() === 1
-                ? "ui.sessionTurn.turnChanges.summary.one"
-                : "ui.sessionTurn.turnChanges.summary.other",
-              { count: turnEdited() },
-            )}
-          </span>
-          <span data-slot="session-turn-changes-additions">+{turnAdditions()}</span>
-          <span data-slot="session-turn-changes-deletions">-{turnDeletions()}</span>
+          <Show
+            when={isUndoneTurn()}
+            fallback={
+              <>
+                <span>
+                  {i18n.t(
+                    turnEdited() === 1
+                      ? "ui.sessionTurn.turnChanges.summary.one"
+                      : "ui.sessionTurn.turnChanges.summary.other",
+                    { count: turnEdited() },
+                  )}
+                </span>
+                <span data-slot="session-turn-changes-additions">+{turnAdditions()}</span>
+                <span data-slot="session-turn-changes-deletions">-{turnDeletions()}</span>
+              </>
+            }
+          >
+            <span data-slot="session-turn-changes-undone-summary">
+              {i18n.t(
+                turnFiles().length === 1
+                  ? "ui.sessionTurn.turnChanges.undoneSummary.one"
+                  : "ui.sessionTurn.turnChanges.undoneSummary.other",
+                { count: turnFiles().length },
+              )}
+            </span>
+          </Show>
           <Show when={props.turnChange.truncated && (props.turnChange.omittedCount ?? 0) > 0}>
             <span data-slot="session-turn-changes-omitted">
               {i18n.t("ui.sessionTurn.turnChanges.omitted", { count: props.turnChange.omittedCount ?? 0 })}
             </span>
-          </Show>
-          <Show when={props.turnChange.kind === "uncaptured" || props.turnChange.kind === "mixed"}>
-            <span data-slot="session-turn-changes-uncaptured">{i18n.t("ui.sessionTurn.turnChanges.uncaptured")}</span>
-          </Show>
-          <Show when={isUndoneTurn()}>
-            <span data-slot="session-turn-changes-undone">{i18n.t("ui.sessionTurn.turnChanges.undone")}</span>
           </Show>
         </div>
         <Show when={turnActionLabel() && hasTurnChangeActionHandler(props.turnChange, props.actions)}>

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -14,12 +14,12 @@ import {
 import {
   hasTurnChangeActionHandler,
   turnChangeAction,
+  turnChangeFiles,
   type TurnChangeActions,
   type TurnChangeDisplay,
   type TurnChangeFile,
 } from "./session-turn-changes"
 
-const emptyTurnFiles: TurnChangeFile[] = []
 const emptyExpanded: readonly string[] = []
 
 export function SessionTurnChangesPanel(props: {
@@ -31,9 +31,7 @@ export function SessionTurnChangesPanel(props: {
   const i18n = useI18n()
   const fileComponent = useFileComponent()
 
-  const turnFiles = createMemo(() =>
-    props.turnChange.kind === "captured" || props.turnChange.kind === "mixed" ? props.turnChange.files : emptyTurnFiles,
-  )
+  const turnFiles = createMemo(() => turnChangeFiles(props.turnChange))
   const appliedFiles = createMemo(() => turnFiles().filter((file) => file.restoreState === "applied"))
   const turnEdited = createMemo(() => appliedFiles().length)
   const turnAdditions = createMemo(() => appliedFiles().reduce((sum, file) => sum + (file.additions ?? 0), 0))

--- a/packages/ui/src/components/session-turn-changes.ts
+++ b/packages/ui/src/components/session-turn-changes.ts
@@ -40,9 +40,19 @@ export type TurnChangeActions = {
   showInFolder?: (path: string) => void
 }
 
+const emptyTurnChangeFiles: readonly TurnChangeFile[] = []
+
+// Tag narrowing for the wire union is centralized here so panel / hooks / tests
+// stay tag-agnostic. New file-bearing variants only need to opt in inside this helper.
+export function turnChangeFiles(display: TurnChangeDisplay | null | undefined): readonly TurnChangeFile[] {
+  if (!display) return emptyTurnChangeFiles
+  if (display.kind === "captured" || display.kind === "mixed") return display.files
+  return emptyTurnChangeFiles
+}
+
 export function hasVisibleTurnChanges(display: TurnChangeDisplay | null | undefined) {
-  if (!display || display.kind === "empty" || display.kind === "uncaptured") return false
-  return display.files.length > 0 || !!display.truncated
+  if (!display) return false
+  return turnChangeFiles(display).length > 0 || !!display.truncated
 }
 
 // After a force-partial undo a turn can have hasApplied (skipped messages still applied)
@@ -50,9 +60,9 @@ export function hasVisibleTurnChanges(display: TurnChangeDisplay | null | undefi
 // continues in the original direction (undo) by design; the redo path for a mixed state
 // is intentionally not exposed inline. Mixed-state recovery UX is tracked as follow-up.
 export function turnChangeAction(display: TurnChangeDisplay | null | undefined): "undo" | "redo" | undefined {
-  if (!display || display.kind === "empty" || display.kind === "uncaptured") return
-  if (display.files.some((file) => file.restoreState === "applied")) return "undo"
-  if (display.files.some((file) => file.restoreState === "undone")) return "redo"
+  const files = turnChangeFiles(display)
+  if (files.some((file) => file.restoreState === "applied")) return "undo"
+  if (files.some((file) => file.restoreState === "undone")) return "redo"
 }
 
 export function hasTurnChangeActionHandler(

--- a/packages/ui/src/components/session-turn-changes.ts
+++ b/packages/ui/src/components/session-turn-changes.ts
@@ -41,9 +41,8 @@ export type TurnChangeActions = {
 }
 
 export function hasVisibleTurnChanges(display: TurnChangeDisplay | null | undefined) {
-  if (!display || display.kind === "empty") return false
-  if (display.kind === "uncaptured") return display.count > 0
-  return display.files.length > 0 || !!display.truncated || (display.kind === "mixed" && (display.count ?? 0) > 0)
+  if (!display || display.kind === "empty" || display.kind === "uncaptured") return false
+  return display.files.length > 0 || !!display.truncated
 }
 
 // After a force-partial undo a turn can have hasApplied (skipped messages still applied)

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -96,11 +96,45 @@
   [data-slot="session-turn-changes"] {
     width: 100%;
     min-width: 0;
-    margin-top: 4px;
+    margin-top: 12px;
     border: 1px solid var(--border-base);
     border-radius: 8px;
     background: var(--surface-base);
     overflow: hidden;
+  }
+
+  [data-slot="assistant-turn-footer"] {
+    min-height: 30px;
+    margin-top: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+    will-change: opacity;
+
+    [data-component="tooltip-trigger"] {
+      display: inline-flex;
+      width: fit-content;
+    }
+  }
+
+  [data-slot="assistant-turn-footer-meta"] {
+    user-select: none;
+  }
+
+  [data-slot="assistant-turn-footer"][data-interrupted] {
+    width: 100%;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  [data-slot="session-turn-message-container"]:hover [data-slot="assistant-turn-footer"],
+  [data-slot="session-turn-message-container"]:focus-within [data-slot="assistant-turn-footer"] {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   [data-slot="session-turn-changes-header"] {
@@ -142,13 +176,10 @@
     font-weight: var(--font-weight-body);
   }
 
-  [data-slot="session-turn-changes-undone"] {
+  [data-slot="session-turn-changes-undone-summary"] {
     color: var(--fg-weaker);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-body);
   }
 
-  [data-slot="session-turn-changes-uncaptured"],
   [data-slot="session-turn-change-restore-state"] {
     color: var(--fg-weaker);
     font-size: var(--font-size-caption);

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -29,6 +29,7 @@ import {
   formatCompactionElapsed,
   type CompactionDividerState,
 } from "./session-turn-compaction"
+import { AssistantTurnFooter } from "./assistant-turn-footer"
 
 function record(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -329,7 +330,7 @@ export function SessionTurn(
   const error = createMemo(
     () => visibleAssistantMessages().find((m) => m.error && m.error.name !== "MessageAbortedError")?.error,
   )
-  const showAssistantCopyPartID = createMemo(() => {
+  const assistantFooterTarget = createMemo(() => {
     const messages = visibleAssistantMessages()
 
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -340,7 +341,7 @@ export function SessionTurn(
       for (let j = parts.length - 1; j >= 0; j--) {
         const part = parts[j]
         if (!part || part.type !== "text" || !part.text?.trim()) continue
-        return part.id
+        return { message, text: part.text.trim() }
       }
     }
 
@@ -361,9 +362,9 @@ export function SessionTurn(
   })
   const showReasoningSummaries = createMemo(() => props.showReasoningSummaries ?? true)
 
-  const assistantCopyPartID = createMemo(() => {
-    if (working()) return null
-    return showAssistantCopyPartID() ?? null
+  const visibleFooterTarget = createMemo(() => {
+    if (working()) return
+    return assistantFooterTarget()
   })
   const turnDurationMs = createMemo(() => {
     const start = message()?.time.created
@@ -504,8 +505,6 @@ export function SessionTurn(
                   <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
                     <AssistantParts
                       messages={visibleAssistantMessages()}
-                      showAssistantCopyPartID={assistantCopyPartID()}
-                      turnDurationMs={turnDurationMs()}
                       working={working()}
                       showReasoningSummaries={showReasoningSummaries()}
                       shellToolDefaultOpen={props.shellToolDefaultOpen}
@@ -534,6 +533,15 @@ export function SessionTurn(
                       actions={props.turnChangeActions}
                       expanded={turnExpanded()}
                       onExpandedChange={(value) => setTurnExpanded(value)}
+                    />
+                  )}
+                </Show>
+                <Show when={visibleFooterTarget()}>
+                  {(target) => (
+                    <AssistantTurnFooter
+                      text={target().text}
+                      message={target().message}
+                      turnDurationMs={turnDurationMs()}
                     />
                   )}
                 </Show>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -58,8 +58,9 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.turnChanges.showInFolder": "Show in folder",
   "ui.sessionTurn.turnChanges.unrestorable": "Not restorable",
   "ui.sessionTurn.turnChanges.undone": "Undone",
+  "ui.sessionTurn.turnChanges.undoneSummary.one": "{{count}} file undone",
+  "ui.sessionTurn.turnChanges.undoneSummary.other": "{{count}} files undone",
   "ui.sessionTurn.turnChanges.superseded": "Superseded",
-  "ui.sessionTurn.turnChanges.uncaptured": "Some shell changes were not individually captured",
   "ui.sessionTurn.turnChanges.reapply": "Reapply",
   "ui.sessionTurn.turnChanges.confirmTitle": "Some files have been changed since this turn",
   "ui.sessionTurn.turnChanges.confirmDescription":

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -61,8 +61,9 @@ export const dict = {
   "ui.sessionTurn.turnChanges.showInFolder": "在文件夹中显示",
   "ui.sessionTurn.turnChanges.unrestorable": "不可撤回",
   "ui.sessionTurn.turnChanges.undone": "已撤销",
+  "ui.sessionTurn.turnChanges.undoneSummary.one": "{{count}} 个文件已撤销",
+  "ui.sessionTurn.turnChanges.undoneSummary.other": "{{count}} 个文件已撤销",
   "ui.sessionTurn.turnChanges.superseded": "已被后续改动取代",
-  "ui.sessionTurn.turnChanges.uncaptured": "部分 shell 改动未逐个捕获",
   "ui.sessionTurn.turnChanges.reapply": "重新应用",
   "ui.sessionTurn.turnChanges.confirmTitle": "此轮之后有文件被改动",
   "ui.sessionTurn.turnChanges.confirmDescription":


### PR DESCRIPTION
## Summary

Fix three small regressions in the turn changes panel and lift the assistant footer (copy / model / duration) out of `text-part` to its own turn-level component, so the panel sits between assistant prose and footer in the natural reading order.

## Why

After #704 the turn changes panel had three rough edges users hit immediately: a noisy "Some shell changes were not individually captured" line, a "0 files changed +0 -0 Undone" state when everything was undone, and the panel glued tight to surrounding chat. Fixing the third one revealed that the panel was rendered after the assistant footer in DOM, which itself was caused by the footer living inside `text-part` — a generic part renderer that was carrying turn-level metadata it shouldn't own.

The fix removes the noise, gives the "fully undone" state a single readable summary, and lifts the footer out of `text-part` so the natural turn order is `prose → panel → footer`. As a side effect, `text-part` becomes a pure markdown renderer (~60 fewer lines) and the `showAssistantCopyPartID` / `turnDurationMs` prop chain that only existed to feed the embedded footer is removed across the part registry.

## Related Issue

None. Captured as a follow-up to #704; the bigger Turn Changes visual redesign is tracked separately in #823.

## Human Review Status

Pending

## Review Focus

- DOM order in `SessionTurn`: `AssistantParts → SessionTurnChangesPanel → AssistantTurnFooter`, with the footer gated on `!working()` so it doesn't appear during streaming.
- `assistantFooterTarget` memo returns `{message, text}` for the last non-empty assistant text part so the footer's meta (agent / model / duration) is read from the message that owns the text being copied, not from "the last assistant message" which can end on a tool part.
- Footer keeps its hover-only behaviour, now gated on `session-turn-message-container:hover` instead of the per-part wrapper.
- Panel `margin-top: 12px` follows the "breathe" tier in DESIGN.md (paragraph-to-paragraph), because the panel is a side-effect of the same turn, not a section switch — see the new "Turn-internal product modules" paragraph added to DESIGN.md (local-only file, not in this diff).
- `message-part-registry.test.ts` clipboard hardening grep stays at try-count 2 after the lift: the scanned source set now includes `assistant-turn-footer.tsx` alongside `message-part/`, so removing the footer's `try { await navigator.clipboard.writeText }` guard still fails the test. `turnChangeFiles` is the single tag-narrowing point for `TurnChangeDisplay.kind`; the panel and helpers consume that helper, not the union directly.

Footer form (left-aligned `Agent · Model · 8s`) is intentionally **unchanged** in this PR. DESIGN.md L519-520 specifies a different form (right-aligned, completion time only, `[Copy] [Fork]`) which is a follow-up.

## Risk Notes

- Behaviour change: footer always rendered at turn level (was: nested inside the last text part). User-visible result is identical for single-text-part assistant turns (the dominant case). For turns that end on a tool part, the footer now appears below the panel/tool output instead of below the last text body — this is the intended new layout.
- Streaming gate (`!working()`) is preserved so the footer doesn't flash in during partial responses.
- `user-message.tsx` is untouched — it already owned its own copy button via `renderMetaAndActions` and never went through `text-part`. The dead `if (props.message.role !== "assistant")` branch in the old `text-part` footer code is removed alongside the rest.

## How To Verify

```text
bun --cwd packages/ui run typecheck             ok
bun --cwd packages/app run typecheck            ok
bun --cwd packages/opencode run typecheck       ok
bun --cwd packages/ui test session-turn         pass
bun --cwd packages/ui test message-part-registry  pass (clipboard hardening scans assistant-turn-footer; try-count stays 2)
bun --cwd packages/opencode test session/turn-change  pass
bun run snap session-turn-changes               pass; grid regenerated; mixed turn asserts panel renders captured row and no uncaptured copy
bun --cwd packages/app run test:e2e:local -- e2e/session/session-turn-footer.spec.ts  2 pass (hover reveal + clipboard copy + prose→panel→footer DOM order)
Manual dev:desktop walk: prose → panel → footer order correct; hover reveals footer; panel margin reads as breathe-tier separator; fully undone turn shows "1 file undone" without the +0 -0 numerics.
```

## Screenshots or Recordings

`docs/design/preview/screenshots/session-turn-changes.png` (regenerated by `bun run snap session-turn-changes`):
- light + dark, each showing applied, undone, and mixed states
- uncaptured-only slot asserts `count(session-turn-changes) === 0` instead of capturing a panel screenshot, because that kind renders no panel

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added footer component to assistant messages displaying metadata (model, duration) and copy-to-clipboard functionality.
  * Improved session turn changes status display with clearer "undone" state handling.

* **Style**
  * Updated styling for session turn components with enhanced visibility and interaction behaviors.

* **Refactor**
  * Simplified assistant message rendering and reorganized component prop structure for cleaner architecture.

* **Tests**
  * Updated test assertions for clipboard functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
