### PR TITLE
fix(app): refresh worktree titlebar state on exit

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -26,6 +26,7 @@ import {
   applyGlobalEvent,
   cleanupDroppedSessionCaches,
 } from "./global-sync/event-reducer"
+import { directoryEventTargets } from "./global-sync/event-routing"
 import { createRefreshQueue } from "./global-sync/queue"
 import { clearSessionPrefetchDirectory } from "./global-sync/session-prefetch"
 import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
@@ -388,8 +389,42 @@ function createGlobalSync() {
       return
     }
 
-    const existing = children.children[directory]
-    if (!existing) {
+    const targets = directoryEventTargets({
+      directory,
+      event,
+      hasChild: (targetDirectory) => !!children.children[targetDirectory],
+    })
+    let applied = false
+
+    for (const targetDirectory of targets) {
+      const existing = children.children[targetDirectory]
+      if (!existing) continue
+      applied = true
+      children.mark(targetDirectory)
+      const [store, setStore] = existing
+      applyDirectoryEvent({
+        event,
+        directory: targetDirectory,
+        store,
+        setStore,
+        push: queue.push,
+        acceptSessionTodo,
+        clearSessionTodoAuthoritative,
+        todoHydrate,
+        blockerTerminals,
+        vcsCache: children.vcsCache.get(targetDirectory),
+        loadLsp: () => {
+          void sdkFor(targetDirectory)
+            .lsp.status()
+            .then((x) => {
+              setStore("lsp", x.data ?? [])
+              setStore("lsp_ready", true)
+            })
+        },
+      })
+    }
+
+    if (!applied) {
       applyDetachedDirectoryEvent({
         directory,
         event,
@@ -399,28 +434,6 @@ function createGlobalSync() {
       })
       return
     }
-    children.mark(directory)
-    const [store, setStore] = existing
-    applyDirectoryEvent({
-      event,
-      directory,
-      store,
-      setStore,
-      push: queue.push,
-      acceptSessionTodo,
-      clearSessionTodoAuthoritative,
-      todoHydrate,
-      blockerTerminals,
-      vcsCache: children.vcsCache.get(directory),
-      loadLsp: () => {
-        void sdkFor(directory)
-          .lsp.status()
-          .then((x) => {
-            setStore("lsp", x.data ?? [])
-            setStore("lsp_ready", true)
-          })
-      },
-    })
 
     if ((event.type as string) === "lsp.server.install.failed") {
       const properties = (

--- a/packages/app/src/context/global-sync/event-routing.test.ts
+++ b/packages/app/src/context/global-sync/event-routing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { directoryEventTargets } from "./event-routing"
+
+describe("global sync event routing", () => {
+  test("mirrors root-owned session updates from active worktree events to the owner directory", () => {
+    const event = {
+      type: "session.updated",
+      properties: {
+        info: {
+          id: "ses_1",
+          directory: "/repo",
+          executionContext: {
+            ownerDirectory: "/repo",
+            activeDirectory: "/repo",
+          },
+        },
+      },
+    }
+
+    const targets = directoryEventTargets({
+      directory: "/repo/.worktrees/pawwork/fix-titlebar",
+      event,
+      hasChild: (directory) => directory === "/repo",
+    })
+
+    expect(targets).toEqual(["/repo/.worktrees/pawwork/fix-titlebar", "/repo"])
+  })
+})

--- a/packages/app/src/context/global-sync/event-routing.ts
+++ b/packages/app/src/context/global-sync/event-routing.ts
@@ -1,0 +1,27 @@
+export type DirectoryEvent = {
+  type: string
+  properties?: unknown
+}
+
+export function directoryEventTargets(input: {
+  directory: string
+  event: DirectoryEvent
+  hasChild: (directory: string) => boolean
+}) {
+  const targets = [input.directory]
+  if (input.event.type !== "session.updated") return targets
+
+  const info = (input.event.properties as { info?: SessionDirectoryInfo } | undefined)?.info
+  const ownerDirectory = info?.executionContext?.ownerDirectory ?? info?.directory
+  if (!ownerDirectory || ownerDirectory === input.directory || !input.hasChild(ownerDirectory)) return targets
+
+  targets.push(ownerDirectory)
+  return targets
+}
+
+type SessionDirectoryInfo = {
+  directory?: string
+  executionContext?: {
+    ownerDirectory?: string
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a stale titlebar worktree badge after `ExitWorktree` by mirroring root-owned `session.updated` events from an active worktree event channel back into the owner/root session store.

No issue was opened for this because the bug was reported directly in the local Codex session.

## Why

`ExitWorktree` runs while the session's active execution directory is the worktree, so the backend event can arrive on the worktree directory channel. The titlebar reads the root-owned session info from the owner/root child store. Without mirroring that update, the badge remains visible until another navigation path forces the root store to refresh.

## Related Issue

None. User-reported bug in local Codex session.

## Human Review Status

Pending

## Review Focus

Please check the directory routing boundary in `directoryEventTargets`: only root-owned `session.updated` events should be mirrored, and only when the owner/root child store already exists.

## Risk Notes

- The change intentionally keeps backend event semantics unchanged and limits the app-side fix to `session.updated` routing.
- The conditional visual/manual check item is left unticked because no visual styling or copy changed; the fixed behavior is covered through the event-routing regression test rather than a manual titlebar walkthrough.
- The conditional platform item is left unticked because this does not touch platform, packaging, updater, signing, shell, permissions, or native filesystem behavior.
- The conditional docs/local-files item is left unticked because no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or PR-scoped local files changed.

## How To Verify

```text
RED check: event-routing regression first failed because the owner/root target was missing.
Focused tests: 37 passed across event-routing, event-reducer, and global-sync tests.
  bun test --preload ./happydom.ts ./src/context/global-sync/event-routing.test.ts ./src/context/global-sync/event-reducer.test.ts ./src/context/global-sync.test.ts
Typecheck: passed.
  bun run typecheck  # from packages/app
Lint: no errors; the new test file is ignored by the current ESLint config with one warning.
  bun run lint -- packages/app/src/context/global-sync.tsx packages/app/src/context/global-sync/event-routing.ts packages/app/src/context/global-sync/event-routing.test.ts
Diff review: staged diff contains only the event routing helper, its regression test, and the global-sync listener wiring.
```

## Screenshots or Recordings

Not included. No visual styling or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
