### PR TITLE
fix(ui): clean up markdown code-block copy button

### DIFF
--- a/packages/app/e2e/snap/code-copy-tooltip.snap.ts
+++ b/packages/app/e2e/snap/code-copy-tooltip.snap.ts
@@ -1,0 +1,78 @@
+import { fileURLToPath } from "node:url"
+import { test } from "../fixtures"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 480, height: 220 }, deviceScaleFactor: 2 })
+
+// The copy button and its tooltip are injected by markdown post-processing
+// (ensureCodeWrapper + setupCodeCopy), not by a Solid component, so we drive
+// those helpers directly instead of standing up the full Markdown context.
+// The code block sits inside a narrow overflow:hidden box that mimics the
+// message stream: the regression we guard is the tooltip getting clipped at the
+// stream's edge. With the fixed body tooltip it must float clear of the box.
+const toolsPath = fileURLToPath(new URL("../../../ui/src/components/markdown-code-tools.ts", import.meta.url))
+
+async function waitForThemeBoot(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForFunction(
+    () => getComputedStyle(document.documentElement).getPropertyValue("--bg-base").trim().length > 0,
+    null,
+    { timeout: 30_000 },
+  )
+}
+
+test("code-copy-tooltip", async ({ page }) => {
+  test.setTimeout(120_000)
+
+  await page.goto("/")
+  await waitForThemeBoot(page)
+
+  await page.evaluate(async (path) => {
+    const mod = await import(path)
+    const labels = { copy: "复制到剪贴板", copied: "已复制" }
+
+    const stream = document.createElement("div")
+    Object.assign(stream.style, {
+      position: "relative",
+      overflow: "hidden",
+      width: "320px",
+      margin: "72px auto 0",
+      padding: "12px",
+      borderRadius: "10px",
+      background: "var(--surface-base)",
+      boxShadow: "var(--shadow-floating)",
+    })
+
+    const markdown = document.createElement("div")
+    markdown.setAttribute("data-component", "markdown")
+    const pre = document.createElement("pre")
+    const code = document.createElement("code")
+    code.textContent = "const total = items.reduce((a, b) => a + b, 0)\nconsole.log(total)"
+    pre.appendChild(code)
+    markdown.appendChild(pre)
+    stream.appendChild(markdown)
+
+    document.body.innerHTML = ""
+    document.body.appendChild(stream)
+
+    mod.ensureCodeWrapper(pre, labels)
+    mod.setupCodeCopy(markdown, () => labels)
+  }, `/@fs/${toolsPath}`)
+
+  const block = page.locator('[data-component="markdown-code"]')
+  await block.hover()
+  const button = page.locator('[data-slot="markdown-copy-button"]')
+  await button.waitFor({ state: "visible", timeout: 30_000 })
+
+  // Button only: confirms the borderless icon-button affordance on hover.
+  const buttonShot: Shot = { name: "button", buf: await page.screenshot() }
+
+  // Tooltip: hovering the button floats the label above it, clear of the box's
+  // overflow:hidden clip.
+  await button.hover()
+  await page.locator('[data-slot="markdown-copy-tooltip"][data-show="true"]').waitFor({ state: "visible", timeout: 30_000 })
+  const tooltipShot: Shot = { name: "tooltip", buf: await page.screenshot() }
+
+  const out = snapOutputPath("code-copy-tooltip")
+  await composeGrid([buttonShot, tooltipShot], out, { cols: 2 })
+  process.stdout.write(`\n[snap] code-copy-tooltip grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/code-copy-tooltip.snap.ts
+++ b/packages/app/e2e/snap/code-copy-tooltip.snap.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test"
 import { fileURLToPath } from "node:url"
 import { test } from "../fixtures"
 import { composeGrid, snapOutputPath, type Shot } from "./_compose"
@@ -69,7 +70,11 @@ test("code-copy-tooltip", async ({ page }) => {
   // Tooltip: hovering the button floats the label above it, clear of the box's
   // overflow:hidden clip.
   await button.hover()
-  await page.locator('[data-slot="markdown-copy-tooltip"][data-show="true"]').waitFor({ state: "visible", timeout: 30_000 })
+  const tooltip = page.locator('[data-slot="markdown-copy-tooltip"][data-show="true"]')
+  await tooltip.waitFor({ state: "visible", timeout: 30_000 })
+  // Wait out the 0.15s opacity fade-in so the screenshot isn't captured
+  // mid-transition, which would make the visual snapshot flaky.
+  await expect.poll(() => tooltip.evaluate((el) => getComputedStyle(el).opacity), { timeout: 5_000 }).toBe("1")
   const tooltipShot: Shot = { name: "tooltip", buf: await page.screenshot() }
 
   const out = snapOutputPath("code-copy-tooltip")

--- a/packages/ui/src/components/markdown-code-tools.ts
+++ b/packages/ui/src/components/markdown-code-tools.ts
@@ -121,7 +121,9 @@ export function markCodeLinks(root: HTMLDivElement) {
 // the viewport. Only one copy button is ever hovered or focused at a time, so a
 // single element is enough.
 let tooltipEl: HTMLDivElement | null = null
-let activeTooltipButton: HTMLButtonElement | null = null
+// WeakRef so a code block removed from the stream (chat re-render) can still be
+// garbage-collected even while it is the last-hovered button.
+let activeTooltipButton: WeakRef<HTMLButtonElement> | null = null
 
 function getTooltipEl(): HTMLDivElement {
   if (tooltipEl?.isConnected) return tooltipEl
@@ -136,7 +138,7 @@ function getTooltipEl(): HTMLDivElement {
 function showTooltip(button: HTMLButtonElement) {
   const label = button.getAttribute("data-tooltip")
   if (!label) return
-  activeTooltipButton = button
+  activeTooltipButton = new WeakRef(button)
   const tip = getTooltipEl()
   tip.textContent = label
   tip.setAttribute("data-show", "true")
@@ -156,7 +158,9 @@ function showTooltip(button: HTMLButtonElement) {
 }
 
 function hideTooltip(button?: HTMLButtonElement) {
-  if (button && activeTooltipButton !== button) return
+  // Early-out avoids redundant DOM writes on scroll/resize when nothing shows.
+  if (!activeTooltipButton) return
+  if (button && activeTooltipButton.deref() !== button) return
   activeTooltipButton = null
   tooltipEl?.removeAttribute("data-show")
 }
@@ -189,7 +193,7 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
       if (existing) clearTimeout(existing)
       const timeout = setTimeout(() => {
         setCopyState(button, getLabels(), false)
-        if (activeTooltipButton === button) {
+        if (activeTooltipButton?.deref() === button) {
           if (button.matches(":hover")) showTooltip(button)
           else hideTooltip(button)
         }
@@ -246,7 +250,8 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     root.removeEventListener("focusout", handleFocusOut)
     window.removeEventListener("scroll", handleReposition, true)
     window.removeEventListener("resize", handleReposition)
-    if (activeTooltipButton && root.contains(activeTooltipButton)) hideTooltip()
+    const activeBtn = activeTooltipButton?.deref()
+    if (activeBtn && root.contains(activeBtn)) hideTooltip()
     for (const timeout of timeouts.values()) {
       clearTimeout(timeout)
     }

--- a/packages/ui/src/components/markdown-code-tools.ts
+++ b/packages/ui/src/components/markdown-code-tools.ts
@@ -165,6 +165,29 @@ function hideTooltip(button?: HTMLButtonElement) {
   tooltipEl?.removeAttribute("data-show")
 }
 
+// A fixed tooltip would drift away from its button when the page scrolls or
+// resizes, so we dismiss it. The tooltip is a single shared element, so these
+// global listeners are reference-counted and registered once for the whole app
+// rather than once per Markdown instance.
+let viewportDismissCount = 0
+function dismissOnViewportChange() {
+  hideTooltip()
+}
+function retainViewportDismiss() {
+  if (viewportDismissCount === 0) {
+    window.addEventListener("scroll", dismissOnViewportChange, true)
+    window.addEventListener("resize", dismissOnViewportChange)
+  }
+  viewportDismissCount++
+}
+function releaseViewportDismiss() {
+  viewportDismissCount = Math.max(0, viewportDismissCount - 1)
+  if (viewportDismissCount === 0) {
+    window.removeEventListener("scroll", dismissOnViewportChange, true)
+    window.removeEventListener("resize", dismissOnViewportChange)
+  }
+}
+
 export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   const timeouts = new Map<HTMLButtonElement, ReturnType<typeof setTimeout>>()
 
@@ -194,7 +217,9 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
       const timeout = setTimeout(() => {
         setCopyState(button, getLabels(), false)
         if (activeTooltipButton?.deref() === button) {
-          if (button.matches(":hover")) showTooltip(button)
+          // Keep the tooltip while the button is still hovered OR keyboard-
+          // focused; a keyboard copy leaves focus on the button, not hover.
+          if (button.matches(":hover") || document.activeElement === button) showTooltip(button)
           else hideTooltip(button)
         }
         timeouts.delete(button)
@@ -225,22 +250,26 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     const button = buttonFromEvent(event.target)
     if (button instanceof HTMLButtonElement) hideTooltip(button)
   }
-  // A fixed tooltip would drift away from its button once the page scrolls or
-  // resizes; dismissing it is simpler and matches its transient nature.
-  const handleReposition = () => hideTooltip()
-
   const buttons = Array.from(root.querySelectorAll('[data-slot="markdown-copy-button"]'))
   for (const button of buttons) {
     if (button instanceof HTMLButtonElement) updateLabel(button)
   }
+
+  // Markdown updates content via morphdom or innerHTML = "", neither of which
+  // fires a mouse/focus event; watch the subtree so a tooltip whose button was
+  // removed (chat re-render, content cleared) is dismissed, not left on screen.
+  const detachObserver = new MutationObserver(() => {
+    const active = activeTooltipButton?.deref()
+    if (active && !active.isConnected) hideTooltip()
+  })
+  detachObserver.observe(root, { childList: true, subtree: true })
 
   root.addEventListener("click", handleClick)
   root.addEventListener("mouseover", handlePointerOver)
   root.addEventListener("mouseout", handlePointerOut)
   root.addEventListener("focusin", handleFocusIn)
   root.addEventListener("focusout", handleFocusOut)
-  window.addEventListener("scroll", handleReposition, true)
-  window.addEventListener("resize", handleReposition)
+  retainViewportDismiss()
 
   return () => {
     root.removeEventListener("click", handleClick)
@@ -248,8 +277,8 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     root.removeEventListener("mouseout", handlePointerOut)
     root.removeEventListener("focusin", handleFocusIn)
     root.removeEventListener("focusout", handleFocusOut)
-    window.removeEventListener("scroll", handleReposition, true)
-    window.removeEventListener("resize", handleReposition)
+    releaseViewportDismiss()
+    detachObserver.disconnect()
     const activeBtn = activeTooltipButton?.deref()
     if (activeBtn && root.contains(activeBtn)) hideTooltip()
     for (const timeout of timeouts.values()) {

--- a/packages/ui/src/components/markdown-code-tools.ts
+++ b/packages/ui/src/components/markdown-code-tools.ts
@@ -39,7 +39,6 @@ function createCopyButton(labels: CopyLabels) {
   const button = document.createElement("button")
   button.type = "button"
   button.setAttribute("data-component", "icon-button")
-  button.setAttribute("data-variant", "secondary")
   button.setAttribute("data-slot", "markdown-copy-button")
   button.setAttribute("aria-label", labels.copy)
   button.setAttribute("data-tooltip", labels.copy)
@@ -115,6 +114,53 @@ export function markCodeLinks(root: HTMLDivElement) {
   }
 }
 
+// Copy-button tooltip. A CSS ::after on the button gets clipped by the message
+// stream's overflow:hidden when a code block sits near the stream's top or
+// right edge. Instead one shared element lives on document.body with fixed
+// positioning, so it escapes every ancestor's clipping and can be clamped into
+// the viewport. Only one copy button is ever hovered or focused at a time, so a
+// single element is enough.
+let tooltipEl: HTMLDivElement | null = null
+let activeTooltipButton: HTMLButtonElement | null = null
+
+function getTooltipEl(): HTMLDivElement {
+  if (tooltipEl?.isConnected) return tooltipEl
+  const el = document.createElement("div")
+  el.setAttribute("data-slot", "markdown-copy-tooltip")
+  el.setAttribute("aria-hidden", "true")
+  document.body.appendChild(el)
+  tooltipEl = el
+  return el
+}
+
+function showTooltip(button: HTMLButtonElement) {
+  const label = button.getAttribute("data-tooltip")
+  if (!label) return
+  activeTooltipButton = button
+  const tip = getTooltipEl()
+  tip.textContent = label
+  tip.setAttribute("data-show", "true")
+  const anchor = button.getBoundingClientRect()
+  const tip_box = tip.getBoundingClientRect()
+  const gap = 4
+  const margin = 4
+  // Prefer above the button; flip below when there isn't room near the top.
+  let top = anchor.top - tip_box.height - gap
+  if (top < margin) top = anchor.bottom + gap
+  // Center on the button, then clamp so neither edge leaves the viewport.
+  let left = anchor.left + anchor.width / 2 - tip_box.width / 2
+  const maxLeft = window.innerWidth - tip_box.width - margin
+  left = Math.max(margin, Math.min(left, maxLeft))
+  tip.style.top = `${Math.round(top)}px`
+  tip.style.left = `${Math.round(left)}px`
+}
+
+function hideTooltip(button?: HTMLButtonElement) {
+  if (button && activeTooltipButton !== button) return
+  activeTooltipButton = null
+  tooltipEl?.removeAttribute("data-show")
+}
+
 export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   const timeouts = new Map<HTMLButtonElement, ReturnType<typeof setTimeout>>()
 
@@ -124,11 +170,11 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     setCopyState(button, labels, copied)
   }
 
-  const handleClick = async (event: MouseEvent) => {
-    const target = event.target
-    if (!(target instanceof Element)) return
+  const buttonFromEvent = (target: EventTarget | null) =>
+    target instanceof Element ? target.closest('[data-slot="markdown-copy-button"]') : null
 
-    const button = target.closest('[data-slot="markdown-copy-button"]')
+  const handleClick = async (event: MouseEvent) => {
+    const button = buttonFromEvent(event.target)
     if (!(button instanceof HTMLButtonElement)) return
     const code = button.closest('[data-component="markdown-code"]')?.querySelector("code")
     const content = code?.textContent ?? ""
@@ -138,10 +184,15 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     try {
       await clipboard.writeText(content)
       setCopyState(button, getLabels(), true)
+      showTooltip(button)
       const existing = timeouts.get(button)
       if (existing) clearTimeout(existing)
       const timeout = setTimeout(() => {
         setCopyState(button, getLabels(), false)
+        if (activeTooltipButton === button) {
+          if (button.matches(":hover")) showTooltip(button)
+          else hideTooltip(button)
+        }
         timeouts.delete(button)
       }, 2000)
       timeouts.set(button, timeout)
@@ -150,15 +201,52 @@ export function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels)
     }
   }
 
+  const handlePointerOver = (event: MouseEvent) => {
+    const button = buttonFromEvent(event.target)
+    if (button instanceof HTMLButtonElement) showTooltip(button)
+  }
+  const handlePointerOut = (event: MouseEvent) => {
+    const button = buttonFromEvent(event.target)
+    if (!(button instanceof HTMLButtonElement)) return
+    // Moving between the button and its child icon should not dismiss it.
+    const next = event.relatedTarget
+    if (next instanceof Node && button.contains(next)) return
+    hideTooltip(button)
+  }
+  const handleFocusIn = (event: FocusEvent) => {
+    const button = buttonFromEvent(event.target)
+    if (button instanceof HTMLButtonElement) showTooltip(button)
+  }
+  const handleFocusOut = (event: FocusEvent) => {
+    const button = buttonFromEvent(event.target)
+    if (button instanceof HTMLButtonElement) hideTooltip(button)
+  }
+  // A fixed tooltip would drift away from its button once the page scrolls or
+  // resizes; dismissing it is simpler and matches its transient nature.
+  const handleReposition = () => hideTooltip()
+
   const buttons = Array.from(root.querySelectorAll('[data-slot="markdown-copy-button"]'))
   for (const button of buttons) {
     if (button instanceof HTMLButtonElement) updateLabel(button)
   }
 
   root.addEventListener("click", handleClick)
+  root.addEventListener("mouseover", handlePointerOver)
+  root.addEventListener("mouseout", handlePointerOut)
+  root.addEventListener("focusin", handleFocusIn)
+  root.addEventListener("focusout", handleFocusOut)
+  window.addEventListener("scroll", handleReposition, true)
+  window.addEventListener("resize", handleReposition)
 
   return () => {
     root.removeEventListener("click", handleClick)
+    root.removeEventListener("mouseover", handlePointerOver)
+    root.removeEventListener("mouseout", handlePointerOut)
+    root.removeEventListener("focusin", handleFocusIn)
+    root.removeEventListener("focusout", handleFocusOut)
+    window.removeEventListener("scroll", handleReposition, true)
+    window.removeEventListener("resize", handleReposition)
+    if (activeTooltipButton && root.contains(activeTooltipButton)) hideTooltip()
     for (const timeout of timeouts.values()) {
       clearTimeout(timeout)
     }

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -347,42 +347,6 @@
     opacity: 0;
     transition: opacity 0.15s ease;
     z-index: 1;
-
-    &::after {
-      content: attr(data-tooltip);
-      position: absolute;
-      left: 50%;
-      bottom: calc(100% + 4px);
-      transform: translateX(-50%);
-      z-index: 1000;
-      max-width: 320px;
-      border-radius: var(--radius-sm);
-      background: var(--surface-raised);
-      color: var(--fg-strong);
-      padding: 2px 8px;
-      border: 1px solid var(--border-weak, rgba(0, 0, 0, 0.07));
-      box-shadow: var(--shadow-floating);
-      pointer-events: none;
-      white-space: nowrap;
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-caption);
-      font-style: normal;
-      font-weight: var(--font-weight-emphasis);
-      line-height: var(--line-height-h3);
-      opacity: 0;
-      transition: opacity 0.15s ease;
-    }
-  }
-  [data-slot="markdown-copy-button"]:hover::after,
-  [data-slot="markdown-copy-button"]:focus-visible::after {
-    opacity: 1;
-  }
-  [data-slot="markdown-copy-button"][data-variant="secondary"] {
-    box-shadow: none;
-    border: 1px solid var(--border-weak);
-  }
-  [data-slot="markdown-copy-button"][data-variant="secondary"] [data-slot="icon-svg"] {
-    color: var(--icon-base);
   }
   [data-component="markdown-code"]:hover [data-slot="markdown-copy-button"],
   [data-component="markdown-code"]:focus-within [data-slot="markdown-copy-button"] {
@@ -397,4 +361,31 @@
   [data-slot="markdown-copy-button"][data-copied="true"] [data-slot="check-icon"] {
     display: inline-flex;
   }
+}
+
+/* Copy-button tooltip lives on document.body (see markdown-code-tools.ts), so it
+   escapes the message stream's overflow:hidden clipping. Kept outside the
+   [data-component="markdown"] nest because the element is not a markdown
+   descendant; positioning is set inline via fixed coordinates. */
+[data-slot="markdown-copy-tooltip"] {
+  position: fixed;
+  z-index: 1000;
+  max-width: 320px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  color: var(--fg-strong);
+  padding: 2px 8px;
+  border: 1px solid var(--border-weak, rgba(0, 0, 0, 0.07));
+  box-shadow: var(--shadow-floating);
+  pointer-events: none;
+  white-space: nowrap;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-emphasis);
+  line-height: var(--line-height-h3);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+[data-slot="markdown-copy-tooltip"][data-show="true"] {
+  opacity: 1;
 }

--- a/packages/ui/src/components/markdown.test.ts
+++ b/packages/ui/src/components/markdown.test.ts
@@ -305,6 +305,27 @@ describe("markdown code decoration", () => {
       vi.useRealTimers()
     }
   })
+
+  test("hovering the copy button shows a tooltip on document.body and hides on leave", () => {
+    document.body.innerHTML =
+      '<div data-component="markdown-code"><pre><code>echo hi</code></pre><button type="button" data-slot="markdown-copy-button" data-tooltip="Copy to clipboard">Copy</button></div>'
+    const cleanup = setupCodeCopy(document.body as HTMLDivElement, () => ({
+      copy: "Copy to clipboard",
+      copied: "Copied",
+    }))
+    const button = document.querySelector("button")!
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+    const tip = document.querySelector('[data-slot="markdown-copy-tooltip"]')
+    expect(tip).not.toBeNull()
+    expect(tip!.getAttribute("data-show")).toBe("true")
+    expect(tip!.textContent).toBe("Copy to clipboard")
+
+    button.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }))
+    expect(tip!.getAttribute("data-show")).toBeNull()
+
+    cleanup()
+  })
 })
 
 describe("forceOpenAllDetails (streaming UX)", () => {

--- a/packages/ui/src/components/markdown.test.ts
+++ b/packages/ui/src/components/markdown.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test, vi } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test, vi } from "bun:test"
 import {
   forceOpenAllDetails,
   preserveDetailsOpenState,
@@ -325,6 +325,95 @@ describe("markdown code decoration", () => {
     expect(tip!.getAttribute("data-show")).toBeNull()
 
     cleanup()
+  })
+
+  test("dismisses the tooltip when its code block is removed from the DOM", async () => {
+    document.body.innerHTML =
+      '<div data-component="markdown-code"><pre><code>echo hi</code></pre><button type="button" data-slot="markdown-copy-button" data-tooltip="Copy to clipboard">Copy</button></div>'
+    const cleanup = setupCodeCopy(document.body as HTMLDivElement, () => ({
+      copy: "Copy to clipboard",
+      copied: "Copied",
+    }))
+    const button = document.querySelector("button")!
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+    const tip = document.querySelector('[data-slot="markdown-copy-tooltip"]')!
+    expect(tip.getAttribute("data-show")).toBe("true")
+
+    // Markdown clears/re-renders content without any mouse or focus event;
+    // the MutationObserver must dismiss the now-orphaned tooltip.
+    document.querySelector('[data-component="markdown-code"]')!.remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(tip.getAttribute("data-show")).toBeNull()
+    cleanup()
+  })
+
+  test("keyboard copy keeps the tooltip after the reset timer while the button stays focused", async () => {
+    vi.useFakeTimers()
+    try {
+      const writeText = mock(async () => undefined)
+      setClipboard(writeText)
+
+      document.body.innerHTML =
+        '<div data-component="markdown-code"><pre><code>echo hi</code></pre><button type="button" data-slot="markdown-copy-button" data-tooltip="Copy">Copy</button></div>'
+      const cleanup = setupCodeCopy(document.body as HTMLDivElement, () => ({
+        copy: "Copy",
+        copied: "Copied",
+      }))
+      const button = document.querySelector("button")!
+
+      button.focus()
+      button.click()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      const tip = document.querySelector('[data-slot="markdown-copy-tooltip"]')!
+      expect(tip.getAttribute("data-show")).toBe("true")
+      expect(tip.textContent).toBe("Copied")
+
+      vi.advanceTimersByTime(2000)
+
+      // Button is still focused (no hover), so the tooltip stays and the label
+      // reverts to copy instead of disappearing.
+      expect(document.activeElement).toBe(button)
+      expect(tip.getAttribute("data-show")).toBe("true")
+      expect(tip.textContent).toBe("Copy")
+      cleanup()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test("reference-counts the global scroll/resize listeners across instances", () => {
+    const addSpy = spyOn(window, "addEventListener")
+    const removeSpy = spyOn(window, "removeEventListener")
+    try {
+      const countScroll = (spy: typeof addSpy) =>
+        spy.mock.calls.filter((args) => args[0] === "scroll").length
+
+      const root1 = document.createElement("div")
+      const root2 = document.createElement("div")
+      document.body.append(root1, root2)
+      const labels = () => ({ copy: "Copy", copied: "Copied" })
+
+      const addsBefore = countScroll(addSpy)
+      const cleanup1 = setupCodeCopy(root1 as HTMLDivElement, labels)
+      const cleanup2 = setupCodeCopy(root2 as HTMLDivElement, labels)
+      // Two instances, but the global scroll listener is registered only once.
+      expect(countScroll(addSpy) - addsBefore).toBe(1)
+
+      const removesBefore = countScroll(removeSpy)
+      cleanup1()
+      // One instance still holds the ref, so nothing is removed yet.
+      expect(countScroll(removeSpy) - removesBefore).toBe(0)
+      cleanup2()
+      // Last instance gone, the single global listener is removed.
+      expect(countScroll(removeSpy) - removesBefore).toBe(1)
+    } finally {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Two visual fixes for the copy button overlaid on fenced code blocks in the markdown message stream:

- Removed the `1px` border so the button matches the design system's borderless icon-button (transparent background, hover overlay, focus ring restored).
- Reworked its tooltip to render as a fixed singleton on `document.body`, so it no longer gets clipped by the message stream's `overflow:hidden` and flips/clamps into the viewport as needed.

## Why

The code-block copy button carried a `border: 1px solid` override that diverged from the standard borderless icon-button affordance (and also suppressed the focus ring). Its tooltip was a CSS `::after` pseudo-element, so an ancestor's `overflow:hidden` clipped it whenever a code block sat near the stream's top or right edge.

## Related Issue

None — reported directly by the maintainer.

## Human Review Status

Pending

## Review Focus

- `markdown-code-tools.ts`: the body-mounted singleton tooltip — event wiring (mouseover/out, focusin/out, scroll/resize dismissal), viewport clamping, label refresh after copy, and cleanup on unmount.
- `markdown.css`: the removed `::after` and border rules; the new top-level `[data-slot="markdown-copy-tooltip"]` rule sits outside the `[data-component="markdown"]` nest on purpose (the element is not a markdown descendant).

## Risk Notes

- No platform/packaging surface touched: pure web rendering (CSS + DOM), no `platform.*` / `window.api` / IPC, so snap (web Chromium) is the appropriate check. The platform checklist item is left unticked for this reason.
- No docs, release notes, dependency, or permission surface touched; that conditional item is left unticked.
- The tooltip is now a shared body singleton across all code blocks; only one button is hovered or focused at a time, so one element is sufficient.

## How To Verify

```text
bun test markdown.test.ts: 41 pass (incl. new hover-shows-tooltip test)
ui typecheck (tsgo --noEmit): clean
bun run snap code-copy-tooltip: borderless button + tooltip floats clear of the overflow box
```

## Screenshots or Recordings

Snap target `code-copy-tooltip` (added in this PR) renders a side-by-side grid: left = borderless button on hover; right = tooltip floating above the button, clear of the simulated stream's `overflow:hidden` clip and clamped within the viewport.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
