### PR TITLE
fix: dedupe discovered skill files

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -56,7 +56,6 @@ export namespace Skill {
   type State = {
     skills: Record<string, Info>
     dirs: Set<string>
-    matches: Set<string>
   }
 
   export interface Interface {
@@ -138,6 +137,7 @@ export namespace Skill {
 
   const scan = Effect.fnUntraced(function* (
     state: State,
+    scanned: Set<string>,
     bus: Bus.Interface,
     root: string,
     pattern: string,
@@ -163,8 +163,8 @@ export namespace Skill {
 
     const uniqueMatches: string[] = []
     for (const match of matches) {
-      if (state.matches.has(match)) continue
-      state.matches.add(match)
+      if (scanned.has(match)) continue
+      scanned.add(match)
       uniqueMatches.push(match)
     }
 
@@ -183,12 +183,14 @@ export namespace Skill {
     directory: string,
     worktree: string,
   ) {
+    const scanned = new Set<string>()
+
     if (!Flag.OPENCODE_DISABLE_EXTERNAL_SKILLS) {
       const externalDirs = [AGENTS_EXTERNAL_DIR]
       for (const dir of externalDirs) {
         const root = path.join(Global.Path.home, dir)
         if (!(yield* fsys.isDir(root))) continue
-        yield* scan(state, bus, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
+        yield* scan(state, scanned, bus, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
       }
 
       const upDirs = yield* fsys
@@ -196,18 +198,18 @@ export namespace Skill {
         .pipe(Effect.catch(() => Effect.succeed([] as string[])))
 
       for (const root of upDirs) {
-        yield* scan(state, bus, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
+        yield* scan(state, scanned, bus, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
       }
     }
 
     for (const root of builtinRoots()) {
       if (!(yield* fsys.isDir(root))) continue
-      yield* scan(state, bus, root, BUILTIN_SKILL_PATTERN, { scope: "builtin" })
+      yield* scan(state, scanned, bus, root, BUILTIN_SKILL_PATTERN, { scope: "builtin" })
     }
 
     const configDirs = yield* config.directories()
     for (const dir of configDirs) {
-      yield* scan(state, bus, dir, OPENCODE_SKILL_PATTERN)
+      yield* scan(state, scanned, bus, dir, OPENCODE_SKILL_PATTERN)
     }
 
     const cfg = yield* config.get()
@@ -219,14 +221,14 @@ export namespace Skill {
         continue
       }
 
-      yield* scan(state, bus, dir, SKILL_PATTERN)
+      yield* scan(state, scanned, bus, dir, SKILL_PATTERN)
     }
 
     for (const url of cfg.skills?.urls ?? []) {
       const pulledDirs = yield* discovery.pull(url)
       for (const dir of pulledDirs) {
         state.dirs.add(dir)
-        yield* scan(state, bus, dir, SKILL_PATTERN)
+        yield* scan(state, scanned, bus, dir, SKILL_PATTERN)
       }
     }
 
@@ -244,7 +246,7 @@ export namespace Skill {
       const fsys = yield* AppFileSystem.Service
       const state = yield* InstanceState.make(
         Effect.fn("Skill.state")(function* (ctx) {
-          const s: State = { skills: {}, dirs: new Set(), matches: new Set() }
+          const s: State = { skills: {}, dirs: new Set() }
           yield* loadSkills(s, config, discovery, bus, fsys, ctx.directory, ctx.worktree)
           return s
         }),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -169,7 +169,7 @@ export namespace Skill {
     }
 
     yield* Effect.forEach(uniqueMatches, (match) => add(state, match, bus), {
-      concurrency: "unbounded",
+      concurrency: 1,
       discard: true,
     })
   })

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -56,6 +56,7 @@ export namespace Skill {
   type State = {
     skills: Record<string, Info>
     dirs: Set<string>
+    matches: Set<string>
   }
 
   export interface Interface {
@@ -160,7 +161,14 @@ export namespace Skill {
       }),
     )
 
-    yield* Effect.forEach(matches, (match) => add(state, match, bus), {
+    const uniqueMatches: string[] = []
+    for (const match of matches) {
+      if (state.matches.has(match)) continue
+      state.matches.add(match)
+      uniqueMatches.push(match)
+    }
+
+    yield* Effect.forEach(uniqueMatches, (match) => add(state, match, bus), {
       concurrency: "unbounded",
       discard: true,
     })
@@ -236,7 +244,7 @@ export namespace Skill {
       const fsys = yield* AppFileSystem.Service
       const state = yield* InstanceState.make(
         Effect.fn("Skill.state")(function* (ctx) {
-          const s: State = { skills: {}, dirs: new Set() }
+          const s: State = { skills: {}, dirs: new Set(), matches: new Set() }
           yield* loadSkills(s, config, discovery, bus, fsys, ctx.directory, ctx.worktree)
           return s
         }),

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -328,6 +328,7 @@ description: A global skill from ~/.agents/skills for testing.
 })
 
 test("warns when different skill files declare the same name", async () => {
+  await using home = await tmpdir()
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
@@ -350,7 +351,9 @@ description: Duplicate skill name from ${folder}.
 
   const logger = Log.create({ service: "skill" })
   const originalWarn = logger.warn
+  const originalHome = process.env.OPENCODE_TEST_HOME
   const warnings: Array<{ message?: unknown; extra?: Record<string, unknown> }> = []
+  process.env.OPENCODE_TEST_HOME = home.path
   logger.warn = (message, extra) => {
     warnings.push({ message, extra })
   }
@@ -369,6 +372,8 @@ description: Duplicate skill name from ${folder}.
     expect(duplicateWarnings[0]!.extra?.existing).not.toBe(duplicateWarnings[0]!.extra?.duplicate)
   } finally {
     logger.warn = originalWarn
+    if (originalHome === undefined) delete process.env.OPENCODE_TEST_HOME
+    else process.env.OPENCODE_TEST_HOME = originalHome
   }
 })
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -4,6 +4,7 @@ import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
+import { Log } from "@opencode-ai/core/util/log"
 
 const processWithResourcesPath = process as NodeJS.Process & { resourcesPath?: string }
 
@@ -281,6 +282,48 @@ This skill is loaded from the global home directory.
     })
   } finally {
     process.env.OPENCODE_TEST_HOME = originalHome
+  }
+})
+
+test("does not warn when the same .agents skill is discovered globally and by walking up", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  const originalHome = process.env.OPENCODE_TEST_HOME
+  const logger = Log.create({ service: "skill" })
+  const originalWarn = logger.warn
+  const warnings: Array<{ message?: unknown; extra?: Record<string, unknown> }> = []
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  logger.warn = (message, extra) => {
+    warnings.push({ message, extra })
+  }
+
+  try {
+    const skillDir = path.join(tmp.path, ".agents", "skills", "global-agent-skill")
+    await fs.mkdir(skillDir, { recursive: true })
+    await Bun.write(
+      path.join(skillDir, "SKILL.md"),
+      `---
+name: global-agent-skill
+description: A global skill from ~/.agents/skills for testing.
+---
+
+# Global Agent Skill
+`,
+    )
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const skills = await Skill.all()
+        expect(skills.filter((item) => item.name === "global-agent-skill")).toHaveLength(1)
+      },
+    })
+
+    expect(warnings.filter((item) => item.message === "duplicate skill name")).toEqual([])
+  } finally {
+    logger.warn = originalWarn
+    if (originalHome === undefined) delete process.env.OPENCODE_TEST_HOME
+    else process.env.OPENCODE_TEST_HOME = originalHome
   }
 })
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -327,6 +327,51 @@ description: A global skill from ~/.agents/skills for testing.
   }
 })
 
