### PR TITLE
test(opencode): stabilize runner cancel tests

### DIFF
--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -485,11 +485,13 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("interrupted") })
+      const blocked = yield* makeBlockedWork("ignored", "defective shell")
 
       const sh = yield* runner
-        .startShell(Effect.never.pipe(Effect.ensuring(Effect.die("boom")), Effect.as("ignored")))
+        .startShell(blocked.work.pipe(Effect.ensuring(Effect.die("boom"))))
         .pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Shell")
+      yield* blocked.waitUntilStarted
 
       yield* runner.cancel
       expect(Exit.isFailure(yield* Fiber.await(sh))).toBe(true)
@@ -501,11 +503,13 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string, string>(s, { onInterrupt: () => Effect.succeed("interrupted") })
+      const blocked = yield* makeBlockedWork("ignored", "typed failing shell")
 
       const sh = yield* runner
-        .startShell(Effect.never.pipe(Effect.onInterrupt(() => Effect.fail("boom")), Effect.as("ignored")))
+        .startShell(blocked.work.pipe(Effect.onInterrupt(() => Effect.fail("boom"))))
         .pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Shell")
+      yield* blocked.waitUntilStarted
 
       yield* runner.cancel
       const exit = yield* Fiber.await(sh)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -29,7 +29,7 @@ function waitForRunnerState<A, E>(runner: RunnerInstance<A, E>, tag: State<A, E>
 }
 
 // Effect Deferred does not expose waiter counts publicly; keep this runtime-shape check
-// local so queued-caller tests can prove a forked caller is attached before cancel/release.
+// local so runner tests can prove a forked caller/work fiber is attached before cancel/release.
 function deferredWaiterCount<A, E>(deferred: Deferred.Deferred<A, E>) {
   return (deferred as DeferredRuntimeWaiters).resumes?.length ?? 0
 }
@@ -46,6 +46,16 @@ function currentRunDone<A, E>(runner: RunnerInstance<A, E>) {
     const state = runner.state
     if (state._tag === "Running" || state._tag === "ShellThenRun") return state.run.done
     return yield* Effect.die(new Error(`Runner has no current run; current state is ${state._tag}`))
+  })
+}
+
+function makeBlockedWork<A>(value: A, label = "running work") {
+  return Effect.gen(function* () {
+    const release = yield* Deferred.make<void>()
+    return {
+      waitUntilBlocked: waitForDeferredWaiters(release, 1, label),
+      work: Deferred.await(release).pipe(Effect.as(value)),
+    }
   })
 }
 
@@ -161,8 +171,10 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("never")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
       expect(runner.busy).toBe(true)
       expect(runner.state._tag).toBe("Running")
 
@@ -189,8 +201,10 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("never")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
 
       yield* runner.cancel
 
@@ -207,8 +221,10 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, {
         onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
       })
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("never")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
 
       yield* runner.cancel
 
@@ -225,8 +241,10 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, {
         onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
       })
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("never")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
 
       yield* Scope.close(s, Exit.void)
 
@@ -243,9 +261,11 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
+      const blocked = yield* makeBlockedWork("x")
 
-      const a = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
+      const a = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
       const done = yield* currentRunDone(runner)
       const b = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
       yield* waitForDeferredWaiters(done, 2, "running run")
@@ -268,13 +288,14 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, {
         onInterrupt: (meta) => Effect.succeed(meta?.reason ?? "missing"),
       })
-      const work = Effect.never.pipe(
+      const blocked = yield* makeBlockedWork("never")
+      const work = blocked.work.pipe(
         Effect.onInterrupt(() => Deferred.await(release)),
-        Effect.as("never"),
       )
 
       const fiber = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
 
       yield* runner.cancelWith({ source: "first", reason: "first" }).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Idle")
@@ -292,8 +313,10 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("x")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
       yield* runner.cancel
       yield* Fiber.await(fiber)
 
@@ -585,8 +608,10 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, {
         onIdle: Ref.update(count, (n) => n + 1),
       })
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("x")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilBlocked
       yield* runner.cancel
       yield* Fiber.await(fiber)
       expect(yield* Ref.get(count)).toBeGreaterThanOrEqual(1)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, test } from "bun:test"
 import { Cause, Deferred, Effect, Exit, Fiber, Ref, Scope } from "effect"
 import { Runner } from "../../src/effect"
