### PR TITLE
fix(ui): render turn-change diffs statically

### DIFF
--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -2,8 +2,10 @@ import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import {
   routeTurnChangeDiff,
+  routeTailTurnChangeDiff,
   TURN_CHANGE_MODIFIED_DIFF_FILE_PATH,
   TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH,
+  TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH,
 } from "./turn-change-diff-fixture"
 
 async function installClsProbe(page: Page) {
@@ -125,4 +127,51 @@ test("small replacement diffs settle close to rendered content height", async ({
     .toBeLessThan(96)
 
   expect(await readClsProbe(page)).toBeLessThan(0.1)
+})
+
+test("tail one-line replacement diff renders without inline virtualization", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+  await routeTailTurnChangeDiff(page, { sessionID: "e2e-tail-session" })
+
+  await llm.text(
+    Array.from({ length: 18 }, (_, index) => `Tail context paragraph ${index + 1}.`).join("\n\n"),
+  )
+  await project.prompt(`seed tail turn-change diff ${Date.now()}`)
+
+  const card = page.locator('[data-component="session-turn-changes"]').last()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  const row = card
+    .locator('[data-component="session-turn-change-row"]')
+    .filter({ hasText: TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH })
+    .first()
+  await expect(row).toBeVisible()
+
+  await row.click()
+  const diff = card.locator('[data-component="session-turn-change-diff"]').first()
+  await expect(diff).toBeVisible()
+  await expect
+    .poll(async () => {
+      const box = await diff.boundingBox()
+      return box?.y ?? 0
+    })
+    .toBeGreaterThan(240)
+
+  const lines = diff.locator("[data-line]")
+  await expect.poll(async () => await lines.count()).toBeGreaterThan(0)
+  await expect(lines.first()).toBeVisible({ timeout: 30_000 })
+  await expect(lines.filter({ hasText: "worktree is removed" }).first()).toBeVisible({ timeout: 30_000 })
+  await expect(lines.filter({ hasText: "any current agent session has exited" }).first()).toBeVisible({
+    timeout: 30_000,
+  })
+
+  await expect
+    .poll(async () =>
+      await page.evaluate(() => {
+        const root = (window as unknown as { __INSTANCE?: { root?: Element } }).__INSTANCE?.root
+        return root?.matches('[data-component="session-turn-change-diff"]') ?? false
+      }),
+    )
+    .toBe(false)
 })

--- a/packages/app/e2e/session/session-turn-change-diff.spec.ts
+++ b/packages/app/e2e/session/session-turn-change-diff.spec.ts
@@ -3,6 +3,8 @@ import { test, expect } from "../fixtures"
 import {
   routeTurnChangeDiff,
   routeTailTurnChangeDiff,
+  routeDenseTurnChangeDiff,
+  TURN_CHANGE_DENSE_DIFF_FILE_PATH,
   TURN_CHANGE_MODIFIED_DIFF_FILE_PATH,
   TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH,
   TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH,
@@ -64,6 +66,13 @@ async function expectDiffLinesVisible(diff: Locator, expectedText: string) {
   await expect(lines.first()).toBeVisible({ timeout: 30_000 })
   await expect(lines.filter({ hasText: expectedText }).first()).toBeVisible({ timeout: 30_000 })
   return lines
+}
+
+async function turnChangeDiffUsesInlineVirtualizer(page: Page) {
+  return await page.evaluate(() => {
+    const root = (window as unknown as { __INSTANCE?: { root?: Element } }).__INSTANCE?.root
+    return root?.matches('[data-component="session-turn-change-diff"]') ?? false
+  })
 }
 
 test("turn-change file rows reserve diff height before rendering", async ({ page, llm, project }) => {
@@ -167,11 +176,34 @@ test("tail one-line replacement diff renders without inline virtualization", asy
   })
 
   await expect
-    .poll(async () =>
-      await page.evaluate(() => {
-        const root = (window as unknown as { __INSTANCE?: { root?: Element } }).__INSTANCE?.root
-        return root?.matches('[data-component="session-turn-change-diff"]') ?? false
-      }),
-    )
+    .poll(async () => await turnChangeDiffUsesInlineVirtualizer(page))
     .toBe(false)
+})
+
+test("dense short-line turn-change diffs avoid the static render path", async ({ page, llm, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+  await routeDenseTurnChangeDiff(page, { sessionID: "e2e-dense-session" })
+
+  await llm.text(
+    Array.from({ length: 18 }, (_, index) => `Dense context paragraph ${index + 1}.`).join("\n\n"),
+  )
+  await project.prompt(`seed dense turn-change diff ${Date.now()}`)
+
+  const card = page.locator('[data-component="session-turn-changes"]').last()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  const row = card
+    .locator('[data-component="session-turn-change-row"]')
+    .filter({ hasText: TURN_CHANGE_DENSE_DIFF_FILE_PATH })
+    .first()
+  await expect(row).toBeVisible()
+
+  await row.click()
+  const diff = card.locator('[data-component="session-turn-change-diff"]').first()
+  await expect(diff).toBeVisible()
+  await expect(diff.locator("[data-line]").first()).toBeVisible({ timeout: 5_000 })
+  await expect
+    .poll(async () => await turnChangeDiffUsesInlineVirtualizer(page), { timeout: 5_000 })
+    .toBe(true)
 })

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -3,6 +3,7 @@ import type { Page } from "@playwright/test"
 export const TURN_CHANGE_DIFF_FILE_PATH = "turn-change-cls-fixture.ts"
 export const TURN_CHANGE_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-replacement.ts"
 export const TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-small-replacement.ts"
+export const TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH = "AGENTS.md"
 
 const turnChangeDiffPatch = [
   `diff --git a/${TURN_CHANGE_DIFF_FILE_PATH} b/${TURN_CHANGE_DIFF_FILE_PATH}`,
@@ -67,6 +68,22 @@ const turnChangeSmallModifiedDiffPatch = [
   " ]",
 ].join("\n")
 
+const turnChangeTailReplacementPatch = [
+  `diff --git a/${TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH} b/${TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH}`,
+  "index 6666666..7777777 100644",
+  `--- a/${TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH}`,
+  `+++ b/${TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH}`,
+  "@@ -1,7 +1,7 @@",
+  " - Treat `.github/workflows/` as source of truth.",
+  " - Prefer targeted local verification over broad local suites.",
+  " - Use squash merge by default for PawWork PRs.",
+  "-- Merge closeout is not complete until local `dev` is fast-forwarded and the worktree is removed.",
+  "+- Merge closeout is not complete until local `dev` is fast-forwarded and any current agent session has exited that PR's worktree.",
+  " - After squash merge, do not rely on local branch ancestry.",
+  " - Never skip hooks. Never force-push to `dev` or `main`.",
+  " - Never commit `.env` or other secret files.",
+].join("\n")
+
 export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
   await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes(?:\?.*)?$/, async (route) => {
     const url = new URL(route.request().url())
@@ -104,6 +121,34 @@ export async function routeTurnChangeDiff(page: Page, input: { sessionID: string
             additions: 1,
             deletions: 1,
             patch: turnChangeSmallModifiedDiffPatch,
+            expandable: true,
+            restoreState: "applied",
+          },
+        ],
+      }),
+    })
+  })
+}
+
+export async function routeTailTurnChangeDiff(page: Page, input: { sessionID: string }) {
+  await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes(?:\?.*)?$/, async (route) => {
+    const url = new URL(route.request().url())
+    const parts = url.pathname.split("/")
+    const turnID = parts.at(-2) ?? "turn"
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessionID: input.sessionID,
+        turnID,
+        messageID: turnID,
+        kind: "captured",
+        files: [
+          {
+            path: TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH,
+            status: "modified",
+            additions: 1,
+            deletions: 1,
+            patch: turnChangeTailReplacementPatch,
             expandable: true,
             restoreState: "applied",
           },

--- a/packages/app/e2e/session/turn-change-diff-fixture.ts
+++ b/packages/app/e2e/session/turn-change-diff-fixture.ts
@@ -4,6 +4,8 @@ export const TURN_CHANGE_DIFF_FILE_PATH = "turn-change-cls-fixture.ts"
 export const TURN_CHANGE_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-replacement.ts"
 export const TURN_CHANGE_SMALL_MODIFIED_DIFF_FILE_PATH = "turn-change-cls-small-replacement.ts"
 export const TURN_CHANGE_TAIL_REPLACEMENT_FILE_PATH = "AGENTS.md"
+export const TURN_CHANGE_DENSE_DIFF_FILE_PATH = "turn-change-dense-lines.ts"
+export const TURN_CHANGE_DENSE_DIFF_LINES = 1_200
 
 const turnChangeDiffPatch = [
   `diff --git a/${TURN_CHANGE_DIFF_FILE_PATH} b/${TURN_CHANGE_DIFF_FILE_PATH}`,
@@ -84,6 +86,16 @@ const turnChangeTailReplacementPatch = [
   " - Never commit `.env` or other secret files.",
 ].join("\n")
 
+const turnChangeDenseDiffPatch = [
+  `diff --git a/${TURN_CHANGE_DENSE_DIFF_FILE_PATH} b/${TURN_CHANGE_DENSE_DIFF_FILE_PATH}`,
+  "new file mode 100644",
+  "index 0000000..8888888",
+  "--- /dev/null",
+  `+++ b/${TURN_CHANGE_DENSE_DIFF_FILE_PATH}`,
+  `@@ -0,0 +1,${TURN_CHANGE_DENSE_DIFF_LINES} @@`,
+  ...Array.from({ length: TURN_CHANGE_DENSE_DIFF_LINES }, (_, index) => `+export const denseLine${index + 1} = ${index + 1}`),
+].join("\n")
+
 export async function routeTurnChangeDiff(page: Page, input: { sessionID: string }) {
   await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes(?:\?.*)?$/, async (route) => {
     const url = new URL(route.request().url())
@@ -149,6 +161,34 @@ export async function routeTailTurnChangeDiff(page: Page, input: { sessionID: st
             additions: 1,
             deletions: 1,
             patch: turnChangeTailReplacementPatch,
+            expandable: true,
+            restoreState: "applied",
+          },
+        ],
+      }),
+    })
+  })
+}
+
+export async function routeDenseTurnChangeDiff(page: Page, input: { sessionID: string }) {
+  await page.route(/\/session\/[^/]+\/turn\/[^/]+\/changes(?:\?.*)?$/, async (route) => {
+    const url = new URL(route.request().url())
+    const parts = url.pathname.split("/")
+    const turnID = parts.at(-2) ?? "turn"
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessionID: input.sessionID,
+        turnID,
+        messageID: turnID,
+        kind: "captured",
+        files: [
+          {
+            path: TURN_CHANGE_DENSE_DIFF_FILE_PATH,
+            status: "added",
+            additions: TURN_CHANGE_DENSE_DIFF_LINES,
+            deletions: 0,
+            patch: turnChangeDenseDiffPatch,
             expandable: true,
             restoreState: "applied",
           },

--- a/packages/ui/src/components/file.tsx
+++ b/packages/ui/src/components/file.tsx
@@ -82,7 +82,7 @@ export type TextFileProps<T = {}> = FileOptions<T> &
   }
 
 type DiffPreload<T> = PreloadMultiFileDiffResult<T> | PreloadFileDiffResult<T>
-type DiffRenderStrategy = "auto" | "static" | "virtualized"
+type DiffRenderStrategy = "auto" | "static"
 
 type DiffBaseProps<T> = FileDiffOptions<T> &
   SharedProps<T> & {

--- a/packages/ui/src/components/file.tsx
+++ b/packages/ui/src/components/file.tsx
@@ -82,12 +82,14 @@ export type TextFileProps<T = {}> = FileOptions<T> &
   }
 
 type DiffPreload<T> = PreloadMultiFileDiffResult<T> | PreloadFileDiffResult<T>
+type DiffRenderStrategy = "auto" | "static" | "virtualized"
 
 type DiffBaseProps<T> = FileDiffOptions<T> &
   SharedProps<T> & {
     mode: "diff"
     annotations?: DiffLineAnnotation<T>[]
     preloadedDiff?: DiffPreload<T>
+    renderStrategy?: DiffRenderStrategy
   }
 
 type DiffPairProps<T> = DiffBaseProps<T> & {
@@ -123,7 +125,7 @@ const sharedKeys = [
 ] as const
 
 const textKeys = ["file", ...sharedKeys] as const
-const diffKeys = ["fileDiff", "before", "after", ...sharedKeys] as const
+const diffKeys = ["fileDiff", "before", "after", "renderStrategy", ...sharedKeys] as const
 
 // ---------------------------------------------------------------------------
 // Shared viewer hook
@@ -566,7 +568,7 @@ function createLocalVirtualStrategy(host: () => HTMLDivElement | undefined, enab
   }
 }
 
-function createSharedVirtualStrategy(host: () => HTMLDivElement | undefined): VirtualStrategy {
+function createSharedVirtualStrategy(host: () => HTMLDivElement | undefined, enabled: () => boolean): VirtualStrategy {
   let shared: NonNullable<ReturnType<typeof acquireVirtualizer>> | undefined
 
   const release = () => {
@@ -576,6 +578,10 @@ function createSharedVirtualStrategy(host: () => HTMLDivElement | undefined): Vi
 
   return {
     get: () => {
+      if (!enabled()) {
+        release()
+        return
+      }
       if (shared) return shared.virtualizer
 
       const container = host()
@@ -988,7 +994,8 @@ function DiffViewer<T>(props: DiffFileProps<T>) {
     adapter,
   )
 
-  const virtuals = createSharedVirtualStrategy(() => viewer.container)
+  const renderStrategy = () => local.renderStrategy ?? "auto"
+  const virtuals = createSharedVirtualStrategy(() => viewer.container, () => renderStrategy() !== "static")
 
   const large = createMemo(() => {
     if (local.fileDiff) {

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -21,6 +21,18 @@ import {
 } from "./session-turn-changes"
 
 const emptyExpanded: readonly string[] = []
+const TURN_CHANGE_STATIC_DIFF_MAX_PATCH_LINES = 800
+
+function turnChangeDiffRenderStrategy(patch: string) {
+  if (!patch) return "static"
+  let count = 1
+  for (let index = 0; index < patch.length; index += 1) {
+    if (patch.charCodeAt(index) !== 10) continue
+    count += 1
+    if (count > TURN_CHANGE_STATIC_DIFF_MAX_PATCH_LINES) return "auto"
+  }
+  return "static"
+}
 
 export function SessionTurnChangesPanel(props: {
   turnChange: TurnChangeDisplay
@@ -263,7 +275,7 @@ export function SessionTurnChangesPanel(props: {
                         component={fileComponent}
                         mode="diff"
                         fileDiff={diff().fileDiff}
-                        renderStrategy="static"
+                        renderStrategy={turnChangeDiffRenderStrategy(diff().patch)}
                         onRendered={handleDiffRendered}
                       />
                     </div>

--- a/packages/ui/src/components/session-turn-changes-panel.tsx
+++ b/packages/ui/src/components/session-turn-changes-panel.tsx
@@ -263,6 +263,7 @@ export function SessionTurnChangesPanel(props: {
                         component={fileComponent}
                         mode="diff"
                         fileDiff={diff().fileDiff}
+                        renderStrategy="static"
                         onRendered={handleDiffRendered}
                       />
                     </div>


### PR DESCRIPTION
## Summary

Render small turn-change panel diffs through the shared `File` component's static diff path, while keeping dense turn-change patches on the default virtualized path. This also adds regression coverage for the final/tail one-line replacement case from #852 and for dense short-line patches above the static threshold.

## Why

Issue #852 showed that a `+1 -1` diff at the tail of the final turn could expand to a blank panel. The root cause was not CSS hiding the line. The inline turn-change panel still entered `VirtualizedFileDiff`, and the shared virtualizer could measure the inline scroll root before the `diffs-container` was fully mounted. In that state the render range collapsed to no visible `[data-line]` rows.

Small turn-change patches are safe to render statically and avoid that measurement path. Dense patches can still be below the server's 2 MiB display limit but expensive as DOM, so this PR uses static rendering only up to 800 patch lines and falls back to the existing `auto` strategy above that. Full review/file diff surfaces keep the default behavior.

## Related Issue

Fixes #852

## Human Review Status

Pending

## Review Focus

Please focus on the `renderStrategy` boundary in `packages/ui/src/components/file.tsx`, the 800-line static threshold in `packages/ui/src/components/session-turn-changes-panel.tsx`, and the two E2E paths that lock the split: one-line tail patches stay static, dense short-line patches avoid static rendering.

## Risk Notes

Small turn-change inline diffs now render statically; dense patches keep the default `auto` path to avoid static DOM cost. The 800-line cutoff is intentionally local to the turn-change panel and is lower than the server payload size limit, so it protects the renderer without changing server capture or restore behavior. A packaged installed-profile repro was not rerun against this PR build; current-source Electron build and raw desktop smoke passed, and the focused web E2E covers the failing tail path plus the dense-patch boundary.

## How To Verify

```text
Red check before the first fix: bun run test:e2e:local -- e2e/session/session-turn-change-diff.spec.ts --project=chromium --workers=1 --reporter=line -g "tail one-line replacement diff renders without inline virtualization" -> failed on the old code with Expected false, Received true for the inline virtualizer assertion
Red check before the review follow-up: bun run test:e2e:local -- e2e/session/session-turn-change-diff.spec.ts --project=chromium --workers=1 --reporter=line -g "dense short-line turn-change diffs avoid the static render path" -> failed before the threshold with Expected true, Received false for the inline virtualizer assertion
Focused spec: bun run test:e2e:local -- e2e/session/session-turn-change-diff.spec.ts --project=chromium --workers=1 --reporter=line -> 4 passed
App typecheck: bun run typecheck in packages/app -> passed
UI typecheck: bun run typecheck in packages/ui -> passed
Lint: bun run lint -> passed
Visual snap: bun run snap turn-change-diff -> 1 passed; generated screenshot reviewed and expanded diff lines were visible
Desktop build: bun run build in packages/desktop-electron -> passed with existing bundler warnings
Desktop raw smoke: bun run smoke:ci in packages/desktop-electron -> passed
Diff check: git diff --check -> no whitespace errors
```

## Screenshots or Recordings

Visual snap target `turn-change-diff` was run locally and the generated grid screenshot was reviewed: the expanded turn-change diff rendered real rows instead of a blank panel.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