+test("warns when different skill files declare the same name", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      for (const folder of ["shared-skill-a", "shared-skill-b"]) {
+        const skillDir = path.join(dir, ".agents", "skills", folder)
+        await fs.mkdir(skillDir, { recursive: true })
+        await Bun.write(
+          path.join(skillDir, "SKILL.md"),
+          `---
+name: shared-skill
+description: Duplicate skill name from ${folder}.
+---
+
+# Shared Skill
+`,
+        )
+      }
+    },
+  })
+
+  const logger = Log.create({ service: "skill" })
+  const originalWarn = logger.warn
+  const warnings: Array<{ message?: unknown; extra?: Record<string, unknown> }> = []
+  logger.warn = (message, extra) => {
+    warnings.push({ message, extra })
+  }
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const skill = await Skill.get("shared-skill")
+        expect(skill).toBeDefined()
+      },
+    })
+
+    const duplicateWarnings = warnings.filter((item) => item.message === "duplicate skill name")
+    expect(duplicateWarnings).toHaveLength(1)
+    expect(duplicateWarnings[0]!.extra?.existing).not.toBe(duplicateWarnings[0]!.extra?.duplicate)
+  } finally {
+    logger.warn = originalWarn
+  }
+})
+
 test("discovers skills from .agents/skills/ only", async () => {
   await using tmp = await tmpdir({
     git: true,


### PR DESCRIPTION
## Summary

- De-duplicate discovered skill file paths before registering skills.
- Add a regression test for the home `.agents` directory being discovered both globally and by upward walking.

## Why

When PawWork starts in a context where `~/.agents` is both the global external skill directory and an upward-discovered project `.agents` directory, the same `SKILL.md` path can be passed to registration twice. That produces misleading `duplicate skill name` warnings where `existing` and `duplicate` are identical paths.

The fix keeps duplicate-name warnings for different files with the same skill name, but makes repeated discovery of the same physical file idempotent.

## Related Issue

Fixes #904

## Human Review Status

Pending

## Review Focus

- Confirm the de-duplication is scoped to exact discovered `SKILL.md` paths.
- Confirm different files declaring the same skill name still flow through the existing duplicate-name warning path.
- Confirm review follow-up keeps the scan de-duplication set local to skill loading rather than long-lived state.

## Risk Notes

Skipped conditional checklist items:
- Visible UI or copy check: no visible UI or copy changed.
- macOS/Windows platform check: no platform, packaging, updater, signing, paths, shell, or permissions surface changed.
- Docs/release/dependency/permission/local-file check: no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surfaces changed.

## How To Verify

```text
RED: bun test test/skill/skill.test.ts
Result: failed for the predicted duplicate skill warning, with existing and duplicate pointing at the same SKILL.md path.

GREEN/refactor: bun test test/skill/skill.test.ts
Result: 17 passed, including the duplicate-discovery regression and different-file duplicate-name warning coverage.

Home isolation: bun test test/skill/skill.test.ts
Result: 17 passed; the duplicate-name warning test now creates its own empty OPENCODE_TEST_HOME fixture before loading skills.

Related downstream: bun test test/tool/skill.test.ts
Result: 4 passed.

Typecheck: bun run typecheck
Result: tsgo --noEmit completed successfully.

Diff check: git diff --cached --check
Result: no whitespace errors before commit.
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



