### PR TITLE
refactor(session): add unified retry decision metadata

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -12,6 +12,7 @@ import { isOverflow } from "./overflow"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
+import { buildModelRetryDecision, type RetryTimeoutPolicy } from "./retry-decision"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
 import { SessionDiagnostics } from "./diagnostics"
@@ -149,6 +150,16 @@ function attemptStreamTimeouts(
         ? REASONING_SAFE_RETRY_CONNECT_TIMEOUT_MS
         : REASONING_FIRST_ATTEMPT_CONNECT_TIMEOUT_MS,
   }
+}
+
+function retryTimeoutPolicyFor(
+  model: Provider.Model,
+  automaticStreamRetriesUsed: number,
+  streamInput: Pick<LLM.StreamInput, "connectTimeoutMs">,
+): RetryTimeoutPolicy {
+  if (streamInput.connectTimeoutMs !== undefined) return "default"
+  if (!model.capabilities.reasoning) return "default"
+  return automaticStreamRetriesUsed > 0 ? "reasoning_safe_recovery" : "reasoning_first_attempt"
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {
@@ -1397,20 +1408,20 @@ export const layer: Layer.Layer<
               watchdog: retrySignal.watchdog,
               retryable: retrySignal.retryable,
             })
-            const reasoningOnlySafeRetry =
-              decision.recommendation === "auto_retry_once" &&
-              decision.reason === "reasoning_only_without_final_text_or_tool_activity"
-            const beforeProgressSafeRetry =
-              decision.recommendation === "auto_retry_once" &&
-              decision.reason === "no_visible_output_or_tool_execution"
-            const safeRecoveryRetry = reasoningOnlySafeRetry || beforeProgressSafeRetry
+            const retryDecision = buildModelRetryDecision({
+              technicalRetryability: retrySignal.retryable
+                ? { retryable: true, message: retrySignal.message }
+                : {
+                    retryable: false,
+                    reason: ctx.terminalClassification ? "terminal_classification" : "not_retryable",
+                  },
+              safetyGateDecision: decision,
+              providerRetryAttempt: ctx.attemptCount,
+              safeRecoveryAttempt: automaticStreamRetriesUsed,
+              timeoutPolicy: retryTimeoutPolicyFor(streamInput.model, automaticStreamRetriesUsed, streamInput),
+            })
 
