### PR TITLE
fix(app): right-panel titlebar seam — alignment, stable toggle, drag-resize sync

### DIFF
--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -147,23 +147,27 @@ test.describe("titlebar right rail contract", () => {
     await openRightPanel(page)
     await page.mouse.move(0, 0)
 
-    const lefts = await page.evaluate(() => {
-      const tabs = document.getElementById("pawwork-titlebar-tabs") as HTMLElement | null
-      const body = document.querySelector(
-        '[data-component="right-panel-body"]',
-      ) as HTMLElement | null
-      return {
-        tabs: tabs ? tabs.getBoundingClientRect().left : null,
-        body: body ? body.getBoundingClientRect().left : null,
-      }
-    })
-
-    expect(lefts.tabs).not.toBeNull()
-    expect(lefts.body).not.toBeNull()
-    // Sub-pixel tolerance — both use the same panel-width source, so they
-    // should be identical at integer-CSS-pixel widths, but devicePixelRatio
-    // rounding can introduce ≤0.5px noise on Retina.
-    expect(Math.abs((lefts.tabs ?? 0) - (lefts.body ?? 0))).toBeLessThan(1)
+    // Poll for steady state instead of reading immediately: the panel
+    // `<aside>` width and shell `--right-panel-width` both transition over
+    // 240ms (CSS width transition vs @property var transition) and the
+    // `data-resizing-right-panel` snap-gate only fires during drag-resize,
+    // not panel open/close. Reading mid-flight can hit transient sub-pixel
+    // drift between the two interpolators and bust the <1px tolerance.
+    // Sub-pixel tolerance at steady state — both use the same panel-width
+    // source, so they should be identical at integer-CSS-pixel widths,
+    // but devicePixelRatio rounding can introduce ≤0.5px noise on Retina.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const tabs = document.getElementById("pawwork-titlebar-tabs")
+            const body = document.querySelector('[data-component="right-panel-body"]')
+            if (!tabs || !body) return null
+            return Math.abs(tabs.getBoundingClientRect().left - body.getBoundingClientRect().left)
+          }),
+        { timeout: 2_000 },
+      )
+      .toBeLessThan(1)
   })
 
   test("right utility toggle keeps the same x-position across open/close", async ({
@@ -191,13 +195,21 @@ test.describe("titlebar right rail contract", () => {
         return btn ? btn.getBoundingClientRect().right : null
       })
 
-    // Sanity: start closed (the default session view starts with the panel
-    // closed in the e2e harness).
+    // Normalize to closed before sampling — the e2e harness defaults to
+    // closed today, but persisting that as a fixture assumption is fragile
+    // (a future session-fixture or persisted-layout shift would flip it
+    // and the test would silently measure "open" twice). aria-expanded is
+    // the source of truth.
+    const toggleButton = page.locator('button[aria-label="Right utility panel"]')
+    if ((await toggleButton.getAttribute("aria-expanded")) === "true") {
+      await toggleButton.click()
+      await expect(toggleButton).toHaveAttribute("aria-expanded", "false")
+    }
     const closed = await toggleRight()
     expect(closed).not.toBeNull()
 
     // Open the panel via the toggle itself.
-    await page.getByRole("button", { name: "Right utility panel" }).click()
+    await toggleButton.click()
     // Wait for `open()` to flip — aria-expanded reflects the source of truth.
     await expect
       .poll(

--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -165,4 +165,73 @@ test.describe("titlebar right rail contract", () => {
     // rounding can introduce ≤0.5px noise on Retina.
     expect(Math.abs((lefts.tabs ?? 0) - (lefts.body ?? 0))).toBeLessThan(1)
   })
+
+  test("right utility toggle keeps the same x-position across open/close", async ({
+    page,
+    gotoSession,
+  }) => {
+    // Regression guard from the post-#887 design discussion: PR #880's
+    // structural layout (toggle as a flex sibling of the tabs slot) made
+    // the toggle slide left by `--right-panel-width` whenever the panel
+    // opened, which the maintainer reported as visually jarring once the
+    // alignment seam was fixed and the motion became visible. The agreed
+    // fix renders the toggle in two locations — `#pawwork-titlebar-right`
+    // when closed, and as the rightmost child of the portalled Tabs.List
+    // when open — both pinned to the same titlebar top-right corner so
+    // the user perceives no x-motion when toggling. This test pins that
+    // contract: the toggle's right edge stays within a small tolerance
+    // across open and closed states.
+    await gotoSession()
+    await page.mouse.move(0, 0)
+
+    const toggleRect = async () => {
+      const rect = await page.evaluate(() => {
+        const btn = document.querySelector<HTMLElement>(
+          'button[aria-label="Right utility panel"]',
+        )
+        if (!btn) return null
+        const r = btn.getBoundingClientRect()
+        return { right: r.right, top: r.top, height: r.height }
+      })
+      return rect
+    }
+
+    // Sanity: start closed (the default session view starts with the panel
+    // closed in the e2e harness).
+    const closed = await toggleRect()
+    expect(closed).not.toBeNull()
+
+    // Open the panel via the toggle itself (clicking the closed-state copy
+    // in `#pawwork-titlebar-right` triggers the open).
+    await page.getByRole("button", { name: "Right utility panel" }).click()
+    // Wait for `open()` to flip and the in-tabs toggle to mount.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const btn = document.querySelector<HTMLElement>(
+              'button[aria-label="Right utility panel"][aria-expanded="true"]',
+            )
+            return !!btn
+          }),
+        { timeout: 2_000 },
+      )
+      .toBe(true)
+    // Let the 240ms width transition finish so the tabs slot is at its
+    // resting width — toggle.right shouldn't drift, but reading mid-
+    // transition can hit sub-pixel noise unrelated to the contract.
+    await page.waitForTimeout(300)
+
+    const open = await toggleRect()
+    expect(open).not.toBeNull()
+
+    // The two copies are intentionally different DOM nodes (closed copy
+    // in `#pawwork-titlebar-right`, open copy at the right end of the
+    // portalled Tabs.List). Their right edges should align within a few
+    // CSS pixels — perfect alignment requires matching the `pr-2` (8px)
+    // toggle inset against the Tabs.List `px-1` (4px) plus any toggle
+    // wrapper padding, so a small drift is acceptable; anything beyond
+    // ~12px would visibly read as motion.
+    expect(Math.abs((open?.right ?? 0) - (closed?.right ?? 0))).toBeLessThan(12)
+  })
 })

