### PR TITLE
fix: allow safe retry before provider progress

### DIFF
--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -196,7 +196,11 @@ function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
   if (!snapshot) return false
   if (snapshot.provider_executed_capability_present !== false) return false
   if (snapshot.external_boundary_present !== false) return false
-  if (snapshot.proof_reason === "provider_executed_capability" || snapshot.proof_reason === "external_boundary") {
+  if (
+    snapshot.proof_reason === "provider_executed_capability" ||
+    snapshot.proof_reason === "external_boundary" ||
+    snapshot.proof_reason === "unknown"
+  ) {
     return false
   }
   return true
@@ -207,7 +211,11 @@ function beforeProgressBoundaryEvidenceBlocksRetry(facts: IncidentFacts) {
   if (!snapshot) return false
   if (snapshot.provider_executed_capability_present !== false) return true
   if (snapshot.external_boundary_present !== false) return true
-  return snapshot.proof_reason === "provider_executed_capability" || snapshot.proof_reason === "external_boundary"
+  return (
+    snapshot.proof_reason === "provider_executed_capability" ||
+    snapshot.proof_reason === "external_boundary" ||
+    snapshot.proof_reason === "unknown"
+  )
 }
 
 function boundaryAllowsReasoningRetry(facts: IncidentFacts) {

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -40,6 +40,14 @@ export function recoveryFor(input: {
       auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
     }
   }
+  if (isBeforeFirstProviderProgressCause(input.cause) && beforeProgressBoundaryEvidenceBlocksRetry(terminalFacts)) {
+    return {
+      ...base,
+      recommendation: "ask_user_before_retry",
+      confidence: "high",
+      reason: "side_effect_facts_incomplete",
+    }
+  }
   if (
     retryableTransport &&
     noToolActivity &&
@@ -192,6 +200,14 @@ function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
     return false
   }
   return true
+}
+
+function beforeProgressBoundaryEvidenceBlocksRetry(facts: IncidentFacts) {
+  const snapshot = facts.side_effect_boundary_snapshot
+  if (!snapshot) return false
+  if (snapshot.provider_executed_capability_present !== false) return true
+  if (snapshot.external_boundary_present !== false) return true
+  return snapshot.proof_reason === "provider_executed_capability" || snapshot.proof_reason === "external_boundary"
 }
 
 function boundaryAllowsReasoningRetry(facts: IncidentFacts) {

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -9,15 +9,41 @@ export function recoveryFor(input: {
   const base = { safety_scope: "visible_output_and_tool_side_effects" as const }
   const terminalFacts = input.terminalFacts ?? input.facts
   const noToolActivity =
-    !terminalFacts.tool_input_started &&
-    !terminalFacts.tool_call_materialized &&
-    !terminalFacts.tool_execution_started
+    !terminalFacts.tool_input_started && !terminalFacts.tool_call_materialized && !terminalFacts.tool_execution_started
   const retryableTransport =
     input.retryable === true &&
     (input.cause.category === "provider_transport_disconnect" || input.cause.category === "watchdog_timeout")
+  if (input.cause.category === "user_cancel") {
+    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
+  }
+  if (input.cause.category === "local_lifecycle_close") {
+    return {
+      ...base,
+      recommendation: "do_not_retry",
+      confidence: input.cause.confidence,
+      reason: "local_lifecycle_close",
+    }
+  }
+  if (
+    canAutoRetryBeforeFirstProviderProgress({
+      cause: input.cause,
+      facts: input.facts,
+      terminalFacts,
+      retryableTransport,
+    })
+  ) {
+    return {
+      ...base,
+      recommendation: "auto_retry_once",
+      confidence: "high",
+      reason: "no_visible_output_or_tool_execution",
+      auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
+    }
+  }
   if (
     retryableTransport &&
     noToolActivity &&
+    !isBeforeFirstProviderProgressCause(input.cause) &&
     terminalFacts.reasoning_output_started &&
     !terminalFacts.text_output_started &&
     !terminalFacts.unsafe_side_effect_started &&
@@ -29,17 +55,6 @@ export function recoveryFor(input: {
       confidence: "high",
       reason: "reasoning_only_without_final_text_or_tool_activity",
       auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
-    }
-  }
-  if (input.cause.category === "user_cancel") {
-    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
-  }
-  if (input.cause.category === "local_lifecycle_close") {
-    return {
-      ...base,
-      recommendation: "do_not_retry",
-      confidence: input.cause.confidence,
-      reason: "local_lifecycle_close",
     }
   }
   if (!terminalFacts.side_effect_facts_complete) {
@@ -130,6 +145,53 @@ export function recoveryFor(input: {
     }
   }
   return { ...base, recommendation: "unknown", confidence: "low", reason: "unknown" }
+}
+
+function canAutoRetryBeforeFirstProviderProgress(input: {
+  cause: TerminalCause
+  facts: IncidentFacts
+  terminalFacts: IncidentFacts
+  retryableTransport: boolean
+}) {
+  if (!input.retryableTransport) return false
+  if (input.facts.user_cancel_seen || input.facts.lifecycle_close_seen) return false
+  if (!isBeforeFirstProviderProgressCause(input.cause)) return false
+  if (input.terminalFacts.provider_progress_seen) return false
+  if (!attemptHasNoOutputOrToolActivity(input.terminalFacts)) return false
+  return boundaryAllowsBeforeProgressRetry(input.terminalFacts)
+}
+
+function isBeforeFirstProviderProgressCause(cause: TerminalCause) {
+  if (cause.category === "provider_transport_disconnect") return cause.subcategory === "before_first_provider_progress"
+  if (cause.category === "watchdog_timeout") return cause.subcategory === "connect"
+  return false
+}
+
+function attemptHasNoOutputOrToolActivity(facts: IncidentFacts) {
+  return (
+    !facts.visible_output_seen &&
+    !facts.text_output_started &&
+    !facts.reasoning_output_started &&
+    !facts.tool_input_started &&
+    !facts.tool_input_completed &&
+    !facts.tool_call_materialized &&
+    !facts.tool_execution_started &&
+    !facts.tool_execution_completed &&
+    !facts.read_only_tool_started &&
+    !facts.unsafe_side_effect_started &&
+    (facts.pending_tool_parts_interrupted ?? 0) === 0
+  )
+}
+
+function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
+  const snapshot = facts.side_effect_boundary_snapshot
+  if (!snapshot) return false
+  if (snapshot.provider_executed_capability_present !== false) return false
+  if (snapshot.external_boundary_present !== false) return false
+  if (snapshot.proof_reason === "provider_executed_capability" || snapshot.proof_reason === "external_boundary") {
+    return false
+  }
+  return true
 }
 
 function boundaryAllowsReasoningRetry(facts: IncidentFacts) {

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -208,7 +208,7 @@ function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
 
 function beforeProgressBoundaryEvidenceBlocksRetry(facts: IncidentFacts) {
   const snapshot = facts.side_effect_boundary_snapshot
-  if (!snapshot) return false
+  if (!snapshot) return true
   if (snapshot.provider_executed_capability_present !== false) return true
   if (snapshot.external_boundary_present !== false) return true
   return (

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -3,6 +3,48 @@ import { MessageID, SessionID } from "../../src/session/schema"
 import { RunIncident } from "../../src/session/run-incident"
 import { RunObservability } from "../../src/session/run-observability"
 
+const beforeProgressCause = {
+  category: "provider_transport_disconnect",
+  subcategory: "before_first_provider_progress",
+  confidence: "medium",
+} satisfies RunIncident.TerminalCause
+
+function beforeProgressFacts(overrides: Partial<RunIncident.Facts> = {}): RunIncident.Facts {
+  return {
+    provider_progress_seen: false,
+    visible_output_seen: false,
+    text_output_started: false,
+    reasoning_output_started: false,
+    tool_input_started: false,
+    tool_input_completed: false,
+    tool_call_materialized: false,
+    tool_execution_started: false,
+    tool_execution_completed: false,
+    read_only_tool_started: false,
+    unsafe_side_effect_started: false,
+    unsafe_side_effect_kinds: [],
+    side_effect_facts_complete: false,
+    side_effect_boundary_snapshot: {
+      exposed_tool_count: 16,
+      unknown_tool_count: 10,
+      unclassified_effect_count: 10,
+      provider_executed_capability_present: false,
+      external_boundary_present: false,
+      proof_result: "incomplete",
+      proof_reason: "unknown_tool_boundary",
+    },
+    lifecycle_close_seen: false,
+    user_cancel_seen: false,
+    watchdog_fired: false,
+    ...overrides,
+  }
+}
+
+function recoveryForBeforeProgress(overrides: Partial<RunIncident.Facts> = {}, retryable = true) {
+  const facts = beforeProgressFacts(overrides)
+  return RunIncident.recoveryFor({ cause: beforeProgressCause, facts, retryable })
+}
+
 describe("RunObservability", () => {
   test("does not treat stream lifecycle events as provider progress", () => {
     expect(RunObservability.isProviderProgressEvent({ type: "start" })).toBe(false)
@@ -951,7 +993,7 @@ describe("RunObservability", () => {
     expect(summary.incident?.evidence?.map((event) => event.event_type)).toContain("provider_executed_tool_boundary")
   })
 
-  test("unknown request side-effect boundary prevents auto retry before local tool events", () => {
+  test("unknown exposed tools still allow retry before first provider progress when no tool activity occurred", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_unknown_request_boundary"),
       traceID: MessageID.make("msg_unknown_request_boundary"),
@@ -988,6 +1030,7 @@ describe("RunObservability", () => {
         cause: { name: "SocketError", message: "other side closed", code: "UND_ERR_SOCKET" },
       },
       evidence: ["iterator_error"],
+      retryable: true,
     })
 
     const summary = recorder.finalize({ completedAt: 14, monotonicMs: 140 })
@@ -1003,10 +1046,69 @@ describe("RunObservability", () => {
       proof_reason: "unknown_tool_boundary",
     })
     expect(decision).toMatchObject({
+      recommendation: "auto_retry_once",
+      reason: "no_visible_output_or_tool_execution",
+    })
+    expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "auto_retry_once",
+      reason: "no_visible_output_or_tool_execution",
+    })
+  })
+
+  test("before-progress retry stays conservative when the boundary snapshot is missing", () => {
+    const decision = recoveryForBeforeProgress({ side_effect_boundary_snapshot: undefined })
+
+    expect(decision).toMatchObject({
       recommendation: "ask_user_before_retry",
       reason: "side_effect_facts_incomplete",
     })
-    expect(summary.incident?.recovery).toMatchObject({
+  })
+
+  test("before-progress retry fails closed for output, tool activity, or external boundary evidence", () => {
+    const cases: Array<[string, Partial<RunIncident.Facts>]> = [
+      ["visible output", { visible_output_seen: true }],
+      ["text output", { text_output_started: true }],
+      ["reasoning output", { reasoning_output_started: true }],
+      ["tool input started", { tool_input_started: true }],
+      ["tool input completed", { tool_input_completed: true }],
+      ["tool call materialized", { tool_call_materialized: true }],
+      ["tool execution started", { tool_execution_started: true }],
+      ["tool execution completed", { tool_execution_completed: true }],
+      ["read-only tool started", { read_only_tool_started: true }],
+      ["unsafe side effect", { unsafe_side_effect_started: true }],
+      ["pending tool parts", { pending_tool_parts_interrupted: 1 }],
+      [
+        "provider-executed capability",
+        {
+          side_effect_boundary_snapshot: {
+            ...beforeProgressFacts().side_effect_boundary_snapshot!,
+            provider_executed_capability_present: true,
+            proof_reason: "provider_executed_capability",
+          },
+        },
+      ],
+      [
+        "external boundary",
+        {
+          side_effect_boundary_snapshot: {
+            ...beforeProgressFacts().side_effect_boundary_snapshot!,
+            external_boundary_present: true,
+            proof_reason: "external_boundary",
+          },
+        },
+      ],
+    ]
+
+    for (const [name, overrides] of cases) {
+      const decision = recoveryForBeforeProgress(overrides)
+      expect(decision, name).not.toMatchObject({ recommendation: "auto_retry_once" })
+    }
+  })
+
+  test("before-progress retry is denied when the transport error is not retryable", () => {
+    const decision = recoveryForBeforeProgress({}, false)
+
+    expect(decision).toMatchObject({
       recommendation: "ask_user_before_retry",
       reason: "side_effect_facts_incomplete",
     })

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -45,6 +45,18 @@ function recoveryForBeforeProgress(overrides: Partial<RunIncident.Facts> = {}, r
   return RunIncident.recoveryFor({ cause: beforeProgressCause, facts, retryable })
 }
 
+function noToolBoundarySnapshot(): RunObservability.SideEffectBoundarySnapshot {
+  return {
+    exposed_tool_count: 0,
+    unknown_tool_count: 0,
+    unclassified_effect_count: 0,
+    provider_executed_capability_present: false,
+    external_boundary_present: false,
+    proof_result: "complete",
+    proof_reason: "all_boundaries_classified",
+  }
+}
+
 describe("RunObservability", () => {
   test("does not treat stream lifecycle events as provider progress", () => {
     expect(RunObservability.isProviderProgressEvent({ type: "start" })).toBe(false)
@@ -100,6 +112,12 @@ describe("RunObservability", () => {
     })
 
     const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: attempt.attemptID,
+      at: 12,
+      monotonicMs: 120,
+      snapshot: noToolBoundarySnapshot(),
+    })
     const decision = recorder.recordAttemptFailureAndDeriveRecovery({
       attemptID: attempt.attemptID,
       at: 130,
@@ -899,6 +917,12 @@ describe("RunObservability", () => {
       monotonicStartMs: 200,
     })
     const currentAttempt = current.beginAttempt({ attemptIndex: 1, at: 21, monotonicMs: 210 })
+    current.recordSideEffectBoundarySnapshot({
+      attemptID: currentAttempt.attemptID,
+      at: 21,
+      monotonicMs: 211,
+      snapshot: noToolBoundarySnapshot(),
+    })
     const decision = current.recordAttemptFailureAndDeriveRecovery({
       attemptID: currentAttempt.attemptID,
       at: 22,
@@ -1057,6 +1081,18 @@ describe("RunObservability", () => {
 
   test("before-progress retry stays conservative when the boundary snapshot is missing", () => {
     const decision = recoveryForBeforeProgress({ side_effect_boundary_snapshot: undefined })
+
+    expect(decision).toMatchObject({
+      recommendation: "ask_user_before_retry",
+      reason: "side_effect_facts_incomplete",
+    })
+  })
+
+  test("before-progress retry stays conservative when complete facts lack a boundary snapshot", () => {
+    const decision = recoveryForBeforeProgress({
+      side_effect_facts_complete: true,
+      side_effect_boundary_snapshot: undefined,
+    })
 
     expect(decision).toMatchObject({
       recommendation: "ask_user_before_retry",
@@ -1987,6 +2023,12 @@ describe("RunObservability", () => {
       effect: RunObservability.toolEffect("bash"),
     })
     const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: second.attemptID,
+      at: 20,
+      monotonicMs: 201,
+      snapshot: noToolBoundarySnapshot(),
+    })
     recorder.recordTransportFailure({
       attemptID: second.attemptID,
       at: 21,
@@ -2026,6 +2068,12 @@ describe("RunObservability", () => {
       effect: RunObservability.toolEffect("read"),
     })
     const second = recorder.beginAttempt({ attemptIndex: 2, at: 20, monotonicMs: 200 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: second.attemptID,
+      at: 20,
+      monotonicMs: 201,
+      snapshot: noToolBoundarySnapshot(),
+    })
     recorder.recordTransportFailure({
       attemptID: second.attemptID,
       at: 21,

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1088,8 +1088,30 @@ describe("RunObservability", () => {
         },
       ],
       [
+        "provider-executed capability with complete facts",
+        {
+          side_effect_facts_complete: true,
+          side_effect_boundary_snapshot: {
+            ...beforeProgressFacts().side_effect_boundary_snapshot!,
+            provider_executed_capability_present: true,
+            proof_reason: "provider_executed_capability",
+          },
+        },
+      ],
+      [
         "external boundary",
         {
+          side_effect_boundary_snapshot: {
+            ...beforeProgressFacts().side_effect_boundary_snapshot!,
+            external_boundary_present: true,
+            proof_reason: "external_boundary",
+          },
+        },
+      ],
+      [
+        "external boundary with complete facts",
+        {
+          side_effect_facts_complete: true,
           side_effect_boundary_snapshot: {
             ...beforeProgressFacts().side_effect_boundary_snapshot!,
             external_boundary_present: true,

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1119,6 +1119,16 @@ describe("RunObservability", () => {
           },
         },
       ],
+      [
+        "unknown boundary proof with complete facts",
+        {
+          side_effect_facts_complete: true,
+          side_effect_boundary_snapshot: {
+            ...beforeProgressFacts().side_effect_boundary_snapshot!,
+            proof_reason: "unknown",
+          },
+        },
+      ],
     ]
 
     for (const [name, overrides] of cases) {


### PR DESCRIPTION
## Summary

- Allow one automatic retry for retryable provider transport failures that happen before first provider progress when the terminal attempt produced no output and no tool activity.
- Keep the path fail-closed when the boundary snapshot is missing, provider/external boundaries are present, lifecycle/user cancel is observed, or telemetry shows any output/tool activity.
- Add regression coverage for the Issue #912 export shape plus negative cases for missing evidence and contradictory tool/output state.

## Why

Issue #912 showed a production session where the provider returned `Service Unavailable` before any provider progress, assistant output, tool input, tool call, or tool execution. PawWork still asked the user before retrying because unknown exposed tool metadata made the static side-effect boundary proof incomplete. Retry safety should be based on what the terminal attempt actually reached; unknown metadata for uncalled tools should not block this early safe-retry case.

## Related Issue

Closes #912

## Human Review Status

- `Pending` — waiting for a human reviewer to approve.

## Review Focus

- The new `canAutoRetryBeforeFirstProviderProgress` predicate in `packages/opencode/src/session/run-incident/policy.ts`, especially the fail-closed guards for missing snapshots, global lifecycle/user cancel, provider/external boundaries, and contradictory output/tool facts.
- The negative matrix in `packages/opencode/test/session/run-observability.test.ts` to ensure the fast path only applies to truly early no-output/no-tool failures.

## Risk Notes

The behavior change is intentionally narrow, but it affects retry policy for model transport failures. The main risk is over-retrying if evidence is incomplete; the fast path requires a recorded boundary snapshot and explicit absence of provider/external boundaries to mitigate that.

Skipped conditional checklist items:

- Visible UI/copy check: not applicable; no visible UI or copy changed.
- Platform impact check: not applicable; no platform, packaging, updater, signing, paths, shell, or permissions surface changed.
- Docs/release/dependencies/etc.: not applicable; no docs, release notes, dependencies, permissions, credentials, generated content, or local file behavior changed.

## How To Verify

```text
RED check: bun test test/session/run-observability.test.ts failed on the new Issue #912 regression with side_effect_facts_incomplete before the fix.
Focused observability tests: bun test test/session/run-observability.test.ts — 62 passed.
Processor integration tests: bun test test/session/processor-effect.test.ts — 29 passed.
Typecheck: bun run typecheck in packages/opencode — passed.
Diff check: git diff --check — no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery logic with enhanced automatic retry capabilities during incident handling.
  * Refined safety checks to ensure retries are attempted only when appropriate conditions are met.

* **Tests**
  * Expanded test coverage for error recovery scenarios and retry behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->