### PR TITLE
fix: make assistant turn aria hiding focus-safe

### DIFF
--- a/packages/ui/src/components/session-turn-focus.test.ts
+++ b/packages/ui/src/components/session-turn-focus.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+import { blurActiveElementInside } from "./session-turn-focus"
+
+let registeredDom = false
+
+beforeAll(() => {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    GlobalRegistrator.register()
+    registeredDom = true
+  }
+})
+
+beforeEach(() => {
+  document.body.textContent = ""
+})
+
+afterAll(() => {
+  if (registeredDom) GlobalRegistrator.unregister()
+})
+
+describe("blurActiveElementInside", () => {
+  test("blurs the focused descendant before its ancestor is hidden from assistive tech", () => {
+    const container = document.createElement("div")
+    const button = document.createElement("button")
+    button.textContent = "Copy"
+    container.append(button)
+    document.body.append(container)
+
+    button.focus()
+
+    expect(document.activeElement).toBe(button)
+    expect(blurActiveElementInside(container)).toBe(true)
+    expect(document.activeElement).not.toBe(button)
+    expect(container.contains(document.activeElement)).toBe(false)
+  })
+
+  test("leaves focus alone when the active element is outside the hidden subtree", () => {
+    const container = document.createElement("div")
+    const inside = document.createElement("button")
+    const outside = document.createElement("button")
+    container.append(inside)
+    document.body.append(container, outside)
+
+    outside.focus()
+
+    expect(document.activeElement).toBe(outside)
+    expect(blurActiveElementInside(container)).toBe(false)
+    expect(document.activeElement).toBe(outside)
+  })
+
+  test("handles a missing subtree", () => {
+    expect(blurActiveElementInside(undefined)).toBe(false)
+  })
+})

--- a/packages/ui/src/components/session-turn-focus.test.ts
+++ b/packages/ui/src/components/session-turn-focus.test.ts
@@ -35,6 +35,21 @@ describe("blurActiveElementInside", () => {
     expect(container.contains(document.activeElement)).toBe(false)
   })
 
