### PR TITLE
fix: reduce perf comparator false positives

### DIFF
--- a/packages/app/script/compare-perf.ts
+++ b/packages/app/script/compare-perf.ts
@@ -30,8 +30,19 @@ async function readFailureScope(filePath: string): Promise<{ scenarioKeys: strin
   if (!Array.isArray(payload.scenarios)) {
     throw new Error(`Expected a perf comparison with scenarios in ${filePath}`)
   }
+  if (!Array.isArray(payload.failures)) {
+    throw new Error(`Expected a perf comparison with failures in ${filePath}`)
+  }
   const scenarioKeys = new Set<string>()
   const failureKeys = new Set<PerfFailureKey>()
+
+  for (const failure of payload.failures) {
+    if (failure.startsWith("missing_base_scenario:")) {
+      scenarioKeys.add(failure.slice("missing_base_scenario:".length))
+    } else if (failure.startsWith("missing_head_scenario:")) {
+      scenarioKeys.add(failure.slice("missing_head_scenario:".length))
+    }
+  }
 
   for (const scenario of payload.scenarios) {
     if (scenario.failures.length === 0) continue

--- a/packages/app/script/compare-perf.ts
+++ b/packages/app/script/compare-perf.ts
@@ -2,8 +2,10 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import {
   comparePerfBaselines,
+  perfFailureKey,
   renderPerfBaselineComment,
   type PerfBaselineComparison,
+  type PerfFailureKey,
   type PerfScenarioSummary,
 } from "../src/testing/perf-metrics"
 
@@ -23,14 +25,26 @@ async function readPerfFile(filePath: string) {
   return payload
 }
 
-async function readFailureScenarioKeys(filePath: string) {
+async function readFailureScope(filePath: string): Promise<{ scenarioKeys: string[]; failureKeys: PerfFailureKey[] }> {
   const payload = JSON.parse(await fs.readFile(filePath, "utf8")) as PerfBaselineComparison
   if (!Array.isArray(payload.scenarios)) {
     throw new Error(`Expected a perf comparison with scenarios in ${filePath}`)
   }
-  return payload.scenarios
-    .filter((scenario) => scenario.failures.length > 0)
-    .map((scenario) => `${scenario.profile}:${scenario.scenario}`)
+  const scenarioKeys = new Set<string>()
+  const failureKeys = new Set<PerfFailureKey>()
+
+  for (const scenario of payload.scenarios) {
+    if (scenario.failures.length === 0) continue
+    scenarioKeys.add(`${scenario.profile}:${scenario.scenario}`)
+    for (const failure of scenario.failures) {
+      failureKeys.add(perfFailureKey({ profile: scenario.profile, scenario: scenario.scenario, metric: failure }))
+    }
+  }
+
+  return {
+    scenarioKeys: [...scenarioKeys],
+    failureKeys: [...failureKeys],
+  }
 }
 
 async function inferFailureScenarioSource(input: { outputPath?: string; failuresFromPath?: string }) {
@@ -59,12 +73,17 @@ async function main() {
   }
 
   const failuresSourcePath = await inferFailureScenarioSource({ outputPath, failuresFromPath })
-  const [base, head, scenarioKeys] = await Promise.all([
+  const [base, head, failureScope] = await Promise.all([
     readPerfFile(basePath),
     readPerfFile(headPath),
-    failuresSourcePath ? readFailureScenarioKeys(failuresSourcePath) : undefined,
+    failuresSourcePath ? readFailureScope(failuresSourcePath) : undefined,
   ])
-  const comparison = comparePerfBaselines({ base, head, scenarioKeys })
+  const comparison = comparePerfBaselines({
+    base,
+    head,
+    scenarioKeys: failureScope?.scenarioKeys,
+    failureKeys: failureScope?.failureKeys,
+  })
 
   if (outputPath) {
     await fs.mkdir(path.dirname(outputPath), { recursive: true })
@@ -79,6 +98,7 @@ async function main() {
     pass: comparison.pass,
     failures: comparison.failures,
     warnings: comparison.warnings,
+    confirmation: comparison.confirmation,
   }
   console.log(JSON.stringify(summary, null, 2))
 

--- a/packages/app/src/testing/compare-perf-script.test.ts
+++ b/packages/app/src/testing/compare-perf-script.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { PerfBaselineComparison, PerfProfile, PerfScenarioSummary } from "./perf-metrics"
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+function scenario(input: {
+  branch: string
+  profile?: PerfProfile
+  scenario?: string
+  interaction?: number
+  frameMax?: number
+}): PerfScenarioSummary {
+  const interaction = input.interaction ?? 40
+  return {
+    branch: input.branch,
+    profile: input.profile ?? "default",
+    scenario: input.scenario ?? "session-scroll-reading",
+    runs: 3,
+    interaction_ms_median: interaction,
+    interaction_ms_worst: interaction,
+    interaction_ms: interaction,
+    interaction_delay_ms: 0,
+    long_task_count: 0,
+    long_task_max_ms: 0,
+    tbt_ms: 0,
+    frame_gap_p95_ms: 16,
+    frame_gap_max_ms: input.frameMax ?? 16,
+    jank_count_50ms: 0,
+    cls: 0,
+    window_ms: 900,
+    run_details: [],
+  }
+}
+
+async function writeJson(filePath: string, payload: unknown) {
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`)
+}
+
+describe("compare-perf script", () => {
+  test("confirms only the initial metric failure key from failures-from", async () => {
+    const root = await mkdtemp(join(tmpdir(), "compare-perf-script-"))
+    tempRoots.push(root)
+    const basePath = join(root, "base.json")
+    const headPath = join(root, "head.json")
+    const initialPath = join(root, "perf-compare.json")
+    const outputPath = join(root, "perf-compare-confirm.json")
+    const initialComparison: PerfBaselineComparison = {
+      pass: false,
+      failures: ["default:session-scroll-reading:interaction_ms_median"],
+      warnings: [],
+      scenarios: [
+        {
+          profile: "default",
+          scenario: "session-scroll-reading",
+          pass: false,
+          failures: ["interaction_ms_median"],
+          warnings: [],
+          base: scenario({ branch: "base", interaction: 48 }),
+          head: scenario({ branch: "head", interaction: 76 }),
+        },
+      ],
+    }
+
+    await writeJson(basePath, [scenario({ branch: "base", interaction: 32, frameMax: 16 })])
+    await writeJson(headPath, [scenario({ branch: "head", interaction: 40, frameMax: 120 })])
+    await writeJson(initialPath, initialComparison)
+
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "script/compare-perf.ts",
+        "--base",
+        basePath,
+        "--head",
+        headPath,
+        "--output",
+        outputPath,
+        "--failures-from",
+        initialPath,
+      ],
+      {
+        cwd: process.cwd(),
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    expect(stderr).toBe("")
+    expect(exitCode).toBe(0)
+    const summary = JSON.parse(stdout) as Pick<PerfBaselineComparison, "confirmation" | "failures" | "pass">
+    expect(summary.pass).toBe(true)
+    expect(summary.failures).toHaveLength(0)
+    expect(summary.confirmation).toEqual({
+      initialFailureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+      rawConfirmedFailures: ["default:session-scroll-reading:frame_gap_max_ms_delta"],
+      intersectedFailures: [],
+    })
+    const comparison = JSON.parse(await readFile(outputPath, "utf8")) as PerfBaselineComparison
+    expect(comparison.pass).toBe(true)
+    expect(comparison.failures).toHaveLength(0)
+    expect(comparison.confirmation).toEqual({
+      initialFailureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+      rawConfirmedFailures: ["default:session-scroll-reading:frame_gap_max_ms_delta"],
+      intersectedFailures: [],
+    })
+  })
+})

--- a/packages/app/src/testing/compare-perf-script.test.ts
+++ b/packages/app/src/testing/compare-perf-script.test.ts
@@ -116,4 +116,57 @@ describe("compare-perf script", () => {
       intersectedFailures: [],
     })
   })
+
+  test("keeps top-level missing scenario failures in the confirmation scope", async () => {
+    const root = await mkdtemp(join(tmpdir(), "compare-perf-script-"))
+    tempRoots.push(root)
+    const basePath = join(root, "base.json")
+    const headPath = join(root, "head.json")
+    const initialPath = join(root, "perf-compare.json")
+    const outputPath = join(root, "perf-compare-confirm.json")
+    const initialComparison: PerfBaselineComparison = {
+      pass: false,
+      failures: ["missing_head_scenario:default:session-scroll-reading"],
+      warnings: [],
+      scenarios: [],
+    }
+
+    await writeJson(basePath, [scenario({ branch: "base" })])
+    await writeJson(headPath, [])
+    await writeJson(initialPath, initialComparison)
+
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "script/compare-perf.ts",
+        "--base",
+        basePath,
+        "--head",
+        headPath,
+        "--output",
+        outputPath,
+        "--failures-from",
+        initialPath,
+      ],
+      {
+        cwd: process.cwd(),
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    expect(stderr).toBe("")
+    expect(exitCode).toBe(1)
+    const summary = JSON.parse(stdout) as Pick<PerfBaselineComparison, "failures" | "pass">
+    expect(summary.pass).toBe(false)
+    expect(summary.failures).toEqual(["missing_head_scenario:default:session-scroll-reading"])
+    const comparison = JSON.parse(await readFile(outputPath, "utf8")) as PerfBaselineComparison
+    expect(comparison.pass).toBe(false)
+    expect(comparison.failures).toEqual(["missing_head_scenario:default:session-scroll-reading"])
+  })
 })

--- a/packages/app/src/testing/perf-metrics.test.ts
+++ b/packages/app/src/testing/perf-metrics.test.ts
@@ -434,6 +434,73 @@ describe("perf metrics", () => {
     ])
   })
 
+  test("does not confirm a different metric failure from the same scenario", () => {
+    const result = comparePerfBaselines({
+      base: [scenario({ branch: "base", scenario: "session-scroll-reading", interaction: 32, frameMax: 16 })],
+      head: [scenario({ branch: "head", scenario: "session-scroll-reading", interaction: 40, frameMax: 120 })],
+      scenarioKeys: ["default:session-scroll-reading"],
+      failureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+
+    expect(result.pass).toBe(true)
+    expect(result.failures).toHaveLength(0)
+    expect(result.scenarios[0].failures).toHaveLength(0)
+    expect(result.confirmation).toEqual({
+      initialFailureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+      rawConfirmedFailures: ["default:session-scroll-reading:frame_gap_max_ms_delta"],
+      intersectedFailures: [],
+    })
+  })
+
+  test("confirms the same metric failure from the same scenario", () => {
+    const result = comparePerfBaselines({
+      base: [scenario({ branch: "base", scenario: "session-scroll-reading", interaction: 48 })],
+      head: [scenario({ branch: "head", scenario: "session-scroll-reading", interaction: 76 })],
+      scenarioKeys: ["default:session-scroll-reading"],
+      failureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+
+    expect(result.pass).toBe(false)
+    expect(result.failures).toEqual(["default:session-scroll-reading:interaction_ms_median"])
+    expect(result.scenarios[0].failures).toEqual(["interaction_ms_median"])
+    expect(result.confirmation).toEqual({
+      initialFailureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+      rawConfirmedFailures: ["default:session-scroll-reading:interaction_ms_median"],
+      intersectedFailures: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+  })
+
+  test("keeps missing requested confirmation scenarios as hard failures", () => {
+    const missingHead = comparePerfBaselines({
+      base: [scenario({ branch: "base", scenario: "session-scroll-reading" })],
+      head: [],
+      scenarioKeys: ["default:session-scroll-reading"],
+      failureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+    const missingBase = comparePerfBaselines({
+      base: [],
+      head: [scenario({ branch: "head", scenario: "session-scroll-reading" })],
+      scenarioKeys: ["default:session-scroll-reading"],
+      failureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+    const missingBoth = comparePerfBaselines({
+      base: [],
+      head: [],
+      scenarioKeys: ["default:session-scroll-reading"],
+      failureKeys: ["default:session-scroll-reading:interaction_ms_median"],
+    })
+
+    expect(missingHead.pass).toBe(false)
+    expect(missingHead.failures).toEqual(["missing_head_scenario:default:session-scroll-reading"])
+    expect(missingBase.pass).toBe(false)
+    expect(missingBase.failures).toEqual(["missing_base_scenario:default:session-scroll-reading"])
+    expect(missingBoth.pass).toBe(false)
+    expect(missingBoth.failures).toEqual([
+      "missing_base_scenario:default:session-scroll-reading",
+      "missing_head_scenario:default:session-scroll-reading",
+    ])
+  })
+
   test("keeps low-end moderate regressions warning-only", () => {
     const result = comparePerfScenarioSummaries({
       scenario: "session-timeline-recompute",

--- a/packages/app/src/testing/perf-metrics.test.ts
+++ b/packages/app/src/testing/perf-metrics.test.ts
@@ -405,6 +405,20 @@ describe("perf metrics", () => {
     ])
   })
 
+  test("deduplicates fallback comparison keys from baseline scenarios", () => {
+    const result = comparePerfBaselines({
+      base: [
+        scenario({ branch: "base", profile: "default", scenario: "session-scroll-reading" }),
+        scenario({ branch: "base", profile: "default", scenario: "session-scroll-reading" }),
+      ],
+      head: [scenario({ branch: "head", profile: "default", scenario: "session-scroll-reading" })],
+    })
+
+    expect(result.scenarios.map((entry) => `${entry.profile}:${entry.scenario}`)).toEqual([
+      "default:session-scroll-reading",
+    ])
+  })
+
   test("fails when the matching profile and scenario is missing", () => {
     const base = [
       scenario({ branch: "base", profile: "default", scenario: "session-timeline-recompute" }),

--- a/packages/app/src/testing/perf-metrics.test.ts
+++ b/packages/app/src/testing/perf-metrics.test.ts
@@ -160,6 +160,39 @@ describe("perf metrics", () => {
     expect(summary.run_details).toHaveLength(3)
   })
 
+  test("does not fail default interaction median on a single-frame delta", () => {
+    const result = comparePerfScenarioSummaries({
+      scenario: "long-session-input-lag",
+      base: scenario({ branch: "base", scenario: "long-session-input-lag", interaction: 48 }),
+      head: scenario({ branch: "head", scenario: "long-session-input-lag", interaction: 64 }),
+    })
+
+    expect(result.pass).toBe(true)
+    expect(result.failures).not.toContain("interaction_ms_median")
+  })
+
+  test("keeps default interaction median at the 20ms floor passing", () => {
+    const result = comparePerfScenarioSummaries({
+      scenario: "long-session-input-lag",
+      base: scenario({ branch: "base", scenario: "long-session-input-lag", interaction: 100 }),
+      head: scenario({ branch: "head", scenario: "long-session-input-lag", interaction: 120 }),
+    })
+
+    expect(result.pass).toBe(true)
+    expect(result.failures).not.toContain("interaction_ms_median")
+  })
+
+  test("fails default interaction median above the 20ms floor", () => {
+    const result = comparePerfScenarioSummaries({
+      scenario: "long-session-input-lag",
+      base: scenario({ branch: "base", scenario: "long-session-input-lag", interaction: 100 }),
+      head: scenario({ branch: "head", scenario: "long-session-input-lag", interaction: 121 }),
+    })
+
+    expect(result.pass).toBe(false)
+    expect(result.failures).toContain("interaction_ms_median")
+  })
+
   test("fails a scenario when median regression breaks both the ms and percentage budgets", () => {
     const result = comparePerfScenarioSummaries({
       scenario: "session-streaming-long",
@@ -187,9 +220,9 @@ describe("perf metrics", () => {
         profile: "default",
         scenario: "session-streaming-long",
         runs: 3,
-        interaction_ms_median: 116,
+        interaction_ms_median: 125,
         interaction_ms_worst: 168,
-        interaction_ms: 116,
+        interaction_ms: 125,
         interaction_delay_ms: 14,
         long_task_count: 1,
         long_task_max_ms: 88,
@@ -501,7 +534,7 @@ describe("perf metrics", () => {
           scenario: "session-scroll-reading",
           runs: [
             {
-              interaction_ms: 32,
+              interaction_ms: 40,
               interaction_delay_ms: 1,
               long_task_count: 0,
               long_task_max_ms: 0,

--- a/packages/app/src/testing/perf-metrics.ts
+++ b/packages/app/src/testing/perf-metrics.ts
@@ -74,7 +74,7 @@ export type PerfBaselineComparison = {
 export const PERF_COMMENT_MARKER = "<!-- pawwork-perf-probe-baseline -->"
 
 const perfDeltaThresholds = {
-  interactionMedianMs: 10,
+  interactionMedianMs: 20,
   interactionMedianRatio: 1.05,
   interactionWorstMs: 50,
   longTaskMaxMs: 25,

--- a/packages/app/src/testing/perf-metrics.ts
+++ b/packages/app/src/testing/perf-metrics.ts
@@ -64,11 +64,20 @@ export type PerfScenarioComparison = {
   head: PerfScenarioSummary
 }
 
+export type PerfFailureKey = string
+
+export type PerfBaselineConfirmation = {
+  initialFailureKeys: PerfFailureKey[]
+  rawConfirmedFailures: string[]
+  intersectedFailures: string[]
+}
+
 export type PerfBaselineComparison = {
   pass: boolean
   failures: string[]
   warnings: string[]
   scenarios: PerfScenarioComparison[]
+  confirmation?: PerfBaselineConfirmation
 }
 
 export const PERF_COMMENT_MARKER = "<!-- pawwork-perf-probe-baseline -->"
@@ -420,40 +429,93 @@ function scenarioKey(input: { profile?: PerfProfile; scenario: string }) {
   return `${input.profile ?? "default"}:${input.scenario}`
 }
 
+export function perfFailureKey(input: { profile?: PerfProfile; scenario: string; metric: string }): PerfFailureKey {
+  return `${scenarioKey(input)}:${input.metric}`
+}
+
+function pushUnique(list: string[], value: string) {
+  if (!list.includes(value)) list.push(value)
+}
+
 export function comparePerfBaselines(input: {
   base: PerfScenarioSummary[]
   head: PerfScenarioSummary[]
   scenarioKeys?: string[]
+  failureKeys?: PerfFailureKey[]
 }): PerfBaselineComparison {
   const failures: string[] = []
   const warnings: string[] = []
   const scenarios: PerfScenarioComparison[] = []
+  const baseByScenario = new Map(input.base.map((scenario) => [scenarioKey(scenario), scenario]))
   const headByScenario = new Map(input.head.map((scenario) => [scenarioKey(scenario), scenario]))
-  const requestedScenarioKeys = input.scenarioKeys ? new Set(input.scenarioKeys) : undefined
+  const requestedScenarioKeys = input.scenarioKeys ? [...new Set(input.scenarioKeys)] : undefined
+  const requestedFailureKeys = input.failureKeys ? new Set(input.failureKeys) : undefined
+  const confirmation: PerfBaselineConfirmation | undefined = input.failureKeys
+    ? {
+        initialFailureKeys: [...new Set(input.failureKeys)],
+        rawConfirmedFailures: [],
+        intersectedFailures: [],
+      }
+    : undefined
 
-  for (const baseScenario of input.base) {
-    const key = scenarioKey(baseScenario)
-    if (requestedScenarioKeys && !requestedScenarioKeys.has(key)) continue
+  function addHardFailure(failure: string) {
+    pushUnique(failures, failure)
+    if (!confirmation) return
+    pushUnique(confirmation.rawConfirmedFailures, failure)
+    pushUnique(confirmation.intersectedFailures, failure)
+  }
+
+  const comparisonKeys = requestedScenarioKeys ?? input.base.map((scenario) => scenarioKey(scenario))
+
+  for (const key of comparisonKeys) {
+    const baseScenario = baseByScenario.get(key)
     const headScenario = headByScenario.get(key)
+    if (!baseScenario) {
+      addHardFailure(`missing_base_scenario:${key}`)
+    }
     if (!headScenario) {
-      failures.push(`missing_head_scenario:${key}`)
+      addHardFailure(`missing_head_scenario:${key}`)
+    }
+    if (!baseScenario || !headScenario) {
       continue
     }
-    const comparison = comparePerfScenarioSummaries({
+
+    const rawComparison = comparePerfScenarioSummaries({
       scenario: baseScenario.scenario,
       base: baseScenario,
       head: headScenario,
     })
+    const filteredFailures: string[] = []
+    for (const failure of rawComparison.failures) {
+      const fullFailureKey = perfFailureKey({
+        profile: rawComparison.profile,
+        scenario: rawComparison.scenario,
+        metric: failure,
+      })
+      if (confirmation) pushUnique(confirmation.rawConfirmedFailures, fullFailureKey)
+      if (requestedFailureKeys && !requestedFailureKeys.has(fullFailureKey)) continue
+      pushUnique(filteredFailures, failure)
+      pushUnique(failures, fullFailureKey)
+      if (confirmation) pushUnique(confirmation.intersectedFailures, fullFailureKey)
+    }
+
+    const comparison = requestedFailureKeys
+      ? {
+          ...rawComparison,
+          pass: filteredFailures.length === 0,
+          failures: filteredFailures,
+        }
+      : rawComparison
     scenarios.push(comparison)
-    for (const failure of comparison.failures) failures.push(`${key}:${failure}`)
-    for (const warning of comparison.warnings) warnings.push(`${key}:${warning}`)
+    for (const warning of comparison.warnings) pushUnique(warnings, `${key}:${warning}`)
   }
 
-  for (const headScenario of input.head) {
-    const key = scenarioKey(headScenario)
-    if (requestedScenarioKeys && !requestedScenarioKeys.has(key)) continue
-    if (!input.base.some((scenario) => scenarioKey(scenario) === key)) {
-      failures.push(`missing_base_scenario:${key}`)
+  if (!requestedScenarioKeys) {
+    for (const headScenario of input.head) {
+      const key = scenarioKey(headScenario)
+      if (!baseByScenario.has(key)) {
+        addHardFailure(`missing_base_scenario:${key}`)
+      }
     }
   }
 
@@ -462,5 +524,6 @@ export function comparePerfBaselines(input: {
     failures,
     warnings,
     scenarios,
+    confirmation,
   }
 }

--- a/packages/app/src/testing/perf-metrics.ts
+++ b/packages/app/src/testing/perf-metrics.ts
@@ -465,7 +465,7 @@ export function comparePerfBaselines(input: {
     pushUnique(confirmation.intersectedFailures, failure)
   }
 
-  const comparisonKeys = requestedScenarioKeys ?? input.base.map((scenario) => scenarioKey(scenario))
+  const comparisonKeys = requestedScenarioKeys ?? [...new Set(input.base.map((scenario) => scenarioKey(scenario)))]
 
   for (const key of comparisonKeys) {
     const baseScenario = baseByScenario.get(key)


### PR DESCRIPTION
## Summary

- Raise the default `interaction_ms_median` floor from `10ms` to `20ms` so single-frame-ish deltas do not block the gate.
- Confirm perf-probe failures by full `profile:scenario:metric` keys instead of any failure in the same scenario.
- Keep requested confirm scenarios as hard input-integrity failures and expose confirmation diagnostics in JSON/stdout.

## Why

Issue #736 showed two structural false positives in the perf comparator: the default interaction median threshold treated below-frame timing noise as a blocking regression, and the confirm pass could fail when a different metric regressed in the same scenario. This keeps the gate blocking only when the same metric failure repeats, while still failing corrupted or incomplete confirm artifacts.

## Related Issue

Closes #736.

## Human Review Status

Pending

## Review Focus

Please check the boundary between metric-key filtering and hard missing-scenario failures, especially the requested scenario case where base and head are both absent.

## Risk Notes

Behavior risk: this intentionally stops blocking on default `interaction_ms_median` deltas at or below `20ms`, and on confirm-stage failures for different metrics in the same scenario. Catastrophic thresholds, low-end warning behavior, the perf scenario list, and the #746/#853 probe-window guard are unchanged.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable, no visible UI or copy changed.
- macOS/Windows platform check: not applicable, no platform, packaging, updater, signing, shell, or permissions surface changed.
- Docs/release/dependencies/permissions check: not applicable, no docs, release notes, dependencies, permissions, credentials, deletion, generated content, or local-file surfaces changed.

Pre-fix workflow context only: the most recent 50 `perf-probe-baseline` runs sampled before this PR showed 38 success, 11 failure, and 1 run with no conclusion. This PR still relies on post-merge/PR CI to measure whether the false-positive rate drops in practice.

## How To Verify

```text
bun --cwd packages/app test
Result: 1541 pass, 0 fail, 3635 expect() calls.

bun --cwd packages/app typecheck
Result: tsgo -b completed with exit code 0.

git diff --check origin/dev...HEAD
Result: no whitespace errors.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
