### PR TITLE
fix(ui): restore shimmer for running trow summaries

### DIFF
--- a/packages/app/e2e/snap/session-trow.snap.ts
+++ b/packages/app/e2e/snap/session-trow.snap.ts
@@ -6,6 +6,7 @@ import { composeGrid, snapOutputPath, type Shot } from "./_compose"
 test.use({ viewport: { width: 900, height: 560 }, deviceScaleFactor: 2 })
 
 const LANGUAGE_KEY = "pawwork.global.dat:language"
+const ACTIVE_SHIMMER = '[data-slot="trow-summary-text"] [data-component="text-shimmer"][data-active="true"]'
 const fixturePath = fileURLToPath(new URL("./fixtures/trow-snap-fixture.tsx", import.meta.url))
 async function captureBlock(name: string, block: Locator): Promise<Shot> {
   await expect(block).toBeVisible({ timeout: 30_000 })
@@ -37,15 +38,18 @@ test("session-trow", async ({ page }) => {
   const shots: Shot[] = []
   const running = page.locator('[data-snap="running-current"]')
   await expect(running).toContainText("执行命令 third command", { timeout: 30_000 })
+  await expect(running.locator(ACTIVE_SHIMMER)).toBeVisible({ timeout: 30_000 })
   shots.push(await captureBlock("running-current", running))
 
   const activitySummary = page.locator('[data-snap="activity-summary-collapsed"]')
   await expect(activitySummary).toContainText("读取 1 个文件，运行 1 条命令，搜索文件 1 次", { timeout: 30_000 })
   await expect(activitySummary).toContainText("使用 1 个工具", { timeout: 30_000 })
+  await expect(activitySummary.locator(ACTIVE_SHIMMER)).toHaveCount(0)
   shots.push(await captureBlock("activity-summary-collapsed", activitySummary))
 
   const failedSummary = page.locator('[data-snap="failed-summary-collapsed"]')
   await expect(failedSummary).toContainText("运行 1 条命令，读取 1 个文件，1 个失败", { timeout: 30_000 })
+  await expect(failedSummary.locator(ACTIVE_SHIMMER)).toHaveCount(0)
   shots.push(await captureBlock("failed-summary-collapsed", failedSummary))
 
   shots.push(await captureBlock("mixed-collapsed", page.locator('[data-snap="mixed-collapsed"]')))

--- a/packages/ui/src/components/session-turn-trow-block.css
+++ b/packages/ui/src/components/session-turn-trow-block.css
@@ -142,12 +142,10 @@
   transform: rotate(0deg);
 }
 
-/* Running state — summary shimmer hook. The actual pw-shimmer animation
- * is wired by the caller (session-turn.css owns the `.pw-shimmer` class
- * application against `[data-running]` after the Phase 2a rewrite); this
- * file leaves the data attribute exposed so the shimmer can attach. */
+/* Running state marker remains on the block; summary text uses TextShimmer
+ * directly so the shared reduced-motion and swap behavior stay centralized. */
 [data-component="session-turn-trow-block"][data-running] [data-slot="trow-summary-text"] {
-  /* Hook for shimmer; intentionally no animation rule here. */
+  /* Marker target for state-specific overrides; no local animation here. */
 }
 
 /* Body — the outer wrapper that holds the per-tool sub-rows. AstroHan

--- a/packages/ui/src/components/session-turn-trow-block.tsx
+++ b/packages/ui/src/components/session-turn-trow-block.tsx
@@ -231,10 +231,10 @@ export function TrowBlock(props: TrowBlockProps) {
               <span data-slot="trow-summary-icon">
                 <Icon name={leadingIcon()} />
               </span>
-              <Show keyed when={summaryText()}>
+              <Show when={summaryText()}>
                 {(text) => (
                   <span data-slot="trow-summary-text">
-                    <TextShimmer text={text} active={!!activeTool()} />
+                    <TextShimmer text={text()} active={!!activeTool()} />
                   </span>
                 )}
               </Show>

--- a/packages/ui/src/components/session-turn-trow-block.tsx
+++ b/packages/ui/src/components/session-turn-trow-block.tsx
@@ -2,6 +2,7 @@ import { For, Show, createMemo, createSignal, type JSX } from "solid-js"
 import type { ToolPart } from "@opencode-ai/sdk/v2"
 import { patchFiles } from "./apply-patch-file"
 import { Icon, type IconName } from "./icon"
+import { TextShimmer } from "./text-shimmer"
 import "./session-turn-trow-block.css"
 
 // ============================================================================
@@ -231,7 +232,11 @@ export function TrowBlock(props: TrowBlockProps) {
                 <Icon name={leadingIcon()} />
               </span>
               <Show keyed when={summaryText()}>
-                {(text) => <span data-slot="trow-summary-text">{text}</span>}
+                {(text) => (
+                  <span data-slot="trow-summary-text">
+                    <TextShimmer text={text} active={!!activeTool()} />
+                  </span>
+                )}
               </Show>
               <Show when={hasExpandableBody()}>
                 <span data-slot="trow-summary-chev" aria-hidden="true">


### PR DESCRIPTION
## Summary

Restore the shared `TextShimmer` treatment for active trow summary text while keeping completed trow summaries stable.

## Why

Issue #882 tracks the follow-up from PR #874: grouped trow summaries expose running state, but the summary text was still rendered as plain text. This makes active tool-group changes feel abrupt and leaves the existing shimmer contract unused.

## Related Issue

Fixes #882

## Human Review Status

Approved by @Astro-Han

## Review Focus

Please check that the shimmer is scoped only to active trow summary text and that completed summaries do not keep an active animation node.

## Risk Notes

The change adds one shared TextShimmer instance to active trow summaries, so the main risk is render/perf cost during tool-heavy sessions. Targeted snap and perf probe scenarios passed. Platform/packaging checklist item is unticked because this touches only web-rendered UI component code and snap coverage.

## How To Verify

```text
RED check: bun run snap session-trow failed before implementation because active running-current trow had no active TextShimmer node.
bun install --frozen-lockfile: installed dependencies in the isolated worktree.
bun run typecheck: passed.
bun test --preload ./happydom.ts ./src/components/session-turn-trow-block.reducer.test.ts: 19 passed.
bun run snap session-trow: passed; screenshot grid generated at docs/design/preview/screenshots/session-trow.png.
PAWWORK_PERF_SCENARIOS=tool-call-expand bun run test:e2e:local:perf: 1 passed, 9 skipped.
PAWWORK_PERF_PROFILE=low-end PAWWORK_PERF_SCENARIOS=concurrent-shimmer-extreme bun run test:e2e:local:perf: 1 passed, 9 skipped.
git diff --cached --check: passed.
Review follow-up for Gemini suggestion: removed keyed remount path for TextShimmer text updates.
Follow-up bun run typecheck: passed.
Follow-up bun test --preload ./happydom.ts ./src/components/session-turn-trow-block.reducer.test.ts: 19 passed.
Follow-up bun run snap session-trow: passed.
Follow-up git diff --check: passed.
```

## Screenshots or Recordings

Updated snap target: `session-trow`, generated `docs/design/preview/screenshots/session-trow.png`.

Manual Electron check passed by @Astro-Han.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shimmer loading animations to session summary text during active operations and various summary states

* **Tests**
  * Extended snapshot tests to verify shimmer animation visibility and behavior across different session summary display states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
