### PR TITLE
fix(app): make session timeline frame total

### DIFF
--- a/packages/app/e2e/session/session-home-submit-regression.spec.ts
+++ b/packages/app/e2e/session/session-home-submit-regression.spec.ts
@@ -1,0 +1,72 @@
+import type { CDPSession, Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { openSidebar, sessionIDFromUrl, waitSession } from "../actions"
+import {
+  pawworkSessionNewSelector,
+  sessionVirtualizerSelector,
+  sessionTurnListSelector,
+} from "../selectors"
+
+function collectRendererExceptions(page: Page) {
+  const pageErrors: string[] = []
+  const runtimeExceptions: string[] = []
+  let cdp: CDPSession | undefined
+
+  const onPageError = (error: Error) => {
+    pageErrors.push(error.stack || error.message || String(error))
+  }
+
+  return {
+    async start() {
+      page.on("pageerror", onPageError)
+      cdp = await page.context().newCDPSession(page)
+      await cdp.send("Runtime.enable")
+      cdp.on("Runtime.exceptionThrown", (event) => {
+        const details = event.exceptionDetails
+        runtimeExceptions.push(details.exception?.description || details.text || JSON.stringify(details))
+      })
+    },
+    async stop() {
+      page.off("pageerror", onPageError)
+      await cdp?.detach().catch(() => undefined)
+    },
+    expectClean() {
+      expect(pageErrors).toEqual([])
+      expect(runtimeExceptions).toEqual([])
+    },
+  }
+}
+
+test("homepage submit enters the new session after an existing timeline was mounted", async ({
+  page,
+  project,
+  assistant,
+}) => {
+  test.setTimeout(120_000)
+
+  const exceptions = collectRendererExceptions(page)
+  await exceptions.start()
+
+  try {
+    await project.open()
+    await assistant.reply("mounted")
+    const firstSessionID = await project.prompt(`mount existing timeline ${Date.now()}`)
+    await expect(page.locator(sessionVirtualizerSelector)).toBeVisible({ timeout: 30_000 })
+
+    await openSidebar(page)
+    await page.locator(pawworkSessionNewSelector).first().click()
+    await waitSession(page, { directory: project.directory, serverUrl: project.url })
+    expect(sessionIDFromUrl(page.url())).toBeUndefined()
+
+    await assistant.reply("submitted")
+    const nextSessionID = await project.prompt(`submit after timeline unmount ${Date.now()}`)
+
+    expect(nextSessionID).not.toBe(firstSessionID)
+    await expect(page).toHaveURL(new RegExp(`/session/${nextSessionID}(?:[/?#]|$)`), { timeout: 30_000 })
+    await expect(page.locator(sessionVirtualizerSelector)).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator(sessionTurnListSelector)).toHaveAttribute("data-total-rows", /[1-9]/)
+    exceptions.expectClean()
+  } finally {
+    await exceptions.stop()
+  }
+})

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -22,16 +22,16 @@ import {
   shouldMarkTimelineBoundaryGesture,
 } from "@/pages/session/session-timeline-scroll-intents"
 import { createTimelineStaging } from "@/pages/session/session-timeline-staging"
+import type { TimelineVirtualRow } from "@/pages/session/timeline-virtual-rows"
 import {
-  createTimelineVirtualRows,
-  classifyTimelineRowMutation,
-  type TimelineRowMutation,
-  type TimelineVirtualRow,
-} from "@/pages/session/timeline-virtual-rows"
+  createTimelineFrame,
+  emptyTimelineFrame,
+  visibleRangeDataFromFrame,
+  type TimelineFrame,
+} from "@/pages/session/timeline-frame"
 import { TimelineRowRenderer } from "@/pages/session/timeline-row-renderer"
 import { timelineMessageRowStyle } from "@/pages/session/timeline-row-layout"
 import type { TimelineVirtualizerBridge } from "@/pages/session/timeline-virtualizer-bridge"
