### PR TITLE
fix(app): remove titlebar toggle selected chip

### DIFF
--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -27,36 +27,44 @@ test.describe("titlebar right rail contract", () => {
     await gotoSession()
 
     const sidebarToggle = page.locator('[data-action="pawwork-sidebar-toggle"]')
+    const rightPanelToggle = page.getByRole("button", { name: "Right utility panel" })
     if ((await sidebarToggle.getAttribute("aria-expanded")) !== "true") {
       await sidebarToggle.click()
     }
+    await expect(sidebarToggle).toHaveAttribute("aria-expanded", "true")
     await openRightPanel(page)
+    await expect(rightPanelToggle).toHaveAttribute("aria-expanded", "true")
     await page.mouse.move(400, 200)
+
+    const backgroundAlpha = (selector: string) =>
+      page.evaluate((target) => {
+        const el = document.querySelector<HTMLElement>(target)
+        if (!el) return null
+        const bg = getComputedStyle(el).backgroundColor
+        const rgba = bg.match(/^rgba\((.+)\)$/)
+        if (!rgba) return bg.startsWith("rgb(") ? 1 : null
+        const parts = rgba[1].split(",").map((part) => part.trim())
+        return Number(parts[3])
+      }, selector)
 
     await expect
       .poll(
-        () =>
-          page.evaluate(() => {
-            const alpha = (selector: string) => {
-              const el = document.querySelector<HTMLElement>(selector)
-              if (!el) return null
-              const bg = getComputedStyle(el).backgroundColor
-              const rgba = bg.match(/^rgba\((.+)\)$/)
-              if (!rgba) return bg.startsWith("rgb(") ? 1 : null
-              const parts = rgba[1].split(",").map((part) => part.trim())
-              return Number(parts[3])
-            }
-            return {
-              sidebar: alpha('[data-action="pawwork-sidebar-toggle"]'),
-              rightPanel: alpha('button[aria-label="Right utility panel"]'),
-            }
-          }),
+        async () => ({
+          sidebar: await backgroundAlpha('[data-action="pawwork-sidebar-toggle"]'),
+          rightPanel: await backgroundAlpha('button[aria-label="Right utility panel"]'),
+        }),
         { timeout: 2_000 },
       )
       .toEqual({
         sidebar: 0,
         rightPanel: 0,
       })
+
+    await sidebarToggle.hover()
+    await expect.poll(() => backgroundAlpha('[data-action="pawwork-sidebar-toggle"]')).toBeGreaterThan(0)
+
+    await rightPanelToggle.hover()
+    await expect.poll(() => backgroundAlpha('button[aria-label="Right utility panel"]')).toBeGreaterThan(0)
   })
 
   test("right utility toggle stays clickable with the full tab set open", async ({

--- a/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
+++ b/packages/app/e2e/session/titlebar-right-rail-contract.spec.ts
@@ -20,6 +20,45 @@ import { modKey } from "../utils"
 //     selection overlay, 4pt grid pinning)
 
 test.describe("titlebar right rail contract", () => {
+  test("expanded titlebar toggles change icon shape without selected-chip background", async ({
+    page,
+    gotoSession,
+  }) => {
+    await gotoSession()
+
+    const sidebarToggle = page.locator('[data-action="pawwork-sidebar-toggle"]')
+    if ((await sidebarToggle.getAttribute("aria-expanded")) !== "true") {
+      await sidebarToggle.click()
+    }
+    await openRightPanel(page)
+    await page.mouse.move(400, 200)
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const alpha = (selector: string) => {
+              const el = document.querySelector<HTMLElement>(selector)
+              if (!el) return null
+              const bg = getComputedStyle(el).backgroundColor
+              const rgba = bg.match(/^rgba\((.+)\)$/)
+              if (!rgba) return bg.startsWith("rgb(") ? 1 : null
+              const parts = rgba[1].split(",").map((part) => part.trim())
+              return Number(parts[3])
+            }
+            return {
+              sidebar: alpha('[data-action="pawwork-sidebar-toggle"]'),
+              rightPanel: alpha('button[aria-label="Right utility panel"]'),
+            }
+          }),
+        { timeout: 2_000 },
+      )
+      .toEqual({
+        sidebar: 0,
+        rightPanel: 0,
+      })
+  })
+
   test("right utility toggle stays clickable with the full tab set open", async ({
     page,
     gotoSession,

--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -18,10 +18,10 @@ test("desktop right-panel toggle opens the status tab by default", async ({ page
   // Servers/MCP/LSP/Plugins render as collapsible SectionRow `<button aria-expanded>`
   // inside the Status panel body (see SessionStatusConnections.SectionRow) —
   // not as `role="tab"`. Mobile still uses tabs in the popover (separate test below).
-  await expect(rightPanel.getByRole("button", { name: /servers/i })).toBeVisible()
-  await expect(rightPanel.getByRole("button", { name: /mcp/i })).toBeVisible()
-  await expect(rightPanel.getByRole("button", { name: /lsp/i })).toBeVisible()
-  await expect(rightPanel.getByRole("button", { name: /plugins/i })).toBeVisible()
+  await expect(rightPanel.getByRole("button", { name: /^Servers\b/i })).toBeVisible()
+  await expect(rightPanel.getByRole("button", { name: /^MCP\b/i })).toBeVisible()
+  await expect(rightPanel.getByRole("button", { name: /^LSP\b/i })).toBeVisible()
+  await expect(rightPanel.getByRole("button", { name: /^Plugins\b/i })).toBeVisible()
 })
 
 test("session status panel can expand mcp section", async ({ page, gotoSession }) => {
@@ -57,10 +57,34 @@ test("mobile session status button still opens the status popover", async ({ pag
   await page.setViewportSize({ width: 390, height: 844 })
   await gotoSession()
 
-  const statusButton = page.getByRole("button", { name: "Status" }).first()
+  const statusButton = page.locator('[data-action="pawwork-status-popover-toggle"]')
   const popoverBody = page.locator('[data-slot="popover-body"]').filter({ has: page.locator('[data-component="tabs"]') })
 
   await statusButton.click()
+  await expect(statusButton).toHaveAttribute("aria-expanded", "true")
   await expect(popoverBody).toBeVisible()
   await expect(popoverBody.getByRole("tab", { name: /servers/i })).toBeVisible()
+
+  const expandedStyles = await statusButton.evaluate((el) => {
+    const icon = el.querySelector<HTMLElement>('[data-slot="icon-svg"]')
+    const style = getComputedStyle(el)
+    const probe = document.createElement("div")
+    probe.style.backgroundColor = style.getPropertyValue("--surface-base")
+    probe.style.color = style.getPropertyValue("--icon-strong")
+    document.body.appendChild(probe)
+    const expected = {
+      background: getComputedStyle(probe).backgroundColor,
+      iconColor: getComputedStyle(probe).color,
+    }
+    probe.remove()
+    return {
+      expected,
+      actual: {
+        background: style.backgroundColor,
+        iconColor: icon ? getComputedStyle(icon).color : null,
+      },
+    }
+  })
+  expect(expandedStyles.actual.background).not.toBe("rgba(0, 0, 0, 0)")
+  expect(expandedStyles.actual.iconColor).toBe(expandedStyles.expected.iconColor)
 })

--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -64,27 +64,29 @@ test("mobile session status button still opens the status popover", async ({ pag
   await expect(statusButton).toHaveAttribute("aria-expanded", "true")
   await expect(popoverBody).toBeVisible()
   await expect(popoverBody.getByRole("tab", { name: /servers/i })).toBeVisible()
+  await page.mouse.move(10, 500, { steps: 5 })
 
-  const expandedStyles = await statusButton.evaluate((el) => {
-    const icon = el.querySelector<HTMLElement>('[data-slot="icon-svg"]')
-    const style = getComputedStyle(el)
-    const probe = document.createElement("div")
-    probe.style.backgroundColor = style.getPropertyValue("--surface-base")
-    probe.style.color = style.getPropertyValue("--icon-strong")
-    document.body.appendChild(probe)
-    const expected = {
-      background: getComputedStyle(probe).backgroundColor,
-      iconColor: getComputedStyle(probe).color,
-    }
-    probe.remove()
-    return {
-      expected,
-      actual: {
-        background: style.backgroundColor,
-        iconColor: icon ? getComputedStyle(icon).color : null,
-      },
-    }
-  })
-  expect(expandedStyles.actual.background).not.toBe("rgba(0, 0, 0, 0)")
-  expect(expandedStyles.actual.iconColor).toBe(expandedStyles.expected.iconColor)
+  const expandedStyles = () =>
+    statusButton.evaluate((el) => {
+      const icon = el.querySelector<HTMLElement>('[data-slot="icon-svg"]')
+      const style = getComputedStyle(el)
+      const probe = document.createElement("div")
+      probe.style.backgroundColor = style.getPropertyValue("--surface-base")
+      probe.style.color = style.getPropertyValue("--icon-strong")
+      document.body.appendChild(probe)
+      const expected = {
+        background: getComputedStyle(probe).backgroundColor,
+        iconColor: getComputedStyle(probe).color,
+      }
+      probe.remove()
+      return {
+        expected,
+        actual: {
+          background: style.backgroundColor,
+          iconColor: icon ? getComputedStyle(icon).color : null,
+        },
+      }
+    })
+  const expectedStyles = (await expandedStyles()).expected
+  await expect.poll(async () => (await expandedStyles()).actual).toEqual(expectedStyles)
 })

--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -29,6 +29,7 @@ export function StatusPopover() {
       triggerProps={{
         variant: "ghost",
         class: "titlebar-icon w-8 h-[30px] p-0 box-border",
+        "data-action": "pawwork-status-popover-toggle",
         "aria-label": language.t("status.popover.trigger"),
         style: { scale: 1 },
       }}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -150,7 +150,10 @@
   }
 
   [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"]
-    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-expanded="true"] {
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"]:is(
+      [data-action="pawwork-sidebar-toggle"],
+      [aria-controls="right-panel"]
+    )[aria-expanded="true"]:not(:hover):not(:active) {
     background-color: transparent;
   }
 

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -149,6 +149,11 @@
     background-color: var(--surface-sunken);
   }
 
+  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"]
+    :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"][aria-expanded="true"] {
+    background-color: transparent;
+  }
+
   [data-component="desktop-shell-main"][data-shell="desktop"][data-shell-os="macos"] {
     border-top-width: 0;
   }

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -78,20 +78,23 @@
 
 /* titlebar-icon: 32×30 non-square, DESIGN.md §346.
    Lives in icon-button.css for historical reasons but is intentionally NOT
-   scoped to `[data-component="icon-button"]` — the four titlebar usages in
-   `titlebar.tsx` + `session-header.tsx` render `<Button variant="ghost">`
-   (data-component="button"), not `<IconButton>`. The class name carries the
-   titlebar sizing + expanded-icon contract; the selector should not narrow it. */
+   scoped to `[data-component="icon-button"]` — the live titlebar toggles render
+   `<Button variant="ghost">` (data-component="button"), not `<IconButton>`.
+   Expanded state is visualized by icon shape only; idle state has no selected
+   chip, while hover/press feedback still comes from the normal ghost button
+   rules. */
 .titlebar-icon {
   width: 32px;
   height: 30px;
   aspect-ratio: auto;
 }
 
-.titlebar-icon[data-variant="ghost"][aria-expanded="true"] {
-  background-color: transparent;
-
+.titlebar-icon[data-variant="ghost"]:is([data-action="pawwork-sidebar-toggle"], [aria-controls="right-panel"])[aria-expanded="true"] {
   [data-slot="icon-svg"] {
     color: var(--icon-strong);
   }
+}
+
+.titlebar-icon[data-variant="ghost"]:is([data-action="pawwork-sidebar-toggle"], [aria-controls="right-panel"])[aria-expanded="true"]:not(:hover):not(:active) {
+  background-color: transparent;
 }

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -80,24 +80,18 @@
    Lives in icon-button.css for historical reasons but is intentionally NOT
    scoped to `[data-component="icon-button"]` — the four titlebar usages in
    `titlebar.tsx` + `session-header.tsx` render `<Button variant="ghost">`
-   (data-component="button"), not `<IconButton>`. Scoping to icon-button
-   silently dropped the `aria-expanded` selected-state chip on the sidebar
-   toggle and Right utility panel toggle. The class name carries the contract;
-   the selector should not narrow it. */
+   (data-component="button"), not `<IconButton>`. The class name carries the
+   titlebar sizing + expanded-icon contract; the selector should not narrow it. */
 .titlebar-icon {
   width: 32px;
   height: 30px;
   aspect-ratio: auto;
 }
 
-.titlebar-icon[aria-expanded="true"] {
-  background-color: var(--surface-base);
+.titlebar-icon[data-variant="ghost"][aria-expanded="true"] {
+  background-color: transparent;
 
   [data-slot="icon-svg"] {
     color: var(--icon-strong);
-  }
-
-  &:hover:not(:disabled) {
-    background-color: var(--surface-base);
   }
 }

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -98,3 +98,11 @@
 .titlebar-icon[data-variant="ghost"]:is([data-action="pawwork-sidebar-toggle"], [aria-controls="right-panel"])[aria-expanded="true"]:not(:hover):not(:active) {
   background-color: transparent;
 }
+
+.titlebar-icon[data-variant="ghost"][data-action="pawwork-status-popover-toggle"][aria-expanded="true"] {
+  background-color: var(--surface-base);
+
+  [data-slot="icon-svg"] {
+    color: var(--icon-strong);
+  }
+}


### PR DESCRIPTION
## Summary

Remove the selected-chip background from the titlebar sidebar toggle and right utility panel toggle when they are expanded. There is no standalone issue; this is a direct regression follow-up from the titlebar toggle visual contract restored in PR #880.

## Why

The titlebar sidebar/right-panel toggles should express their expanded state by switching icon shape only. PR #880 broadened the `.titlebar-icon[aria-expanded="true"]` rule so these `<Button variant="ghost">` callsites started receiving a selected background chip. That made the sidebar toggle look selected in both light and dark mode.

StatusPopover previously also inherited PR #880's expanded chip through the same broad selector. This PR keeps that StatusPopover contract explicit with a dedicated data hook instead of relying on every expanded `.titlebar-icon` sharing one visual rule.

## Related Issue

No standalone issue — direct regression follow-up from PR #880.

## Human Review Status

Pending

## Review Focus

Please review the CSS specificity boundary around `titlebar-icon`:

- sidebar toggle and right utility panel toggle: expanded idle state keeps the stronger icon color but no persistent selected-chip background; normal hover/press feedback remains visible.
- StatusPopover fallback: expanded state keeps the PR #880 selected-chip / strong-icon treatment via `data-action="pawwork-status-popover-toggle"`.

## Risk Notes

Low. This is CSS plus E2E regression assertions for the titlebar toggles and StatusPopover fallback. The titlebar toggle test now first asserts both toggles are actually expanded, checks idle background is transparent, and checks hover feedback is still visible. The StatusPopover test covers the mobile/non-desktop fallback path that still renders the popover trigger.

During Electron verification, `dev:desktop` regenerated `packages/opencode/src/provider/models-snapshot.js`; that unrelated generated file was restored and is not part of this PR.

## How To Verify

```text
bun install --frozen-lockfile → installed this worktree's dependencies
bun run --filter=@opencode-ai/app test:e2e session/titlebar-right-rail-contract.spec.ts -g "expanded titlebar toggles" → 1 passed
bun run --filter=@opencode-ai/app test:e2e session/titlebar-right-rail-contract.spec.ts → 9 passed
bun run --filter=@opencode-ai/app test:e2e status/status-popover.spec.ts → 4 passed
bun run --filter=@opencode-ai/app snap right-panel-titlebar → 1 passed; reviewed the light/dark grid locally
bun run dev:desktop → manually verified in the Electron window that the sidebar toggle and right utility panel toggle only change icon shape in expanded idle state, with no persistent selected-chip background
git diff --check → no whitespace errors
```

## Screenshots or Recordings

Generated and reviewed locally with `bun run --filter=@opencode-ai/app snap right-panel-titlebar`:

- `docs/design/preview/screenshots/right-panel-titlebar.png`

The light/dark grid shows both titlebar toggles without selected-chip backgrounds.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
