### PR TITLE
fix: decouple config plugin dependency version

### DIFF
--- a/packages/core/src/installation/version.ts
+++ b/packages/core/src/installation/version.ts
@@ -7,5 +7,10 @@ declare global {
 export const InstallationVersion = typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"
 export const InstallationChannel = typeof OPENCODE_CHANNEL === "string" ? OPENCODE_CHANNEL : "local"
 export const InstallationLocal = InstallationChannel === "local"
+const DefinedInstallationPluginVersion =
+  typeof OPENCODE_PLUGIN_VERSION === "string" && OPENCODE_PLUGIN_VERSION.trim() ? OPENCODE_PLUGIN_VERSION : undefined
+if (!InstallationLocal && !DefinedInstallationPluginVersion) {
+  throw new Error("OPENCODE_PLUGIN_VERSION must be defined for non-local builds")
+}
 export const InstallationPluginVersion =
-  typeof OPENCODE_PLUGIN_VERSION === "string" && OPENCODE_PLUGIN_VERSION ? OPENCODE_PLUGIN_VERSION : "latest"
+  DefinedInstallationPluginVersion ?? "latest"

--- a/packages/core/src/installation/version.ts
+++ b/packages/core/src/installation/version.ts
@@ -1,8 +1,11 @@
 declare global {
   const OPENCODE_VERSION: string
   const OPENCODE_CHANNEL: string
+  const OPENCODE_PLUGIN_VERSION: string | undefined
 }
 
 export const InstallationVersion = typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"
 export const InstallationChannel = typeof OPENCODE_CHANNEL === "string" ? OPENCODE_CHANNEL : "local"
 export const InstallationLocal = InstallationChannel === "local"
+export const InstallationPluginVersion =
+  typeof OPENCODE_PLUGIN_VERSION === "string" && OPENCODE_PLUGIN_VERSION ? OPENCODE_PLUGIN_VERSION : "latest"

--- a/packages/core/test/installation-version.test.ts
+++ b/packages/core/test/installation-version.test.ts
@@ -1,0 +1,37 @@
+import path from "path"
+import { expect, test } from "bun:test"
+
+const cwd = path.resolve(import.meta.dir, "..")
+const decode = (input: { toString(): string } | undefined) => input?.toString() ?? ""
+
+function runVersionImport(defines: string[]) {
+  return Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      ...defines.flatMap((value) => ["--define", value]),
+      "-e",
+      'import("./src/installation/version.ts").then((mod) => console.log(mod.InstallationPluginVersion))',
+    ],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+test("fails packaged builds when the plugin version define is missing", () => {
+  const result = runVersionImport(['OPENCODE_CHANNEL="prod"', 'OPENCODE_VERSION="0.0.0-prod-202605230200"'])
+
+  expect(result.exitCode).not.toBe(0)
+  expect(decode(result.stderr)).toContain("OPENCODE_PLUGIN_VERSION")
+})
+
+test("uses the injected plugin version for packaged builds", () => {
+  const result = runVersionImport([
+    'OPENCODE_CHANNEL="prod"',
+    'OPENCODE_VERSION="0.0.0-prod-202605230200"',
+    'OPENCODE_PLUGIN_VERSION="1.14.19"',
+  ])
+
+  expect(result.exitCode).toBe(0)
+  expect(decode(result.stdout).trim()).toBe("1.14.19")
+})

--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -4,6 +4,7 @@ import { Script } from "@opencode-ai/script"
 import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
+import pluginPkg from "../../plugin/package.json"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -57,6 +58,7 @@ await Bun.build({
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
     OPENCODE_VERSION: `'${Script.version}'`,
+    OPENCODE_PLUGIN_VERSION: `'${pluginPkg.version}'`,
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -15,6 +15,7 @@ await import("./generate.ts")
 
 import { Script } from "@opencode-ai/script"
 import pkg from "../package.json"
+import pluginPkg from "../../plugin/package.json"
 
 // Load migrations from migration directories
 const migrationDirs = (
@@ -200,6 +201,7 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts", ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
+      OPENCODE_PLUGIN_VERSION: `'${pluginPkg.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -49,6 +49,7 @@ import { Npm } from "@opencode-ai/core/npm"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@/util/flock"
 import { Installation } from "@/installation"
+import { InstallationPluginVersion } from "@opencode-ai/core/installation/version"
 import { withLifecycleOrigin } from "@/session/lifecycle-provenance"
 import { Runtime } from "@opencode-ai/core/runtime"
 
@@ -97,6 +98,10 @@ async function isWritable(dir: string) {
   } catch {
     return false
   }
+}
+
+function configPluginDependencyTarget() {
+  return Installation.isLocal() ? "*" : InstallationPluginVersion
 }
 
 // Custom merge function that concatenates array fields instead of replacing them
@@ -1300,7 +1305,7 @@ export async function installDependencies(dir: string) {
   await using _ = await Flock.acquire(key)
 
   const pkg = path.join(dir, "package.json")
-  const target = Installation.isLocal() ? "*" : Installation.VERSION
+  const target = configPluginDependencyTarget()
   const json = await Filesystem.readJson<Package>(pkg).catch(
     (): Package => ({
       dependencies: {},

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -32,6 +32,7 @@ import { ConfigPlugin } from "@/config/plugin"
 import { withConfigDepsLock } from "../shared/config-deps-lock"
 import { writeInstalledConfigDeps } from "../shared/mock-npm-install"
 import { Npm } from "@opencode-ai/core/npm"
+import { InstallationPluginVersion } from "@opencode-ai/core/installation/version"
 import { Installation } from "../../src/installation"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 
@@ -1498,6 +1499,30 @@ test("installDependencies bootstraps the config plugin package metadata", async 
     expect(await Filesystem.readText(path.join(tmp.path, ".gitignore"))).toContain("package-lock.json")
     expect(install).toHaveBeenCalledWith(tmp.path)
   } finally {
+    install.mockRestore()
+  }
+})
+
+test("installDependencies does not pin config plugin metadata to a packaged app build version", async () => {
+  await using tmp = await tmpdir()
+  const install = spyOn(Npm, "install").mockResolvedValue(undefined)
+  const previousVersion = Installation.VERSION
+  const previousChannel = Installation.CHANNEL
+
+  try {
+    ;(Installation as { VERSION: string }).VERSION = "0.0.0-prod-202605230200"
+    ;(Installation as { CHANNEL: string }).CHANNEL = "prod"
+
+    await Config.installDependencies(tmp.path)
+
+    const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
+
+    expect(pkg.dependencies?.["@opencode-ai/plugin"]).toBe(InstallationPluginVersion)
+    expect(pkg.dependencies?.["@opencode-ai/plugin"]).not.toBe(Installation.VERSION)
+    expect(install).toHaveBeenCalledWith(tmp.path)
+  } finally {
+    ;(Installation as { VERSION: string }).VERSION = previousVersion
+    ;(Installation as { CHANNEL: string }).CHANNEL = previousChannel
     install.mockRestore()
   }
 })


### PR DESCRIPTION
## Summary

Decouple the config-scoped `@opencode-ai/plugin` dependency from the packaged PawWork/OpenCode build version.

This PR has no related GitHub issue; it comes from a local v2026.5.23 startup log investigation where `~/.pawwork/package.json` was written but `node_modules` was never installed.

## Why

PawWork config dependency bootstrap wrote `@opencode-ai/plugin` using `Installation.VERSION`. In the packaged app, that value can be a synthetic app build version such as `0.0.0-prod-202605230200`, while `@opencode-ai/plugin` is published on its own npm version line. npm returns E404 for that synthetic version, so `Npm.install()` fails after `package.json` is written.

The fix injects a separate `OPENCODE_PLUGIN_VERSION` from `packages/plugin/package.json` during opencode server builds, and `installDependencies()` uses that value for the config plugin dependency. Local development still uses `*`. As a review follow-up, non-local builds now fail fast if the plugin version define is missing instead of silently falling back to npm `latest`.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that the config dependency target is sourced from the plugin package version, not the app build version, and that packaged builds fail fast if the plugin version define is missing.

## Risk Notes

No visible UI or copy changed, so manual UI verification is skipped. Platform impact was considered because config dependency installation runs inside packaged macOS and Windows desktop flows; this changes only the plugin version metadata passed to npm and adds an explicit startup/build-runtime guard for missing packaged plugin metadata. Dependency/local-file impact is limited to the `@opencode-ai/plugin` entry written into config-scope `package.json` files.

## How To Verify

```text
npm view @opencode-ai/plugin@0.0.0-prod-202605230200 version --json: E404, confirming the packaged app build version is not a plugin npm version
npm view @opencode-ai/plugin@1.14.19 version --json: returned 1.14.19
bun --cwd packages/core test test/installation-version.test.ts: 2 pass, 0 fail
bun --cwd packages/opencode test test/config/config.test.ts --test-name-pattern "installDependencies|service dependency loading uses config plugin package metadata": 3 pass, 0 fail
bun --cwd packages/core test test/npm.test.ts: 4 pass, 0 fail
bun --cwd packages/core typecheck: passed
bun --cwd packages/opencode typecheck: passed
git diff --check: passed
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved plugin version tracking and injection during builds
  * Enhanced dependency resolution to use correct plugin versions
  
* **Tests**
  * Added validation tests for plugin version handling in production builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->