-import { chooseTimelineRowRenderMode } from "@/pages/session/timeline-virtualization-strategy"
 import {
   areMessageCommentsEqual,
   extractMessageComments,
@@ -125,26 +125,28 @@ export function MessageTimeline(props: {
     if (scrollSampleFrame !== undefined) cancelAnimationFrame(scrollSampleFrame)
   })
 
-  const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
-  const visibleRange = createMemo(() => {
-    const ids = rendered()
-    const first = ids[0]
-    const last = ids.at(-1)
-    return {
-      rendered_count: ids.length,
-      visible_first_message_id: first,
-      visible_last_message_id: last,
-      signature: `${ids.length}:${first ?? ""}:${last ?? ""}`,
-    }
+  const timelineFrame = createMemo<TimelineFrame>(
+    (previous) =>
+      createTimelineFrame({
+        previous,
+        messages: props.renderedUserMessages,
+        historyMore: props.historyMore,
+        turnStart: props.turnStart,
+      }),
+    emptyTimelineFrame,
+  )
+  const frameRows = createMemo(() => timelineFrame().rows)
+  const frameMutation = createMemo(() => timelineFrame().mutation)
+  const frameRenderMode = createMemo(() => timelineFrame().renderMode)
+  const currentVisibleRangeData = () => visibleRangeDataFromFrame(timelineFrame())
+  let lastTimelineFrame = emptyTimelineFrame
+
+  // Cleanup can run while Solid is disposing derived memos, so diagnostics use
+  // the last stable frame instead of recomputing through live reactive chains.
+  createEffect(() => {
+    lastTimelineFrame = timelineFrame()
   })
-  const visibleRangeData = () => {
-    const range = visibleRange()
-    return {
-      rendered_count: range.rendered_count,
-      visible_first_message_id: range.visible_first_message_id,
-      visible_last_message_id: range.visible_last_message_id,
-    }
-  }
+
   const sessionKey = createMemo(() => props.sessionKey)
   const sessionID = createMemo(() => props.sessionID)
   const sessionMessages = createMemo(() => props.sessionMessages)
@@ -160,7 +162,7 @@ export function MessageTimeline(props: {
       route_session_id: params.id,
       visible_session_id: props.sessionID,
       timeline_session_id: props.sessionID,
-      data: visibleRangeData(),
+      data: currentVisibleRangeData(),
     })
   })
 
@@ -170,20 +172,20 @@ export function MessageTimeline(props: {
       route_session_id: params.id,
       visible_session_id: props.sessionID,
       timeline_session_id: props.sessionID,
-      data: visibleRangeData(),
+      data: visibleRangeDataFromFrame(lastTimelineFrame),
     })
   })
 
   createEffect(
     on(
-      () => visibleRange().signature,
+      () => timelineFrame().visibleRange.signature,
       () => {
         void emitRendererDiagnostic({
           name: "session.timeline.visible",
           route_session_id: params.id,
           visible_session_id: props.sessionID,
           timeline_session_id: props.sessionID,
-          data: visibleRangeData(),
+          data: currentVisibleRangeData(),
         })
       },
     ),
@@ -268,19 +270,6 @@ export function MessageTimeline(props: {
     messages: () => props.renderedUserMessages,
     config: stageCfg,
   })
-  const rows = createMemo(() =>
-    createTimelineVirtualRows({
-      messages: props.renderedUserMessages,
-      historyMore: props.historyMore,
-      turnStart: props.turnStart,
-    }),
-  )
-  const rowMutation = createMemo<{ rows: TimelineVirtualRow[]; mutation: TimelineRowMutation }>((previous) => {
-    const next = rows()
-    return { rows: next, mutation: classifyTimelineRowMutation({ previous: previous?.rows ?? [], next }) }
-  })
-  const rowRenderMode = createMemo(() => chooseTimelineRowRenderMode({ rowCount: rowMutation().rows.length }))
-
   const renderTimelineRow = (row: TimelineVirtualRow): JSX.Element => {
     if (row.type === "load-earlier") {
       return (
@@ -316,7 +305,7 @@ export function MessageTimeline(props: {
           "min-w-0 w-full max-w-full": true,
           "md:max-w-[800px] 2xl:max-w-[1000px]": props.centered,
         }}
-        style={timelineMessageRowStyle({ mode: rowRenderMode(), active: active() })}
+        style={timelineMessageRowStyle({ mode: frameRenderMode(), active: active() })}
       >
         <SessionMessageComments comments={comments()} />
         <SessionTurn
@@ -457,7 +446,7 @@ export function MessageTimeline(props: {
                   route_session_id: params.id,
                   visible_session_id: props.sessionID,
                   timeline_session_id: props.sessionID,
-                  data: { ...sample, ...visibleRangeData() },
+                  data: { ...sample, ...currentVisibleRangeData() },
                 }).catch(() => {})
               })
             }
@@ -487,8 +476,8 @@ export function MessageTimeline(props: {
               role="log"
               data-component="session-timeline-virtualizer"
               data-slot="session-turn-list"
-              data-render-mode={rowRenderMode()}
-              data-total-rows={rowMutation().rows.length}
+              data-render-mode={frameRenderMode()}
+              data-total-rows={frameRows().length}
               data-layout-transaction-active={props.layoutTransactionActive() ? "true" : "false"}
               data-layout-transaction-id={props.layoutTransactionID()}
               data-layout-transaction-kind={props.layoutTransactionKind()}
@@ -501,11 +490,11 @@ export function MessageTimeline(props: {
               }}
             >
               <TimelineRowRenderer
-                mode={rowRenderMode()}
-                rows={rowMutation().rows}
+                mode={frameRenderMode()}
+                rows={frameRows()}
                 viewport={virtualizerViewport()}
                 virtualizerBridge={props.virtualizerBridge}
-                shift={rowMutation().mutation === "prepend"}
+                shift={frameMutation() === "prepend"}
                 transactionActive={props.layoutTransactionActive()}
                 renderRow={renderTimelineRow}
               />

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -135,9 +135,9 @@ export function MessageTimeline(props: {
       }),
     emptyTimelineFrame,
   )
-  const frameRows = createMemo(() => timelineFrame().rows)
-  const frameMutation = createMemo(() => timelineFrame().mutation)
-  const frameRenderMode = createMemo(() => timelineFrame().renderMode)
+  const frameRows = createMemo(() => timelineFrame().rows, emptyTimelineFrame.rows)
+  const frameMutation = createMemo(() => timelineFrame().mutation, emptyTimelineFrame.mutation)
+  const frameRenderMode = createMemo(() => timelineFrame().renderMode, emptyTimelineFrame.renderMode)
   const currentVisibleRangeData = () => visibleRangeDataFromFrame(timelineFrame())
   let lastTimelineFrame = emptyTimelineFrame
 

--- a/packages/app/src/pages/session/timeline-frame.test.ts
+++ b/packages/app/src/pages/session/timeline-frame.test.ts
@@ -1,0 +1,89 @@
+import type { UserMessage } from "@opencode-ai/sdk/v2"
+import { describe, expect, test } from "bun:test"
+import { createTimelineFrame, emptyTimelineFrame, visibleRangeDataFromFrame } from "./timeline-frame"
+
+function userMessage(id: number): UserMessage {
+  return {
+    id: `msg_${id}`,
+    role: "user",
+    time: { created: id },
+  } as UserMessage
+}
+
+function userMessages(start: number, end: number) {
+  return Array.from({ length: end - start }, (_, index) => userMessage(start + index))
+}
+
+describe("timeline frame", () => {
+  test("starts from a total empty frame", () => {
+    expect(emptyTimelineFrame.rows).toEqual([])
+    expect(emptyTimelineFrame.mutation).toBe("same")
+    expect(emptyTimelineFrame.renderMode).toBe("plain")
+    expect(visibleRangeDataFromFrame(emptyTimelineFrame)).toEqual({
+      rendered_count: 0,
+      visible_first_message_id: undefined,
+      visible_last_message_id: undefined,
+    })
+  })
+
+  test("creates an initial frame from messages", () => {
+    const frame = createTimelineFrame({
+      previous: emptyTimelineFrame,
+      messages: userMessages(0, 2),
+      historyMore: false,
+      turnStart: 0,
+    })
+
+    expect(frame.visibleRange).toEqual({
+      rendered_count: 2,
+      visible_first_message_id: "msg_0",
+      visible_last_message_id: "msg_1",
+      signature: "2:msg_0:msg_1",
+    })
+    expect(frame.rows.map((row) => row.key)).toEqual(["message:msg_0", "message:msg_1"])
+    expect(frame.mutation).toBe("initial")
+    expect(frame.renderMode).toBe("plain")
+  })
+
+  test("preserves row mutation semantics across frame updates", () => {
+    const previous = createTimelineFrame({
+      previous: emptyTimelineFrame,
+      messages: userMessages(5, 8),
+      historyMore: false,
+      turnStart: 0,
+    })
+
+    expect(
+      createTimelineFrame({
+        previous,
+        messages: userMessages(2, 8),
+        historyMore: false,
+        turnStart: 0,
+      }).mutation,
+    ).toBe("prepend")
+    expect(
+      createTimelineFrame({
+        previous,
+        messages: userMessages(5, 10),
+        historyMore: false,
+        turnStart: 0,
+      }).mutation,
+    ).toBe("append")
+    expect(
+      createTimelineFrame({
+        previous,
+        messages: userMessages(20, 23),
+        historyMore: false,
+        turnStart: 0,
+      }).mutation,
+    ).toBe("replace")
+    expect(
+      createTimelineFrame({
+        previous,
+        messages: userMessages(5, 8),
+        historyMore: false,
+        turnStart: 0,
+      }).mutation,
+    ).toBe("same")
+  })
+})

--- a/packages/app/src/pages/session/timeline-frame.ts
+++ b/packages/app/src/pages/session/timeline-frame.ts
@@ -1,0 +1,70 @@
+import type { UserMessage } from "@opencode-ai/sdk/v2"
+import {
+  classifyTimelineRowMutation,
+  createTimelineVirtualRows,
+  type TimelineRowMutation,
+  type TimelineVirtualRow,
+} from "./timeline-virtual-rows"
+import { chooseTimelineRowRenderMode, type TimelineRowRenderMode } from "./timeline-virtualization-strategy"
+
+export type TimelineVisibleRange = {
+  rendered_count: number
+  visible_first_message_id: string | undefined
+  visible_last_message_id: string | undefined
+  signature: string
+}
+
+export type TimelineFrame = {
+  visibleRange: TimelineVisibleRange
+  rows: TimelineVirtualRow[]
+  mutation: TimelineRowMutation
+  renderMode: TimelineRowRenderMode
+}
+
+export const emptyTimelineVisibleRange: TimelineVisibleRange = {
+  rendered_count: 0,
+  visible_first_message_id: undefined,
+  visible_last_message_id: undefined,
+  signature: "0::",
+}
+
+export const emptyTimelineFrame: TimelineFrame = {
+  visibleRange: emptyTimelineVisibleRange,
+  rows: [],
+  mutation: "same",
+  renderMode: chooseTimelineRowRenderMode({ rowCount: 0 }),
+}
+
+export function createTimelineFrame(input: {
+  previous: TimelineFrame | undefined
+  messages: readonly UserMessage[]
+  historyMore: boolean
+  turnStart: number
+}): TimelineFrame {
+  const ids = input.messages.map((message) => message.id)
+  const rows = createTimelineVirtualRows({
+    messages: input.messages,
+    historyMore: input.historyMore,
+    turnStart: input.turnStart,
+  })
+
+  return {
+    visibleRange: {
+      rendered_count: ids.length,
+      visible_first_message_id: ids[0],
+      visible_last_message_id: ids.at(-1),
+      signature: `${ids.length}:${ids[0] ?? ""}:${ids.at(-1) ?? ""}`,
+    },
+    rows,
+    mutation: classifyTimelineRowMutation({ previous: input.previous?.rows ?? [], next: rows }),
+    renderMode: chooseTimelineRowRenderMode({ rowCount: rows.length }),
+  }
+}
+
+export function visibleRangeDataFromFrame(frame: TimelineFrame) {
+  return {
+    rendered_count: frame.visibleRange.rendered_count,
+    visible_first_message_id: frame.visibleRange.visible_first_message_id,
+    visible_last_message_id: frame.visibleRange.visible_last_message_id,
+  }
+}

--- a/packages/app/src/pages/session/timeline-frame.ts
+++ b/packages/app/src/pages/session/timeline-frame.ts
@@ -41,7 +41,9 @@ export function createTimelineFrame(input: {
   historyMore: boolean
   turnStart: number
 }): TimelineFrame {
-  const ids = input.messages.map((message) => message.id)
+  const count = input.messages.length
+  const firstId = input.messages[0]?.id
+  const lastId = input.messages.at(-1)?.id
   const rows = createTimelineVirtualRows({
     messages: input.messages,
     historyMore: input.historyMore,
@@ -50,10 +52,10 @@ export function createTimelineFrame(input: {
 
   return {
     visibleRange: {
-      rendered_count: ids.length,
-      visible_first_message_id: ids[0],
-      visible_last_message_id: ids.at(-1),
-      signature: `${ids.length}:${ids[0] ?? ""}:${ids.at(-1) ?? ""}`,
+      rendered_count: count,
+      visible_first_message_id: firstId,
+      visible_last_message_id: lastId,
+      signature: `${count}:${firstId ?? ""}:${lastId ?? ""}`,
     },
     rows,
     mutation: classifyTimelineRowMutation({ previous: input.previous?.rows ?? [], next: rows }),

--- a/packages/app/src/pages/session/timeline-virtual-rows.test.ts
+++ b/packages/app/src/pages/session/timeline-virtual-rows.test.ts
@@ -45,6 +45,15 @@ describe("timeline virtual rows", () => {
     expect(classifyTimelineRowMutation({ previous, next: appended })).toBe("append")
   })
 
+  test("classifies empty, initial, and same row sets", () => {
+    const empty = createTimelineVirtualRows({ messages: [], historyMore: false, turnStart: 0 })
+    const rows = createTimelineVirtualRows({ messages: userMessages(5, 8), historyMore: false, turnStart: 0 })
+
+    expect(classifyTimelineRowMutation({ previous: empty, next: empty })).toBe("same")
+    expect(classifyTimelineRowMutation({ previous: empty, next: rows })).toBe("initial")
+    expect(classifyTimelineRowMutation({ previous: rows, next: rows })).toBe("same")
+  })
+
   test("classifies replacement when neither end remains stable", () => {
     const previous = createTimelineVirtualRows({ messages: userMessages(5, 8), historyMore: false, turnStart: 0 })
     const next = createTimelineVirtualRows({ messages: userMessages(20, 23), historyMore: false, turnStart: 0 })


### PR DESCRIPTION
## Summary

Fixes the homepage submit regression where a new prompt could leave the UI stuck on the homepage after a session timeline had already mounted in the same window.

## Why

`MessageTimeline` had several lifecycle-sensitive reads spread across separate memos. During route/session transitions, cleanup and render paths could read a disposed or not-yet-initialized timeline range or row mutation state, crashing the renderer while the backend session and model response still completed.

This PR introduces a total `timelineFrame` so visible range, rows, row mutation, and render mode are computed as one readable frame. Cleanup diagnostics now read the last stable frame snapshot instead of recomputing live reactive memo chains during disposal.

## Related Issue

Closes #864.

## Human Review Status

Pending

## Review Focus

Please focus on the `MessageTimeline` lifecycle boundary: all render/diagnostics/cleanup reads should go through the total frame or last stable snapshot, while preserving row mutation semantics for virtualizer `shift`.

## Risk Notes

No platform, packaging, permissions, dependencies, generated files, or migration surfaces were touched.

Skipped conditional checklist items:

- Manual visible UI/copy check: no visual styling or copy changed; the changed user route is covered by a controlled Playwright E2E.
- Platform/packaging impact: not touched.
- Docs/release notes/dependencies/permissions/credentials/deletion/generated/local-file surfaces: not touched in the PR.

## How To Verify

```text
bun test --preload ./happydom.ts src/pages/session/timeline-frame.test.ts src/pages/session/timeline-virtual-rows.test.ts
Result: 8 pass, 0 fail

bun run typecheck
Result: tsgo -b completed with exit 0

git diff --check origin/dev...HEAD
Result: no whitespace errors

bun run test:e2e:local -- e2e/session/session-home-submit-regression.spec.ts
Result: 1 passed; the test covers existing timeline -> New session -> homepage submit -> new session timeline visible, and asserts no pageerror or CDP Runtime.exceptionThrown
```

## Screenshots or Recordings

Not applicable: no visual styling or copy changed. The route behavior was checked by the focused Playwright E2E.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