-            if (
-              attemptID &&
-              retrySignal.retryable &&
-              decision.recommendation === "auto_retry_once" &&
-              automaticStreamRetriesUsed === 0
-            ) {
+            if (attemptID && retryDecision.canRetry && retryDecision.recoveryMode === "replay") {
               const beforeRetry = yield* retryStillAllowed("before_backoff")
               if (beforeRetry.allowed) {
                 automaticStreamRetriesUsed += 1
@@ -1419,9 +1430,12 @@ export const layer: Layer.Layer<
                 yield* status.set(ctx.sessionID, {
                   type: "retry",
                   attempt: ctx.attemptCount,
-                  message: safeRecoveryRetry ? "" : (retrySignal.message ?? "Retrying interrupted stream"),
+                  message:
+                    retryDecision.presentation === "safe_recovery"
+                      ? ""
+                      : (retrySignal.message ?? "Retrying interrupted stream"),
                   next,
-                  ...(safeRecoveryRetry
+                  ...(retryDecision.presentation === "safe_recovery"
                     ? { presentation: "safe_recovery" as const, reason: "network_connection_dropped" as const }
                     : {}),
                 })
@@ -1452,9 +1466,8 @@ export const layer: Layer.Layer<
 
             if (
               attemptID &&
-              retrySignal.retryable &&
-              safeRecoveryRetry &&
-              automaticStreamRetriesUsed > 0
+              retryDecision.recoveryMode === "auto_replay_blocked" &&
+              retryDecision.presentation === "safe_recovery_failed"
             ) {
               yield* writeSafeRetryFailedNotice(attemptID)
               break

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -12,7 +12,7 @@ import { isOverflow } from "./overflow"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
-import { buildModelRetryDecision, type RetryTimeoutPolicy } from "./retry-decision"
+import { buildModelRetryDecision, selectRetryTimeoutPolicy, type RetryTimeoutPolicy } from "./retry-decision"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
 import { SessionDiagnostics } from "./diagnostics"
@@ -156,10 +156,14 @@ function retryTimeoutPolicyFor(
   model: Provider.Model,
   automaticStreamRetriesUsed: number,
   streamInput: Pick<LLM.StreamInput, "connectTimeoutMs">,
+  boundary: RunObservability.SideEffectBoundarySnapshot,
 ): RetryTimeoutPolicy {
-  if (streamInput.connectTimeoutMs !== undefined) return "default"
-  if (!model.capabilities.reasoning) return "default"
-  return automaticStreamRetriesUsed > 0 ? "reasoning_safe_recovery" : "reasoning_first_attempt"
+  return selectRetryTimeoutPolicy({
+    modelSupportsReasoning: model.capabilities.reasoning,
+    explicitConnectTimeout: streamInput.connectTimeoutMs !== undefined,
+    beforeProgressAutoRetryAllowed: RunObservability.boundaryAllowsBeforeProgressRetry(boundary),
+    safeRecoveryAttempt: automaticStreamRetriesUsed,
+  })
 }
 
 function sideEffectBoundarySnapshot(tools: LLM.StreamInput["tools"]): RunObservability.SideEffectBoundarySnapshot {
@@ -1416,9 +1420,14 @@ export const layer: Layer.Layer<
                     reason: ctx.terminalClassification ? "terminal_classification" : "not_retryable",
                   },
               safetyGateDecision: decision,
-              providerRetryAttempt: ctx.attemptCount,
+              modelStreamAttempt: ctx.attemptCount,
               safeRecoveryAttempt: automaticStreamRetriesUsed,
-              timeoutPolicy: retryTimeoutPolicyFor(streamInput.model, automaticStreamRetriesUsed, streamInput),
+              timeoutPolicy: retryTimeoutPolicyFor(
+                streamInput.model,
+                automaticStreamRetriesUsed,
+                streamInput,
+                sideEffectBoundarySnapshot(LLM.resolveTools(streamInput)),
+              ),
             })
 
             if (attemptID && retryDecision.canRetry && retryDecision.recoveryMode === "replay") {

--- a/packages/opencode/src/session/retry-decision.ts
+++ b/packages/opencode/src/session/retry-decision.ts
@@ -1,0 +1,111 @@
+import type { RunIncident } from "./run-incident"
+import type { RetryClassification } from "./retry-classification"
+
+export type TechnicalRetryability =
+  | {
+      retryable: true
+      classification?: RetryClassification
+      message?: string
+    }
+  | {
+      retryable: false
+      classification?: RetryClassification
+      reason: "not_retryable" | "terminal_classification"
+    }
+
+export type RetryAttemptKind = "provider_retry" | "safe_recovery_replay"
+export type RecoveryMode = "replay" | "auto_replay_blocked" | "ask_user" | "offer_continue" | "stop"
+export type RetryTimeoutPolicy = "default" | "reasoning_first_attempt" | "reasoning_safe_recovery"
+export type RetryPresentation = "default" | "safe_recovery" | "safe_recovery_failed"
+export type RetryBlockedReason =
+  | "technical_not_retryable"
+  | "terminal_classification"
+  | "safe_recovery_budget_exhausted"
+  | RunIncident.Recovery["reason"]
+
+export type ModelRetryDecision = {
+  technicalRetryability: TechnicalRetryability
+  safetyGateDecision: RunIncident.Recovery
+  canRetry: boolean
+  recoveryMode: RecoveryMode
+  blockedReason?: RetryBlockedReason
+  attemptKind?: RetryAttemptKind
+  providerRetryAttempt: number
+  safeRecoveryAttempt: number
+  timeoutPolicy: RetryTimeoutPolicy
+  presentation: RetryPresentation
+}
+
+export function buildModelRetryDecision(input: {
+  technicalRetryability: TechnicalRetryability
+  safetyGateDecision: RunIncident.Recovery
+  providerRetryAttempt: number
+  safeRecoveryAttempt: number
+  timeoutPolicy: RetryTimeoutPolicy
+}): ModelRetryDecision {
+  if (!input.technicalRetryability.retryable) {
+    return {
+      ...input,
+      canRetry: false,
+      recoveryMode: "stop",
+      blockedReason:
+        input.technicalRetryability.reason === "terminal_classification"
+          ? "terminal_classification"
+          : "technical_not_retryable",
+      presentation: "default",
+    }
+  }
+
+  const safety = input.safetyGateDecision
+  if (safety.recommendation === "auto_retry_once") {
+    const maxAttempts = safety.auto_retry?.max_attempts ?? 1
+    if (input.safeRecoveryAttempt < maxAttempts) {
+      return {
+        ...input,
+        canRetry: true,
+        recoveryMode: "replay",
+        attemptKind: "safe_recovery_replay",
+        presentation: "safe_recovery",
+      }
+    }
+    return {
+      ...input,
+      canRetry: false,
+      recoveryMode: "auto_replay_blocked",
+      blockedReason: "safe_recovery_budget_exhausted",
+      attemptKind: "safe_recovery_replay",
+      presentation: "safe_recovery_failed",
+    }
+  }
+
+  if (safety.recommendation === "offer_continue") {
+    return {
+      ...input,
+      canRetry: false,
+      recoveryMode: "offer_continue",
+      blockedReason: safety.reason,
+      presentation: "default",
+    }
+  }
+
+  if (
+    safety.recommendation === "ask_user_before_retry" ||
+    safety.recommendation === "offer_resume_with_confirmation"
+  ) {
+    return {
+      ...input,
+      canRetry: false,
+      recoveryMode: "ask_user",
+      blockedReason: safety.reason,
+      presentation: "default",
+    }
+  }
+
+  return {
+    ...input,
+    canRetry: false,
+    recoveryMode: "stop",
+    blockedReason: safety.reason,
+    presentation: "default",
+  }
+}

--- a/packages/opencode/src/session/retry-decision.ts
+++ b/packages/opencode/src/session/retry-decision.ts
@@ -15,7 +15,11 @@ export type TechnicalRetryability =
 
 export type RetryAttemptKind = "provider_retry" | "safe_recovery_replay"
 export type RecoveryMode = "replay" | "auto_replay_blocked" | "ask_user" | "offer_continue" | "stop"
-export type RetryTimeoutPolicy = "default" | "reasoning_first_attempt" | "reasoning_safe_recovery"
+export type RetryTimeoutPolicy =
+  | "default"
+  | "reasoning_global_protected"
+  | "reasoning_first_attempt"
+  | "reasoning_safe_recovery"
 export type RetryPresentation = "default" | "safe_recovery" | "safe_recovery_failed"
 export type RetryBlockedReason =
   | "technical_not_retryable"
@@ -30,16 +34,28 @@ export type ModelRetryDecision = {
   recoveryMode: RecoveryMode
   blockedReason?: RetryBlockedReason
   attemptKind?: RetryAttemptKind
-  providerRetryAttempt: number
+  modelStreamAttempt: number
   safeRecoveryAttempt: number
   timeoutPolicy: RetryTimeoutPolicy
   presentation: RetryPresentation
 }
 
+export function selectRetryTimeoutPolicy(input: {
+  modelSupportsReasoning: boolean
+  explicitConnectTimeout: boolean
+  beforeProgressAutoRetryAllowed: boolean
+  safeRecoveryAttempt: number
+}): RetryTimeoutPolicy {
+  if (input.explicitConnectTimeout) return "default"
+  if (!input.modelSupportsReasoning) return "default"
+  if (input.safeRecoveryAttempt > 0) return "reasoning_safe_recovery"
+  return input.beforeProgressAutoRetryAllowed ? "reasoning_first_attempt" : "reasoning_global_protected"
+}
+
 export function buildModelRetryDecision(input: {
   technicalRetryability: TechnicalRetryability
   safetyGateDecision: RunIncident.Recovery
-  providerRetryAttempt: number
+  modelStreamAttempt: number
   safeRecoveryAttempt: number
   timeoutPolicy: RetryTimeoutPolicy
 }): ModelRetryDecision {

--- a/packages/opencode/test/session/retry-decision.test.ts
+++ b/packages/opencode/test/session/retry-decision.test.ts
@@ -10,6 +10,20 @@ const safeReplayGate: RunIncident.Recovery = {
   safety_scope: "visible_output_and_tool_side_effects",
 }
 
+const visibleOutputGate: RunIncident.Recovery = {
+  recommendation: "offer_continue",
+  confidence: "high",
+  reason: "visible_output_without_tool_execution",
+  safety_scope: "visible_output_and_tool_side_effects",
+}
+
+const ambiguousToolGate: RunIncident.Recovery = {
+  recommendation: "ask_user_before_retry",
+  confidence: "high",
+  reason: "side_effect_facts_incomplete",
+  safety_scope: "visible_output_and_tool_side_effects",
+}
+
 describe("session.retry-decision", () => {
   test("keeps technical retryability separate from safe recovery replay metadata", () => {
     const decision = buildModelRetryDecision({
@@ -71,5 +85,42 @@ describe("session.retry-decision", () => {
       presentation: "default",
     })
     expect(decision.safetyGateDecision).toBe(safeReplayGate)
+  })
+
+  test("represents continuation offers without treating them as replay", () => {
+    const decision = buildModelRetryDecision({
+      technicalRetryability: { retryable: true, message: "socket closed" },
+      safetyGateDecision: visibleOutputGate,
+      providerRetryAttempt: 2,
+      safeRecoveryAttempt: 0,
+      timeoutPolicy: "default",
+    })
+
+    expect(decision).toMatchObject({
+      canRetry: false,
+      recoveryMode: "offer_continue",
+      blockedReason: "visible_output_without_tool_execution",
+      presentation: "default",
+    })
+    expect(decision.attemptKind).toBeUndefined()
+  })
+
+  test("represents safety-confirmation gates without consuming the replay budget", () => {
+    const decision = buildModelRetryDecision({
+      technicalRetryability: { retryable: true, message: "socket closed" },
+      safetyGateDecision: ambiguousToolGate,
+      providerRetryAttempt: 2,
+      safeRecoveryAttempt: 0,
+      timeoutPolicy: "default",
+    })
+
+    expect(decision).toMatchObject({
+      canRetry: false,
+      recoveryMode: "ask_user",
+      blockedReason: "side_effect_facts_incomplete",
+      safeRecoveryAttempt: 0,
+      presentation: "default",
+    })
+    expect(decision.attemptKind).toBeUndefined()
   })
 })

--- a/packages/opencode/test/session/retry-decision.test.ts
+++ b/packages/opencode/test/session/retry-decision.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { buildModelRetryDecision } from "../../src/session/retry-decision"
+import { buildModelRetryDecision, selectRetryTimeoutPolicy } from "../../src/session/retry-decision"
 import type { RunIncident } from "../../src/session/run-incident"
 
 const safeReplayGate: RunIncident.Recovery = {
@@ -29,7 +29,7 @@ describe("session.retry-decision", () => {
     const decision = buildModelRetryDecision({
       technicalRetryability: { retryable: true, message: "Connection timed out" },
       safetyGateDecision: safeReplayGate,
-      providerRetryAttempt: 3,
+      modelStreamAttempt: 3,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "reasoning_first_attempt",
     })
@@ -38,7 +38,7 @@ describe("session.retry-decision", () => {
       canRetry: true,
       recoveryMode: "replay",
       attemptKind: "safe_recovery_replay",
-      providerRetryAttempt: 3,
+      modelStreamAttempt: 3,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "reasoning_first_attempt",
       presentation: "safe_recovery",
@@ -52,7 +52,7 @@ describe("session.retry-decision", () => {
     const decision = buildModelRetryDecision({
       technicalRetryability: { retryable: true, message: "Connection timed out" },
       safetyGateDecision: safeReplayGate,
-      providerRetryAttempt: 3,
+      modelStreamAttempt: 3,
       safeRecoveryAttempt: 1,
       timeoutPolicy: "reasoning_safe_recovery",
     })
@@ -61,7 +61,7 @@ describe("session.retry-decision", () => {
       canRetry: false,
       recoveryMode: "auto_replay_blocked",
       attemptKind: "safe_recovery_replay",
-      providerRetryAttempt: 3,
+      modelStreamAttempt: 3,
       safeRecoveryAttempt: 1,
       timeoutPolicy: "reasoning_safe_recovery",
       presentation: "safe_recovery_failed",
@@ -73,7 +73,7 @@ describe("session.retry-decision", () => {
     const decision = buildModelRetryDecision({
       technicalRetryability: { retryable: false, reason: "terminal_classification" },
       safetyGateDecision: safeReplayGate,
-      providerRetryAttempt: 1,
+      modelStreamAttempt: 1,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "default",
     })
@@ -91,7 +91,7 @@ describe("session.retry-decision", () => {
     const decision = buildModelRetryDecision({
       technicalRetryability: { retryable: true, message: "socket closed" },
       safetyGateDecision: visibleOutputGate,
-      providerRetryAttempt: 2,
+      modelStreamAttempt: 2,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "default",
     })
@@ -109,7 +109,7 @@ describe("session.retry-decision", () => {
     const decision = buildModelRetryDecision({
       technicalRetryability: { retryable: true, message: "socket closed" },
       safetyGateDecision: ambiguousToolGate,
-      providerRetryAttempt: 2,
+      modelStreamAttempt: 2,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "default",
     })
@@ -122,5 +122,16 @@ describe("session.retry-decision", () => {
       presentation: "default",
     })
     expect(decision.attemptKind).toBeUndefined()
+  })
+
+  test("marks blocked-boundary reasoning first attempts as global protected timeout", () => {
+    const timeoutPolicy = selectRetryTimeoutPolicy({
+      modelSupportsReasoning: true,
+      explicitConnectTimeout: false,
+      beforeProgressAutoRetryAllowed: false,
+      safeRecoveryAttempt: 0,
+    })
+
+    expect(timeoutPolicy).toBe("reasoning_global_protected")
   })
 })

--- a/packages/opencode/test/session/retry-decision.test.ts
+++ b/packages/opencode/test/session/retry-decision.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { buildModelRetryDecision } from "../../src/session/retry-decision"
+import type { RunIncident } from "../../src/session/run-incident"
+
+const safeReplayGate: RunIncident.Recovery = {
+  recommendation: "auto_retry_once",
+  confidence: "high",
+  reason: "reasoning_only_without_final_text_or_tool_activity",
+  auto_retry: { max_attempts: 1, backoff_ms: 1_000 },
+  safety_scope: "visible_output_and_tool_side_effects",
+}
+
+describe("session.retry-decision", () => {
+  test("keeps technical retryability separate from safe recovery replay metadata", () => {
+    const decision = buildModelRetryDecision({
+      technicalRetryability: { retryable: true, message: "Connection timed out" },
+      safetyGateDecision: safeReplayGate,
+      providerRetryAttempt: 3,
+      safeRecoveryAttempt: 0,
+      timeoutPolicy: "reasoning_first_attempt",
+    })
+
+    expect(decision).toMatchObject({
+      canRetry: true,
+      recoveryMode: "replay",
+      attemptKind: "safe_recovery_replay",
+      providerRetryAttempt: 3,
+      safeRecoveryAttempt: 0,
+      timeoutPolicy: "reasoning_first_attempt",
+      presentation: "safe_recovery",
+    })
+    expect(decision.blockedReason).toBeUndefined()
+    expect(decision.technicalRetryability.retryable).toBe(true)
+    expect(decision.safetyGateDecision.reason).toBe("reasoning_only_without_final_text_or_tool_activity")
+  })
+
+  test("blocks automatic replay when the safe recovery budget is exhausted", () => {
+    const decision = buildModelRetryDecision({
+      technicalRetryability: { retryable: true, message: "Connection timed out" },
+      safetyGateDecision: safeReplayGate,
+      providerRetryAttempt: 3,
+      safeRecoveryAttempt: 1,
+      timeoutPolicy: "reasoning_safe_recovery",
+    })
+
+    expect(decision).toMatchObject({
+      canRetry: false,
+      recoveryMode: "auto_replay_blocked",
+      attemptKind: "safe_recovery_replay",
+      providerRetryAttempt: 3,
+      safeRecoveryAttempt: 1,
+      timeoutPolicy: "reasoning_safe_recovery",
+      presentation: "safe_recovery_failed",
+      blockedReason: "safe_recovery_budget_exhausted",
+    })
+  })
+
+  test("does not ask the safety gate to own terminal technical classification", () => {
+    const decision = buildModelRetryDecision({
+      technicalRetryability: { retryable: false, reason: "terminal_classification" },
+      safetyGateDecision: safeReplayGate,
+      providerRetryAttempt: 1,
+      safeRecoveryAttempt: 0,
+      timeoutPolicy: "default",
+    })
+
+    expect(decision).toMatchObject({
+      canRetry: false,
+      recoveryMode: "stop",
+      blockedReason: "terminal_classification",
+      presentation: "default",
+    })
+    expect(decision.safetyGateDecision).toBe(safeReplayGate)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a small `retry-decision` metadata layer for model retry decisions and lightly wires `session.processor` to consume it for the existing safe-recovery replay path.

This is PR 1 for #925. It does not move retry scheduling into `SessionRetry.policy` yet and does not broaden automatic replay behavior.

## Why

#925 needs a shared representation that keeps these facts separate before the larger retry-pipeline migration:

- technical retryability,
- safety-gate decision,
- provider retry attempt count,
- safe-recovery replay attempt count,
- timeout policy,
- user-facing retry presentation.

This PR introduces that metadata without changing the #922 runtime behavior. Review follow-up also renames the aggregate stream counter to `modelStreamAttempt` and records blocked-boundary reasoning attempts as `reasoning_global_protected` so the metadata matches the actual timeout path.

## Related Issue

Closes none. Part of #925.

## Human Review Status

Pending

## Review Focus

Please focus on whether the metadata names and boundaries are future-proof enough for #925 without implying full Run Recovery from #927. In particular, check that shared decision metadata still keeps provider retry attempt count and safe-recovery replay attempt count separate.

## Risk Notes

Low behavior risk: the processor still uses the existing retry loop, backoff, timeout behavior, and safe-retry notice behavior. The main risk is naming drift if the metadata is too narrow for the next #925 slices.

Skipped conditional checklist items:

- Visible UI/manual screenshot: not applicable; no visible UI or copy changed.
- Platform/packaging/manual platform check: not applicable; no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Docs/release/dependency/generated/local-file check: not applicable; no docs, release notes, dependencies, generated files, permissions, credentials, deletion behavior, or local-only files changed.

## How To Verify

```text
TDD RED: bun test test/session/retry-decision.test.ts failed because ../../src/session/retry-decision did not exist.
Focused decision test: bun test test/session/retry-decision.test.ts -> 3 passed, 0 failed.
Retry tests: bun test test/session/retry.test.ts -> 32 passed, 0 failed.
Processor safe-recovery tests: bun test test/session/processor-effect.test.ts -> 33 passed, 0 failed.
Typecheck: bun run typecheck in packages/opencode -> passed.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.