### PR TITLE
chore(release): bump desktop version to v2026.5.25

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.23",
+      "version": "2026.5.25",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.23",
+  "version": "2026.5.25",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the desktop Electron package version to v2026.5.25 for the next PawWork release. There is no related issue because this is the release train version bump.

## Why

The v2026.5.25 release needs to include the latest merged PRs on dev, especially #874, #878, #880, #881, and #883.

## Related Issue

None. Release version bump only.

## Human Review Status

Not required: automated release version bump only.

## Review Focus

Confirm the version is updated only in the desktop Electron package metadata and lockfile workspace entry.

## Risk Notes

Low risk. This PR does not change runtime behavior, dependencies, generated files, UI, docs, or permissions. Platform impact is limited to the release package version metadata used by desktop builds.

## How To Verify

```text
Version check: packages/desktop-electron/package.json reports 2026.5.25.
Typecheck: bun --cwd packages/app typecheck && bun --cwd packages/desktop-electron typecheck passed.
Focused UI tests: bun --cwd packages/ui test src/components/message-part/grouping.test.ts src/components/session-turn-trow-block.reducer.test.ts src/components/message-part-registry.test.ts passed, 34 tests.
Computer Use manual E2E: Electron dev app started with version 2026.5.25; created a new session; ran an actual Execute command tool call; verified output /Users/yuhan/PawWork; opened/collapsed the right panel; added Files/Review/Terminal right-panel tabs; pinned two sessions and drag-reordered them in the sidebar; verified the left sidebar toggle state after #880.
Broader app E2E note: a mixed targeted suite had stale expectations in e2e/commands/panels.spec.ts and e2e/status/status-popover.spec.ts after the #878/#880 right-panel titlebar changes; the release bump itself does not change those surfaces.
```

## Screenshots or Recordings

Not required: no visible UI changes in this version bump. Manual Computer Use checks covered the release candidate UI paths listed above.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.