### PR TITLE
fix(session): gate post-compaction auto-continue on finish reason

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -633,23 +633,30 @@ export const layer: Layer.Layer<
         }
 
         if (!replay) {
-          // Only auto-continue when the turn the compaction interrupted had NOT
-          // finished cleanly. A clean finish (e.g. "stop"/"end_turn") means the
-          // agent itself chose to end the turn, so injecting a synthetic continue
-          // would override that decision and make compaction-turns behave more
-          // eagerly than normal turns. Resume only when the last real turn was
-          // still mid-flight (no finish, or "tool-calls"/"unknown"). Keys on the
-          // turn's finish reason rather than the overflow flag, matching upstream
-          // opencode #27730 — the overflow flag stranded mid-task work that
-          // happened to compact without a provider-side overflow.
-          const lastNonSummaryAssistant = input.messages.findLast(
-            (m) => m.info.role === "assistant" && !m.info.summary,
-          )?.info as MessageV2.Assistant | undefined
-          const shouldAutoContinue =
-            !lastNonSummaryAssistant?.finish ||
-            lastNonSummaryAssistant.finish === "tool-calls" ||
-            lastNonSummaryAssistant.finish === "unknown"
-          if (!shouldAutoContinue) return result
+          // Overflow recovery: the provider rejected the turn mid-flight, so there
+          // is always unfinished work — continue. Natural compaction: only continue
+          // when the interrupted turn had NOT finished cleanly. A clean finish
+          // ("stop"/"end_turn") means the agent itself chose to end the turn, so a
+          // synthetic continue would override that and make compaction-turns more
+          // eager than normal turns. Resume only when the last real turn was still
+          // mid-flight (no finish, "tool-calls", or "unknown"). Keying on the finish
+          // reason rather than the overflow flag matches upstream opencode #27730;
+          // the old overflow gate stranded mid-task work that compacted without a
+          // provider-side overflow.
+          if (!input.overflow) {
+            const lastNonSummaryAssistant = input.messages.findLast(
+              (m) => m.info.role === "assistant" && !m.info.summary,
+            )?.info as MessageV2.Assistant | undefined
+            // A missing turn has nothing to resume; guard `!== undefined` explicitly
+            // so `!lastNonSummaryAssistant?.finish` can't inject a spurious continue
+            // when no assistant turn exists.
+            const shouldAutoContinue =
+              lastNonSummaryAssistant !== undefined &&
+              (!lastNonSummaryAssistant.finish ||
+                lastNonSummaryAssistant.finish === "tool-calls" ||
+                lastNonSummaryAssistant.finish === "unknown")
+            if (!shouldAutoContinue) return result
+          }
           const info = yield* provider.getProvider(userMessage.model.providerID)
           if (
             (yield* plugin.trigger(

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -643,6 +643,7 @@ export const layer: Layer.Layer<
           // reason rather than the overflow flag matches upstream opencode #27730;
           // the old overflow gate stranded mid-task work that compacted without a
           // provider-side overflow.
+          let shouldAutoContinue = true
           if (!input.overflow) {
             const lastNonSummaryAssistant = input.messages.findLast(
               (m) => m.info.role === "assistant" && !m.info.summary,
@@ -650,61 +651,66 @@ export const layer: Layer.Layer<
             // A missing turn has nothing to resume; guard `!== undefined` explicitly
             // so `!lastNonSummaryAssistant?.finish` can't inject a spurious continue
             // when no assistant turn exists.
-            const shouldAutoContinue =
+            shouldAutoContinue =
               lastNonSummaryAssistant !== undefined &&
               (!lastNonSummaryAssistant.finish ||
                 lastNonSummaryAssistant.finish === "tool-calls" ||
                 lastNonSummaryAssistant.finish === "unknown")
-            if (!shouldAutoContinue) return result
           }
-          const info = yield* provider.getProvider(userMessage.model.providerID)
-          if (
-            (yield* plugin.trigger(
-              "experimental.compaction.autocontinue",
-              {
-                sessionID: input.sessionID,
-                agent: userMessage.agent,
-                model: yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID),
-                provider: {
-                  source: info.source,
-                  info,
-                  options: info.options,
+          // Gate ONLY the synthetic continue on shouldAutoContinue — never the
+          // function exit. A clean finish skips the continue but still falls
+          // through to the shared tail below (error check + Compacted event), so
+          // a successful compaction is always observed by subscribers.
+          if (shouldAutoContinue) {
+            const info = yield* provider.getProvider(userMessage.model.providerID)
+            if (
+              (yield* plugin.trigger(
+                "experimental.compaction.autocontinue",
+                {
+                  sessionID: input.sessionID,
+                  agent: userMessage.agent,
+                  model: yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID),
+                  provider: {
+                    source: info.source,
+                    info,
+                    options: info.options,
+                  },
+                  message: userMessage,
+                  overflow: input.overflow === true,
                 },
-                message: userMessage,
-                overflow: input.overflow === true,
-              },
-              { enabled: true },
-            )).enabled
-          ) {
-            const continueMsg = yield* session.updateMessage({
-              id: MessageID.ascending(),
-              role: "user",
-              sessionID: input.sessionID,
-              time: { created: Date.now() },
-              agent: userMessage.agent,
-              model: userMessage.model,
-            })
-            const text =
-              (input.overflow
-                ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
-                : "") +
-              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
-            yield* session.updatePart({
-              id: PartID.ascending(),
-              messageID: continueMsg.id,
-              sessionID: input.sessionID,
-              type: "text",
-              // Internal marker for auto-compaction followups so provider plugins
-              // can distinguish them from manual post-compaction user prompts.
-              // This is not a stable plugin contract and may change or disappear.
-              metadata: { compaction_continue: true },
-              synthetic: true,
-              text,
-              time: {
-                start: Date.now(),
-                end: Date.now(),
-              },
-            })
+                { enabled: true },
+              )).enabled
+            ) {
+              const continueMsg = yield* session.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: input.sessionID,
+                time: { created: Date.now() },
+                agent: userMessage.agent,
+                model: userMessage.model,
+              })
+              const text =
+                (input.overflow
+                  ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
+                  : "") +
+                "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+              yield* session.updatePart({
+                id: PartID.ascending(),
+                messageID: continueMsg.id,
+                sessionID: input.sessionID,
+                type: "text",
+                // Internal marker for auto-compaction followups so provider plugins
+                // can distinguish them from manual post-compaction user prompts.
+                // This is not a stable plugin contract and may change or disappear.
+                metadata: { compaction_continue: true },
+                synthetic: true,
+                text,
+                time: {
+                  start: Date.now(),
+                  end: Date.now(),
+                },
+              })
+            }
           }
         }
       }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -598,7 +598,7 @@ export const layer: Layer.Layer<
         })
       }
 
