### PR TITLE
fix: ignore nested worktrees in file watcher

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -23,6 +23,7 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
+  const WORKSPACE_SUBSCRIBE_ENTRIES = [".worktrees"]
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
   const VCS_REFRESH_FILES = new Set(["HEAD", "index", "packed-refs"])
   const VCS_REFRESH_PREFIXES = ["refs/heads/", "refs/remotes/"]
@@ -137,6 +138,12 @@ export namespace FileWatcher {
     return entries.filter((entry) => !VCS_SUBSCRIBE_ENTRIES.has(entry))
   }
 
+  export function workspaceWatcherIgnoreEntries(input: { config: string[]; protected: string[] }) {
+    return [
+      ...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_SUBSCRIBE_ENTRIES, ...input.config, ...input.protected]),
+    ]
+  }
+
   export function shouldPublishVcsWatcherPath(file: string, vcsDir: string) {
     const relative = path.relative(vcsDir, file).replaceAll(path.sep, "/")
     if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return false
@@ -231,11 +238,13 @@ export namespace FileWatcher {
             const cfgIgnores = cfg.watcher?.ignore ?? []
 
             if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
-              yield* subscribe(ctx.directory, [
-                ...FileIgnore.PATTERNS,
-                ...cfgIgnores,
-                ...protecteds(ctx.directory),
-              ])
+              yield* subscribe(
+                ctx.directory,
+                workspaceWatcherIgnoreEntries({
+                  config: cfgIgnores,
+                  protected: protecteds(ctx.directory),
+                }),
+              )
             }
 
             if (ctx.project.vcs === "git") {

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -23,7 +23,7 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
-  const WORKSPACE_SUBSCRIBE_ENTRIES = [".worktrees"]
+  const WORKSPACE_IGNORE_ENTRIES = [".worktrees"]
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
   const VCS_REFRESH_FILES = new Set(["HEAD", "index", "packed-refs"])
   const VCS_REFRESH_PREFIXES = ["refs/heads/", "refs/remotes/"]
@@ -184,9 +184,7 @@ export namespace FileWatcher {
   }
 
   export function workspaceWatcherIgnoreEntries(input: { config: string[]; protected: string[] }) {
-    return [
-      ...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_SUBSCRIBE_ENTRIES, ...input.config, ...input.protected]),
-    ]
+    return [...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_IGNORE_ENTRIES, ...input.config, ...input.protected])]
   }
 
   export function watcherSubscriptionDiagnostics(input: {
@@ -203,6 +201,27 @@ export namespace FileWatcher {
       ignore_count: input.ignore.length,
       ignores_worktrees: input.ignore.includes(".worktrees"),
       ...(input.vcsDir ? { vcs_dir: input.vcsDir } : {}),
+    }
+  }
+
+  export function workspaceWatcherSubscription(input: {
+    directory: string
+    backend: string
+    configIgnores: string[]
+    protectedPaths: string[]
+  }) {
+    const ignore = workspaceWatcherIgnoreEntries({
+      config: input.configIgnores,
+      protected: input.protectedPaths,
+    })
+    return {
+      ignore,
+      diagnostics: watcherSubscriptionDiagnostics({
+        directory: input.directory,
+        backend: input.backend,
+        ignore,
+        scope: "workspace",
+      }),
     }
   }
 
@@ -303,22 +322,16 @@ export namespace FileWatcher {
             const cfgIgnores = cfg.watcher?.ignore ?? []
 
             if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
-              const ignore = workspaceWatcherIgnoreEntries({
-                config: cfgIgnores,
-                protected: protecteds(ctx.directory),
+              const workspaceSubscription = workspaceWatcherSubscription({
+                directory: ctx.directory,
+                backend,
+                configIgnores: cfgIgnores,
+                protectedPaths: protecteds(ctx.directory),
               })
-              log.info(
-                "watcher subscription configured",
-                watcherSubscriptionDiagnostics({
-                  directory: ctx.directory,
-                  backend,
-                  ignore,
-                  scope: "workspace",
-                }),
-              )
+              log.info("watcher subscription configured", workspaceSubscription.diagnostics)
               yield* subscribe(
                 ctx.directory,
-                ignore,
+                workspaceSubscription.ignore,
               )
             }
 

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -76,11 +76,32 @@ export namespace FileWatcher {
     return message.includes("Events were dropped") && message.includes("File system must be re-scanned")
   }
 
+  export type WatchScope = "workspace" | "vcs"
+  export type RescanIncidentSummary = {
+    directory: string
+    request_count: number
+    coalesced_count: number
+    leading_published: boolean
+    trailing_published: boolean
+    quiet_ms: number
+    duration_ms: number
+  }
+
   export function createRescanScheduler(input: {
     publish: (directory: string) => void
     schedule?: (callback: () => void) => (() => void) | void
+    now?: () => number
+    onIncidentSettled?: (summary: RescanIncidentSummary) => void
   }) {
-    type RescanState = { dirty: boolean; needsTrailing: boolean; cancel?: () => void }
+    type RescanState = {
+      dirty: boolean
+      needsTrailing: boolean
+      cancel?: () => void
+      startedAt: number
+      requestCount: number
+      leadingPublished: boolean
+      trailingPublished: boolean
+    }
     const pending = new Map<string, RescanState>()
     const schedule = (callback: () => void) => {
       const cancel = input.schedule?.(callback)
@@ -88,7 +109,20 @@ export namespace FileWatcher {
       const timer = setTimeout(callback, RESCAN_QUIET_MS)
       return () => clearTimeout(timer)
     }
+    const now = () => input.now?.() ?? Date.now()
     let disposed = false
+
+    const settle = (directory: string, state: RescanState) => {
+      input.onIncidentSettled?.({
+        directory,
+        request_count: state.requestCount,
+        coalesced_count: Math.max(0, state.requestCount - 1),
+        leading_published: state.leadingPublished,
+        trailing_published: state.trailingPublished,
+        quiet_ms: RESCAN_QUIET_MS,
+        duration_ms: Math.max(0, now() - state.startedAt),
+      })
+    }
 
     const arm = (directory: string, state: RescanState) => {
       state.cancel = schedule(() => {
@@ -101,11 +135,14 @@ export namespace FileWatcher {
         }
         if (state.needsTrailing) {
           state.needsTrailing = false
+          state.trailingPublished = true
           pending.delete(directory)
           input.publish(directory)
+          settle(directory, state)
           return
         }
         pending.delete(directory)
+        settle(directory, state)
       })
     }
 
@@ -116,10 +153,18 @@ export namespace FileWatcher {
         if (state) {
           state.dirty = true
           state.needsTrailing = true
+          state.requestCount++
           return
         }
 
-        const next = { dirty: false, needsTrailing: false }
+        const next: RescanState = {
+          dirty: false,
+          needsTrailing: false,
+          startedAt: now(),
+          requestCount: 1,
+          leadingPublished: true,
+          trailingPublished: false,
+        }
         pending.set(directory, next)
         input.publish(directory)
         arm(directory, next)
@@ -142,6 +187,23 @@ export namespace FileWatcher {
     return [
       ...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_SUBSCRIBE_ENTRIES, ...input.config, ...input.protected]),
     ]
+  }
+
+  export function watcherSubscriptionDiagnostics(input: {
+    directory: string
+    backend: string
+    ignore: string[]
+    scope: WatchScope
+    vcsDir?: string
+  }) {
+    return {
+      dir: input.directory,
+      backend: input.backend,
+      watch_scope: input.scope,
+      ignore_count: input.ignore.length,
+      ignores_worktrees: input.ignore.includes(".worktrees"),
+      ...(input.vcsDir ? { vcs_dir: input.vcsDir } : {}),
+    }
   }
 
   export function shouldPublishVcsWatcherPath(file: string, vcsDir: string) {
@@ -193,6 +255,9 @@ export namespace FileWatcher {
                   log.warn("failed to publish watcher rescan", { dir, error }),
                 )
               },
+              onIncidentSettled: (summary) => {
+                log.warn("watcher rescan incident settled", summary)
+              },
               schedule: (callback) => {
                 const timer = setTimeout(() => Instance.restore(ctx, callback), RESCAN_QUIET_MS)
                 return () => clearTimeout(timer)
@@ -238,12 +303,22 @@ export namespace FileWatcher {
             const cfgIgnores = cfg.watcher?.ignore ?? []
 
             if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
+              const ignore = workspaceWatcherIgnoreEntries({
+                config: cfgIgnores,
+                protected: protecteds(ctx.directory),
+              })
+              log.info(
+                "watcher subscription configured",
+                watcherSubscriptionDiagnostics({
+                  directory: ctx.directory,
+                  backend,
+                  ignore,
+                  scope: "workspace",
+                }),
+              )
               yield* subscribe(
                 ctx.directory,
-                workspaceWatcherIgnoreEntries({
-                  config: cfgIgnores,
-                  protected: protecteds(ctx.directory),
-                }),
+                ignore,
               )
             }
 
@@ -255,6 +330,16 @@ export namespace FileWatcher {
                 result.exitCode === 0 ? path.resolve(ctx.project.worktree, result.text().trim()) : undefined
               if (vcsDir && !cfgIgnores.includes(".git") && !cfgIgnores.includes(vcsDir)) {
                 const ignore = vcsWatcherIgnoreEntries(yield* Effect.promise(() => readdir(vcsDir).catch(() => [])))
+                log.info(
+                  "watcher subscription configured",
+                  watcherSubscriptionDiagnostics({
+                    directory: vcsDir,
+                    backend,
+                    ignore,
+                    scope: "vcs",
+                    vcsDir,
+                  }),
+                )
                 yield* subscribe(vcsDir, ignore, (file) => shouldPublishVcsWatcherPath(file, vcsDir))
               }
             }

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -14,9 +14,15 @@ describe("FileWatcher error handling", () => {
   test("publishes a trailing rescan after repeated dropped-event errors go quiet", () => {
     const published: string[] = []
     const scheduled: Array<() => void> = []
+    const settled: FileWatcher.RescanIncidentSummary[] = []
+    let now = 100
     const scheduler = FileWatcher.createRescanScheduler({
       publish: (directory) => {
         published.push(directory)
+      },
+      now: () => now,
+      onIncidentSettled: (summary) => {
+        settled.push(summary)
       },
       schedule: (callback) => {
         scheduled.push(callback)
@@ -24,19 +30,33 @@ describe("FileWatcher error handling", () => {
     })
 
     scheduler.request("/repo")
+    now = 150
     scheduler.request("/repo")
 
     expect(published).toEqual(["/repo"])
     expect(scheduled).toHaveLength(1)
 
+    now = 1_150
     scheduled[0]?.()
 
     expect(published).toEqual(["/repo"])
     expect(scheduled).toHaveLength(2)
 
+    now = 2_150
     scheduled[1]?.()
 
     expect(published).toEqual(["/repo", "/repo"])
+    expect(settled).toEqual([
+      {
+        directory: "/repo",
+        request_count: 2,
+        coalesced_count: 1,
+        leading_published: true,
+        trailing_published: true,
+        quiet_ms: 1_000,
+        duration_ms: 2_050,
+      },
+    ])
   })
 
   test("coalesces dropped-event errors that keep arriving at the quiet-window boundary", () => {

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -158,6 +158,23 @@ describe("FileWatcher git metadata filtering", () => {
     expect(entries).toContain("/secret")
   })
 
+  test("summarizes workspace watcher subscription diagnostics", () => {
+    expect(
+      FileWatcher.watcherSubscriptionDiagnostics({
+        directory: "/repo",
+        backend: "fs-events",
+        ignore: [".worktrees", "node_modules"],
+        scope: "workspace",
+      }),
+    ).toEqual({
+      dir: "/repo",
+      backend: "fs-events",
+      watch_scope: "workspace",
+      ignore_count: 2,
+      ignores_worktrees: true,
+    })
+  })
+
   test("keeps review-diff git metadata subscribed", () => {
     expect(
       FileWatcher.vcsWatcherIgnoreEntries(["HEAD", "index", "packed-refs", "refs", "objects", "logs", "hooks"]),

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -159,18 +159,22 @@ describe("FileWatcher git metadata filtering", () => {
   })
 
   test("summarizes workspace watcher subscription diagnostics", () => {
-    expect(
-      FileWatcher.watcherSubscriptionDiagnostics({
-        directory: "/repo",
-        backend: "fs-events",
-        ignore: [".worktrees", "node_modules"],
-        scope: "workspace",
-      }),
-    ).toEqual({
+    const subscription = FileWatcher.workspaceWatcherSubscription({
+      directory: "/repo",
+      backend: "fs-events",
+      configIgnores: ["custom-cache"],
+      protectedPaths: ["/secret"],
+    })
+
+    expect(subscription.ignore).toContain("node_modules")
+    expect(subscription.ignore).toContain(".worktrees")
+    expect(subscription.ignore).toContain("custom-cache")
+    expect(subscription.ignore).toContain("/secret")
+    expect(subscription.diagnostics).toEqual({
       dir: "/repo",
       backend: "fs-events",
       watch_scope: "workspace",
-      ignore_count: 2,
+      ignore_count: subscription.ignore.length,
       ignores_worktrees: true,
     })
   })

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -146,6 +146,18 @@ function ready(directory: string) {
 // ---------------------------------------------------------------------------
 
 describe("FileWatcher git metadata filtering", () => {
+  test("ignores nested PawWork worktree roots from the workspace watcher", () => {
+    const entries = FileWatcher.workspaceWatcherIgnoreEntries({
+      config: ["custom-cache"],
+      protected: ["/secret"],
+    })
+
+    expect(entries).toContain("node_modules")
+    expect(entries).toContain(".worktrees")
+    expect(entries).toContain("custom-cache")
+    expect(entries).toContain("/secret")
+  })
+
   test("keeps review-diff git metadata subscribed", () => {
     expect(
       FileWatcher.vcsWatcherIgnoreEntries(["HEAD", "index", "packed-refs", "refs", "objects", "logs", "hooks"]),


### PR DESCRIPTION
## Summary

Ignore nested PawWork worktree roots from the workspace file watcher. This keeps the parent checkout watcher from recursively subscribing to `.worktrees` while preserving the existing default ignores, configured watcher ignores, and protected paths.

Add structured watcher diagnostics for the same path:
- `watcher subscription configured` records the watched directory, backend, watch scope, ignore count, and whether `.worktrees` is ignored.
- `watcher rescan incident settled` records request count, coalesced count, leading/trailing publishes, quiet window, and duration.

There is no related issue; this came from local runtime logs showing repeated dropped watcher events for the main checkout and nested PawWork worktrees in the same bursts.

## Why

The file watcher currently subscribes to the full workspace root without excluding PawWork's nested `.worktrees` directory. When a nested worktree is active, PawWork can end up watching both the parent checkout and the child worktree, so one burst of file changes inside the child worktree can pressure both watcher queues and trigger repeated `watcher events dropped, requesting rescan` recovery.

The extra diagnostics make the next incident easier to read from logs without adding raw request or file contents.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that `.worktrees` is the right workspace-level ignore boundary, that the helper still preserves configured watcher ignores and protected paths, and that the new diagnostic fields are useful without making logs noisy.

## Risk Notes

The parent checkout watcher will no longer publish file events for files under `.worktrees`. That is intentional because active worktrees get their own watcher. The dedicated git metadata watcher is unchanged.

The new diagnostics add structured metadata only. They do not log file contents or LLM request bodies.

Skipped conditional checklist items:
- Manual UI check: no visible UI or copy changed.

## How To Verify

```text
packages/opencode: bun test test/file/watcher.test.ts test/file/watcher-error.test.ts
Result: 16 passed, 0 failed

packages/opencode: bun run typecheck
Result: tsgo --noEmit completed successfully

repo root: git diff --check
Result: no whitespace errors
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
