### PR TITLE
fix: coalesce dropped watcher rescans

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -22,7 +22,7 @@ declare const OPENCODE_LIBC: string | undefined
 export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
-  const RESCAN_DEDUPE_MS = 1_000
+  const RESCAN_QUIET_MS = 1_000
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
   const VCS_REFRESH_FILES = new Set(["HEAD", "index", "packed-refs"])
   const VCS_REFRESH_PREFIXES = ["refs/heads/", "refs/remotes/"]
@@ -79,12 +79,12 @@ export namespace FileWatcher {
     publish: (directory: string) => void
     schedule?: (callback: () => void) => (() => void) | void
   }) {
-    type RescanState = { dirty: boolean; cancel?: () => void }
+    type RescanState = { dirty: boolean; needsTrailing: boolean; cancel?: () => void }
     const pending = new Map<string, RescanState>()
     const schedule = (callback: () => void) => {
       const cancel = input.schedule?.(callback)
       if (cancel) return cancel
-      const timer = setTimeout(callback, RESCAN_DEDUPE_MS)
+      const timer = setTimeout(callback, RESCAN_QUIET_MS)
       return () => clearTimeout(timer)
     }
     let disposed = false
@@ -95,8 +95,13 @@ export namespace FileWatcher {
         if (disposed) return
         if (state.dirty) {
           state.dirty = false
-          input.publish(directory)
           arm(directory, state)
+          return
+        }
+        if (state.needsTrailing) {
+          state.needsTrailing = false
+          pending.delete(directory)
+          input.publish(directory)
           return
         }
         pending.delete(directory)
@@ -109,10 +114,11 @@ export namespace FileWatcher {
         const state = pending.get(directory)
         if (state) {
           state.dirty = true
+          state.needsTrailing = true
           return
         }
 
-        const next = { dirty: false }
+        const next = { dirty: false, needsTrailing: false }
         pending.set(directory, next)
         input.publish(directory)
         arm(directory, next)
@@ -181,7 +187,7 @@ export namespace FileWatcher {
                 )
               },
               schedule: (callback) => {
-                const timer = setTimeout(() => Instance.restore(ctx, callback), RESCAN_DEDUPE_MS)
+                const timer = setTimeout(() => Instance.restore(ctx, callback), RESCAN_QUIET_MS)
                 return () => clearTimeout(timer)
               },
             })

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -11,7 +11,7 @@ describe("FileWatcher error handling", () => {
     expect(FileWatcher.isDroppedEventsError(new Error("permission denied"))).toBe(false)
   })
 
-  test("publishes a trailing rescan when dropped-event errors repeat inside the dedupe window", () => {
+  test("publishes a trailing rescan after repeated dropped-event errors go quiet", () => {
     const published: string[] = []
     const scheduled: Array<() => void> = []
     const scheduler = FileWatcher.createRescanScheduler({
@@ -31,12 +31,60 @@ describe("FileWatcher error handling", () => {
 
     scheduled[0]?.()
 
-    expect(published).toEqual(["/repo", "/repo"])
+    expect(published).toEqual(["/repo"])
     expect(scheduled).toHaveLength(2)
 
     scheduled[1]?.()
 
     expect(published).toEqual(["/repo", "/repo"])
+  })
+
+  test("coalesces dropped-event errors that keep arriving at the quiet-window boundary", () => {
+    const published: string[] = []
+    const scheduled: Array<() => void> = []
+    const scheduler = FileWatcher.createRescanScheduler({
+      publish: (directory) => {
+        published.push(directory)
+      },
+      schedule: (callback) => {
+        scheduled.push(callback)
+      },
+    })
+
+    scheduler.request("/repo")
+
+    for (let index = 0; index < 6; index++) {
+      scheduler.request("/repo")
+      scheduled[index]?.()
+    }
+
+    scheduled[6]?.()
+
+    expect(published).toEqual(["/repo", "/repo"])
+  })
+
+  test("keeps synchronous requests published during a trailing rescan", () => {
+    const published: string[] = []
+    const scheduled: Array<() => void> = []
+    let scheduler: ReturnType<typeof FileWatcher.createRescanScheduler>
+    scheduler = FileWatcher.createRescanScheduler({
+      publish: (directory) => {
+        published.push(directory)
+        if (published.length === 2) scheduler.request(directory)
+      },
+      schedule: (callback) => {
+        scheduled.push(callback)
+      },
+    })
+
+    scheduler.request("/repo")
+    scheduler.request("/repo")
+
+    scheduled[0]?.()
+    scheduled[1]?.()
+    scheduled[2]?.()
+
+    expect(published).toEqual(["/repo", "/repo", "/repo"])
   })
 
   test("does not publish queued trailing rescans after dispose", () => {


### PR DESCRIPTION
## Summary

Coalesce dropped file watcher recovery into a quiet-window incident flow so repeated macOS FSEvents dropped-event callbacks do not publish a rescan every second. No new issue: this is a follow-up to the local log evidence after #848 / PR #849.

## Why

The existing dropped-event recovery published an immediate rescan and then another trailing rescan whenever the scheduler was dirty at the one-second timer boundary. When FSEvents reported dropped events roughly once per second, each callback landed near that boundary and produced another `file.watcher.rescan` plus another `watcher events dropped, requesting rescan` warning.

This keeps the fast leading recovery but waits for a quiet window before publishing at most one trailing recovery for the burst.

## Related Issue

Follow-up to #848.

## Human Review Status

Pending

## Review Focus

Please focus on the scheduler state transition in `createRescanScheduler`: a burst should publish immediately once, stay quiet while dropped events continue, then publish at most one final trailing rescan after the quiet window.

## Risk Notes

Visible UI check skipped: no visible UI or copy changed. Docs/release/dependencies skipped: no docs, release notes, dependency, permission, credential, deletion, generated-content, or local-file contract changed.

Platform impact considered: the trigger is macOS FSEvents dropped-event recovery, but the scheduler itself is platform-neutral and only changes recovery event coalescing.

## How To Verify

```text
packages/opencode: bun test test/file/watcher-error.test.ts — 5 pass, 0 fail
packages/opencode: bun run typecheck — passed
packages/app: bun test --preload ./happydom.ts src/context/file/watcher.test.ts src/pages/session/use-session-vcs-refresh.test.ts — 8 pass, 0 fail
Scope blast: rg createRescanScheduler / RESCAN_* / watcher events dropped / file.watcher.rescan — no second scheduler; app and SDK matches are consumers or type contracts
```

## Screenshots or Recordings

Not applicable: no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file change detection and rescan scheduling for improved efficiency in handling rapid file modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->