+import type { Runner as RunnerInstance, State } from "../../src/effect/runner"
 import { it } from "../lib/effect"
+
+function waitForRunnerState<A, E>(runner: RunnerInstance<A, E>, tag: State<A, E>["_tag"]) {
+  return Effect.gen(function* () {
+    const stop = Date.now() + 1_000
+    while (runner.state._tag !== tag) {
+      if (Date.now() > stop) {
+        throw new Error(`Runner did not enter ${tag}; current state is ${runner.state._tag}`)
+      }
+      yield* Effect.sleep("1 millis")
+    }
+  })
+}
 
 describe("Runner", () => {
   // --- ensureRunning semantics ---
@@ -116,7 +129,7 @@ describe("Runner", () => {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
       expect(runner.busy).toBe(true)
       expect(runner.state._tag).toBe("Running")
 
@@ -144,7 +157,7 @@ describe("Runner", () => {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
 
       yield* runner.cancel
 
@@ -162,7 +175,7 @@ describe("Runner", () => {
         onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
       })
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
 
       yield* runner.cancel
 
@@ -180,7 +193,7 @@ describe("Runner", () => {
         onInterrupt: (meta) => Effect.succeed(`${meta?.source}:${meta?.reason}:${typeof meta?.recordedAt}`),
       })
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("never"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
 
       yield* Scope.close(s, Exit.void)
 
@@ -199,9 +212,9 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, { onInterrupt: () => Effect.succeed("fallback") })
 
       const a = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
       const b = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* Effect.yieldNow
 
       yield* runner.cancel
 
@@ -227,10 +240,10 @@ describe("Runner", () => {
       )
 
       const fiber = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
 
       yield* runner.cancelWith({ source: "first", reason: "first" }).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Idle")
       yield* runner.cancelWith({ source: "second", reason: "second" })
       yield* Deferred.succeed(release, undefined)
 
@@ -246,7 +259,7 @@ describe("Runner", () => {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
       yield* runner.cancel
       yield* Fiber.await(fiber)
 
@@ -327,7 +340,7 @@ describe("Runner", () => {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
 
       const exit = yield* runner.startShell(Effect.succeed("nope")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
@@ -345,7 +358,7 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("first"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       const exit = yield* runner.startShell(Effect.succeed("second")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
@@ -366,7 +379,7 @@ describe("Runner", () => {
       })
 
       const sh = yield* runner.startShell(Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       const exit = yield* runner.startShell(Effect.succeed("second")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
@@ -385,7 +398,7 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("ignored"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       const stop = yield* runner.cancel.pipe(Effect.forkChild)
       const stopExit = yield* Fiber.await(stop).pipe(Effect.timeout("250 millis"))
@@ -408,7 +421,7 @@ describe("Runner", () => {
       const sh = yield* runner
         .startShell(Effect.never.pipe(Effect.ensuring(Effect.die("boom")), Effect.as("ignored")))
         .pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       yield* runner.cancel
       expect(Exit.isFailure(yield* Fiber.await(sh))).toBe(true)
@@ -424,7 +437,7 @@ describe("Runner", () => {
       const sh = yield* runner
         .startShell(Effect.never.pipe(Effect.onInterrupt(() => Effect.fail("boom")), Effect.as("ignored")))
         .pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       yield* runner.cancel
       const exit = yield* Fiber.await(sh)
@@ -445,11 +458,11 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("shell-result"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
       expect(runner.state._tag).toBe("Shell")
 
       const run = yield* runner.ensureRunning(Effect.succeed("run-result")).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "ShellThenRun")
       expect(runner.state._tag).toBe("ShellThenRun")
 
       yield* Deferred.succeed(gate, undefined)
@@ -471,7 +484,7 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("shell"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       const work = Effect.gen(function* () {
         yield* Ref.update(calls, (n) => n + 1)
@@ -479,7 +492,8 @@ describe("Runner", () => {
       })
       const a = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
       const b = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "ShellThenRun")
+      yield* Effect.yieldNow
 
       yield* Deferred.succeed(gate, undefined)
       yield* Fiber.await(sh)
@@ -498,10 +512,10 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s)
 
       const sh = yield* runner.startShell(Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
 
       const run = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "ShellThenRun")
       expect(runner.state._tag).toBe("ShellThenRun")
 
       yield* runner.cancel
@@ -537,7 +551,7 @@ describe("Runner", () => {
         onIdle: Ref.update(count, (n) => n + 1),
       })
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
       yield* runner.cancel
       yield* Fiber.await(fiber)
       expect(yield* Ref.get(count)).toBeGreaterThanOrEqual(1)
@@ -567,7 +581,7 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const fiber = yield* runner.ensureRunning(Deferred.await(gate).pipe(Effect.as("ok"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Running")
       expect(runner.busy).toBe(true)
 
       yield* Deferred.succeed(gate, undefined)
@@ -584,7 +598,7 @@ describe("Runner", () => {
       const gate = yield* Deferred.make<void>()
 
       const fiber = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("ok"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      yield* waitForRunnerState(runner, "Shell")
       expect(runner.busy).toBe(true)
 
       yield* Deferred.succeed(gate, undefined)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -405,8 +405,10 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
+      const blocked = yield* makeBlockedWork("x")
+      const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      yield* blocked.waitUntilStarted
 
       const exit = yield* runner.startShell(Effect.succeed("nope")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -28,13 +28,14 @@ function waitForRunnerState<A, E>(runner: RunnerInstance<A, E>, tag: State<A, E>
   )
 }
 
-// Effect Deferred does not expose waiter counts publicly; keep this runtime-shape check
-// local so runner tests can prove a forked caller/work fiber is attached before cancel/release.
+// Effect Deferred does not expose waiter counts publicly. Keep this test-only
+// runtime-shape check private to the shared-run tests that need to prove a
+// second caller is waiting on the existing run before cancel/release.
 function deferredWaiterCount<A, E>(deferred: Deferred.Deferred<A, E>) {
   return (deferred as DeferredRuntimeWaiters).resumes?.length ?? 0
 }
 
-function waitForDeferredWaiters<A, E>(deferred: Deferred.Deferred<A, E>, count: number, label: string) {
+function waitForSharedRunWaiters<A, E>(deferred: Deferred.Deferred<A, E>, count: number, label: string) {
   return waitUntil(
     () => `${label} did not attach ${count} waiter(s); current waiters=${deferredWaiterCount(deferred)}`,
     () => deferredWaiterCount(deferred) >= count,
@@ -51,10 +52,18 @@ function currentRunDone<A, E>(runner: RunnerInstance<A, E>) {
 
 function makeBlockedWork<A>(value: A, label = "running work") {
   return Effect.gen(function* () {
+    const started = yield* Deferred.make<void>()
     const release = yield* Deferred.make<void>()
     return {
-      waitUntilBlocked: waitForDeferredWaiters(release, 1, label),
-      work: Deferred.await(release).pipe(Effect.as(value)),
+      waitUntilStarted: Deferred.await(started).pipe(
+        Effect.timeoutOrElse({
+          duration: "1 second",
+          orElse: () => Effect.die(new Error(`${label} did not start`)),
+        }),
+      ),
+      work: Effect.uninterruptibleMask((restore) =>
+        Deferred.succeed(started, undefined).pipe(Effect.andThen(restore(Deferred.await(release))), Effect.as(value)),
+      ),
     }
   })
 }
@@ -174,7 +183,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("never")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
       expect(runner.busy).toBe(true)
       expect(runner.state._tag).toBe("Running")
 
@@ -204,7 +213,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("never")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
 
       yield* runner.cancel
 
@@ -224,7 +233,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("never")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
 
       yield* runner.cancel
 
@@ -244,7 +253,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("never")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
 
       yield* Scope.close(s, Exit.void)
 
@@ -265,10 +274,10 @@ describe("Runner", () => {
 
       const a = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
       const done = yield* currentRunDone(runner)
       const b = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
-      yield* waitForDeferredWaiters(done, 2, "running run")
+      yield* waitForSharedRunWaiters(done, 2, "running run")
 
       yield* runner.cancel
 
@@ -295,7 +304,7 @@ describe("Runner", () => {
 
       const fiber = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
 
       yield* runner.cancelWith({ source: "first", reason: "first" }).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Idle")
@@ -316,7 +325,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("x")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
       yield* runner.cancel
       yield* Fiber.await(fiber)
 
@@ -551,7 +560,7 @@ describe("Runner", () => {
       yield* waitForRunnerState(runner, "ShellThenRun")
       const done = yield* currentRunDone(runner)
       const b = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
-      yield* waitForDeferredWaiters(done, 2, "queued shell run")
+      yield* waitForSharedRunWaiters(done, 2, "queued shell run")
 
       yield* Deferred.succeed(gate, undefined)
       yield* Fiber.await(sh)
@@ -611,7 +620,7 @@ describe("Runner", () => {
       const blocked = yield* makeBlockedWork("x")
       const fiber = yield* runner.ensureRunning(blocked.work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
-      yield* blocked.waitUntilBlocked
+      yield* blocked.waitUntilStarted
       yield* runner.cancel
       yield* Fiber.await(fiber)
       expect(yield* Ref.get(count)).toBeGreaterThanOrEqual(1)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -1,18 +1,51 @@
 import { describe, expect, test } from "bun:test"
-import { Cause, Deferred, Effect, Exit, Fiber, Ref, Scope } from "effect"
+import { Cause, Clock, Deferred, Effect, Exit, Fiber, Ref, Scope } from "effect"
 import { Runner } from "../../src/effect"
 import type { Runner as RunnerInstance, State } from "../../src/effect/runner"
 import { it } from "../lib/effect"
 
-function waitForRunnerState<A, E>(runner: RunnerInstance<A, E>, tag: State<A, E>["_tag"]) {
+interface DeferredRuntimeWaiters {
+  readonly resumes?: ReadonlyArray<unknown>
+}
+
+function waitUntil(message: () => string, ready: () => boolean) {
   return Effect.gen(function* () {
-    const stop = Date.now() + 1_000
-    while (runner.state._tag !== tag) {
-      if (Date.now() > stop) {
-        throw new Error(`Runner did not enter ${tag}; current state is ${runner.state._tag}`)
+    const started = yield* Clock.currentTimeMillis
+    while (!ready()) {
+      const now = yield* Clock.currentTimeMillis
+      if (now - started > 1_000) {
+        return yield* Effect.die(new Error(message()))
       }
       yield* Effect.sleep("1 millis")
     }
+  })
+}
+
+function waitForRunnerState<A, E>(runner: RunnerInstance<A, E>, tag: State<A, E>["_tag"]) {
+  return waitUntil(
+    () => `Runner did not enter ${tag}; current state is ${runner.state._tag}`,
+    () => runner.state._tag === tag,
+  )
+}
+
+// Effect Deferred does not expose waiter counts publicly; keep this runtime-shape check
+// local so queued-caller tests can prove a forked caller is attached before cancel/release.
+function deferredWaiterCount<A, E>(deferred: Deferred.Deferred<A, E>) {
+  return (deferred as DeferredRuntimeWaiters).resumes?.length ?? 0
+}
+
+function waitForDeferredWaiters<A, E>(deferred: Deferred.Deferred<A, E>, count: number, label: string) {
+  return waitUntil(
+    () => `${label} did not attach ${count} waiter(s); current waiters=${deferredWaiterCount(deferred)}`,
+    () => deferredWaiterCount(deferred) >= count,
+  )
+}
+
+function currentRunDone<A, E>(runner: RunnerInstance<A, E>) {
+  return Effect.gen(function* () {
+    const state = runner.state
+    if (state._tag === "Running" || state._tag === "ShellThenRun") return state.run.done
+    return yield* Effect.die(new Error(`Runner has no current run; current state is ${state._tag}`))
   })
 }
 
@@ -213,8 +246,9 @@ describe("Runner", () => {
 
       const a = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "Running")
+      const done = yield* currentRunDone(runner)
       const b = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
-      yield* Effect.yieldNow
+      yield* waitForDeferredWaiters(done, 2, "running run")
 
       yield* runner.cancel
 
@@ -491,9 +525,10 @@ describe("Runner", () => {
         return "run"
       })
       const a = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
-      const b = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
       yield* waitForRunnerState(runner, "ShellThenRun")
-      yield* Effect.yieldNow
+      const done = yield* currentRunDone(runner)
+      const b = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
+      yield* waitForDeferredWaiters(done, 2, "queued shell run")
 
       yield* Deferred.succeed(gate, undefined)
       yield* Fiber.await(sh)


### PR DESCRIPTION
## Summary

- Add bounded runner-state and `Deferred` synchronization helpers for runner tests.
- Replace fixed sleep / `yieldNow` synchronization in cancel, shell, and queued-caller tests with explicit state and waiter handshakes.
- Wait for cancellation tests' blocking work fiber to start before calling `cancel`, closing the CI-only timeouts exposed by follow-up runs.
- Narrow the `Deferred` runtime waiter-count check to only the shared-run caller tests that have no public Effect hook for "second caller is waiting on the existing run".
- No related issue; this is a CI flake follow-up from recent post-merge failures.

## Why

Recent post-merge CI runs timed out in `Runner > cancel with onInterrupt resolves callers gracefully`. The original test forked `ensureRunning(...)`, slept for 10ms, then cancelled. On a slow runner, cancel can run before the runner has entered `Running`, making cancel a no-op and leaving the `Effect.never` waiter to time out.

Review follow-up also pointed out that two queued-caller tests still used `Effect.yieldNow` as a scheduling hint. Those now wait for the shared run `Deferred` to have both waiters attached before the test advances.

Later PR CI runs exposed the same class of race one layer deeper. `runner.state === "Running"` proves the runner state was installed, but it does not prove the work fiber has actually started. `runner.state === "Shell"` has the same boundary for shell masking assertions: it proves shell state was installed, but not that the shell effect and interrupt finalizers have started. The affected tests now use a local blocked-work helper with a public `Deferred` start handshake before cancelling.

The remaining `Deferred` runtime waiter-count check is intentionally private to this test file and only used for the two shared-run caller assertions. Effect does not expose a public signal for "this second caller is now awaiting the same run Deferred", and replacing that proof with sleep/yield would weaken the tests again.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that the test helpers stay local to runner test synchronization and that the queued-caller, cancel, and shell masking assertions now wait for the relevant caller/work fiber to attach before cancel/release.

## Risk Notes

No product behavior risk; this is test-only. Skipped conditional checklist items: visible UI or copy check because no visible UI or copy changed; platform/packaging impact because no runtime platform surface changed; docs/release/dependencies/permissions/generated-content checks because none of those surfaces were touched.

## How To Verify

```text
RED proof: bun --cwd packages/opencode -e '...' confirmed cancel-before-running leaves the waiter timing out.
Focused runner tests: cd packages/opencode && bun test test/effect/runner.test.ts --timeout 30000 -> 30 pass, 0 fail.
Focused runner repeat with CI Bun: for i in {1..100}; do /tmp/pawwork-bun-1.3.13/bun-darwin-aarch64/bun test test/effect/runner.test.ts --timeout 30000; done -> 100/100 runs passed.
Typecheck: cd packages/opencode && bun run typecheck -> passed.
Opencode CI subset with CI Bun: PATH=/tmp/pawwork-bun-1.3.13/bun-darwin-aarch64:$PATH bun turbo test:ci --filter=opencode -> 3071 pass, 9 skip, 1 todo, 0 fail.
Diff check: git diff --check -> no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.