### PR TITLE
fix: auto retry safe reasoning-only disconnects

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,11 @@ ci:
           - ".github/workflows/**"
           - ".github/**"
 
+task:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
 platform:
   - changed-files:
       - any-glob-to-any-file:

--- a/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
@@ -64,9 +64,10 @@ function SafeRetrySnapFixture() {
             status={{
               type: "retry",
               attempt: 1,
-              message: "Network connection dropped, retrying automatically",
+              message: "",
               next: Date.now() + 1000,
               presentation: "safe_recovery",
+              reason: "network_connection_dropped",
             }}
           />
         </div>

--- a/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
@@ -64,7 +64,7 @@ function SafeRetrySnapFixture() {
             status={{
               type: "retry",
               attempt: 1,
-              message: "网络连接断开，正在自动重试",
+              message: "Network connection dropped, retrying automatically",
               next: Date.now() + 1000,
               presentation: "safe_recovery",
             }}

--- a/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
@@ -1,0 +1,85 @@
+import { render } from "solid-js/web"
+import type { AssistantMessage, NoticePart } from "@opencode-ai/sdk/v2"
+import { DataProvider, I18nProvider } from "@opencode-ai/ui/context"
+import { dict as zh } from "@opencode-ai/ui/i18n/zh"
+import { AssistantParts } from "@opencode-ai/ui/message-part"
+import { SessionRetry } from "@opencode-ai/ui/session-retry"
+import type { UiI18nKey, UiI18nParams } from "@opencode-ai/ui/context/i18n"
+
+const assistant: AssistantMessage = {
+  id: "msg_safe_retry_assistant",
+  role: "assistant",
+  sessionID: "ses_safe_retry",
+  parentID: "msg_safe_retry_user",
+  modelID: "test-model",
+  providerID: "test-provider",
+  mode: "build",
+  agent: "build",
+  path: { cwd: "/Users/yuhan/PawWork", root: "/Users/yuhan/PawWork" },
+  cost: 0,
+  tokens: {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cache: { read: 0, write: 0 },
+  },
+  time: {
+    created: 0,
+    completed: 1,
+  },
+}
+
+const notice: NoticePart = {
+  id: "part_safe_retry_failed",
+  sessionID: assistant.sessionID,
+  messageID: assistant.id,
+  type: "notice",
+  kind: "safe_retry_failed",
+  time: { created: 1 },
+}
+
+const i18n = {
+  locale: () => "zh",
+  t: (key: UiI18nKey, params?: UiI18nParams) => {
+    const template = zh[key] ?? String(key)
+    return template.replace(/{{\s*([^}]+?)\s*}}/g, (_, rawKey) => String(params?.[String(rawKey)] ?? ""))
+  },
+}
+
+function SafeRetrySnapFixture() {
+  return (
+    <I18nProvider value={i18n}>
+      <div
+        style={{
+          display: "grid",
+          gap: "20px",
+          padding: "24px",
+          background: "var(--bg-base)",
+          color: "var(--fg-base)",
+          width: "520px",
+        }}
+      >
+        <div data-snap="running">
+          <SessionRetry
+            status={{
+              type: "retry",
+              attempt: 1,
+              message: "网络连接断开，正在自动重试",
+              next: Date.now() + 1000,
+              presentation: "safe_recovery",
+            }}
+          />
+        </div>
+        <div data-snap="notice">
+          <DataProvider data={{ message: {}, part: { [assistant.id]: [notice] } }} directory="/Users/yuhan/PawWork">
+            <AssistantParts messages={[assistant]} />
+          </DataProvider>
+        </div>
+      </div>
+    </I18nProvider>
+  )
+}
+
+export function mountSafeRetrySnapFixture(root: HTMLElement) {
+  render(() => <SafeRetrySnapFixture />, root)
+}

--- a/packages/app/e2e/snap/safe-retry.snap.ts
+++ b/packages/app/e2e/snap/safe-retry.snap.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator } from "@playwright/test"
+import { fileURLToPath } from "node:url"
+import { test } from "../fixtures"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 720, height: 360 }, deviceScaleFactor: 2 })
+
+const fixturePath = fileURLToPath(new URL("./fixtures/safe-retry-snap-fixture.tsx", import.meta.url))
+
+async function captureBlock(name: string, block: Locator): Promise<Shot> {
+  await expect(block).toBeVisible({ timeout: 30_000 })
+  return { name, buf: await block.screenshot() }
+}
+
+async function waitForThemeBoot(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForFunction(
+    () => getComputedStyle(document.documentElement).getPropertyValue("--bg-base").trim().length > 0,
+    null,
+    { timeout: 30_000 },
+  )
+}
+
+test("safe-retry", async ({ page }) => {
+  test.setTimeout(180_000)
+
+  await page.goto("/")
+  await waitForThemeBoot(page)
+  await page.evaluate(async (path) => {
+    const mod = await import(path)
+    mod.mountSafeRetrySnapFixture(document.body)
+  }, `/@fs/${fixturePath}`)
+
+  const running = page.locator('[data-snap="running"]')
+  await expect(running).toContainText("网络连接断开，正在自动重试", { timeout: 30_000 })
+  await expect(running.locator('[data-slot="session-turn-safe-retry"]')).toBeVisible({ timeout: 30_000 })
+  await expect(running.locator(".error-card")).toHaveCount(0)
+
+  const notice = page.locator('[data-snap="notice"]')
+  await expect(notice).toContainText("网络连接断开，自动重试未完成", { timeout: 30_000 })
+  await expect(notice.locator('[data-kind="safe_retry_failed"]')).toBeVisible({ timeout: 30_000 })
+
+  const out = snapOutputPath("safe-retry")
+  await composeGrid([await captureBlock("running", running), await captureBlock("notice", notice)], out)
+  process.stdout.write(`\n[snap] safe-retry grid -> ${out}\n\n`)
+})

--- a/packages/opencode/src/session/export.ts
+++ b/packages/opencode/src/session/export.ts
@@ -830,6 +830,8 @@ export namespace Export {
           text: redact("reasoning", part.id, part.text),
           metadata: dataField("reasoning-metadata", part.id, part.metadata),
         }
+      case "notice":
+        return part
       case "file":
         return filepart(part)
       case "subtask":

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -165,6 +165,17 @@ export const ReasoningPart = PartBase.extend({
 })
 export type ReasoningPart = z.infer<typeof ReasoningPart>
 