--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -127,4 +127,42 @@ test.describe("titlebar right rail contract", () => {
     expect(heights.tabs).not.toBeNull()
     expect(heights.tabs).toBe(heights.titlebar)
   })
+
+  test("tabs slot border-l aligns horizontally with the right-panel body border-l (no x-axis seam break)", async ({
+    page,
+    gotoSession,
+  }) => {
+    // Regression guard for the post-release seam reported after PR #880:
+    // the macOS titlebar-shell carried a symmetric `padding-inline: 8px`,
+    // which pushed the tabs slot's right edge 8px inboard of the viewport.
+    // The right-panel `<aside>` directly below sits in a sibling layout
+    // tree without that padding, so its `border-left` reached the viewport
+    // edge — the two `border-l`s ended up offset by 8px on macOS only.
+    // Fix: macOS titlebar uses `padding-inline-start: 8px` only (see
+    // `packages/app/src/index.css` `[data-shell-os="macos"]` rule). This
+    // test asserts the horizontal seam is continuous so any future
+    // re-introduction of right-side titlebar padding (or any other
+    // x-offset between the two `border-l`s) fails fast.
+    await gotoSession()
+    await openRightPanel(page)
+    await page.mouse.move(0, 0)
+
+    const lefts = await page.evaluate(() => {
+      const tabs = document.getElementById("pawwork-titlebar-tabs") as HTMLElement | null
+      const body = document.querySelector(
+        '[data-component="right-panel-body"]',
+      ) as HTMLElement | null
+      return {
+        tabs: tabs ? tabs.getBoundingClientRect().left : null,
+        body: body ? body.getBoundingClientRect().left : null,
+      }
+    })
+
+    expect(lefts.tabs).not.toBeNull()
+    expect(lefts.body).not.toBeNull()
+    // Sub-pixel tolerance — both use the same panel-width source, so they
+    // should be identical at integer-CSS-pixel widths, but devicePixelRatio
+    // rounding can introduce ≤0.5px noise on Retina.
+    expect(Math.abs((lefts.tabs ?? 0) - (lefts.body ?? 0))).toBeLessThan(1)
+  })
 })

