### PR TITLE
fix: recover from dropped file watcher events

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -211,6 +211,14 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
         node: tree.node,
         isDirLoaded: tree.isLoaded,
         loadedDirs: tree.loadedDirs,
+        filesToReload: () => [
+          ...Object.keys(store.file),
+          ...tabs
+            .all()
+            .map((tab) => path.pathFromTab(tab))
+            .filter((file): file is string => !!file),
+        ],
+        rootDirectory: scope,
         refreshDir: (dir) => {
           void tree.listDir(dir, { force: true })
         },

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -210,6 +210,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
         },
         node: tree.node,
         isDirLoaded: tree.isLoaded,
+        loadedDirs: tree.loadedDirs,
         refreshDir: (dir) => {
           void tree.listDir(dir, { force: true })
         },

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -165,6 +165,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     children,
     node: (path: string) => tree.node[path],
     isLoaded: (path: string) => Boolean(tree.dir[path]?.loaded),
+    loadedDirs: () => Object.keys(tree.dir).filter((path) => Boolean(tree.dir[path]?.loaded)),
     reset,
   }
 }

--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -164,10 +164,68 @@ describe("file watcher invalidation", () => {
         node: () => undefined,
         isDirLoaded: (path) => path === "" || path === "src" || path === "src/components",
         loadedDirs: () => ["", "src", "src/components", "src/unloaded"],
+        rootDirectory: () => "/repo",
+        filesToReload: () => [],
         refreshDir: (path) => refresh.push(path),
       },
     )
 
     expect(refresh).toEqual(["", "src", "src/components"])
+  })
+
+  test("reloads cached and open files on worktree rescan", () => {
+    const loads: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.rescan",
+        properties: {
+          directory: "/repo",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: (path) => path === "src/cached.ts",
+        isOpen: (path) => path === "src/open.ts",
+        loadFile: (path) => loads.push(path),
+        node: () => undefined,
+        isDirLoaded: () => false,
+        loadedDirs: () => [],
+        rootDirectory: () => "/repo",
+        filesToReload: () => ["src/cached.ts", "src/open.ts", "src/cached.ts"],
+        refreshDir: () => {},
+      },
+    )
+
+    expect(loads).toEqual(["src/cached.ts", "src/open.ts"])
+  })
+
+  test("does not refresh the file tree for git directory rescans", () => {
+    const loads: string[] = []
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.rescan",
+        properties: {
+          directory: "/repo/.git",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => true,
+        isOpen: () => true,
+        loadFile: (path) => loads.push(path),
+        node: () => undefined,
+        isDirLoaded: () => true,
+        loadedDirs: () => ["", "src"],
+        rootDirectory: () => "/repo",
+        filesToReload: () => ["src/open.ts"],
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(loads).toEqual([])
+    expect(refresh).toEqual([])
   })
 })

--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -146,4 +146,28 @@ describe("file watcher invalidation", () => {
 
     expect(refresh).toEqual([])
   })
+
+  test("refreshes loaded directories on rescan", () => {
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.rescan",
+        properties: {
+          directory: "/repo",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        loadFile: () => {},
+        node: () => undefined,
+        isDirLoaded: (path) => path === "" || path === "src" || path === "src/components",
+        loadedDirs: () => ["", "src", "src/components", "src/unloaded"],
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(refresh).toEqual(["", "src", "src/components"])
+  })
 })

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -12,10 +12,18 @@ type WatcherOps = {
   loadFile: (path: string) => void
   node: (path: string) => FileNode | undefined
   isDirLoaded: (path: string) => boolean
+  loadedDirs?: () => string[]
   refreshDir: (path: string) => void
 }
 
 export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
