### PR TITLE
fix: defer lifecycle closes during active runs

### DIFF
--- a/packages/app/src/components/dialog-connect-provider-source.test.ts
+++ b/packages/app/src/components/dialog-connect-provider-source.test.ts
@@ -34,6 +34,7 @@ describe("dialog-connect-provider source boundary", () => {
     expect(dialogSource).toContain("globalSDK.client.provider.oauth")
     expect(dialogSource).toContain(".authorize(")
     expect(dialogSource).toContain("actionClient.global.dispose")
+    expect(dialogSource).toContain("provider.connect.toast.connected.deferredDescription")
   })
 
   test("tags provider connect lifecycle dispose calls with client action headers", () => {

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -203,13 +203,18 @@ export function DialogConnectProvider(props: { provider: string }) {
       headers: clientActionHeaders({ kind: "settings.provider.connect" }),
       throwOnError: true,
     })
-    await actionClient.global.dispose()
+    const dispose = await actionClient.global.dispose()
     dialog.close()
     showToast({
       variant: "success",
       icon: "circle-check",
       title: language.t("provider.connect.toast.connected.title", { provider: provider().name }),
-      description: language.t("provider.connect.toast.connected.description", { provider: provider().name }),
+      description: language.t(
+        dispose.data?.status === "deferred"
+          ? "provider.connect.toast.connected.deferredDescription"
+          : "provider.connect.toast.connected.description",
+        { provider: provider().name },
+      ),
     })
   }
 

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -118,12 +118,17 @@ export const SettingsProviders: Component = () => {
     await actionClient.auth
       .remove({ providerID })
       .then(async () => {
-        await actionClient.global.dispose()
+        const dispose = await actionClient.global.dispose()
         showToast({
           variant: "success",
           icon: "circle-check",
           title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
-          description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
+          description: language.t(
+            dispose.data?.status === "deferred"
+              ? "provider.disconnect.toast.disconnected.deferredDescription"
+              : "provider.disconnect.toast.disconnected.description",
+            { provider: name },
+          ),
         })
       })
       .catch((err: unknown) => {

--- a/packages/app/src/context/global-sync/client-action-source.test.ts
+++ b/packages/app/src/context/global-sync/client-action-source.test.ts
@@ -20,6 +20,7 @@ describe("global sync client action provenance wiring", () => {
     expect(settingsProvidersSource).toContain("clientActionHeaders")
     expect(settingsProvidersSource).toContain('kind: "settings.provider.disconnect"')
     expect(settingsProvidersSource).toContain("actionClient.global.dispose")
+    expect(settingsProvidersSource).toContain("provider.disconnect.toast.disconnected.deferredDescription")
   })
 
   test("tags workspace reset instance disposal with client action headers", () => {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -171,6 +171,8 @@ export const dict = {
   "provider.connect.oauth.auto.confirmationCode": "Confirmation code",
   "provider.connect.toast.connected.title": "{{provider}} connected",
   "provider.connect.toast.connected.description": "{{provider}} models are now available to use.",
+  "provider.connect.toast.connected.deferredDescription":
+    "{{provider}} is connected. Model refresh will finish after the current run.",
 
   "provider.custom.title": "Custom provider",
   "provider.custom.description.prefix": "Configure an OpenAI-compatible provider. See the ",
@@ -211,6 +213,8 @@ export const dict = {
 
   "provider.disconnect.toast.disconnected.title": "{{provider}} disconnected",
   "provider.disconnect.toast.disconnected.description": "{{provider}} models are no longer available.",
+  "provider.disconnect.toast.disconnected.deferredDescription":
+    "{{provider}} is disconnected. Model refresh will finish after the current run.",
 
   "model.tag.free": "Free",
   "model.tag.latest": "Latest",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -190,6 +190,7 @@ export const dict = {
   "provider.connect.oauth.auto.confirmationCode": "确认码",
   "provider.connect.toast.connected.title": "{{provider}} 已连接",
   "provider.connect.toast.connected.description": "现在可以使用 {{provider}} 模型了。",
+  "provider.connect.toast.connected.deferredDescription": "{{provider}} 已连接。模型刷新会在当前任务结束后完成。",
 
   "provider.custom.title": "自定义提供商",
   "provider.custom.description.prefix": "配置与 OpenAI 兼容的提供商。请查看",
@@ -230,6 +231,7 @@ export const dict = {
 
   "provider.disconnect.toast.disconnected.title": "{{provider}} 已断开连接",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
+  "provider.disconnect.toast.disconnected.deferredDescription": "{{provider}} 已断开连接。模型刷新会在当前任务结束后完成。",
 
   "model.tag.free": "免费",
   "model.tag.latest": "最新",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1161,17 +1161,20 @@ const rawLayer = Layer.effect(
 
     const invalidate = Effect.fn("Config.invalidate")(function* (wait?: boolean, operation = "config.invalidate") {
       yield* invalidateGlobal
-      const task = withLifecycleOrigin({ source: "config", operation, reason: operation }, () => Instance.disposeAll())
+      const emitDisposed = () => {
+        GlobalBus.emit("event", {
+          directory: "global",
+          payload: {
+            type: Event.Disposed.type,
+            properties: {},
+          },
+        })
+      }
+      const task = withLifecycleOrigin({ source: "config", operation, reason: operation }, async () => {
+        const result = await Instance.disposeAll({ onCompleted: emitDisposed })
+        if (wait && result.completed) await result.completed
+      })
         .catch(() => undefined)
-        .finally(() =>
-          GlobalBus.emit("event", {
-            directory: "global",
-            payload: {
-              type: Event.Disposed.type,
-              properties: {},
-            },
-          }),
-        )
       if (wait) yield* Effect.promise(() => task)
       else void task
     })

--- a/packages/opencode/src/project/instance-runtime.ts
+++ b/packages/opencode/src/project/instance-runtime.ts
@@ -1,16 +1,16 @@
 import { AppRuntime } from "@/effect/app-runtime"
-import { InstanceStore, type LoadInput } from "./instance-store"
+import { InstanceStore, type LifecycleCloseOptions, type LoadInput } from "./instance-store"
 
 export const load = (input: LoadInput) => AppRuntime.runPromise(InstanceStore.Service.use((store) => store.load(input)))
 
-export const reloadInstance = (input: LoadInput) =>
-  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.reload(input)))
+export const reloadInstance = (input: LoadInput & LifecycleCloseOptions) =>
+  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.reload(input, undefined, input)))
 
-export const disposeInstance = (ctx: Parameters<InstanceStore.Interface["dispose"]>[0]) =>
-  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.dispose(ctx)))
+export const disposeInstance = (ctx: Parameters<InstanceStore.Interface["dispose"]>[0], options?: LifecycleCloseOptions) =>
+  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.dispose(ctx, options)))
 
-export const disposeDirectory = (directory: string) =>
-  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeDirectory(directory)))
+export const disposeDirectory = (directory: string, options?: LifecycleCloseOptions) =>
+  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeDirectory(directory, options)))
 
 export const disposeAllInstances = () =>
   AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeAll()))

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -68,8 +68,13 @@ export type LifecycleCloseResult = {
 const disposeLoadedInstances = new Set<(options?: LifecycleCloseOptions) => Promise<LifecycleCloseResult>>()
 
 export async function disposeAllLoadedInstances(options?: LifecycleCloseOptions): Promise<LifecycleCloseResult> {
-  const results = await Promise.all([...disposeLoadedInstances].map((dispose) => dispose(options)))
+  const storeOptions = options?.onCompleted ? { ...options, onCompleted: undefined } : options
+  const results = await Promise.all([...disposeLoadedInstances].map((dispose) => dispose(storeOptions)))
+  const completeAggregate = async () => {
+    await options?.onCompleted?.()
+  }
   if (results.length === 0) {
+    await completeAggregate()
     return {
       status: "completed",
       lifecycleActionID: "lifecycle:instance_dispose_all:empty",
@@ -83,11 +88,14 @@ export async function disposeAllLoadedInstances(options?: LifecycleCloseOptions)
     affectedDirectoryKeys: [...new Set(results.flatMap((entry) => entry.affectedDirectoryKeys))],
   }
   const completions = results.flatMap((entry) => (entry.completed ? [entry.completed] : []))
-  if (completions.length > 0) {
+  const completed = Promise.all(completions).then(() => completeAggregate())
+  if (status === "deferred") {
     Object.defineProperty(result, "completed", {
-      value: Promise.all(completions).then(() => undefined),
+      value: completed,
       enumerable: false,
     })
+  } else {
+    await completed
   }
   return result
 }

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -11,8 +11,10 @@ import { State } from "./state"
 import {
   createLifecycleCloseAction,
   currentLifecycleOrigin,
+  hasActiveRuns,
   type LifecycleCloseAction,
   withLifecycleCloseAction,
+  whenAllRunsIdle,
 } from "@/session/lifecycle-provenance"
 import { currentRequestContext } from "@/server/request-context"
 
@@ -31,10 +33,14 @@ type ContextMismatchReason =
 
 export interface Interface {
   readonly load: (input: LoadInput) => Effect.Effect<InstanceContext, unknown>
-  readonly reload: (input: LoadInput) => Effect.Effect<InstanceContext, unknown>
-  readonly dispose: (ctx: InstanceContext) => Effect.Effect<void>
-  readonly disposeDirectory: (directory: string) => Effect.Effect<void>
-  readonly disposeAll: () => Effect.Effect<void>
+  readonly reload: (
+    input: LoadInput,
+    reason?: ContextMismatchReason | "reload",
+    options?: LifecycleCloseOptions,
+  ) => Effect.Effect<InstanceContext, unknown>
+  readonly dispose: (ctx: InstanceContext, options?: LifecycleCloseOptions) => Effect.Effect<boolean>
+  readonly disposeDirectory: (directory: string, options?: LifecycleCloseOptions) => Effect.Effect<boolean>
+  readonly disposeAll: (options?: LifecycleCloseOptions) => Effect.Effect<LifecycleCloseResult>
   readonly provide: <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E | unknown, R>
 }
 
@@ -44,10 +50,32 @@ type Entry = {
   readonly deferred: Deferred.Deferred<InstanceContext, unknown>
 }
 
-const disposeLoadedInstances = new Set<() => Promise<void>>()
+export type LifecycleCloseMode = "maintenance" | "force"
 
-export async function disposeAllLoadedInstances() {
-  await Promise.all([...disposeLoadedInstances].map((dispose) => dispose()))
+export type LifecycleCloseOptions = {
+  readonly mode?: LifecycleCloseMode
+  readonly onCompleted?: () => void | Promise<void>
+}
+
+export type LifecycleCloseResult = {
+  readonly status: "completed" | "deferred"
+  readonly lifecycleActionID: string
+  readonly affectedDirectoryKeys: readonly string[]
+}
+
+const disposeLoadedInstances = new Set<(options?: LifecycleCloseOptions) => Promise<LifecycleCloseResult>>()
+
+export async function disposeAllLoadedInstances(options?: LifecycleCloseOptions): Promise<LifecycleCloseResult> {
+  const results = await Promise.all([...disposeLoadedInstances].map((dispose) => dispose(options)))
+  const deferred = results.find((result) => result.status === "deferred")
+  return (
+    deferred ??
+    results[0] ?? {
+      status: "completed",
+      lifecycleActionID: "lifecycle:instance_dispose_all:empty",
+      affectedDirectoryKeys: [],
+    }
+  )
 }
 
 function hasExplicitContext(input: LoadInput) {
@@ -159,10 +187,28 @@ export const layer = Layer.effect(
         yield* emitDisposed(ctx)
       })
 
-    const disposeEntry = (directory: string, entry: Entry, ctx: InstanceContext, action?: LifecycleCloseAction) =>
+    const disposeEntry = (
+      directory: string,
+      entry: Entry,
+      ctx: InstanceContext,
+      action?: LifecycleCloseAction,
+      options?: LifecycleCloseOptions,
+    ) =>
       Effect.gen(function* () {
         if (entries.get(directory) !== entry) return false
-        yield* disposeContext(ctx, action)
+        const closeAction =
+          action ??
+          createLifecycleCloseAction("instance_dispose", {
+            affectedDirectories: [ctx.directory],
+            ...lifecycleContext("instance.dispose", "dispose_context"),
+          })
+        if ((options?.mode ?? "maintenance") === "maintenance" && hasActiveRuns([ctx.directory])) {
+          void whenAllRunsIdle([ctx.directory]).then(() =>
+            Effect.runPromise(disposeEntry(directory, entry, ctx, closeAction, { mode: "force" })).then(() => undefined),
+          )
+          return false
+        }
+        yield* disposeContext(ctx, closeAction)
         if (entries.get(directory) !== entry) return false
         entries.delete(directory)
         return true
@@ -171,12 +217,22 @@ export const layer = Layer.effect(
     const reload = (
       input: LoadInput,
       reason: ContextMismatchReason | "reload" = "reload",
+      options?: LifecycleCloseOptions,
     ): Effect.Effect<InstanceContext, unknown> => {
       const directory = Filesystem.resolve(input.directory)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           validateExplicitContext(input)
           const previous = entries.get(directory)
+          if ((options?.mode ?? "maintenance") === "maintenance" && previous) {
+            const exit = yield* restore(Deferred.await(previous.deferred)).pipe(Effect.exit)
+            if (Exit.isSuccess(exit) && hasActiveRuns([exit.value.directory])) {
+              void whenAllRunsIdle([exit.value.directory]).then(() =>
+                Effect.runPromise(reload(input, reason, { mode: "maintenance" })).then(() => undefined),
+              )
+              return exit.value
+            }
+          }
           const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext, unknown>() }
           entries.set(directory, entry)
           yield* Effect.gen(function* () {
@@ -229,16 +285,19 @@ export const layer = Layer.effect(
       ).pipe(Effect.withSpan("InstanceStore.load"))
     }
 
-    const dispose = (ctx: InstanceContext) =>
+    const dispose = (ctx: InstanceContext, options?: LifecycleCloseOptions) =>
       Effect.gen(function* () {
         const directory = Filesystem.resolve(ctx.directory)
         const entry = entries.get(directory)
-        if (!entry) return yield* disposeContext(ctx)
+        if (!entry) {
+          yield* disposeContext(ctx)
+          return true
+        }
 
         const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-        if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
-        if (exit.value !== ctx) return
-        yield* disposeEntry(
+        if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry)
+        if (exit.value !== ctx) return false
+        return yield* disposeEntry(
           directory,
           entry,
           ctx,
@@ -246,18 +305,19 @@ export const layer = Layer.effect(
             affectedDirectories: [ctx.directory],
             ...lifecycleContext("instance.dispose", "dispose"),
           }),
-        ).pipe(Effect.asVoid)
+          options,
+        )
       })
 
-    const disposeDirectory = (inputDirectory: string) =>
+    const disposeDirectory = (inputDirectory: string, options?: LifecycleCloseOptions) =>
       Effect.gen(function* () {
         const directory = Filesystem.resolve(inputDirectory)
         const entry = entries.get(directory)
-        if (!entry) return
+        if (!entry) return false
 
         const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-        if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
-        yield* disposeEntry(
+        if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry)
+        return yield* disposeEntry(
           directory,
           entry,
           exit.value,
@@ -265,16 +325,12 @@ export const layer = Layer.effect(
             affectedDirectories: [exit.value.directory],
             ...lifecycleContext("instance.disposeDirectory", "dispose_directory"),
           }),
-        ).pipe(Effect.asVoid)
+          options,
+        )
       })
 
-    const disposeAllOnce = Effect.gen(function* () {
-      const activeDirectories = [...entries.keys()]
-      const action = createLifecycleCloseAction("instance_dispose_all", {
-        affectedDirectories: activeDirectories,
-        ...lifecycleContext("instance.disposeAll", "dispose_all"),
-      })
-      yield* Effect.forEach(
+    const closeAllEntries = (action: LifecycleCloseAction, options?: LifecycleCloseOptions) =>
+      Effect.forEach(
         [...entries.entries()],
         ([directory, entry]) =>
           Effect.gen(function* () {
@@ -283,20 +339,46 @@ export const layer = Layer.effect(
               yield* removeEntry(directory, entry)
               return
             }
-            yield* disposeEntry(directory, entry, exit.value, action)
+            yield* disposeEntry(directory, entry, exit.value, action, options)
           }),
         { discard: true },
       )
+
+    const resultFor = (
+      status: LifecycleCloseResult["status"],
+      action: LifecycleCloseAction,
+    ): LifecycleCloseResult => ({
+      status,
+      lifecycleActionID: action.actionID,
+      affectedDirectoryKeys: [...action.affectedDirectoryKeys],
     })
 
-    const disposeAll = () => disposeAllOnce
+    const disposeAllOnce = (options?: LifecycleCloseOptions) =>
+      Effect.gen(function* () {
+        const activeDirectories = [...entries.keys()]
+        const action = createLifecycleCloseAction("instance_dispose_all", {
+          affectedDirectories: activeDirectories,
+          ...lifecycleContext("instance.disposeAll", "dispose_all"),
+        })
+        const close = closeAllEntries(action, options).pipe(
+          Effect.andThen(Effect.promise(() => Promise.resolve(options?.onCompleted?.()))),
+        )
+        if ((options?.mode ?? "maintenance") === "maintenance" && hasActiveRuns(activeDirectories)) {
+          void whenAllRunsIdle(activeDirectories).then(() => Effect.runPromise(close))
+          return resultFor("deferred", action)
+        }
+        yield* close
+        return resultFor("completed", action)
+      })
 
-    const disposeAllPromise = () => Effect.runPromise(disposeAll())
+    const disposeAll = (options?: LifecycleCloseOptions) => disposeAllOnce(options)
+
+    const disposeAllPromise = (options?: LifecycleCloseOptions) => Effect.runPromise(disposeAll(options))
     yield* Effect.sync(() => {
       disposeLoadedInstances.add(disposeAllPromise)
     })
     yield* Effect.addFinalizer(() =>
-      disposeAll().pipe(
+      disposeAll({ mode: "force" }).pipe(
         Effect.andThen(
           Effect.sync(() => {
             disposeLoadedInstances.delete(disposeAllPromise)

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -69,15 +69,27 @@ const disposeLoadedInstances = new Set<(options?: LifecycleCloseOptions) => Prom
 
 export async function disposeAllLoadedInstances(options?: LifecycleCloseOptions): Promise<LifecycleCloseResult> {
   const results = await Promise.all([...disposeLoadedInstances].map((dispose) => dispose(options)))
-  const deferred = results.find((result) => result.status === "deferred")
-  return (
-    deferred ??
-    results[0] ?? {
+  if (results.length === 0) {
+    return {
       status: "completed",
       lifecycleActionID: "lifecycle:instance_dispose_all:empty",
       affectedDirectoryKeys: [],
     }
-  )
+  }
+  const status = results.some((result) => result.status === "deferred") ? "deferred" : "completed"
+  const result: LifecycleCloseResult = {
+    status,
+    lifecycleActionID: results[0].lifecycleActionID,
+    affectedDirectoryKeys: [...new Set(results.flatMap((entry) => entry.affectedDirectoryKeys))],
+  }
+  const completions = results.flatMap((entry) => (entry.completed ? [entry.completed] : []))
+  if (completions.length > 0) {
+    Object.defineProperty(result, "completed", {
+      value: Promise.all(completions).then(() => undefined),
+      enumerable: false,
+    })
+  }
+  return result
 }
 
 function hasExplicitContext(input: LoadInput) {

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -3,6 +3,7 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { Filesystem } from "@/util/filesystem"
+import { Log } from "@opencode-ai/core/util/log"
 import { Context, Deferred, Effect, Exit, Layer, Scope } from "effect"
 import { InstanceBootstrap } from "./bootstrap-service"
 import { type InstanceContext } from "./instance-context"
@@ -12,12 +13,15 @@ import {
   beginLifecycleClose,
   createLifecycleCloseAction,
   currentLifecycleOrigin,
+  directoryKey,
   hasActiveRuns,
   type LifecycleCloseAction,
   withLifecycleCloseAction,
   whenAllRunsIdle,
 } from "@/session/lifecycle-provenance"
 import { currentRequestContext } from "@/server/request-context"
+
+const log = Log.create({ service: "instance.store" })
 
 export interface LoadInput {
   directory: string
@@ -212,6 +216,20 @@ export const layer = Layer.effect(
     const completeLifecycleClose = (options?: LifecycleCloseOptions) =>
       Effect.promise(() => Promise.resolve(options?.onCompleted?.()))
 
+    const reportDeferredFailure = (
+      operation: "disposeEntry" | "reload",
+      directory: string,
+      action: LifecycleCloseAction,
+      error: unknown,
+    ) =>
+      log.error("deferred lifecycle close failed", {
+        operation,
+        directoryKey: directoryKey(directory),
+        lifecycleActionID: action.actionID,
+        lifecycleKind: action.kind,
+        error,
+      })
+
     const disposeEntryNow = (
       directory: string,
       entry: Entry,
@@ -250,6 +268,7 @@ export const layer = Layer.effect(
         if (hasActiveRuns([ctx.directory])) {
           const completed = whenAllRunsIdle([ctx.directory])
             .then(() => Effect.runPromise(disposeEntryNow(directory, entry, ctx, closeAction, options)))
+            .catch((error) => reportDeferredFailure("disposeEntry", ctx.directory, closeAction, error))
             .finally(releaseClose)
             .then(() => undefined)
           void completed
@@ -278,9 +297,15 @@ export const layer = Layer.effect(
             const exit = yield* restore(Deferred.await(previous.deferred)).pipe(Effect.exit)
             if (Exit.isSuccess(exit) && hasActiveRuns([exit.value.directory])) {
               const releaseDeferredClose = releaseClose
-              void whenAllRunsIdle([exit.value.directory]).then(() =>
-                Effect.runPromise(reload(input, reason, { mode: "force" })).finally(releaseDeferredClose).then(() => undefined),
-              )
+              const deferredAction = createLifecycleCloseAction("instance_reload", {
+                affectedDirectories: [exit.value.directory],
+                ...lifecycleContext("instance.reload", reason),
+              })
+              void whenAllRunsIdle([exit.value.directory])
+                .then(() => Effect.runPromise(reload(input, reason, { mode: "force" })))
+                .catch((error) => reportDeferredFailure("reload", exit.value.directory, deferredAction, error))
+                .finally(releaseDeferredClose)
+                .then(() => undefined)
               return exit.value
             }
           }

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -9,6 +9,7 @@ import { type InstanceContext } from "./instance-context"
 import { Project } from "./project"
 import { State } from "./state"
 import {
+  beginLifecycleClose,
   createLifecycleCloseAction,
   currentLifecycleOrigin,
   hasActiveRuns,
@@ -61,6 +62,7 @@ export type LifecycleCloseResult = {
   readonly status: "completed" | "deferred"
   readonly lifecycleActionID: string
   readonly affectedDirectoryKeys: readonly string[]
+  readonly completed?: Promise<void>
 }
 
 const disposeLoadedInstances = new Set<(options?: LifecycleCloseOptions) => Promise<LifecycleCloseResult>>()
@@ -187,6 +189,25 @@ export const layer = Layer.effect(
         yield* emitDisposed(ctx)
       })
 
+    const completeLifecycleClose = (options?: LifecycleCloseOptions) =>
+      Effect.promise(() => Promise.resolve(options?.onCompleted?.()))
+
+    const disposeEntryNow = (
+      directory: string,
+      entry: Entry,
+      ctx: InstanceContext,
+      closeAction: LifecycleCloseAction,
+      options?: LifecycleCloseOptions,
+    ) =>
+      Effect.gen(function* () {
+        if (entries.get(directory) !== entry) return false
+        yield* disposeContext(ctx, closeAction)
+        if (entries.get(directory) !== entry) return false
+        entries.delete(directory)
+        yield* completeLifecycleClose(options)
+        return true
+      })
+
     const disposeEntry = (
       directory: string,
       entry: Entry,
@@ -195,23 +216,30 @@ export const layer = Layer.effect(
       options?: LifecycleCloseOptions,
     ) =>
       Effect.gen(function* () {
-        if (entries.get(directory) !== entry) return false
         const closeAction =
           action ??
           createLifecycleCloseAction("instance_dispose", {
             affectedDirectories: [ctx.directory],
             ...lifecycleContext("instance.dispose", "dispose_context"),
           })
-        if ((options?.mode ?? "maintenance") === "maintenance" && hasActiveRuns([ctx.directory])) {
-          void whenAllRunsIdle([ctx.directory]).then(() =>
-            Effect.runPromise(disposeEntry(directory, entry, ctx, closeAction, { mode: "force" })).then(() => undefined),
-          )
+        if ((options?.mode ?? "maintenance") !== "maintenance") {
+          return yield* disposeEntryNow(directory, entry, ctx, closeAction, options)
+        }
+
+        const releaseClose = beginLifecycleClose([ctx.directory])
+        if (hasActiveRuns([ctx.directory])) {
+          const completed = whenAllRunsIdle([ctx.directory])
+            .then(() => Effect.runPromise(disposeEntryNow(directory, entry, ctx, closeAction, options)))
+            .finally(releaseClose)
+            .then(() => undefined)
+          void completed
           return false
         }
-        yield* disposeContext(ctx, closeAction)
-        if (entries.get(directory) !== entry) return false
-        entries.delete(directory)
-        return true
+        try {
+          return yield* disposeEntryNow(directory, entry, ctx, closeAction, options)
+        } finally {
+          releaseClose()
+        }
       })
 
     const reload = (
@@ -224,11 +252,14 @@ export const layer = Layer.effect(
         Effect.gen(function* () {
           validateExplicitContext(input)
           const previous = entries.get(directory)
+          let releaseClose: (() => void) | undefined
           if ((options?.mode ?? "maintenance") === "maintenance" && previous) {
+            releaseClose = beginLifecycleClose([directory])
             const exit = yield* restore(Deferred.await(previous.deferred)).pipe(Effect.exit)
             if (Exit.isSuccess(exit) && hasActiveRuns([exit.value.directory])) {
+              const releaseDeferredClose = releaseClose
               void whenAllRunsIdle([exit.value.directory]).then(() =>
-                Effect.runPromise(reload(input, reason, { mode: "maintenance" })).then(() => undefined),
+                Effect.runPromise(reload(input, reason, { mode: "force" })).finally(releaseDeferredClose).then(() => undefined),
               )
               return exit.value
             }
@@ -250,7 +281,11 @@ export const layer = Layer.effect(
             }
             yield* completeLoad(directory, input, entry)
           }).pipe(Effect.forkIn(scope, { startImmediately: true }))
-          return yield* restore(Deferred.await(entry.deferred))
+          try {
+            return yield* restore(Deferred.await(entry.deferred))
+          } finally {
+            releaseClose?.()
+          }
         }),
       ).pipe(Effect.withSpan("InstanceStore.reload"))
     }
@@ -347,11 +382,16 @@ export const layer = Layer.effect(
     const resultFor = (
       status: LifecycleCloseResult["status"],
       action: LifecycleCloseAction,
-    ): LifecycleCloseResult => ({
-      status,
-      lifecycleActionID: action.actionID,
-      affectedDirectoryKeys: [...action.affectedDirectoryKeys],
-    })
+      completed?: Promise<void>,
+    ): LifecycleCloseResult => {
+      const result: LifecycleCloseResult = {
+        status,
+        lifecycleActionID: action.actionID,
+        affectedDirectoryKeys: [...action.affectedDirectoryKeys],
+      }
+      if (completed) Object.defineProperty(result, "completed", { value: completed, enumerable: false })
+      return result
+    }
 
     const disposeAllOnce = (options?: LifecycleCloseOptions) =>
       Effect.gen(function* () {
@@ -360,12 +400,23 @@ export const layer = Layer.effect(
           affectedDirectories: activeDirectories,
           ...lifecycleContext("instance.disposeAll", "dispose_all"),
         })
-        const close = closeAllEntries(action, options).pipe(
-          Effect.andThen(Effect.promise(() => Promise.resolve(options?.onCompleted?.()))),
-        )
-        if ((options?.mode ?? "maintenance") === "maintenance" && hasActiveRuns(activeDirectories)) {
-          void whenAllRunsIdle(activeDirectories).then(() => Effect.runPromise(close))
-          return resultFor("deferred", action)
+        const entryOptions = { ...options, onCompleted: undefined }
+        const close = closeAllEntries(action, entryOptions).pipe(Effect.andThen(completeLifecycleClose(options)))
+        if ((options?.mode ?? "maintenance") === "maintenance") {
+          const releaseClose = beginLifecycleClose(activeDirectories)
+          if (hasActiveRuns(activeDirectories)) {
+            const completed = whenAllRunsIdle(activeDirectories)
+              .then(() => Effect.runPromise(close))
+              .finally(releaseClose)
+            void completed
+            return resultFor("deferred", action, completed)
+          }
+          try {
+            yield* close
+          } finally {
+            releaseClose()
+          }
+          return resultFor("completed", action)
         }
         yield* close
         return resultFor("completed", action)

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -94,6 +94,7 @@ export async function disposeAllLoadedInstances(options?: LifecycleCloseOptions)
   const completions = results.flatMap((entry) => (entry.completed ? [entry.completed] : []))
   const completed = Promise.all(completions).then(() => completeAggregate())
   if (status === "deferred") {
+    void completed.catch(() => undefined)
     Object.defineProperty(result, "completed", {
       value: completed,
       enumerable: false,
@@ -217,14 +218,15 @@ export const layer = Layer.effect(
       Effect.promise(() => Promise.resolve(options?.onCompleted?.()))
 
     const reportDeferredFailure = (
-      operation: "disposeEntry" | "reload",
-      directory: string,
+      operation: "disposeAll" | "disposeEntry" | "reload",
+      directory: string | undefined,
       action: LifecycleCloseAction,
       error: unknown,
     ) =>
       log.error("deferred lifecycle close failed", {
         operation,
-        directoryKey: directoryKey(directory),
+        directoryKey: directory ? directoryKey(directory) : undefined,
+        lifecycleAffectedDirectoryKeys: [...action.affectedDirectoryKeys],
         lifecycleActionID: action.actionID,
         lifecycleKind: action.kind,
         error,
@@ -452,8 +454,12 @@ export const layer = Layer.effect(
           if (hasActiveRuns(activeDirectories)) {
             const completed = whenAllRunsIdle(activeDirectories)
               .then(() => Effect.runPromise(close))
+              .catch((error) => {
+                reportDeferredFailure("disposeAll", undefined, action, error)
+                throw error
+              })
               .finally(releaseClose)
-            void completed
+            void completed.catch(() => undefined)
             return resultFor("deferred", action, completed)
           }
           try {

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -104,6 +104,7 @@ export const Instance = {
     init?: () => Promise<any>
     project?: Project.Info
     worktree?: string
+    mode?: "maintenance" | "force"
   }) {
     if (!!input.worktree !== !!input.project) {
       throw new Error("Instance.reload requires both worktree and project when overriding context")
@@ -114,26 +115,28 @@ export const Instance = {
       directory,
       worktree: input.worktree,
       project: input.project,
+      mode: input.mode,
     })
     directories.add(ctx.directory)
     await context.provide(ctx, () => input.init?.())
     return ctx
   },
-  async dispose() {
+  async dispose(input?: { mode?: "maintenance" | "force" }) {
     const ctx = Instance.current
     const instanceRuntime = await runtime()
-    await instanceRuntime.disposeInstance(ctx)
-    directories.delete(ctx.directory)
+    const disposed = await instanceRuntime.disposeInstance(ctx, input)
+    if (disposed) directories.delete(ctx.directory)
   },
-  async disposeDirectory(inputDirectory: string) {
+  async disposeDirectory(inputDirectory: string, input?: { mode?: "maintenance" | "force" }) {
     const directory = Filesystem.resolve(inputDirectory)
     const instanceRuntime = await runtime()
-    await instanceRuntime.disposeDirectory(directory)
-    directories.delete(directory)
+    const disposed = await instanceRuntime.disposeDirectory(directory, input)
+    if (disposed) directories.delete(directory)
   },
-  async disposeAll() {
+  async disposeAll(input?: { mode?: "maintenance" | "force"; onCompleted?: () => void | Promise<void> }) {
     const { disposeAllLoadedInstances } = await import("./instance-store")
-    await disposeAllLoadedInstances()
-    directories.clear()
+    const result = await disposeAllLoadedInstances(input)
+    if (result.status === "completed") directories.clear()
+    return result
   },
 }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -121,21 +121,36 @@ export const Instance = {
     await context.provide(ctx, () => input.init?.())
     return ctx
   },
-  async dispose(input?: { mode?: "maintenance" | "force" }) {
+  async dispose(input?: { mode?: "maintenance" | "force"; onCompleted?: () => void | Promise<void> }) {
     const ctx = Instance.current
     const instanceRuntime = await runtime()
-    const disposed = await instanceRuntime.disposeInstance(ctx, input)
+    const onCompleted = async () => {
+      directories.delete(ctx.directory)
+      await input?.onCompleted?.()
+    }
+    const disposed = await instanceRuntime.disposeInstance(ctx, { ...input, onCompleted })
     if (disposed) directories.delete(ctx.directory)
   },
-  async disposeDirectory(inputDirectory: string, input?: { mode?: "maintenance" | "force" }) {
+  async disposeDirectory(
+    inputDirectory: string,
+    input?: { mode?: "maintenance" | "force"; onCompleted?: () => void | Promise<void> },
+  ) {
     const directory = Filesystem.resolve(inputDirectory)
     const instanceRuntime = await runtime()
-    const disposed = await instanceRuntime.disposeDirectory(directory, input)
+    const onCompleted = async () => {
+      directories.delete(directory)
+      await input?.onCompleted?.()
+    }
+    const disposed = await instanceRuntime.disposeDirectory(directory, { ...input, onCompleted })
     if (disposed) directories.delete(directory)
   },
   async disposeAll(input?: { mode?: "maintenance" | "force"; onCompleted?: () => void | Promise<void> }) {
     const { disposeAllLoadedInstances } = await import("./instance-store")
-    const result = await disposeAllLoadedInstances(input)
+    const onCompleted = async () => {
+      directories.clear()
+      await input?.onCompleted?.()
+    }
+    const result = await disposeAllLoadedInstances({ ...input, onCompleted })
     if (result.status === "completed") directories.clear()
     return result
   },

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -21,6 +21,22 @@ const log = Log.create({ service: "server" })
 
 export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
 
+const LifecycleCloseResult = z.object({
+  status: z.enum(["completed", "deferred"]),
+  lifecycleActionID: z.string(),
+  affectedDirectoryKeys: z.array(z.string()),
+})
+
+function emitGlobalDisposed() {
+  GlobalBus.emit("event", {
+    directory: "global",
+    payload: {
+      type: GlobalDisposedEvent.type,
+      properties: {},
+    },
+  })
+}
+
 type SsePacket = {
   id?: string
   data: string
@@ -397,22 +413,15 @@ export const GlobalRoutes = lazy(() =>
             description: "Global disposed",
             content: {
               "application/json": {
-                schema: resolver(z.boolean()),
+                schema: resolver(LifecycleCloseResult),
               },
             },
           },
         },
       }),
       async (c) => {
-        await Instance.disposeAll()
-        GlobalBus.emit("event", {
-          directory: "global",
-          payload: {
-            type: GlobalDisposedEvent.type,
-            properties: {},
-          },
-        })
-        return c.json(true)
+        const result = await Instance.disposeAll({ onCompleted: emitGlobalDisposed })
+        return c.json(result)
       },
     )
     .post(

--- a/packages/opencode/src/session/lifecycle-provenance.ts
+++ b/packages/opencode/src/session/lifecycle-provenance.ts
@@ -43,6 +43,8 @@ export type CreateLifecycleCloseActionOptions = {
 let nextActionID = 0
 const activeByDirectory = new Map<string, LifecycleCloseAction[]>()
 const originContext = new AsyncLocalStorage<LifecycleOrigin>()
+const activeRunsByDirectory = new Map<string, number>()
+const idleWaiters = new Set<{ directories: readonly string[]; resolve: () => void }>()
 
 export function directoryKey(directory: string): string {
   const digest = createHash("sha256").update(directory).digest("hex").slice(0, 16)
@@ -124,4 +126,37 @@ export function currentLifecycleOrigin(): LifecycleOrigin | undefined {
 
 export async function withLifecycleOrigin<T>(origin: LifecycleOrigin, fn: () => Promise<T>): Promise<T> {
   return originContext.run({ ...origin }, fn)
+}
+
+function notifyIdleWaiters() {
+  for (const waiter of [...idleWaiters]) {
+    if (hasActiveRuns(waiter.directories)) continue
+    idleWaiters.delete(waiter)
+    waiter.resolve()
+  }
+}
+
+export function trackActiveRun(directory: string): () => void {
+  activeRunsByDirectory.set(directory, (activeRunsByDirectory.get(directory) ?? 0) + 1)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const next = (activeRunsByDirectory.get(directory) ?? 1) - 1
+    if (next > 0) activeRunsByDirectory.set(directory, next)
+    else activeRunsByDirectory.delete(directory)
+    notifyIdleWaiters()
+  }
+}
+
+export function hasActiveRuns(directories: readonly string[]): boolean {
+  return directories.some((directory) => (activeRunsByDirectory.get(directory) ?? 0) > 0)
+}
+
+export function whenAllRunsIdle(directories: readonly string[]): Promise<void> {
+  const uniqueDirectories = [...new Set(directories)]
+  if (!hasActiveRuns(uniqueDirectories)) return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    idleWaiters.add({ directories: uniqueDirectories, resolve })
+  })
 }

--- a/packages/opencode/src/session/lifecycle-provenance.ts
+++ b/packages/opencode/src/session/lifecycle-provenance.ts
@@ -163,11 +163,30 @@ function acquireActiveRun(directory: string): () => void {
   }
 }
 
-export function trackActiveRun(directory: string): Promise<() => void> {
-  if (!hasLifecycleClose([directory])) return Promise.resolve(acquireActiveRun(directory))
-  return new Promise<() => void>((resolve) => {
-    closeWaiters.add({ directory, resolve })
+export function trackActiveRun(directory: string): { promise: Promise<() => void>; cancel: () => void } {
+  if (!hasLifecycleClose([directory])) {
+    return { promise: Promise.resolve(acquireActiveRun(directory)), cancel: () => {} }
+  }
+  let settled = false
+  let waiter: { directory: string; resolve: (release: () => void) => void }
+  const promise = new Promise<() => void>((resolve) => {
+    waiter = {
+      directory,
+      resolve: (release: () => void) => {
+        settled = true
+        resolve(release)
+      },
+    }
+    closeWaiters.add(waiter)
   })
+  return {
+    promise,
+    cancel: () => {
+      if (settled) return
+      settled = true
+      closeWaiters.delete(waiter)
+    },
+  }
 }
 
 export function hasActiveRuns(directories: readonly string[]): boolean {

--- a/packages/opencode/src/session/lifecycle-provenance.ts
+++ b/packages/opencode/src/session/lifecycle-provenance.ts
@@ -45,6 +45,8 @@ const activeByDirectory = new Map<string, LifecycleCloseAction[]>()
 const originContext = new AsyncLocalStorage<LifecycleOrigin>()
 const activeRunsByDirectory = new Map<string, number>()
 const idleWaiters = new Set<{ directories: readonly string[]; resolve: () => void }>()
+const closingByDirectory = new Map<string, number>()
+const closeWaiters = new Set<{ directory: string; resolve: (release: () => void) => void }>()
 
 export function directoryKey(directory: string): string {
   const digest = createHash("sha256").update(directory).digest("hex").slice(0, 16)
@@ -136,7 +138,19 @@ function notifyIdleWaiters() {
   }
 }
 
-export function trackActiveRun(directory: string): () => void {
+function hasLifecycleClose(directories: readonly string[]): boolean {
+  return directories.some((directory) => (closingByDirectory.get(directory) ?? 0) > 0)
+}
+
+function notifyCloseWaiters() {
+  for (const waiter of [...closeWaiters]) {
+    if (hasLifecycleClose([waiter.directory])) continue
+    closeWaiters.delete(waiter)
+    waiter.resolve(acquireActiveRun(waiter.directory))
+  }
+}
+
+function acquireActiveRun(directory: string): () => void {
   activeRunsByDirectory.set(directory, (activeRunsByDirectory.get(directory) ?? 0) + 1)
   let released = false
   return () => {
@@ -149,6 +163,13 @@ export function trackActiveRun(directory: string): () => void {
   }
 }
 
+export function trackActiveRun(directory: string): Promise<() => void> {
+  if (!hasLifecycleClose([directory])) return Promise.resolve(acquireActiveRun(directory))
+  return new Promise<() => void>((resolve) => {
+    closeWaiters.add({ directory, resolve })
+  })
+}
+
 export function hasActiveRuns(directories: readonly string[]): boolean {
   return directories.some((directory) => (activeRunsByDirectory.get(directory) ?? 0) > 0)
 }
@@ -159,4 +180,22 @@ export function whenAllRunsIdle(directories: readonly string[]): Promise<void> {
   return new Promise<void>((resolve) => {
     idleWaiters.add({ directories: uniqueDirectories, resolve })
   })
+}
+
+export function beginLifecycleClose(directories: readonly string[]): () => void {
+  const uniqueDirectories = [...new Set(directories)]
+  for (const directory of uniqueDirectories) {
+    closingByDirectory.set(directory, (closingByDirectory.get(directory) ?? 0) + 1)
+  }
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    for (const directory of uniqueDirectories) {
+      const next = (closingByDirectory.get(directory) ?? 1) - 1
+      if (next > 0) closingByDirectory.set(directory, next)
+      else closingByDirectory.delete(directory)
+    }
+    notifyCloseWaiters()
+  }
 }

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -71,11 +71,14 @@ export const layer = Layer.effect(
     )
 
     const withActiveRun = <A, E>(directory: string, work: Effect.Effect<A, E>) =>
-      Effect.acquireUseRelease(
-        Effect.promise(() => trackActiveRun(directory)),
-        () => work,
-        (release) => Effect.sync(release),
-      )
+      Effect.suspend(() => {
+        const activeRun = trackActiveRun(directory)
+        return Effect.acquireUseRelease(
+          Effect.promise(() => activeRun.promise).pipe(Effect.onInterrupt(() => Effect.sync(activeRun.cancel))),
+          () => work,
+          (release) => Effect.sync(release),
+        )
+      })
 
     const runner = Effect.fn("SessionRunState.runner")(function* (
       sessionID: SessionID,

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -5,7 +5,7 @@ import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
-import { currentLifecycleCloseAction, lifecycleCloseActionMeta } from "./lifecycle-provenance"
+import { currentLifecycleCloseAction, lifecycleCloseActionMeta, trackActiveRun } from "./lifecycle-provenance"
 
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
@@ -65,9 +65,16 @@ export const layer = Layer.effect(
             runners.clear()
           }),
         )
-        return { runners, scope, interruptFallback }
+        return { directory: ctx.directory, runners, scope, interruptFallback }
       }),
     )
+
+    const protectActiveRun = <A, E>(directory: string, work: Effect.Effect<A, E>) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => trackActiveRun(directory)),
+        () => work,
+        (release) => Effect.sync(release),
+      )
 
     const runner = Effect.fn("SessionRunState.runner")(function* (
       sessionID: SessionID,
@@ -114,7 +121,8 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       options?: { rejectIfBusy?: boolean },
     ) {
-      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work, options)
+      const data = yield* InstanceState.get(state)
+      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(protectActiveRun(data.directory, work), options)
     })
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
@@ -123,7 +131,8 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       ready?: Deferred.Deferred<void>,
     ) {
-      return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
+      const data = yield* InstanceState.get(state)
+      return yield* (yield* runner(sessionID, onInterrupt)).startShell(protectActiveRun(data.directory, work), { ready })
     })
 
     return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,6 +1,7 @@
 import { InstanceState } from "@/effect/instance-state"
 import { Runner, type InterruptMeta } from "@/effect/runner"
 import { Deferred, Effect, Layer, Scope, Context } from "effect"
+import { Instance } from "@/project/instance"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID } from "./schema"
@@ -69,9 +70,9 @@ export const layer = Layer.effect(
       }),
     )
 
-    const protectActiveRun = <A, E>(directory: string, work: Effect.Effect<A, E>) =>
+    const withActiveRun = <A, E>(directory: string, work: Effect.Effect<A, E>) =>
       Effect.acquireUseRelease(
-        Effect.sync(() => trackActiveRun(directory)),
+        Effect.promise(() => trackActiveRun(directory)),
         () => work,
         (release) => Effect.sync(release),
       )
@@ -121,8 +122,13 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       options?: { rejectIfBusy?: boolean },
     ) {
-      const data = yield* InstanceState.get(state)
-      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(protectActiveRun(data.directory, work), options)
+      const directory = yield* Effect.sync(() => Instance.directory)
+      return yield* withActiveRun(
+        directory,
+        Effect.gen(function* () {
+          return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work, options)
+        }),
+      )
     })
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
@@ -131,8 +137,13 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       ready?: Deferred.Deferred<void>,
     ) {
-      const data = yield* InstanceState.get(state)
-      return yield* (yield* runner(sessionID, onInterrupt)).startShell(protectActiveRun(data.directory, work), { ready })
+      const directory = yield* Effect.sync(() => Instance.directory)
+      return yield* withActiveRun(
+        directory,
+        Effect.gen(function* () {
+          return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
+        }),
+      )
     })
 
     return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,7 +1,6 @@
 import { InstanceState } from "@/effect/instance-state"
 import { Runner, type InterruptMeta } from "@/effect/runner"
 import { Deferred, Effect, Layer, Scope, Context } from "effect"
-import { Instance } from "@/project/instance"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID } from "./schema"
@@ -125,9 +124,9 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       options?: { rejectIfBusy?: boolean },
     ) {
-      const directory = yield* Effect.sync(() => Instance.directory)
+      const data = yield* InstanceState.get(state)
       return yield* withActiveRun(
-        directory,
+        data.directory,
         Effect.gen(function* () {
           return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work, options)
         }),
@@ -140,9 +139,9 @@ export const layer = Layer.effect(
       work: Effect.Effect<MessageV2.WithParts>,
       ready?: Deferred.Deferred<void>,
     ) {
-      const directory = yield* Effect.sync(() => Instance.directory)
+      const data = yield* InstanceState.get(state)
       return yield* withActiveRun(
-        directory,
+        data.directory,
         Effect.gen(function* () {
           return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, { ready })
         }),

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -10,7 +10,7 @@ import { InstanceStore } from "../../src/project/instance-store"
 import { Project } from "../../src/project/project"
 import { ProjectTable } from "../../src/project/project.sql"
 import { Database, eq } from "../../src/storage/db"
-import { currentLifecycleCloseAction } from "../../src/session/lifecycle-provenance"
+import { currentLifecycleCloseAction, directoryKey } from "../../src/session/lifecycle-provenance"
 import { disposeAllInstances, tmpdir, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -226,9 +226,10 @@ describe("InstanceStore", () => {
       await firstRuntime.runPromise(InstanceStore.Service.use((store) => store.load({ directory: first.path })))
       await secondRuntime.runPromise(InstanceStore.Service.use((store) => store.load({ directory: second.path })))
 
-      await Instance.disposeAll()
+      const result = await Instance.disposeAll()
 
       expect(new Set(disposed)).toEqual(new Set([first.path, second.path]))
+      expect(new Set(result.affectedDirectoryKeys)).toEqual(new Set([directoryKey(first.path), directoryKey(second.path)]))
     } finally {
       off()
       await Promise.all([firstRuntime.dispose(), secondRuntime.dispose()])

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -235,4 +235,38 @@ describe("InstanceStore", () => {
       await Promise.all([firstRuntime.dispose(), secondRuntime.dispose()])
     }
   })
+
+  test("disposeAll runs aggregate onCompleted once after every active store runtime closes", async () => {
+    await using first = await tmpdir()
+    await using second = await tmpdir()
+    const disposed: string[] = []
+    const completions: string[][] = []
+    const off = registerDisposer(async (directory) => {
+      disposed.push(directory)
+    })
+    const layer = Layer.mergeAll(
+      InstanceStore.defaultLayer.pipe(Layer.provide(noopBootstrap)),
+      CrossSpawnSpawner.defaultLayer,
+    )
+    const firstRuntime = ManagedRuntime.make(layer)
+    const secondRuntime = ManagedRuntime.make(layer)
+
+    try {
+      await firstRuntime.runPromise(InstanceStore.Service.use((store) => store.load({ directory: first.path })))
+      await secondRuntime.runPromise(InstanceStore.Service.use((store) => store.load({ directory: second.path })))
+
+      await Instance.disposeAll({
+        onCompleted: () => {
+          completions.push([...disposed])
+        },
+      })
+
+      expect(new Set(disposed)).toEqual(new Set([first.path, second.path]))
+      expect(completions).toHaveLength(1)
+      expect(new Set(completions[0])).toEqual(new Set([first.path, second.path]))
+    } finally {
+      off()
+      await Promise.all([firstRuntime.dispose(), secondRuntime.dispose()])
+    }
+  })
 })

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -6,6 +6,7 @@ import { GlobalBus } from "../../src/bus/global"
 import { Config } from "../../src/config"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
+import { registerDisposer } from "../../src/effect/instance-registry"
 import { GlobalRoutes } from "../../src/server/instance/global"
 import {
   createLifecycleCloseAction,
@@ -438,6 +439,102 @@ describe("SessionRunState", () => {
           )
           const followUp = yield* Effect.promise(() => Instance.disposeAll())
           expect(followUp.status).toBe("completed")
+        }),
+      { git: true },
+    ))
+
+  it.live("logs deferred disposeDirectory failures without leaving lifecycle close active", () =>
+    provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const unhandled: unknown[] = []
+          const onUnhandled = (error: unknown) => unhandled.push(error)
+          const off = registerDisposer(async () => {
+            throw new Error("dispose failed after idle")
+          })
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              off()
+              process.off("unhandledRejection", onUnhandled)
+            }),
+          )
+          yield* Effect.sync(() => process.on("unhandledRejection", onUnhandled))
+
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_deferred_dispose_failure"),
+              () => Effect.succeed({} as never),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Instance.disposeDirectory(directory))
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          yield* Effect.sleep("20 millis")
+          expect(unhandled).toEqual([])
+
+          let started = false
+          yield* run.ensureRunning(
+            SessionID.make("ses_after_deferred_dispose_failure"),
+            () => Effect.succeed({} as never),
+            Effect.sync(() => {
+              started = true
+              return {} as never
+            }),
+          )
+          expect(started).toBe(true)
+        }),
+      { git: true },
+    ))
+
+  it.live("logs deferred reload failures without leaving lifecycle close active", () =>
+    provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const unhandled: unknown[] = []
+          const onUnhandled = (error: unknown) => unhandled.push(error)
+          const off = registerDisposer(async () => {
+            throw new Error("reload close failed after idle")
+          })
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              off()
+              process.off("unhandledRejection", onUnhandled)
+            }),
+          )
+          yield* Effect.sync(() => process.on("unhandledRejection", onUnhandled))
+
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_deferred_reload_failure"),
+              () => Effect.succeed({} as never),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Instance.reload({ directory }))
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          yield* Effect.sleep("20 millis")
+          expect(unhandled).toEqual([])
+
+          let started = false
+          yield* run.ensureRunning(
+            SessionID.make("ses_after_deferred_reload_failure"),
+            () => Effect.succeed({} as never),
+            Effect.sync(() => {
+              started = true
+              return {} as never
+            }),
+          )
+          expect(started).toBe(true)
         }),
       { git: true },
     ))

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -392,6 +392,56 @@ describe("SessionRunState", () => {
       { git: true },
     ))
 
+  it.live("does not leave an active-run marker when a run is cancelled while waiting for close", () =>
+    provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const disposeStarted = yield* Deferred.make<void>()
+          const releaseDispose = yield* Deferred.make<void>()
+          const state = Instance.state(
+            () => ({ ready: true }),
+            async () => {
+              Effect.runPromise(Deferred.succeed(disposeStarted, undefined)).catch(() => undefined)
+              await Effect.runPromise(Deferred.await(releaseDispose))
+            },
+          )
+          state()
+
+          const disposeFiber = yield* Effect.promise(() => Instance.disposeAll()).pipe(Effect.forkChild)
+          yield* Deferred.await(disposeStarted)
+
+          let started = false
+          const runFiber = yield* Effect.gen(function* () {
+            const run = yield* SessionRunState.Service
+            return yield* run.ensureRunning(
+              SessionID.make("ses_close_wait_cancelled"),
+              () => Effect.succeed({} as never),
+              Effect.sync(() => {
+                started = true
+                return "ran" as never
+              }),
+            )
+          }).pipe(provideInstance(directory), Effect.forkChild)
+
+          yield* Effect.sleep("20 millis")
+          expect(started).toBe(false)
+          yield* Fiber.interrupt(runFiber)
+
+          yield* Deferred.succeed(releaseDispose, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(disposeFiber))).toBe(true)
+
+          yield* Effect.promise(() =>
+            Instance.provide({
+              directory,
+              fn: () => undefined,
+            }),
+          )
+          const followUp = yield* Effect.promise(() => Instance.disposeAll())
+          expect(followUp.status).toBe("completed")
+        }),
+      { git: true },
+    ))
+
   it.live("defers Config.update while a run is active", () => {
     let captured: unknown
 

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -279,6 +279,132 @@ describe("SessionRunState", () => {
       expect(Instance.directories()).not.toContain(second)
     }))
 
+  it.live("logs deferred disposeAll failures without emitting completion or leaving lifecycle close active", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const unhandled: unknown[] = []
+          const onUnhandled = (error: unknown) => unhandled.push(error)
+          yield* Effect.addFinalizer(() =>
+            Effect.gen(function* () {
+              process.off("unhandledRejection", onUnhandled)
+              yield* Effect.promise(() => Instance.disposeAll({ mode: "force" }))
+            }),
+          )
+          yield* Effect.sync(() => process.on("unhandledRejection", onUnhandled))
+
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_deferred_dispose_all_failure"),
+              () => Effect.succeed({} as never),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          const result = yield* Effect.promise(() =>
+            Instance.disposeAll({
+              onCompleted: () => {
+                throw new Error("disposeAll failed after idle")
+              },
+            }),
+          )
+          expect(result.status).toBe("deferred")
+
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          const completedExit = yield* Effect.promise(() => result.completed ?? Promise.resolve()).pipe(Effect.exit)
+          expect(Exit.isFailure(completedExit)).toBe(true)
+          yield* Effect.sleep("20 millis")
+          expect(unhandled).toEqual([])
+
+          let started = false
+          yield* run.ensureRunning(
+            SessionID.make("ses_after_deferred_dispose_all_failure"),
+            () => Effect.succeed({} as never),
+            Effect.sync(() => {
+              started = true
+              return {} as never
+            }),
+          )
+          expect(started).toBe(true)
+        }),
+      { git: true },
+    ))
+
+  it.live("logs deferred global dispose failures without unhandled rejection", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const seen: { payload: { type: string } }[] = []
+          const unhandled: unknown[] = []
+          const onEvent = (event: { payload: { type: string } }) => {
+            seen.push(event)
+          }
+          const onUnhandled = (error: unknown) => unhandled.push(error)
+          const originalEmit = GlobalBus.emit.bind(GlobalBus) as (
+            eventName: "event",
+            event: { payload?: { type?: string } },
+          ) => boolean
+          yield* Effect.addFinalizer(() =>
+            Effect.gen(function* () {
+              GlobalBus.emit = originalEmit as typeof GlobalBus.emit
+              GlobalBus.off("event", onEvent)
+              process.off("unhandledRejection", onUnhandled)
+              yield* Effect.promise(() => Instance.disposeAll({ mode: "force" }))
+            }),
+          )
+          yield* Effect.sync(() => {
+            GlobalBus.on("event", onEvent)
+            process.on("unhandledRejection", onUnhandled)
+            GlobalBus.emit = ((eventName: string, event: { payload?: { type?: string } }) => {
+              if (eventName === "event" && event?.payload?.type === "global.disposed") {
+                throw new Error("global dispose failed after idle")
+              }
+              return originalEmit(eventName as "event", event)
+            }) as typeof GlobalBus.emit
+          })
+
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_deferred_global_dispose_failure"),
+              () => Effect.succeed({} as never),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(async () => {
+            const app = new Hono().route("/global", GlobalRoutes())
+            const response = await app.request("/global/dispose", { method: "POST" })
+            expect(response.status).toBe(200)
+            expect(await response.json()).toMatchObject({ status: "deferred" })
+          })
+
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          yield* Effect.sleep("40 millis")
+          expect(unhandled).toEqual([])
+          expect(seen.some((event) => event.payload.type === "global.disposed")).toBe(false)
+
+          let started = false
+          yield* run.ensureRunning(
+            SessionID.make("ses_after_deferred_global_dispose_failure"),
+            () => Effect.succeed({} as never),
+            Effect.sync(() => {
+              started = true
+              return {} as never
+            }),
+          )
+          expect(started).toBe(true)
+        }),
+      { git: true },
+    ))
+
   it.live("cleans directory tracking after deferred disposeDirectory completes", () =>
     provideTmpdirInstance(
       (directory) =>

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -273,7 +273,37 @@ describe("SessionRunState", () => {
       expect(captured).toBeUndefined()
       yield* Deferred.succeed(release, undefined)
       expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+      yield* Effect.sleep("20 millis")
+      expect(Instance.directories()).not.toContain(first)
+      expect(Instance.directories()).not.toContain(second)
     }))
+
+  it.live("cleans directory tracking after deferred disposeDirectory completes", () =>
+    provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_dispose_directory_tracking"),
+              () => Effect.succeed({} as never),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          expect(Instance.directories()).toContain(directory)
+          yield* Effect.promise(() => Instance.disposeDirectory(directory))
+          expect(Instance.directories()).toContain(directory)
+
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          yield* Effect.sleep("20 millis")
+          expect(Instance.directories()).not.toContain(directory)
+        }),
+      { git: true },
+    ))
 
   it.live("defers instance reload while a run is active", () => {
     let captured: unknown
@@ -302,10 +332,65 @@ describe("SessionRunState", () => {
           expect(captured).toBeUndefined()
           yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          yield* Effect.gen(function* () {
+            const nextRun = yield* SessionRunState.Service
+            let started = false
+            yield* nextRun.ensureRunning(
+              SessionID.make("ses_reload_after_idle"),
+              () => Effect.succeed({} as never),
+              Effect.sync(() => {
+                started = true
+                return {} as never
+              }),
+            )
+            expect(started).toBe(true)
+          }).pipe(provideInstance(directory))
         }),
       { git: true },
     )
   })
