### PR TITLE
feat(app): show context cache hit rate

### DIFF
--- a/packages/app/e2e/snap/session-context-cache.snap.ts
+++ b/packages/app/e2e/snap/session-context-cache.snap.ts
@@ -40,6 +40,7 @@ test("session-context-cache", async ({ page, llm, project }) => {
 
   await expect(panel.getByText("Cache Hit Rate")).toBeVisible()
   await expect(panel.getByText("90%")).toBeVisible()
+  await expect(panel.getByText("Cache Tokens (read/write): 900 / 0")).toBeVisible()
 
   const toastCloseButtons = page.locator('[data-component="toast"] [data-slot="toast-close-button"]')
   const toastCount = await toastCloseButtons.count()

--- a/packages/app/e2e/snap/session-context-cache.snap.ts
+++ b/packages/app/e2e/snap/session-context-cache.snap.ts
@@ -2,6 +2,30 @@ import { test, expect } from "../fixtures"
 import { openRightPanel } from "../actions"
 import { composeGrid, snapOutputPath } from "./_compose"
 
+async function widenRightPanel(page: Parameters<typeof openRightPanel>[0]) {
+  const handle = page.locator('[data-component="right-panel-resize-wrapper"] [data-component="resize-handle"]')
+  const box = await handle.boundingBox()
+  if (!box) throw new Error("right panel resize handle is not visible")
+
+  const startX = box.x + box.width / 2
+  const startY = box.y + box.height / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  await page.mouse.move(startX - 180, startY, { steps: 12 })
+  await page.mouse.up()
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const panel = document.getElementById("right-panel")
+          return panel?.getBoundingClientRect().width ?? 0
+        }),
+      { timeout: 2_000 },
+    )
+    .toBeGreaterThanOrEqual(512)
+}
+
 test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
 
 test("session-context-cache", async ({ page, llm, project }) => {
@@ -24,8 +48,17 @@ test("session-context-cache", async ({ page, llm, project }) => {
   }
   await expect(page.locator('[data-component="toast"]')).toHaveCount(0)
 
-  const shot = await panel.screenshot({ animations: "disabled" })
+  const defaultShot = await panel.screenshot({ animations: "disabled" })
+  await widenRightPanel(page)
+  const wideShot = await panel.screenshot({ animations: "disabled" })
+
   const out = snapOutputPath("session-context-cache")
-  await composeGrid([{ name: "right-panel context cache", buf: shot }], out)
+  await composeGrid(
+    [
+      { name: "default width", buf: defaultShot },
+      { name: "wide two-column", buf: wideShot },
+    ],
+    out,
+  )
   process.stdout.write(`\n[snap] session-context-cache grid -> ${out}\n\n`)
 })

--- a/packages/app/e2e/snap/session-context-cache.snap.ts
+++ b/packages/app/e2e/snap/session-context-cache.snap.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "../fixtures"
+import { openRightPanel } from "../actions"
+import { composeGrid, snapOutputPath } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+test("session-context-cache", async ({ page, llm, project }) => {
+  await project.open()
+
+  await llm.text("Seeded context cache usage.", { usage: { input: 1_000, output: 40, cacheRead: 900 } })
+  await project.prompt("snap context cache hit rate")
+
+  const panel = await openRightPanel(page)
+  await page.getByRole("button", { name: "View context usage" }).click()
+  await page.getByRole("tab", { name: "Context" }).click()
+
+  await expect(panel.getByText("Cache Hit Rate")).toBeVisible()
+  await expect(panel.getByText("90%")).toBeVisible()
+
+  const toastCloseButtons = page.locator('[data-component="toast"] [data-slot="toast-close-button"]')
+  const toastCount = await toastCloseButtons.count()
+  for (let index = 0; index < toastCount; index++) {
+    await toastCloseButtons.first().click()
+  }
+  await expect(page.locator('[data-component="toast"]')).toHaveCount(0)
+
+  const shot = await panel.screenshot({ animations: "disabled" })
+  const out = snapOutputPath("session-context-cache")
+  await composeGrid([{ name: "right-panel context cache", buf: shot }], out)
+  process.stdout.write(`\n[snap] session-context-cache grid -> ${out}\n\n`)
+})

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -68,8 +68,17 @@ describe("getSessionContextMetrics", () => {
     expect(metrics.context?.compactThreshold).toBe(900)
     expect(metrics.context?.usagePercent).toBe(45)
     expect(metrics.context?.usage).toBe(45)
+    expect(metrics.context?.cacheHitRate).toBe(Math.round((25 / (300 + 25 + 25)) * 100))
     expect(metrics.context?.providerLabel).toBe("OpenAI")
     expect(metrics.context?.modelLabel).toBe("GPT-4.1")
+  })
+
+  test("leaves cache hit rate empty when provider reports no cache data", () => {
+    const messages = [assistant("a1", { input: 300, output: 100, reasoning: 0, read: 0, write: 0 }, 0.25)]
+
+    const metrics = getSessionContextMetrics(messages, [{ id: "openai", models: {} }])
+
+    expect(metrics.context?.cacheHitRate).toBeNull()
   })
 
   test("uses input limit and custom compaction reserve for usage metrics", () => {

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -43,6 +43,7 @@ type Context = {
   reasoning: number
   cacheRead: number
   cacheWrite: number
+  cacheHitRate: number | null
   total: number
   usagePercent: number | null
   usage: number | null
@@ -64,6 +65,13 @@ const lastAssistantWithTokens = (messages: Message[]) => {
     if (tokenTotal(msg) <= 0) continue
     return msg
   }
+}
+
+const cacheHitRate = (input: number, read: number, write: number) => {
+  const denominator = input + read + write
+  if (denominator <= 0) return null
+  if (read <= 0) return null
+  return Math.round((read / denominator) * 100)
 }
 
 const build = (messages: Message[] = [], providers: Provider[] = [], config: Config = {}): Metrics => {
@@ -99,6 +107,7 @@ const build = (messages: Message[] = [], providers: Provider[] = [], config: Con
       reasoning: message.tokens.reasoning,
       cacheRead: message.tokens.cache.read,
       cacheWrite: message.tokens.cache.write,
+      cacheHitRate: cacheHitRate(message.tokens.input, message.tokens.cache.read, message.tokens.cache.write),
       total,
       usagePercent: usage.usagePercent,
       usage: usage.usagePercent === null ? null : Math.round(usage.usagePercent),

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -62,6 +62,13 @@ function RawMessageContent(props: { message: Message; getParts: (id: string) => 
   )
 }
 
+function cacheHitRateClass(value: number | null | undefined) {
+  if (value === undefined || value === null) return "text-fg-strong"
+  if (value >= 90) return "text-success-text"
+  if (value >= 50) return "text-warning-text"
+  return "text-error-text"
+}
+
 function RawMessage(props: {
   message: Message
   getParts: (id: string) => Part[]
@@ -180,6 +187,17 @@ export function SessionContextTab() {
     return formatter().number(c.compactThreshold)
   })
 
+  const cacheHitRate = createMemo(() => {
+    const c = ctx()
+    const value = c?.cacheHitRate
+    const raw = `${language.t("context.stats.cacheTokens")}: ${formatter().number(c?.cacheRead)} / ${formatter().number(c?.cacheWrite)}`
+    return (
+      <span class={cacheHitRateClass(value)} title={raw}>
+        {formatter().percent(value)}
+      </span>
+    )
+  })
+
   const breakdown = createMemo(
     on(
       () => [ctx()?.message.id, ctx()?.input, messages().length, systemPrompt()],
@@ -217,10 +235,7 @@ export function SessionContextTab() {
     { label: "context.stats.inputTokens", value: () => formatter().number(ctx()?.input) },
     { label: "context.stats.outputTokens", value: () => formatter().number(ctx()?.output) },
     { label: "context.stats.reasoningTokens", value: () => formatter().number(ctx()?.reasoning) },
-    {
-      label: "context.stats.cacheTokens",
-      value: () => `${formatter().number(ctx()?.cacheRead)} / ${formatter().number(ctx()?.cacheWrite)}`,
-    },
+    { label: "context.stats.cacheHitRate", value: cacheHitRate },
     { label: "context.stats.userMessages", value: () => counts().user.toLocaleString(language.intl()) },
     { label: "context.stats.assistantMessages", value: () => counts().assistant.toLocaleString(language.intl()) },
     { label: "context.stats.totalCost", value: cost },

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -191,9 +191,13 @@ export function SessionContextTab() {
     const c = ctx()
     const value = c?.cacheHitRate
     const raw = `${language.t("context.stats.cacheTokens")}: ${formatter().number(c?.cacheRead)} / ${formatter().number(c?.cacheWrite)}`
+    const hasCacheTokens = !!c && (c.cacheRead > 0 || c.cacheWrite > 0)
     return (
-      <span class={cacheHitRateClass(value)} title={raw}>
-        {formatter().percent(value)}
+      <span class="flex flex-col gap-1" title={raw}>
+        <span class={cacheHitRateClass(value)}>{formatter().percent(value)}</span>
+        <Show when={hasCacheTokens}>
+          <span class="text-body text-fg-weak">{raw}</span>
+        </Show>
       </span>
     )
   })

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -405,6 +405,7 @@ export const dict = {
   "context.stats.inputTokens": "Input Tokens",
   "context.stats.outputTokens": "Output Tokens",
   "context.stats.reasoningTokens": "Reasoning Tokens",
+  "context.stats.cacheHitRate": "Cache Hit Rate",
   "context.stats.cacheTokens": "Cache Tokens (read/write)",
   "context.stats.userMessages": "User Messages",
   "context.stats.assistantMessages": "Assistant Messages",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -403,6 +403,7 @@ export const dict = {
   "context.stats.inputTokens": "输入 token",
   "context.stats.outputTokens": "输出 token",
   "context.stats.reasoningTokens": "推理 token",
+  "context.stats.cacheHitRate": "缓存命中率",
   "context.stats.cacheTokens": "缓存 token（读/写）",
   "context.stats.userMessages": "用户消息",
   "context.stats.assistantMessages": "助手消息",

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -326,9 +326,14 @@ function flowParts(parts: Iterable<unknown>) {
     if (part && typeof part === "object" && "usage" in part && part.usage && typeof part.usage === "object") {
       const raw = part.usage as Record<string, unknown>
       if (typeof raw.prompt_tokens === "number" && typeof raw.completion_tokens === "number") {
+        const details =
+          raw.prompt_tokens_details && typeof raw.prompt_tokens_details === "object"
+            ? (raw.prompt_tokens_details as Record<string, unknown>)
+            : undefined
+        const cacheRead = typeof details?.cached_tokens === "number" ? details.cached_tokens : undefined
         out.push({
           type: "usage",
-          usage: { input: raw.prompt_tokens, output: raw.completion_tokens },
+          usage: { input: raw.prompt_tokens, output: raw.completion_tokens, cacheRead },
         })
       }
     }

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -4,7 +4,7 @@ import { Deferred, Effect, Layer, Context, Stream } from "effect"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 
-export type Usage = { input: number; output: number }
+export type Usage = { input: number; output: number; cacheRead?: number }
 
 type Line = Record<string, unknown>
 
@@ -66,6 +66,7 @@ function tokens(input?: Usage) {
   if (!input) return
   return {
     prompt_tokens: input.input,
+    prompt_tokens_details: { cached_tokens: input.cacheRead ?? null },
     completion_tokens: input.output,
     total_tokens: input.input + input.output,
   }
@@ -160,7 +161,7 @@ function responseCompleted(input: { seq: number; usage?: Usage }) {
       service_tier: null,
       usage: {
         input_tokens: input.usage?.input ?? 0,
-        input_tokens_details: { cached_tokens: null },
+        input_tokens_details: { cached_tokens: input.usage?.cacheRead ?? null },
         output_tokens: input.usage?.output ?? 0,
         output_tokens_details: { reasoning_tokens: null },
       },

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -2187,6 +2187,64 @@ it.live("session.processor effect tests execute Responses args-done-only tool ca
   ),
 )
 
+it.live("test LLM server preserves cached input tokens when converting chat chunks to Responses API events", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const previousToken = process.env.GITHUB_COPILOT_TOKEN
+        process.env.GITHUB_COPILOT_TOKEN = "test-copilot-key"
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            if (previousToken === undefined) delete process.env.GITHUB_COPILOT_TOKEN
+            else process.env.GITHUB_COPILOT_TOKEN = previousToken
+          }),
+        )
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.text("cached response", { usage: { input: 1_000, output: 40, cacheRead: 900 } })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "responses cache usage")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(copilotResponsesRef.providerID, copilotResponsesRef.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: copilotResponsesRef.providerID, modelID: copilotResponsesRef.modelID },
+            tools: {},
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "responses cache usage" }],
+          tools: {},
+        })
+
+        const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
+        const hits = yield* llm.hits
+
+        expect(hits[0]?.url.pathname).toBe("/v1/responses")
+        expect(stored.info.role).toBe("assistant")
+        if (stored.info.role === "assistant") {
+          expect(stored.info.tokens.input).toBe(100)
+          expect(stored.info.tokens.cache.read).toBe(900)
+        }
+      }),
+    { git: true, config: (url) => copilotResponsesProviderCfg(url) },
+  ),
+)
+
 // Question tool aborted on cleanup gets a clearer message than the generic
 // "Tool execution aborted". The LLM reads part.state.error as the tool result
 // and the generic phrasing made models think the user dismissed the question.


### PR DESCRIPTION
## Summary

- Show a computed Cache Hit Rate row in the Context tab instead of requiring users to interpret raw cache read/write tokens.
- Keep raw cache read/write values visibly available below the percentage and add a focused Context tab snap that verifies the 90% display path in default and wide panel states.
- Extend the e2e LLM fixture usage payload so chat and Responses API test paths can preserve cached input tokens.

## Why

Issue #884 asks for cache hit rate visibility in the Context tab. The raw cache token row made users do the math manually and made cache behavior harder to observe during cache-first work.

## Related Issue

Fixes #884

## Human Review Status

Pending

## Review Focus

- Confirm the hit-rate formula matches the intended display contract: cache read / (input + cache read + cache write), rounded to a whole percent.
- Confirm the visible raw cache token line is the right density/accessibility tradeoff for Context tab stats.
- Confirm the e2e fixture cacheRead extension is narrow enough for both chat and Responses API test seeding.

## Risk Notes

- This changes a visible Context tab stat label/value and adds semantic color for cache hit rate.
- Platform checklist item is left unticked because this does not touch platform, packaging, updater, signing, paths, shell behavior, or permissions.
- Docs/release/dependency checklist item is left unticked because this does not touch docs, release notes, dependencies, credentials, deletion behavior, or generated content.

## How To Verify

```text
Focused app tests: bun test --preload ./happydom.ts ./src/components/session/session-context-metrics.test.ts ./src/components/session/session-context-breakdown.test.ts — 11 passed.
Responses fixture regression: bun test test/session/processor-effect.test.ts -t "preserves cached input tokens" — 1 passed; RED first showed input=1000 before cacheRead was preserved.
Typecheck: bun run typecheck — passed.
Lint: bun eslint "packages/app/src/components/session/session-context-metrics.ts" "packages/app/src/components/session/session-context-tab.tsx" — passed; follow-up lint on session-context-tab.tsx passed.
Visual snap: bun run snap session-context-cache — passed and wrote docs/design/preview/screenshots/session-context-cache.png showing default-width and wide two-column Context tab states with Cache Hit Rate = 90% and visible raw Cache Tokens (read/write): 900 / 0.
Diff check: git diff --cached --check — passed before commits.
```

## Screenshots or Recordings

- `docs/design/preview/screenshots/session-context-cache.png` from `bun run snap session-context-cache`.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced cache hit rate metric in session context statistics, displaying cached token usage as a rounded percentage with color-coded visual indicators.

* **Localization**
  * Added cache hit rate label translations for English and Chinese language support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->