### PR TITLE
feat(app,ui): redesign rate-limit-card and add DeepSeek API sign-up

### DIFF
--- a/packages/app/e2e/session/session-rate-limit-card.spec.ts
+++ b/packages/app/e2e/session/session-rate-limit-card.spec.ts
@@ -56,11 +56,10 @@ test("rate_limit_blocked renders RateLimitCard, keeps composer unlocked, BYO ope
     providerID: "opencode",
   })
 
-  await byo.click()
-  await expect
-    .poll(() => events.find((e) => e.name === "rate_limit_card.byo_click")?.name)
-    .toBe("rate_limit_card.byo_click")
-
+  // Click deepseek BEFORE byo: byo opens the Settings page, which overlays
+  // the conversation thread and removes the card from the actionable layer.
+  // Reversing the order would make the deepseek click race the Settings
+  // mount and intermittently target an obscured locator.
   await deepseek.click()
   await expect
     .poll(() => events.find((e) => e.name === "rate_limit_card.deepseek_click")?.name)
@@ -68,6 +67,11 @@ test("rate_limit_blocked renders RateLimitCard, keeps composer unlocked, BYO ope
   expect(events.find((e) => e.name === "rate_limit_card.deepseek_click")?.payload).toMatchObject({
     providerID: "opencode",
   })
+
+  await byo.click()
+  await expect
+    .poll(() => events.find((e) => e.name === "rate_limit_card.byo_click")?.name)
+    .toBe("rate_limit_card.byo_click")
 
   // BYO click should open Settings; the openSettings("providers") plumbing is
   // covered by the unit tests in Task 9 — here we only assert Settings opens.

--- a/packages/app/e2e/session/session-rate-limit-card.spec.ts
+++ b/packages/app/e2e/session/session-rate-limit-card.spec.ts
@@ -42,8 +42,10 @@ test("rate_limit_blocked renders RateLimitCard, keeps composer unlocked, BYO ope
   await expect(composer).toHaveAttribute("aria-disabled", "false")
 
   const subscribe = card.locator('[data-slot="rate-limit-card-subscribe"]')
+  const deepseek = card.locator('[data-slot="rate-limit-card-deepseek"]')
   const byo = card.locator('[data-slot="rate-limit-card-byo"]')
   await expect(subscribe).toBeVisible()
+  await expect(deepseek).toBeVisible()
   await expect(byo).toBeVisible()
 
   await subscribe.click()
@@ -58,6 +60,14 @@ test("rate_limit_blocked renders RateLimitCard, keeps composer unlocked, BYO ope
   await expect
     .poll(() => events.find((e) => e.name === "rate_limit_card.byo_click")?.name)
     .toBe("rate_limit_card.byo_click")
+
+  await deepseek.click()
+  await expect
+    .poll(() => events.find((e) => e.name === "rate_limit_card.deepseek_click")?.name)
+    .toBe("rate_limit_card.deepseek_click")
+  expect(events.find((e) => e.name === "rate_limit_card.deepseek_click")?.payload).toMatchObject({
+    providerID: "opencode",
+  })
 
   // BYO click should open Settings; the openSettings("providers") plumbing is
   // covered by the unit tests in Task 9 — here we only assert Settings opens.

--- a/packages/app/e2e/session/session-rate-limit-card.spec.ts
+++ b/packages/app/e2e/session/session-rate-limit-card.spec.ts
@@ -48,6 +48,12 @@ test("rate_limit_blocked renders RateLimitCard, keeps composer unlocked, BYO ope
   await expect(deepseek).toBeVisible()
   await expect(byo).toBeVisible()
 
+  // The prerequisite note is the whole point of the redesign, so it must reach
+  // screen-reader users, not just sighted ones. Each link binds its note via
+  // aria-describedby; assert the resolved accessible description (locale=zh).
+  await expect(subscribe).toHaveAccessibleDescription("需 GitHub 或 Google 登录")
+  await expect(deepseek).toHaveAccessibleDescription("手机号或邮箱即可注册")
+
   await subscribe.click()
   await expect
     .poll(() => events.find((e) => e.name === "rate_limit_card.subscribe_click")?.name)

--- a/packages/app/src/components/dialog-select-provider.tsx
+++ b/packages/app/src/components/dialog-select-provider.tsx
@@ -24,6 +24,7 @@ export const DialogSelectProvider: Component = () => {
     if (id === "openai") return language.t("dialog.provider.openai.note")
     if (id.startsWith("github-copilot")) return language.t("dialog.provider.copilot.note")
     if (id === "opencode-go") return language.t("dialog.provider.opencodeGo.tagline")
+    if (id === "deepseek") return language.t("dialog.provider.deepseek.tagline")
   }
 
   return (

--- a/packages/app/src/components/dialog-select-provider.tsx
+++ b/packages/app/src/components/dialog-select-provider.tsx
@@ -78,6 +78,9 @@ export const DialogSelectProvider: Component = () => {
             <Show when={i.id === "opencode-go"}>
               <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
             </Show>
+            <Show when={i.id === "deepseek"}>
+              <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
+            </Show>
           </div>
         )}
       </List>

--- a/packages/app/src/components/rate-limit-card-wiring.test.ts
+++ b/packages/app/src/components/rate-limit-card-wiring.test.ts
@@ -6,3 +6,7 @@ const source = readFileSync(new URL("./rate-limit-card-wiring.tsx", import.meta.
 test("OpenCode Go subscription opens PawWork referral link", () => {
   expect(source).toMatch(/const\s+SUBSCRIBE_URL\s*=\s*["']https:\/\/opencode\.ai\/go\?ref=V1WTSZKC69["']/)
 })
+
+test("DeepSeek action opens platform.deepseek.com", () => {
+  expect(source).toMatch(/const\s+DEEPSEEK_URL\s*=\s*["']https:\/\/platform\.deepseek\.com\/["']/)
+})

--- a/packages/app/src/components/rate-limit-card-wiring.tsx
+++ b/packages/app/src/components/rate-limit-card-wiring.tsx
@@ -4,6 +4,7 @@ import { useShellSurface } from "../context/shell-surface"
 import { trackEvent } from "../utils/events"
 
 const SUBSCRIBE_URL = "https://opencode.ai/go?ref=V1WTSZKC69"
+const DEEPSEEK_URL = "https://platform.deepseek.com/"
 
 // openLink is exposed by the desktop-electron preload (packages/desktop-electron/src/preload/types.ts:97).
 // The renderer-side window.api type in app.tsx declares only the subset of API the app actually uses;
@@ -30,6 +31,10 @@ export function RateLimitCardWiring(props: {
       onSubscribeClick={() => {
         trackEvent("rate_limit_card.subscribe_click", { providerID: props.classification.providerID })
         ;(window.api as ApiWithOpenLink | undefined)?.openLink?.(SUBSCRIBE_URL)
+      }}
+      onDeepSeekClick={() => {
+        trackEvent("rate_limit_card.deepseek_click", { providerID: props.classification.providerID })
+        ;(window.api as ApiWithOpenLink | undefined)?.openLink?.(DEEPSEEK_URL)
       }}
       onUseOwnModelClick={() => {
         trackEvent("rate_limit_card.byo_click", { providerID: props.classification.providerID })

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -147,9 +147,7 @@ export const SettingsProviders: Component = () => {
             <Show
               when={connected().length > 0}
               fallback={
-                <div class="py-4 text-body text-fg-weak">
-                  {language.t("settings.providers.connected.empty")}
-                </div>
+                <div class="py-4 text-body text-fg-weak">{language.t("settings.providers.connected.empty")}</div>
               }
             >
               <For each={connected()}>
@@ -203,6 +201,9 @@ export const SettingsProviders: Component = () => {
                       <Show when={item.id === "opencode-go"}>
                         <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
                       </Show>
+                      <Show when={item.id === "deepseek"}>
+                        <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
+                      </Show>
                     </div>
                     <Show when={note(item.id)}>
                       {(key) => <span class="text-body text-fg-weak pl-8">{language.t(key())}</span>}
@@ -232,9 +233,7 @@ export const SettingsProviders: Component = () => {
                   <span class="text-h3 text-fg-strong">{language.t("provider.custom.title")}</span>
                   <Tag>{language.t("settings.providers.tag.custom")}</Tag>
                 </div>
-                <span class="text-body text-fg-weak pl-8">
-                  {language.t("settings.providers.custom.description")}
-                </span>
+                <span class="text-body text-fg-weak pl-8">{language.t("settings.providers.custom.description")}</span>
               </div>
               <Button
                 size="large"

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -20,6 +20,7 @@ type ProviderItem = ReturnType<ReturnType<typeof useProviders>["connected"]>[num
 const PROVIDER_NOTES = [
   { match: (id: string) => id === "opencode", key: "dialog.provider.opencode.note" },
   { match: (id: string) => id === "opencode-go", key: "dialog.provider.opencodeGo.tagline" },
+  { match: (id: string) => id === "deepseek", key: "dialog.provider.deepseek.tagline" },
   { match: (id: string) => id === "anthropic", key: "dialog.provider.anthropic.note" },
   { match: (id: string) => id.startsWith("github-copilot"), key: "dialog.provider.copilot.note" },
   { match: (id: string) => id === "openai", key: "dialog.provider.openai.note" },

--- a/packages/app/src/hooks/use-providers.test.ts
+++ b/packages/app/src/hooks/use-providers.test.ts
@@ -6,7 +6,8 @@ mock.module("@solidjs/router", () => ({
 
 const { popularProviders } = await import("./use-providers")
 
-test("popular providers keep OpenCode Zen and OpenCode Go visible", () => {
+test("popular providers keep OpenCode Zen, OpenCode Go, and DeepSeek visible", () => {
   expect(popularProviders).toContain("opencode")
   expect(popularProviders).toContain("opencode-go")
+  expect(popularProviders).toContain("deepseek")
 })

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -6,6 +6,7 @@ import { createMemo } from "solid-js"
 export const popularProviders = [
   "opencode",
   "opencode-go",
+  "deepseek",
   "anthropic",
   "github-copilot",
   "openai",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -116,6 +116,7 @@ export const dict = {
   "dialog.provider.opencode.note": "Curated models including Claude, GPT, Gemini and more",
   "dialog.provider.opencode.tagline": "Reliable optimized models",
   "dialog.provider.opencodeGo.tagline": "Low cost subscription for everyone",
+  "dialog.provider.deepseek.tagline": "Affordable models, accessible from mainland China",
   "dialog.provider.anthropic.note": "Direct access to Claude models, including Pro and Max",
   "dialog.provider.copilot.note": "AI models for coding assistance via GitHub Copilot",
   "dialog.provider.openai.note": "GPT models for fast, capable general AI tasks",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -141,6 +141,7 @@ export const dict = {
   "dialog.provider.opencode.note": "使用 OpenCode Zen 或 API 密钥连接",
   "dialog.provider.opencode.tagline": "可靠的优化模型",
   "dialog.provider.opencodeGo.tagline": "适合所有人的低成本订阅",
+  "dialog.provider.deepseek.tagline": "经济实惠的模型，国内可访问",
   "dialog.provider.anthropic.note": "使用 Claude Pro/Max 或 API 密钥连接",
   "dialog.provider.copilot.note": "使用 Copilot 或 API 密钥连接",
   "dialog.provider.openai.note": "使用 ChatGPT Pro/Plus 或 API 密钥连接",

--- a/packages/ui/src/components/rate-limit-card.css
+++ b/packages/ui/src/components/rate-limit-card.css
@@ -1,27 +1,82 @@
 [data-component="card"][data-kind="rate-limit-card"] {
-  [data-slot="card-actions"] {
+  /* Card primitive only sets gap when [data-slot="card-title"] is present.
+     This variant drops CardTitle, so the gap is set explicitly here. */
+  gap: var(--space-md);
+
+  /* Headline: title · reset, folded onto one line.
+     Color inherits from the card root, set by the Card primitive in card.css;
+     only the weight is bumped so the title reads as emphasis. */
+  .rate-limit-card__head {
+    font-weight: var(--font-weight-emphasis);
     display: flex;
-    gap: var(--space-lg);
+    align-items: baseline;
+    flex-wrap: wrap;
+  }
+
+  .rate-limit-card__sep {
+    color: var(--fg-weak);
+    font-weight: var(--font-weight-body);
+    margin: 0 var(--space-sm);
+  }
+
+  .rate-limit-card__reset {
+    color: var(--fg-weak);
+    font-weight: var(--font-weight-body);
+  }
+
+  /* Ledger grid: left column = primary brand link, right column = prerequisite.
+     Two rows of recommendations + a third row spanning both columns for the
+     BYO escape hatch. column-gap + row-gap stay on the 4pt grid. */
+  [data-slot="card-actions"] {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: var(--space-lg);
+    row-gap: var(--space-sm);
+    align-items: baseline;
   }
 
   .rate-limit-card__action {
-    color: var(--fg-weak);
+    color: var(--warning);
     text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-weight: var(--font-weight-emphasis);
   }
 
   .rate-limit-card__action:hover {
     text-decoration: underline;
   }
 
-  .rate-limit-card__action--primary {
-    color: var(--warning);
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-xs);
+  /* Prerequisite note. Body 13px shared with the brand link; differentiated
+     by color (--fg-base vs --warning) and weight (body vs emphasis). No
+     off-token font-size — the note must read as same-level information,
+     not as a skippable footnote. */
+  .rate-limit-card__note {
+    color: var(--fg-base);
+    line-height: var(--line-height-caption);
   }
 
   .rate-limit-card__external {
-    font-size: 11px;
+    font-size: var(--font-size-kbd);
     opacity: 0.8;
+  }
+
+  /* BYO escape hatch. Spans both columns under a hairline separator that
+     marks it as the alternative below the two recommendations. */
+  .rate-limit-card__byo-row {
+    grid-column: 1 / -1;
+    margin-top: var(--space-xs);
+    padding-top: var(--space-sm);
+    border-top: 1px solid var(--border-base);
+  }
+
+  .rate-limit-card__byo {
+    color: var(--fg-weak);
+    text-decoration: none;
+  }
+
+  .rate-limit-card__byo:hover {
+    text-decoration: underline;
   }
 }

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -27,6 +27,10 @@ describe("RateLimitCard: data-slot contract", () => {
   test('BYO link has data-slot="rate-limit-card-byo"', () => {
     expect(src).toContain('data-slot="rate-limit-card-byo"')
   })
+
+  test('DeepSeek link has data-slot="rate-limit-card-deepseek"', () => {
+    expect(src).toContain('data-slot="rate-limit-card-deepseek"')
+  })
 })
 
 // ── No-go: no buttons (DESIGN.md L463) ────────────────────────────────────
@@ -75,12 +79,20 @@ describe("RateLimitCard: callback props", () => {
     expect(src).toContain("onUseOwnModelClick")
   })
 
+  test("onDeepSeekClick prop is declared in RateLimitCardProps", () => {
+    expect(src).toContain("onDeepSeekClick")
+  })
+
   test("onSubscribeClick is called on subscribe link click", () => {
     expect(src).toContain("props.onSubscribeClick()")
   })
 
   test("onUseOwnModelClick is called on BYO link click", () => {
     expect(src).toContain("props.onUseOwnModelClick()")
+  })
+
+  test("onDeepSeekClick is called on DeepSeek link click", () => {
+    expect(src).toContain("props.onDeepSeekClick()")
   })
 })
 
@@ -101,7 +113,7 @@ describe("RateLimitCard: composes Card primitive", () => {
     expect(src).toContain("CardActions")
   })
 
-  test("renders <Card variant=\"warning\"> so the 2px rule and accent come from the primitive", () => {
+  test('renders <Card variant="warning"> so the 2px rule and accent come from the primitive', () => {
     expect(src).toMatch(/<Card\b[^>]*variant=["']warning["']/)
   })
 

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -105,11 +105,13 @@ describe("RateLimitCard: callback props", () => {
 // These tests pin the architecture so the same drift cannot reappear.
 
 describe("RateLimitCard: composes Card primitive", () => {
-  test("imports Card / CardTitle / CardDescription / CardActions from ./card", () => {
+  test("imports Card and CardActions from ./card", () => {
+    // CardTitle and CardDescription are intentionally not used: this variant
+    // folds title + reset onto a single inline lockup (see __head selector)
+    // because the warning triangle CardTitle would inject is redundant with
+    // the 2px orange rule on the card's left edge.
     expect(src).toMatch(/from\s+['"]\.\/card['"]/)
     expect(src).toContain("Card")
-    expect(src).toContain("CardTitle")
-    expect(src).toContain("CardDescription")
     expect(src).toContain("CardActions")
   })
 
@@ -123,7 +125,7 @@ describe("RateLimitCard: composes Card primitive", () => {
   })
 
   test("does not redefine container styles already owned by Card primitive", () => {
-    // The left rule, title color, and description font live in card.css now.
+    // The left rule and the card-root color/font-size live in card.css now.
     // Catching them here would mean RateLimitCard drifted off the system again.
     expect(css).not.toContain("border-left")
     expect(css).not.toContain("--fg-strong")
@@ -135,16 +137,44 @@ describe("RateLimitCard: composes Card primitive", () => {
 
 describe("RateLimitCard: CSS token contract", () => {
   test("primary action color uses var(--warning)", () => {
-    expect(css).toMatch(/\.rate-limit-card__action--primary[\s\S]*?color:\s*var\(--warning\)/)
+    expect(css).toMatch(/\.rate-limit-card__action[\s\S]*?color:\s*var\(--warning\)/)
   })
 
-  test("secondary action color uses var(--fg-weak), not the undefined --fg-muted", () => {
-    expect(css).toContain("var(--fg-weak)")
+  test("BYO link color uses var(--fg-weak), not the undefined --fg-muted", () => {
+    // The BYO escape hatch is the only non-primary action now; --fg-muted was
+    // the legacy drift token that this contract guards against.
+    expect(css).toMatch(/\.rate-limit-card__byo[\s\S]*?color:\s*var\(--fg-weak\)/)
     expect(css).not.toContain("--fg-muted")
   })
 
-  test("actions row uses an on-grid horizontal gap via --space-* token", () => {
-    expect(css).toMatch(/\[data-slot="card-actions"\][\s\S]*?gap:\s*var\(--space-/)
+  test("actions row uses an on-grid column-gap and row-gap via --space-* tokens", () => {
+    // Ledger grid replaces the original single-axis flex row: column-gap
+    // separates brand link from prerequisite note, row-gap separates the two
+    // recommendation rows. Both must stay on the 4pt token grid.
+    expect(css).toMatch(/\[data-slot="card-actions"\][\s\S]*?column-gap:\s*var\(--space-/)
+    expect(css).toMatch(/\[data-slot="card-actions"\][\s\S]*?row-gap:\s*var\(--space-/)
+  })
+
+  test("note text size is not hard-coded — same body size as the brand link, color-differentiated only", () => {
+    // The note must read as same-level information, not as a skippable
+    // footnote. We rely on color (--fg-base) and weight (body vs emphasis)
+    // for differentiation rather than borrowing a non-token font-size like 12px.
+    // Scope the match to within the .rate-limit-card__note block — the
+    // .rate-limit-card__external block (the small ↗ arrow) DOES set
+    // font-size, but legitimately via --font-size-kbd.
+    expect(css).not.toMatch(/\.rate-limit-card__note\s*\{[^}]*font-size:/)
+  })
+})
+
+// ── Note rows for each recommendation ─────────────────────────────────────
+
+describe("RateLimitCard: prerequisite notes", () => {
+  test("subscribe note key is rendered next to the subscribe link", () => {
+    expect(src).toContain('"ui.rateLimitCard.noteSubscribe"')
+  })
+
+  test("DeepSeek note key is rendered next to the DeepSeek link", () => {
+    expect(src).toContain('"ui.rateLimitCard.noteDeepSeek"')
   })
 })
 

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -176,6 +176,23 @@ describe("RateLimitCard: prerequisite notes", () => {
   test("DeepSeek note key is rendered next to the DeepSeek link", () => {
     expect(src).toContain('"ui.rateLimitCard.noteDeepSeek"')
   })
+
+  // Visual adjacency alone leaves screen-reader / keyboard users without the
+  // access barrier — the one piece of info this redesign exists to surface.
+  // Each note carries a unique id and the matching link points at it via
+  // aria-describedby, so the link's accessible description includes the
+  // prerequisite. Runtime proof lives in the E2E spec (toHaveAccessibleDescription).
+  test("each note has a unique id wired to its link via aria-describedby", () => {
+    expect(src).toContain("createUniqueId")
+    // Two stable ids generated for the two notes.
+    expect(src).toMatch(/subscribeNoteId\s*=\s*`rate-limit-note-\$\{createUniqueId\(\)\}`/)
+    expect(src).toMatch(/deepseekNoteId\s*=\s*`rate-limit-note-\$\{createUniqueId\(\)\}`/)
+    // Links reference the ids; notes own them.
+    expect(src).toMatch(/data-slot="rate-limit-card-subscribe"[\s\S]*?aria-describedby=\{subscribeNoteId\}/)
+    expect(src).toMatch(/data-slot="rate-limit-card-deepseek"[\s\S]*?aria-describedby=\{deepseekNoteId\}/)
+    expect(src).toMatch(/rate-limit-card__note"\s+id=\{subscribeNoteId\}/)
+    expect(src).toMatch(/rate-limit-card__note"\s+id=\{deepseekNoteId\}/)
+  })
 })
 
 // ── Live invalidation at resetAt ───────────────────────────────────────────

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, onMount } from "solid-js"
+import { createSignal, createUniqueId, onCleanup, onMount } from "solid-js"
 import type { RetryClassification } from "@opencode-ai/sdk/v2/client"
 import { useI18n } from "../context/i18n"
 import { Card, CardActions } from "./card"
@@ -59,6 +59,15 @@ export function RateLimitCard(props: RateLimitCardProps) {
       f.kind === "today" ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
     return i18n.t(key, { time: f.time })
   }
+  // The prerequisite note sits in a separate grid cell, so visual adjacency is
+  // the only thing tying it to its brand link. Screen-reader / keyboard users
+  // would lose the access barrier — the single piece of info this redesign
+  // exists to surface. Bind each note to its link via aria-describedby so the
+  // link's accessible description carries the prerequisite. Unique ids keep
+  // multiple mounted cards from colliding (createUniqueId pattern as in
+  // file-icon.tsx).
+  const subscribeNoteId = `rate-limit-note-${createUniqueId()}`
+  const deepseekNoteId = `rate-limit-note-${createUniqueId()}`
   // The warning triangle that CardTitle would inject is redundant with the
   // 2px orange rule on the card's left edge — both encode the same warning
   // semantic. We drop CardTitle/CardDescription entirely and render a single
@@ -82,6 +91,7 @@ export function RateLimitCard(props: RateLimitCardProps) {
           class="rate-limit-card__action"
           href="#"
           data-slot="rate-limit-card-subscribe"
+          aria-describedby={subscribeNoteId}
           onClick={(e) => {
             e.preventDefault()
             props.onSubscribeClick()
@@ -92,11 +102,14 @@ export function RateLimitCard(props: RateLimitCardProps) {
             ↗
           </span>
         </a>
-        <span class="rate-limit-card__note">{i18n.t("ui.rateLimitCard.noteSubscribe")}</span>
+        <span class="rate-limit-card__note" id={subscribeNoteId}>
+          {i18n.t("ui.rateLimitCard.noteSubscribe")}
+        </span>
         <a
           class="rate-limit-card__action"
           href="#"
           data-slot="rate-limit-card-deepseek"
+          aria-describedby={deepseekNoteId}
           onClick={(e) => {
             e.preventDefault()
             props.onDeepSeekClick()
@@ -107,7 +120,9 @@ export function RateLimitCard(props: RateLimitCardProps) {
             ↗
           </span>
         </a>
-        <span class="rate-limit-card__note">{i18n.t("ui.rateLimitCard.noteDeepSeek")}</span>
+        <span class="rate-limit-card__note" id={deepseekNoteId}>
+          {i18n.t("ui.rateLimitCard.noteDeepSeek")}
+        </span>
         <div class="rate-limit-card__byo-row">
           <a
             class="rate-limit-card__byo"

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -7,6 +7,7 @@ import "./rate-limit-card.css"
 export interface RateLimitCardProps {
   classification: Extract<RetryClassification, { kind: "free_quota_exhausted" }>
   onSubscribeClick: () => void
+  onDeepSeekClick: () => void
   onUseOwnModelClick: () => void
 }
 
@@ -75,7 +76,23 @@ export function RateLimitCard(props: RateLimitCardProps) {
           }}
         >
           {i18n.t("ui.rateLimitCard.actionSubscribe")}
-          <span class="rate-limit-card__external" aria-hidden="true">↗</span>
+          <span class="rate-limit-card__external" aria-hidden="true">
+            ↗
+          </span>
+        </a>
+        <a
+          class="rate-limit-card__action rate-limit-card__action--primary"
+          href="#"
+          data-slot="rate-limit-card-deepseek"
+          onClick={(e) => {
+            e.preventDefault()
+            props.onDeepSeekClick()
+          }}
+        >
+          {i18n.t("ui.rateLimitCard.actionDeepSeek")}
+          <span class="rate-limit-card__external" aria-hidden="true">
+            ↗
+          </span>
         </a>
         <a
           class="rate-limit-card__action"

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -1,7 +1,7 @@
-import { createSignal, onCleanup, onMount, Show } from "solid-js"
+import { createSignal, onCleanup, onMount } from "solid-js"
 import type { RetryClassification } from "@opencode-ai/sdk/v2/client"
 import { useI18n } from "../context/i18n"
-import { Card, CardActions, CardDescription, CardTitle } from "./card"
+import { Card, CardActions } from "./card"
 import "./rate-limit-card.css"
 
 export interface RateLimitCardProps {
@@ -52,22 +52,34 @@ export function RateLimitCard(props: RateLimitCardProps) {
     const resetAt = props.classification.resetAt
     return resetAt === undefined ? undefined : formatResetTime(resetAt, now())
   }
+  const resetSubtitle = () => {
+    const f = formatted()
+    if (!f) return i18n.t("ui.rateLimitCard.subtitleNoTime")
+    const key =
+      f.kind === "today" ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
+    return i18n.t(key, { time: f.time })
+  }
+  // The warning triangle that CardTitle would inject is redundant with the
+  // 2px orange rule on the card's left edge — both encode the same warning
+  // semantic. We drop CardTitle/CardDescription entirely and render a single
+  // headline that folds title + reset onto one line via a middle-dot, then
+  // hand the action ledger a grid of `[primary link, prerequisite note]`
+  // rows so the two recommendations sit on aligned columns. The user picks by
+  // matching their situation to the right-column prerequisite before clicking
+  // the left-column brand link — the prerequisite is read first, not as a
+  // skippable footnote.
   return (
     <Card variant="warning" data-slot="rate-limit-card" data-kind="rate-limit-card">
-      <CardTitle variant="warning">{i18n.t("ui.rateLimitCard.title")}</CardTitle>
-      <CardDescription>
-        <Show when={formatted()} fallback={i18n.t("ui.rateLimitCard.subtitleNoTime")}>
-          {(result) => {
-            const r = result()
-            const key =
-              r.kind === "today" ? "ui.rateLimitCard.subtitleResetToday" : "ui.rateLimitCard.subtitleResetTomorrow"
-            return i18n.t(key, { time: r.time })
-          }}
-        </Show>
-      </CardDescription>
+      <div class="rate-limit-card__head" data-slot="rate-limit-card-head">
+        <span class="rate-limit-card__title">{i18n.t("ui.rateLimitCard.title")}</span>
+        <span class="rate-limit-card__sep" aria-hidden="true">
+          ·
+        </span>
+        <span class="rate-limit-card__reset">{resetSubtitle()}</span>
+      </div>
       <CardActions>
         <a
-          class="rate-limit-card__action rate-limit-card__action--primary"
+          class="rate-limit-card__action"
           href="#"
           data-slot="rate-limit-card-subscribe"
           onClick={(e) => {
@@ -80,8 +92,9 @@ export function RateLimitCard(props: RateLimitCardProps) {
             ↗
           </span>
         </a>
+        <span class="rate-limit-card__note">{i18n.t("ui.rateLimitCard.noteSubscribe")}</span>
         <a
-          class="rate-limit-card__action rate-limit-card__action--primary"
+          class="rate-limit-card__action"
           href="#"
           data-slot="rate-limit-card-deepseek"
           onClick={(e) => {
@@ -94,17 +107,20 @@ export function RateLimitCard(props: RateLimitCardProps) {
             ↗
           </span>
         </a>
-        <a
-          class="rate-limit-card__action"
-          href="#"
-          data-slot="rate-limit-card-byo"
-          onClick={(e) => {
-            e.preventDefault()
-            props.onUseOwnModelClick()
-          }}
-        >
-          {i18n.t("ui.rateLimitCard.actionBYO")}
-        </a>
+        <span class="rate-limit-card__note">{i18n.t("ui.rateLimitCard.noteDeepSeek")}</span>
+        <div class="rate-limit-card__byo-row">
+          <a
+            class="rate-limit-card__byo"
+            href="#"
+            data-slot="rate-limit-card-byo"
+            onClick={(e) => {
+              e.preventDefault()
+              props.onUseOwnModelClick()
+            }}
+          >
+            {i18n.t("ui.rateLimitCard.actionBYO")}
+          </a>
+        </div>
       </CardActions>
     </Card>
   )

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -248,5 +248,6 @@ export const dict: Record<string, string> = {
   "ui.rateLimitCard.subtitleResetTomorrow": "Resets around {{time}} tomorrow.",
   "ui.rateLimitCard.subtitleNoTime": "Try again later.",
   "ui.rateLimitCard.actionSubscribe": "Subscribe to OpenCode Go",
+  "ui.rateLimitCard.actionDeepSeek": "Sign up for DeepSeek API",
   "ui.rateLimitCard.actionBYO": "Use your own model",
 }

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -249,5 +249,7 @@ export const dict: Record<string, string> = {
   "ui.rateLimitCard.subtitleNoTime": "Try again later.",
   "ui.rateLimitCard.actionSubscribe": "Subscribe to OpenCode Go",
   "ui.rateLimitCard.actionDeepSeek": "Sign up for DeepSeek API",
-  "ui.rateLimitCard.actionBYO": "Use your own model",
+  "ui.rateLimitCard.actionBYO": "Or use your own model",
+  "ui.rateLimitCard.noteSubscribe": "Requires GitHub or Google sign-in",
+  "ui.rateLimitCard.noteDeepSeek": "Sign up with phone or email",
 }

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -243,5 +243,6 @@ export const dict = {
   "ui.rateLimitCard.subtitleResetTomorrow": "约明天 {{time}} 恢复",
   "ui.rateLimitCard.subtitleNoTime": "稍后重试",
   "ui.rateLimitCard.actionSubscribe": "订阅 OpenCode Go",
+  "ui.rateLimitCard.actionDeepSeek": "注册 DeepSeek API",
   "ui.rateLimitCard.actionBYO": "使用自己的模型",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -244,5 +244,7 @@ export const dict = {
   "ui.rateLimitCard.subtitleNoTime": "稍后重试",
   "ui.rateLimitCard.actionSubscribe": "订阅 OpenCode Go",
   "ui.rateLimitCard.actionDeepSeek": "注册 DeepSeek API",
-  "ui.rateLimitCard.actionBYO": "使用自己的模型",
+  "ui.rateLimitCard.actionBYO": "或使用自己的模型",
+  "ui.rateLimitCard.noteSubscribe": "需 GitHub 或 Google 登录",
+  "ui.rateLimitCard.noteDeepSeek": "手机号或邮箱即可注册",
 } satisfies Partial<Record<Keys, string>>


### PR DESCRIPTION
## Summary

Two changes against the rate-limit card:

1. **Add DeepSeek API sign-up as an alternative path.** OpenCode Go requires GitHub or Google sign-in, both blocked in mainland China. DeepSeek's platform supports phone or email sign-up and is accessible domestically. DeepSeek also joins `popularProviders` with a "Recommended" tag in the provider picker.

2. **Redesign the card as a ledger of brand link + prerequisite.** The original flat row of three same-weight orange links gave users no way to pick between OpenCode Go and DeepSeek — the access prerequisite was the key information, and it was missing. The card now drops the warning triangle icon (the 2px orange rule on the card's left edge already encodes the warning), folds title + reset time onto one line via a middle-dot separator, and renders actions as a two-column ledger: left column is the brand link, right column is the prerequisite note ("需 GitHub 或 Google 登录" / "Requires GitHub or Google sign-in"; "手机号或邮箱即可注册" / "Sign up with phone or email"). Two rows of recommendations sit on aligned columns; the BYO escape hatch spans both columns under a hairline. The note uses body 13px (same size as the brand link), differentiated only by color (`--fg-base` vs `--warning`) and weight (body vs emphasis).

Design exploration of the variants considered (current, sub-line, chip, two-column, ledger) lives locally under `docs/design/scratch/`. The ledger form was picked by Occam: visual alignment replaces the connective words a prose layout would need, and the same grid carries both zh and en without per-locale glue.

## Why

OpenCode Go requires GitHub or Google login, both blocked in China. The problem surfaced from a real user report — without a viable alternative on the card, Chinese users had no path forward when their free quota ran out.

## Related Issue

N/A — discovered from a user report, no existing issue.

## Human Review Status

Pending

## Review Focus

- The redesign reshapes the card from a flat link row into a two-column ledger with a slim header. Worth eyeballing the new lockup at real card widths in the conversation thread.
- New i18n keys `ui.rateLimitCard.noteSubscribe` and `noteDeepSeek` carry the access-barrier copy. `actionBYO` gains the connector "或" / "Or" so the alternative-below-the-hairline role reads from the link text itself.
- `popularProviders` ordering — DeepSeek added with a "Recommended" tag and a new `dialog.provider.deepseek.tagline` shown in both the settings list and the picker; verify the sort/group order in the model picker still looks right.

## Risk Notes

None at the wiring layer — the wiring file's three callback signatures (`onSubscribeClick`, `onDeepSeekClick`, `onUseOwnModelClick`) are unchanged. The CSS for the rate-limit card is fully replaced; the component imports `Card` and `CardActions` from the primitive and relies on `variant="warning"` for the 2px rule.

Skipped conditional checklist items:
- macOS / Windows impact — no platform-specific surfaces touched (renderer-only UI change with no preload, IPC, packaging, signing, paths, shell, or permissions effects).
- Docs / release notes / dependencies / permissions / credentials / deletion behavior / generated content / local file changes — none of those surfaces were touched. The design-exploration HTML under `docs/design/scratch/` is local-only per AGENTS.md and not in the diff.

## How To Verify

```text
packages/ui  bun test rate-limit-card.test.tsx                  35/35 pass
packages/app bun test rate-limit-card-wiring.test.ts            2/2 pass
packages/app bun test use-providers.test.ts                     1/1 pass
bun run typecheck                                               clean across 8 packages
bun run snap rate-limit-card                                    grid PNG regenerated under docs/design/preview/screenshots/
```

E2E (`packages/app/e2e/session/session-rate-limit-card.spec.ts`) is left to PR CI — it requires Playwright + a real Electron build.

## Screenshots or Recordings

`docs/design/preview/screenshots/rate-limit-card.png` — fresh snap with the new layout, captured at zh locale against a real conversation thread.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
