### PR TITLE
chore(release): bump desktop version to v2026.5.23

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.22",
+      "version": "2026.5.23",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.22",
+  "version": "2026.5.23",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release version to 2026.5.23.

No runtime code changes are included in this PR.

## Why

Prepare the next stable desktop release after the post-2026.5.22 changes on dev.

## Related Issue

No tracking issue. This is the release version bump for v2026.5.23.

## Human Review Status

- `Not required: automated release bump only changes the desktop version metadata.`

## Review Focus

- Confirm the only changed files are `packages/desktop-electron/package.json` and `bun.lock`.
- Confirm both files carry the same 2026.5.23 desktop version.

## Risk Notes

Skipped conditional visible UI/manual check: no UI or copy changed in this PR.
Skipped conditional platform check: the release itself will exercise macOS and Windows packaging; this PR only changes version metadata.
Skipped conditional docs/release/dependency/local-file note: no docs, dependencies, permissions, credentials, deletion behavior, generated output, or local-only files changed.

## How To Verify

```text
Version metadata: packages/desktop-electron/package.json reports 2026.5.23 and bun.lock records packages/desktop-electron version 2026.5.23.
Whitespace: git diff --check completed with no output.
Diff review: only bun.lock and packages/desktop-electron/package.json changed, 2 insertions and 2 deletions.
```

## Screenshots or Recordings

Not required: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

