### PR TITLE
test(app): cover aggregate turn-change diff rows

### DIFF
--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import {
   routeTurnChangeDiff,
@@ -57,6 +57,12 @@ async function readClsProbe(page: Page) {
   )
 }
 
+async function expectDiffLinesVisible(diff: Locator) {
+  const lines = diff.locator("[data-line]")
+  await expect(lines.first()).toBeVisible({ timeout: 30_000 })
+  return lines
+}
+
 test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
   test.setTimeout(180_000)
 
@@ -80,6 +86,7 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
       })
       .toBeGreaterThanOrEqual(384)
     await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
+    await expectDiffLinesVisible(diff)
     await row.click()
     await expect(diff).toHaveCount(0)
   }
@@ -103,8 +110,7 @@ test("small replacement diffs settle close to rendered content height", async ({
   const diff = card.locator('[data-component="session-turn-change-diff"]').first()
   await expect(diff).toBeVisible()
   await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
-  const lines = diff.locator("[data-line]")
-  await expect(lines.first()).toBeVisible({ timeout: 30_000 })
+  const lines = await expectDiffLinesVisible(diff)
 
   await expect
     .poll(async () => {

--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -57,9 +57,10 @@ async function readClsProbe(page: Page) {
   )
 }
 
-async function expectDiffLinesVisible(diff: Locator) {
+async function expectDiffLinesVisible(diff: Locator, expectedText: string) {
   const lines = diff.locator("[data-line]")
   await expect(lines.first()).toBeVisible({ timeout: 30_000 })
+  await expect(lines.filter({ hasText: expectedText }).first()).toBeVisible({ timeout: 30_000 })
   return lines
 }
 
@@ -86,7 +87,7 @@ test("turn-change file rows reserve diff height before rendering", async ({ page
       })
       .toBeGreaterThanOrEqual(384)
     await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
-    await expectDiffLinesVisible(diff)
+    await expectDiffLinesVisible(diff, "alpha replacement")
     await row.click()
     await expect(diff).toHaveCount(0)
   }
@@ -110,7 +111,7 @@ test("small replacement diffs settle close to rendered content height", async ({
   const diff = card.locator('[data-component="session-turn-change-diff"]').first()
   await expect(diff).toBeVisible()
   await expect(diff.locator('[data-component="file"]').first()).toBeVisible({ timeout: 30_000 })
-  const lines = await expectDiffLinesVisible(diff)
+  const lines = await expectDiffLinesVisible(diff, "delta replacement")
 
   await expect
     .poll(async () => {

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -78,8 +78,7 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
         sessionID: input.sessionID,
         turnID,
         messageID: turnID,
-        undoAvailable: true,
-        redoAvailable: false,
+        kind: "captured",
         files: [
           {
             path: TURN_CHANGE_DIFF_FILE_PATH,
@@ -88,6 +87,7 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             deletions: 0,
             patch: turnChangeDiffPatch,
             expandable: true,
+            restoreState: "applied",
           },
           {
             path: TURN_CHANGE_MODIFIED_DIFF_FILE_PATH,
@@ -96,6 +96,7 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             deletions: 6,
             patch: turnChangeModifiedDiffPatch,
             expandable: true,
+            restoreState: "applied",
           },
           {
             path: TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH,
@@ -104,6 +105,7 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             deletions: 1,
             patch: turnChangeSmallModifiedDiffPatch,
             expandable: true,
+            restoreState: "applied",
           },
         ],
       }),


### PR DESCRIPTION

## Summary

Adds aggregate-schema coverage for the turn-change diff E2E fixture and requires expanded diff rows to render real diff line content.

## Why

Fixes a regression guard gap from Issue #843: the mocked turn-change payload still used the old display shape, so the expanded file panel could render blank while the E2E only asserted the file container existed.

## Related Issue

Fixes #843

## Human Review Status

Pending

## Review Focus

Please check that the fixture contract matches the current aggregate turn-change schema and that the E2E assertion locks real diff line rendering without broadening into visual UI scope.

## Risk Notes

Skipped conditional visible UI/manual check: no production UI or copy changed.
Skipped conditional platform check: only app E2E fixture and assertion code changed.
Skipped conditional docs/release/dependency/local-file note: none of those surfaces changed.

## How To Verify

```text
bun run test:e2e:local -- e2e/session/session-turn-change-diff.spec.ts --project=chromium --workers=1 --reporter=line
Result: 2 passed

bun run typecheck
Result: tsgo -b passed

git diff --check origin/dev...HEAD
Result: no whitespace errors
```

## Screenshots or Recordings

Not required: this PR changes only E2E fixture/assertion code, not production UI or copy.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