+export const NoticePart = PartBase.extend({
+  type: z.literal("notice"),
+  kind: z.literal("safe_retry_failed"),
+  time: z.object({
+    created: z.number(),
+  }),
+}).meta({
+  ref: "NoticePart",
+})
+export type NoticePart = z.infer<typeof NoticePart>
+
 const FilePartSourceBase = z.object({
   text: z
     .object({
@@ -450,6 +461,7 @@ export const Part = z
     TextPart,
     SubtaskPart,
     ReasoningPart,
+    NoticePart,
     FilePart,
     ToolPart,
     StepStartPart,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1301,6 +1301,7 @@ export const layer: Layer.Layer<
               error: result.error,
               evidence: retrySignal.watchdog ? ["watchdog_fired", "iterator_error"] : ["iterator_error"],
               watchdog: retrySignal.watchdog,
+              retryable: retrySignal.retryable,
             })
 
             if (

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1206,6 +1206,7 @@ export const layer: Layer.Layer<
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
         let processAttemptID: RunObservability.AttemptID | undefined
         let automaticStreamRetriesUsed = 0
+        let safeRetryNoticeWritten = false
 
         const retryStillAllowed = Effect.fn("SessionProcessor.retryStillAllowed")(function* (stage: string) {
           const lifecycleAction = currentLifecycleCloseAction(ctx.directory)
@@ -1259,6 +1260,23 @@ export const layer: Layer.Layer<
             if (partIDs.has(part.id)) delete ctx.reasoningMap[id]
           }
           delete ctx.reasoningPartIDsByAttempt[String(attemptID)]
+        })
+
+        const writeSafeRetryFailedNotice = Effect.fn("SessionProcessor.writeSafeRetryFailedNotice")(function* (
+          attemptID: RunObservability.AttemptID,
+        ) {
+          ctx.streamError = true
+          yield* removeReasoningForAttempt(attemptID)
+          yield* session.updatePart({
+            id: PartID.ascending(),
+            sessionID: ctx.sessionID,
+            messageID: ctx.assistantMessage.id,
+            type: "notice",
+            kind: "safe_retry_failed",
+            time: { created: Date.now() },
+          } satisfies MessageV2.NoticePart)
+          yield* status.set(ctx.sessionID, { type: "idle" })
+          safeRetryNoticeWritten = true
         })
 
         const runAttempt = Effect.fn("SessionProcessor.runAttempt")(function* () {
@@ -1326,6 +1344,9 @@ export const layer: Layer.Layer<
               watchdog: retrySignal.watchdog,
               retryable: retrySignal.retryable,
             })
+            const reasoningOnlySafeRetry =
+              decision.recommendation === "auto_retry_once" &&
+              decision.reason === "reasoning_only_without_final_text_or_tool_activity"
 
             if (
               attemptID &&
@@ -1341,8 +1362,11 @@ export const layer: Layer.Layer<
                 yield* status.set(ctx.sessionID, {
                   type: "retry",
                   attempt: ctx.attemptCount,
-                  message: retrySignal.message ?? "Retrying interrupted stream",
+                  message: reasoningOnlySafeRetry
+                    ? "Network connection dropped, retrying automatically"
+                    : (retrySignal.message ?? "Retrying interrupted stream"),
                   next,
+                  ...(reasoningOnlySafeRetry ? { presentation: "safe_recovery" as const } : {}),
                 })
                 yield* Effect.sleep(`${SAFE_RECOVERY_AUTO_RETRY_BACKOFF_MS} millis`).pipe(
                   Effect.onInterrupt(() => recordProcessInterrupt(attemptID)),
@@ -1369,6 +1393,16 @@ export const layer: Layer.Layer<
               break
             }
 
+            if (
+              attemptID &&
+              retrySignal.retryable &&
+              reasoningOnlySafeRetry &&
+              automaticStreamRetriesUsed > 0
+            ) {
+              yield* writeSafeRetryFailedNotice(attemptID)
+              break
+            }
+
             yield* halt(result.error, attemptID, {
               recordFailure: false,
               interruptionMessage: recoveryInterruptionMessage(decision),
@@ -1377,7 +1411,7 @@ export const layer: Layer.Layer<
           }
 
           if (ctx.needsCompaction) return "compact"
-          if (ctx.blocked || ctx.assistantMessage.error) return "stop"
+          if (ctx.blocked || ctx.assistantMessage.error || safeRetryNoticeWritten) return "stop"
           return "continue"
         }).pipe(Effect.ensuring(cleanup()))
       })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -128,19 +128,39 @@ function watchdogPhase(error: unknown): "connect" | "silent_stream" | "unknown" 
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {
-  const names = Object.keys(tools ?? {})
+  const entries = Object.entries(tools ?? {})
+  const names = entries.map(([name]) => name)
   const effects = names.map((name) => RunObservability.toolEffect(name))
   const unknownCount = effects.filter((effect) => effect.kind === "unknown").length
   const unclassifiedCount = effects.filter((effect) => !effect.complete).length
+  const providerExecutedCapabilityPresent = entries.some(([, item]) => isRecord(item) && item.type === "provider")
+  const externalBoundaryPresent = entries.some(
+    ([, item]) => isRecord(item) && (item as { externalResult?: unknown }).externalResult === true,
+  )
+  const unknownBoundaryPresent = entries.some(([, item]) => !isRecord(item))
   const incomplete = unknownCount > 0 || unclassifiedCount > 0
+  const proofReason = providerExecutedCapabilityPresent
+    ? "provider_executed_capability"
+    : externalBoundaryPresent
+      ? "external_boundary"
+      : unknownBoundaryPresent
+        ? "unknown"
+        : incomplete
+          ? unknownCount > 0
+            ? "unknown_tool_boundary"
+            : "unclassified_effect"
+          : "all_boundaries_classified"
   return {
     exposed_tool_count: names.length,
     unknown_tool_count: unknownCount,
     unclassified_effect_count: unclassifiedCount,
-    provider_executed_capability_present: false,
-    external_boundary_present: false,
-    proof_result: incomplete ? "incomplete" : "complete",
-    proof_reason: incomplete ? (unknownCount > 0 ? "unknown_tool_boundary" : "unclassified_effect") : "all_boundaries_classified",
+    provider_executed_capability_present: providerExecutedCapabilityPresent,
+    external_boundary_present: externalBoundaryPresent,
+    proof_result:
+      incomplete || providerExecutedCapabilityPresent || externalBoundaryPresent || unknownBoundaryPresent
+        ? "incomplete"
+        : "complete",
+    proof_reason: proofReason,
   }
 }
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1382,11 +1382,11 @@ export const layer: Layer.Layer<
                 yield* status.set(ctx.sessionID, {
                   type: "retry",
                   attempt: ctx.attemptCount,
-                  message: reasoningOnlySafeRetry
-                    ? "Network connection dropped, retrying automatically"
-                    : (retrySignal.message ?? "Retrying interrupted stream"),
+                  message: reasoningOnlySafeRetry ? "" : (retrySignal.message ?? "Retrying interrupted stream"),
                   next,
-                  ...(reasoningOnlySafeRetry ? { presentation: "safe_recovery" as const } : {}),
+                  ...(reasoningOnlySafeRetry
+                    ? { presentation: "safe_recovery" as const, reason: "network_connection_dropped" as const }
+                    : {}),
                 })
                 yield* Effect.sleep(`${SAFE_RECOVERY_AUTO_RETRY_BACKOFF_MS} millis`).pipe(
                   Effect.onInterrupt(() => recordProcessInterrupt(attemptID)),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -194,6 +194,7 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
+  reasoningPartIDsByAttempt: Record<string, Set<PartID>>
   trace: LLMTrace.Recorder
   runTrace: RunObservability.Recorder
   attemptCount: number
@@ -255,6 +256,7 @@ export const layer: Layer.Layer<
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        reasoningPartIDsByAttempt: {},
         trace: LLMTrace.createRecorder({
           traceID: input.assistantMessage.id,
           sessionID: input.sessionID,
@@ -760,7 +762,10 @@ export const layer: Layer.Layer<
               time: { start: Date.now() },
               metadata: value.providerMetadata,
             }
-            yield* session.updatePart(ctx.reasoningMap[value.id])
+            const persistedReasoning = yield* session.updatePart(ctx.reasoningMap[value.id])
+            const attemptKey = String(attemptID)
+            ctx.reasoningPartIDsByAttempt[attemptKey] ??= new Set()
+            ctx.reasoningPartIDsByAttempt[attemptKey].add(persistedReasoning.id)
             return
 
           case "reasoning-delta":
@@ -1238,6 +1243,24 @@ export const layer: Layer.Layer<
           return { retryable: true, message: classification.raw }
         }
 
+        const removeReasoningForAttempt = Effect.fn("SessionProcessor.removeReasoningForAttempt")(function* (
+          attemptID: RunObservability.AttemptID,
+        ) {
+          const partIDs = ctx.reasoningPartIDsByAttempt[String(attemptID)]
+          if (!partIDs?.size) return
+          for (const partID of partIDs) {
+            yield* session.removePart({
+              sessionID: ctx.sessionID,
+              messageID: ctx.assistantMessage.id,
+              partID,
+            })
+          }
+          for (const [id, part] of Object.entries(ctx.reasoningMap)) {
+            if (partIDs.has(part.id)) delete ctx.reasoningMap[id]
+          }
+          delete ctx.reasoningPartIDsByAttempt[String(attemptID)]
+        })
+
         const runAttempt = Effect.fn("SessionProcessor.runAttempt")(function* () {
           ctx.currentText = undefined
           ctx.reasoningMap = {}
@@ -1313,6 +1336,7 @@ export const layer: Layer.Layer<
               const beforeRetry = yield* retryStillAllowed("before_backoff")
               if (beforeRetry.allowed) {
                 automaticStreamRetriesUsed += 1
+                yield* removeReasoningForAttempt(attemptID)
                 const next = Date.now() + SAFE_RECOVERY_AUTO_RETRY_BACKOFF_MS
                 yield* status.set(ctx.sessionID, {
                   type: "retry",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -823,7 +823,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: input.agent,
       })) {
         const schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
-        tools[item.id] = tool({
+        const aiTool = tool({
           description: item.description,
           inputSchema: jsonSchema(schema),
           execute(args, options) {
@@ -889,6 +889,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             )
           },
         })
+        tools[item.id] = item.externalResult ? Object.assign(aiTool, { externalResult: true }) : aiTool
       }
 
       for (const [key, item] of Object.entries(yield* mcp.tools())) {

--- a/packages/opencode/src/session/run-incident/derive.ts
+++ b/packages/opencode/src/session/run-incident/derive.ts
@@ -21,6 +21,7 @@ export type DeriveIncidentInput = {
   parentMessageID?: MessageID
   createdAt: number
   completedAt?: number
+  retryable?: boolean
   evidence: IncidentEvidenceEvent[]
   unsafeSideEffectKinds: ToolEffectKind[]
   sideEffectFactsComplete: boolean
@@ -47,7 +48,7 @@ export function deriveIncident(input: DeriveIncidentInput): RunIncident | undefi
   const facts = factsFromEvidence(input)
   const terminalFacts = terminal.attempt_id ? factsFromEvidence(input, terminal.attempt_id) : facts
   const terminalPhaseFacts = factsFromEvidence(input, terminal.attempt_id, terminal)
-  const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts })
+  const recovery = recoveryFor({ cause: terminal.cause, facts, terminalFacts, retryable: input.retryable })
   const summary = userSummary({ cause: terminal.cause, recovery })
   const missingProvenance = [...(input.missingProvenance ?? []), ...diagnosticGaps(input, terminal, facts)]
   return sanitizeIncident({
@@ -128,6 +129,9 @@ function factsFromEvidence(
   const materializedToolBoundary = summarizeMaterializedToolBoundaries(input.materializedToolBoundaries, attemptID)
   const has = (eventType: string) => scopedEvidence.some((event) => event.event_type === eventType)
   const count = (eventType: string) => scopedEvidence.filter((event) => event.event_type === eventType).length
+  const snapshots = scopedEvidence.flatMap((event) =>
+    event.side_effect_boundary_snapshot ? [event.side_effect_boundary_snapshot] : [],
+  )
   const sideEffectFactsComplete = attemptID
     ? scopedSideEffectFactsComplete(scopedEvidence, materializedToolBoundary)
     : input.sideEffectFactsComplete
@@ -149,6 +153,7 @@ function factsFromEvidence(
       ? materializedToolBoundary.effect.unsafe || !materializedToolBoundary.effect.complete
       : undefined,
     side_effect_facts_complete: sideEffectFactsComplete,
+    side_effect_boundary_snapshot: snapshots.at(-1),
     lifecycle_close_seen: has("lifecycle_close_seen"),
     user_cancel_seen: has("user_cancel_seen"),
     watchdog_fired: has("watchdog_fired"),

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -4,9 +4,33 @@ export function recoveryFor(input: {
   cause: TerminalCause
   facts: IncidentFacts
   terminalFacts?: IncidentFacts
+  retryable?: boolean
 }): RecoveryDecision {
   const base = { safety_scope: "visible_output_and_tool_side_effects" as const }
   const terminalFacts = input.terminalFacts ?? input.facts
+  const noToolActivity =
+    !terminalFacts.tool_input_started &&
+    !terminalFacts.tool_call_materialized &&
+    !terminalFacts.tool_execution_started
+  const retryableTransport =
+    input.retryable === true &&
+    (input.cause.category === "provider_transport_disconnect" || input.cause.category === "watchdog_timeout")
+  if (
+    retryableTransport &&
+    noToolActivity &&
+    terminalFacts.reasoning_output_started &&
+    !terminalFacts.text_output_started &&
+    !terminalFacts.unsafe_side_effect_started &&
+    boundaryAllowsReasoningRetry(terminalFacts)
+  ) {
+    return {
+      ...base,
+      recommendation: "auto_retry_once",
+      confidence: "high",
+      reason: "reasoning_only_without_final_text_or_tool_activity",
+      auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
+    }
+  }
   if (input.cause.category === "user_cancel") {
     return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
   }
@@ -19,6 +43,19 @@ export function recoveryFor(input: {
     }
   }
   if (!terminalFacts.side_effect_facts_complete) {
+    return {
+      ...base,
+      recommendation: "ask_user_before_retry",
+      confidence: "high",
+      reason: "side_effect_facts_incomplete",
+    }
+  }
+  if (
+    retryableTransport &&
+    noToolActivity &&
+    terminalFacts.reasoning_output_started &&
+    !terminalFacts.text_output_started
+  ) {
     return {
       ...base,
       recommendation: "ask_user_before_retry",
@@ -69,7 +106,7 @@ export function recoveryFor(input: {
       reason: "partial_tool_input_without_execution",
     }
   }
-  if (terminalFacts.visible_output_seen) {
+  if (terminalFacts.text_output_started || terminalFacts.visible_output_seen) {
     return {
       ...base,
       recommendation: "offer_continue",
@@ -83,7 +120,7 @@ export function recoveryFor(input: {
   if (input.facts.lifecycle_close_seen) {
     return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "local_lifecycle_close" }
   }
-  if (input.cause.category === "provider_transport_disconnect" || input.cause.category === "watchdog_timeout") {
+  if (retryableTransport) {
     return {
       ...base,
       recommendation: "auto_retry_once",
@@ -93,4 +130,19 @@ export function recoveryFor(input: {
     }
   }
   return { ...base, recommendation: "unknown", confidence: "low", reason: "unknown" }
+}
+
+function boundaryAllowsReasoningRetry(facts: IncidentFacts) {
+  const snapshot = facts.side_effect_boundary_snapshot
+  if (!snapshot) return false
+  if (snapshot.provider_executed_capability_present) return false
+  if (snapshot.external_boundary_present) return false
+  if (
+    snapshot.proof_reason === "provider_executed_capability" ||
+    snapshot.proof_reason === "external_boundary" ||
+    snapshot.proof_reason === "unknown"
+  ) {
+    return false
+  }
+  return true
 }

--- a/packages/opencode/src/session/run-incident/types.ts
+++ b/packages/opencode/src/session/run-incident/types.ts
@@ -131,6 +131,7 @@ export type IncidentFacts = {
   materialized_tool_effect_kind?: ToolEffectKind
   materialized_tool_requires_confirmation?: boolean
   side_effect_facts_complete: boolean
+  side_effect_boundary_snapshot?: SideEffectBoundarySnapshot
   lifecycle_close_seen: boolean
   user_cancel_seen: boolean
   watchdog_fired: boolean
@@ -176,6 +177,7 @@ export type RecoveryDecision = {
   confidence: Confidence
   reason:
     | "no_visible_output_or_tool_execution"
+    | "reasoning_only_without_final_text_or_tool_activity"
     | "visible_output_without_tool_execution"
     | "partial_tool_input_without_execution"
     | "tool_call_materialized_without_execution"

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -20,7 +20,15 @@ import { cloneRequest, type LifecycleRequest } from "../lifecycle-provenance"
 type AttemptMutable = AttemptSummary & { lastMonotonicMs: number }
 
 type Failure =
-  | { type: "transport"; at: number; monotonicMs: number; error: unknown; evidence: string[]; attemptID?: AttemptID }
+  | {
+      type: "transport"
+      at: number
+      monotonicMs: number
+      error: unknown
+      evidence: string[]
+      attemptID?: AttemptID
+      retryable?: boolean
+    }
   | { type: "setup"; at: number; monotonicMs: number; error: unknown }
   | {
       type: "scope_closed"
@@ -103,10 +111,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       const { cause: _cause, ...nonTerminalEvent } = event
       return { ...nonTerminalEvent, terminal_candidate: false }
     })
-  const deriveCurrentIncident = (
-    completedAt?: number,
-    options?: { includeRecoveredTerminal?: boolean },
-  ) => {
+  const deriveCurrentIncident = (completedAt?: number, options?: { includeRecoveredTerminal?: boolean }) => {
     const incidentLifecycle = lifecycleSummary(lifecycleFailure)
     return RunIncident.derive({
       runID: input.runID,
@@ -116,6 +121,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       parentMessageID: input.parentMessageID,
       createdAt: input.createdAt,
       completedAt,
+      retryable: failure?.type === "transport" ? failure.retryable : undefined,
       evidence: options?.includeRecoveredTerminal ? evidence : terminalEvidence(),
       unsafeSideEffectKinds: unsafeKinds,
       sideEffectFactsComplete,
@@ -136,6 +142,7 @@ export function createRecorder(input: RecorderInput): Recorder {
     monotonicMs: number
     error: unknown
     evidence?: string[]
+    retryable?: boolean
   }) => {
     const error = safeErrorFingerprint(next.error)
     const factsAtFailure = transportFactsAt(next.attemptID, next.monotonicMs)
@@ -146,6 +153,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       error: next.error,
       evidence: next.evidence ?? [],
       attemptID: next.attemptID,
+      retryable: next.retryable,
     }
     appendEvidence({
       monotonic_ms: next.monotonicMs,
@@ -173,6 +181,7 @@ export function createRecorder(input: RecorderInput): Recorder {
     monotonicMs: number
     error: unknown
     phase: "connect" | "silent_stream" | "unknown"
+    retryable?: boolean
   }) => {
     const error = safeErrorFingerprint(next.error)
     failure ??= {
@@ -182,6 +191,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       error: next.error,
       evidence: ["watchdog_fired", "iterator_error"],
       attemptID: next.attemptID,
+      retryable: next.retryable,
     }
     appendEvidence({
       monotonic_ms: next.monotonicMs,
@@ -205,6 +215,8 @@ export function createRecorder(input: RecorderInput): Recorder {
         started_at: next.at,
         provider_progress_seen: false,
         visible_output_seen: false,
+        text_output_started: false,
+        reasoning_output_started: false,
         tool_call_seen: false,
         tool_input_started: false,
         tool_input_completed: false,
@@ -245,6 +257,8 @@ export function createRecorder(input: RecorderInput): Recorder {
       visibleOutputSeen = true
       updateAttempt(next.attemptID, (attempt) => {
         attempt.visible_output_seen = true
+        if (next.kind === "reasoning") attempt.reasoning_output_started = true
+        else attempt.text_output_started = true
         attempt.lastMonotonicMs = Math.max(attempt.lastMonotonicMs, next.monotonicMs)
       })
       appendEvidence({
@@ -584,6 +598,9 @@ export function createRecorder(input: RecorderInput): Recorder {
       const retrySafety = retrySafetyFor({
         classification,
         visibleOutputSeen: terminalAttempt?.visible_output_seen ?? visibleOutputSeen,
+        textOutputStarted:
+          terminalAttempt?.text_output_started ?? incident?.facts.text_output_started ?? visibleOutputSeen,
+        reasoningOutputStarted: terminalAttempt?.reasoning_output_started ?? incident?.facts.reasoning_output_started ?? false,
         toolExecutionStarted: terminalAttempt?.tool_execution_started ?? toolExecutionStarted,
         unsafeSideEffectStarted: terminalAttempt?.unsafe_side_effect_started ?? unsafeSideEffectStarted,
       })
@@ -773,6 +790,8 @@ export function isProviderProgressEvent(event: { type: string }) {
 function retrySafetyFor(input: {
   classification: Classification
   visibleOutputSeen: boolean
+  textOutputStarted: boolean
+  reasoningOutputStarted: boolean
   toolExecutionStarted: boolean
   unsafeSideEffectStarted: boolean
 }): Summary["retry_safety"] {
@@ -780,7 +799,7 @@ function retrySafetyFor(input: {
   if (input.classification === "success") {
     return { ...base, recommendation: "unknown", confidence: "high", reason: "completed_without_failure" }
   }
-  if (input.visibleOutputSeen) {
+  if (input.textOutputStarted) {
     return { ...base, recommendation: "do_not_auto_retry", confidence: "high", reason: "visible_output_seen" }
   }
   if (input.unsafeSideEffectStarted) {
@@ -790,6 +809,14 @@ function retrySafetyFor(input: {
     return { ...base, recommendation: "ask_user", confidence: "medium", reason: "tool_execution_started" }
   }
   if (input.classification === "external_stream_disconnect") {
+    if (input.reasoningOutputStarted && input.visibleOutputSeen) {
+      return {
+        ...base,
+        recommendation: "candidate_safe_auto_retry",
+        confidence: "medium",
+        reason: "reasoning_only_without_final_text_or_tool_activity",
+      }
+    }
     return {
       ...base,
       recommendation: "candidate_safe_auto_retry",

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -599,7 +599,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         classification,
         visibleOutputSeen: terminalAttempt?.visible_output_seen ?? visibleOutputSeen,
         textOutputStarted:
-          terminalAttempt?.text_output_started ?? incident?.facts.text_output_started ?? visibleOutputSeen,
+          terminalAttempt?.text_output_started ?? incident?.facts.text_output_started ?? false,
         reasoningOutputStarted: terminalAttempt?.reasoning_output_started ?? incident?.facts.reasoning_output_started ?? false,
         toolExecutionStarted: terminalAttempt?.tool_execution_started ?? toolExecutionStarted,
         unsafeSideEffectStarted: terminalAttempt?.unsafe_side_effect_started ?? unsafeSideEffectStarted,

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -35,6 +35,7 @@ export type RetrySafety = {
   reason:
     | "completed_without_failure"
     | "no_visible_output_or_tool_execution"
+    | "reasoning_only_without_final_text_or_tool_activity"
     | "visible_output_seen"
     | "tool_execution_started"
     | "unsafe_side_effect_started"
@@ -88,6 +89,8 @@ export type AttemptSummary = {
   last_tool_completed_at?: number
   provider_progress_seen: boolean
   visible_output_seen: boolean
+  text_output_started: boolean
+  reasoning_output_started: boolean
   tool_call_seen: boolean
   tool_input_started: boolean
   tool_input_completed: boolean
@@ -219,6 +222,7 @@ export type Recorder = {
     error: unknown
     evidence?: string[]
     watchdog?: { phase: "connect" | "silent_stream" | "unknown" }
+    retryable?: boolean
   }): RunIncident.Recovery
   recordAutoRetryAttempted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordTransportFailure(input: {
@@ -227,6 +231,7 @@ export type Recorder = {
     monotonicMs: number
     error: unknown
     evidence?: string[]
+    retryable?: boolean
   }): void
   recordSetupFailure(input: { at: number; monotonicMs: number; error: unknown }): void
   recordScopeClosed(input: {

--- a/packages/opencode/src/session/status.test.ts
+++ b/packages/opencode/src/session/status.test.ts
@@ -37,6 +37,23 @@ describe("SessionStatus.Info schema", () => {
     }
   })
 
+  test("parses safe recovery retry with stable reason", () => {
+    const result = SessionStatus.Info.parse({
+      type: "retry",
+      attempt: 1,
+      message: "",
+      next: 1_000,
+      presentation: "safe_recovery",
+      reason: "network_connection_dropped",
+    })
+    expect(result.type).toBe("retry")
+    if (result.type === "retry") {
+      expect(result.message).toBe("")
+      expect(result.presentation).toBe("safe_recovery")
+      expect(result.reason).toBe("network_connection_dropped")
+    }
+  })
+
   test("parses rate_limit_blocked with required classification", () => {
     const result = SessionStatus.Info.parse({
       type: "rate_limit_blocked",

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -16,6 +16,7 @@ export const Info = z
       attempt: z.number(),
       message: z.string(),
       next: z.number(),
+      presentation: z.literal("safe_recovery").optional(),
       // optional: populated when the retry is caused by a classifiable rate-limit error
       classification: RetryClassification.optional(),
     }),

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -17,6 +17,7 @@ export const Info = z
       message: z.string(),
       next: z.number(),
       presentation: z.literal("safe_recovery").optional(),
+      reason: z.literal("network_connection_dropped").optional(),
       // optional: populated when the retry is caused by a classifiable rate-limit error
       classification: RetryClassification.optional(),
     }),

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -157,6 +157,26 @@ describe("session.message-v2.toModelMessage", () => {
     expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
   })
 
+  test("filters out assistant recovery notice parts", async () => {
+    const messageID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(messageID, "m-user"),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "notice",
+            kind: "safe_retry_failed",
+            time: { created: 0 },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
+  })
+
   test("filters out user messages with only empty text parts", async () => {
     const messageID = "m-user"
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1488,6 +1488,87 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
   ),
 )
 
+it.live("reasoning-only retry writes a notice after the one safe retry is exhausted", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        for (const suffix of ["first", "second"]) {
+          yield* llm.push(
+            raw({
+              head: [
+                {
+                  id: `chatcmpl-reasoning-retry-${suffix}`,
+                  object: "chat.completion.chunk",
+                  choices: [{ delta: { role: "assistant" } }],
+                },
+                {
+                  id: `chatcmpl-reasoning-retry-${suffix}`,
+                  object: "chat.completion.chunk",
+                  choices: [{ delta: { reasoning_content: `${suffix} failed draft` } }],
+                },
+              ],
+              tail: [
+                {
+                  error: {
+                    message: "rate limit",
+                    type: "server_error",
+                    code: "rate_limit",
+                  },
+                },
+              ],
+            }),
+          )
+        }
+        yield* llm.text("third attempt should not run")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reasoning retry fails twice")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reasoning retry fails twice" }],
+          tools: {
+            mcp_write: tool({
+              description: "unknown local boundary",
+              inputSchema: z.object({}),
+            }),
+          },
+        })
+
+        const parts = MessageV2.parts(msg.id)
+
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(2)
+        expect(parts.some((part) => part.type === "reasoning")).toBe(false)
+        expect(parts.some((part) => part.type === "text" && part.text === "third attempt should not run")).toBe(false)
+        expect(parts.some((part) => part.type === "notice" && part.kind === "safe_retry_failed")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+        expect(handle.message.diagnostics?.run_observability?.recovered_incidents).toHaveLength(1)
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("retryable stream error after visible output does not replay the assistant message", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1405,6 +1405,8 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
     ({ dir, llm }) =>
       Effect.gen(function* () {
         const { processors, session, provider } = yield* boot()
+        const bus = yield* Bus.Service
+        const retrySeen = defer<SessionStatus.Info>()
 
         yield* llm.push(
           raw({
@@ -1437,6 +1439,10 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
         const parent = yield* user(chat.id, "reasoning retry")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
+          if (evt.properties.sessionID !== chat.id) return
+          if (evt.properties.status.type === "retry") retrySeen.resolve(evt.properties.status)
+        })
         const handle = yield* processors.create({
           assistantMessage: msg,
           sessionID: chat.id,
@@ -1466,12 +1472,20 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
         })
 
         const parts = MessageV2.parts(msg.id)
+        const retryStatus = yield* Effect.promise(() => retrySeen.promise)
         const stored = (yield* session.messages({ sessionID: chat.id })).find(
           (message) => message.info.role === "assistant" && message.info.id === msg.id,
         )
+        off()
 
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(2)
+        expect(retryStatus).toMatchObject({
+          type: "retry",
+          message: "",
+          presentation: "safe_recovery",
+          reason: "network_connection_dropped",
+        })
         expect(parts.some((part) => part.type === "reasoning")).toBe(false)
         expect(parts.some((part) => part.type === "reasoning" && part.text === "failed draft")).toBe(false)
         expect(parts.some((part) => part.type === "text" && part.text === "after retry")).toBe(true)

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1488,6 +1488,186 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
   ),
 )
 
+it.live("reasoning-only failure with an external-result tool does not auto retry", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-external-boundary",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-external-boundary",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { reasoning_content: "draft" } }],
+              },
+            ],
+            tail: [
+              {
+                error: {
+                  message: "rate limit",
+                  type: "server_error",
+                  code: "rate_limit",
+                },
+              },
+            ],
+          }),
+        )
+        yield* llm.text("after retry should not run")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "external boundary retry")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const externalTool = Object.assign(
+          tool({
+            description: "external boundary",
+            inputSchema: z.object({}),
+          }),
+          { externalResult: true },
+        )
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "external boundary retry" }],
+          tools: {
+            question: externalTool,
+          },
+        })
+
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(1)
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          expect(stored.info.diagnostics?.run_observability?.side_effect_boundary_snapshot).toMatchObject({
+            external_boundary_present: true,
+            proof_reason: "external_boundary",
+          })
+          expect(stored.info.diagnostics?.run_observability?.incident?.recovery).toMatchObject({
+            recommendation: "ask_user_before_retry",
+            reason: "side_effect_facts_incomplete",
+          })
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("reasoning-only failure with a provider-executed tool does not auto retry", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-provider-boundary",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-provider-boundary",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { reasoning_content: "draft" } }],
+              },
+            ],
+            tail: [
+              {
+                error: {
+                  message: "rate limit",
+                  type: "server_error",
+                  code: "rate_limit",
+                },
+              },
+            ],
+          }),
+        )
+        yield* llm.text("after retry should not run")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "provider boundary retry")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "provider boundary retry" }],
+          tools: {
+            web_search: {
+              type: "provider",
+              id: "openai.web_search",
+              args: {},
+              inputSchema: z.object({}),
+            } as any,
+          },
+        })
+
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(1)
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          expect(stored.info.diagnostics?.run_observability?.side_effect_boundary_snapshot).toMatchObject({
+            provider_executed_capability_present: true,
+            proof_reason: "provider_executed_capability",
+          })
+          expect(stored.info.diagnostics?.run_observability?.incident?.recovery).toMatchObject({
+            recommendation: "ask_user_before_retry",
+            reason: "side_effect_facts_incomplete",
+          })
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("reasoning-only retry writes a notice after the one safe retry is exhausted", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1400,6 +1400,94 @@ it.live("disabled unknown tools do not block safe connect-timeout auto retry", (
   ),
 )
 
+it.live("reasoning-only retry removes failed reasoning before replaying the assistant message", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-reasoning-retry",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-reasoning-retry",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { reasoning_content: "failed draft" } }],
+              },
+            ],
+            tail: [
+              {
+                error: {
+                  message: "rate limit",
+                  type: "server_error",
+                  code: "rate_limit",
+                },
+              },
+            ],
+          }),
+        )
+        yield* llm.text("after retry")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reasoning retry")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reasoning retry" }],
+          tools: {
+            mcp_write: tool({
+              description: "unknown local boundary",
+              inputSchema: z.object({}),
+            }),
+          },
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const stored = (yield* session.messages({ sessionID: chat.id })).find(
+          (message) => message.info.role === "assistant" && message.info.id === msg.id,
+        )
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(parts.some((part) => part.type === "reasoning")).toBe(false)
+        expect(parts.some((part) => part.type === "reasoning" && part.text === "failed draft")).toBe(false)
+        expect(parts.some((part) => part.type === "text" && part.text === "after retry")).toBe(true)
+        expect(stored?.info.role).toBe("assistant")
+        if (stored?.info.role === "assistant") {
+          expect(stored.info.error).toBeUndefined()
+          expect(stored.info.diagnostics?.run_observability?.recovered_incidents?.[0]?.recovery).toMatchObject({
+            recommendation: "auto_retry_once",
+            reason: "reasoning_only_without_final_text_or_tool_activity",
+          })
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("retryable stream error after visible output does not replay the assistant message", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1524,6 +1524,33 @@ describe("RunObservability", () => {
     expect(summary.incident?.phase.stream_phase).toBe("reasoning_generation")
   })
 
+  test("retry safety does not treat reasoning output as final text when terminal attempt is unknown", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_reasoning_unknown_terminal_attempt"),
+      traceID: MessageID.make("msg_reasoning_unknown_terminal_attempt"),
+      sessionID: SessionID.make("ses_reasoning_unknown_terminal_attempt"),
+      messageID: MessageID.make("msg_reasoning_unknown_terminal_attempt"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130, kind: "reasoning" })
+    recorder.recordTransportFailure({
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+    })
+
+    const summary = recorder.finalize({ completedAt: 15, monotonicMs: 150 })
+    expect(summary.retry_safety).toMatchObject({
+      recommendation: "candidate_safe_auto_retry",
+      reason: "reasoning_only_without_final_text_or_tool_activity",
+    })
+  })
+
   test("reasoning-only transport failure with only local unknown tool boundaries is a safe retry candidate", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_reasoning_only_safe_retry_boundary"),

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -65,6 +65,7 @@ describe("RunObservability", () => {
       error: new Error("LLM stream connection timed out after 120000ms without provider progress"),
       evidence: ["watchdog_fired", "iterator_error"],
       watchdog: { phase: "connect" },
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 131, monotonicMs: 231 })
@@ -104,6 +105,7 @@ describe("RunObservability", () => {
       error: new Error("LLM stream connection timed out after 120000ms without provider progress"),
       evidence: ["watchdog_fired", "iterator_error"],
       watchdog: { phase: "connect" },
+      retryable: true,
     })
     recorder.recordAutoRetryAttempted({ attemptID: first.attemptID, at: 13, monotonicMs: 130 })
     const second = recorder.beginAttempt({ attemptIndex: 2, at: 14, monotonicMs: 140 })
@@ -862,6 +864,7 @@ describe("RunObservability", () => {
       error: new Error("LLM stream connection timed out after 120000ms without provider progress"),
       evidence: ["watchdog_fired", "iterator_error"],
       watchdog: { phase: "connect" },
+      retryable: true,
     })
 
     expect(decision).toMatchObject({
@@ -891,6 +894,7 @@ describe("RunObservability", () => {
       at: 22,
       monotonicMs: 220,
       error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 23, monotonicMs: 230 })
@@ -1520,6 +1524,87 @@ describe("RunObservability", () => {
     expect(summary.incident?.phase.stream_phase).toBe("reasoning_generation")
   })
 
+  test("reasoning-only transport failure with only local unknown tool boundaries is a safe retry candidate", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_reasoning_only_safe_retry_boundary"),
+      traceID: MessageID.make("msg_reasoning_only_safe_retry_boundary"),
+      sessionID: SessionID.make("ses_reasoning_only_safe_retry_boundary"),
+      messageID: MessageID.make("msg_reasoning_only_safe_retry_boundary"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      snapshot: {
+        exposed_tool_count: 1,
+        unknown_tool_count: 1,
+        unclassified_effect_count: 1,
+        provider_executed_capability_present: false,
+        external_boundary_present: false,
+        proof_result: "incomplete",
+        proof_reason: "unknown_tool_boundary",
+      },
+    })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 14, monotonicMs: 140, kind: "reasoning" })
+    const decision = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      evidence: ["iterator_error"],
+      retryable: true,
+    })
+
+    const summary = recorder.finalize({ completedAt: 16, monotonicMs: 160 })
+    expect(decision).toMatchObject({
+      recommendation: "auto_retry_once",
+      reason: "reasoning_only_without_final_text_or_tool_activity",
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "auto_retry_once",
+      reason: "reasoning_only_without_final_text_or_tool_activity",
+    })
+    expect(summary.retry_safety).toMatchObject({
+      recommendation: "candidate_safe_auto_retry",
+      reason: "reasoning_only_without_final_text_or_tool_activity",
+    })
+  })
+
+  test("reasoning-only transport failure without terminal boundary evidence stays conservative", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_reasoning_only_missing_boundary"),
+      traceID: MessageID.make("msg_reasoning_only_missing_boundary"),
+      sessionID: SessionID.make("ses_reasoning_only_missing_boundary"),
+      messageID: MessageID.make("msg_reasoning_only_missing_boundary"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130, kind: "reasoning" })
+    const decision = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: attempt.attemptID,
+      at: 14,
+      monotonicMs: 140,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      evidence: ["iterator_error"],
+      retryable: true,
+    })
+
+    expect(decision).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+  })
+
   test("materialized tool recovery keeps unsafe boundary even when a later safe tool materializes", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_unsafe_then_safe_materialized_tool"),
@@ -1678,6 +1763,7 @@ describe("RunObservability", () => {
       at: 21,
       monotonicMs: 210,
       error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 22, monotonicMs: 220 })
@@ -1716,6 +1802,7 @@ describe("RunObservability", () => {
       at: 21,
       monotonicMs: 210,
       error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 22, monotonicMs: 220 })
@@ -1751,6 +1838,7 @@ describe("RunObservability", () => {
       at: 22,
       monotonicMs: 220,
       error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 23, monotonicMs: 230 })

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1576,6 +1576,74 @@ describe("RunObservability", () => {
     })
   })
 
+  test.each([
+    [
+      "provider-executed capability",
+      {
+        provider_executed_capability_present: true,
+        external_boundary_present: false,
+        proof_reason: "provider_executed_capability" as const,
+      },
+    ],
+    [
+      "external boundary",
+      {
+        provider_executed_capability_present: false,
+        external_boundary_present: true,
+        proof_reason: "external_boundary" as const,
+      },
+    ],
+    [
+      "unknown boundary proof",
+      {
+        provider_executed_capability_present: false,
+        external_boundary_present: false,
+        proof_reason: "unknown" as const,
+      },
+    ],
+  ])("reasoning-only transport failure with %s stays conservative", (_label, boundary) => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make(`run_reasoning_only_${boundary.proof_reason}`),
+      traceID: MessageID.make(`msg_reasoning_only_${boundary.proof_reason}`),
+      sessionID: SessionID.make(`ses_reasoning_only_${boundary.proof_reason}`),
+      messageID: MessageID.make(`msg_reasoning_only_${boundary.proof_reason}`),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      snapshot: {
+        exposed_tool_count: 1,
+        unknown_tool_count: 0,
+        unclassified_effect_count: 0,
+        provider_executed_capability_present: boundary.provider_executed_capability_present,
+        external_boundary_present: boundary.external_boundary_present,
+        proof_result: "incomplete",
+        proof_reason: boundary.proof_reason,
+      },
+    })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 13, monotonicMs: 130 })
+    recorder.recordVisibleOutput({ attemptID: attempt.attemptID, at: 14, monotonicMs: 140, kind: "reasoning" })
+    const decision = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: attempt.attemptID,
+      at: 15,
+      monotonicMs: 150,
+      error: { name: "TypeError", message: "terminated", cause: { code: "UND_ERR_SOCKET" } },
+      evidence: ["iterator_error"],
+      retryable: true,
+    })
+
+    expect(decision).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+  })
+
   test("reasoning-only transport failure without terminal boundary evidence stays conservative", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_reasoning_only_missing_boundary"),

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -189,6 +189,17 @@ export type ReasoningPart = {
   }
 }
 