--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -174,64 +174,233 @@ test.describe("titlebar right rail contract", () => {
     // structural layout (toggle as a flex sibling of the tabs slot) made
     // the toggle slide left by `--right-panel-width` whenever the panel
     // opened, which the maintainer reported as visually jarring once the
-    // alignment seam was fixed and the motion became visible. The agreed
-    // fix renders the toggle in two locations — `#pawwork-titlebar-right`
-    // when closed, and as the rightmost child of the portalled Tabs.List
-    // when open — both pinned to the same titlebar top-right corner so
-    // the user perceives no x-motion when toggling. This test pins that
-    // contract: the toggle's right edge stays within a small tolerance
-    // across open and closed states.
+    // alignment seam was fixed and the motion became visible. The fix
+    // keeps the toggle in `#pawwork-titlebar-right` (still rendered by
+    // `SessionHeader` via Portal) but makes that container absolute-
+    // positioned to the rail's top-right corner — so the same DOM node
+    // sits at the same viewport-pixel `right` across open and closed
+    // states. This test pins that contract.
     await gotoSession()
     await page.mouse.move(0, 0)
 
-    const toggleRect = async () => {
-      const rect = await page.evaluate(() => {
+    const toggleRight = () =>
+      page.evaluate(() => {
         const btn = document.querySelector<HTMLElement>(
           'button[aria-label="Right utility panel"]',
         )
-        if (!btn) return null
-        const r = btn.getBoundingClientRect()
-        return { right: r.right, top: r.top, height: r.height }
+        return btn ? btn.getBoundingClientRect().right : null
       })
-      return rect
-    }
 
     // Sanity: start closed (the default session view starts with the panel
     // closed in the e2e harness).
-    const closed = await toggleRect()
+    const closed = await toggleRight()
     expect(closed).not.toBeNull()
 
-    // Open the panel via the toggle itself (clicking the closed-state copy
-    // in `#pawwork-titlebar-right` triggers the open).
+    // Open the panel via the toggle itself.
     await page.getByRole("button", { name: "Right utility panel" }).click()
-    // Wait for `open()` to flip and the in-tabs toggle to mount.
+    // Wait for `open()` to flip — aria-expanded reflects the source of truth.
     await expect
       .poll(
         () =>
           page.evaluate(() => {
             const btn = document.querySelector<HTMLElement>(
-              'button[aria-label="Right utility panel"][aria-expanded="true"]',
+              'button[aria-label="Right utility panel"]',
             )
-            return !!btn
+            return btn?.getAttribute("aria-expanded") ?? null
           }),
         { timeout: 2_000 },
       )
+      .toBe("true")
+    // Poll until the toggle's right edge is stable (two consecutive reads
+    // match within sub-pixel rounding). The slot's 240ms width transition
+    // doesn't move the toggle (it's absolute-positioned to the rail), but
+    // reading mid-paint can hit transient values; polling for stability
+    // beats a fixed `waitForTimeout` that's either too short or wasteful.
+    let prev: number | null = null
+    await expect
+      .poll(
+        async () => {
+          const current = await toggleRight()
+          const stable = prev !== null && current !== null && Math.abs(current - prev) < 1
+          prev = current
+          return stable
+        },
+        { timeout: 2_000, intervals: [50, 80, 120, 200] },
+      )
       .toBe(true)
-    // Let the 240ms width transition finish so the tabs slot is at its
-    // resting width — toggle.right shouldn't drift, but reading mid-
-    // transition can hit sub-pixel noise unrelated to the contract.
-    await page.waitForTimeout(300)
 
-    const open = await toggleRect()
+    const open = await toggleRight()
     expect(open).not.toBeNull()
 
-    // The two copies are intentionally different DOM nodes (closed copy
-    // in `#pawwork-titlebar-right`, open copy at the right end of the
-    // portalled Tabs.List). Their right edges should align within a few
-    // CSS pixels — perfect alignment requires matching the `pr-2` (8px)
-    // toggle inset against the Tabs.List `px-1` (4px) plus any toggle
-    // wrapper padding, so a small drift is acceptable; anything beyond
-    // ~12px would visibly read as motion.
-    expect(Math.abs((open?.right ?? 0) - (closed?.right ?? 0))).toBeLessThan(12)
+    // Same DOM node, absolute-positioned to the same `right` inset in both
+    // states — should be pixel-identical within sub-pixel rounding noise
+    // (Retina devicePixelRatio 2x can introduce ≤0.5px deltas).
+    expect(Math.abs((open ?? 0) - (closed ?? 0))).toBeLessThan(1)
+  })
+
+  test('"+" add-tab button stays clickable and does not close the panel (no toggle overlap)', async ({
+    page,
+    gotoSession,
+  }) => {
+    // Regression guard for the P1 risk raised in code review of #887:
+    // the right utility toggle is absolute-positioned over the rightmost
+    // area of the tabs slot, and the `+` (add-tab DropdownMenu trigger)
+    // lives inside the portalled Tabs.List. If `+` ever slides under the
+    // toggle's hit-target (e.g. Tabs.List grows to fill the slot, or the
+    // slot's right-reserve gets removed), clicks meant for `+` would be
+    // intercepted by the toggle — opening the dropdown would instead
+    // close the panel. This test asserts the user-visible contract:
+    // clicking `+` opens its menu AND the panel stays open.
+    await gotoSession()
+    await openRightPanel(page)
+    await page.mouse.move(0, 0)
+    // Let the open animation settle so the slot is at resting width
+    // and the `+` button is at its final position.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const btn = document.querySelector<HTMLElement>(
+              'button[aria-label="Right utility panel"]',
+            )
+            return btn?.getAttribute("aria-expanded") ?? null
+          }),
+        { timeout: 2_000 },
+      )
+      .toBe("true")
+
+    // Click the `+` add-tab trigger. If the toggle's hit-target covers it,
+    // this click triggers the toggle instead and aria-expanded flips false.
+    await page.getByRole("button", { name: "Add tab" }).click()
+
+    // Contract 1: panel stays open. Use a raw selector instead of
+    // `getByRole` because the open DropdownMenu makes the rest of the page
+    // inert/aria-hidden, which `getByRole` filters out.
+    await expect(
+      page.locator('button[aria-label="Right utility panel"]'),
+    ).toHaveAttribute("aria-expanded", "true")
+    // Contract 2: the dropdown menu actually opened. Solid-ui's DropdownMenu
+    // renders content in a portal with role="menu".
+    await expect(page.getByRole("menu")).toBeVisible({ timeout: 2_000 })
+  })
+
+  test('"+" stays clickable even if Tabs.List is forced to fill the slot (collision guard)', async ({
+    page,
+    gotoSession,
+  }) => {
+    // Fortification test for the same P1 risk: the no-collision guarantee
+    // in production today depends on Kobalte's `Tabs.List` rendering at
+    // content-width. If a future change makes the list fill the slot, the
+    // `+` button would slide to the slot's right edge. The titlebar slot
+    // reserves a 44px right padding to make that case safe; this test
+    // injects the future scenario (`width: 100% !important` on
+    // `[data-slot="tabs-list"]`) and asserts the contract still holds.
+    await gotoSession()
+    await openRightPanel(page)
+
+    // Force the "future" layout: Tabs.List fills the slot.
+    await page.addStyleTag({
+      content: `
+        #pawwork-titlebar-tabs [data-slot="tabs-list"] {
+          width: 100% !important;
+          flex-grow: 1 !important;
+        }
+      `,
+    })
+
+    await page.mouse.move(0, 0)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const btn = document.querySelector<HTMLElement>(
+              'button[aria-label="Right utility panel"]',
+            )
+            return btn?.getAttribute("aria-expanded") ?? null
+          }),
+        { timeout: 2_000 },
+      )
+      .toBe("true")
+
+    // Geometry check: `+` button's right edge must stop before the toggle's
+    // left edge — i.e. the slot's padding-end reserve actually keeps them
+    // apart even with Tabs.List filling the slot.
+    const geom = await page.evaluate(() => {
+      const plus = document.querySelector<HTMLElement>('button[aria-label="Add tab"]')
+      const toggle = document.querySelector<HTMLElement>(
+        'button[aria-label="Right utility panel"]',
+      )
+      return {
+        plusRight: plus?.getBoundingClientRect().right ?? null,
+        toggleLeft: toggle?.getBoundingClientRect().left ?? null,
+      }
+    })
+    expect(geom.plusRight).not.toBeNull()
+    expect(geom.toggleLeft).not.toBeNull()
+    expect(geom.plusRight!).toBeLessThan(geom.toggleLeft!)
+
+    // Behavioral check: `+` still actually opens its dropdown without
+    // closing the panel — geometry alone could be misleading if some
+    // hit-test layer intercepts.
+    await page.getByRole("button", { name: "Add tab" }).click()
+    await expect(
+      page.locator('button[aria-label="Right utility panel"]'),
+    ).toHaveAttribute("aria-expanded", "true")
+    await expect(page.getByRole("menu")).toBeVisible({ timeout: 2_000 })
+  })
+
+  test("data-resizing-right-panel attribute does not leak when viewport drops below the desktop breakpoint mid-resize state", async ({
+    page,
+    gotoSession,
+  }) => {
+    // Regression guard from review of #887: the sizing effect mirrors
+    // `props.size.active()` to a `data-resizing-right-panel` attribute on
+    // `<desktop-shell>`, which a `!important` CSS rule reads to suppress
+    // the shell's transition. If the effect leaves the attribute set
+    // (early-return on breakpoint flip without cleanup, or component
+    // unmount with active=true), the shell's `--right-panel-width` and
+    // `--sidebar-width` transitions stay disabled across the whole
+    // session — sidebar/right-panel open/close animations silently die.
+    //
+    // We simulate the leak path by setting the attribute via DOM directly
+    // (mimicking an in-progress drag), then triggering the breakpoint flip
+    // that previously hit the unguarded `early return`, and assert the
+    // attribute is gone — proving the effect re-runs cleanup correctly.
+    await gotoSession()
+    await openRightPanel(page)
+
+    // Pre-condition: the attribute is absent at rest.
+    await expect.poll(
+      () =>
+        page.evaluate(() =>
+          document
+            .querySelector('[data-component="desktop-shell"]')
+            ?.hasAttribute("data-resizing-right-panel"),
+        ),
+      { timeout: 2_000 },
+    ).toBe(false)
+
+    // Force the attribute on (simulates "drag is active").
+    await page.evaluate(() => {
+      document
+        .querySelector('[data-component="desktop-shell"]')
+        ?.setAttribute("data-resizing-right-panel", "")
+    })
+
+    // Now flip the breakpoint — viewport shrinks below 768px. The sizing
+    // effect must re-run, hit its "always-clear" step, and remove the
+    // attribute even though `isDesktop()` will then early-return.
+    await page.setViewportSize({ width: 600, height: 900 })
+
+    // Attribute should be gone within a tick or two of the breakpoint flip.
+    await expect.poll(
+      () =>
+        page.evaluate(() =>
+          document
+            .querySelector('[data-component="desktop-shell"]')
+            ?.hasAttribute("data-resizing-right-panel"),
+        ),
+      { timeout: 2_000 },
+    ).toBe(false)
   })
 })

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -167,62 +167,65 @@ export function Titlebar() {
         <div id="pawwork-titlebar-center" class="pointer-events-auto min-w-0 flex justify-center w-fit max-w-full" />
       </div>
 
-      {/* Right titlebar rail. Two in-flow flex siblings, ordered left→right:
-          (1) `#pawwork-titlebar-right` — the right utility toggle (or
-              StatusPopover fallback on non-session routes), portalled in
-              by SessionHeader.
-          (2) `#pawwork-titlebar-tabs` — the right-panel tab strip, portalled
-              in by SessionSidePanel only when the panel is open.
+      {/* Right titlebar rail. Two children, intentionally NOT flex siblings:
 
-          The tabs slot's width follows `var(--right-panel-width)` so it
-          occupies the same x-range as the right-panel body directly below
-          and the `border-l` reads as one continuous separator from titlebar
-          top to viewport bottom. Because the two slots are flex siblings
-          (not an absolute overlay over the toggle), the toggle is naturally
-          pushed left by `--right-panel-width` when the panel opens and
-          slides back to the viewport edge when it closes. The 240ms
-          transition on `--right-panel-width` carries the toggle smoothly
-          along with the panel edge, and no pointer-events choreography is
-          needed — the toggle and the tab strip own disjoint geometry.
+          (1) `#pawwork-titlebar-tabs` — the right-panel tab strip, portalled
+              in by SessionSidePanel only when the panel is open. In-flow,
+              the only flex child of the rail; with `justify-end` on the
+              rail it pins to the viewport right edge. Its width follows
+              `var(--right-panel-width)` so the `border-l` lands at the
+              same x as the right-panel body's `border-left` directly
+              below, forming one continuous separator from titlebar top to
+              viewport bottom.
+
+          (2) `#pawwork-titlebar-right` — the right utility toggle (or
+              StatusPopover fallback on non-session routes), portalled in
+              by SessionHeader. **Absolute-positioned** to the rail's
+              top-right corner (`right-2`) so it stays at the same visual
+              x-coordinate (`viewport.right - 8px`) regardless of whether
+              the panel is open or closed. PR #880 had this as an in-flow
+              flex sibling that got pushed left by `--right-panel-width`
+              when the panel opened; the resulting 240ms slide read as
+              visually jarring once the alignment seam was fixed and the
+              motion became visible against the now-aligned border-l. The
+              absolute position trades a 240ms slide for a stable corner.
+
+              The toggle visually overlaps the rightmost area of the tabs
+              slot when open, but in practice they don't collide: Kobalte's
+              `Tabs.List` sizes to its content (~150px for 1-4 chips, well
+              under the ~380px panel width), so the trailing `+` button
+              sits in the middle of the panel column with empty space to
+              its right. The toggle floats in that empty space at the
+              viewport corner.
 
           "Borrowed identity": the tabs slot stamps `data-component="tabs"`
           + `data-variant="sidepanel"` + `data-scope` + `data-orientation`
           so the descendant selectors in `packages/ui/src/components/tabs.css`
           (e.g. `[data-component="tabs"] [data-slot="tabs-list"]`) match the
           portalled `Tabs.List`. The base `[data-component="tabs"]` rule
-          also sets `flex-direction: column` on the host (expecting
-          Tabs.List + Tabs.Content stacked vertically); the slot's own
+          also sets `flex-direction: column` on the host; the slot's own
           `flex-row` class flips that locally so it stays a horizontal
           strip.
 
           `border-l` and the panel-width track only when `tabsRailActive`
-          (session route + right panel open). On home/settings the slot
-          shrinks to 0 width — without this gate, navigating away while
-          the panel was left open would still claim panel-width in the
-          titlebar (the CSS var survives navigation) and push the
-          StatusPopover fallback to the left.
+          (desktop + session route + right panel open). On home/settings
+          the slot shrinks to 0 width — without this gate, navigating away
+          while the panel was left open would still claim panel-width in
+          the titlebar (the CSS var survives navigation) and the empty
+          slot would still paint a border-l.
 
-          `pr-2` lives on `#pawwork-titlebar-right` (not the outer rail)
-          so it reads as "toggle inset from viewport edge" when the panel
-          is closed and "gap between toggle and tabs border-l" when open.
-          Putting it on the outer rail would shift the tabs slot 8px
-          inboard of the viewport, misaligning its `border-l` with the
-          right-panel body's `border-l` directly below it.
+          `pr-2` on `#pawwork-titlebar-right` is gone — the absolute
+          `right-2` positioning replaces it. `right-2` is `--space-2`
+          (8px) by default per the design tokens, matching the old `pr-2`
+          inset from the viewport edge.
 
           `self-stretch` on the rail is load-bearing — the titlebar root
           uses `items-center`, which lets each grid cell collapse to its
           child's content height. Without this opt-out, the tabs slot's
           `self-stretch` would only reach the rail's content height
-          (≈30px toggle row), and its `border-l` would break above and
-          below the toggle row instead of meeting the right-panel body's
-          `border-l` as one continuous separator. */}
-      <div class="self-stretch flex items-center min-w-0 justify-end">
-        <div
-          id="pawwork-titlebar-right"
-          data-shell-slot="right-portal"
-          class="flex items-center gap-1 shrink-0 justify-end"
-          classList={{ "pr-2": !windows() }}
-        />
+          (≈0px when the absolute toggle takes the rail out of intrinsic
+          sizing), and its `border-l` would not paint full-height. */}
+      <div class="self-stretch relative flex items-center min-w-0 justify-end">
         <div
           id="pawwork-titlebar-tabs"
           data-shell-slot="tabs-portal"
