### PR TITLE
fix(ci): stabilize recent dev smoke flakes

### DIFF
--- a/packages/desktop-electron/scripts/report-problem-smoke.mjs
+++ b/packages/desktop-electron/scripts/report-problem-smoke.mjs
@@ -55,6 +55,38 @@ function latestMarkdownReport(reportRoot) {
   }
 }
 
+function childIsRunning(child) {
+  return child.exitCode === null && child.signalCode === null
+}
+
+async function withTimeout(promise, ms, timeoutValue) {
+  let timeout
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve(timeoutValue), ms)
+      }),
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function waitForExit(child, ms) {
+  if (!childIsRunning(child)) return
+  await withTimeout(new Promise((resolve) => child.once("exit", resolve)), ms, undefined)
+}
+
+async function closeApp(app) {
+  const child = app.process()
+  const closed = await withTimeout(app.close().then(() => true).catch(() => false), 5_000, false)
+  if (closed || !childIsRunning(child)) return
+
+  child.kill("SIGKILL")
+  await waitForExit(child, 5_000)
+}
+
 const homeDir = mkdtempSync(join(tmpdir(), "pawwork-report-smoke-"))
 const app = await electron.launch({
   executablePath: require("electron/index.js"),
@@ -101,6 +133,6 @@ try {
   assert(summary.markdownHasRendererError, "expected full report to include renderer error details")
   assert(summary.markdownHasReportPayload, "expected full report to include the fenced JSON payload")
 } finally {
-  await app.close().catch(() => undefined)
+  await closeApp(app)
   rmSync(homeDir, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })
 }

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -300,6 +300,7 @@ function makeHttp(httpLayer: Layer.Layer<HttpClient.HttpClient> = FetchHttpClien
 // setup; default the live() timeout instead of bandaging individual tests.
 // An explicit third-arg timeout still overrides.
 const defaultLiveTimeout = process.platform === "win32" ? 10_000 : 3_000
+const slowWindowsLiveTimeout = process.platform === "win32" ? 30_000 : undefined
 
 function withDefaultLiveTimeout<
   T extends { live: ((...args: any[]) => any) & { only: any; skip: any } },
@@ -1049,6 +1050,7 @@ it.live("loop gate records same-step repeated tool errors without block or stop"
       }),
     { git: true, config: providerCfg },
   ),
+  slowWindowsLiveTimeout,
 )
 
 it.live("loop gate blocks repeated tool errors across model steps", () =>


### PR DESCRIPTION
## Summary

Fixes two recent merged `dev` CI flakes without changing product behavior:

- Adds a bounded shutdown fallback to the desktop report-problem smoke script so a successful smoke result cannot hang until the workflow timeout.
- Keeps the slow same-step loop-gate live test on the default timeout outside Windows, while giving Windows a 30s budget after it exceeded the 10s default by milliseconds.

No issue exists; this came from live investigation of the latest merged `dev` CI failures.

## Why

Recent merged `dev` runs showed two separate failure shapes:

- `desktop-smoke` on `2a6d53d` completed the report-problem assertions and printed a ready result, then stayed alive until GitHub cancelled the job at 30 minutes.
- `windows-advisory` on `9d1b7a8` failed only because `loop gate records same-step repeated tool errors without block or stop` timed out at 10.016s on Windows.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that the smoke-script shutdown fallback is scoped to test cleanup only, and that the timeout increase stays limited to the known slow Windows live test.

## Risk Notes

No product runtime behavior changes. Platform impact considered: this touches macOS Electron smoke cleanup and Windows advisory test timing only. Manual `workflow_dispatch` for `windows-advisory` was attempted after the review cleanup, but GitHub returned HTTP 500 for Actions dispatch creation; the Windows-specific path remains covered by the platform-gated test change and will be rechecked on the next dispatchable Windows advisory run.

## How To Verify

```text
GitHub Actions log inspection: latest merged dev failures were desktop-smoke cancellation after successful report result, and windows-advisory timeout in one prompt-effect live test.
Focused prompt test: cd packages/opencode && bun test --timeout 30000 test/session/prompt-effect.test.ts -t "loop gate records same-step repeated tool errors without block or stop" -> 1 pass.
Workflow contract tests: cd packages/opencode && bun test test/github/desktop-smoke-workflow.test.ts test/github/ci-workflow.test.ts -> 12 pass.
Desktop build: cd packages/desktop-electron && bun run build -> passed.
Report smoke: cd packages/desktop-electron && perl -e 'alarm shift; exec @ARGV' 25 bun run smoke:report -> passed and exited with code 0.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application shutdown reliability on desktop with improved process management and robust termination handling.

* **Tests**
  * Improved test stability on Windows with optimized timeout configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
