### PR TITLE
perf(app): gate right-panel context and files tabs when inactive

### DIFF
--- a/packages/app/src/pages/session/session-side-panel.test.tsx
+++ b/packages/app/src/pages/session/session-side-panel.test.tsx
@@ -1,6 +1,20 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
 
 let SessionSidePanel: typeof import("./session-side-panel").SessionSidePanel
+
+const SOURCE_PATH = path.join(__dirname, "session-side-panel.tsx")
+
+// Extract the JSX block bounded by <Tabs.Content value="X" …> … </Tabs.Content>.
+// Used by the gating-contract tests below to assert each tab body sits inside
+// a Show guard tied to the matching sidePanelTab id.
+function findTabContentBlock(source: string, value: string): string {
+  const re = new RegExp(`<Tabs\\.Content value="${value}"[\\s\\S]*?</Tabs\\.Content>`)
+  const match = source.match(re)
+  if (!match) throw new Error(`no <Tabs.Content value="${value}"> block found`)
+  return match[0]
+}
 
 beforeAll(async () => {
   mock.module("@solid-primitives/media", () => ({
@@ -191,5 +205,39 @@ describe("makeRightPanelResizeHandler", () => {
     )
     handler(280) // below MIN; handler doesn't clamp, store.resize clamps internally
     expect(received).toBe(280)
+  })
+})
+
+// Inactive-tab gating contract: each right-panel tab body must be wrapped in a
+// <Show when={sidePanelTab() === "<id>"}> so its content fully unmounts when the
+// user is on another tab. A render test would need to mock SessionSidePanel's
+// entire context surface; this source-grep matches the project pattern used in
+// `no-mode-picker.test.ts` and catches the most likely regressions: tab-id
+// typos, copy-paste mistakes, and any future "let's drop the Show wrap" change.
+describe("right-panel inactive-tab gating contract", () => {
+  test("files tab body is gated by Show when={sidePanelTab() === \"files\"}", async () => {
+    const source = await fs.readFile(SOURCE_PATH, "utf8")
+    const block = findTabContentBlock(source, "files")
+    expect(block).toContain(`<Show when={sidePanelTab() === "files"}>`)
+    expect(block).toContain("<FilesTab")
+    const showIdx = block.indexOf(`<Show when={sidePanelTab() === "files"}>`)
+    const compIdx = block.indexOf("<FilesTab")
+    expect(compIdx).toBeGreaterThan(showIdx) // FilesTab must sit inside the Show
+  })
+
+  test("context tab body is gated by Show when={sidePanelTab() === \"context\"}", async () => {
+    const source = await fs.readFile(SOURCE_PATH, "utf8")
+    const block = findTabContentBlock(source, "context")
+    expect(block).toContain(`<Show when={sidePanelTab() === "context"}>`)
+    expect(block).toContain("<SessionContextTab")
+    const showIdx = block.indexOf(`<Show when={sidePanelTab() === "context"}>`)
+    const compIdx = block.indexOf("<SessionContextTab")
+    expect(compIdx).toBeGreaterThan(showIdx)
+  })
+
+  test("terminal tab body keeps its existing Show when={sidePanelTab() === \"terminal\"} guard", async () => {
+    const source = await fs.readFile(SOURCE_PATH, "utf8")
+    const block = findTabContentBlock(source, "terminal")
+    expect(block).toContain(`<Show when={sidePanelTab() === "terminal"}>`)
   })
 })

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -409,7 +409,9 @@ export function SessionSidePanel(props: {
             </Tabs.Content>
 
             <Tabs.Content value="files" class="min-h-0 flex-1 overflow-hidden">
-              <FilesTab files={props.files()} />
+              <Show when={sidePanelTab() === "files"}>
+                <FilesTab files={props.files()} />
+              </Show>
             </Tabs.Content>
 
             <Tabs.Content value="review" class="min-h-0 flex-1 overflow-hidden">
@@ -541,7 +543,9 @@ export function SessionSidePanel(props: {
               </Tabs.Content>
 
               <Tabs.Content value="context" class="min-h-0 flex-1 overflow-hidden">
-                <SessionContextTab />
+                <Show when={sidePanelTab() === "context"}>
+                  <SessionContextTab />
+                </Show>
               </Tabs.Content>
             </Tabs>
           </DragDropProvider>


### PR DESCRIPTION
## Summary

Wrap `SessionContextTab` and `FilesTab` in `<Show when={sidePanelTab() === ...}>` so inactive right-panel tab content fully unmounts instead of staying live.

Two-line change at [`session-side-panel.tsx:411-413`](https://github.com/Astro-Han/pawwork/blob/claude/right-panel-gate-inactive-work/packages/app/src/pages/session/session-side-panel.tsx#L411-L413) and [`session-side-panel.tsx:543-545`](https://github.com/Astro-Han/pawwork/blob/claude/right-panel-gate-inactive-work/packages/app/src/pages/session/session-side-panel.tsx#L543-L545), matching the existing terminal pattern at [line 531](https://github.com/Astro-Han/pawwork/blob/claude/right-panel-gate-inactive-work/packages/app/src/pages/session/session-side-panel.tsx#L531).

## Why

Area B right-panel audit (#602) found that Context and Files tab content stayed mounted while the user was on another tab, doing real work:

- `SessionContextTab` recomputes `metrics` / `breakdown` / `systemPrompt` memos and queues a `requestAnimationFrame` on every message-length change
- `FilesTab` runs `file.load()` for each previewable artifact and calls `platform.statPaths` whenever `props.files` changes — and `props.files` itself reacts to Review state, so this fires while users review diffs

This contributes to the typing-lag observation in #615. The other right-panel tabs (Status, Review inner, Terminal) already have explicit guards; Context and Files were the two arms that slipped through.

The fix is not "completely stop all Context-related work" — the tab strip itself, including any per-tab indicators, is unaffected. Only the tab body content unmounts.

## Related Issue

Refs #602 (Area B right-panel rewrite)
Contributes to #615 (session UI typing lag)

## Human Review Status

Pending

## Review Focus

- The Show wrap correctness — does it correctly match each tab id?
- Whether full unmount (vs gating only the heavy effects) is the right choice. Trade-off accepted: Context Accordion expansion state and Files scroll position are lost across remount. Context scroll position is preserved via the existing `view().scroll("context")` store; Files scroll persistence is not currently implemented and can be added separately if it becomes user-visible.
- Pattern consistency with terminal at line 531.

## Risk Notes

- Behavior change: previously inactive Context/Files tabs kept their internal state (open Accordion items, Files scroll position). After this PR, that state resets on tab switch. Accepted as part of the perf win per the audit recommendation.
- No platform, packaging, or shell surface touched.
- No new dependencies.

## How To Verify

```text
typecheck:                bun run typecheck — 8/8 packages pass
lint:                     bun run lint packages/app/src/pages/session/session-side-panel.tsx — clean
focused tests:            bun test --preload ./happydom.ts \
                            src/pages/session/session-side-panel.test.tsx \
                            src/pages/session/right-panel-tabs.test.ts \
                            src/pages/session/migrate-session-view.test.ts
                          — 46 pass, 0 fail
visual check (snap):      bun run snap app-shell — passed, screenshot reviewed at
                            docs/design/preview/screenshots/app-shell.png;
                            sidebar + center chat + right-pane rendering unchanged
```

Manual desktop walk-through of all four tabs (Status / Files / Review / Context) deferred — change is purely additive control flow that mirrors the existing terminal pattern (line 531), and the active-tab render path is unchanged. Reviewer is welcome to request a `dev:desktop` recording if tab-switching dynamic verification is desired.

## Screenshots or Recordings

`docs/design/preview/screenshots/app-shell.png` regenerated; no visible diff from baseline. Default app-shell snap does not exercise the right panel in an open state, so this confirms no regression to the default surface but does not visually demonstrate the gated tabs.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.