+  test("blurs a focused SVG descendant before its ancestor is hidden from assistive tech", () => {
+    const container = document.createElement("div")
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    icon.setAttribute("tabindex", "0")
+    container.append(icon)
+    document.body.append(container)
+
+    icon.focus()
+
+    expect(document.activeElement).toBe(icon)
+    expect(blurActiveElementInside(container)).toBe(true)
+    expect(document.activeElement).not.toBe(icon)
+    expect(container.contains(document.activeElement)).toBe(false)
+  })
+
   test("leaves focus alone when the active element is outside the hidden subtree", () => {
     const container = document.createElement("div")
     const inside = document.createElement("button")

--- a/packages/ui/src/components/session-turn-focus.ts
+++ b/packages/ui/src/components/session-turn-focus.ts
@@ -2,7 +2,9 @@ export function blurActiveElementInside(container: HTMLElement | undefined): boo
   if (!container || typeof document === "undefined") return false
 
   const active = document.activeElement
-  if (!(active instanceof HTMLElement)) return false
+  const isFocusableElement =
+    active instanceof HTMLElement || (typeof SVGElement !== "undefined" && active instanceof SVGElement)
+  if (!isFocusableElement) return false
   if (!container.contains(active)) return false
 
   active.blur()

--- a/packages/ui/src/components/session-turn-focus.ts
+++ b/packages/ui/src/components/session-turn-focus.ts
@@ -1,0 +1,10 @@
+export function blurActiveElementInside(container: HTMLElement | undefined): boolean {
+  if (!container || typeof document === "undefined") return false
+
+  const active = document.activeElement
+  if (!(active instanceof HTMLElement)) return false
+  if (!container.contains(active)) return false
+
+  active.blur()
+  return true
+}

--- a/packages/ui/src/components/session-turn-parent.test.ts
+++ b/packages/ui/src/components/session-turn-parent.test.ts
@@ -35,3 +35,20 @@ test("visible turn-change memo is declared after working state", () => {
 
   expect(source.indexOf("const working = createMemo")).toBeLessThan(source.indexOf("const visibleTurnChange = createMemo"))
 })
+
+test("assistant content aria-hidden is driven by focus-safe state", () => {
+  const source = readFileSync(new URL("./session-turn.tsx", import.meta.url), "utf8")
+
+  const blurIndex = source.indexOf("if (shouldHide) blurActiveElementInside(assistantContent())")
+  const hideIndex = source.indexOf("setAssistantHidden(shouldHide)")
+
+  expect(source).toContain('import { blurActiveElementInside } from "./session-turn-focus"')
+  expect(source).toContain("const [assistantContent, setAssistantContent] = createSignal<HTMLElement>()")
+  expect(source).toContain("const [assistantHidden, setAssistantHidden] = createSignal(false)")
+  expect(blurIndex).toBeGreaterThanOrEqual(0)
+  expect(hideIndex).toBeGreaterThanOrEqual(0)
+  expect(blurIndex).toBeLessThan(hideIndex)
+  expect(source).toContain("aria-hidden={assistantHidden()}")
+  expect(source).toContain("onFocusIn={() =>")
+  expect(source).not.toContain("aria-hidden={working()}")
+})

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -22,6 +22,7 @@ import { useI18n } from "../context/i18n"
 import { hasVisibleTurnChanges, type TurnChangeActions, type TurnChangeDisplay } from "./session-turn-changes"
 import { SessionTurnChangesPanel } from "./session-turn-changes-panel"
 import { SessionTurnDiffs } from "./session-turn-diffs"
+import { blurActiveElementInside } from "./session-turn-focus"
 import {
   compactionDividerLabelKey,
   compactionDividerState,
@@ -308,6 +309,13 @@ export function SessionTurn(
     return data.store.session_status[props.sessionID] ?? idle
   })
   const working = createMemo(() => isWorkInFlightStatus(status()) && active())
+  const [assistantContent, setAssistantContent] = createSignal<HTMLElement>()
+  const [assistantHidden, setAssistantHidden] = createSignal(false)
+  createEffect(() => {
+    const shouldHide = working()
+    if (shouldHide) blurActiveElementInside(assistantContent())
+    setAssistantHidden(shouldHide)
+  })
   const compactionDivider = createMemo<CompactionDividerState | undefined>(() => {
     if (!compaction()) return undefined
     return compactionDividerState({ summaryAssistant: compactionSummary(), isWorking: working() })
@@ -502,7 +510,14 @@ export function SessionTurn(
                   </div>
                 </Show>
                 <Show when={visibleAssistantMessages().length > 0}>
-                  <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
+                  <div
+                    ref={setAssistantContent}
+                    data-slot="session-turn-assistant-content"
+                    aria-hidden={assistantHidden()}
+                    onFocusIn={() => {
+                      if (assistantHidden()) blurActiveElementInside(assistantContent())
+                    }}
+                  >
                     <AssistantParts
                       messages={visibleAssistantMessages()}
                       working={working()}


### PR DESCRIPTION
## Summary

Make assistant turn `aria-hidden` transitions focus-safe so a focused control inside assistant content is blurred before the subtree is hidden from assistive technology.

## Why

Issue #745 reported Chromium warning that `session-turn-assistant-content` can become `aria-hidden=true` while a descendant button still owns focus. The root cause was that `SessionTurn` drove `aria-hidden` directly from `working()`, even though assistant content can contain copy buttons, tool triggers, and links.

## Related Issue

Closes #745

## Human Review Status

Pending

## Review Focus

Please focus on whether the helper keeps the existing streaming screen-reader hiding intent while preventing focus from remaining inside the hidden subtree.

## Risk Notes

Skipped conditional visual check because this changes focus handling and accessibility state only; it does not change visible UI or copy. Skipped platform check because no platform, packaging, updater, path, shell, or permission surface was touched. Skipped docs/release/dependency check because no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local-only files were touched.

## How To Verify

```text
Focused UI tests: bun --cwd packages/ui test ./src/components/session-turn-focus.test.ts ./src/components/session-turn-parent.test.ts -> 8 pass, 0 fail
UI typecheck: bun --cwd packages/ui typecheck -> exit 0
Lint: bun run lint -> exit 0
Diff check: git diff --check -> exit 0
```

## Screenshots or Recordings

Not required; no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