@@ -233,6 +236,12 @@ export function Titlebar() {
           class="self-stretch flex flex-row items-center shrink-0"
           classList={{ "border-l border-border-weaker": tabsRailActive() }}
           style={{ width: tabsRailWidth() }}
+        />
+        <div
+          id="pawwork-titlebar-right"
+          data-shell-slot="right-portal"
+          class="absolute top-1/2 -translate-y-1/2 z-10 flex items-center gap-1 justify-end"
+          classList={{ "right-2": !windows(), "right-0": windows() }}
         />
       </div>
     </header>

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -191,12 +191,14 @@ export function Titlebar() {
               absolute position trades a 240ms slide for a stable corner.
 
               The toggle visually overlaps the rightmost area of the tabs
-              slot when open, but in practice they don't collide: Kobalte's
-              `Tabs.List` sizes to its content (~150px for 1-4 chips, well
-              under the ~380px panel width), so the trailing `+` button
-              sits in the middle of the panel column with empty space to
-              its right. The toggle floats in that empty space at the
-              viewport corner.
+              slot when open. The slot explicitly reserves a 44px
+              padding-end (toggle width + viewport inset + gap + buffer;
+              see the math in the inline style on the slot below) so the
+              trailing `+` button cannot enter the toggle's hit-target
+              zone — even if a future change makes Kobalte's Tabs.List
+              fill the slot 100% (today it renders at content width as a
+              CSS side-effect; the reserve makes the no-collision contract
+              independent of that side-effect).
 
           "Borrowed identity": the tabs slot stamps `data-component="tabs"`
           + `data-variant="sidepanel"` + `data-scope` + `data-orientation`
@@ -235,7 +237,30 @@ export function Titlebar() {
           data-scope="right-panel"
           class="self-stretch flex flex-row items-center shrink-0"
           classList={{ "border-l border-border-weaker": tabsRailActive() }}
-          style={{ width: tabsRailWidth() }}
+          style={{
+            width: tabsRailWidth(),
+            // Reserve the rightmost area of the slot for the absolute-
+            // positioned toggle above it. Today Kobalte's Tabs.List renders
+            // at content-width (~150px for 1-4 chips), so the `+` button
+            // never reaches the slot's right edge and doesn't collide with
+            // the toggle's hit-target. That's a coincidence of the current
+            // CSS — if a future change makes Tabs.List fill 100% (a `w-full`
+            // on the consumer, a tabs.css refactor, a Kobalte upgrade), the
+            // `+` would slide under the toggle and intercept clicks meant
+            // for it. The explicit padding-end makes the right-edge zone
+            // part of the slot's layout contract, not a CSS coincidence.
+            //
+            // Math (44px): toggle button width 30 + `right-2` viewport
+            // inset 8 + minimum visual gap 4 + 2px buffer for the Tabs.List
+            // `px-1` content padding. Physical `padding-right` matches the
+            // physical `right-2`/`right-0` on the toggle — they must stay
+            // in the same writing-mode axis (both physical, or both
+            // logical) or RTL flips one but not the other.
+            //
+            // Only applied when the rail is active; an empty slot
+            // (panel closed, non-session route) needs no reserve.
+            "padding-right": tabsRailActive() ? "44px" : undefined,
+          }}
         />
         <div
           id="pawwork-titlebar-right"

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -88,6 +88,23 @@
     initial-value: 140px;
   }
 
+  /* During right-panel drag-resize, the inline `width` on the right-panel
+     `<aside>` snaps to each pointermove value (its own transition is gated
+     on `props.size.active()`), but `--right-panel-width` on the desktop
+     shell keeps its 240ms transition (gated on a separate `state.sizing`
+     flag scoped to the sidebar). That mismatch leaves the titlebar tabs
+     slot — whose width follows the var — lagging behind the panel body,
+     so the seam line visibly drifts apart while dragging. The attribute
+     is set imperatively by `SessionSidePanel`'s sizing effect; here we
+     match it and disable the var transition so both sides snap together.
+     `--right-panel-width` is the only transitioning property that needs
+     gating; the sidebar's `--sidebar-width` is unaffected because the
+     sidebar resize handler already flips `state.sizing` which suppresses
+     the entire shorthand class. */
+  [data-component="desktop-shell"][data-resizing-right-panel] {
+    transition: none !important;
+  }
+
   /* Mac native unified-chrome pattern: titlebar bg matches whatever surface
      sits below it. Left of --sidebar-width = sidebar bg (seamless vertical
      extension of the sidebar panel up through the titlebar). Right = main

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -118,7 +118,8 @@
      titlebar top to viewport bottom. A symmetric `padding-inline: 8px`
      pushes the tabs slot 8px inboard and breaks that seam on macOS only —
      see issue tracked alongside PR #880 follow-up. The toggle's own
-     `pr-2` provides the closed-state inset from the viewport edge. */
+     absolute `right-2` (or `right-0` on Windows) provides the inset from
+     the viewport edge in both open and closed states. */
   [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"] {
     padding-inline-start: 8px;
     background: linear-gradient(

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -94,8 +94,16 @@
      bg. Right-panel boundary is intentionally NOT drawn into the titlebar
      (Mail / Finder / Notes do not split their toolbar) so it never overlaps
      with breadcrumb or center-portal content when the panel is wide. */
+  /* Right edge intentionally has no padding so the right-panel tabs slot
+     (inside the rightmost grid cell) ends at the viewport edge. Its
+     `border-l` then aligns pixel-for-pixel with the right-panel body's
+     `border-left` directly below it, forming one continuous separator from
+     titlebar top to viewport bottom. A symmetric `padding-inline: 8px`
+     pushes the tabs slot 8px inboard and breaks that seam on macOS only —
+     see issue tracked alongside PR #880 follow-up. The toggle's own
+     `pr-2` provides the closed-state inset from the viewport edge. */
   [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"] {
-    padding-inline: 8px;
+    padding-inline-start: 8px;
     background: linear-gradient(
       to right,
       var(--sidebar) 0,

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -213,13 +213,29 @@ export function SessionSidePanel(props: {
   // attribute lets a CSS rule in `index.css` turn the var transition off
   // for the drag without needing to plumb session-scope sizing state up
   // into the global layout context.
+  //
+  // The effect must guard against three leak paths that would lock the
+  // shell's transition off indefinitely (CSS rule is `!important`):
+  //  1. Viewport shrinks mid-drag and `isDesktop()` flips to false — the
+  //     early-return must not skip removing the attribute.
+  //  2. Navigation away from the session route unmounts SessionSidePanel
+  //     while drag is still "active" — `onCleanup` must remove the
+  //     attribute even if `props.size.active()` is still true.
+  //  3. Component re-mount finds a stale attribute from a previous
+  //     instance — we always clear before optionally re-setting.
   createEffect(() => {
-    if (!isDesktop()) return
-    const active = props.size.active()
     const shell = document.querySelector<HTMLElement>('[data-component="desktop-shell"]')
     if (!shell) return
-    if (active) shell.setAttribute("data-resizing-right-panel", "")
-    else shell.removeAttribute("data-resizing-right-panel")
+    // Always clear first; only re-set when desktop AND actively resizing.
+    shell.removeAttribute("data-resizing-right-panel")
+    if (!isDesktop()) return
+    if (props.size.active()) shell.setAttribute("data-resizing-right-panel", "")
+  })
+
+  onCleanup(() => {
+    document
+      .querySelector<HTMLElement>('[data-component="desktop-shell"]')
+      ?.removeAttribute("data-resizing-right-panel")
   })
 
   createEffect(() => {

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -201,6 +201,27 @@ export function SessionSidePanel(props: {
     activeDraggable: undefined as string | undefined,
   })
 
+  // Mirror right-panel drag-resize state to the desktop shell so the CSS
+  // `--right-panel-width` transition on `<desktop-shell>` can be suppressed
+  // while the user is dragging. Without this, the aside's inline `width`
+  // (gated on `props.size.active()`) snaps to the new value on every
+  // pointermove, but `--right-panel-width` is set on the desktop-shell —
+  // which uses `state.sizing` (a layout.tsx-local flag scoped to the
+  // sidebar resize handler only) as its transition gate. During right-panel
+  // drag the var keeps its 240ms cubic-bezier transition, so the titlebar
+  // tabs slot (whose width follows the var) lags behind the body. The
+  // attribute lets a CSS rule in `index.css` turn the var transition off
+  // for the drag without needing to plumb session-scope sizing state up
+  // into the global layout context.
+  createEffect(() => {
+    if (!isDesktop()) return
+    const active = props.size.active()
+    const shell = document.querySelector<HTMLElement>('[data-component="desktop-shell"]')
+    if (!shell) return
+    if (active) shell.setAttribute("data-resizing-right-panel", "")
+    else shell.removeAttribute("data-resizing-right-panel")
+  })
+
   createEffect(() => {
     if (!isDesktop()) return
 


### PR DESCRIPTION
## Summary

Three connected fixes for the right-panel titlebar seam, reported post-release as a follow-up to [#880](https://github.com/Astro-Han/pawwork/pull/880). All three only become visible together: once the seam aligns, the toggle slide and the drag-resize lag become readable.

1. **macOS seam misalignment (8px)** — original report.
2. **Toggle slides 320px when panel opens** — surfaced after fix #1 made the now-aligned seam clearly visible.
3. **Drag-resize seam drifts** — surfaced after fix #2 made the corner stable; while dragging the body and the titlebar slot moved at different speeds.

## Fix 1 — macOS seam alignment

[`padding-inline: 8px` → `padding-inline-start: 8px`](packages/app/src/index.css:97) on the macOS `[data-component="titlebar-shell"]` rule.

The symmetric 8px padding pushed the right rail (and the tabs slot pinned to its right edge) 8px inboard of the viewport. The right-panel `<aside>` directly below sits in a sibling layout tree without that padding, so its `border-left` reached the actual viewport edge — the two `border-l`s ended up 8px apart on macOS. Windows has no equivalent rule and was already correct.

The titlebar comment block in #880 explicitly assumed the right rail's outer edge = `viewport.right` — true on Windows, false on macOS. The toggle's existing `pr-2` now provides the closed-state 8px inset directly (matching macOS native toolbar conventions for the rightmost control), without doubling up with the rail's own padding.

## Fix 2 — Stable toggle position across open/close

[`#pawwork-titlebar-right`](packages/app/src/components/titlebar.tsx:228) changed from in-flow flex sibling of the tabs slot to **absolute-positioned** at the rail's top-right corner (`right-2` on macOS, `right-0` on Windows).

PR #880's structural layout made the toggle a flex sibling, so opening the panel pushed it left by `--right-panel-width` over the 240ms transition. That slide read as visually jarring once fix #1 aligned the seam and the motion became readable against the now-continuous border-l.

The toggle visually overlaps the tabs slot's rightmost area when open, but they don't collide in practice — Kobalte's `Tabs.List` sizes to content (~150px for 1-4 chips, observed `146.5px` in the regression test debug dump), leaving the trailing `+` button in the middle of the panel column with empty space at the corner for the toggle to float in.

## Fix 3 — Drag-resize seam sync

[New effect in `SessionSidePanel`](packages/app/src/pages/session/session-side-panel.tsx) mirrors `props.size.active()` to a `data-resizing-right-panel` attribute on `<desktop-shell>`. [Matching CSS rule in `index.css`](packages/app/src/index.css) disables the shell's transition while the attribute is present.

Root cause: while dragging the panel resize handle, the body's `<aside>` inline `width` snapped to each pointermove (its transition is gated on the session-scope `props.size.active()`), but `--right-panel-width` on the desktop shell kept its 240ms cubic-bezier transition because the shell's gate uses `state.sizing` — a layout.tsx-local flag scoped to the sidebar resize handler only. The two sides of the seam moved at different speeds; one led, one trailed.

The attribute-bridge approach avoids plumbing session-scope sizing state into the global layout context — the bridge stays one attribute wide and one CSS rule shallow. The 120ms timeout in `createSizing` re-enables the transition shortly after the user lets go, so the open/close animation still uses the full 240ms cubic-bezier curve.

## Regression tests

Two new assertions in [`titlebar-right-rail-contract.spec.ts`](packages/app/e2e/session/titlebar-right-rail-contract.spec.ts):

- **`tabs slot border-l aligns horizontally with the right-panel body border-l (no x-axis seam break)`** — asserts `|tabs.left - body.left| < 1px` (sub-pixel tolerance for Retina rounding). Pre-fix #1: `Received: 8`. Post-fix: passes.
- **`right utility toggle keeps the same x-position across open/close`** — asserts `|toggle.right(open) - toggle.right(closed)| < 12px`. Pre-fix #2: `Received: 229.25` (the full panel-width displacement). Post-fix: within sub-pixel rounding.

## Related Issue

None — post-release regression report; no separate GitHub issue filed.

## Human Review Status

Pending

## Review Focus

- [packages/app/src/components/titlebar.tsx](packages/app/src/components/titlebar.tsx) — the right rail restructure (absolute-positioned toggle + the long comment block above explaining why). The Tabs.List content-width observation is load-bearing for the no-collision claim; if a future change makes the strip fill the slot, the toggle and `+` would overlap.
- [packages/app/src/pages/session/session-side-panel.tsx](packages/app/src/pages/session/session-side-panel.tsx) — the imperative `createEffect` that mirrors sizing state to the DOM attribute. The alternative was lifting `createSizing` into the layout context; this is the smaller change.
- [packages/app/src/index.css](packages/app/src/index.css) — both new rules (`padding-inline-start` on macOS titlebar, `[data-resizing-right-panel]` transition reset).

## Risk Notes

- **Platform**: fix #1 is macOS-only (the `padding-inline` rule is already gated on `[data-shell-os="macos"]`). Fixes #2 and #3 affect both macOS and Windows.
- **Visual side effect (fix #1)**: when the right panel is **closed**, the right utility toggle's distance from the viewport edge changes from 16px (`padding-inline: 8px` + `pr-2`) to 8px (`pr-2` only on macOS, `right-0` on Windows after fix #2). Matches macOS native toolbar conventions.
- **Visual side effect (fix #2)**: when the right panel is open, the closing/opening 240ms slide of the toggle is gone — the toggle stays at the corner across the transition. The body's width still animates as before.
- **Tabs.List width assumption (fix #2)**: the no-collision claim depends on `Tabs.List` sizing to content. If a future change makes the strip stretch to fill the slot, the trailing `+` button would slide under the absolute-positioned toggle. The new regression test would not catch this — it only checks toggle position, not collision.
- No `.github/workflows/` touched.

## How To Verify

```text
bun run test:e2e:local titlebar-right-rail-contract.spec.ts  → 5/5 pass
bun run snap right-panel-titlebar                            → 1 passed; grid PNG shows toggle at corner, seam continuous in light + dark
bun run lint                                                 → clean
bun --cwd packages/app run typecheck                         → clean
```

Manual Electron (mac) verification: toggle stable across open/close, drag-resize seam moves as one continuous line.

## Screenshots or Recordings

Snap grid at `docs/design/preview/screenshots/right-panel-titlebar.png` (local-only per `docs/` exclusion) shows the toggle at the viewport corner in both light + dark, with the seam continuous from titlebar top through the right-panel body's left edge.

## Checklist

- [x] Type label (`bug`)
- [x] Routing labels (`app`, `ui`)
- [x] Priority label (`P2`)
- [x] Human Review Status set to `Pending`
- [x] Linked the related context (no issue; references #880 follow-up)
- [x] Described review focus and risks
- [x] Replaced How To Verify with real steps and results
- [x] No unrelated refactors, deps, or generated files
- [x] Manually checked visible UI via snap regrid + Electron dev
- [x] Considered macOS / Windows impact
- [x] Reviewed final diff for unrelated changes
- [x] Targeting `dev`; title is Conventional Commits in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misalignment between the titlebar and right-panel borders during resizing.
  * Eliminated visual drift during active right-panel drag-resize, including macOS unified-titlebar seam and spacing adjustments to keep the right-rail toggle stable.
* **Tests**
  * Added a contract test to verify titlebar and right-panel border alignment consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->