+  if (event.type === "file.watcher.rescan") {
+    for (const dir of ops.loadedDirs?.() ?? [""]) {
+      if (!ops.isDirLoaded(dir)) continue
+      ops.refreshDir(dir)
+    }
+    return
+  }
   if (event.type !== "file.watcher.updated") return
   const props =
     typeof event.properties === "object" && event.properties ? (event.properties as Record<string, unknown>) : undefined

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -13,11 +13,35 @@ type WatcherOps = {
   node: (path: string) => FileNode | undefined
   isDirLoaded: (path: string) => boolean
   loadedDirs?: () => string[]
+  filesToReload?: () => string[]
+  rootDirectory?: () => string
   refreshDir: (path: string) => void
+}
+
+function normalizedFilesystemPath(input: string) {
+  const normalized = input.replace(/\\/g, "/").replace(/\/+$/, "")
+  if (/^[A-Za-z]:/.test(normalized)) return normalized.toLowerCase()
+  return normalized
 }
 
 export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (event.type === "file.watcher.rescan") {
+    const props =
+      typeof event.properties === "object" && event.properties ? (event.properties as Record<string, unknown>) : undefined
+    const directory = typeof props?.directory === "string" ? props.directory : undefined
+    const root = ops.rootDirectory?.()
+    if (directory && root && normalizedFilesystemPath(directory) !== normalizedFilesystemPath(root)) return
+
+    const reloaded = new Set<string>()
+    for (const rawFile of ops.filesToReload?.() ?? []) {
+      const file = ops.normalize(rawFile)
+      if (!file || file.startsWith(".git/")) continue
+      if (reloaded.has(file)) continue
+      if (!ops.hasFile(file) && !ops.isOpen?.(file)) continue
+      reloaded.add(file)
+      ops.loadFile(file)
+    }
+
     for (const dir of ops.loadedDirs?.() ?? [""]) {
       if (!ops.isDirLoaded(dir)) continue
       ops.refreshDir(dir)

--- a/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { isFileWatcherVcsRefreshEvent } from "./use-session-vcs-refresh"
+
+describe("session vcs refresh watcher events", () => {
+  test("refreshes for rescan and non-git file updates only", () => {
+    expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.rescan", properties: { directory: "/repo" } })).toBe(true)
+    expect(
+      isFileWatcherVcsRefreshEvent({
+        type: "file.watcher.updated",
+        properties: { file: "src/app.ts", event: "change" },
+      }),
+    ).toBe(true)
+    expect(
+      isFileWatcherVcsRefreshEvent({
+        type: "file.watcher.updated",
+        properties: { file: ".git/index", event: "change" },
+      }),
+    ).toBe(false)
+    expect(isFileWatcherVcsRefreshEvent({ type: "session.updated", properties: {} })).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/use-session-vcs-refresh.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.ts
@@ -44,14 +44,17 @@ export function useSessionVcsRefresh(input: {
   )
 
   const stop = input.event.listen((evt) => {
-    if (evt.details.type !== "file.watcher.updated") return
-    const props =
-      typeof evt.details.properties === "object" && evt.details.properties
-        ? (evt.details.properties as Record<string, unknown>)
-        : undefined
-    const file = typeof props?.file === "string" ? props.file : undefined
-    if (!file || file.startsWith(".git/")) return
+    if (!isFileWatcherVcsRefreshEvent(evt.details)) return
     refresh()
   })
   onCleanup(stop)
+}
+
+export function isFileWatcherVcsRefreshEvent(event: { type: string; properties?: unknown }) {
+  if (event.type === "file.watcher.rescan") return true
+  if (event.type !== "file.watcher.updated") return false
+  const props =
+    typeof event.properties === "object" && event.properties ? (event.properties as Record<string, unknown>) : undefined
+  const file = typeof props?.file === "string" ? props.file : undefined
+  return !!file && !file.startsWith(".git/")
 }

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -74,13 +74,22 @@ export namespace FileWatcher {
 
   export function createRescanScheduler(input: {
     publish: (directory: string) => void
-    schedule?: (callback: () => void) => void
+    schedule?: (callback: () => void) => (() => void) | void
   }) {
-    const pending = new Map<string, { dirty: boolean }>()
-    const schedule = input.schedule ?? ((callback: () => void) => setTimeout(callback, RESCAN_DEDUPE_MS))
+    type RescanState = { dirty: boolean; cancel?: () => void }
+    const pending = new Map<string, RescanState>()
+    const schedule = (callback: () => void) => {
+      const cancel = input.schedule?.(callback)
+      if (cancel) return cancel
+      const timer = setTimeout(callback, RESCAN_DEDUPE_MS)
+      return () => clearTimeout(timer)
+    }
+    let disposed = false
 
-    const arm = (directory: string, state: { dirty: boolean }) => {
-      schedule(() => {
+    const arm = (directory: string, state: RescanState) => {
+      state.cancel = schedule(() => {
+        state.cancel = undefined
+        if (disposed) return
         if (state.dirty) {
           state.dirty = false
           input.publish(directory)
@@ -91,17 +100,27 @@ export namespace FileWatcher {
       })
     }
 
-    return (directory: string) => {
-      const state = pending.get(directory)
-      if (state) {
-        state.dirty = true
-        return
-      }
+    return {
+      request(directory: string) {
+        if (disposed) return
+        const state = pending.get(directory)
+        if (state) {
+          state.dirty = true
+          return
+        }
 
-      const next = { dirty: false }
-      pending.set(directory, next)
-      input.publish(directory)
-      arm(directory, next)
+        const next = { dirty: false }
+        pending.set(directory, next)
+        input.publish(directory)
+        arm(directory, next)
+      },
+      dispose() {
+        disposed = true
+        for (const state of pending.values()) {
+          state.cancel?.()
+        }
+        pending.clear()
+      },
     }
   }
 
@@ -148,14 +167,16 @@ export namespace FileWatcher {
                 )
               },
               schedule: (callback) => {
-                setTimeout(() => Instance.restore(ctx, callback), RESCAN_DEDUPE_MS)
+                const timer = setTimeout(() => Instance.restore(ctx, callback), RESCAN_DEDUPE_MS)
+                return () => clearTimeout(timer)
               },
             })
+            yield* Effect.addFinalizer(() => Effect.sync(() => requestRescan.dispose()))
             const createCallback = (dir: string): ParcelWatcher.SubscribeCallback => (err, evts) =>
               Instance.restore(ctx, () => {
                 if (err) {
                   if (isDroppedEventsError(err)) {
-                    requestRescan(dir)
+                    requestRescan.request(dir)
                     return
                   }
                   log.error("watcher callback error", { err })

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -31,6 +31,12 @@ export namespace FileWatcher {
         event: z.union([z.literal("add"), z.literal("change"), z.literal("unlink")]),
       }),
     ),
+    Rescan: BusEvent.define(
+      "file.watcher.rescan",
+      z.object({
+        directory: z.string(),
+      }),
+    ),
   }
 
   const watcher = lazy((): typeof import("@parcel/watcher") | undefined => {
@@ -59,6 +65,11 @@ export namespace FileWatcher {
   }
 
   export const hasNativeBinding = () => !!watcher()
+
+  export function isDroppedEventsError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    return message.includes("Events were dropped") && message.includes("File system must be re-scanned")
+  }
 
   export interface Interface {
     readonly init: () => Effect.Effect<void>
@@ -95,9 +106,20 @@ export namespace FileWatcher {
               Effect.promise(() => Promise.allSettled(subs.map((sub) => sub.unsubscribe()))),
             )
 
-            const cb: ParcelWatcher.SubscribeCallback = (err, evts) =>
+            const rescanQueued = new Set<string>()
+            const createCallback = (dir: string): ParcelWatcher.SubscribeCallback => (err, evts) =>
               Instance.restore(ctx, () => {
                 if (err) {
+                  if (isDroppedEventsError(err)) {
+                    if (rescanQueued.has(dir)) return
+                    rescanQueued.add(dir)
+                    setTimeout(() => rescanQueued.delete(dir), 1000)
+                    log.warn("watcher events dropped, requesting rescan", { dir, err })
+                    Bus.publish(Event.Rescan, { directory: dir }).catch((error) =>
+                      log.warn("failed to publish watcher rescan", { dir, error }),
+                    )
+                    return
+                  }
                   log.error("watcher callback error", { err })
                   return
                 }
@@ -109,7 +131,7 @@ export namespace FileWatcher {
               })
 
             const subscribe = (dir: string, ignore: string[]) => {
-              const pending = w.subscribe(dir, cb, { ignore, backend })
+              const pending = w.subscribe(dir, createCallback(dir), { ignore, backend })
               return Effect.gen(function* () {
                 const sub = yield* Effect.promise(() => pending)
                 subs.push(sub)

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -22,6 +22,7 @@ declare const OPENCODE_LIBC: string | undefined
 export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
+  const RESCAN_DEDUPE_MS = 1_000
 
   export const Event = {
     Updated: BusEvent.define(
@@ -71,6 +72,39 @@ export namespace FileWatcher {
     return message.includes("Events were dropped") && message.includes("File system must be re-scanned")
   }
 
+  export function createRescanScheduler(input: {
+    publish: (directory: string) => void
+    schedule?: (callback: () => void) => void
+  }) {
+    const pending = new Map<string, { dirty: boolean }>()
+    const schedule = input.schedule ?? ((callback: () => void) => setTimeout(callback, RESCAN_DEDUPE_MS))
+
+    const arm = (directory: string, state: { dirty: boolean }) => {
+      schedule(() => {
+        if (state.dirty) {
+          state.dirty = false
+          input.publish(directory)
+          arm(directory, state)
+          return
+        }
+        pending.delete(directory)
+      })
+    }
+
+    return (directory: string) => {
+      const state = pending.get(directory)
+      if (state) {
+        state.dirty = true
+        return
+      }
+
+      const next = { dirty: false }
+      pending.set(directory, next)
+      input.publish(directory)
+      arm(directory, next)
+    }
+  }
+
   export interface Interface {
     readonly init: () => Effect.Effect<void>
   }
@@ -106,18 +140,22 @@ export namespace FileWatcher {
               Effect.promise(() => Promise.allSettled(subs.map((sub) => sub.unsubscribe()))),
             )
 
-            const rescanQueued = new Set<string>()
+            const requestRescan = createRescanScheduler({
+              publish: (dir) => {
+                log.warn("watcher events dropped, requesting rescan", { dir })
+                Bus.publish(Event.Rescan, { directory: dir }).catch((error) =>
+                  log.warn("failed to publish watcher rescan", { dir, error }),
+                )
+              },
+              schedule: (callback) => {
+                setTimeout(() => Instance.restore(ctx, callback), RESCAN_DEDUPE_MS)
+              },
+            })
             const createCallback = (dir: string): ParcelWatcher.SubscribeCallback => (err, evts) =>
               Instance.restore(ctx, () => {
                 if (err) {
                   if (isDroppedEventsError(err)) {
-                    if (rescanQueued.has(dir)) return
-                    rescanQueued.add(dir)
-                    setTimeout(() => rescanQueued.delete(dir), 1000)
-                    log.warn("watcher events dropped, requesting rescan", { dir, err })
-                    Bus.publish(Event.Rescan, { directory: dir }).catch((error) =>
-                      log.warn("failed to publish watcher rescan", { dir, error }),
-                    )
+                    requestRescan(dir)
                     return
                   }
                   log.error("watcher callback error", { err })

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -10,4 +10,32 @@ describe("FileWatcher error handling", () => {
     ).toBe(true)
     expect(FileWatcher.isDroppedEventsError(new Error("permission denied"))).toBe(false)
   })
+
+  test("publishes a trailing rescan when dropped-event errors repeat inside the dedupe window", () => {
+    const published: string[] = []
+    const scheduled: Array<() => void> = []
+    const requestRescan = FileWatcher.createRescanScheduler({
+      publish: (directory) => {
+        published.push(directory)
+      },
+      schedule: (callback) => {
+        scheduled.push(callback)
+      },
+    })
+
+    requestRescan("/repo")
+    requestRescan("/repo")
+
+    expect(published).toEqual(["/repo"])
+    expect(scheduled).toHaveLength(1)
+
+    scheduled[0]?.()
+
+    expect(published).toEqual(["/repo", "/repo"])
+    expect(scheduled).toHaveLength(2)
+
+    scheduled[1]?.()
+
+    expect(published).toEqual(["/repo", "/repo"])
+  })
 })

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -14,7 +14,7 @@ describe("FileWatcher error handling", () => {
   test("publishes a trailing rescan when dropped-event errors repeat inside the dedupe window", () => {
     const published: string[] = []
     const scheduled: Array<() => void> = []
-    const requestRescan = FileWatcher.createRescanScheduler({
+    const scheduler = FileWatcher.createRescanScheduler({
       publish: (directory) => {
         published.push(directory)
       },
@@ -23,8 +23,8 @@ describe("FileWatcher error handling", () => {
       },
     })
 
-    requestRescan("/repo")
-    requestRescan("/repo")
+    scheduler.request("/repo")
+    scheduler.request("/repo")
 
     expect(published).toEqual(["/repo"])
     expect(scheduled).toHaveLength(1)
@@ -37,5 +37,26 @@ describe("FileWatcher error handling", () => {
     scheduled[1]?.()
 
     expect(published).toEqual(["/repo", "/repo"])
+  })
+
+  test("does not publish queued trailing rescans after dispose", () => {
+    const published: string[] = []
+    const scheduled: Array<() => void> = []
+    const scheduler = FileWatcher.createRescanScheduler({
+      publish: (directory) => {
+        published.push(directory)
+      },
+      schedule: (callback) => {
+        scheduled.push(callback)
+      },
+    })
+
+    scheduler.request("/repo")
+    scheduler.request("/repo")
+    scheduler.dispose()
+
+    scheduled[0]?.()
+
+    expect(published).toEqual(["/repo"])
   })
 })

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { FileWatcher } from "../../src/file/watcher"
+
+describe("FileWatcher error handling", () => {
+  test("recognizes FSEvents dropped-event errors as rescan signals", () => {
+    expect(
+      FileWatcher.isDroppedEventsError(
+        new Error("Events were dropped by the FSEvents client. File system must be re-scanned."),
+      ),
+    ).toBe(true)
+    expect(FileWatcher.isDroppedEventsError(new Error("permission denied"))).toBe(false)
+  })
+})

--- a/packages/sdk/js/src/event-types.test-d.ts
+++ b/packages/sdk/js/src/event-types.test-d.ts
@@ -1,0 +1,12 @@
+import type { Event, EventFileWatcherRescan } from "./gen/types.gen.js"
+
+type Assert<T extends true> = T
+
+type _RescanIsSdkEvent = Assert<EventFileWatcherRescan extends Event ? true : false>
+
+const _rescan: EventFileWatcherRescan = {
+  type: "file.watcher.rescan",
+  properties: {
+    directory: "/repo",
+  },
+}

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -615,6 +615,13 @@ export type EventFileWatcherUpdated = {
   }
 }
 
+export type EventFileWatcherRescan = {
+  type: "file.watcher.rescan"
+  properties: {
+    directory: string
+  }
+}
+
 export type EventVcsBranchUpdated = {
   type: "vcs.branch.updated"
   properties: {
@@ -692,6 +699,7 @@ export type Event =
   | EventSessionDiff
   | EventSessionError
   | EventFileWatcherUpdated
+  | EventFileWatcherRescan
   | EventVcsBranchUpdated
   | EventPtyCreated
   | EventPtyUpdated

--- a/packages/sdk/js/src/v2/event-types.test-d.ts
+++ b/packages/sdk/js/src/v2/event-types.test-d.ts
@@ -1,0 +1,12 @@
+import type { Event, EventFileWatcherRescan } from "./gen/types.gen.js"
+
+type Assert<T extends true> = T
+
+type _RescanIsSdkEvent = Assert<EventFileWatcherRescan extends Event ? true : false>
+
+const _rescan: EventFileWatcherRescan = {
+  type: "file.watcher.rescan",
+  properties: {
+    directory: "/repo",
+  },
+}

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -297,6 +297,13 @@ export type EventFileWatcherUpdated = {
   }
 }
 
+export type EventFileWatcherRescan = {
+  type: "file.watcher.rescan"
+  properties: {
+    directory: string
+  }
+}
+
 export type Todo = {
   id: string
   /**
@@ -1082,6 +1089,7 @@ export type Event =
   | EventProjectUpdated
   | EventFileEdited
   | EventFileWatcherUpdated
+  | EventFileWatcherRescan
   | EventTodoUpdated
   | EventSessionCompacted
   | EventWorktreeReady


### PR DESCRIPTION
## Summary

Recover from dropped macOS file watcher events by converting FSEvents dropped-event errors into a directory rescan signal.

## Why

The macOS watcher can report that filesystem events were dropped and that the filesystem must be re-scanned. PawWork previously treated that callback as a generic error, so the log could fill with repeated `service=file.watcher` errors while the file tree and VCS UI never received a recovery signal.

Fixes #848

## Related Issue

Fixes #848

## Human Review Status

Pending

## Review Focus

Please review whether `file.watcher.rescan` is the right recovery boundary for both file tree refresh and VCS refresh, and whether the short per-directory dedupe window is small enough to avoid hiding distinct recovery events.

## Risk Notes

No visible UI or copy changed, so the visual check item is left unticked. No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes are relevant, so that conditional item is left unticked.

Platform impact: this directly handles macOS FSEvents dropped-event recovery. Windows and Linux watcher event handling remains unchanged except for the new event schema existing in the shared bus.

## How To Verify

```text
packages/app: bun test --preload ./happydom.ts src/context/file/watcher.test.ts src/pages/session/use-session-vcs-refresh.test.ts
Result: 8 pass, 0 fail

packages/opencode: bun test test/file/watcher-error.test.ts
Result: 3 pass, 0 fail

packages/app: bun run typecheck
Result: passed

packages/opencode: bun run typecheck
Result: passed

packages/sdk/js: bun run typecheck
Result: passed
```

## Screenshots or Recordings

Not applicable. This change has no visible UI or copy changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic rescan flow to recover from dropped filesystem events and coalesce rescan requests per directory.
  * Directory load tracking and selective file reloads so only relevant cached or open files are refreshed on a rescan.
  * Session VCS refresh now filters events to ignore git-internal paths and only trigger on meaningful file changes.

* **Tests**
  * Expanded test coverage for rescan behavior, dropped-event recovery, and VCS refresh filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