+export type NoticePart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "notice"
+  kind: "safe_retry_failed"
+  time: {
+    created: number
+  }
+}
+
 export type FilePartSourceText = {
   value: string
   start: number
@@ -393,6 +404,7 @@ export type Part =
       agent: string
     }
   | ReasoningPart
+  | NoticePart
   | FilePart
   | ToolPart
   | StepStartPart
@@ -459,6 +471,7 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
+      presentation?: "safe_recovery"
     }
   | {
       type: "busy"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -72,6 +72,7 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
+      presentation?: "safe_recovery"
       classification?: RetryClassification
     }
   | {
@@ -748,6 +749,17 @@ export type ReasoningPart = {
   }
 }
 
+export type NoticePart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "notice"
+  kind: "safe_retry_failed"
+  time: {
+    created: number
+  }
+}
+
 export type FilePartSourceText = {
   value: string
   start: number
@@ -961,6 +973,7 @@ export type Part =
   | TextPart
   | SubtaskPart
   | ReasoningPart
+  | NoticePart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -73,6 +73,7 @@ export type SessionStatus =
       message: string
       next: number
       presentation?: "safe_recovery"
+      reason?: "network_connection_dropped"
       classification?: RetryClassification
     }
   | {

--- a/packages/ui/src/components/message-part-registry.test.ts
+++ b/packages/ui/src/components/message-part-registry.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url"
 const COMPONENT_DIR = dirname(fileURLToPath(import.meta.url))
 const MESSAGE_PART_DIR = join(COMPONENT_DIR, "message-part")
 
-const expectedParts = ["compaction", "reasoning", "text", "tool"]
+const expectedParts = ["compaction", "notice", "reasoning", "text", "tool"]
 const expectedTools = [
   "read",
   "list",
@@ -87,7 +87,7 @@ test("part and tool side-effect barrels cover every registered renderer", () => 
     expect(source).toContain(`name: "${tool}"`)
   }
 
-  for (const path of ["./compaction-and-divider", "./reasoning", "./text", "./tool"]) {
+  for (const path of ["./compaction-and-divider", "./notice", "./reasoning", "./text", "./tool"]) {
     expect(partsIndex).toContain(`import "${path}"`)
   }
 

--- a/packages/ui/src/components/message-part/parts/index.ts
+++ b/packages/ui/src/components/message-part/parts/index.ts
@@ -1,4 +1,5 @@
 import "./compaction-and-divider"
+import "./notice"
 import "./reasoning"
 import "./text"
 import "./tool"

--- a/packages/ui/src/components/message-part/parts/notice.tsx
+++ b/packages/ui/src/components/message-part/parts/notice.tsx
@@ -1,0 +1,19 @@
+import { Match, Switch } from "solid-js"
+import type { NoticePart } from "@opencode-ai/sdk/v2"
+import { useI18n } from "../../../context/i18n"
+import { registerPartComponent } from "../registry"
+
+registerPartComponent("notice", function NoticePartDisplay(props) {
+  const i18n = useI18n()
+  const part = () => props.part as NoticePart
+
+  return (
+    <Switch>
+      <Match when={part().kind === "safe_retry_failed"}>
+        <div data-component="notice-part" data-kind="safe_retry_failed" class="text-text-muted text-sm">
+          {i18n.t("ui.sessionTurn.notice.safeRetryFailed")}
+        </div>
+      </Match>
+    </Switch>
+  )
+})

--- a/packages/ui/src/components/message-part/parts/notice.tsx
+++ b/packages/ui/src/components/message-part/parts/notice.tsx
@@ -10,7 +10,7 @@ registerPartComponent("notice", function NoticePartDisplay(props) {
   return (
     <Switch>
       <Match when={part().kind === "safe_retry_failed"}>
-        <div data-component="notice-part" data-kind="safe_retry_failed" class="text-text-muted text-sm">
+        <div data-component="notice-part" data-kind="safe_retry_failed" class="text-caption text-fg-weak">
           {i18n.t("ui.sessionTurn.notice.safeRetryFailed")}
         </div>
       </Match>

--- a/packages/ui/src/components/session-retry.tsx
+++ b/packages/ui/src/components/session-retry.tsx
@@ -38,6 +38,11 @@ export function SessionRetry(props: {
     if (props.status.type !== "retry") return
     return props.status
   })
+  const safeRecoveryRetry = createMemo(() => {
+    const current = retry()
+    if (current?.presentation !== "safe_recovery") return
+    return current
+  })
   const [seconds, setSeconds] = createSignal(0)
   createEffect(
     on(retry, (current) => {
@@ -82,23 +87,35 @@ export function SessionRetry(props: {
       when={freeQuotaClassification()}
       fallback={
         <Show when={retry() && (props.show ?? true)}>
-          <div data-slot="session-turn-retry">
-            <Card variant="error" class="error-card">
-              <div class="flex items-start gap-2">
-                <Spinner class="size-4 mt-0.5" />
-                <div class="min-w-0">
-                  <Show when={truncated()} fallback={<div data-slot="session-turn-retry-message">{message()}</div>}>
-                    <Tooltip value={retry()?.message ?? ""} placement="top">
-                      <div data-slot="session-turn-retry-message" class="cursor-help truncate">
-                        {message()}
-                      </div>
-                    </Tooltip>
-                  </Show>
-                  <Show when={info()}>{(line) => <div data-slot="session-turn-retry-info">{line()}</div>}</Show>
-                </div>
+          <Show
+            when={safeRecoveryRetry()}
+            fallback={
+              <div data-slot="session-turn-retry">
+                <Card variant="error" class="error-card">
+                  <div class="flex items-start gap-2">
+                    <Spinner class="size-4 mt-0.5" />
+                    <div class="min-w-0">
+                      <Show when={truncated()} fallback={<div data-slot="session-turn-retry-message">{message()}</div>}>
+                        <Tooltip value={retry()?.message ?? ""} placement="top">
+                          <div data-slot="session-turn-retry-message" class="cursor-help truncate">
+                            {message()}
+                          </div>
+                        </Tooltip>
+                      </Show>
+                      <Show when={info()}>{(line) => <div data-slot="session-turn-retry-info">{line()}</div>}</Show>
+                    </div>
+                  </div>
+                </Card>
               </div>
-            </Card>
-          </div>
+            }
+          >
+            {(current) => (
+              <div data-slot="session-turn-safe-retry" class="text-text-muted flex items-center gap-2 text-sm">
+                <Spinner class="size-3.5" />
+                <div data-slot="session-turn-safe-retry-message">{current().message}</div>
+              </div>
+            )}
+          </Show>
         </Show>
       }
     >

--- a/packages/ui/src/components/session-retry.tsx
+++ b/packages/ui/src/components/session-retry.tsx
@@ -112,7 +112,9 @@ export function SessionRetry(props: {
             {(current) => (
               <div data-slot="session-turn-safe-retry" class="flex items-center gap-2 text-caption text-fg-weak">
                 <Spinner class="size-3.5" />
-                <div data-slot="session-turn-safe-retry-message">{current().message}</div>
+                <div data-slot="session-turn-safe-retry-message">
+                  {i18n.t("ui.sessionTurn.retry.safeRecovery")}
+                </div>
               </div>
             )}
           </Show>

--- a/packages/ui/src/components/session-retry.tsx
+++ b/packages/ui/src/components/session-retry.tsx
@@ -110,7 +110,7 @@ export function SessionRetry(props: {
             }
           >
             {(current) => (
-              <div data-slot="session-turn-safe-retry" class="text-text-muted flex items-center gap-2 text-sm">
+              <div data-slot="session-turn-safe-retry" class="flex items-center gap-2 text-caption text-fg-weak">
                 <Spinner class="size-3.5" />
                 <div data-slot="session-turn-safe-retry-message">{current().message}</div>
               </div>

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -8,6 +8,7 @@ test("safe recovery retry uses a lightweight status row instead of the error car
   expect(retry).toContain('presentation !== "safe_recovery"')
   expect(retry).toContain('data-slot="session-turn-safe-retry"')
   expect(retry).toContain('data-slot="session-turn-safe-retry-message"')
+  expect(retry).toContain('i18n.t("ui.sessionTurn.retry.safeRecovery")')
   expect(retry).toContain('fallback={')
   expect(retry).toContain('<Card variant="error" class="error-card">')
 })

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const retry = readFileSync(new URL("./session-retry.tsx", import.meta.url), "utf8")
+const notice = readFileSync(new URL("./message-part/parts/notice.tsx", import.meta.url), "utf8")
+
+test("safe recovery retry uses a lightweight status row instead of the error card", () => {
+  expect(retry).toContain('presentation !== "safe_recovery"')
+  expect(retry).toContain('data-slot="session-turn-safe-retry"')
+  expect(retry).toContain('data-slot="session-turn-safe-retry-message"')
+  expect(retry).toContain('fallback={')
+  expect(retry).toContain('<Card variant="error" class="error-card">')
+})
+
+test("safe retry failure renders as a dedicated notice part", () => {
+  expect(notice).toContain('registerPartComponent("notice"')
+  expect(notice).toContain('part().kind === "safe_retry_failed"')
+  expect(notice).toContain('data-kind="safe_retry_failed"')
+  expect(notice).toContain('i18n.t("ui.sessionTurn.notice.safeRetryFailed")')
+})

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini مزدحم حاليا",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "تم تجاوز حد الاستخدام المجاني",
   "ui.sessionTurn.error.addCredits": "إضافة رصيد",

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini مزدحم حاليا",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "تم تجاوز حد الاستخدام المجاني",
   "ui.sessionTurn.error.addCredits": "إضافة رصيد",
 

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentativa #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentativa #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está muito sobrecarregado agora",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Adicionar créditos",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentativa #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentativa #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está muito sobrecarregado agora",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Adicionar créditos",
 

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -47,6 +47,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini je trenutno preopterećen",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Besplatna upotreba premašena",
   "ui.sessionTurn.error.addCredits": "Dodaj kredite",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -47,6 +47,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini je trenutno preopterećen",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Besplatna upotreba premašena",
   "ui.sessionTurn.error.addCredits": "Dodaj kredite",
 

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "forsøg #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøg #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er meget overbelastet lige nu",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis forbrug overskredet",
   "ui.sessionTurn.error.addCredits": "Tilføj kreditter",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "forsøg #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøg #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er meget overbelastet lige nu",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis forbrug overskredet",
   "ui.sessionTurn.error.addCredits": "Tilføj kreditter",
 

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -48,6 +48,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "Versuch #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - Versuch #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini ist gerade sehr überlastet",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Kostenloses Nutzungslimit überschritten",
   "ui.sessionTurn.error.addCredits": "Guthaben aufladen",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -48,6 +48,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "Versuch #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - Versuch #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini ist gerade sehr überlastet",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Kostenloses Nutzungslimit überschritten",
   "ui.sessionTurn.error.addCredits": "Guthaben aufladen",
 

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -74,6 +74,7 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.retry.attempt": "attempt #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - attempt #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini is way too hot right now",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Free usage exceeded",
   "ui.sessionTurn.error.addCredits": "Add credits",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -74,6 +74,7 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.retry.attempt": "attempt #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - attempt #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini is way too hot right now",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Free usage exceeded",
   "ui.sessionTurn.error.addCredits": "Add credits",
 

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "intento #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - intento #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está demasiado saturado",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Límite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Añadir créditos",
 

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "intento #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - intento #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está demasiado saturado",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Límite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Añadir créditos",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentative n°{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentative n°{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini est en surchauffe",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite d'utilisation gratuite dépassée",
   "ui.sessionTurn.error.addCredits": "Ajouter des crédits",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentative n°{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentative n°{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini est en surchauffe",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite d'utilisation gratuite dépassée",
   "ui.sessionTurn.error.addCredits": "Ajouter des crédits",
 

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}回目",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}回目",
   "ui.sessionTurn.retry.geminiHot": "gemini が混雑しています",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "無料使用制限に達しました",
   "ui.sessionTurn.error.addCredits": "クレジットを追加",
 

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}回目",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}回目",
   "ui.sessionTurn.retry.geminiHot": "gemini が混雑しています",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "無料使用制限に達しました",
   "ui.sessionTurn.error.addCredits": "クレジットを追加",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}번째",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}번째",
   "ui.sessionTurn.retry.geminiHot": "gemini가 현재 과부하 상태입니다",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "무료 사용량 초과",
   "ui.sessionTurn.error.addCredits": "크레딧 추가",
 

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}번째",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}번째",
   "ui.sessionTurn.retry.geminiHot": "gemini가 현재 과부하 상태입니다",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "무료 사용량 초과",
   "ui.sessionTurn.error.addCredits": "크레딧 추가",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -46,6 +46,7 @@ export const dict: Record<Keys, string> = {
   "ui.sessionTurn.retry.attempt": "forsøk #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøk #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er veldig overbelastet nå",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis bruk overskredet",
   "ui.sessionTurn.error.addCredits": "Legg til kreditt",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -46,6 +46,7 @@ export const dict: Record<Keys, string> = {
   "ui.sessionTurn.retry.attempt": "forsøk #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøk #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er veldig overbelastet nå",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis bruk overskredet",
   "ui.sessionTurn.error.addCredits": "Legg til kreditt",
 

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "próba #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - próba #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini jest teraz mocno przeciążony",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Przekroczono limit darmowego użytkowania",
   "ui.sessionTurn.error.addCredits": "Dodaj kredyty",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "próba #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - próba #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini jest teraz mocno przeciążony",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Przekroczono limit darmowego użytkowania",
   "ui.sessionTurn.error.addCredits": "Dodaj kredyty",
 

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "попытка №{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - попытка №{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini сейчас перегружен",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Лимит бесплатного использования превышен",
   "ui.sessionTurn.error.addCredits": "Добавить кредиты",
 

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "попытка №{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - попытка №{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini сейчас перегружен",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Лимит бесплатного использования превышен",
   "ui.sessionTurn.error.addCredits": "Добавить кредиты",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -44,6 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini กำลังใช้งานหนาแน่นมาก",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "เกินขีดจำกัดการใช้งานฟรี",
   "ui.sessionTurn.error.addCredits": "เพิ่มเครดิต",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -44,6 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini กำลังใช้งานหนาแน่นมาก",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "เกินขีดจำกัดการใช้งานฟรี",
   "ui.sessionTurn.error.addCredits": "เพิ่มเครดิต",
 

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -49,6 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "deneme #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - deneme #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini şu anda aşırı yoğun",
+  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Ücretsiz kullanım aşıldı",
   "ui.sessionTurn.error.addCredits": "Kredi ekle",
 

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -49,6 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "deneme #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - deneme #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini şu anda aşırı yoğun",
+  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Ücretsiz kullanım aşıldı",
   "ui.sessionTurn.error.addCredits": "Kredi ekle",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -77,6 +77,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 当前过载",
+  "ui.sessionTurn.retry.safeRecovery": "网络连接断开，正在自动重试",
   "ui.sessionTurn.notice.safeRetryFailed": "网络连接断开，自动重试未完成",
   "ui.sessionTurn.error.freeUsageExceeded": "免费使用额度已用完",
   "ui.sessionTurn.error.addCredits": "添加积分",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -77,6 +77,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 当前过载",
+  "ui.sessionTurn.notice.safeRetryFailed": "网络连接断开，自动重试未完成",
   "ui.sessionTurn.error.freeUsageExceeded": "免费使用额度已用完",
   "ui.sessionTurn.error.addCredits": "添加积分",
 

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -49,6 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 目前過載",
+  "ui.sessionTurn.notice.safeRetryFailed": "網路連線中斷，自動重試未完成",
   "ui.sessionTurn.error.freeUsageExceeded": "免費使用額度已用完",
   "ui.sessionTurn.error.addCredits": "新增點數",
 

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -49,6 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 目前過載",
+  "ui.sessionTurn.retry.safeRecovery": "網路連線中斷，正在自動重試",
   "ui.sessionTurn.notice.safeRetryFailed": "網路連線中斷，自動重試未完成",
   "ui.sessionTurn.error.freeUsageExceeded": "免費使用額度已用完",
   "ui.sessionTurn.error.addCredits": "新增點數",


### PR DESCRIPTION
## Summary

Allow PawWork to automatically retry one safe reasoning-only provider/watchdog disconnect, clear failed reasoning drafts before replaying, and show lightweight recovery status/notice UI when the retry is in progress or exhausted.

## Why

Closes #893. The captured failures were network/provider stream interruptions during reasoning generation, before final assistant text or any tool activity. PawWork previously stopped with a conservative recovery error because side-effect facts were incomplete, even though the terminal stage was safe to replay once when boundary evidence proves no provider/external/unobservable side effect exists.

## Related Issue

Closes #893

## Human Review Status

Pending

## Review Focus

Please focus on the recovery policy boundary: the auto retry path should only activate when retryability, terminal stage, and side-effect boundary evidence all prove the failed attempt is reasoning-only and side-effect safe. Also check that failed reasoning cleanup is scoped to the failed attempt and that the persistent notice cannot enter model context.

## Risk Notes

Generated SDK types were updated for the new notice part and retry presentation field. The CI follow-up also restores the workflow `task` labeler route required by the existing PR triage contract. Platform/packaging surfaces were not touched, so the platform checklist item is left unticked.

## How To Verify

```text
Run-observability + message conversion: 94 passed, 0 failed (`cd packages/opencode && bun test test/session/run-observability.test.ts test/session/message-v2.test.ts --timeout 20000`).
Processor integration: 27 passed, 0 failed (`cd packages/opencode && bun test test/session/processor-effect.test.ts --timeout 30000`).
Focused opencode CI regression set: 130 passed, 0 failed (`cd packages/opencode && bun test test/github/pr-triage-workflow.test.ts test/session/run-observability.test.ts test/session/message-v2.test.ts test/session/processor-effect.test.ts --timeout 30000`).
UI package CI: 687 passed, 0 failed (`cd packages/ui && bun run test:ci`).
UI contract tests: 7 passed, 0 failed (`cd packages/ui && bun test src/components/message-part-registry.test.ts src/components/session-safe-retry-contract.test.ts`).
Typecheck: passed for packages/opencode, packages/ui, packages/app, and packages/sdk/js (`bun run typecheck` in each package).
Visual check: passed `bun run snap safe-retry`; reviewed generated grid at `docs/design/preview/screenshots/safe-retry.png`.
Diff check: `git diff --check` passed.
```

## Screenshots or Recordings

Visible UI was checked with the focused `safe-retry` snap target. The generated grid shows the lightweight in-progress retry row and the final persistent notice without rendering the red error card.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; \"not required\" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.