### PR TITLE
fix: scope reasoning safe retry timeouts by attempt

### DIFF
--- a/packages/app/e2e/snap/safe-retry.snap.ts
+++ b/packages/app/e2e/snap/safe-retry.snap.ts
@@ -31,12 +31,12 @@ test("safe-retry", async ({ page }) => {
   }, `/@fs/${fixturePath}`)
 
   const running = page.locator('[data-snap="running"]')
-  await expect(running).toContainText("网络连接断开，正在自动重试", { timeout: 30_000 })
+  await expect(running).toContainText("模型暂时没有响应，正在重试…", { timeout: 30_000 })
   await expect(running.locator('[data-slot="session-turn-safe-retry"]')).toBeVisible({ timeout: 30_000 })
   await expect(running.locator(".error-card")).toHaveCount(0)
 
   const notice = page.locator('[data-snap="notice"]')
-  await expect(notice).toContainText("网络连接断开，自动重试未完成", { timeout: 30_000 })
+  await expect(notice).toContainText("模型暂时没有响应。你可以稍后再试，或换一个模型。", { timeout: 30_000 })
   await expect(notice.locator('[data-kind="safe_retry_failed"]')).toBeVisible({ timeout: 30_000 })
 
   const out = snapOutputPath("safe-retry")

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1085,7 +1085,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   return {}
 }
 
