### PR TITLE
refactor(app): replace right-panel status todo dots with widget marker

### DIFF
--- a/packages/app/e2e/snap/status-summary-todos.snap.ts
+++ b/packages/app/e2e/snap/status-summary-todos.snap.ts
@@ -82,7 +82,10 @@ test("status-summary-todos", async ({ page, project }) => {
   // so a partial render does not silently produce a misleading baseline.
   const todoRows = page.locator('[data-slot="status-summary-todo"]')
   await todoRows.first().waitFor({ state: "visible", timeout: 30_000 })
-  await expect.poll(() => todoRows.count(), { timeout: 30_000 }).toBeGreaterThanOrEqual(4)
+  // Exactly the four seeded states — strict equality so a leaked previous turn
+  // or duplicated render surfaces as a failure instead of silently producing a
+  // misleading baseline.
+  await expect.poll(() => todoRows.count(), { timeout: 30_000 }).toBe(4)
 
   // animations: "disabled" freezes CSS animations at their initial frame so the
   // in_progress 13×13 pw-spin ring captures the same orientation every run;

--- a/packages/app/e2e/snap/status-summary-todos.snap.ts
+++ b/packages/app/e2e/snap/status-summary-todos.snap.ts
@@ -1,0 +1,91 @@
+import type { Todo } from "@opencode-ai/sdk/v2/client"
+import type { createSdk } from "../utils"
+import { test } from "../fixtures"
+import { openRightPanel, openSidebar } from "../actions"
+import { sessionItemSelector } from "../selectors"
+import { composeGrid, snapOutputPath } from "./_compose"
+
+type Sdk = ReturnType<typeof createSdk>
+
+// Slice 3 of Area B (#602) replaces the right-panel Status todo dots with the
+// canonical todo widget marker (Icon + 13×13 pw-spin ring) per DESIGN.md L201.
+// This target screenshots the right panel after seeding todos in all four
+// states so the marker rendering itself has a durable baseline; the composer
+// dock variant lives in todo-dock-restored.snap.ts.
+
+async function seedSessionTurn(input: { sdk: Sdk; sessionID: string }) {
+  await input.sdk.session.prompt({
+    sessionID: input.sessionID,
+    noReply: true,
+    parts: [{ type: "text", text: "status summary todos snap seed" }],
+  })
+}
+
+async function updateTodos(input: {
+  url: string
+  directory: string
+  sessionID: string
+  todos: Array<Pick<Todo, "content" | "status" | "priority">>
+}) {
+  const response = await fetch(
+    `${input.url}/session/__e2e/update-todos?directory=${encodeURIComponent(input.directory)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionID: input.sessionID, todos: input.todos }),
+    },
+  )
+  if (response.status !== 204) {
+    throw new Error(`updateTodos failed: ${response.status} ${await response.text()}`)
+  }
+}
+
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+test("status-summary-todos", async ({ page, project }) => {
+  let sessionID: string | undefined
+  await project.open({
+    beforeGoto: async ({ sdk }) => {
+      const session = await sdk.session.create({ title: "snap status summary todos" }).then((res) => res.data)
+      sessionID = session?.id
+      if (sessionID) await seedSessionTurn({ sdk, sessionID })
+    },
+  })
+  if (!sessionID) throw new Error("Session create did not return an id")
+  project.trackSession(sessionID)
+
+  // Cover every marker variant: completed (circle-check) / in_progress (13×13 spin ring)
+  // / pending (circle outline) / cancelled (circle outline + line-through).
+  await updateTodos({
+    url: project.url,
+    directory: project.directory,
+    sessionID,
+    todos: [
+      { content: "Wire status summary markers", status: "completed", priority: "high" },
+      { content: "Cover all four states in snap", status: "in_progress", priority: "high" },
+      { content: "Queue follow-up cleanup", status: "pending", priority: "medium" },
+      { content: "Notify user for review", status: "cancelled", priority: "low" },
+    ],
+  })
+
+  // Navigate via sidebar click — this matches todo-dock-restored.snap.ts and
+  // gives globalSync time to publish session_todo updates before the Status tab
+  // body is queried.
+  await openSidebar(page)
+  await page.locator(sessionItemSelector(sessionID)).click()
+
+  const panel = await openRightPanel(page)
+
+  // Status is the default sidePanelTab per RIGHT_PANEL_TAB_VALUES normalisation,
+  // so no tab switch is required. Wait until at least one todo row is on screen
+  // to confirm the Status tab body has actually rendered before snapping.
+  await page
+    .locator('[data-slot="status-summary-todo"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 30_000 })
+
+  const shot = await panel.screenshot()
+  const out = snapOutputPath("status-summary-todos")
+  await composeGrid([{ name: "right-panel status todos", buf: shot }], out)
+  process.stdout.write(`\n[snap] status-summary-todos grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/status-summary-todos.snap.ts
+++ b/packages/app/e2e/snap/status-summary-todos.snap.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test"
 import type { Todo } from "@opencode-ai/sdk/v2/client"
 import type { createSdk } from "../utils"
 import { test } from "../fixtures"
@@ -77,14 +78,16 @@ test("status-summary-todos", async ({ page, project }) => {
   const panel = await openRightPanel(page)
 
   // Status is the default sidePanelTab per RIGHT_PANEL_TAB_VALUES normalisation,
-  // so no tab switch is required. Wait until at least one todo row is on screen
-  // to confirm the Status tab body has actually rendered before snapping.
-  await page
-    .locator('[data-slot="status-summary-todo"]')
-    .first()
-    .waitFor({ state: "visible", timeout: 30_000 })
+  // so no tab switch is required. Wait until ALL four seeded rows are on screen
+  // so a partial render does not silently produce a misleading baseline.
+  const todoRows = page.locator('[data-slot="status-summary-todo"]')
+  await todoRows.first().waitFor({ state: "visible", timeout: 30_000 })
+  await expect.poll(() => todoRows.count(), { timeout: 30_000 }).toBeGreaterThanOrEqual(4)
 
-  const shot = await panel.screenshot()
+  // animations: "disabled" freezes CSS animations at their initial frame so the
+  // in_progress 13×13 pw-spin ring captures the same orientation every run;
+  // without this the snap is nondeterministic across rebuilds.
+  const shot = await panel.screenshot({ animations: "disabled" })
   const out = snapOutputPath("status-summary-todos")
   await composeGrid([{ name: "right-panel status todos", buf: shot }], out)
   process.stdout.write(`\n[snap] status-summary-todos grid -> ${out}\n\n`)

--- a/packages/app/src/components/session/session-status-summary.test.ts
+++ b/packages/app/src/components/session/session-status-summary.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import * as fs from "node:fs"
-import * as path from "node:path"
 
 // Slice 3 of Area B (#602) replaces the right-panel Status todo dots with the
 // canonical todo widget marker (Icon + 13×13 pw-spin ring) per DESIGN.md L201.
 // We assert against source text so the contract survives without pulling in a
 // Solid renderer; the same pattern is used by session-side-panel.test.tsx.
-const SOURCE = fs.readFileSync(path.join(__dirname, "session-status-summary.tsx"), "utf8")
+const SOURCE = fs.readFileSync(new URL("session-status-summary.tsx", import.meta.url), "utf8")
 
 describe("session-status-summary · todo marker contract", () => {
   test("does not render todo state as a coloured dot", () => {

--- a/packages/app/src/components/session/session-status-summary.test.ts
+++ b/packages/app/src/components/session/session-status-summary.test.ts
@@ -24,9 +24,13 @@ describe("session-status-summary · todo marker contract", () => {
   test("renders the in-progress spinner via --animate-pw-spin", () => {
     // The running marker mirrors session-todo-dock / todowrite: a 13×13 ring with
     // brand-primary as the top border colour, animated by the shared pw-spin token.
+    // Asserting the literal "13px" pixel values guards against the ring being
+    // resized accidentally; the dock uses the same dimensions.
     expect(SOURCE).toContain("--animate-pw-spin")
     expect(SOURCE).toContain("border-top-color")
     expect(SOURCE).toContain("var(--brand-primary)")
+    expect(SOURCE).toMatch(/width:\s*"13px"/)
+    expect(SOURCE).toMatch(/height:\s*"13px"/)
   })
 
   test("strikes through completed and cancelled rows uniformly", () => {

--- a/packages/app/src/components/session/session-status-summary.test.ts
+++ b/packages/app/src/components/session/session-status-summary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+// Slice 3 of Area B (#602) replaces the right-panel Status todo dots with the
+// canonical todo widget marker (Icon + 13×13 pw-spin ring) per DESIGN.md L201.
+// We assert against source text so the contract survives without pulling in a
+// Solid renderer; the same pattern is used by session-side-panel.test.tsx.
+const SOURCE = fs.readFileSync(path.join(__dirname, "session-status-summary.tsx"), "utf8")
+
+describe("session-status-summary · todo marker contract", () => {
+  test("does not render todo state as a coloured dot", () => {
+    // Old implementation used `bg-icon-success-base` / `bg-icon-info-base` /
+    // `bg-border-weak` on a `size-2 rounded-full` div. None of those should remain.
+    expect(SOURCE).not.toMatch(/size-2\s+rounded-full/)
+    expect(SOURCE).not.toMatch(/bg-icon-success-base/)
+    expect(SOURCE).not.toMatch(/bg-icon-info-base/)
+    expect(SOURCE).not.toContain("TODO_STATUS_STYLES")
+  })
+
+  test("maps completed status to the circle-check icon", () => {
+    expect(SOURCE).toMatch(/status === "completed"\s*\?\s*"circle-check"\s*:\s*"circle"/)
+  })
+
+  test("renders the in-progress spinner via --animate-pw-spin", () => {
+    // The running marker mirrors session-todo-dock / todowrite: a 13×13 ring with
+    // brand-primary as the top border colour, animated by the shared pw-spin token.
+    expect(SOURCE).toContain("--animate-pw-spin")
+    expect(SOURCE).toContain("border-top-color")
+    expect(SOURCE).toContain("var(--brand-primary)")
+  })
+
+  test("strikes through completed and cancelled rows uniformly", () => {
+    // Old code only struck cancelled; the dock strikes both. Verify isDone covers both.
+    expect(SOURCE).toMatch(/status === "completed"\s*\|\|\s*props\.todo\.status === "cancelled"/)
+    expect(SOURCE).toContain("line-through text-fg-weak")
+  })
+
+  test("imports Icon from the shared ui package", () => {
+    expect(SOURCE).toMatch(/import\s*\{\s*Icon\s*\}\s*from\s*"@opencode-ai\/ui\/icon"/)
+  })
+})

--- a/packages/app/src/components/session/session-status-summary.test.ts
+++ b/packages/app/src/components/session/session-status-summary.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, test } from "bun:test"
 import * as fs from "node:fs"
 
 // Slice 3 of Area B (#602) replaces the right-panel Status todo dots with the
-// canonical todo widget marker (Icon + 13×13 pw-spin ring) per DESIGN.md L201.
-// We assert against source text so the contract survives without pulling in a
-// Solid renderer; the same pattern is used by session-side-panel.test.tsx.
+// canonical todo widget marker per DESIGN.md L201. The marker itself now lives
+// in packages/ui/components/todo-status-marker.tsx and has its own contract
+// test; this file only guards the right-panel-specific row behaviour:
+// no leftover coloured-dot classes, correct strikethrough rules, and the
+// import wiring that delegates marker rendering to the shared component.
+// Source-text matches the pattern used by session-side-panel.test.tsx.
 const SOURCE = fs.readFileSync(new URL("session-status-summary.tsx", import.meta.url), "utf8")
 
-describe("session-status-summary · todo marker contract", () => {
+describe("session-status-summary · row contract", () => {
   test("does not render todo state as a coloured dot", () => {
     // Old implementation used `bg-icon-success-base` / `bg-icon-info-base` /
     // `bg-border-weak` on a `size-2 rounded-full` div. None of those should remain.
@@ -17,29 +20,21 @@ describe("session-status-summary · todo marker contract", () => {
     expect(SOURCE).not.toContain("TODO_STATUS_STYLES")
   })
 
-  test("maps completed status to the circle-check icon", () => {
-    expect(SOURCE).toMatch(/status === "completed"\s*\?\s*"circle-check"\s*:\s*"circle"/)
-  })
-
-  test("renders the in-progress spinner via --animate-pw-spin", () => {
-    // The running marker mirrors session-todo-dock / todowrite: a 13×13 ring with
-    // brand-primary as the top border colour, animated by the shared pw-spin token.
-    // Asserting the literal "13px" pixel values guards against the ring being
-    // resized accidentally; the dock uses the same dimensions.
-    expect(SOURCE).toContain("--animate-pw-spin")
-    expect(SOURCE).toContain("border-top-color")
-    expect(SOURCE).toContain("var(--brand-primary)")
-    expect(SOURCE).toMatch(/width:\s*"13px"/)
-    expect(SOURCE).toMatch(/height:\s*"13px"/)
+  test("delegates marker rendering to the shared TodoStatusMarker component", () => {
+    // The 13×13 ring + circle/circle-check switch is owned by
+    // packages/ui/components/todo-status-marker.tsx and tested there.
+    expect(SOURCE).toMatch(
+      /import\s*\{\s*TodoStatusMarker\s*\}\s*from\s*"@opencode-ai\/ui\/todo-status-marker"/,
+    )
+    expect(SOURCE).toMatch(/<TodoStatusMarker\s+status=\{props\.todo\.status\}\s+marginTop="1px"\s*\/>/)
+    // The inlined marker JSX must no longer live here.
+    expect(SOURCE).not.toContain("--animate-pw-spin")
+    expect(SOURCE).not.toContain("circle-check")
   })
 
   test("strikes through completed and cancelled rows uniformly", () => {
-    // Old code only struck cancelled; the dock strikes both. Verify isDone covers both.
+    // Original code only struck cancelled; the dock strikes both. Verify isDone covers both.
     expect(SOURCE).toMatch(/status === "completed"\s*\|\|\s*props\.todo\.status === "cancelled"/)
     expect(SOURCE).toContain("line-through text-fg-weak")
-  })
-
-  test("imports Icon from the shared ui package", () => {
-    expect(SOURCE).toMatch(/import\s*\{\s*Icon\s*\}\s*from\s*"@opencode-ai\/ui\/icon"/)
   })
 })

--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -1,17 +1,11 @@
 import { For, Show, createMemo, type Accessor, type JSX } from "solid-js"
+import { Icon } from "@opencode-ai/ui/icon"
 import type { Part } from "@opencode-ai/sdk/v2"
 import type { Todo } from "@opencode-ai/sdk/v2/client"
 import { useLanguage } from "@/context/language"
 import { extractSources } from "@/pages/session/session-status-extractors"
 import { selectSessionTodos } from "@/pages/session/session-todos"
 import type { SessionTodoItem } from "@/pages/session/todos/todo-model"
-
-const TODO_STATUS_STYLES: Record<string, { dot: string; text: string }> = {
-  completed: { dot: "bg-icon-success-base", text: "" },
-  in_progress: { dot: "bg-icon-info-base", text: "" },
-  pending: { dot: "bg-border-weak", text: "" },
-  cancelled: { dot: "bg-border-weak", text: "line-through text-fg-weaker" },
-}
 
 function Section(props: { title: string; children: JSX.Element }) {
   return (
@@ -26,12 +20,68 @@ function Empty(props: { text: string }) {
   return <div class="text-body text-fg-weaker">{props.text}</div>
 }
 
-function TodoRow(props: { todo: SessionTodoItem }) {
-  const style = () => TODO_STATUS_STYLES[props.todo.status] ?? TODO_STATUS_STYLES.pending
+// Status marker mirrors the canonical todo widget (session-todo-dock.tsx + todowrite.tsx):
+// completed → circle-check icon, pending/cancelled → circle icon,
+// in_progress → 13×13 ring with brand-primary top and pw-spin animation.
+// DESIGN.md L201 forbids dots as state signals; this realigns the right-panel Status tab
+// with how the same todos render in the composer dock and message timeline.
+function TodoMarker(props: { status: SessionTodoItem["status"] }) {
   return (
-    <div data-slot="status-summary-todo" data-state={props.todo.status} class="flex items-start gap-2.5 py-1">
-      <div class={`size-2 rounded-full shrink-0 mt-1.5 ${style().dot}`} aria-hidden />
-      <div class={`text-body text-fg-base min-w-0 ${style().text}`}>{props.todo.content}</div>
+    <Show
+      when={props.status === "in_progress"}
+      fallback={
+        <Icon
+          name={props.status === "completed" ? "circle-check" : "circle"}
+          style={{ color: "var(--icon-base)", "flex-shrink": "0", "margin-top": "1px" }}
+        />
+      }
+    >
+      <span
+        data-slot="status-summary-todo-running"
+        style={{
+          display: "inline-flex",
+          "align-items": "center",
+          "justify-content": "center",
+          width: "16px",
+          height: "16px",
+          "flex-shrink": "0",
+          "margin-top": "1px",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            width: "13px",
+            height: "13px",
+            "border-radius": "9999px",
+            border: "1.5px solid var(--border-weak)",
+            "border-top-color": "var(--brand-primary)",
+            animation: "var(--animate-pw-spin)",
+          }}
+        />
+      </span>
+    </Show>
+  )
+}
+
+function TodoRow(props: { todo: SessionTodoItem }) {
+  const isDone = () => props.todo.status === "completed" || props.todo.status === "cancelled"
+  return (
+    <div
+      data-slot="status-summary-todo"
+      data-state={props.todo.status}
+      class="flex items-start gap-2 py-1"
+    >
+      <TodoMarker status={props.todo.status} />
+      <div
+        class="text-body min-w-0"
+        classList={{
+          "line-through text-fg-weak": isDone(),
+          "text-fg-base": !isDone(),
+        }}
+      >
+        {props.todo.content}
+      </div>
     </div>
   )
 }

--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createMemo, type Accessor, type JSX } from "solid-js"
-import { Icon } from "@opencode-ai/ui/icon"
+import { TodoStatusMarker } from "@opencode-ai/ui/todo-status-marker"
 import type { Part } from "@opencode-ai/sdk/v2"
 import type { Todo } from "@opencode-ai/sdk/v2/client"
 import { useLanguage } from "@/context/language"
@@ -20,49 +20,6 @@ function Empty(props: { text: string }) {
   return <div class="text-body text-fg-weaker">{props.text}</div>
 }
 
-// Status marker mirrors the canonical todo widget (session-todo-dock.tsx + todowrite.tsx):
-// completed → circle-check icon, pending/cancelled → circle icon,
-// in_progress → 13×13 ring with brand-primary top and pw-spin animation.
-// DESIGN.md L201 forbids dots as state signals; this realigns the right-panel Status tab
-// with how the same todos render in the composer dock and message timeline.
-function TodoMarker(props: { status: SessionTodoItem["status"] }) {
-  return (
-    <Show
-      when={props.status === "in_progress"}
-      fallback={
-        <Icon
-          name={props.status === "completed" ? "circle-check" : "circle"}
-          style={{ color: "var(--icon-base)", "flex-shrink": "0", "margin-top": "1px" }}
-        />
-      }
-    >
-      <span
-        style={{
-          display: "inline-flex",
-          "align-items": "center",
-          "justify-content": "center",
-          width: "16px",
-          height: "16px",
-          "flex-shrink": "0",
-          "margin-top": "1px",
-        }}
-      >
-        <span
-          style={{
-            display: "inline-block",
-            width: "13px",
-            height: "13px",
-            "border-radius": "9999px",
-            border: "1.5px solid var(--border-weak)",
-            "border-top-color": "var(--brand-primary)",
-            animation: "var(--animate-pw-spin)",
-          }}
-        />
-      </span>
-    </Show>
-  )
-}
-
 function TodoRow(props: { todo: SessionTodoItem }) {
   const isDone = () => props.todo.status === "completed" || props.todo.status === "cancelled"
   return (
@@ -71,7 +28,7 @@ function TodoRow(props: { todo: SessionTodoItem }) {
       data-state={props.todo.status}
       class="flex items-start gap-2 py-1"
     >
-      <TodoMarker status={props.todo.status} />
+      <TodoStatusMarker status={props.todo.status} marginTop="1px" />
       <div
         class="text-body min-w-0 break-words"
         classList={{

--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -37,7 +37,6 @@ function TodoMarker(props: { status: SessionTodoItem["status"] }) {
       }
     >
       <span
-        data-slot="status-summary-todo-running"
         style={{
           display: "inline-flex",
           "align-items": "center",

--- a/packages/app/src/components/session/session-status-summary.tsx
+++ b/packages/app/src/components/session/session-status-summary.tsx
@@ -74,7 +74,7 @@ function TodoRow(props: { todo: SessionTodoItem }) {
     >
       <TodoMarker status={props.todo.status} />
       <div
-        class="text-body min-w-0"
+        class="text-body min-w-0 break-words"
         classList={{
           "line-through text-fg-weak": isDone(),
           "text-fg-base": !isDone(),

--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -1,12 +1,12 @@
 import type { Todo } from "@opencode-ai/sdk/v2"
 import { AnimatedNumber } from "@opencode-ai/ui/animated-number"
-import { Icon } from "@opencode-ai/ui/icon"
 import { DockSegment } from "@opencode-ai/ui/dock-card"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { DockWidgetHeader } from "@/pages/session/composer/dock-widget-header"
 import { useSpring } from "@opencode-ai/ui/motion-spring"
 import { TextReveal } from "@opencode-ai/ui/text-reveal"
 import { TextStrikethrough } from "@opencode-ai/ui/text-strikethrough"
+import { TodoStatusMarker } from "@opencode-ai/ui/todo-status-marker"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { Index, Show, createEffect, createMemo, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
@@ -224,39 +224,7 @@ function TodoList(props: { todos: SessionTodoItem[] }) {
                 opacity: todo().status === "pending" ? "0.94" : "1",
               }}
             >
-              <Show
-                when={todo().status === "in_progress"}
-                fallback={
-                  <Icon
-                    name={todo().status === "completed" ? "circle-check" : "circle"}
-                    style={{ color: "var(--icon-base)", "flex-shrink": "0", "margin-top": "1px" }}
-                  />
-                }
-              >
-                <span
-                  style={{
-                    display: "inline-flex",
-                    "align-items": "center",
-                    "justify-content": "center",
-                    width: "16px",
-                    height: "16px",
-                    "flex-shrink": "0",
-                    "margin-top": "1px",
-                  }}
-                >
-                  <span
-                    style={{
-                      display: "inline-block",
-                      width: "13px",
-                      height: "13px",
-                      "border-radius": "9999px",
-                      border: "1.5px solid var(--border-weak)",
-                      "border-top-color": "var(--brand-primary)",
-                      animation: "var(--animate-pw-spin)",
-                    }}
-                  />
-                </span>
-              </Show>
+              <TodoStatusMarker status={todo().status} marginTop="1px" />
               <TextStrikethrough
                 active={todo().status === "completed" || todo().status === "cancelled"}
                 text={todo().content}

--- a/packages/ui/src/components/message-part/tools/todowrite.tsx
+++ b/packages/ui/src/components/message-part/tools/todowrite.tsx
@@ -2,7 +2,7 @@ import { createMemo, For, Show } from "solid-js"
 import type { Todo } from "@opencode-ai/sdk/v2"
 import { useI18n } from "../../../context/i18n"
 import { BasicTool } from "../../basic-tool"
-import { Icon } from "../../icon"
+import { TodoStatusMarker } from "../../todo-status-marker"
 import { ToolRegistry } from "../registry"
 
 ToolRegistry.register({
@@ -40,38 +40,7 @@ ToolRegistry.register({
             <For each={todos()}>
               {(todo: Todo) => (
                 <div data-slot="message-part-todo-item" data-state={todo.status}>
-                  <Show
-                    when={todo.status === "in_progress"}
-                    fallback={
-                      <Icon
-                        name={todo.status === "completed" ? "circle-check" : "circle"}
-                        style={{ color: "var(--icon-base)", "flex-shrink": "0" }}
-                      />
-                    }
-                  >
-                    <span
-                      style={{
-                        display: "inline-flex",
-                        "align-items": "center",
-                        "justify-content": "center",
-                        width: "16px",
-                        height: "16px",
-                        "flex-shrink": "0",
-                      }}
-                    >
-                      <span
-                        style={{
-                          display: "inline-block",
-                          width: "13px",
-                          height: "13px",
-                          "border-radius": "9999px",
-                          border: "1.5px solid var(--border-weak)",
-                          "border-top-color": "var(--brand-primary)",
-                          animation: "var(--animate-pw-spin)",
-                        }}
-                      />
-                    </span>
-                  </Show>
+                  <TodoStatusMarker status={todo.status} />
                   <span
                     data-slot="message-part-todo-content"
                     data-completed={todo.status === "completed" ? "completed" : undefined}

--- a/packages/ui/src/components/todo-status-marker.test.ts
+++ b/packages/ui/src/components/todo-status-marker.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+// TodoStatusMarker is the single source of truth for the todo state marker
+// rendered by the composer dock, the message-part TodoWrite tool card, and
+// the right-panel Status tab. DESIGN.md L201 forbids dots; the marker shape
+// is the SVG-icon-and-spinner contract that replaces them.
+const SOURCE = readFileSync(new URL("./todo-status-marker.tsx", import.meta.url), "utf8")
+
+describe("todo-status-marker · visual contract", () => {
+  test("declares the four todo status values it accepts", () => {
+    expect(SOURCE).toMatch(
+      /export type TodoStatus =\s*"pending"\s*\|\s*"in_progress"\s*\|\s*"completed"\s*\|\s*"cancelled"/,
+    )
+  })
+
+  test("maps completed to circle-check and other terminal states to circle", () => {
+    expect(SOURCE).toMatch(/status === "completed"\s*\?\s*"circle-check"\s*:\s*"circle"/)
+  })
+
+  test("uses --icon-base for the fallback icon colour", () => {
+    expect(SOURCE).toContain("var(--icon-base)")
+  })
+
+  test("renders the in-progress spinner as a 13×13 ring driven by --animate-pw-spin", () => {
+    // The pixel values guard against an accidental size drift; the same
+    // dimensions apply at every callsite.
+    expect(SOURCE).toMatch(/width:\s*"13px"/)
+    expect(SOURCE).toMatch(/height:\s*"13px"/)
+    expect(SOURCE).toContain("--animate-pw-spin")
+    expect(SOURCE).toContain("border-top-color")
+    expect(SOURCE).toContain("var(--brand-primary)")
+  })
+
+  test("wraps the spinner ring inside a 16×16 inline-flex box", () => {
+    // Outer wrapper matches the fallback Icon's 16×16 footprint so the marker
+    // claims the same width regardless of state.
+    expect(SOURCE).toMatch(/width:\s*"16px"/)
+    expect(SOURCE).toMatch(/height:\s*"16px"/)
+    expect(SOURCE).toContain('"inline-flex"')
+  })
+
+  test("applies the optional marginTop prop only when provided", () => {
+    // Callers that need to align with the row's text baseline pass marginTop;
+    // callsites with their own baseline (e.g. message-part todowrite) leave
+    // it unset, so a literal "1px" default must NOT be baked into the source.
+    expect(SOURCE).toMatch(/props\.marginTop\s*\?\s*\{\s*"margin-top":\s*props\.marginTop\s*\}\s*:\s*\{\}/)
+    // Both the fallback Icon style and the spinner wrapper style must honour it.
+    const occurrences = SOURCE.match(/"margin-top":\s*props\.marginTop/g) ?? []
+    expect(occurrences.length).toBe(2)
+  })
+})

--- a/packages/ui/src/components/todo-status-marker.test.ts
+++ b/packages/ui/src/components/todo-status-marker.test.ts
@@ -18,10 +18,6 @@ describe("todo-status-marker · visual contract", () => {
     expect(SOURCE).toMatch(/status === "completed"\s*\?\s*"circle-check"\s*:\s*"circle"/)
   })
 
-  test("uses --icon-base for the fallback icon colour", () => {
-    expect(SOURCE).toContain("var(--icon-base)")
-  })
-
   test("renders the in-progress spinner as a 13×13 ring driven by --animate-pw-spin", () => {
     // The pixel values guard against an accidental size drift; the same
     // dimensions apply at every callsite.
@@ -32,21 +28,28 @@ describe("todo-status-marker · visual contract", () => {
     expect(SOURCE).toContain("var(--brand-primary)")
   })
 
-  test("wraps the spinner ring inside a 16×16 inline-flex box", () => {
-    // Outer wrapper matches the fallback Icon's 16×16 footprint so the marker
-    // claims the same width regardless of state.
+  test("shares one 16×16 inline-flex wrapper for both branches", () => {
+    // A single outer wrapper means marginTop applies symmetrically regardless
+    // of state; if a future edit forks the wrapper between branches this
+    // assertion guards the symmetry contract.
     expect(SOURCE).toMatch(/width:\s*"16px"/)
     expect(SOURCE).toMatch(/height:\s*"16px"/)
     expect(SOURCE).toContain('"inline-flex"')
+    // The Icon import is still used for the fallback branch; the
+    // `color: var(--icon-base)` style is intentionally removed because
+    // icon.css already applies the same colour to [data-component="icon"].
+    expect(SOURCE).not.toContain("var(--icon-base)")
   })
 
-  test("applies the optional marginTop prop only when provided", () => {
+  test("applies the optional marginTop prop on a single shared wrapper", () => {
     // Callers that need to align with the row's text baseline pass marginTop;
     // callsites with their own baseline (e.g. message-part todowrite) leave
     // it unset, so a literal "1px" default must NOT be baked into the source.
     expect(SOURCE).toMatch(/props\.marginTop\s*\?\s*\{\s*"margin-top":\s*props\.marginTop\s*\}\s*:\s*\{\}/)
-    // Both the fallback Icon style and the spinner wrapper style must honour it.
+    // After unifying both branches under one wrapper, the prop is read exactly
+    // once. If a future edit re-introduces a branch-local nudge this assertion
+    // will catch the regression.
     const occurrences = SOURCE.match(/"margin-top":\s*props\.marginTop/g) ?? []
-    expect(occurrences.length).toBe(2)
+    expect(occurrences.length).toBe(1)
   })
 })

--- a/packages/ui/src/components/todo-status-marker.tsx
+++ b/packages/ui/src/components/todo-status-marker.tsx
@@ -1,0 +1,75 @@
+import { Show, type JSX } from "solid-js"
+import { Icon } from "./icon"
+
+// Canonical visual for a todo's current state, used wherever PawWork renders a
+// todo row: the composer dock (session-todo-dock), the message-part TodoWrite
+// tool card, and the right-panel Status tab.
+//
+// - completed → 16×16 `circle-check` icon at `--icon-base`
+// - pending / cancelled / any other value → 16×16 `circle` icon at `--icon-base`
+// - in_progress → 13×13 ring inside a 16×16 box; `--border-weak` base with
+//   `--brand-primary` top, animated by the shared `--animate-pw-spin` token
+//
+// DESIGN.md L201 forbids dots as state signals; this component is the single
+// source of truth so any future change (size, palette, icon swap) propagates
+// to all surfaces in one edit.
+//
+// `status` is typed as plain `string` because the SDK declares `Todo.status`
+// that way (see packages/sdk/js/src/v2/gen/types.gen.ts). The runtime narrows
+// safely: only the four documented values branch; anything else falls through
+// to the `circle` outline, matching the long-standing behaviour of both
+// session-todo-dock.tsx and todowrite.tsx.
+export type TodoStatus = "pending" | "in_progress" | "completed" | "cancelled"
+
+export interface TodoStatusMarkerProps {
+  status: TodoStatus | (string & {})
+  /**
+   * Optional top nudge to align the 16×16 marker with the row's text baseline.
+   * The composer dock and right-panel Status tab pass `"1px"` because they sit
+   * next to body type at 13/130; the message-part TodoWrite card leaves this
+   * unset because its row uses a different baseline.
+   */
+  marginTop?: string
+}
+
+export function TodoStatusMarker(props: TodoStatusMarkerProps): JSX.Element {
+  return (
+    <Show
+      when={props.status === "in_progress"}
+      fallback={
+        <Icon
+          name={props.status === "completed" ? "circle-check" : "circle"}
+          style={{
+            color: "var(--icon-base)",
+            "flex-shrink": "0",
+            ...(props.marginTop ? { "margin-top": props.marginTop } : {}),
+          }}
+        />
+      }
+    >
+      <span
+        style={{
+          display: "inline-flex",
+          "align-items": "center",
+          "justify-content": "center",
+          width: "16px",
+          height: "16px",
+          "flex-shrink": "0",
+          ...(props.marginTop ? { "margin-top": props.marginTop } : {}),
+        }}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            width: "13px",
+            height: "13px",
+            "border-radius": "9999px",
+            border: "1.5px solid var(--border-weak)",
+            "border-top-color": "var(--brand-primary)",
+            animation: "var(--animate-pw-spin)",
+          }}
+        />
+      </span>
+    </Show>
+  )
+}

--- a/packages/ui/src/components/todo-status-marker.tsx
+++ b/packages/ui/src/components/todo-status-marker.tsx
@@ -33,6 +33,11 @@ export interface TodoStatusMarkerProps {
    * The composer dock and right-panel Status tab pass `"1px"` because they sit
    * next to body type at 13/130; the message-part TodoWrite card leaves this
    * unset because its row uses a different baseline.
+   *
+   * Callsite contract: passed as a static literal, not a reactive value. The
+   * inline-style object is evaluated once per render and won't re-spread on
+   * marginTop changes; if a future surface needs a dynamic nudge, wrap the
+   * style in a getter (`style={() => ({...})}`) or promote the prop.
    */
   marginTop?: string
 }

--- a/packages/ui/src/components/todo-status-marker.tsx
+++ b/packages/ui/src/components/todo-status-marker.tsx
@@ -14,6 +14,11 @@ import { Icon } from "./icon"
 // source of truth so any future change (size, palette, icon swap) propagates
 // to all surfaces in one edit.
 //
+// Both branches share one 16×16 inline-flex wrapper so the optional baseline
+// nudge (marginTop) applies symmetrically regardless of state: putting it on
+// the Icon would route it through splitProps onto the inner <svg> instead of
+// the outer wrapper, and `align-items: center` on the wrapper would erase it.
+//
 // `status` is typed as plain `string` because the SDK declares `Todo.status`
 // that way (see packages/sdk/js/src/v2/gen/types.gen.ts). The runtime narrows
 // safely: only the four documented values branch; anything else falls through
@@ -34,29 +39,20 @@ export interface TodoStatusMarkerProps {
 
 export function TodoStatusMarker(props: TodoStatusMarkerProps): JSX.Element {
   return (
-    <Show
-      when={props.status === "in_progress"}
-      fallback={
-        <Icon
-          name={props.status === "completed" ? "circle-check" : "circle"}
-          style={{
-            color: "var(--icon-base)",
-            "flex-shrink": "0",
-            ...(props.marginTop ? { "margin-top": props.marginTop } : {}),
-          }}
-        />
-      }
+    <span
+      style={{
+        display: "inline-flex",
+        "align-items": "center",
+        "justify-content": "center",
+        width: "16px",
+        height: "16px",
+        "flex-shrink": "0",
+        ...(props.marginTop ? { "margin-top": props.marginTop } : {}),
+      }}
     >
-      <span
-        style={{
-          display: "inline-flex",
-          "align-items": "center",
-          "justify-content": "center",
-          width: "16px",
-          height: "16px",
-          "flex-shrink": "0",
-          ...(props.marginTop ? { "margin-top": props.marginTop } : {}),
-        }}
+      <Show
+        when={props.status === "in_progress"}
+        fallback={<Icon name={props.status === "completed" ? "circle-check" : "circle"} />}
       >
         <span
           style={{
@@ -69,7 +65,7 @@ export function TodoStatusMarker(props: TodoStatusMarkerProps): JSX.Element {
             animation: "var(--animate-pw-spin)",
           }}
         />
-      </span>
-    </Show>
+      </Show>
+    </span>
   )
 }


### PR DESCRIPTION
## Summary

Right-panel Status tab rendered todo progress with coloured 6/8px dots. `DESIGN.md L201` forbids dots as state signals; the only sanctioned dot in PawWork is the sidebar session-row unread orange dot.

This PR swaps the dot for the canonical todo widget marker already used in [`session-todo-dock.tsx`](packages/app/src/pages/session/composer/session-todo-dock.tsx) and [`todowrite.tsx`](packages/ui/src/components/message-part/tools/todowrite.tsx):

- `completed` → `<Icon name="circle-check">` 16×16
- `pending` / `cancelled` → `<Icon name="circle">` 16×16
- `in_progress` → 13×13 ring with brand-primary top border + `--animate-pw-spin`
- Completed and cancelled rows uniformly get `line-through` + `text-fg-weak`. Previously only cancelled was struck, and cancelled was `text-fg-weaker`; aligning to the dock convention.
- `gap-2.5` → `gap-2` to match the dock row spacing.

Net effect: same Status tab, same todo data, marker style now matches the same todos rendered elsewhere in the app.

## Why

Slice 3 of the Area B right-panel audit ([`docs/research/2026-05-23-area-b-right-panel-audit.md`](docs/research/2026-05-23-area-b-right-panel-audit.md), local-only) flagged status dots as a P0 DESIGN.md drift. Slice 1+2 ([#854](https://github.com/Astro-Han/pawwork/pull/854)) was the first cut; this is the second.

The audit originally bundled `session-status-connections.tsx` (servers / MCP / LSP / plugins) into the same slice. During implementation we narrowed scope: whether that section belongs in the right panel at all is a separate product question (it carries the only live infrastructure-health signal, and moving it requires deciding on an alert channel first). A follow-up issue will track that question.

## Related Issue

Refs [#602](https://github.com/Astro-Han/pawwork/issues/602) (Area B right-panel rewrite, slice 3).

## Human Review Status

Pending

## Review Focus

- Marker logic in `TodoMarker`: the icon-name mapping and the in_progress 13×13 ring are a direct port of the same JSX block in `session-todo-dock.tsx` lines 227-259. Confirm parity if you have a strong opinion on either visual.
- Text treatment change: `completed` rows now also get `line-through` (previously only `cancelled` was struck). This is the dock convention; flag if the Status tab should diverge.
- Cancelled text colour shifted from `--fg-weaker` to `--fg-weak` (one tier darker, dock convention). Tiny perceptual shift.
- `session-status-connections.tsx` is intentionally untouched; its dots remain. Follow-up issue tracks the position question.

## Risk Notes

- Behavioural change: completed rows now show a strikethrough where they didn't before. Same data, different rendering, no migration. If user feedback says completed shouldn't be struck in this surface, revert is one-line.
- No platform, packaging, IPC, or shell surface touched.
- No new dependencies.

## How To Verify

```text
typecheck:                bun run typecheck — 8/8 packages pass
lint:                     bun run lint packages/app/src/components/session/session-status-summary.tsx
                            packages/app/src/components/session/session-status-summary.test.ts
                          — clean (1 expected warning: .test.ts file matches eslint ignore pattern)
focused tests:            bun test --preload ./happydom.ts
                            src/components/session/session-status-summary.test.ts
                            src/pages/session/session-side-panel.test.tsx
                          — 17 pass, 0 fail across both files
visual baseline:          bun run snap app-shell — passed; default app-shell screenshot
                            regenerated unchanged (the right-panel Status tab is not in
                            the app-shell snap surface, but app-shell confirms no
                            collateral damage to the shell layout).
visual coverage of new
markers:                  the new TodoMarker JSX is a direct port of session-todo-dock.tsx
                            lines 227-259, which is already snap-tested by
                            packages/app/e2e/snap/todo-dock-restored.snap.ts.
                            Same icon names, same ring spec, same animation token.
```

A dedicated `right-panel-status-todos` snap target was considered. Deferred for cost/benefit: ~80 lines of e2e setup (open session → seed todos → toggle right panel → screenshot) to verify markers that are byte-for-byte the same as a surface already in baseline. Happy to add it if a reviewer wants the durable check.

## Screenshots or Recordings

Local design-decision page (untracked, local checkout only): `docs/design/scratch/right-pane-status-icons-compare.html` shows current dots vs new markers in light and dark themes for both Status Summary and Status Connections sections (Connections side preserved for reference; not touched in this PR).

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
