### PR TITLE
fix(app): protect SSE event data from stale GET overwrite on first sync

### DIFF
--- a/packages/app/src/context/sync-message-resolution.test.ts
+++ b/packages/app/src/context/sync-message-resolution.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test"
+import { resolveLoadMessagePage } from "./sync"
+
+type TestMsg = { id: string; text: string }
+
+const m = (id: string, text: string): TestMsg => ({ id, text })
+
+describe("resolveLoadMessagePage", () => {
+  test("normal initial load without stored data returns fetched as-is", () => {
+    const fetched = [m("msg_1", "hello"), m("msg_2", "world")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored: undefined,
+      fetched,
+      hasCachedMeta: false,
+    })
+    expect(result.map((x) => x.id)).toEqual(["msg_1", "msg_2"])
+  })
+
+  test("race window: SSE data in store, no metadata — merge protects event data from stale GET", () => {
+    // SSE events wrote msg_1 (from shell) into the store
+    const stored = [m("msg_1", "shell-user")]
+    // GET returns empty because it hit the server before shell created messages
+    const fetched: TestMsg[] = []
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored,
+      fetched,
+      hasCachedMeta: false,
+    })
+    // msg_1 from SSE should survive
+    expect(result.map((x) => x.id)).toEqual(["msg_1"])
+    expect(result.map((x) => x.text)).toEqual(["shell-user"])
+  })
+
+  test("race window: SSE + GET both have data — merge fills gaps", () => {
+    // SSE events wrote msg_1
+    const stored = [m("msg_1", "shell-user")]
+    // GET returns msg_1 (from DB, might be more complete) and msg_2
+    const fetched = [m("msg_1", "shell-user-db"), m("msg_2", "shell-assistant")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored,
+      fetched,
+      hasCachedMeta: false,
+    })
+    // Both messages present, msg_1 uses fetched version (source of truth for same ID)
+    expect(result.map((x) => x.id)).toEqual(["msg_1", "msg_2"])
+    expect(result.map((x) => x.text)).toEqual(["shell-user-db", "shell-assistant"])
+  })
+
+  test("normal refresh with cached meta returns fetched (authoritative replace)", () => {
+    // Store has old data from a previous load
+    const stored = [m("msg_1", "old"), m("msg_2", "old-deleted")]
+    // Server returns current state (msg_2 was deleted)
+    const fetched = [m("msg_1", "current")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored,
+      fetched,
+      hasCachedMeta: true,
+    })
+    // Replace with server snapshot: msg_2 is gone
+    expect(result.map((x) => x.id)).toEqual(["msg_1"])
+    expect(result.map((x) => x.text)).toEqual(["current"])
+  })
+
+  test("normal refresh without stored data returns fetched as-is", () => {
+    const fetched = [m("msg_1", "hello")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored: undefined,
+      fetched,
+      hasCachedMeta: true,
+    })
+    expect(result.map((x) => x.id)).toEqual(["msg_1"])
+  })
+
+  test("prepend mode always merges stored with fetched", () => {
+    const stored = [m("msg_3", "existing"), m("msg_4", "existing")]
+    const fetched = [m("msg_1", "older"), m("msg_2", "older")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      mode: "prepend",
+      stored,
+      fetched,
+      hasCachedMeta: true,
+    })
+    // Sorted by ID: older messages first
+    expect(result.map((x) => x.id)).toEqual(["msg_1", "msg_2", "msg_3", "msg_4"])
+    // Retrieved messages override existing ones with same ID
+  })
+
+  test("prepend mode: fetched overrides stored when same ID", () => {
+    const stored = [m("msg_1", "stale")]
+    const fetched = [m("msg_1", "fresh")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      mode: "prepend",
+      stored,
+      fetched,
+      hasCachedMeta: false,
+    })
+    expect(result.map((x) => x.text)).toEqual(["fresh"])
+  })
+
+  test("race window: empty stored array does not trigger merge", () => {
+    // An empty stored array (failed initial load, no event data) should still fall through to replace
+    const stored: TestMsg[] = []
+    const fetched = [m("msg_1", "hello")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored,
+      fetched,
+      hasCachedMeta: false,
+    })
+    expect(result.map((x) => x.id)).toEqual(["msg_1"])
+  })
+
+  test("race window: fetched overrides stored for same message ID — intentional strategy", () => {
+    // SSE events wrote msg_1 with a running tool part; the subsequent
+    // GET returns msg_1 with the completed state. Fetched data from the
+    // DB is at least as fresh as SSE events from the same shell execution.
+    const stored = [m("msg_1", "running")]
+    const fetched = [m("msg_1", "completed")]
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored,
+      fetched,
+      hasCachedMeta: false,
+    })
+    expect(result.map((x) => x.text)).toEqual(["completed"])
+  })
+})

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -41,6 +41,26 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
   return [...map.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
+export function resolveLoadMessagePage<T extends { id: string }>(params: {
+  mode?: "prepend" | "replace"
+  stored: readonly T[] | undefined
+  fetched: readonly T[]
+  hasCachedMeta: boolean
+}): T[] {
+  const { mode, stored, fetched, hasCachedMeta } = params
+  if (mode === "prepend") return merge(stored ?? [], fetched)
+  // Race window: SSE events (from the same request that triggered this load)
+  // have populated the store but page metadata has not been established yet.
+  // Merge rather than replace so event data survives a stale GET response.
+  // When the same message ID exists in both, fetched wins — this is safe
+  // because GET data comes from the DB after the same shell execution that
+  // produced the SSE events, so it is at least as fresh.
+  if (stored && stored.length > 0 && !hasCachedMeta) {
+    return merge(stored, fetched)
+  }
+  return fetched as T[]
+}
+
 type OptimisticStore = {
   message: Record<string, Message[] | undefined>
   part: Record<string, Part[] | undefined>
@@ -386,8 +406,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             clearOptimistic(input.directory, input.sessionID, messageID)
           }
           const [store] = globalSync.child(input.directory, { bootstrap: false })
-          const cached = input.mode === "prepend" ? (store.message[input.sessionID] ?? []) : []
-          const message = input.mode === "prepend" ? merge(cached, next.session) : next.session
+          const hasCachedMeta = meta.limit[key] !== undefined
+          const message = resolveLoadMessagePage({
+            mode: input.mode,
+            stored: store.message[input.sessionID],
+            fetched: next.session,
+            hasCachedMeta,
+          })
           batch(() => {
             input.setStore("message", input.sessionID, reconcile(message, { key: "id" }))
             for (const p of next.part) {


### PR DESCRIPTION
## Summary

Fix #695: home page shell command creates session but page renders empty. Extract `resolveLoadMessagePage` to protect SSE event data from being overwritten by a stale initial load in `loadMessages`.

## Why

When a shell command is submitted from home, the page mount triggers `sync.session.sync` → `loadMessages` → GET request. Concurrently, `client.session.shell()` creates messages and pushes SSE events. The existing `cached` guard requires both `store.message[id]` and `meta.limit[key]` to be set before skipping the load. SSE events only set the former, so `loadMessages` still runs and can replace event data with a stale empty GET result.

## Related Issue

Closes #695

## Human Review Status

Pending

## Review Focus

The `resolveLoadMessagePage` function gates merge-vs-replace on `hasCachedMeta` (presence of `meta.limit[key]`). Verify the three behaviors are correct: authoritative replace for established sessions, merge for the race window where SSE events arrived before the first page load completed, and merge for prepend.

## Risk Notes

- The race window merge (`!hasCachedMeta && stored.length > 0`) is guarded by the same `meta.limit[key]` signal already used for the `cached` skip check. It only activates when events have populated the store but no page metadata exists yet — a narrow window on first load.
- Authoritative replace for normal/force refreshes is unchanged (`hasCachedMeta = true`). Server deletions and reverts will still correctly clear the local store.

## How To Verify

```
# Unit tests for the new resolveLoadMessagePage function (8 scenarios)
bun test src/context/sync-message-resolution.test.ts  → 8 pass

# Existing sync tests (untouched behavior)
bun test src/context/sync-optimistic.test.ts          → 5 pass
bun test src/context/sync-current-child.test.ts       → 4 pass
bun test src/context/global-sync/                     → 70 pass

# Session action readiness tests (unchanged)
bun test src/pages/session/session-action-readiness.test.ts → pass
bun test src/pages/session/session-messages.test.ts         → pass
bun test src/pages/session/use-session-timeline-data.test.ts → pass

# Typecheck
bun run typecheck → ok (0 errors)

# Manual: home page `! echo hello` → session page shows stdout
```

## Checklist

- [x] **Type label** — bug
- [x] **Routing labels** — app
- [x] **Priority label** — P2
- [x] Human Review Status above is set to `Pending`
- [x] I linked the related issue
- [x] I described the review focus and any meaningful risks
- [x] I replaced the example block in How To Verify with the real verification steps
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed — not applicable, no visible UI change
- [ ] **(conditional)** I considered macOS and Windows impact — not applicable, no platform surface touched
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant — no docs/release-notes/deps/permissions/credentials/deletion changes
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English