-const REASONING_CONNECT_TIMEOUT_MS = 120_000
+export const REASONING_GLOBAL_CONNECT_TIMEOUT_MS = 120_000
 
 /**
  * Returns watchdog timeout overrides for reasoning-capable models.
@@ -1093,7 +1093,7 @@ const REASONING_CONNECT_TIMEOUT_MS = 120_000
  */
 export function streamTimeouts(model: Provider.Model): { connectTimeoutMs?: number } {
   if (!model.capabilities.reasoning) return {}
-  return { connectTimeoutMs: REASONING_CONNECT_TIMEOUT_MS }
+  return { connectTimeoutMs: REASONING_GLOBAL_CONNECT_TIMEOUT_MS }
 }
 
 export function options(input: {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -137,7 +137,7 @@ function attemptStreamTimeouts(
 ): { connectTimeoutMs?: number } {
   if (streamInput.connectTimeoutMs !== undefined) return {}
   if (!model.capabilities.reasoning) return {}
-  const firstAttemptCanAutoRetry = boundaryAllowsBeforeProgressSafeRetry(boundary)
+  const firstAttemptCanAutoRetry = RunObservability.boundaryAllowsBeforeProgressRetry(boundary)
   if (automaticStreamRetriesUsed === 0 && !firstAttemptCanAutoRetry) {
     return { connectTimeoutMs: ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS }
   }
@@ -149,16 +149,6 @@ function attemptStreamTimeouts(
         ? REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS
         : REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
   }
-}
-
-function boundaryAllowsBeforeProgressSafeRetry(boundary: RunObservability.SideEffectBoundarySnapshot) {
-  if (boundary.provider_executed_capability_present) return false
-  if (boundary.external_boundary_present) return false
-  return (
-    boundary.proof_reason !== "provider_executed_capability" &&
-    boundary.proof_reason !== "external_boundary" &&
-    boundary.proof_reason !== "unknown"
-  )
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -133,9 +133,17 @@ function attemptStreamTimeouts(
   model: Provider.Model,
   automaticStreamRetriesUsed: number,
   streamInput: Pick<LLM.StreamInput, "connectTimeoutMs">,
+  boundary: RunObservability.SideEffectBoundarySnapshot,
 ): { connectTimeoutMs?: number } {
   if (streamInput.connectTimeoutMs !== undefined) return {}
   if (!model.capabilities.reasoning) return {}
+  const firstAttemptCanAutoRetry =
+    boundary.proof_result === "complete" &&
+    !boundary.provider_executed_capability_present &&
+    !boundary.external_boundary_present
+  if (automaticStreamRetriesUsed === 0 && !firstAttemptCanAutoRetry) {
+    return { connectTimeoutMs: ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS }
+  }
   // #918: fail fast on the first stalled reasoning-model attempt, then give
   // the one safe retry the pre-existing slow-start protection window.
   return {
@@ -1323,7 +1331,13 @@ export const layer: Layer.Layer<
           ctx.reasoningMap = {}
           ctx.attemptCount++
           const activeTools = LLM.resolveTools(streamInput)
-          const sessionTimeouts = attemptStreamTimeouts(streamInput.model, automaticStreamRetriesUsed, streamInput)
+          const boundarySnapshot = sideEffectBoundarySnapshot(activeTools)
+          const sessionTimeouts = attemptStreamTimeouts(
+            streamInput.model,
+            automaticStreamRetriesUsed,
+            streamInput,
+            boundarySnapshot,
+          )
           const attempt = ctx.runTrace.beginAttempt({
             attemptIndex: ctx.attemptCount,
             at: Date.now(),
@@ -1336,7 +1350,7 @@ export const layer: Layer.Layer<
             attemptID: attempt.attemptID,
             at: Date.now(),
             monotonicMs: performance.now(),
-            snapshot: sideEffectBoundarySnapshot(activeTools),
+            snapshot: boundarySnapshot,
           })
           let stream: Stream.Stream<LLM.Event, unknown>
           try {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -137,10 +137,7 @@ function attemptStreamTimeouts(
 ): { connectTimeoutMs?: number } {
   if (streamInput.connectTimeoutMs !== undefined) return {}
   if (!model.capabilities.reasoning) return {}
-  const firstAttemptCanAutoRetry =
-    boundary.proof_result === "complete" &&
-    !boundary.provider_executed_capability_present &&
-    !boundary.external_boundary_present
+  const firstAttemptCanAutoRetry = boundaryAllowsBeforeProgressSafeRetry(boundary)
   if (automaticStreamRetriesUsed === 0 && !firstAttemptCanAutoRetry) {
     return { connectTimeoutMs: ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS }
   }
@@ -152,6 +149,16 @@ function attemptStreamTimeouts(
         ? REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS
         : REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
   }
+}
+
+function boundaryAllowsBeforeProgressSafeRetry(boundary: RunObservability.SideEffectBoundarySnapshot) {
+  if (boundary.provider_executed_capability_present) return false
+  if (boundary.external_boundary_present) return false
+  return (
+    boundary.proof_reason !== "provider_executed_capability" &&
+    boundary.proof_reason !== "external_boundary" &&
+    boundary.proof_reason !== "unknown"
+  )
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -31,6 +31,8 @@ import { currentLifecycleCloseAction, lifecycleCloseActionMeta } from "./lifecyc
 const log = Log.create({ service: "session.processor" })
 const TOOL_CLEANUP_TIMEOUT_MS = 1_000
 const SAFE_RECOVERY_AUTO_RETRY_BACKOFF_MS = 1_000
+export const REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS = 60_000
+export const REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS = 120_000
 const LOCAL_LIFECYCLE_CLOSE_INTERRUPTION_MESSAGE = "The run was interrupted by a local lifecycle close."
 
 export type Result = "compact" | "stop" | "continue"
@@ -125,6 +127,23 @@ function watchdogPhase(error: unknown): "connect" | "silent_stream" | "unknown" 
   if (!message.includes("llm stream connection timed out")) return undefined
   if (message.includes("without provider progress")) return "connect"
   return "silent_stream"
+}
+
+function attemptStreamTimeouts(
+  model: Provider.Model,
+  automaticStreamRetriesUsed: number,
+  streamInput: Pick<LLM.StreamInput, "connectTimeoutMs">,
+): { connectTimeoutMs?: number } {
+  if (streamInput.connectTimeoutMs !== undefined) return {}
+  if (!model.capabilities.reasoning) return {}
+  // #918: fail fast on the first stalled reasoning-model attempt, then give
+  // the one safe retry the pre-existing slow-start protection window.
+  return {
+    connectTimeoutMs:
+      automaticStreamRetriesUsed > 0
+        ? REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS
+        : REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+  }
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {
@@ -1304,10 +1323,12 @@ export const layer: Layer.Layer<
           ctx.reasoningMap = {}
           ctx.attemptCount++
           const activeTools = LLM.resolveTools(streamInput)
+          const sessionTimeouts = attemptStreamTimeouts(streamInput.model, automaticStreamRetriesUsed, streamInput)
           const attempt = ctx.runTrace.beginAttempt({
             attemptIndex: ctx.attemptCount,
             at: Date.now(),
             monotonicMs: performance.now(),
+            connectTimeoutMs: sessionTimeouts.connectTimeoutMs ?? streamInput.connectTimeoutMs,
           })
           ctx.currentAttemptID = attempt.attemptID
           processAttemptID = attempt.attemptID
@@ -1322,6 +1343,7 @@ export const layer: Layer.Layer<
             stream = llm.stream({
               ...ProviderTransform.streamTimeouts(streamInput.model),
               ...streamInput,
+              ...sessionTimeouts,
               tools: activeTools,
               trace: ctx.trace,
             })
@@ -1367,6 +1389,10 @@ export const layer: Layer.Layer<
             const reasoningOnlySafeRetry =
               decision.recommendation === "auto_retry_once" &&
               decision.reason === "reasoning_only_without_final_text_or_tool_activity"
+            const beforeProgressSafeRetry =
+              decision.recommendation === "auto_retry_once" &&
+              decision.reason === "no_visible_output_or_tool_execution"
+            const safeRecoveryRetry = reasoningOnlySafeRetry || beforeProgressSafeRetry
 
             if (
               attemptID &&
@@ -1382,9 +1408,9 @@ export const layer: Layer.Layer<
                 yield* status.set(ctx.sessionID, {
                   type: "retry",
                   attempt: ctx.attemptCount,
-                  message: reasoningOnlySafeRetry ? "" : (retrySignal.message ?? "Retrying interrupted stream"),
+                  message: safeRecoveryRetry ? "" : (retrySignal.message ?? "Retrying interrupted stream"),
                   next,
-                  ...(reasoningOnlySafeRetry
+                  ...(safeRecoveryRetry
                     ? { presentation: "safe_recovery" as const, reason: "network_connection_dropped" as const }
                     : {}),
                 })
@@ -1416,7 +1442,7 @@ export const layer: Layer.Layer<
             if (
               attemptID &&
               retrySignal.retryable &&
-              reasoningOnlySafeRetry &&
+              safeRecoveryRetry &&
               automaticStreamRetriesUsed > 0
             ) {
               yield* writeSafeRetryFailedNotice(attemptID)

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -1,3 +1,4 @@
+import { allowsBeforeProgressRetry as boundaryAllowsBeforeProgressRetry } from "../run-observability/boundary"
 import type { IncidentFacts, RecoveryDecision, TerminalCause } from "./types"
 
 export function recoveryFor(input: {
@@ -166,7 +167,7 @@ function canAutoRetryBeforeFirstProviderProgress(input: {
   if (!isBeforeFirstProviderProgressCause(input.cause)) return false
   if (input.terminalFacts.provider_progress_seen) return false
   if (!attemptHasNoOutputOrToolActivity(input.terminalFacts)) return false
-  return boundaryAllowsBeforeProgressRetry(input.terminalFacts)
+  return boundaryAllowsBeforeProgressRetry(input.terminalFacts.side_effect_boundary_snapshot)
 }
 
 function isBeforeFirstProviderProgressCause(cause: TerminalCause) {
@@ -191,31 +192,8 @@ function attemptHasNoOutputOrToolActivity(facts: IncidentFacts) {
   )
 }
 
-function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
-  const snapshot = facts.side_effect_boundary_snapshot
-  if (!snapshot) return false
-  if (snapshot.provider_executed_capability_present !== false) return false
-  if (snapshot.external_boundary_present !== false) return false
-  if (
-    snapshot.proof_reason === "provider_executed_capability" ||
-    snapshot.proof_reason === "external_boundary" ||
-    snapshot.proof_reason === "unknown"
-  ) {
-    return false
-  }
-  return true
-}
-
 function beforeProgressBoundaryEvidenceBlocksRetry(facts: IncidentFacts) {
-  const snapshot = facts.side_effect_boundary_snapshot
-  if (!snapshot) return true
-  if (snapshot.provider_executed_capability_present !== false) return true
-  if (snapshot.external_boundary_present !== false) return true
-  return (
-    snapshot.proof_reason === "provider_executed_capability" ||
-    snapshot.proof_reason === "external_boundary" ||
-    snapshot.proof_reason === "unknown"
-  )
+  return !boundaryAllowsBeforeProgressRetry(facts.side_effect_boundary_snapshot)
 }
 
 function boundaryAllowsReasoningRetry(facts: IncidentFacts) {

--- a/packages/opencode/src/session/run-incident/policy.ts
+++ b/packages/opencode/src/session/run-incident/policy.ts
@@ -15,6 +15,12 @@ export function recoveryFor(input: {
   const retryableTransport =
     input.retryable === true &&
     (input.cause.category === "provider_transport_disconnect" || input.cause.category === "watchdog_timeout")
+  if (noToolActivity && input.facts.user_cancel_seen) {
+    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
+  }
+  if (noToolActivity && input.facts.lifecycle_close_seen) {
+    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "local_lifecycle_close" }
+  }
   if (
     retryableTransport &&
     noToolActivity &&
@@ -40,6 +46,23 @@ export function recoveryFor(input: {
       recommendation: "do_not_retry",
       confidence: input.cause.confidence,
       reason: "local_lifecycle_close",
+    }
+  }
+  if (
+    retryableTransport &&
+    noToolActivity &&
+    !terminalFacts.visible_output_seen &&
+    !terminalFacts.text_output_started &&
+    !terminalFacts.reasoning_output_started &&
+    !terminalFacts.unsafe_side_effect_started &&
+    boundaryAllowsBeforeProgressRetry(terminalFacts)
+  ) {
+    return {
+      ...base,
+      recommendation: "auto_retry_once",
+      confidence: "medium",
+      reason: "no_visible_output_or_tool_execution",
+      auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
     }
   }
   if (!terminalFacts.side_effect_facts_complete) {
@@ -114,12 +137,6 @@ export function recoveryFor(input: {
       reason: "visible_output_without_tool_execution",
     }
   }
-  if (input.facts.user_cancel_seen) {
-    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "user_cancel" }
-  }
-  if (input.facts.lifecycle_close_seen) {
-    return { ...base, recommendation: "do_not_retry", confidence: "high", reason: "local_lifecycle_close" }
-  }
   if (retryableTransport) {
     return {
       ...base,
@@ -133,6 +150,14 @@ export function recoveryFor(input: {
 }
 
 function boundaryAllowsReasoningRetry(facts: IncidentFacts) {
+  return boundaryAllowsSafeRetry(facts)
+}
+
+function boundaryAllowsBeforeProgressRetry(facts: IncidentFacts) {
+  return boundaryAllowsSafeRetry(facts)
+}
+
+function boundaryAllowsSafeRetry(facts: IncidentFacts) {
   const snapshot = facts.side_effect_boundary_snapshot
   if (!snapshot) return false
   if (snapshot.provider_executed_capability_present) return false

--- a/packages/opencode/src/session/run-observability/boundary.ts
+++ b/packages/opencode/src/session/run-observability/boundary.ts
@@ -1,0 +1,15 @@
+import type { SideEffectBoundarySnapshot } from "./types"
+
+export function allowsBeforeProgressRetry(snapshot: SideEffectBoundarySnapshot | undefined) {
+  if (!snapshot) return false
+  if (snapshot.provider_executed_capability_present !== false) return false
+  if (snapshot.external_boundary_present !== false) return false
+  if (
+    snapshot.proof_reason === "provider_executed_capability" ||
+    snapshot.proof_reason === "external_boundary" ||
+    snapshot.proof_reason === "unknown"
+  ) {
+    return false
+  }
+  return true
+}

--- a/packages/opencode/src/session/run-observability/index.ts
+++ b/packages/opencode/src/session/run-observability/index.ts
@@ -4,6 +4,7 @@ import {
   makeRunID as makeRunIdentifier,
   summaryKeyFor as makeSummaryKey,
 } from "./recorder"
+import { allowsBeforeProgressRetry as allowsBeforeProgressBoundaryRetry } from "./boundary"
 import { safeToolName as makeSafeToolName, toolEffect as classifyToolEffect } from "./sanitize"
 import { SCHEMA_VERSION as VERSION, RunID as RunIDSchema, AttemptID as AttemptIDSchema } from "./types"
 import * as Types from "./types"
@@ -18,6 +19,7 @@ export namespace RunObservability {
   export const isProviderProgressEvent = isProviderProgressStreamEvent
   export const safeToolName = makeSafeToolName
   export const toolEffect = classifyToolEffect
+  export const boundaryAllowsBeforeProgressRetry = allowsBeforeProgressBoundaryRetry
 
   export type RunID = Types.RunID
   export type AttemptID = Types.AttemptID

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -213,6 +213,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         attempt_id: attemptID,
         attempt_index: next.attemptIndex,
         started_at: next.at,
+        connect_timeout_ms: next.connectTimeoutMs,
         provider_progress_seen: false,
         visible_output_seen: false,
         text_output_started: false,

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -86,6 +86,7 @@ export type AttemptSummary = {
   attempt_id: AttemptID
   attempt_index: number
   started_at: number
+  connect_timeout_ms?: number
   last_tool_completed_at?: number
   provider_progress_seen: boolean
   visible_output_seen: boolean
@@ -166,6 +167,7 @@ export type BeginAttemptInput = {
   attemptIndex: number
   at: number
   monotonicMs: number
+  connectTimeoutMs?: number
 }
 
 export type Recorder = {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4761,6 +4761,7 @@ describe("ProviderTransform.streamTimeouts", () => {
   test("policy floor: reasoning model connect timeout meets minimum ceiling", () => {
     const result = ProviderTransform.streamTimeouts(reasoningModel)
     expect(result.connectTimeoutMs).toBeDefined()
+    expect(result.connectTimeoutMs).toBe(ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS)
     expect(result.connectTimeoutMs!).toBeGreaterThan(LLM.CONNECT_STREAM_TIMEOUT_MS)
     expect(result.connectTimeoutMs!).toBeGreaterThanOrEqual(90_000)
   })

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { tool } from "ai"
 import { expect } from "bun:test"
-import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import path from "path"
 import z from "zod"
 import type { Agent } from "../../src/agent/agent"
@@ -25,7 +25,7 @@ import { TurnChange } from "../../src/session/turn-change"
 import { Snapshot } from "../../src/snapshot"
 import { Log } from "../../src/util"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { provideTmpdirServer } from "../fixture/fixture"
+import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { raw, reply, TestLLMServer } from "../lib/llm-server"
 
@@ -46,6 +46,11 @@ const ref = {
   modelID: ModelID.make("test-model"),
 }
 
+const reasoningRef = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("reasoning-model"),
+}
+
 const copilotResponsesRef = {
   providerID: ProviderID.make("github-copilot"),
   modelID: ModelID.make("gpt-5.2"),
@@ -64,6 +69,18 @@ const cfg = {
           name: "Test Model",
           attachment: false,
           reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+        "reasoning-model": {
+          id: "reasoning-model",
+          name: "Reasoning Model",
+          attachment: false,
+          reasoning: true,
           temperature: false,
           tool_call: true,
           release_date: "2025-01-01",
@@ -250,18 +267,18 @@ const assistant = Effect.fn("TestSession.assistant")(function* (
 
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-const deps = Layer.mergeAll(
+const depsWithoutLLM = Layer.mergeAll(
   Session.defaultLayer,
   Snapshot.defaultLayer,
   AgentSvc.defaultLayer,
   Permission.defaultLayer,
   Plugin.defaultLayer,
   Config.defaultLayer,
-  LLM.defaultLayer,
   Provider.defaultLayer,
   TurnChange.defaultLayer,
   status,
 ).pipe(Layer.provideMerge(infra))
+const deps = Layer.mergeAll(depsWithoutLLM, LLM.defaultLayer)
 const env = Layer.mergeAll(
   TestLLMServer.layer,
   SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps)),
@@ -276,9 +293,154 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+function processorEnvWithLLM(llm: LLM.Interface) {
+  const testLLM = Layer.succeed(LLM.Service, LLM.Service.of(llm))
+  const testDeps = Layer.mergeAll(depsWithoutLLM, testLLM)
+  return Layer.mergeAll(
+    testDeps,
+    SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(testDeps)),
+  )
+}
+
+const capturedAttemptConnectTimeouts: number[] = []
+const attemptTimeoutIt = testEffect(
+  processorEnvWithLLM({
+    stream(input) {
+      const connectTimeoutMs = input.connectTimeoutMs ?? LLM.CONNECT_STREAM_TIMEOUT_MS
+      const streamTimeoutMs = input.streamTimeoutMs ?? LLM.SILENT_STREAM_TIMEOUT_MS
+      const error = new Error(`LLM stream connection timed out after ${connectTimeoutMs}ms without provider progress`)
+      capturedAttemptConnectTimeouts.push(connectTimeoutMs)
+      input.trace?.beginStream({
+        collectorCreatedAt: Date.now(),
+        monotonicMs: performance.now(),
+        connectTimeoutMs,
+        streamTimeoutMs,
+      })
+      input.trace?.recordWatchdogFired({
+        phase: "connect",
+        firedAt: Date.now(),
+        monotonicMs: performance.now(),
+      })
+      input.trace?.recordStreamFailure({
+        error,
+        boundary: "watchdog",
+        confidence: "high",
+        evidence: ["watchdog_fired", "watchdog_error"],
+        failedAt: Date.now(),
+        monotonicMs: performance.now(),
+      })
+      return Stream.fail(error)
+    },
+  }),
+)
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+attemptTimeoutIt.live("reasoning connect watchdog is attempt-scoped for before-progress safe retry", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        capturedAttemptConnectTimeouts.length = 0
+        const { processors, session, provider } = yield* boot()
+        const bus = yield* Bus.Service
+        const retrySeen = defer<SessionStatus.Info>()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reasoning connect timeout policy")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(reasoningRef.providerID, reasoningRef.modelID)
+        const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
+          if (evt.properties.sessionID !== chat.id) return
+          if (evt.properties.status.type === "retry") retrySeen.resolve(evt.properties.status)
+        })
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: reasoningRef.providerID, modelID: reasoningRef.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reasoning connect timeout policy" }],
+          tools: {},
+        })
+
+        const retryStatus = yield* Effect.promise(() => retrySeen.promise)
+        const parts = MessageV2.parts(msg.id)
+        off()
+
+        expect(value).toBe("stop")
+        expect(capturedAttemptConnectTimeouts).toEqual([
+          SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+          SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
+        ])
+        expect(retryStatus).toMatchObject({
+          type: "retry",
+          message: "",
+          presentation: "safe_recovery",
+          reason: "network_connection_dropped",
+        })
+        expect(handle.message.diagnostics?.run_observability?.attempts).toMatchObject([
+          {
+            attempt_index: 1,
+            connect_timeout_ms: SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+          },
+          {
+            attempt_index: 2,
+            connect_timeout_ms: SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
+          },
+        ])
+        expect(parts.some((part) => part.type === "notice" && part.kind === "safe_retry_failed")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+
+        const manualParent = yield* user(chat.id, "manual retry starts fresh")
+        const manualMsg = yield* assistant(chat.id, manualParent.id, path.resolve(dir))
+        const manualHandle = yield* processors.create({
+          assistantMessage: manualMsg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        yield* manualHandle.process({
+          user: {
+            id: manualParent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: manualParent.time,
+            agent: manualParent.agent,
+            model: { providerID: reasoningRef.providerID, modelID: reasoningRef.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "manual retry starts fresh" }],
+          tools: {},
+        })
+
+        expect(capturedAttemptConnectTimeouts).toEqual([
+          SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+          SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
+          SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+          SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
+        ])
+      }),
+    { git: true, config: providerCfg("http://localhost:1/v1") },
+  ),
+)
 
 it.live("session.processor keeps late tool execution diagnostics on the bound tool-call attempt", () =>
   provideTmpdirServer(
@@ -987,13 +1149,11 @@ it.live("session.processor effect tests retry recognized structured json errors"
   ),
 )
 
-it.live("retryable API errors stop after one safe recovery retry", () =>
+it.live("retryable API errors write a safe retry notice after one recovery retry", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
-        const seen = defer<void>()
         const { processors, session, provider } = yield* boot()
-        const bus = yield* Bus.Service
 
         yield* llm.error(503, { error: "temporarily unavailable" })
         yield* llm.error(503, { error: "still unavailable" })
@@ -1003,11 +1163,6 @@ it.live("retryable API errors stop after one safe recovery retry", () =>
         const parent = yield* user(chat.id, "retry api twice")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
-        const off = yield* bus.subscribeCallback(Session.Event.Error, (evt) => {
-          if (evt.properties.sessionID !== chat.id) return
-          if (!evt.properties.error) return
-          seen.resolve()
-        })
         const handle = yield* processors.create({
           assistantMessage: msg,
           sessionID: chat.id,
@@ -1031,14 +1186,13 @@ it.live("retryable API errors stop after one safe recovery retry", () =>
           tools: {},
         })
 
-        yield* Effect.promise(() => seen.promise)
         const parts = MessageV2.parts(msg.id)
-        off()
 
         expect(value).toBe("stop")
         expect(yield* llm.calls).toBe(2)
         expect(parts.some((part) => part.type === "text" && part.text === "third attempt should not run")).toBe(false)
-        expect(handle.message.error?.name).toBe("APIError")
+        expect(parts.some((part) => part.type === "notice" && part.kind === "safe_retry_failed")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
         expect(handle.message.diagnostics?.run_observability?.attempts).toHaveLength(2)
         expect(handle.message.diagnostics?.run_observability?.recovered_incidents).toHaveLength(1)
       }),
@@ -2339,13 +2493,11 @@ it.live("session.processor effect tests record aborted errors and idle state", (
   ),
 )
 
-it.live("connect timeout writes assistant info.error and flips session_status idle after retry also fails", () =>
+it.live("connect timeout writes a safe retry notice and flips session_status idle after retry also fails", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
-        const seen = defer<void>()
         const { processors, session, provider } = yield* boot()
-        const bus = yield* Bus.Service
         const sts = yield* SessionStatus.Service
 
         yield* llm.hang
@@ -2355,13 +2507,6 @@ it.live("connect timeout writes assistant info.error and flips session_status id
         const parent = yield* user(chat.id, "bad model")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
-        const errs: string[] = []
-        const off = yield* bus.subscribeCallback(Session.Event.Error, (evt) => {
-          if (evt.properties.sessionID !== chat.id) return
-          if (!evt.properties.error) return
-          errs.push(evt.properties.error.name)
-          seen.resolve()
-        })
         const handle = yield* processors.create({
           assistantMessage: msg,
           sessionID: chat.id,
@@ -2387,20 +2532,19 @@ it.live("connect timeout writes assistant info.error and flips session_status id
           streamTimeoutMs: 1_000,
         })
 
-        yield* Effect.promise(() => seen.promise)
         const stored = MessageV2.get({ sessionID: chat.id, messageID: msg.id })
+        const parts = MessageV2.parts(msg.id)
         const state = yield* sts.get(chat.id)
-        off()
 
         expect(result).toBe("stop")
         expect(yield* llm.calls).toBe(2)
-        expect(handle.message.error).toBeTruthy()
+        expect(handle.message.error).toBeUndefined()
+        expect(parts.some((part) => part.type === "notice" && part.kind === "safe_retry_failed")).toBe(true)
         expect(stored.info.role).toBe("assistant")
         if (stored.info.role === "assistant") {
-          expect(stored.info.error).toBeTruthy()
+          expect(stored.info.error).toBeUndefined()
         }
         expect(state).toMatchObject({ type: "idle" })
-        expect(errs.length).toBeGreaterThan(0)
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -11,6 +11,7 @@ import { Config } from "../../src/config"
 import { Permission } from "../../src/permission"
 import { Plugin } from "../../src/plugin"
 import { Provider } from "../../src/provider"
+import * as ProviderTransform from "../../src/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
@@ -437,6 +438,65 @@ attemptTimeoutIt.live("reasoning connect watchdog is attempt-scoped for before-p
           SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
           SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
         ])
+      }),
+    { git: true, config: providerCfg("http://localhost:1/v1") },
+  ),
+)
+
+attemptTimeoutIt.live("reasoning first attempt keeps global timeout when active tools block safe recovery", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        capturedAttemptConnectTimeouts.length = 0
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reasoning external boundary timeout policy")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(reasoningRef.providerID, reasoningRef.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+        const externalTool = Object.assign(
+          tool({
+            description: "external boundary",
+            inputSchema: z.object({}),
+          }),
+          { externalResult: true },
+        )
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: reasoningRef.providerID, modelID: reasoningRef.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reasoning external boundary timeout policy" }],
+          tools: {
+            question: externalTool,
+          },
+        })
+
+        expect(value).toBe("stop")
+        expect(capturedAttemptConnectTimeouts).toEqual([ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS])
+        expect(handle.message.diagnostics?.run_observability?.attempts).toMatchObject([
+          {
+            attempt_index: 1,
+            connect_timeout_ms: ProviderTransform.REASONING_GLOBAL_CONNECT_TIMEOUT_MS,
+          },
+        ])
+        expect(handle.message.diagnostics?.run_observability?.incident?.recovery).toMatchObject({
+          recommendation: "ask_user_before_retry",
+          reason: "side_effect_facts_incomplete",
+        })
       }),
     { git: true, config: providerCfg("http://localhost:1/v1") },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -502,6 +502,61 @@ attemptTimeoutIt.live("reasoning first attempt keeps global timeout when active 
   ),
 )
 
+attemptTimeoutIt.live("reasoning first attempt uses fast timeout with unclassified local tool boundary", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        capturedAttemptConnectTimeouts.length = 0
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reasoning unclassified local tool timeout policy")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(reasoningRef.providerID, reasoningRef.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: reasoningRef.providerID, modelID: reasoningRef.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reasoning unclassified local tool timeout policy" }],
+          tools: {
+            mcp_write: tool({
+              description: "ordinary local tool with incomplete effect classification",
+              inputSchema: z.object({}),
+            }),
+          },
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        expect(value).toBe("stop")
+        expect(capturedAttemptConnectTimeouts).toEqual([
+          SessionProcessor.REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
+          SessionProcessor.REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS,
+        ])
+        expect(parts.some((part) => part.type === "notice" && part.kind === "safe_retry_failed")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+        expect(handle.message.diagnostics?.run_observability?.recovered_incidents?.[0]?.recovery).toMatchObject({
+          recommendation: "auto_retry_once",
+          reason: "no_visible_output_or_tool_execution",
+        })
+      }),
+    { git: true, config: providerCfg("http://localhost:1/v1") },
+  ),
+)
+
 it.live("session.processor keeps late tool execution diagnostics on the bound tool-call attempt", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -5,6 +5,7 @@ const retry = readFileSync(new URL("./session-retry.tsx", import.meta.url), "utf
 const notice = readFileSync(new URL("./message-part/parts/notice.tsx", import.meta.url), "utf8")
 const en = readFileSync(new URL("../i18n/en.ts", import.meta.url), "utf8")
 const zh = readFileSync(new URL("../i18n/zh.ts", import.meta.url), "utf8")
+const zht = readFileSync(new URL("../i18n/zht.ts", import.meta.url), "utf8")
 
 test("safe recovery retry uses a lightweight status row instead of the error card", () => {
   expect(retry).toContain('presentation !== "safe_recovery"')
@@ -29,4 +30,6 @@ test("safe retry copy stays short and non-technical in English and Chinese", () 
   )
   expect(zh).toContain('"ui.sessionTurn.retry.safeRecovery": "模型暂时没有响应，正在重试…"')
   expect(zh).toContain('"ui.sessionTurn.notice.safeRetryFailed": "模型暂时没有响应。你可以稍后再试，或换一个模型。"')
+  expect(zht).toContain('"ui.sessionTurn.retry.safeRecovery": "模型暫時沒有回應，正在重試…"')
+  expect(zht).toContain('"ui.sessionTurn.notice.safeRetryFailed": "模型暫時沒有回應。你可以稍後再試，或換一個模型。"')
 })

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs"
 
 const retry = readFileSync(new URL("./session-retry.tsx", import.meta.url), "utf8")
 const notice = readFileSync(new URL("./message-part/parts/notice.tsx", import.meta.url), "utf8")
+const en = readFileSync(new URL("../i18n/en.ts", import.meta.url), "utf8")
+const zh = readFileSync(new URL("../i18n/zh.ts", import.meta.url), "utf8")
 
 test("safe recovery retry uses a lightweight status row instead of the error card", () => {
   expect(retry).toContain('presentation !== "safe_recovery"')
@@ -18,4 +20,13 @@ test("safe retry failure renders as a dedicated notice part", () => {
   expect(notice).toContain('part().kind === "safe_retry_failed"')
   expect(notice).toContain('data-kind="safe_retry_failed"')
   expect(notice).toContain('i18n.t("ui.sessionTurn.notice.safeRetryFailed")')
+})
+
+test("safe retry copy stays short and non-technical in English and Chinese", () => {
+  expect(en).toContain('"ui.sessionTurn.retry.safeRecovery": "No response yet. Retrying..."')
+  expect(en).toContain(
+    '"ui.sessionTurn.notice.safeRetryFailed": "The model isn\'t responding right now. Try again later or switch models."',
+  )
+  expect(zh).toContain('"ui.sessionTurn.retry.safeRecovery": "模型暂时没有响应，正在重试…"')
+  expect(zh).toContain('"ui.sessionTurn.notice.safeRetryFailed": "模型暂时没有响应。你可以稍后再试，或换一个模型。"')
 })

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -74,8 +74,8 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.retry.attempt": "attempt #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - attempt #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini is way too hot right now",
-  "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.retry.safeRecovery": "No response yet. Retrying...",
+  "ui.sessionTurn.notice.safeRetryFailed": "The model isn't responding right now. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Free usage exceeded",
   "ui.sessionTurn.error.addCredits": "Add credits",
 

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -77,8 +77,8 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 当前过载",
-  "ui.sessionTurn.retry.safeRecovery": "网络连接断开，正在自动重试",
-  "ui.sessionTurn.notice.safeRetryFailed": "网络连接断开，自动重试未完成",
+  "ui.sessionTurn.retry.safeRecovery": "模型暂时没有响应，正在重试…",
+  "ui.sessionTurn.notice.safeRetryFailed": "模型暂时没有响应。你可以稍后再试，或换一个模型。",
   "ui.sessionTurn.error.freeUsageExceeded": "免费使用额度已用完",
   "ui.sessionTurn.error.addCredits": "添加积分",
 

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -49,8 +49,8 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 目前過載",
-  "ui.sessionTurn.retry.safeRecovery": "網路連線中斷，正在自動重試",
-  "ui.sessionTurn.notice.safeRetryFailed": "網路連線中斷，自動重試未完成",
+  "ui.sessionTurn.retry.safeRecovery": "模型暫時沒有回應，正在重試…",
+  "ui.sessionTurn.notice.safeRetryFailed": "模型暫時沒有回應。你可以稍後再試，或換一個模型。",
   "ui.sessionTurn.error.freeUsageExceeded": "免費使用額度已用完",
   "ui.sessionTurn.error.addCredits": "新增點數",
 


### PR DESCRIPTION
## Summary

Scope reasoning-model safe-retry connect timeouts by processor attempt instead of changing the global reasoning stream timeout.

This PR also updates the safe-recovery retry/failure copy to the agreed short English and Chinese wording.

## Why

Reasoning-model streams currently keep the global `120s` connect watchdog everywhere. That protects legitimate slow starts, but it also makes users wait two minutes before PawWork can safely recover from a no-output/no-tool stalled connection.

#914 made the before-progress no-output/no-tool boundary safe to retry. This follow-up applies the #918 two-attempt strategy: fail fast on the first stalled reasoning-model main response, then protect the one automatic safe retry with the previous 120s ceiling.

## Related Issue

Closes #918

## Human Review Status

Pending

## Review Focus

Please review the processor-level timeout merge order and the safe-recovery presentation predicate. The important invariant is that only the session processor main-response recovery flow gets `60s -> 120s`; title generation and other non-recovery `llm.stream()` callers still use the global reasoning timeout.

## Risk Notes

The intentional behavior change is that retryable no-output/no-tool failures that exhaust the one automatic recovery retry now render the `safe_retry_failed` notice instead of a generic assistant error.

Platform checklist left unticked: no platform, packaging, updater, signing, shell, or native path behavior changed.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in this worktree.
RED check: processor attempt-timeout test first failed with [120000, 120000] before implementation.
Processor tests: bun test --timeout 30000 test/session/processor-effect.test.ts -> 30 passed.
Run observability/provider tests: bun test --timeout 30000 test/session/run-observability.test.ts test/provider/transform.test.ts -t "RunObservability|ProviderTransform.streamTimeouts" -> 62 passed.
UI contract: bun test --timeout 30000 src/components/session-safe-retry-contract.test.ts -> 3 passed.
Typecheck: bun run typecheck in packages/opencode -> passed.
Typecheck: bun run typecheck in packages/ui -> passed.
Lint: bun run lint -> passed.
Visual snap: bun run snap safe-retry -> 1 passed; grid written to docs/design/preview/screenshots/safe-retry.png.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Safe-retry snap target was checked with `bun run snap safe-retry`.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated safe-retry error messaging to clarify when models aren't responding across multiple languages.
  * Improved timeout handling for reasoning-capable models during recovery attempts.
  * Enhanced safe recovery mechanism to handle additional failure scenarios.

* **Tests**
  * Extended test coverage for model retry and timeout behaviors.
  * Added localization verification for retry messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->