### PR TITLE
fix(app): refresh review diffs on git state updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,11 @@ ci:
           - ".github/workflows/**"
           - ".github/**"
 
+task:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
 platform:
   - changed-files:
       - any-glob-to-any-file:

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -24,6 +24,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { SessionPageComposerRegion } from "@/pages/session/session-composer-region"
 import { SessionMainView } from "@/pages/session/session-main-view"
 import { createSessionRunning, isSessionRunning } from "@/pages/session/session-running-state"
+import { createSessionTurnChanges } from "@/pages/session/session-turn-changes"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { createSessionCommentContext } from "@/pages/session/use-session-comment-context"
 import { useSessionDesktopContext } from "@/pages/session/use-session-desktop-context"
@@ -125,6 +126,7 @@ export default function Page() {
   const timelineHistoryMore = timeline.historyMore
   const timelineHistoryLoading = timeline.historyLoading
   const lastUserMessage = timeline.lastUserMessage
+  const turnChangeController = createSessionTurnChanges({ sessionID: timelineSessionID, sessionMessages: timelineMessages })
   const diagnostics = createSessionPageDiagnostics({
     routeSessionID: () => params.id,
     timelineSessionID,
@@ -190,7 +192,10 @@ export default function Page() {
     executionScope: currentExecutionScope,
     sessionKey: timelineSessionKey,
     sessionID: timelineSessionID,
-    lastUserMessageID: () => lastUserMessage()?.id,
+    latestTurnChange: () => {
+      const id = lastUserMessage()?.id
+      return id ? turnChangeController.turnChanges[id] : undefined
+    },
     sync,
     sdk,
     wantsReview,
@@ -470,6 +475,7 @@ export default function Page() {
       timelineSessionKey={timelineSessionKey()}
       timelineMessagesReady={timelineMessagesReady()}
       timelineMessages={timelineMessages()}
+      turnChangeController={turnChangeController}
       mobileChanges={mobileChanges()}
       mobileFallback={reviewPanel.mobileFallback()}
       actions={actions}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -174,7 +174,7 @@ export default function Page() {
   const [mobileTab, setMobileTab] = createSignal<"session" | "changes">("session")
   const deferRender = createSessionDeferredRender(timelineSessionKey)
 
-  const turnDiffs = timelineDiffs
+  const turnDiffs = () => []
   const mobileChanges = createMemo(() => !isDesktop() && mobileTab() === "changes")
   const wantsReview = createMemo(() =>
     isDesktop() ? desktopSidePanelOpen() && view().sidePanel.tab() === "review" : mobileChanges(),
@@ -190,6 +190,7 @@ export default function Page() {
     executionScope: currentExecutionScope,
     sessionKey: timelineSessionKey,
     sessionID: timelineSessionID,
+    lastUserMessageID: () => lastUserMessage()?.id,
     sync,
     sdk,
     wantsReview,

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -38,7 +38,7 @@ import {
   SessionMessageComments,
 } from "@/pages/session/session-message-comments"
 import { buildTurnMessagesByUserID, emptyAssistantMessages } from "@/pages/session/session-messages"
-import { createSessionTurnChanges } from "@/pages/session/session-turn-changes"
+import type { createSessionTurnChanges } from "@/pages/session/session-turn-changes"
 import { createSessionRunning } from "@/pages/session/session-running-state"
 import { useLanguage } from "@/context/language"
 import { useSessionRouteKey } from "@/pages/session/session-layout"
@@ -70,6 +70,7 @@ export function MessageTimeline(props: {
   sessionID: string
   sessionKey: string
   sessionMessages: MessageType[]
+  turnChangeController: ReturnType<typeof createSessionTurnChanges>
   mobileChanges: boolean
   mobileFallback: JSX.Element
   actions?: UserActions
@@ -151,7 +152,6 @@ export function MessageTimeline(props: {
   const sessionID = createMemo(() => props.sessionID)
   const sessionMessages = createMemo(() => props.sessionMessages)
   const turnMessagesByUserID = createMemo(() => buildTurnMessagesByUserID(sessionMessages()))
-  const turnChangeController = createSessionTurnChanges({ sessionID, sessionMessages })
   const webSearchToastSurfaced = new Set<string>()
   const webSearchPartCursor = new Map<string, number>()
   const webSearchPendingParts = new Map<string, Set<string>>()
@@ -321,9 +321,9 @@ export function MessageTimeline(props: {
           showReasoningSummaries={settings.general.showReasoningSummaries()}
           shellToolDefaultOpen={settings.general.shellToolPartsExpanded()}
           editToolDefaultOpen={settings.general.editToolPartsExpanded()}
-          turnChanges={turnChangeController.turnChanges}
+          turnChanges={props.turnChangeController.turnChanges}
           turnChangeActions={{
-            ...turnChangeController.actions,
+            ...props.turnChangeController.actions,
             openFile: (path) => {
               void platform.openPath?.(path)
             },

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -10,6 +10,7 @@ import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
 import type { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
+import type { createSessionTurnChanges } from "@/pages/session/session-turn-changes"
 import { TimelineE2EDriverBoundary } from "@/testing/timeline"
 
 type TimelineProps = ComponentProps<typeof MessageTimeline>
@@ -27,6 +28,7 @@ export function SessionMainView(props: {
   timelineSessionKey: string
   timelineMessagesReady: boolean
   timelineMessages: TimelineProps["sessionMessages"]
+  turnChangeController: ReturnType<typeof createSessionTurnChanges>
   mobileChanges: boolean
   mobileFallback: JSX.Element
   actions: TimelineProps["actions"]
@@ -141,6 +143,7 @@ export function SessionMainView(props: {
                   sessionID={props.timelineSessionID ?? ""}
                   sessionKey={props.timelineSessionKey}
                   sessionMessages={props.timelineMessages}
+                  turnChangeController={props.turnChangeController}
                   mobileChanges={props.mobileChanges}
                   mobileFallback={props.mobileFallback}
                   actions={props.actions}

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import { vcsTaskKey } from "./execution-scope"
 import {
-  buildReviewTurnDiffRequest,
   deriveReviewArtifactFiles,
   reviewTurnDiffsForSession,
   selectReviewChangeMode,
+  turnChangeDisplayDiffs,
 } from "./use-session-review-state"
 
 const scope = (directory = "/repo", epoch = 1) => ({ serverKey: "sidecar", directory, epoch })
@@ -124,26 +124,44 @@ describe("session review state", () => {
     ).toEqual(fallback)
   })
 
-  test("requests review diffs for the latest user turn, not the whole session", () => {
-    expect(
-      buildReviewTurnDiffRequest({
-        sessionID: "ses_1",
-        lastUserMessageID: "msg_latest",
-        scope: scope("/repo", 1),
-      }),
-    ).toEqual({
+  test("builds review turn diffs from the shared turn-change display", () => {
+    const diffs = turnChangeDisplayDiffs({
+      kind: "captured",
       sessionID: "ses_1",
-      messageID: "msg_latest",
-      scope: scope("/repo", 1),
+      turnID: "msg_user",
+      messageID: "msg_user",
+      files: [
+        {
+          path: "base.txt",
+          openPath: "/repo/base.txt",
+          patch: "@@ -1 +1 @@",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          expandable: true,
+          restoreState: "applied",
+        },
+        {
+          path: "undone.txt",
+          patch: "",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          expandable: true,
+          restoreState: "undone",
+        },
+      ],
     })
 
-    expect(
-      buildReviewTurnDiffRequest({
-        sessionID: "ses_1",
-        lastUserMessageID: undefined,
-        scope: scope("/repo", 1),
-      }),
-    ).toBeUndefined()
+    expect(diffs).toEqual([
+      {
+        file: "/repo/base.txt",
+        patch: "@@ -1 +1 @@",
+        additions: 1,
+        deletions: 0,
+        status: "modified",
+      },
+    ])
   })
 
   test("selecting a VCS review mode forces a reload even when cached", () => {

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { vcsTaskKey } from "./execution-scope"
-import { deriveReviewArtifactFiles, reviewTurnDiffsForSession } from "./use-session-review-state"
+import {
+  buildReviewTurnDiffRequest,
+  deriveReviewArtifactFiles,
+  reviewTurnDiffsForSession,
+  selectReviewChangeMode,
+} from "./use-session-review-state"
 
 const scope = (directory = "/repo", epoch = 1) => ({ serverKey: "sidecar", directory, epoch })
 
@@ -117,5 +122,53 @@ describe("session review state", () => {
         turnDiffs: fallback,
       }),
     ).toEqual(fallback)
+  })
+
+  test("requests review diffs for the latest user turn, not the whole session", () => {
+    expect(
+      buildReviewTurnDiffRequest({
+        sessionID: "ses_1",
+        lastUserMessageID: "msg_latest",
+        scope: scope("/repo", 1),
+      }),
+    ).toEqual({
+      sessionID: "ses_1",
+      messageID: "msg_latest",
+      scope: scope("/repo", 1),
+    })
+
+    expect(
+      buildReviewTurnDiffRequest({
+        sessionID: "ses_1",
+        lastUserMessageID: undefined,
+        scope: scope("/repo", 1),
+      }),
+    ).toBeUndefined()
+  })
+
+  test("selecting a VCS review mode forces a reload even when cached", () => {
+    const loads: Array<{ mode: string; force: true }> = []
+    const changes: string[] = []
+
+    selectReviewChangeMode({
+      mode: "branch",
+      setChanges: (mode) => changes.push(mode),
+      wantsReview: () => true,
+      loadVcs: (mode, force) => {
+        loads.push({ mode, force })
+      },
+    })
+
+    selectReviewChangeMode({
+      mode: "turn",
+      setChanges: (mode) => changes.push(mode),
+      wantsReview: () => true,
+      loadVcs: (mode, force) => {
+        loads.push({ mode, force })
+      },
+    })
+
+    expect(changes).toEqual(["branch", "turn"])
+    expect(loads).toEqual([{ mode: "branch", force: true }])
   })
 })

--- a/packages/app/src/pages/session/use-session-review-state.test.ts
+++ b/packages/app/src/pages/session/use-session-review-state.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test"
 import { vcsTaskKey } from "./execution-scope"
 import {
   deriveReviewArtifactFiles,
-  reviewTurnDiffsForSession,
   selectReviewChangeMode,
   turnChangeDisplayDiffs,
 } from "./use-session-review-state"
@@ -96,32 +95,6 @@ describe("session review state", () => {
   test("keys pending VCS diff tasks by execution scope and mode", () => {
     expect(vcsTaskKey(scope("/repo", 1), "unstaged")).not.toBe(vcsTaskKey(scope("/repo", 3), "unstaged"))
     expect(vcsTaskKey(scope("/repo", 3), "unstaged")).not.toBe(vcsTaskKey(scope("/repo", 3), "staged"))
-  })
-
-  test("does not reuse aggregate diffs across sessions or execution scopes", () => {
-    const aggregate = {
-      sessionID: "ses_1",
-      scope: scope("/repo", 1),
-      diffs: [{ file: "old-session.ts", patch: "", additions: 1, deletions: 0, status: "added" as const }],
-    }
-    const fallback = [{ file: "current-session.ts", patch: "", additions: 1, deletions: 0, status: "added" as const }]
-
-    expect(
-      reviewTurnDiffsForSession({
-        currentScope: scope("/repo", 1),
-        sessionID: "ses_2",
-        aggregate,
-        turnDiffs: fallback,
-      }),
-    ).toEqual(fallback)
-    expect(
-      reviewTurnDiffsForSession({
-        currentScope: scope("/repo", 2),
-        sessionID: "ses_1",
-        aggregate,
-        turnDiffs: fallback,
-      }),
-    ).toEqual(fallback)
   })
 
   test("builds review turn diffs from the shared turn-change display", () => {

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -1,5 +1,5 @@
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
-import { createEffect, createMemo, createResource, createSignal, on, onCleanup } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, on, onCleanup, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
@@ -20,6 +20,27 @@ import { aggregateFiles } from "./session-aggregate-files"
 
 type SessionReviewDiff = SnapshotFileDiff | VcsFileDiff
 type SessionAggregateDiffState = { sessionID: string; scope: ExecutionScope; diffs: SnapshotFileDiff[] } | undefined
+
+export function buildReviewTurnDiffRequest(input: {
+  sessionID: string | undefined
+  lastUserMessageID: string | undefined
+  scope: ExecutionScope
+}) {
+  if (!input.sessionID || !input.lastUserMessageID) return
+  return { sessionID: input.sessionID, messageID: input.lastUserMessageID, scope: input.scope }
+}
+
+export function selectReviewChangeMode(input: {
+  mode: ReviewChangeMode
+  setChanges: (mode: ReviewChangeMode) => void
+  wantsReview: () => boolean
+  loadVcs: (mode: VcsReviewMode, force: true) => void | Promise<void>
+}) {
+  input.setChanges(input.mode)
+  if (!isVcsReviewMode(input.mode)) return
+  if (!input.wantsReview()) return
+  void input.loadVcs(input.mode, true)
+}
 
 export function reviewTurnDiffsForSession(input: {
   currentScope: ExecutionScope
@@ -68,14 +89,15 @@ export function createSessionReviewState(input: {
   executionScope: () => ExecutionScope
   sessionKey: () => string
   sessionID: () => string | undefined
+  lastUserMessageID: () => string | undefined
   sync: ReturnType<typeof useSync>
   sdk: ReturnType<typeof useSDK>
   wantsReview: () => boolean
   turnDiffs: () => SessionReviewDiff[]
   artifactDiffs?: () => SessionReviewDiff[]
 }) {
-  const [changes, setChanges] = createSignal<ReviewChangeMode>("turn")
-  const [sessionAggregateDiffs, setSessionAggregateDiffs] = createSignal<SessionAggregateDiffState>()
+  const [changes, setChangesSignal] = createSignal<ReviewChangeMode>("turn")
+  const [turnAggregateDiffs, setTurnAggregateDiffs] = createSignal<SessionAggregateDiffState>()
   const [vcs, setVcs] = createStore<{
     diff: Record<VcsReviewMode, SessionReviewDiff[]>
     ready: Record<VcsReviewMode, boolean>
@@ -167,6 +189,8 @@ export function createSessionReviewState(input: {
     vcsTask.set(key, task)
     return task
   }
+  const setChanges = (mode: ReviewChangeMode) =>
+    selectReviewChangeMode({ mode, setChanges: setChangesSignal, wantsReview: input.wantsReview, loadVcs })
 
   const changesOptions = createMemo<ReviewChangeMode[]>(() =>
     reviewChangeOptions({ isGit: input.sync.project?.vcs === "git" }),
@@ -181,8 +205,8 @@ export function createSessionReviewState(input: {
         turn: reviewTurnDiffsForSession({
           currentScope: input.executionScope(),
           sessionID: input.sessionID(),
-          aggregate: sessionAggregateDiffs(),
-          turnDiffs: input.turnDiffs(),
+          aggregate: turnAggregateDiffs(),
+          turnDiffs: [],
         }),
         vcs: vcs.diff,
       }),
@@ -249,8 +273,8 @@ export function createSessionReviewState(input: {
     on(
       input.sessionKey,
       () => {
-        setChanges(nextReviewModeForSessionChange())
-        setSessionAggregateDiffs(undefined)
+        setChangesSignal(nextReviewModeForSessionChange())
+        setTurnAggregateDiffs(undefined)
       },
       { defer: true },
     ),
@@ -260,7 +284,7 @@ export function createSessionReviewState(input: {
     const options = changesOptions()
     const current = changes()
     const next = coerceReviewChangeMode(current, options)
-    if (next !== current) setChanges(next)
+    if (next !== current) setChangesSignal(next)
   })
 
   createEffect(() => {
@@ -269,6 +293,19 @@ export function createSessionReviewState(input: {
     if (!input.wantsReview()) return
     void loadVcs(mode)
   })
+
+  createEffect(
+    on(
+      input.wantsReview,
+      (wants) => {
+        if (!wants) return
+        const mode = untrack(vcsMode)
+        if (!mode) return
+        void loadVcs(mode, true)
+      },
+      { defer: true },
+    ),
+  )
 
   createEffect(() => {
     const id = input.sessionID()
@@ -280,30 +317,39 @@ export function createSessionReviewState(input: {
   createEffect(() => {
     const id = input.sessionID()
     if (!id) return
-    const scope = input.executionScope()
     if (input.sync.data.turn_change_aggregate[id] === undefined) return
-    setSessionAggregateDiffs({ sessionID: id, scope, diffs: aggregateFiles(input.sync.data.turn_change_aggregate[id]) })
     queueArtifactHistoryRefetch()
   })
 
   createEffect(() => {
-    const id = input.sessionID()
-    if (!id) return
+    const request = buildReviewTurnDiffRequest({
+      sessionID: input.sessionID(),
+      lastUserMessageID: input.lastUserMessageID(),
+      scope: input.executionScope(),
+    })
+    setTurnAggregateDiffs(undefined)
+    if (!request) return
     if (!input.wantsReview()) return
-    const scope = input.executionScope()
     void input.sdk
-      .createClient({ directory: scope.directory, throwOnError: true })
-      .session.diff({ sessionID: id })
+      .createClient({ directory: request.scope.directory, throwOnError: true })
+      .session.diff({ sessionID: request.sessionID, messageID: request.messageID })
       .then((res) => {
-        if (input.sessionID() !== id) return
-        if (!shouldApplyExecutionResult({ requested: scope, current: input.executionScope() })) return
-        setSessionAggregateDiffs({ sessionID: id, scope, diffs: aggregateFiles(res.data) })
+        if (input.sessionID() !== request.sessionID) return
+        if (input.lastUserMessageID() !== request.messageID) return
+        if (!shouldApplyExecutionResult({ requested: request.scope, current: input.executionScope() })) return
+        setTurnAggregateDiffs({ sessionID: request.sessionID, scope: request.scope, diffs: aggregateFiles(res.data) })
       })
       .catch((error: unknown) => {
-        if (input.sessionID() !== id) return
-        if (!shouldApplyExecutionResult({ requested: scope, current: input.executionScope() })) return
-        console.debug("[session-review] failed to fetch aggregate diff", { sessionID: id, scope, error })
-        setSessionAggregateDiffs(undefined)
+        if (input.sessionID() !== request.sessionID) return
+        if (input.lastUserMessageID() !== request.messageID) return
+        if (!shouldApplyExecutionResult({ requested: request.scope, current: input.executionScope() })) return
+        console.debug("[session-review] failed to fetch turn diff", {
+          sessionID: request.sessionID,
+          messageID: request.messageID,
+          scope: request.scope,
+          error,
+        })
+        setTurnAggregateDiffs(undefined)
       })
   })
 

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -4,6 +4,7 @@ import { createStore } from "solid-js/store"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { deriveArtifactFiles, type SessionArtifactFile } from "@/pages/session/files-tab-state"
+import type { TurnChangeDisplay } from "@/pages/session/session-turn-changes"
 import {
   coerceReviewChangeMode,
   isVcsReviewMode,
@@ -20,15 +21,6 @@ import { aggregateFiles } from "./session-aggregate-files"
 
 type SessionReviewDiff = SnapshotFileDiff | VcsFileDiff
 type SessionAggregateDiffState = { sessionID: string; scope: ExecutionScope; diffs: SnapshotFileDiff[] } | undefined
-
-export function buildReviewTurnDiffRequest(input: {
-  sessionID: string | undefined
-  lastUserMessageID: string | undefined
-  scope: ExecutionScope
-}) {
-  if (!input.sessionID || !input.lastUserMessageID) return
-  return { sessionID: input.sessionID, messageID: input.lastUserMessageID, scope: input.scope }
-}
 
 export function selectReviewChangeMode(input: {
   mode: ReviewChangeMode
@@ -56,6 +48,20 @@ export function reviewTurnDiffsForSession(input: {
     return input.aggregate.diffs.length > 0 ? input.aggregate.diffs : input.turnDiffs
   }
   return input.turnDiffs
+}
+
+export function turnChangeDisplayDiffs(display: TurnChangeDisplay | null | undefined): SnapshotFileDiff[] {
+  if (!display) return []
+  if (display.kind === "empty" || display.kind === "uncaptured") return []
+  return display.files
+    .filter((file) => file.restoreState === "applied")
+    .map((file) => ({
+      file: file.openPath ?? file.path,
+      patch: file.patch ?? "",
+      additions: file.additions ?? 0,
+      deletions: file.deletions ?? 0,
+      status: file.status,
+    }))
 }
 
 export function deriveReviewArtifactFiles(input: {
@@ -89,7 +95,7 @@ export function createSessionReviewState(input: {
   executionScope: () => ExecutionScope
   sessionKey: () => string
   sessionID: () => string | undefined
-  lastUserMessageID: () => string | undefined
+  latestTurnChange: () => TurnChangeDisplay | null | undefined
   sync: ReturnType<typeof useSync>
   sdk: ReturnType<typeof useSDK>
   wantsReview: () => boolean
@@ -97,7 +103,6 @@ export function createSessionReviewState(input: {
   artifactDiffs?: () => SessionReviewDiff[]
 }) {
   const [changes, setChangesSignal] = createSignal<ReviewChangeMode>("turn")
-  const [turnAggregateDiffs, setTurnAggregateDiffs] = createSignal<SessionAggregateDiffState>()
   const [vcs, setVcs] = createStore<{
     diff: Record<VcsReviewMode, SessionReviewDiff[]>
     ready: Record<VcsReviewMode, boolean>
@@ -205,8 +210,8 @@ export function createSessionReviewState(input: {
         turn: reviewTurnDiffsForSession({
           currentScope: input.executionScope(),
           sessionID: input.sessionID(),
-          aggregate: turnAggregateDiffs(),
-          turnDiffs: [],
+          aggregate: undefined,
+          turnDiffs: turnChangeDisplayDiffs(input.latestTurnChange()),
         }),
         vcs: vcs.diff,
       }),
@@ -274,7 +279,6 @@ export function createSessionReviewState(input: {
       input.sessionKey,
       () => {
         setChangesSignal(nextReviewModeForSessionChange())
-        setTurnAggregateDiffs(undefined)
       },
       { defer: true },
     ),
@@ -319,38 +323,6 @@ export function createSessionReviewState(input: {
     if (!id) return
     if (input.sync.data.turn_change_aggregate[id] === undefined) return
     queueArtifactHistoryRefetch()
-  })
-
-  createEffect(() => {
-    const request = buildReviewTurnDiffRequest({
-      sessionID: input.sessionID(),
-      lastUserMessageID: input.lastUserMessageID(),
-      scope: input.executionScope(),
-    })
-    setTurnAggregateDiffs(undefined)
-    if (!request) return
-    if (!input.wantsReview()) return
-    void input.sdk
-      .createClient({ directory: request.scope.directory, throwOnError: true })
-      .session.diff({ sessionID: request.sessionID, messageID: request.messageID })
-      .then((res) => {
-        if (input.sessionID() !== request.sessionID) return
-        if (input.lastUserMessageID() !== request.messageID) return
-        if (!shouldApplyExecutionResult({ requested: request.scope, current: input.executionScope() })) return
-        setTurnAggregateDiffs({ sessionID: request.sessionID, scope: request.scope, diffs: aggregateFiles(res.data) })
-      })
-      .catch((error: unknown) => {
-        if (input.sessionID() !== request.sessionID) return
-        if (input.lastUserMessageID() !== request.messageID) return
-        if (!shouldApplyExecutionResult({ requested: request.scope, current: input.executionScope() })) return
-        console.debug("[session-review] failed to fetch turn diff", {
-          sessionID: request.sessionID,
-          messageID: request.messageID,
-          scope: request.scope,
-          error,
-        })
-        setTurnAggregateDiffs(undefined)
-      })
   })
 
   return {

--- a/packages/app/src/pages/session/use-session-review-state.ts
+++ b/packages/app/src/pages/session/use-session-review-state.ts
@@ -17,10 +17,8 @@ import {
 import { diffs as list } from "@/utils/diffs"
 import { same } from "@/utils/same"
 import { sameExecutionScope, shouldApplyExecutionResult, vcsTaskKey, type ExecutionScope } from "./execution-scope"
-import { aggregateFiles } from "./session-aggregate-files"
 
 type SessionReviewDiff = SnapshotFileDiff | VcsFileDiff
-type SessionAggregateDiffState = { sessionID: string; scope: ExecutionScope; diffs: SnapshotFileDiff[] } | undefined
 
 export function selectReviewChangeMode(input: {
   mode: ReviewChangeMode
@@ -32,22 +30,6 @@ export function selectReviewChangeMode(input: {
   if (!isVcsReviewMode(input.mode)) return
   if (!input.wantsReview()) return
   void input.loadVcs(input.mode, true)
-}
-
-export function reviewTurnDiffsForSession(input: {
-  currentScope: ExecutionScope
-  sessionID: string | undefined
-  aggregate: SessionAggregateDiffState
-  turnDiffs: SessionReviewDiff[]
-}) {
-  if (
-    input.aggregate &&
-    input.aggregate.sessionID === input.sessionID &&
-    sameExecutionScope(input.aggregate.scope, input.currentScope)
-  ) {
-    return input.aggregate.diffs.length > 0 ? input.aggregate.diffs : input.turnDiffs
-  }
-  return input.turnDiffs
 }
 
 export function turnChangeDisplayDiffs(display: TurnChangeDisplay | null | undefined): SnapshotFileDiff[] {
@@ -207,12 +189,7 @@ export function createSessionReviewState(input: {
   const reviewDiffs = createMemo(() =>
     list(
       reviewDiffsForMode(changes(), {
-        turn: reviewTurnDiffsForSession({
-          currentScope: input.executionScope(),
-          sessionID: input.sessionID(),
-          aggregate: undefined,
-          turnDiffs: turnChangeDisplayDiffs(input.latestTurnChange()),
-        }),
+        turn: turnChangeDisplayDiffs(input.latestTurnChange()),
         vcs: vcs.diff,
       }),
     ),

--- a/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
@@ -4,30 +4,37 @@ import { isFileWatcherVcsRefreshEvent } from "./use-session-vcs-refresh"
 describe("session vcs refresh watcher events", () => {
   test("refreshes for rescan, source updates, and git state updates", () => {
     expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.rescan", properties: { directory: "/repo" } })).toBe(true)
-    expect(
-      isFileWatcherVcsRefreshEvent({
-        type: "file.watcher.updated",
-        properties: { file: "src/app.ts", event: "change" },
-      }),
-    ).toBe(true)
-    expect(
-      isFileWatcherVcsRefreshEvent({
-        type: "file.watcher.updated",
-        properties: { file: ".git/index", event: "change" },
-      }),
-    ).toBe(true)
-    expect(
-      isFileWatcherVcsRefreshEvent({
-        type: "file.watcher.updated",
-        properties: { file: ".git/refs/heads/feature/test", event: "change" },
-      }),
-    ).toBe(true)
-    expect(
-      isFileWatcherVcsRefreshEvent({
-        type: "file.watcher.updated",
-        properties: { file: ".git/objects/aa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event: "change" },
-      }),
-    ).toBe(false)
+
+    for (const file of [
+      "src/app.ts",
+      ".git/index",
+      ".git/HEAD",
+      ".git/packed-refs",
+      ".git/refs/heads/feature/test",
+      ".git/refs/remotes/origin/dev",
+      ".git/logs/HEAD",
+      ".git/worktrees/review-worktree/gitdir",
+      ".git\\refs\\heads\\feature\\test",
+    ]) {
+      expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.updated", properties: { file, event: "change" } })).toBe(
+        true,
+      )
+    }
+
+    for (const file of [
+      ".git/objects/aa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      ".git/refs/tags/v1.0.0",
+      ".git/refs/stash",
+      ".git/FETCH_HEAD",
+      ".git/MERGE_HEAD",
+      ".git/REVERT_HEAD",
+      ".git/CHERRY_PICK_HEAD",
+    ]) {
+      expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.updated", properties: { file, event: "change" } })).toBe(
+        false,
+      )
+    }
+
     expect(isFileWatcherVcsRefreshEvent({ type: "session.updated", properties: {} })).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
@@ -15,6 +15,9 @@ describe("session vcs refresh watcher events", () => {
       ".git/logs/HEAD",
       ".git/worktrees/review-worktree/gitdir",
       ".git\\refs\\heads\\feature\\test",
+      "/repo/.git/index",
+      "/repo/.git/HEAD",
+      "C:\\repo\\.git\\refs\\heads\\feature\\test",
     ]) {
       expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.updated", properties: { file, event: "change" } })).toBe(
         true,
@@ -29,6 +32,9 @@ describe("session vcs refresh watcher events", () => {
       ".git/MERGE_HEAD",
       ".git/REVERT_HEAD",
       ".git/CHERRY_PICK_HEAD",
+      "/repo/.git/objects/aa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "/repo/.git/refs/tags/v1.0.0",
+      "C:\\repo\\.git\\objects\\aa\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     ]) {
       expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.updated", properties: { file, event: "change" } })).toBe(
         false,

--- a/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { isFileWatcherVcsRefreshEvent } from "./use-session-vcs-refresh"
 
 describe("session vcs refresh watcher events", () => {
-  test("refreshes for rescan and non-git file updates only", () => {
+  test("refreshes for rescan, source updates, and git state updates", () => {
     expect(isFileWatcherVcsRefreshEvent({ type: "file.watcher.rescan", properties: { directory: "/repo" } })).toBe(true)
     expect(
       isFileWatcherVcsRefreshEvent({
@@ -14,6 +14,18 @@ describe("session vcs refresh watcher events", () => {
       isFileWatcherVcsRefreshEvent({
         type: "file.watcher.updated",
         properties: { file: ".git/index", event: "change" },
+      }),
+    ).toBe(true)
+    expect(
+      isFileWatcherVcsRefreshEvent({
+        type: "file.watcher.updated",
+        properties: { file: ".git/refs/heads/feature/test", event: "change" },
+      }),
+    ).toBe(true)
+    expect(
+      isFileWatcherVcsRefreshEvent({
+        type: "file.watcher.updated",
+        properties: { file: ".git/objects/aa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event: "change" },
       }),
     ).toBe(false)
     expect(isFileWatcherVcsRefreshEvent({ type: "session.updated", properties: {} })).toBe(false)

--- a/packages/app/src/pages/session/use-session-vcs-refresh.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.ts
@@ -63,6 +63,7 @@ export function isFileWatcherVcsRefreshEvent(event: { type: string; properties?:
     file === ".git/HEAD" ||
     file === ".git/packed-refs" ||
     file.startsWith(".git/refs/heads/") ||
+    file.startsWith(".git/refs/remotes/") ||
     file.startsWith(".git/logs/HEAD") ||
     file.startsWith(".git/worktrees/")
   )

--- a/packages/app/src/pages/session/use-session-vcs-refresh.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.ts
@@ -55,6 +55,15 @@ export function isFileWatcherVcsRefreshEvent(event: { type: string; properties?:
   if (event.type !== "file.watcher.updated") return false
   const props =
     typeof event.properties === "object" && event.properties ? (event.properties as Record<string, unknown>) : undefined
-  const file = typeof props?.file === "string" ? props.file : undefined
-  return !!file && !file.startsWith(".git/")
+  const file = typeof props?.file === "string" ? props.file.replaceAll("\\", "/") : undefined
+  if (!file) return false
+  if (!file.startsWith(".git/")) return true
+  return (
+    file === ".git/index" ||
+    file === ".git/HEAD" ||
+    file === ".git/packed-refs" ||
+    file.startsWith(".git/refs/heads/") ||
+    file.startsWith(".git/logs/HEAD") ||
+    file.startsWith(".git/worktrees/")
+  )
 }

--- a/packages/app/src/pages/session/use-session-vcs-refresh.ts
+++ b/packages/app/src/pages/session/use-session-vcs-refresh.ts
@@ -55,7 +55,7 @@ export function isFileWatcherVcsRefreshEvent(event: { type: string; properties?:
   if (event.type !== "file.watcher.updated") return false
   const props =
     typeof event.properties === "object" && event.properties ? (event.properties as Record<string, unknown>) : undefined
-  const file = typeof props?.file === "string" ? props.file.replaceAll("\\", "/") : undefined
+  const file = normalizeWatcherFilePath(typeof props?.file === "string" ? props.file : undefined)
   if (!file) return false
   if (!file.startsWith(".git/")) return true
   return (
@@ -67,4 +67,12 @@ export function isFileWatcherVcsRefreshEvent(event: { type: string; properties?:
     file.startsWith(".git/logs/HEAD") ||
     file.startsWith(".git/worktrees/")
   )
+}
+
+function normalizeWatcherFilePath(file: string | undefined) {
+  const normalized = file?.replaceAll("\\", "/")
+  if (!normalized) return
+  const gitSegment = normalized.indexOf("/.git/")
+  if (gitSegment === -1) return normalized
+  return normalized.slice(gitSegment + 1)
 }

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -23,6 +23,9 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_DEDUPE_MS = 1_000
+  const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
+  const VCS_REFRESH_FILES = new Set(["HEAD", "index", "packed-refs"])
+  const VCS_REFRESH_PREFIXES = ["refs/heads/", "refs/remotes/"]
 
   export const Event = {
     Updated: BusEvent.define(
@@ -124,6 +127,17 @@ export namespace FileWatcher {
     }
   }
 
+  export function vcsWatcherIgnoreEntries(entries: string[]) {
+    return entries.filter((entry) => !VCS_SUBSCRIBE_ENTRIES.has(entry))
+  }
+
+  export function shouldPublishVcsWatcherPath(file: string, vcsDir: string) {
+    const relative = path.relative(vcsDir, file).replaceAll(path.sep, "/")
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return false
+    if (VCS_REFRESH_FILES.has(relative)) return true
+    return VCS_REFRESH_PREFIXES.some((prefix) => relative.startsWith(prefix))
+  }
+
   export interface Interface {
     readonly init: () => Effect.Effect<void>
   }
@@ -172,7 +186,9 @@ export namespace FileWatcher {
               },
             })
             yield* Effect.addFinalizer(() => Effect.sync(() => requestRescan.dispose()))
-            const createCallback = (dir: string): ParcelWatcher.SubscribeCallback => (err, evts) =>
+            const createCallback =
+              (dir: string, shouldPublish = (_file: string) => true): ParcelWatcher.SubscribeCallback =>
+              (err, evts) =>
               Instance.restore(ctx, () => {
                 if (err) {
                   if (isDroppedEventsError(err)) {
@@ -183,14 +199,15 @@ export namespace FileWatcher {
                   return
                 }
                 for (const evt of evts) {
+                  if (!shouldPublish(evt.path)) continue
                   if (evt.type === "create") Bus.publish(Event.Updated, { file: evt.path, event: "add" })
                   if (evt.type === "update") Bus.publish(Event.Updated, { file: evt.path, event: "change" })
                   if (evt.type === "delete") Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })
                 }
               })
 
-            const subscribe = (dir: string, ignore: string[]) => {
-              const pending = w.subscribe(dir, createCallback(dir), { ignore, backend })
+            const subscribe = (dir: string, ignore: string[], shouldPublish?: (file: string) => boolean) => {
+              const pending = w.subscribe(dir, createCallback(dir, shouldPublish), { ignore, backend })
               return Effect.gen(function* () {
                 const sub = yield* Effect.promise(() => pending)
                 subs.push(sub)
@@ -222,10 +239,8 @@ export namespace FileWatcher {
               const vcsDir =
                 result.exitCode === 0 ? path.resolve(ctx.project.worktree, result.text().trim()) : undefined
               if (vcsDir && !cfgIgnores.includes(".git") && !cfgIgnores.includes(vcsDir)) {
-                const ignore = (yield* Effect.promise(() => readdir(vcsDir).catch(() => []))).filter(
-                  (entry) => entry !== "HEAD",
-                )
-                yield* subscribe(vcsDir, ignore)
+                const ignore = vcsWatcherIgnoreEntries(yield* Effect.promise(() => readdir(vcsDir).catch(() => [])))
+                yield* subscribe(vcsDir, ignore, (file) => shouldPublishVcsWatcherPath(file, vcsDir))
               }
             }
           },

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -15,6 +15,8 @@ import {
   withLifecycleCloseAction,
 } from "@/session/lifecycle-provenance"
 import { currentRequestContext } from "@/server/request-context"
+import fs from "node:fs"
+import path from "node:path"
 
 export interface LoadInput {
   directory: string
@@ -26,6 +28,7 @@ type ContextMismatchReason =
   | "worktree_mismatch"
   | "project_id_mismatch"
   | "project_row_missing"
+  | "project_vcs_changed"
   | "explicit_context_changed"
   | "unknown_context_mismatch"
 
@@ -68,6 +71,16 @@ function contextMismatchReason(ctx: InstanceContext, input: LoadInput): ContextM
   if (worktreeChanged) return "worktree_mismatch"
   if (projectChanged) return "project_id_mismatch"
   return undefined
+}
+
+function hasGitMarker(directory: string) {
+  let current = directory
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git"))) return true
+    const parent = path.dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
 }
 
 export const layer = Layer.effect(
@@ -211,8 +224,20 @@ export const layer = Layer.effect(
               const mismatchReason = contextMismatchReason(exit.value, input)
               if (!mismatchReason) {
                 const row = yield* project.get(exit.value.project.id)
-                if (row) return exit.value
-                return yield* reload(input, "project_row_missing")
+                if (!row) return yield* reload(input, "project_row_missing")
+                if (exit.value.project.vcs !== "git" && hasGitMarker(directory)) {
+                  const next = yield* project.fromDirectory(directory)
+                  if (next.project.vcs === "git")
+                    return yield* reload(
+                      {
+                        directory,
+                        worktree: next.sandbox,
+                        project: next.project,
+                      },
+                      "project_vcs_changed",
+                    )
+                }
+                return exit.value
               }
               return yield* reload(input, mismatchReason)
             }

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -145,6 +145,31 @@ function ready(directory: string) {
 // Tests
 // ---------------------------------------------------------------------------
 
+describe("FileWatcher git metadata filtering", () => {
+  test("keeps review-diff git metadata subscribed", () => {
+    expect(
+      FileWatcher.vcsWatcherIgnoreEntries(["HEAD", "index", "packed-refs", "refs", "objects", "logs", "hooks"]),
+    ).toEqual(["objects", "logs", "hooks"])
+  })
+
+  test("publishes only review-diff git metadata from the vcs directory", () => {
+    const gitDir = path.join("/tmp", "repo", ".git")
+
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "HEAD"), gitDir)).toBe(true)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "index"), gitDir)).toBe(true)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "packed-refs"), gitDir)).toBe(true)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "refs", "heads", "feature"), gitDir)).toBe(true)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "refs", "remotes", "origin", "dev"), gitDir)).toBe(
+      true,
+    )
+
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "objects", "ab", "hash"), gitDir)).toBe(false)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "refs", "tags", "v1"), gitDir)).toBe(false)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "refs", "stash"), gitDir)).toBe(false)
+    expect(FileWatcher.shouldPublishVcsWatcherPath(path.join(gitDir, "MERGE_HEAD"), gitDir)).toBe(false)
+  })
+})
+
 describeWatcher("FileWatcher", () => {
   afterEach(async () => {
     await Instance.disposeAll()
@@ -206,21 +231,50 @@ describeWatcher("FileWatcher", () => {
     })
   })
 
-  test("ignores .git/index changes", async () => {
+  test("publishes .git/index changes", async () => {
     await using tmp = await tmpdir({ git: true })
     const gitIndex = path.join(tmp.path, ".git", "index")
     const edit = path.join(tmp.path, "tracked.txt")
 
     await withWatcher(
       tmp.path,
-      noUpdate(
+      nextUpdate(
         tmp.path,
         (e) => e.file === gitIndex,
         Effect.promise(async () => {
           await fs.writeFile(edit, "a")
           await $`git add .`.cwd(tmp.path).quiet().nothrow()
         }),
-      ),
+      ).pipe(Effect.tap((evt) => Effect.sync(() => expect(evt.event).not.toBe("unlink")))),
+    )
+  })
+
+  test("publishes .git refs/heads changes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const branchRef = path.join(tmp.path, ".git", "refs", "heads", "watch-ref")
+    const hash = await $`git rev-parse HEAD`.cwd(tmp.path).quiet().text()
+
+    await withWatcher(
+      tmp.path,
+      nextUpdate(
+        tmp.path,
+        (evt) => evt.file === branchRef && evt.event !== "unlink",
+        Effect.promise(() => fs.writeFile(branchRef, hash.trim() + "\n")),
+      ).pipe(Effect.tap((evt) => Effect.sync(() => expect(["add", "change"]).toContain(evt.event)))),
+    )
+  })
+
+  test("publishes .git/packed-refs changes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const packedRefs = path.join(tmp.path, ".git", "packed-refs")
+
+    await withWatcher(
+      tmp.path,
+      nextUpdate(
+        tmp.path,
+        (evt) => evt.file === packedRefs && evt.event !== "unlink",
+        Effect.promise(() => fs.writeFile(packedRefs, "# pack-refs with: peeled fully-peeled sorted\n")),
+      ).pipe(Effect.tap((evt) => Effect.sync(() => expect(["add", "change"]).toContain(evt.event)))),
     )
   })
 

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { $ } from "bun"
 import { Effect, Exit, Fiber, Layer, ManagedRuntime } from "effect"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 
@@ -137,6 +138,29 @@ describe("InstanceStore", () => {
       yield* store.load({ directory: dir })
 
       expect(reasons).toContain("project_row_missing")
+    }),
+  )
+
+  it.live("reloads a cached non-git instance when the directory becomes git", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const disposed: string[] = []
+      const off = registerDisposer(async (directory) => {
+        disposed.push(directory)
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const first = yield* store.load({ directory: dir })
+      expect(first.project.vcs).toBeUndefined()
+
+      yield* Effect.promise(() => $`git init --quiet`.cwd(dir).quiet())
+
+      const second = yield* store.load({ directory: dir })
+      expect(second).not.toBe(first)
+      expect(second.project.vcs).toBe("git")
+      expect(second.worktree).toBe(dir)
+      expect(disposed).toEqual([dir])
     }),
   )
 


### PR DESCRIPTION
## Summary

Refresh the session Review panel's cached VCS diffs when Git state metadata changes.

Also align the backend Git watcher publish boundary with the frontend VCS refresh filter so staged, unstaged, and branch diff invalidation events are actually produced.

Also refresh cached project metadata when a directory becomes a Git repo after it was already opened, so Review does not stay stuck in the non-Git mode list.

A follow-up fixes two Review mode regressions found in live retesting: `Last turn` now requests the latest user turn instead of the whole-session aggregate, and selecting or reopening a VCS-backed Review mode forces a fresh diff load instead of reusing a prior empty cache.

Also restore workflow PR `task` labeling so the PR triage workflow contract matches the live labeler config.

## Why

Fixes #895.

The right-side Review panel could show stale data for `Branch changes` because the VCS refresh path ignored Git state updates. The frontend filter originally ignored every `.git/` update, and the backend watcher only published `.git/HEAD` from the Git directory subscription. That meant updates to `.git/index`, branch refs, and packed refs could fail to invalidate cached staged, unstaged, or branch diffs.

A live test also found a separate transition bug: if a directory was opened before it was a Git repo and later became one via shell commands, the cached instance context kept `project.vcs` empty. The Review mode selector then only showed `Last turn` and hid `Unstaged`, `Staged`, and `Branch`, even though the filesystem was now a Git repo.

A second live retest found that `Last turn` was still backed by the full session aggregate, and `Branch changes` could keep a stale empty result after the branch changed. The Review panel now fetches turn diffs with the latest user message ID, and VCS modes force-refresh when selected or when the Review panel is reopened.

The watcher path is now narrow on both sides:

- backend subscription keeps `.git/HEAD`, `.git/index`, `.git/packed-refs`, and `.git/refs` visible to the watcher;
- backend publish filtering only emits `HEAD`, `index`, `packed-refs`, `refs/heads/**`, and `refs/remotes/**` from the Git directory;
- frontend refresh filtering accepts those same Git metadata paths, including repo-relative, absolute POSIX, and Windows-style watcher paths;
- object-store updates, tags, stash, and transient Git heads stay filtered as noise.

Cached non-Git instances now re-check the directory when a `.git` marker appears and reload once the project is confirmed as Git.

A review follow-up also covers remote branch refs, because branch diffs are computed from the default branch ref via `merge-base`.

The CI follow-up fixes a pre-existing workflow contract drift surfaced by `unit-opencode`: workflow PRs are expected to receive both `ci` and `task` labels, but `.github/labeler.yml` no longer had the `task` workflow rule.

## Related Issue

Fixes #895

## Human Review Status

Pending

## Review Focus

Please focus on the Git watcher event boundary across `packages/opencode/src/file/watcher.ts` and `packages/app/src/pages/session/use-session-vcs-refresh.ts`, the cached project transition in `packages/opencode/src/project/instance-store.ts`, and the Review mode state in `packages/app/src/pages/session/use-session-review-state.ts`. The expected behavior is: a directory opened as non-Git can become Git later, Review should expose VCS modes, Git metadata changes should refresh staged, unstaged, or branch diffs while noisy Git internals remain filtered, `Last turn` should only show the latest user turn, and selecting `Branch changes` should not reuse a prior empty cache.

For the CI follow-up, please check that the restored `task` labeler rule only applies to workflow files and matches the existing contract test.

## Risk Notes

No copy or layout changed. This does change visible Review panel data behavior, so I launched the dev Electron app from this branch for live retesting and verified the backend VCS branch diff against the same `/Users/yuhan/PawWork` repo state.

This PR touches Git metadata path filtering in the backend watcher and frontend refresh consumer. The intended path surface is narrow: POSIX native watcher events are covered locally, Windows-style watcher paths are covered in the frontend normalization test, and backend Windows behavior uses `path.relative`/`path.sep` through Node's platform path implementation.

This PR also touches cached project reload behavior for directories that transition from non-Git to Git. The reload check is limited to cached non-Git instances where a `.git` marker exists; already-Git projects keep the existing fast path.

This PR also touches GitHub labeler automation. The intended behavior is narrow: workflow-only PRs get `task` in addition to `ci`, while priority remains owned by the priority triage script.

No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes are relevant.

The main residual risk is platform-specific watcher path shape variation that is not reproduced by the native macOS watcher test. The filtering is intentionally limited to VCS state paths instead of all `.git/` updates.

## How To Verify

```text
Targeted frontend RED: bun test --preload ./happydom.ts src/pages/session/use-session-vcs-refresh.test.ts failed before the first fix because .git/index did not refresh.
Backend watcher RED: bun --cwd packages/opencode test test/file/watcher.test.ts failed before the backend watcher fix because .git/index and refs/heads updates were not published.
Cached project RED: bun --cwd packages/opencode test test/project/instance-store.test.ts failed before the project reload fix because a directory opened as non-Git stayed cached as non-Git after git init.
Review state RED: bun test src/pages/session/use-session-review-state.test.ts failed before the follow-up because the last-turn request and VCS force-refresh helpers did not exist.
Related app tests: bun test src/pages/session/use-session-review-state.test.ts src/pages/session/use-session-vcs-refresh.test.ts src/pages/session/review-change-mode.test.ts src/pages/session/use-session-timeline-data.test.ts src/context/global-sync/event-reducer.test.ts passed, 69 tests / 174 assertions.
App typecheck: bun run typecheck from packages/app passed.
Backend, VCS, watcher, and project tests: bun run --cwd packages/opencode test test/project/instance-store.test.ts test/project/vcs.test.ts test/file/watcher.test.ts test/server/project-init-git.test.ts passed, 34 tests / 80 assertions.
Opencode typecheck: bun run typecheck from packages/opencode passed.
Lint: bunx eslint packages/app/src/pages/session/use-session-vcs-refresh.ts packages/opencode/src/file/watcher.ts returned 0; packages/opencode/src/file/watcher.ts is ignored by repo eslint config.
Whitespace: git diff --check passed.
Runtime VCS probe: bun --cwd packages/opencode -e against /Users/yuhan/PawWork returned branch=demo-branch, defaultBranch=main, and 2 branch diff files: demo-invoices/invoice-2026-1001.txt and temp/branch-note.md.
Manual dev app: bun run dev:desktop launched Electron from this branch at http://localhost:5173/ for live Review-panel retesting.
```

## Screenshots or Recordings

Not applicable. This change updates refresh invalidation behavior, cached project metadata, and GitHub labeler configuration; it does not change visible UI or copy.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detect when a directory becomes a Git repository and reload the project.
  * Session review now uses turn-change based diffs and exposes a controller for turn-change handling.

* **Bug Fixes**
  * Refined Git metadata filtering so only relevant .git files trigger refreshes, reducing spurious updates.

* **Tests**
  * Added and updated tests covering Git metadata filtering and repository-detection reload behavior.

* **Chores**
  * Added a workflow labeler rule for task-related workflow changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->