### PR TITLE
feat(app): keyboard pinned reorder (Alt+Arrow), remove menu move items

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
@@ -2,16 +2,13 @@ import { test, expect } from "../fixtures"
 import { openSidebar } from "../actions"
 import { pawworkSidebarSelector } from "../selectors"
 
-// Menu-driven keyboard-accessible reorder within the pinned zone. SortableJS
-// drag itself uses pointer-event fallback (forceFallback: true), which
-// Playwright's high-level dragTo() does not drive. The real-pointer path
-// is covered by sidebar-drag-pointer.spec.ts via page.mouse.{down,move,up};
-// the menu actions here back the keyboard-accessible reorder path.
-test("pinned sessions can be reordered via the Move up / Move down menu", async ({
-  page,
-  sdk,
-  gotoSession,
-}) => {
+// Keyboard-accessible reorder within the pinned zone. Mouse drag is pointer-only
+// (SortableJS forceFallback, covered by sidebar-drag-pointer.spec.ts); these
+// specs cover the keyboard path: with focus on a pinned row, ⌥↑ / ⌥↓
+// (Alt+Arrow) moves it. The menu no longer carries Move up / Move down — that
+// surface is asserted by session-menu-actions.test.ts.
+
+test("pinned rows reorder via ⌥↑ / ⌥↓ on the focused row", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
   const a = await sdk.session.create({ title: `pinned-reorder a ${stamp}` }).then((r) => r.data)
   const b = await sdk.session.create({ title: `pinned-reorder b ${stamp}` }).then((r) => r.data)
@@ -23,8 +20,6 @@ test("pinned sessions can be reordered via the Move up / Move down menu", async 
 
   const sidebar = page.locator(pawworkSidebarSelector).first()
 
-  // Pin both via the existing menu Pin action so we land in the same order
-  // togglePinnedSession produces (prepend → b then a in pinned).
   const pinViaMenu = async (id: string) => {
     const row = sidebar.locator(`[data-session-id="${id}"]`).first()
     await row.hover()
@@ -37,42 +32,32 @@ test("pinned sessions can be reordered via the Move up / Move down menu", async 
 
   const pinned = sidebar.locator('[data-component="pawwork-sidebar-pinned"]')
   await expect(pinned.locator(`[data-session-id="${b.id}"]`)).toBeVisible()
-  await expect(pinned.locator(`[data-session-id="${a.id}"]`)).toBeVisible()
 
-  // After pinning b then a in that order, togglePinnedSession prepends each
-  // new pin to the front of pawworkPinnedSessions: [a] -> [b, a] after the
-  // second call. So at this point the order is b (top) then a (bottom).
-  const initialOrder = async () =>
+  // togglePinnedSession prepends each new pin, so pinning a then b yields the
+  // pinned order [b, a] — b on top, a on the bottom.
+  const order = async () =>
     (
       await pinned
         .locator("[data-session-id]")
         .evaluateAll((nodes) => nodes.map((n) => (n as HTMLElement).dataset.sessionId))
     ).filter(Boolean) as string[]
 
-  expect(await initialOrder()).toEqual([b.id, a.id])
+  expect(await order()).toEqual([b.id, a.id])
 
-  // Move b down via the menu — order should flip to [a, b].
-  const bRow = pinned.locator(`[data-session-id="${b.id}"]`).first()
-  await bRow.hover()
-  await bRow.locator('[data-action="session-row-menu"]').click()
-  await page.getByRole("menuitem", { name: /^move down$/i }).click()
+  const focusRow = (id: string) => pinned.locator(`[data-session-id="${id}"] a`).first().focus()
 
-  await expect.poll(initialOrder).toEqual([a.id, b.id])
+  // Move b (top) down → [a, b].
+  await focusRow(b.id)
+  await page.keyboard.press("Alt+ArrowDown")
+  await expect.poll(order).toEqual([a.id, b.id])
 
-  // Move b back up — order returns to [b, a].
-  const bRowAfter = pinned.locator(`[data-session-id="${b.id}"]`).first()
-  await bRowAfter.hover()
-  await bRowAfter.locator('[data-action="session-row-menu"]').click()
-  await page.getByRole("menuitem", { name: /^move up$/i }).click()
-
-  await expect.poll(initialOrder).toEqual([b.id, a.id])
+  // Move b (now bottom) back up → [b, a]. Re-focus: the move re-renders the row.
+  await focusRow(b.id)
+  await page.keyboard.press("Alt+ArrowUp")
+  await expect.poll(order).toEqual([b.id, a.id])
 })
 
-test("Move up is hidden for the top pinned row, Move down hidden for the bottom", async ({
-  page,
-  sdk,
-  gotoSession,
-}) => {
+test("⌥↑ on the top pinned row and ⌥↓ on the bottom are silent no-ops", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
   const a = await sdk.session.create({ title: `pinned-edge a ${stamp}` }).then((r) => r.data)
   const b = await sdk.session.create({ title: `pinned-edge b ${stamp}` }).then((r) => r.data)
@@ -96,27 +81,29 @@ test("Move up is hidden for the top pinned row, Move down hidden for the bottom"
 
   // pinned order is [b, a] — b is top, a is bottom.
   const pinned = sidebar.locator('[data-component="pawwork-sidebar-pinned"]')
+  const order = async () =>
+    (
+      await pinned
+        .locator("[data-session-id]")
+        .evaluateAll((nodes) => nodes.map((n) => (n as HTMLElement).dataset.sessionId))
+    ).filter(Boolean) as string[]
 
-  // Open menu on top row (b): expect no Move up.
-  const bRow = pinned.locator(`[data-session-id="${b.id}"]`).first()
-  await bRow.hover()
-  await bRow.locator('[data-action="session-row-menu"]').click()
-  await expect(page.getByRole("menuitem", { name: /^move up$/i })).toHaveCount(0)
-  await expect(page.getByRole("menuitem", { name: /^move down$/i })).toBeVisible()
-  await page.keyboard.press("Escape")
+  expect(await order()).toEqual([b.id, a.id])
 
-  // Open menu on bottom row (a): expect no Move down.
-  const aRow = pinned.locator(`[data-session-id="${a.id}"]`).first()
-  await aRow.hover()
-  await aRow.locator('[data-action="session-row-menu"]').click()
-  await expect(page.getByRole("menuitem", { name: /^move down$/i })).toHaveCount(0)
-  await expect(page.getByRole("menuitem", { name: /^move up$/i })).toBeVisible()
-  await page.keyboard.press("Escape")
+  // ⌥↑ on the top row (b) cannot go higher.
+  await pinned.locator(`[data-session-id="${b.id}"] a`).first().focus()
+  await page.keyboard.press("Alt+ArrowUp")
+  await expect.poll(order).toEqual([b.id, a.id])
+
+  // ⌥↓ on the bottom row (a) cannot go lower.
+  await pinned.locator(`[data-session-id="${a.id}"] a`).first().focus()
+  await page.keyboard.press("Alt+ArrowDown")
+  await expect.poll(order).toEqual([b.id, a.id])
 })
 
-test("non-pinned rows do not show Move up or Move down menu items", async ({ page, sdk, gotoSession }) => {
+test("⌥↑ / ⌥↓ on a non-pinned row neither pins nor reorders it", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
-  const session = await sdk.session.create({ title: `unpinned no move ${stamp}` }).then((r) => r.data)
+  const session = await sdk.session.create({ title: `unpinned-noop ${stamp}` }).then((r) => r.data)
 
   if (!session?.id) throw new Error("missing session id")
 
@@ -124,12 +111,15 @@ test("non-pinned rows do not show Move up or Move down menu items", async ({ pag
   await openSidebar(page)
 
   const sidebar = page.locator(pawworkSidebarSelector).first()
-  const row = sidebar.locator(`[data-session-id="${session.id}"]`).first()
 
-  await row.hover()
-  await row.locator('[data-action="session-row-menu"]').click()
+  // Focus the (non-pinned) row and press the reorder keys.
+  await sidebar.locator(`[data-session-id="${session.id}"] a`).first().focus()
+  await page.keyboard.press("Alt+ArrowDown")
+  await page.keyboard.press("Alt+ArrowUp")
 
-  await expect(page.getByRole("menuitem", { name: /^pin session$/i })).toBeVisible()
-  await expect(page.getByRole("menuitem", { name: /^move up$/i })).toHaveCount(0)
-  await expect(page.getByRole("menuitem", { name: /^move down$/i })).toHaveCount(0)
+  // The keys only act on rows in the visible pinned order, so nothing was
+  // pinned: the pinned section never materialises for this session.
+  await expect(
+    sidebar.locator(`[data-component="pawwork-sidebar-pinned"] [data-session-id="${session.id}"]`),
+  ).toHaveCount(0)
 })

--- a/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
@@ -177,3 +177,43 @@ test("Shift+Alt / Mod+Alt + Arrow on a pinned row are left to the global command
   await page.keyboard.press("ControlOrMeta+Alt+ArrowDown")
   expect(await order()).toEqual([b.id, a.id])
 })
+
+test("Alt+Arrow while the “…” menu button is focused does not reorder", async ({ page, sdk, gotoSession }) => {
+  const stamp = Date.now()
+  const a = await sdk.session.create({ title: `pinned-menu a ${stamp}` }).then((r) => r.data)
+  const b = await sdk.session.create({ title: `pinned-menu b ${stamp}` }).then((r) => r.data)
+
+  if (!a?.id || !b?.id) throw new Error("missing session ids")
+
+  await gotoSession(a.id)
+  await openSidebar(page)
+
+  const sidebar = page.locator(pawworkSidebarSelector).first()
+
+  const pinViaMenu = async (id: string) => {
+    const row = sidebar.locator(`[data-session-id="${id}"]`).first()
+    await row.hover()
+    await row.locator('[data-action="session-row-menu"]').click()
+    await page.getByRole("menuitem", { name: /^pin session$/i }).click()
+  }
+
+  await pinViaMenu(a.id)
+  await pinViaMenu(b.id)
+
+  const pinned = sidebar.locator('[data-component="pawwork-sidebar-pinned"]')
+  const order = async () =>
+    (
+      await pinned
+        .locator("[data-session-id]")
+        .evaluateAll((nodes) => nodes.map((n) => (n as HTMLElement).dataset.sessionId))
+    ).filter(Boolean) as string[]
+
+  expect(await order()).toEqual([b.id, a.id])
+
+  // Only the row's main link owns ⌥↑/⌥↓ — the keycap hint shows on a:focus-visible
+  // only, so the "…" menu button never displays it. Focusing that button and
+  // pressing Alt+Arrow must be inert: no reorder, no focus jump to the link.
+  await pinned.locator(`[data-session-id="${b.id}"] [data-action="session-row-menu"]`).first().focus()
+  await page.keyboard.press("Alt+ArrowDown")
+  expect(await order()).toEqual([b.id, a.id])
+})

--- a/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-pinned-reorder.spec.ts
@@ -5,10 +5,11 @@ import { pawworkSidebarSelector } from "../selectors"
 // Keyboard-accessible reorder within the pinned zone. Mouse drag is pointer-only
 // (SortableJS forceFallback, covered by sidebar-drag-pointer.spec.ts); these
 // specs cover the keyboard path: with focus on a pinned row, ⌥↑ / ⌥↓
-// (Alt+Arrow) moves it. The menu no longer carries Move up / Move down — that
-// surface is asserted by session-menu-actions.test.ts.
+// (Alt+Arrow) moves it. Note: session.previous/next bind the SAME alt+arrow
+// globally, so the reorder must claim the event (stopPropagation) and not also
+// navigate — several assertions below pin that down via an unchanged URL.
 
-test("pinned rows reorder via ⌥↑ / ⌥↓ on the focused row", async ({ page, sdk, gotoSession }) => {
+test("pinned rows reorder via ⌥↑ / ⌥↓ without navigating away", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
   const a = await sdk.session.create({ title: `pinned-reorder a ${stamp}` }).then((r) => r.data)
   const b = await sdk.session.create({ title: `pinned-reorder b ${stamp}` }).then((r) => r.data)
@@ -44,6 +45,8 @@ test("pinned rows reorder via ⌥↑ / ⌥↓ on the focused row", async ({ page
 
   expect(await order()).toEqual([b.id, a.id])
 
+  // The active session is `a`; reorder must not navigate away from it.
+  const urlBefore = page.url()
   const focusRow = (id: string) => pinned.locator(`[data-session-id="${id}"] a`).first().focus()
 
   // Move b (top) down → [a, b].
@@ -55,9 +58,12 @@ test("pinned rows reorder via ⌥↑ / ⌥↓ on the focused row", async ({ page
   await focusRow(b.id)
   await page.keyboard.press("Alt+ArrowUp")
   await expect.poll(order).toEqual([b.id, a.id])
+
+  // Critical: reordering claimed the event, so session.previous/next never fired.
+  expect(page.url()).toBe(urlBefore)
 })
 
-test("⌥↑ on the top pinned row and ⌥↓ on the bottom are silent no-ops", async ({ page, sdk, gotoSession }) => {
+test("⌥↑ at the top and ⌥↓ at the bottom are no-ops that never navigate", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
   const a = await sdk.session.create({ title: `pinned-edge a ${stamp}` }).then((r) => r.data)
   const b = await sdk.session.create({ title: `pinned-edge b ${stamp}` }).then((r) => r.data)
@@ -89,16 +95,19 @@ test("⌥↑ on the top pinned row and ⌥↓ on the bottom are silent no-ops", 
     ).filter(Boolean) as string[]
 
   expect(await order()).toEqual([b.id, a.id])
+  const urlBefore = page.url()
 
-  // ⌥↑ on the top row (b) cannot go higher.
+  // ⌥↑ on the top row (b) cannot go higher — and must not navigate.
   await pinned.locator(`[data-session-id="${b.id}"] a`).first().focus()
   await page.keyboard.press("Alt+ArrowUp")
   await expect.poll(order).toEqual([b.id, a.id])
+  expect(page.url()).toBe(urlBefore)
 
-  // ⌥↓ on the bottom row (a) cannot go lower.
+  // ⌥↓ on the bottom row (a) cannot go lower — and must not navigate.
   await pinned.locator(`[data-session-id="${a.id}"] a`).first().focus()
   await page.keyboard.press("Alt+ArrowDown")
   await expect.poll(order).toEqual([b.id, a.id])
+  expect(page.url()).toBe(urlBefore)
 })
 
 test("⌥↑ / ⌥↓ on a non-pinned row neither pins nor reorders it", async ({ page, sdk, gotoSession }) => {
@@ -122,4 +131,49 @@ test("⌥↑ / ⌥↓ on a non-pinned row neither pins nor reorders it", async (
   await expect(
     sidebar.locator(`[data-component="pawwork-sidebar-pinned"] [data-session-id="${session.id}"]`),
   ).toHaveCount(0)
+})
+
+test("Shift+Alt / Mod+Alt + Arrow on a pinned row are left to the global commands", async ({
+  page,
+  sdk,
+  gotoSession,
+}) => {
+  const stamp = Date.now()
+  const a = await sdk.session.create({ title: `pinned-modifier a ${stamp}` }).then((r) => r.data)
+  const b = await sdk.session.create({ title: `pinned-modifier b ${stamp}` }).then((r) => r.data)
+
+  if (!a?.id || !b?.id) throw new Error("missing session ids")
+
+  await gotoSession(a.id)
+  await openSidebar(page)
+
+  const sidebar = page.locator(pawworkSidebarSelector).first()
+
+  const pinViaMenu = async (id: string) => {
+    const row = sidebar.locator(`[data-session-id="${id}"]`).first()
+    await row.hover()
+    await row.locator('[data-action="session-row-menu"]').click()
+    await page.getByRole("menuitem", { name: /^pin session$/i }).click()
+  }
+
+  await pinViaMenu(a.id)
+  await pinViaMenu(b.id)
+
+  const pinned = sidebar.locator('[data-component="pawwork-sidebar-pinned"]')
+  const order = async () =>
+    (
+      await pinned
+        .locator("[data-session-id]")
+        .evaluateAll((nodes) => nodes.map((n) => (n as HTMLElement).dataset.sessionId))
+    ).filter(Boolean) as string[]
+
+  expect(await order()).toEqual([b.id, a.id])
+
+  // The reorder handler accepts plain Alt+Arrow only. Shift+Alt and Mod+Alt are
+  // bound to other global session commands, so they must NOT reorder the pinned
+  // zone — the order stays put regardless of what the global command does.
+  await pinned.locator(`[data-session-id="${b.id}"] a`).first().focus()
+  await page.keyboard.press("Shift+Alt+ArrowDown")
+  await page.keyboard.press("ControlOrMeta+Alt+ArrowDown")
+  expect(await order()).toEqual([b.id, a.id])
 })

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -792,8 +792,6 @@ export const dict = {
   "sidebar.pawwork.all": "All sessions",
   "sidebar.pawwork.pinSession": "Pin session",
   "sidebar.pawwork.unpinSession": "Unpin session",
-  "sidebar.pawwork.movePinnedUp": "Move up",
-  "sidebar.pawwork.movePinnedDown": "Move down",
   "sidebar.pawwork.dragToPin": "Drag here to pin",
   "sidebar.pawwork.sort.byProject": "Group by project",
   "sidebar.pawwork.sort.byTime": "Sort by time",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -702,8 +702,6 @@ export const dict = {
   "sidebar.pawwork.all": "全部会话",
   "sidebar.pawwork.pinSession": "置顶会话",
   "sidebar.pawwork.unpinSession": "取消置顶",
-  "sidebar.pawwork.movePinnedUp": "上移",
-  "sidebar.pawwork.movePinnedDown": "下移",
   "sidebar.pawwork.dragToPin": "拖到这里置顶",
   "sidebar.pawwork.sort.byProject": "按项目分组",
   "sidebar.pawwork.sort.byTime": "按时间排序",

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -135,7 +135,7 @@ export const PawworkSidebar = (props: {
     visiblePinnedIDs: string[]
     visibleTargetIndex: number
   }) => void
-  /** Menu-driven move up / down within the visible pinned zone. */
+  /** Keyboard-driven move up / down within the visible pinned zone (⌥↑ / ⌥↓ on a pinned row). */
   onMovePinnedSession?: (input: { sessionID: string; direction: "up" | "down"; visiblePinnedIDs: string[] }) => void
   exportSessionAvailable: Accessor<boolean>
   onExportSession: (session: Session) => Promise<void>
@@ -209,35 +209,46 @@ export const PawworkSidebar = (props: {
   const menuLabels = () => ({
     pin: language.t("sidebar.pawwork.pinSession"),
     unpin: language.t("sidebar.pawwork.unpinSession"),
-    moveUp: language.t("sidebar.pawwork.movePinnedUp"),
-    moveDown: language.t("sidebar.pawwork.movePinnedDown"),
     rename: language.t("common.rename"),
     export: language.t("session.export.action.export"),
     delete: language.t("common.delete"),
   })
   const menuActions = (target: Session, onRenameSession: (session: Session) => void) => {
-    // Use rendered pinned order, not the raw pinnedIDs array. Move up / down
-    // visibility tracks visible adjacency, so the action is hidden on the
-    // visually-top or visually-bottom row regardless of un-loaded pinned IDs.
-    const visibleIDs = visiblePinnedIDs()
-    const visibleIndex = visibleIDs.indexOf(target.id)
-    const isVisiblyPinned = visibleIndex !== -1
-    const isPinned = isVisiblyPinned || props.pinnedIDs().includes(target.id)
-    const onMovePinnedSession = props.onMovePinnedSession
+    const isPinned = visiblePinnedIDs().includes(target.id) || props.pinnedIDs().includes(target.id)
     return buildSessionMenuActions({
       session: target,
       pinned: isPinned,
-      pinnedIndex: isVisiblyPinned ? visibleIndex : undefined,
-      pinnedCount: isVisiblyPinned ? visibleIDs.length : undefined,
       exportAvailable: props.exportSessionAvailable(),
       labels: menuLabels(),
       onTogglePinnedSession: props.onTogglePinnedSession,
-      onMovePinnedSession: onMovePinnedSession
-        ? (input) => onMovePinnedSession({ ...input, visiblePinnedIDs: visibleIDs })
-        : undefined,
       onRenameSession,
       onExportSession: props.onExportSession,
       onDeleteSession: props.onDeleteSession,
+    })
+  }
+
+  // Keyboard-accessible reorder for pinned rows: when focus is anywhere inside a
+  // pinned row, ⌥↑ / ⌥↓ (Alt+Arrow) moves it within the pinned zone. This is the
+  // keyboard equivalent of mouse drag — drag is pointer-only and cannot serve
+  // keyboard users on its own. Rows whose id is not in the visible pinned order
+  // ignore the keys and let the browser default stand, so non-pinned rows and
+  // the list edges are silent no-ops.
+  const onPinnedRowKeyDown = (event: KeyboardEvent, session: Session) => {
+    if (!event.altKey) return
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+    const visibleIDs = visiblePinnedIDs()
+    const index = visibleIDs.indexOf(session.id)
+    if (index === -1) return
+    event.preventDefault()
+    const direction = event.key === "ArrowUp" ? "up" : "down"
+    if (direction === "up" && index === 0) return
+    if (direction === "down" && index === visibleIDs.length - 1) return
+    props.onMovePinnedSession?.({ sessionID: session.id, direction, visiblePinnedIDs: visibleIDs })
+    // The row keeps its session id across the move; re-focus it next frame so
+    // repeated ⌥↑/↓ keep working without Tabbing back into the list.
+    requestAnimationFrame(() => {
+      const row = scrollEl?.querySelector<HTMLElement>(`[data-session-id="${session.id}"]`)
+      row?.querySelector<HTMLElement>('a, [data-action="session-row-menu"]')?.focus()
     })
   }
   const markSessionSwitchPaint = (session: Session, event: MouseEvent) => {
@@ -302,10 +313,12 @@ export const PawworkSidebar = (props: {
               as="div"
               class="flex flex-col gap-1 pw-drag-row"
               data-pw-drag-session-id={current().session.id}
+              onKeyDown={(event: KeyboardEvent) => onPinnedRowKeyDown(event, current().session)}
             >
               <SessionItem
                 session={current().session}
                 list={navList()}
+                reorderHint={visiblePinnedIDs().includes(current().session.id)}
                 navList={navList}
                 slug={current().slug}
                 showChild

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -237,10 +237,24 @@ export const PawworkSidebar = (props: {
     // Alt and only Alt — Ctrl/Cmd/Shift combos belong to other shortcuts.
     if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+    // The handler sits on the row wrapper, which also wraps the active child row.
+    // Only act when the event originates from THIS row, so focusing a nested child
+    // and pressing Alt+Arrow never reorders the parent.
+    const originID = (event.target as HTMLElement | null)
+      ?.closest?.("[data-session-id]")
+      ?.getAttribute("data-session-id")
+    if (originID !== session.id) return
     const visibleIDs = visiblePinnedIDs()
     const index = visibleIDs.indexOf(session.id)
     if (index === -1) return
+    // This pinned row owns ⌥↑/⌥↓. session.previous/next bind the SAME alt+arrow on
+    // a document-level keydown listener. Solid delegates keydown to document too,
+    // so that listener sits on the same node as ours — stopPropagation alone would
+    // not stop it (it only blocks bubbling to ancestors, not co-located listeners).
+    // stopImmediatePropagation blocks the other document listener, so a reorder —
+    // and an edge no-op — never also navigates to another session.
     event.preventDefault()
+    event.stopImmediatePropagation()
     const direction = event.key === "ArrowUp" ? "up" : "down"
     if (direction === "up" && index === 0) return
     if (direction === "down" && index === visibleIDs.length - 1) return

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -237,13 +237,13 @@ export const PawworkSidebar = (props: {
     // Alt and only Alt — Ctrl/Cmd/Shift combos belong to other shortcuts.
     if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
-    // The handler sits on the row wrapper, which also wraps the active child row.
-    // Only act when the event originates from THIS row, so focusing a nested child
-    // and pressing Alt+Arrow never reorders the parent.
-    const originID = (event.target as HTMLElement | null)
-      ?.closest?.("[data-session-id]")
-      ?.getAttribute("data-session-id")
-    if (originID !== session.id) return
+    // The handler sits on the row wrapper, which also wraps the active child row
+    // and the "…" menu button. Only the row's main LINK owns ⌥↑/⌥↓ — matching the
+    // keycap hint, which sidebar.css reveals on `a:focus-visible` only. Focus on the
+    // "…" button (not an <a>) or a nested child row's link therefore never reorders.
+    const link = (event.target as HTMLElement | null)?.closest?.("a")
+    const originID = link?.closest?.("[data-session-id]")?.getAttribute("data-session-id")
+    if (!link || originID !== session.id) return
     const visibleIDs = visiblePinnedIDs()
     const index = visibleIDs.indexOf(session.id)
     if (index === -1) return
@@ -259,11 +259,11 @@ export const PawworkSidebar = (props: {
     if (direction === "up" && index === 0) return
     if (direction === "down" && index === visibleIDs.length - 1) return
     props.onMovePinnedSession?.({ sessionID: session.id, direction, visiblePinnedIDs: visibleIDs })
-    // The row keeps its session id across the move; re-focus it next frame so
-    // repeated ⌥↑/↓ keep working without Tabbing back into the list.
+    // The row keeps its session id across the move; re-focus its link next frame
+    // so repeated ⌥↑/↓ keep working without Tabbing back into the list.
     requestAnimationFrame(() => {
       const row = scrollEl?.querySelector<HTMLElement>(`[data-session-id="${session.id}"]`)
-      row?.querySelector<HTMLElement>('a, [data-action="session-row-menu"]')?.focus()
+      row?.querySelector<HTMLElement>("a")?.focus()
     })
   }
   const markSessionSwitchPaint = (session: Session, event: MouseEvent) => {

--- a/packages/app/src/pages/layout/pawwork-sidebar.tsx
+++ b/packages/app/src/pages/layout/pawwork-sidebar.tsx
@@ -234,7 +234,8 @@ export const PawworkSidebar = (props: {
   // ignore the keys and let the browser default stand, so non-pinned rows and
   // the list edges are silent no-ops.
   const onPinnedRowKeyDown = (event: KeyboardEvent, session: Session) => {
-    if (!event.altKey) return
+    // Alt and only Alt — Ctrl/Cmd/Shift combos belong to other shortcuts.
+    if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
     const visibleIDs = visiblePinnedIDs()
     const index = visibleIDs.indexOf(session.id)

--- a/packages/app/src/pages/layout/session-menu-actions.test.ts
+++ b/packages/app/src/pages/layout/session-menu-actions.test.ts
@@ -7,8 +7,6 @@ const session = { id: "ses_123", title: "Bug hunt", directory: "/repo" } as Sess
 const labels = {
   pin: "Pin",
   unpin: "Unpin",
-  moveUp: "Move up",
-  moveDown: "Move down",
   rename: "Rename",
   export: "Export",
   delete: "Delete",
@@ -73,85 +71,5 @@ describe("buildSessionMenuActions", () => {
     for (const action of actions) void action.run()
 
     expect(calls).toEqual(["pin:ses_123", "rename:ses_123", "export:ses_123", "delete:ses_123"])
-  })
-
-  test("offers move-up and move-down only when pinned + index allows", () => {
-    const onMove = () => undefined
-    const baseInput = {
-      session,
-      pinned: true,
-      exportAvailable: false,
-      labels,
-      onTogglePinnedSession: () => undefined,
-      onMovePinnedSession: onMove,
-      onRenameSession: () => undefined,
-      onExportSession: () => undefined,
-      onDeleteSession: () => undefined,
-    } as const
-
-    // Middle of a 3-pinned list: both moves available
-    expect(
-      buildSessionMenuActions({ ...baseInput, pinnedIndex: 1, pinnedCount: 3 }).map((action) => action.id),
-    ).toEqual(["pin", "move-up", "move-down", "rename", "delete"])
-
-    // Top of pinned list: only move-down
-    expect(
-      buildSessionMenuActions({ ...baseInput, pinnedIndex: 0, pinnedCount: 3 }).map((action) => action.id),
-    ).toEqual(["pin", "move-down", "rename", "delete"])
-
-    // Bottom of pinned list: only move-up
-    expect(
-      buildSessionMenuActions({ ...baseInput, pinnedIndex: 2, pinnedCount: 3 }).map((action) => action.id),
-    ).toEqual(["pin", "move-up", "rename", "delete"])
-
-    // Single pinned row: neither move offered
-    expect(
-      buildSessionMenuActions({ ...baseInput, pinnedIndex: 0, pinnedCount: 1 }).map((action) => action.id),
-    ).toEqual(["pin", "rename", "delete"])
-
-    // Pinned but no onMovePinnedSession callback: neither move offered
-    expect(
-      buildSessionMenuActions({
-        ...baseInput,
-        onMovePinnedSession: undefined,
-        pinnedIndex: 1,
-        pinnedCount: 3,
-      }).map((action) => action.id),
-    ).toEqual(["pin", "rename", "delete"])
-
-    // Unpinned: neither move offered, even with index supplied
-    expect(
-      buildSessionMenuActions({
-        ...baseInput,
-        pinned: false,
-        pinnedIndex: 1,
-        pinnedCount: 3,
-      }).map((action) => action.id),
-    ).toEqual(["pin", "rename", "delete"])
-  })
-
-  test("move-up and move-down dispatch the correct direction", () => {
-    const calls: Array<{ sessionID: string; direction: "up" | "down" }> = []
-    const actions = buildSessionMenuActions({
-      session,
-      pinned: true,
-      pinnedIndex: 1,
-      pinnedCount: 3,
-      exportAvailable: false,
-      labels,
-      onTogglePinnedSession: () => undefined,
-      onMovePinnedSession: (input) => calls.push(input),
-      onRenameSession: () => undefined,
-      onExportSession: () => undefined,
-      onDeleteSession: () => undefined,
-    })
-
-    void actions.find((a) => a.id === "move-up")?.run()
-    void actions.find((a) => a.id === "move-down")?.run()
-
-    expect(calls).toEqual([
-      { sessionID: "ses_123", direction: "up" },
-      { sessionID: "ses_123", direction: "down" },
-    ])
   })
 })

--- a/packages/app/src/pages/layout/session-menu-actions.ts
+++ b/packages/app/src/pages/layout/session-menu-actions.ts
@@ -1,7 +1,7 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
 import type { IconName } from "@opencode-ai/ui/icon"
 
-export type SessionMenuActionID = "pin" | "move-up" | "move-down" | "rename" | "export" | "delete"
+export type SessionMenuActionID = "pin" | "rename" | "export" | "delete"
 
 export type SessionMenuAction = {
   id: SessionMenuActionID
@@ -11,28 +11,18 @@ export type SessionMenuAction = {
   run: () => Promise<void> | void
 }
 
-export type MovePinnedDirection = "up" | "down"
-
 export function buildSessionMenuActions(input: {
   session: Session
   pinned: boolean
-  /** Index inside the pinned array, when `pinned` is true. Drives whether move-up / move-down show. */
-  pinnedIndex?: number
-  /** Total count of pinned sessions, when `pinned` is true. Drives whether move-down shows. */
-  pinnedCount?: number
   exportAvailable: boolean
   labels: {
     pin: string
     unpin: string
-    moveUp: string
-    moveDown: string
     rename: string
     export: string
     delete: string
   }
   onTogglePinnedSession: (sessionID: string) => void
-  /** Optional. When omitted, move-up / move-down are never offered (mouse-only environments). */
-  onMovePinnedSession?: (input: { sessionID: string; direction: MovePinnedDirection }) => void
   onRenameSession: (session: Session) => Promise<void> | void
   onExportSession: (session: Session) => Promise<void> | void
   onDeleteSession: (session: Session) => void
@@ -45,33 +35,6 @@ export function buildSessionMenuActions(input: {
       run: () => input.onTogglePinnedSession(input.session.id),
     },
   ]
-
-  const onMove = input.onMovePinnedSession
-  const pinnedIndex = input.pinnedIndex
-  const pinnedCount = input.pinnedCount
-  if (
-    input.pinned &&
-    onMove &&
-    typeof pinnedIndex === "number" &&
-    typeof pinnedCount === "number"
-  ) {
-    if (pinnedIndex > 0) {
-      actions.push({
-        id: "move-up",
-        label: input.labels.moveUp,
-        icon: "chevron-up",
-        run: () => onMove({ sessionID: input.session.id, direction: "up" }),
-      })
-    }
-    if (pinnedIndex < pinnedCount - 1) {
-      actions.push({
-        id: "move-down",
-        label: input.labels.moveDown,
-        icon: "chevron-down",
-        run: () => onMove({ sessionID: input.session.id, direction: "down" }),
-      })
-    }
-  }
 
   actions.push({
     id: "rename",

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -1,9 +1,11 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Keybind } from "@opencode-ai/ui/keybind"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { A, useParams } from "@solidjs/router"
 import { type Accessor, createMemo, For, type JSX, Show } from "solid-js"
+import { formatKeybind } from "@/context/command"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useNotification } from "@/context/notification"
@@ -38,6 +40,8 @@ export type SessionItemProps = {
   titleContent?: (input: { session: Session; title: Accessor<string> }) => JSX.Element
   actionSlot?: (session: Session) => JSX.Element
   timeText?: (session: Session) => string | undefined
+  /** When true (pinned rows), keyboard focus reveals the ⌥↑ / ⌥↓ reorder caps. */
+  reorderHint?: boolean
 }
 
 const SessionRow = (props: {
@@ -240,6 +244,19 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
               <div data-status-overlay class="absolute inset-y-0 right-0 flex items-center justify-end">
                 <Show when={props.actionSlot}>{props.actionSlot?.(props.session)}</Show>
               </div>
+              {/* keyboard-only reorder hint: pinned rows reveal ⌥↑ / ⌥↓ caps on
+                 keyboard focus. sidebar.css gates visibility off :focus-visible,
+                 so mouse hover never shows it. */}
+              <Show when={props.reorderHint}>
+                <div
+                  data-status-reorder
+                  aria-hidden="true"
+                  class="absolute inset-y-0 right-0 flex items-center justify-end gap-1"
+                >
+                  <Keybind class="rounded-[4px]">{formatKeybind("alt+arrowup", language.t)}</Keybind>
+                  <Keybind class="rounded-[4px]">{formatKeybind("alt+arrowdown", language.t)}</Keybind>
+                </div>
+              </Show>
             </div>
           </Show>
         </div>
@@ -247,7 +264,9 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       <Show when={currentChild()}>
         {(child) => (
           <div class="w-full">
-            <SessionItem {...props} session={child()} level={(props.level ?? 0) + 1} />
+            {/* Child rows inherit props via spread; force the reorder hint off so
+               nested sessions never show ⌥↑/⌥↓ — only the top-level pinned row reorders. */}
+            <SessionItem {...props} session={child()} level={(props.level ?? 0) + 1} reorderHint={false} />
           </div>
         )}
       </Show>

--- a/packages/app/src/pages/layout/sidebar.css
+++ b/packages/app/src/pages/layout/sidebar.css
@@ -97,6 +97,25 @@
   pointer-events: auto;
 }
 
+/* Pinned-row keyboard reorder hint. Only pinned rows render [data-status-reorder]
+ * (the ⌥↑ / ⌥↓ caps), so :has([data-status-reorder]) is "this is a pinned row".
+ * On keyboard focus the caps replace both the time/status and the "…" button.
+ * Mouse hover has no :focus-visible, so it still shows the "…" button — the hint
+ * stays keyboard-only. The extra :has() raises specificity over the rule above,
+ * so the overlay is forced back to 0 for the focused pinned row. */
+[data-component="pawwork-session-row"] [data-status-reorder] {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-base) ease-out;
+}
+[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(:focus-visible) [data-status-overlay] {
+  opacity: 0;
+  pointer-events: none;
+}
+[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(:focus-visible) [data-status-reorder] {
+  opacity: 1;
+}
+
 /* ─────────────────────────────────────────────────────────────────────
  * Sidebar session row drag-and-drop · variant A (DESIGN.md restrained)
  * Decision source: docs/design/scratch/sidebar-drag-variants-compare.html

--- a/packages/app/src/pages/layout/sidebar.css
+++ b/packages/app/src/pages/layout/sidebar.css
@@ -99,20 +99,24 @@
 
 /* Pinned-row keyboard reorder hint. Only pinned rows render [data-status-reorder]
  * (the ⌥↑ / ⌥↓ caps), so :has([data-status-reorder]) is "this is a pinned row".
- * On keyboard focus the caps replace both the time/status and the "…" button.
- * Mouse hover has no :focus-visible, so it still shows the "…" button — the hint
- * stays keyboard-only. The extra :has() raises specificity over the rule above,
- * so the overlay is forced back to 0 for the focused pinned row. */
+ * The trigger is :has(a:focus-visible) — keyboard focus on the row's main LINK,
+ * not any focus inside the row. Scoping to the link matters: the "…" menu button
+ * lives in [data-status-overlay], so a broad :has(:focus-visible) would hide the
+ * very button the user just Tabbed onto. With the link scope, focusing the link
+ * shows the caps (and hides the time/status + "…"), while focusing the "…" button
+ * falls through to the rule above and keeps the button visible. Mouse hover has no
+ * :focus-visible, so the hint stays keyboard-only. The extra :has() also raises
+ * specificity over the rule above, forcing the overlay back to 0 on link focus. */
 [data-component="pawwork-session-row"] [data-status-reorder] {
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--duration-base) ease-out;
 }
-[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(:focus-visible) [data-status-overlay] {
+[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(a:focus-visible) [data-status-overlay] {
   opacity: 0;
   pointer-events: none;
 }
-[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(:focus-visible) [data-status-reorder] {
+[data-component="pawwork-session-row"]:not([data-switch-paint]):has([data-status-reorder]):has(a:focus-visible) [data-status-reorder] {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary

Pinned-session reorder moves out of the menu. The right-click context menu and the row "…" dropdown drop their Move up / Move down items, and a keyboard reorder takes over:

- **⌥↑ / ⌥↓** (Alt+Arrow on Windows) on a focused pinned row moves it within the pinned zone, reusing the existing `movePinnedSessionByOne` data path. List edges and non-pinned rows are silent no-ops; focus follows the moved row so repeated presses keep working.
- A **keyboard-only hint** (⌥↑ / ⌥↓ caps, rendered with the existing `Keybind` + `formatKeybind`) appears on `:focus-visible` of a pinned row, replacing the time/status and the "…" button. Mouse hover has no `:focus-visible`, so the hint never shows for mouse users and the menu stays lean.

Menu is now: Pin/Unpin, Rename, Export, Delete.

## Why

The Move up / Move down items duplicated what mouse drag already does and bloated the menu for *every* user, including the majority who never reorder pinned sessions. Their stated a11y rationale (Atlassian menu-command guidance, added in #859) was an isolated over-reach — the app does no screen-reader live-region work anywhere else, so a single menu-command a11y surface was inconsistent and visually heavy. The agreed goal is "keyboard-operable, not screen-reader-narrated," which a focused-row shortcut serves more cleanly.

## Related Issue

No standalone issue — follow-up adjustment to the drag/reorder work merged in #859.

## Human Review Status

Pending

## Review Focus

- Keyboard handler is attached to the `ContextMenu.Trigger` row wrapper and relies on `keydown` bubbling from the focused `<a>`; e2e confirms it fires.
- The `:focus-visible`-gated CSS that swaps the time/status and "…" button for the caps **only** on keyboard focus — mouse hover must not show caps.
- Child (nested) rows force `reorderHint={false}` so they never show caps via prop spread.
- No data-layer change: `movePinnedSessionByOne` / `reorderPawworkPinnedByVisible` reused as-is.

## Risk Notes

- The hint's visibility depends on `:focus-visible`. The e2e asserts reorder *behavior* (which does not depend on it); the hint's visual form was reviewed on the scratch compare page. Real keyboard-Tab focus shows the caps; programmatic focus may not trigger `:focus-visible`, which is expected.
- **platform** conditional left unticked: no Electron/packaging/OS surface touched (sidebar renderer only; `formatKeybind` is already platform-aware for ⌥ vs Alt).
- **docs/release/deps/permissions** conditional left unticked: none of those surfaces touched.

## How To Verify

```text
app typecheck (tsgo -b): pass
eslint (changed src files): 0 errors
unit — session-menu-actions.test.ts: 3 passed (menu = pin/rename/export/delete, no move)
e2e — sidebar-pinned-reorder.spec.ts (keyboard-driven): 3 passed
  · reorder via ⌥↑/⌥↓ on focused row
  · ⌥↑ at top / ⌥↓ at bottom are no-ops
  · ⌥↑/⌥↓ on a non-pinned row neither pins nor reorders
snap — sidebar-pinned: default-state layout intact, caps hidden, time shown (light + dark)
```

## Screenshots or Recordings

- **Default state** verified via the `sidebar-pinned` snap target (light + dark): pinned row layout unchanged, caps hidden, time/status normal.
- **Focused-row hint** form chosen from a side-by-side compare of three variants (plain caps / caps+label / tooltip bubble) built with real DESIGN.md tokens; variant A (plain caps) selected. Both artifacts are local-only under `docs/design/` (git-excluded).

## Checklist

- [x] **Type label** — `enhancement`.
- [x] **Routing labels** — `app`.
- [x] **Priority label** — `P2`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI changes (snap default state + scratch variant compare).
- [ ] **(conditional)** platform impact — no platform/packaging surface touched (see Risk Notes).
- [ ] **(conditional)** docs/release/deps/permissions — none touched (see Risk Notes).
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pinned sessions can now be reordered using keyboard shortcuts (Alt+Arrow Up/Down) with visual hints displayed on focus.
  * New sorting options for pinned sessions (by project or by time).
  * Drag-to-pin visual indicator added to session rows.

* **Tests**
  * E2E sidebar tests updated to verify keyboard-driven session reordering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->