-      if (result === "continue" && input.auto && input.overflow) {
+      if (result === "continue" && input.auto) {
         if (replay) {
           const original = replay.info
           const replayMsg = yield* session.updateMessage({
@@ -633,6 +633,23 @@ export const layer: Layer.Layer<
         }
 
         if (!replay) {
+          // Only auto-continue when the turn the compaction interrupted had NOT
+          // finished cleanly. A clean finish (e.g. "stop"/"end_turn") means the
+          // agent itself chose to end the turn, so injecting a synthetic continue
+          // would override that decision and make compaction-turns behave more
+          // eagerly than normal turns. Resume only when the last real turn was
+          // still mid-flight (no finish, or "tool-calls"/"unknown"). Keys on the
+          // turn's finish reason rather than the overflow flag, matching upstream
+          // opencode #27730 — the overflow flag stranded mid-task work that
+          // happened to compact without a provider-side overflow.
+          const lastNonSummaryAssistant = input.messages.findLast(
+            (m) => m.info.role === "assistant" && !m.info.summary,
+          )?.info as MessageV2.Assistant | undefined
+          const shouldAutoContinue =
+            !lastNonSummaryAssistant?.finish ||
+            lastNonSummaryAssistant.finish === "tool-calls" ||
+            lastNonSummaryAssistant.finish === "unknown"
+          if (!shouldAutoContinue) return result
           const info = yield* provider.getProvider(userMessage.model.providerID)
           if (
             (yield* plugin.trigger(

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1180,6 +1180,23 @@ describe("session.compaction.process", () => {
       fn: async () => {
         const session = await svc.create({})
         const msg = await user(session.id, "hello")
+        // Mid-task turn so shouldAutoContinue is true; the plugin returning
+        // enabled=false is then what suppresses the continue, not the guard.
+        await svc.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          parentID: msg.id,
+          time: { created: Date.now() },
+          finish: "tool-calls",
+        })
         const rt = runtime("continue", autocontinue(false), wide())
         try {
           const msgs = await svc.messages({ sessionID: session.id })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1031,6 +1031,72 @@ describe("session.compaction.process", () => {
     })
   })
 
+  test("publishes compacted event after natural auto compaction with a clean finish", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const msg = await user(session.id, "hello")
+        // Clean finish (end_turn): compaction must NOT inject a synthetic
+        // continue, but a successful compaction must still publish Compacted so
+        // external subscribers (status/divider/etc.) observe it.
+        await assistant(session.id, msg.id, tmp.path)
+        const msgs = await svc.messages({ sessionID: session.id })
+        const done = defer()
+        let seen = false
+        const rt = runtime("continue", Plugin.defaultLayer, wide())
+        let unsub: (() => void) | undefined
+        try {
+          unsub = await rt.runPromise(
+            Bus.Service.use((svc) =>
+              svc.subscribeCallback(SessionCompaction.Event.Compacted, (evt) => {
+                if (evt.properties.sessionID !== session.id) return
+                seen = true
+                done.resolve()
+              }),
+            ),
+          )
+
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: msg.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+
+          await Promise.race([
+            done.promise,
+            wait(500).then(() => {
+              throw new Error("timed out waiting for compacted event")
+            }),
+          ])
+          expect(result).toBe("continue")
+          expect(seen).toBe(true)
+
+          const all = await svc.messages({ sessionID: session.id })
+          expect(
+            all.some(
+              (m) =>
+                m.info.role === "user" &&
+                m.parts.some(
+                  (part) =>
+                    part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+                ),
+            ),
+          ).toBe(false)
+        } finally {
+          unsub?.()
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
   test("marks summary message as errored on compact result", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1076,6 +1076,9 @@ describe("session.compaction.process", () => {
       fn: async () => {
         const session = await svc.create({})
         const msg = await user(session.id, "hello")
+        // The interrupted turn finished cleanly (end_turn): the agent chose to
+        // stop, so compaction must not inject a synthetic continue over that.
+        await assistant(session.id, msg.id, tmp.path)
         const rt = runtime("continue", Plugin.defaultLayer, wide())
         try {
           const msgs = await svc.messages({ sessionID: session.id })
@@ -1105,6 +1108,64 @@ describe("session.compaction.process", () => {
                 ),
             ),
           ).toBe(false)
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("injects synthetic continue when auto compaction interrupts a mid-task turn", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const parent = await user(session.id, "do a multi-step task")
+        // The interrupted turn did not finish cleanly: it stopped on a
+        // tool-calls step, so there is unfinished work to resume after compaction.
+        await svc.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          parentID: parent.id,
+          time: { created: Date.now() },
+          finish: "tool-calls",
+        })
+        const rt = runtime("continue", Plugin.defaultLayer, wide())
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+
+          const all = await svc.messages({ sessionID: session.id })
+
+          expect(result).toBe("continue")
+          expect(
+            all.some(
+              (msg) =>
+                msg.info.role === "user" &&
+                msg.parts.some(
+                  (part) =>
+                    part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+                ),
+            ),
+          ).toBe(true)
         } finally {
           await rt.dispose()
         }

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -530,6 +530,49 @@ it.live("loop compacts a finished assistant turn before exiting when it overflow
   ),
 )
 
+it.live("loop continues a mid-task turn after auto compaction interrupts it", () =>
+  provideTmpdirServer(
+    ({ llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Interrupted mid-task turn" })
+        // The overflowing turn stopped on a tool-calls step (mid-task), so there
+        // is unfinished work the loop must resume after compacting — unlike a
+        // cleanly finished turn, which should compact and wait.
+        const seeded = yield* seed(chat.id, { finish: "tool-calls" })
+        yield* sessions.updateMessage({
+          ...seeded.assistant,
+          tokens: { input: 95_000, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+        })
+        yield* llm.text("## Goal\n- Compacted mid-task turn")
+        yield* llm.text("resumed the interrupted work")
+
+        const result = yield* prompt.loop({ sessionID: chat.id })
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const compactionPart = messages
+          .flatMap((message) => message.parts)
+          .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+        const syntheticContinue = messages.find(
+          (message) =>
+            message.info.role === "user" &&
+            message.parts.some(
+              (part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+            ),
+        )
+
+        expect(compactionPart).toBeDefined()
+        expect(compactionPart?.overflow).not.toBe(true)
+        // Mid-task interruption: compaction injects the synthetic continue and the
+        // loop resumes (a second LLM call) instead of stopping at the summary.
+        expect(syntheticContinue).toBeDefined()
+        expect(yield* llm.calls).toBeGreaterThanOrEqual(2)
+        expect(result.info.role).toBe("assistant")
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("finished compaction with retained tail does not compact that tail again", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
## Summary

Auto-compaction decided whether to inject the synthetic "continue" prompt from the `overflow` flag, so a natural (non-overflow) auto-compaction that interrupted a **mid-task** turn (last assistant `finish="tool-calls"`, `overflow=false`) stopped instead of resuming — stranding the unfinished work and forcing the user to type "continue" by hand.

The fix gates the synthetic continue on the interrupted turn's **finish reason** instead of the overflow flag, matching upstream opencode #27730: resume only when the last non-summary assistant was still mid-flight (no finish / `tool-calls` / `unknown`); a cleanly finished turn (`stop`/`end_turn`) stops and waits, exactly as it would without compaction. Compaction becomes transparent to normal turn-taking.

## Why

Regressed in `eb765ec2e3` ("guard compaction control flow"), which added `&& input.overflow` while porting the *intent* of upstream #27730. But #27730 keys on the turn's finish reason, not on overflow. The two diverge for a mid-task interruption: upstream resumes, our port stopped. The overflow replay path and the stalled-tail guard are unchanged; manual `/compact` is unaffected (`auto=false`).

Prior-fix miss: `eb765ec2e3` used overflow as a proxy for "unfinished" and shipped no mid-task regression test, so the strand went uncaught. This PR adds both a unit test and a loop test for it.

## Related Issue

Fixes #913.

## Human Review Status

Pending

## Review Focus

- The `shouldAutoContinue` predicate in `compaction.ts` — does it correctly resume only mid-task interruptions and leave clean finishes waiting?
- That the overflow replay branch (`if (replay)`) and the stalled-tail guard are untouched.

## Risk Notes

- Behavior change: auto-compaction that interrupts a mid-task turn now resumes automatically (previously stopped). Cleanly-finished turns and manual `/compact` are unchanged.
- User-facing behavior fix; a one-line release-notes bullet may be warranted (deferring to maintainer).
- Skipped conditional checklist items: visible-UI/copy (no UI or copy changed); platform/packaging (no platform surface touched).

## How To Verify

```text
bun --cwd packages/opencode test test/session/compaction.test.ts test/session/prompt-effect.test.ts → 110 passed (incl. 2 new regression tests)
bun --cwd packages/opencode run typecheck (tsgo --noEmit) → clean
RED check: stashed compaction.ts fix, both new tests fail for the predicted reason; restored → green
```

## Screenshots or Recordings

N/A — no visible UI change (agent engine session mechanics).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