+
+  it.live("blocks new runs while a maintenance close is already in progress", () =>
+    provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const disposeStarted = yield* Deferred.make<void>()
+          const releaseDispose = yield* Deferred.make<void>()
+          const state = Instance.state(
+            () => ({ ready: true }),
+            async () => {
+              Effect.runPromise(Deferred.succeed(disposeStarted, undefined)).catch(() => undefined)
+              await Effect.runPromise(Deferred.await(releaseDispose))
+            },
+          )
+          state()
+
+          const disposeFiber = yield* Effect.promise(() => Instance.disposeAll()).pipe(Effect.forkChild)
+          yield* Deferred.await(disposeStarted)
+
+          let started = false
+          const runFiber = yield* Effect.gen(function* () {
+            const run = yield* SessionRunState.Service
+            return yield* run.ensureRunning(
+              SessionID.make("ses_close_race"),
+              () => Effect.succeed({} as never),
+              Effect.sync(() => {
+                started = true
+                return "ran" as never
+              }),
+            )
+          }).pipe(provideInstance(directory), Effect.forkChild)
+
+          yield* Effect.sleep("20 millis")
+          expect(started).toBe(false)
+
+          yield* Deferred.succeed(releaseDispose, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(disposeFiber))).toBe(true)
+          expect(Exit.isSuccess(yield* Fiber.await(runFiber))).toBe(true)
+          expect(started).toBe(true)
+        }),
+      { git: true },
+    ))
 
   it.live("defers Config.update while a run is active", () => {
     let captured: unknown
@@ -341,6 +426,10 @@ describe("SessionRunState", () => {
 
   it.live("defers Config.invalidate while a run is active", () => {
     let captured: unknown
+    const seen: { payload: { type: string } }[] = []
+    const onEvent = (event: { payload: { type: string } }) => {
+      seen.push(event)
+    }
 
     return provideTmpdirInstance(
       () =>
@@ -359,13 +448,19 @@ describe("SessionRunState", () => {
             )
             .pipe(Effect.forkChild)
 
+          yield* Effect.sync(() => GlobalBus.on("event", onEvent))
+          yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", onEvent)))
           yield* Effect.sleep("10 millis")
-          yield* Effect.promise(() => Config.invalidate(true))
+          const invalidateFiber = yield* Effect.promise(() => Config.invalidate(true)).pipe(Effect.forkChild)
 
           yield* Effect.sleep("20 millis")
           expect(captured).toBeUndefined()
+          expect(seen.some((event) => event.payload.type === "global.disposed")).toBe(false)
           yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+          expect(Exit.isSuccess(yield* Fiber.await(invalidateFiber))).toBe(true)
+          yield* Effect.sleep("20 millis")
+          expect(seen.some((event) => event.payload.type === "global.disposed")).toBe(true)
         }),
       { git: true },
     )

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Exit, Fiber, Layer } from "effect"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Hono } from "hono"
+import { GlobalBus } from "../../src/bus/global"
 import { Config } from "../../src/config"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -15,7 +16,7 @@ import {
 } from "../../src/session/lifecycle-provenance"
 import { SessionRunState } from "../../src/session/run-state"
 import { SessionID } from "../../src/session/schema"
-import { provideTmpdirInstance, tmpdir } from "../fixture/fixture"
+import { provideInstance, provideTmpdirInstance, tmpdir, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, SessionRunState.defaultLayer))
@@ -87,7 +88,7 @@ describe("SessionRunState", () => {
     expect(action.affectedDirectoryKeys).toHaveLength(1)
   })
 
-  it.live("annotates runner interrupts caused by instance disposal with lifecycle provenance", () => {
+  it.live("annotates runner interrupts caused by force instance disposal with lifecycle provenance", () => {
     let captured:
       | {
           source?: string
@@ -119,7 +120,7 @@ describe("SessionRunState", () => {
             .pipe(Effect.forkChild)
 
           yield* Effect.sleep("10 millis")
-          yield* Effect.promise(() => Instance.dispose())
+          yield* Effect.promise(() => Instance.dispose({ mode: "force" }))
 
           const exit = yield* Fiber.await(fiber)
           expect(Exit.isSuccess(exit)).toBe(true)
@@ -140,11 +141,11 @@ describe("SessionRunState", () => {
     )
   })
 
-  it.live("fans out one disposeAll lifecycle action to multiple in-flight runs", () => {
+  it.live("allows force disposeAll to interrupt multiple in-flight runs", () => {
     const captured = new Map<string, { lifecycleActionID?: string; lifecycleKind?: string } | undefined>()
 
     return provideTmpdirInstance(
-      () =>
+      (directory) =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
           const firstID = SessionID.make("ses_dispose_all_first")
@@ -166,10 +167,11 @@ describe("SessionRunState", () => {
           const secondFiber = yield* start(secondID)
 
           yield* Effect.sleep("10 millis")
-          yield* Effect.promise(() => Instance.disposeAll())
+          const result = yield* Effect.promise(() => Instance.disposeAll({ mode: "force" }))
 
           expect(Exit.isSuccess(yield* Fiber.await(firstFiber))).toBe(true)
           expect(Exit.isSuccess(yield* Fiber.await(secondFiber))).toBe(true)
+          expect(result.status).toBe("completed")
 
           const first = captured.get(firstID)
           const second = captured.get(secondID)
@@ -182,18 +184,19 @@ describe("SessionRunState", () => {
     )
   })
 
-  it.live("annotates global dispose interrupts with request origin", () => {
-    let captured:
-      | {
-          lifecycleKind?: string
-          lifecycleOrigin?: { source: string; operation?: string; reason?: string }
-        }
-      | undefined
+  it.live("defers global dispose while a run is active", () => {
+    let captured: unknown
+    let responseBody: unknown
+    const seen: { payload: { type: string } }[] = []
+    const onEvent = (event: { payload: { type: string } }) => {
+      seen.push(event)
+    }
 
     return provideTmpdirInstance(
-      () =>
+      (directory) =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
           const fiber = yield* run
             .ensureRunning(
               SessionID.make("ses_global_dispose_origin"),
@@ -202,10 +205,12 @@ describe("SessionRunState", () => {
                   captured = meta
                   return {} as never
                 }),
-              Effect.never,
+              Deferred.await(release).pipe(Effect.as({} as never)),
             )
             .pipe(Effect.forkChild)
 
+          yield* Effect.sync(() => GlobalBus.on("event", onEvent))
+          yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", onEvent)))
           yield* Effect.sleep("10 millis")
           yield* Effect.promise(async () => {
             const app = new Hono().route("/global", GlobalRoutes())
@@ -217,38 +222,99 @@ describe("SessionRunState", () => {
               },
             })
             expect(response.status).toBe(200)
+            responseBody = await response.json()
           })
 
+          yield* Effect.sleep("20 millis")
+          expect(captured).toBeUndefined()
+          expect(seen.some((event) => event.payload.type === "global.disposed")).toBe(false)
+          yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
-          expect(captured).toMatchObject({
-            lifecycleKind: "instance_dispose_all",
-            lifecycleOrigin: {
-              source: "server_handler",
-              operation: "instance.disposeAll",
-              reason: "global.dispose.button",
-            },
-            lifecycleRequest: {
-              method: "POST",
-              path: "/global/dispose",
-              source: "renderer",
-              client_action: {
-                id: "client-global-dispose",
-                kind: "global.dispose.button",
-              },
-            },
-          })
+          expect(responseBody).toMatchObject({ status: "deferred" })
+          yield* Effect.sleep("20 millis")
+          expect(seen.some((event) => event.payload.type === "global.disposed")).toBe(true)
         }),
       { git: true },
     )
   })
 
-  it.live("annotates Config.update interrupts with config origin", () => {
-    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+  it.live("defers disposeAll across all loaded directories when any directory has an active run", () =>
+    Effect.gen(function* () {
+      const first = yield* tmpdirScoped({ git: true })
+      const second = yield* tmpdirScoped({ git: true })
+      const release = yield* Deferred.make<void>()
+      let captured: unknown
+
+      const fiber = yield* Effect.gen(function* () {
+        const run = yield* SessionRunState.Service
+        return yield* run.ensureRunning(
+          SessionID.make("ses_dispose_all_global_scope"),
+          (meta) =>
+            Effect.sync(() => {
+              captured = meta
+              return {} as never
+            }),
+          Deferred.await(release).pipe(Effect.as({} as never)),
+        )
+      }).pipe(provideInstance(first), Effect.forkChild)
+
+      yield* Effect.promise(() =>
+        Instance.provide({
+          directory: second,
+          fn: () => undefined,
+        }),
+      )
+
+      yield* Effect.sleep("10 millis")
+      const result = yield* Effect.promise(() => Instance.disposeAll())
+      expect(result.status).toBe("deferred")
+
+      yield* Effect.sleep("20 millis")
+      expect(captured).toBeUndefined()
+      yield* Deferred.succeed(release, undefined)
+      expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+    }))
+
+  it.live("defers instance reload while a run is active", () => {
+    let captured: unknown
+
+    return provideTmpdirInstance(
+      (directory) =>
+        Effect.gen(function* () {
+          const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
+          const fiber = yield* run
+            .ensureRunning(
+              SessionID.make("ses_reload_deferred"),
+              (meta) =>
+                Effect.sync(() => {
+                  captured = meta
+                  return {} as never
+                }),
+              Deferred.await(release).pipe(Effect.as({} as never)),
+            )
+            .pipe(Effect.forkChild)
+
+          yield* Effect.sleep("10 millis")
+          yield* Effect.promise(() => Instance.reload({ directory }))
+
+          yield* Effect.sleep("20 millis")
+          expect(captured).toBeUndefined()
+          yield* Deferred.succeed(release, undefined)
+          expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+        }),
+      { git: true },
+    )
+  })
+
+  it.live("defers Config.update while a run is active", () => {
+    let captured: unknown
 
     return provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
           const fiber = yield* run
             .ensureRunning(
               SessionID.make("ses_config_update_origin"),
@@ -257,31 +323,30 @@ describe("SessionRunState", () => {
                   captured = meta
                   return {} as never
                 }),
-              Effect.never,
+              Deferred.await(release).pipe(Effect.as({} as never)),
             )
             .pipe(Effect.forkChild)
 
           yield* Effect.sleep("10 millis")
           yield* Effect.promise(() => Config.update({ username: "config-update-origin" }))
 
+          yield* Effect.sleep("20 millis")
+          expect(captured).toBeUndefined()
+          yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
-          expect(captured?.lifecycleOrigin).toMatchObject({
-            source: "config",
-            operation: "config.update",
-            reason: "config.update",
-          })
         }),
       { git: true },
     )
   })
 
-  it.live("annotates Config.invalidate interrupts with config origin", () => {
-    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+  it.live("defers Config.invalidate while a run is active", () => {
+    let captured: unknown
 
     return provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
           const fiber = yield* run
             .ensureRunning(
               SessionID.make("ses_config_invalidate_origin"),
@@ -290,31 +355,30 @@ describe("SessionRunState", () => {
                   captured = meta
                   return {} as never
                 }),
-              Effect.never,
+              Deferred.await(release).pipe(Effect.as({} as never)),
             )
             .pipe(Effect.forkChild)
 
           yield* Effect.sleep("10 millis")
           yield* Effect.promise(() => Config.invalidate(true))
 
+          yield* Effect.sleep("20 millis")
+          expect(captured).toBeUndefined()
+          yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
-          expect(captured?.lifecycleOrigin).toMatchObject({
-            source: "config",
-            operation: "config.invalidate",
-            reason: "config.invalidate",
-          })
         }),
       { git: true },
     )
   })
 
-  it.live("annotates Config.updateGlobal interrupts with config origin", () => {
-    let captured: { lifecycleOrigin?: { source: string; operation?: string; reason?: string } } | undefined
+  it.live("defers Config.updateGlobal invalidation while a run is active", () => {
+    let captured: unknown
 
     return provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
+          const release = yield* Deferred.make<void>()
           const fiber = yield* run
             .ensureRunning(
               SessionID.make("ses_config_update_global_origin"),
@@ -323,7 +387,7 @@ describe("SessionRunState", () => {
                   captured = meta
                   return {} as never
                 }),
-              Effect.never,
+              Deferred.await(release).pipe(Effect.as({} as never)),
             )
             .pipe(Effect.forkChild)
 
@@ -339,12 +403,10 @@ describe("SessionRunState", () => {
             }
           })
 
+          yield* Effect.sleep("20 millis")
+          expect(captured).toBeUndefined()
+          yield* Deferred.succeed(release, undefined)
           expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
-          expect(captured?.lifecycleOrigin).toMatchObject({
-            source: "config",
-            operation: "config.updateGlobal",
-            reason: "config.updateGlobal",
-          })
         }),
       { git: true },
     )

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2412,7 +2412,11 @@ export type GlobalDisposeResponses = {
   /**
    * Global disposed
    */
-  200: boolean
+  200: {
+    status: "completed" | "deferred"
+    lifecycleActionID: string
+    affectedDirectoryKeys: Array<string>
+  }
 }
 
 export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]


### PR DESCRIPTION
## Summary

Fixes active assistant runs being interrupted by local lifecycle maintenance closes.

- Tracks active runs by directory while runner work is executing.
- Defers maintenance lifecycle closes (`disposeAll`, config invalidation, reload, dispose) until affected directories are idle.
- Preserves force cleanup for shutdown / teardown / explicit force paths.
- Changes `global.dispose` from `boolean` to a structured `completed` / `deferred` result and updates the generated SDK type.
- Updates provider connect/disconnect to show pending-refresh copy when provider refresh is deferred.

## Why

Issue #898 showed that provider connect, config refresh, or instance reload could close `InstanceState` while an assistant turn was still running. Because `SessionRunState` lived under that disposable state, the run finalizer cancelled the active runner and surfaced as misleading failed tool cards.

The fix moves the lifecycle decision to the central instance close seam: normal maintenance waits for active runs; force cleanup still works.

## Related Issue

Closes #898

## Human Review Status

Approved by maintainer

## Review Focus

- Whether the maintenance vs force boundary is clear enough for future lifecycle callers.
- Whether deferred `global.dispose` semantics are acceptable for provider connect/disconnect and config refresh.
- Whether the active-run tracking belongs in the current lifecycle provenance module or should be split into a dedicated coordinator in a follow-up.

## Risk Notes

- Maintenance refreshes can now apply after the current run finishes instead of immediately. Provider/config changes should affect the next turn, not the active one.
- `global.dispose` response shape changed from `boolean` to `{ status, lifecycleActionID, affectedDirectoryKeys }`; generated SDK v2 types were updated.
- Visible provider toast copy changed for deferred refresh; source-boundary tests cover the branch, and `app-shell` snap was run as the available visual smoke target.
- Platform-specific packaging/updater/signing paths were not touched.

## How To Verify

```text
Focused lifecycle tests: 41 passed
- bun test test/session/run-state.test.ts test/project/instance-store.test.ts test/effect/instance-state.test.ts test/server/project-init-git.test.ts

Review follow-up coverage:
- Deferred reload waits for active run idle before replacing state.
- Deferred dispose clears Instance.directories() after actual completion.
- Config.invalidate emits global.disposed only after actual deferred close.
- New runs wait while a maintenance close is in progress.
- Multi-runtime disposeAll aggregates affected directory keys.
- Cancelled runs waiting for lifecycle close do not leave phantom active-run markers.
- Multi-runtime disposeAll runs caller onCompleted once after every store closes.
- Deferred disposeDirectory/reload failures are logged with lifecycle action metadata and do not leave close state active.
- Deferred disposeAll/global dispose failures are logged, reject completion when awaited, do not emit completion, and do not leave close state active.
- Prompt busy/queued caller regression checks pass after restoring InstanceState directory lookup.

Provider wiring tests: 7 passed
- bun test src/components/dialog-connect-provider-source.test.ts src/context/global-sync/client-action-source.test.ts

Typecheck:
- packages/opencode: bun run typecheck passed
- packages/app: bun run typecheck passed
- packages/sdk/js: bun run typecheck passed

SDK generation:
- packages/sdk/js: bun run build passed and updated v2 generated dispose response type

Diff hygiene:
- git diff --check passed

Visual smoke:
- bun run snap app-shell passed and wrote docs/design/preview/screenshots/app-shell.png
```

## Screenshots or Recordings

`bun run snap app-shell` passed. The changed deferred provider toast branch is state-dependent and covered by source-boundary tests rather than a dedicated snap fixture in this PR.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider connection and disconnection now display deferred status messages when model refresh completion is deferred until after the current run finishes.
  * Added translations for deferred provider status messages in English and Chinese.

* **Refactor**
  * Enhanced system lifecycle management to support deferring operations while active tasks are running with improved coordination between ongoing work and system maintenance.

* **Tests**
  * Extended test coverage for deferred disposal behavior and lifecycle handling across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->