### PR TITLE
fix: keep apply patch trow summaries single-line

### DIFF
--- a/packages/ui/src/components/message-part/context-tool-helpers.test.ts
+++ b/packages/ui/src/components/message-part/context-tool-helpers.test.ts
@@ -103,4 +103,35 @@ describe("contextTrowSummaryText", () => {
     expect(summary).toBe("Edit files 1 file")
     expect(summary).not.toContain("\n")
   })
+
+  test("falls back to legacy apply_patch input files when metadata is missing", () => {
+    const part = tool(
+      "patch",
+      "apply_patch",
+      "completed",
+      {},
+      {
+        files: [{}, {}],
+      },
+      "Success. Updated the following files:\nM one.ts\nM two.ts",
+    )
+
+    expect(contextToolSummaryText(part, i18n("en"))).toBe("Edit files 2 files")
+  })
+
+  test("prefers apply_patch metadata files over legacy input files", () => {
+    const part = tool(
+      "patch",
+      "apply_patch",
+      "completed",
+      {
+        files: [{}],
+      },
+      {
+        files: [{}, {}],
+      },
+    )
+
+    expect(contextToolSummaryText(part, i18n("en"))).toBe("Edit files 1 file")
+  })
 })

--- a/packages/ui/src/components/message-part/context-tool-helpers.test.ts
+++ b/packages/ui/src/components/message-part/context-tool-helpers.test.ts
@@ -3,7 +3,7 @@ import type { ToolPart, ToolState } from "@opencode-ai/sdk/v2"
 import type { UiI18n, UiI18nKey, UiI18nParams } from "../../context/i18n"
 import { dict as en } from "../../i18n/en"
 import { dict as zh } from "../../i18n/zh"
-import { contextTrowSummaryText } from "./context-tool-helpers"
+import { contextToolSummaryText, contextTrowSummaryText } from "./context-tool-helpers"
 
 function resolveTemplate(text: string, params?: UiI18nParams) {
   if (!params) return text
@@ -28,11 +28,13 @@ function tool(
   name: string,
   status: "completed" | "error" = "completed",
   metadata: Record<string, unknown> = {},
+  input: Record<string, unknown> = {},
+  title = "",
 ): ToolPart {
   const state: ToolState =
     status === "error"
-      ? { status, input: {}, error: "boom", time: { start: 0, end: 1 } }
-      : { status, input: {}, output: "", title: "", metadata, time: { start: 0, end: 1 } }
+      ? { status, input, error: "boom", time: { start: 0, end: 1 } }
+      : { status, input, output: "", title, metadata, time: { start: 0, end: 1 } }
 
   return {
     id,
@@ -75,5 +77,30 @@ describe("contextTrowSummaryText", () => {
     const parts = [tool("read", "read"), tool("bash", "bash"), tool("skill", "skill")]
 
     expect(contextTrowSummaryText(parts, 0, i18n("en"))).toBe("Read 1 file, Ran 1 command, Used 1 tool")
+  })
+
+  test("keeps a completed apply_patch tool summary on one line", () => {
+    const part = tool(
+      "patch",
+      "apply_patch",
+      "completed",
+      {
+        files: [
+          {
+            type: "update",
+            filePath: "/repo/packages/app/src/pages/session/session-timeline-scroll-controller.test.ts",
+            relativePath: "packages/app/src/pages/session/session-timeline-scroll-controller.test.ts",
+            patch: "@@ -1 +1 @@\n-old\n+new\n",
+          },
+        ],
+      },
+      {},
+      "Success. Updated the following files:\nM packages/app/src/pages/session/session-timeline-scroll-controller.test.ts",
+    )
+
+    const summary = contextToolSummaryText(part, i18n("en"))
+
+    expect(summary).toBe("Edit files 1 file")
+    expect(summary).not.toContain("\n")
   })
 })

--- a/packages/ui/src/components/tool-info.ts
+++ b/packages/ui/src/components/tool-info.ts
@@ -161,11 +161,16 @@ export function toolInfoForInput(
         subtitle: input.filePath ? getFilename(input.filePath) : undefined,
       }
     case "apply_patch":
+      const fileCount = Array.isArray(metadata.files)
+        ? metadata.files.length
+        : Array.isArray(input.files)
+          ? input.files.length
+          : 0
       return {
         icon: "code-lines",
         title: i18n.t("ui.tool.patch"),
-        subtitle: input.files?.length
-          ? `${input.files.length} ${i18n.t(input.files.length > 1 ? "ui.common.file.other" : "ui.common.file.one")}`
+        subtitle: fileCount
+          ? `${fileCount} ${i18n.t(fileCount > 1 ? "ui.common.file.other" : "ui.common.file.one")}`
           : undefined,
       }
     case TOOL_TODOWRITE:

--- a/packages/ui/src/components/tool-info.ts
+++ b/packages/ui/src/components/tool-info.ts
@@ -160,7 +160,7 @@ export function toolInfoForInput(
         title: i18n.t("ui.messagePart.title.write"),
         subtitle: input.filePath ? getFilename(input.filePath) : undefined,
       }
-    case "apply_patch":
+    case "apply_patch": {
       const fileCount = Array.isArray(metadata.files)
         ? metadata.files.length
         : Array.isArray(input.files)
@@ -173,6 +173,7 @@ export function toolInfoForInput(
           ? `${fileCount} ${i18n.t(fileCount > 1 ? "ui.common.file.other" : "ui.common.file.one")}`
           : undefined,
       }
+    }
     case TOOL_TODOWRITE:
       return {
         icon: "checklist",


### PR DESCRIPTION
## Summary

Keep completed `apply_patch` trow summaries compact by deriving the subtitle from patch metadata file counts instead of falling back to the multiline backend tool title.

## Why

A completed single-tool `apply_patch` row could show `Success. Updated the following files:` on one line and the modified path on the next line. The backend title intentionally includes newlines, but the collapsed trow summary should remain a one-line UI summary.

## Related Issue

Closes #915

## Human Review Status

Pending

## Review Focus

Please check that `apply_patch` still supports legacy `input.files` while preferring the current `metadata.files` shape used by rendered tool parts.

## Risk Notes

Low risk. This only changes the short summary label for `apply_patch`; expanded patch details and backend tool output are unchanged. Platform-specific behavior is not touched.

## How To Verify

```text
RED: bun --cwd packages/ui test src/components/message-part/context-tool-helpers.test.ts
Result: failed before the fix because the apply_patch summary contained the multiline backend title.

Focused tests: bun --cwd packages/ui test src/components/message-part/context-tool-helpers.test.ts src/components/session-turn-trow-block.reducer.test.ts src/components/apply-patch-file.test.ts
Result: 25 passed, 0 failed.

Typecheck: bun --cwd packages/ui typecheck
Result: passed.

Lint: bun run lint
Result: passed.

Visual check: bun run snap session-trow
Result: passed and generated docs/design/preview/screenshots/session-trow.png; trow summaries remain one-line in the rendered grid.
```

## Screenshots or Recordings

Visual verification was performed with the existing `session-trow` snap target. The generated grid showed compact one-line trow summaries after the fix.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.