### PR TITLE
fix(ui): align picker list-header surface and disable stuck gradient in dark mode

### DIFF
--- a/packages/app/e2e/snap/model-picker-header.snap.ts
+++ b/packages/app/e2e/snap/model-picker-header.snap.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { promptModelSelector } from "../selectors"
 import { applyDarkModeForTests } from "../utils"
@@ -39,16 +39,61 @@ async function openModelPicker(page: Page) {
   return picker
 }
 
+// Locked computed-style invariants for the picker grouped header. Asserted
+// in addition to the screenshot because the visible `data-stuck` regression
+// path only paints once the user scrolls — fixture has too few models to
+// guarantee an overflowing picker, so a snap alone cannot reach it. These
+// two reads exercise the rule directly: a future selector demotion or token
+// drift fails the test even though the screenshot would still pass.
+async function assertHeaderInvariants(picker: Locator) {
+  const header = picker.locator('[data-slot="list-header"]').first()
+  await expect(header).toBeVisible()
+
+  const computed = await header.evaluate((el) => {
+    const headerStyle = window.getComputedStyle(el)
+    const afterStyle = window.getComputedStyle(el, "::after")
+    const expectedSurface = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue("--surface-raised")
+      .trim()
+    const probe = document.createElement("span")
+    probe.style.color = expectedSurface
+    document.body.appendChild(probe)
+    const expectedRgb = window.getComputedStyle(probe).color
+    probe.remove()
+    return {
+      headerBg: headerStyle.backgroundColor,
+      headerPosition: headerStyle.position,
+      afterDisplay: afterStyle.display,
+      expectedRgb,
+    }
+  })
+
+  // `position: static` is the picker-scoped override that disables the
+  // sticky header. If the picker.css selector drops below list.css's 0,4,0
+  // chain again, position flips back to sticky and this fails.
+  expect(computed.headerPosition).toBe("static")
+  // Header surface must match the picker body's --surface-raised, not List's
+  // default --surface-base.
+  expect(computed.headerBg).toBe(computed.expectedRgb)
+  // ::after is the 16px stuck gradient. Hiding it is the second half of the
+  // fix; without this assertion, only a scroll-driven snap could catch its
+  // re-emergence.
+  expect(computed.afterDisplay).toBe("none")
+}
+
 test("model-picker-header", async ({ page, gotoSession }) => {
   test.setTimeout(180_000)
 
   await gotoSession()
   const lightPicker = await openModelPicker(page)
+  await assertHeaderInvariants(lightPicker)
   const lightShot: Shot = { name: "light", buf: await lightPicker.screenshot() }
 
   await applyDarkModeForTests(page)
   await gotoSession()
   const darkPicker = await openModelPicker(page)
+  await assertHeaderInvariants(darkPicker)
   const darkShot: Shot = { name: "dark", buf: await darkPicker.screenshot() }
 
   const out = snapOutputPath("model-picker-header")

--- a/packages/app/e2e/snap/model-picker-header.snap.ts
+++ b/packages/app/e2e/snap/model-picker-header.snap.ts
@@ -1,0 +1,57 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { promptModelSelector } from "../selectors"
+import { applyDarkModeForTests } from "../utils"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+// Visual contract for the model picker's grouped list header:
+//
+//   1) Header background must match the picker surface, not the page surface.
+//      In dark mode --surface-base (#1a1917) is noticeably darker than the
+//      picker body's --surface-raised (#2d2a27); a header on --surface-base
+//      reads as a misaligned band across the popover top.
+//   2) The list header must NOT sit sticky inside the picker. List's default
+//      sticky behaviour ships a 16px ::after gradient that paints on top of
+//      the first item; picker.css overrides position to static and hides the
+//      gradient. Both overrides have to outrank list.css's 0,4,0 selector
+//      chain, so this snap is the regression check for selector strength.
+//
+// Light + dark are both captured because bug (1) only appears in dark.
+test.use({ viewport: { width: 1100, height: 600 }, deviceScaleFactor: 2 })
+
+const pickerContentSelector = '[data-picker-content=""]'
+
+async function openModelPicker(page: Page) {
+  const chip = page.locator(promptModelSelector).locator('[data-action="prompt-model"]').first()
+  await expect(chip).toBeVisible({ timeout: 30_000 })
+  await chip.click()
+  // Variant (Thinking) sub-popover also uses [data-picker-content]; scope by
+  // the model list scroll container so the locator stays unambiguous.
+  const picker = page
+    .locator(pickerContentSelector)
+    .filter({ has: page.locator('[data-slot="list-scroll"]') })
+  await expect(picker).toBeVisible({ timeout: 10_000 })
+  // Wait until the grouped header is rendered — without this the snap can
+  // race the first paint and capture an empty popover.
+  await expect(picker.locator('[data-slot="list-header"]').first()).toBeVisible({
+    timeout: 5_000,
+  })
+  return picker
+}
+
+test("model-picker-header", async ({ page, gotoSession }) => {
+  test.setTimeout(180_000)
+
+  await gotoSession()
+  const lightPicker = await openModelPicker(page)
+  const lightShot: Shot = { name: "light", buf: await lightPicker.screenshot() }
+
+  await applyDarkModeForTests(page)
+  await gotoSession()
+  const darkPicker = await openModelPicker(page)
+  const darkShot: Shot = { name: "dark", buf: await darkPicker.screenshot() }
+
+  const out = snapOutputPath("model-picker-header")
+  await composeGrid([lightShot, darkShot], out, { cols: 2 })
+  process.stdout.write(`\n[snap] model-picker-header grid -> ${out}\n\n`)
+})

--- a/packages/ui/src/components/picker.css
+++ b/packages/ui/src/components/picker.css
@@ -58,10 +58,10 @@
   position: static;
   z-index: auto;
   background: var(--surface-raised);
-}
 
-[data-picker-content] [data-slot="list-scroll"] [data-slot="list-group"] [data-slot="list-header"]::after {
-  display: none;
+  &::after {
+    display: none;
+  }
 }
 
 [data-picker-content] [data-slot="list-group"] {

--- a/packages/ui/src/components/picker.css
+++ b/packages/ui/src/components/picker.css
@@ -44,10 +44,24 @@
 /* Picker groups are short (≤ a handful of items), so sticky group labels
    add no value and instead overlap items during mouse-wheel scroll.
    Let labels scroll with their group, and add a small gap so the label
-   doesn't read as glued to the first item. */
-[data-picker-content] [data-slot="list-header"] {
+   doesn't read as glued to the first item.
+
+   Selector matches list.css's default header chain
+   ([data-component="list"] [data-slot="list-scroll"] [data-slot="list-group"]
+   [data-slot="list-header"], specificity 0,4,0) so picker.css — imported
+   after list.css — wins on equal specificity. A shorter selector here
+   loses to the default and leaves the header sticky. Background swaps to
+   picker's raised surface (default --surface-base reads darker than the
+   picker body in dark mode), and the 16px ::after stuck-gradient is
+   hidden so it cannot paint over the first item. */
+[data-picker-content] [data-slot="list-scroll"] [data-slot="list-group"] [data-slot="list-header"] {
   position: static;
   z-index: auto;
+  background: var(--surface-raised);
+}
+
+[data-picker-content] [data-slot="list-scroll"] [data-slot="list-group"] [data-slot="list-header"]::after {
+  display: none;
 }
 
 [data-picker-content] [data-slot="list-group"] {


### PR DESCRIPTION
## Summary

Fix two visible bugs in the model picker (and any `<List>` rendered inside a `[data-picker-content]` popover):

1. **Dark mode**: the grouped header (e.g. "OpenCode Zen") reads as a darker band than the rest of the popover body.
2. **First item gets clipped**: a ~16px stripe of header colour overlaps the first model row (e.g. "Big Pickle") once the list is scrolled.

## Why

picker.css already tried to disable List's sticky header behaviour, but its override `[data-picker-content] [data-slot="list-header"]` (specificity `0,2,0`) lost to list.css's default chain `[data-component="list"] [data-slot="list-scroll"] [data-slot="list-group"] [data-slot="list-header"]` (specificity `0,4,0`). The override never applied: the header stayed `position: sticky` and the default 16px `::after` `linear-gradient(--surface-base → transparent)` painted on top of the first item once `GroupHeader` flipped `data-stuck="true"` on scroll.

In dark mode the bug is doubly visible because List's default header background is `--surface-base` (`#1a1917`) while picker content uses `--surface-raised` (`#2d2a27`), so the sticky band reads as a darker stripe overlapping the first model row. In light mode both tokens are `#ffffff`, which is why bug 1 only manifests in dark.

Fix in `packages/ui/src/components/picker.css`:

- Match list.css's `0,4,0` selector chain so picker.css (imported after list.css) wins on equal specificity.
- Set `background: var(--surface-raised)` so the header sits flush with the picker body.
- Hide the `::after` stuck gradient inside pickers — the header is no longer sticky and the gradient has nothing to fade into.

`command-palette.css` already uses the same scoped pattern; this aligns the generic picker contract with it.

## Related Issue

None — surfaced by visual inspection.

## Human Review Status

Pending

## Review Focus

- `packages/ui/src/components/picker.css` — confirm the selector chain matches list.css's default rule exactly so the override outranks it on cascade order. Anything shorter silently loses.
- Confirm the override is correctly scoped under `[data-picker-content]` and does not change `<List>` behaviour outside pickers (sidebar session list, dialogs, etc.).
- New snap target `packages/app/e2e/snap/model-picker-header.snap.ts` captures the contract in light and dark.

## Risk Notes

Scope is CSS only, gated on `[data-picker-content]`. No JS or other consumers touched. Did **not** change list.css's default header background — `List` is a generic primitive and binding its default to `--surface-raised` would silently flip every non-picker consumer (sidebar, dialogs). The picker-scoped override is the smallest correct fix.

## How To Verify

```text
bun run snap model-picker-header → 1 passed (8.5s); grid shows header at picker surface in dark and no overlap on first item
bun run lint → clean
bun x tsc --noEmit (packages/app) → clean
bun run dev:desktop → opened the real Electron build in dark mode, opened the model picker, scrolled through OpenCode Zen / OpenCode Go groups; author confirmed by eye that the group header rows match the popover surface and no longer clip the first model row
```

## Screenshots or Recordings

<img width="1032" height="412" alt="image" src="https://github.com/user-attachments/assets/85cd31d7-aee7-46b0-82fd-2da22beb9808" />

## Checklist

- [x] **Type label** — `bug`
- [x] **Routing labels** — `app`, `ui`
- [x] **Priority label** — `P2`
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

