### PR TITLE
refactor(session): normalize retry recovery presentation

### DIFF
--- a/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
@@ -66,7 +66,7 @@ function SafeRetrySnapFixture() {
               attempt: 1,
               message: "",
               next: Date.now() + 1000,
-              presentation: "safe_recovery",
+              presentation: "recovery",
               reason: "network_connection_dropped",
             }}
           />

--- a/packages/app/e2e/snap/safe-retry.snap.ts
+++ b/packages/app/e2e/snap/safe-retry.snap.ts
@@ -31,12 +31,12 @@ test("safe-retry", async ({ page }) => {
   }, `/@fs/${fixturePath}`)
 
   const running = page.locator('[data-snap="running"]')
-  await expect(running).toContainText("模型暂时没有响应，正在重试…", { timeout: 30_000 })
+  await expect(running).toContainText("正在恢复…", { timeout: 30_000 })
   await expect(running.locator('[data-slot="session-turn-safe-retry"]')).toBeVisible({ timeout: 30_000 })
   await expect(running.locator(".error-card")).toHaveCount(0)
 
   const notice = page.locator('[data-snap="notice"]')
-  await expect(notice).toContainText("模型暂时没有响应。你可以稍后再试，或换一个模型。", { timeout: 30_000 })
+  await expect(notice).toContainText("恢复失败。你可以稍后再试，或换一个模型。", { timeout: 30_000 })
   await expect(notice.locator('[data-kind="safe_retry_failed"]')).toBeVisible({ timeout: 30_000 })
 
   const out = snapOutputPath("safe-retry")

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1405,6 +1405,23 @@ export const layer: Layer.Layer<
                 RunObservability.sideEffectBoundarySnapshot(LLM.resolveTools(streamInput)),
               ),
             })
+            ctx.runTrace.recordRecoveryDecision({
+              attemptID,
+              at: Date.now(),
+              monotonicMs: performance.now(),
+              technical_retryable: retryDecision.technicalRetryability.retryable,
+              technical_retry_blocked_reason: retryDecision.technicalRetryability.retryable
+                ? undefined
+                : retryDecision.technicalRetryability.reason,
+              safety_gate_decision: retryDecision.safetyGateDecision,
+              recovery_mode: retryDecision.recoveryMode,
+              blocked_reason: retryDecision.blockedReason,
+              attempt_kind: retryDecision.attemptKind,
+              model_stream_attempt: retryDecision.modelStreamAttempt,
+              safe_recovery_attempt: retryDecision.safeRecoveryAttempt,
+              timeout_policy: retryDecision.timeoutPolicy,
+              presentation: retryDecision.presentation,
+            })
 
             if (attemptID && retryDecision.canRetry && retryDecision.recoveryMode === "replay") {
               const beforeRetry = yield* retryStillAllowed("before_backoff")

--- a/packages/opencode/src/session/retry-decision.ts
+++ b/packages/opencode/src/session/retry-decision.ts
@@ -20,7 +20,7 @@ export type RetryTimeoutPolicy =
   | "reasoning_global_protected"
   | "reasoning_first_attempt"
   | "reasoning_safe_recovery"
-export type RetryPresentation = "default" | "safe_recovery" | "safe_recovery_failed"
+export type RetryPresentation = "default" | "recovery" | "safe_recovery_failed"
 export type RetryBlockedReason =
   | "technical_not_retryable"
   | "terminal_classification"
@@ -82,7 +82,7 @@ export function buildModelRetryDecision(input: {
       canRetry: true,
       recoveryMode: safety.recoveryMode,
       attemptKind: "safe_recovery_replay",
-      presentation: "safe_recovery",
+      presentation: "recovery",
     }
   }
   const blockedSafeRecoveryReplay = safety.recoveryMode === "auto_replay_blocked"

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -182,7 +182,7 @@ export function safeRecoveryPolicy(opts: {
     attempt: number
     message: string
     next: number
-    presentation: "safe_recovery"
+    presentation: "recovery"
     reason: "network_connection_dropped"
   }) => Effect.Effect<void>
 }) {
@@ -195,7 +195,7 @@ export function safeRecoveryPolicy(opts: {
           attempt: meta.attempt,
           message: "",
           next: now + SAFE_RECOVERY_REPLAY_DELAY,
-          presentation: "safe_recovery",
+          presentation: "recovery",
           reason: "network_connection_dropped",
         })
         return [meta.attempt, Duration.millis(SAFE_RECOVERY_REPLAY_DELAY)] as [number, Duration.Duration]

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -113,6 +113,33 @@ export function createRecorder(input: RecorderInput): Recorder {
       const { cause: _cause, ...nonTerminalEvent } = event
       return { ...nonTerminalEvent, terminal_candidate: false }
     })
+  const recoveryAttemptFor = (decision: RecoveryDecisionDiagnostics | undefined) => {
+    if (!decision?.retry_attempted) return undefined
+    return attempts.find((attempt) => attempt.attempt_index > decision.model_stream_attempt)
+  }
+  const recoveryDecisionOutcome = (
+    decision: RecoveryDecisionDiagnostics,
+    classification: Classification,
+    recoveryAttempt: AttemptMutable | undefined,
+  ): RecoveryDecisionDiagnostics["outcome"] => {
+    if (decision.recovery_mode !== "replay") return decision.outcome
+    if (!decision.retry_attempted) return "blocked"
+    if (!recoveryAttempt) return "retrying"
+    return classification === "success" ? "recovered" : "failed"
+  }
+  const finalizedRecoveryDecision = (
+    decision: RecoveryDecisionDiagnostics | undefined,
+    classification: Classification,
+  ): RecoveryDecisionDiagnostics | undefined => {
+    if (!decision) return undefined
+    const recoveryAttempt = recoveryAttemptFor(decision)
+    return {
+      ...decision,
+      recovery_attempt_id: recoveryAttempt?.attempt_id,
+      recovery_attempt_provider_progress_seen: recoveryAttempt?.provider_progress_seen ?? false,
+      outcome: recoveryDecisionOutcome(decision, classification, recoveryAttempt),
+    }
+  }
   const deriveCurrentIncident = (completedAt?: number, options?: { includeRecoveredTerminal?: boolean }) => {
     const incidentLifecycle = lifecycleSummary(lifecycleFailure)
     return RunIncident.derive({
@@ -507,6 +534,10 @@ export function createRecorder(input: RecorderInput): Recorder {
       return deriveCurrentIncident(next.at, { includeRecoveredTerminal: true })?.recovery ?? unknownRecovery()
     },
     recordRecoveryDecision(next) {
+      if (recoveryDecision?.retry_attempted && next.safe_recovery_attempt > recoveryDecision.safe_recovery_attempt) {
+        rememberEvent(next.monotonicMs)
+        return
+      }
       const attempt = getAttempt(next.attemptID)
       recoveryDecision = {
         attempt_id: next.attemptID,
@@ -523,7 +554,8 @@ export function createRecorder(input: RecorderInput): Recorder {
         timeout_policy: next.timeout_policy,
         presentation: next.presentation,
         retry_attempted: false,
-        provider_progress_seen: attempt?.provider_progress_seen ?? providerProgressSeen,
+        failed_attempt_provider_progress_seen: attempt?.provider_progress_seen ?? providerProgressSeen,
+        recovery_attempt_provider_progress_seen: false,
         outcome: next.recovery_mode === "replay" ? "retrying" : next.technical_retryable ? "blocked" : "stopped",
       }
       appendEvidence({
@@ -554,7 +586,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       }
       recoveredAttemptIDs.add(next.attemptID)
       if (recoveryDecision?.attempt_id === next.attemptID) {
-        recoveryDecision = { ...recoveryDecision, retry_attempted: true, outcome: "recovered" }
+        recoveryDecision = { ...recoveryDecision, retry_attempted: true }
       }
       if (failure && "attemptID" in failure && failure.attemptID === next.attemptID) failure = undefined
       rememberEvent(next.monotonicMs)
@@ -646,6 +678,7 @@ export function createRecorder(input: RecorderInput): Recorder {
       const terminalAttemptID = incident
         ? (incident.phase.terminal_attempt_id ?? (failure && "attemptID" in failure ? failure.attemptID : undefined))
         : undefined
+      const finalRecoveryDecision = finalizedRecoveryDecision(recoveryDecision, classification)
       return {
         schema_version: SCHEMA_VERSION,
         run_id: input.runID,
@@ -677,7 +710,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         pending_tool_parts_interrupted: pendingToolPartsInterrupted || undefined,
         incident,
         recovered_incidents: recoveredIncidents.length ? recoveredIncidents : undefined,
-        recovery_decision: recoveryDecision,
+        recovery_decision: finalRecoveryDecision,
         lifecycle,
         missing_provenance: missingProvenance,
         durations_ms: {

--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -5,6 +5,7 @@ import {
   type Classification,
   type Recorder,
   type RecorderInput,
+  type RecoveryDecisionDiagnostics,
   RunID,
   SCHEMA_VERSION,
   type SideEffectBoundarySnapshot,
@@ -71,6 +72,7 @@ export function createRecorder(input: RecorderInput): Recorder {
   const evidence: RunIncident.EvidenceEvent[] = []
   const recoveredAttemptIDs = new Set<AttemptID>()
   const recoveredIncidents: RunIncident.Summary[] = []
+  let recoveryDecision: RecoveryDecisionDiagnostics | undefined
 
   const rememberEvent = (monotonicMs: number) => {
     lastEventMonotonicMs = Math.max(lastEventMonotonicMs, monotonicMs)
@@ -504,6 +506,36 @@ export function createRecorder(input: RecorderInput): Recorder {
       }
       return deriveCurrentIncident(next.at, { includeRecoveredTerminal: true })?.recovery ?? unknownRecovery()
     },
+    recordRecoveryDecision(next) {
+      const attempt = getAttempt(next.attemptID)
+      recoveryDecision = {
+        attempt_id: next.attemptID,
+        technical_retryable: next.technical_retryable,
+        technical_retry_blocked_reason: next.technical_retry_blocked_reason,
+        safety_gate_recommendation: next.safety_gate_decision.recommendation,
+        safety_gate_reason: next.safety_gate_decision.reason,
+        safety_gate_confidence: next.safety_gate_decision.confidence,
+        recovery_mode: next.recovery_mode,
+        blocked_reason: next.blocked_reason,
+        attempt_kind: next.attempt_kind,
+        model_stream_attempt: next.model_stream_attempt,
+        safe_recovery_attempt: next.safe_recovery_attempt,
+        timeout_policy: next.timeout_policy,
+        presentation: next.presentation,
+        retry_attempted: false,
+        provider_progress_seen: attempt?.provider_progress_seen ?? providerProgressSeen,
+        outcome: next.recovery_mode === "replay" ? "retrying" : next.technical_retryable ? "blocked" : "stopped",
+      }
+      appendEvidence({
+        monotonic_ms: next.monotonicMs,
+        source: "recovery",
+        attempt_id: next.attemptID,
+        event_type: "recovery_decision",
+        terminal_candidate: false,
+        confidence: "high",
+      })
+      rememberEvent(next.monotonicMs)
+    },
     recordAutoRetryAttempted(next) {
       appendEvidence({
         monotonic_ms: next.monotonicMs,
@@ -521,6 +553,9 @@ export function createRecorder(input: RecorderInput): Recorder {
         })
       }
       recoveredAttemptIDs.add(next.attemptID)
+      if (recoveryDecision?.attempt_id === next.attemptID) {
+        recoveryDecision = { ...recoveryDecision, retry_attempted: true, outcome: "recovered" }
+      }
       if (failure && "attemptID" in failure && failure.attemptID === next.attemptID) failure = undefined
       rememberEvent(next.monotonicMs)
     },
@@ -642,6 +677,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         pending_tool_parts_interrupted: pendingToolPartsInterrupted || undefined,
         incident,
         recovered_incidents: recoveredIncidents.length ? recoveredIncidents : undefined,
+        recovery_decision: recoveryDecision,
         lifecycle,
         missing_provenance: missingProvenance,
         durations_ms: {

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -116,8 +116,10 @@ export type RecoveryDecisionDiagnostics = {
   timeout_policy: "default" | "reasoning_global_protected" | "reasoning_first_attempt" | "reasoning_safe_recovery"
   presentation: "default" | "recovery" | "safe_recovery" | "safe_recovery_failed"
   retry_attempted: boolean
-  provider_progress_seen: boolean
-  outcome: "recovered" | "retrying" | "blocked" | "stopped"
+  failed_attempt_provider_progress_seen: boolean
+  recovery_attempt_id?: AttemptID
+  recovery_attempt_provider_progress_seen: boolean
+  outcome: "recovered" | "retrying" | "blocked" | "failed" | "stopped"
 }
 
 export type Summary = {

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -101,6 +101,25 @@ export type AttemptSummary = {
   unsafe_side_effect_started: boolean
 }
 
+export type RecoveryDecisionDiagnostics = {
+  attempt_id?: AttemptID
+  technical_retryable: boolean
+  technical_retry_blocked_reason?: "not_retryable" | "terminal_classification"
+  safety_gate_recommendation: RunIncident.Recovery["recommendation"]
+  safety_gate_reason: RunIncident.Recovery["reason"]
+  safety_gate_confidence: RunIncident.Recovery["confidence"]
+  recovery_mode: "replay" | "auto_replay_blocked" | "ask_user" | "offer_continue" | "stop"
+  blocked_reason?: string
+  attempt_kind?: "provider_retry" | "safe_recovery_replay"
+  model_stream_attempt: number
+  safe_recovery_attempt: number
+  timeout_policy: "default" | "reasoning_global_protected" | "reasoning_first_attempt" | "reasoning_safe_recovery"
+  presentation: "default" | "recovery" | "safe_recovery" | "safe_recovery_failed"
+  retry_attempted: boolean
+  provider_progress_seen: boolean
+  outcome: "recovered" | "retrying" | "blocked" | "stopped"
+}
+
 export type Summary = {
   schema_version: typeof SCHEMA_VERSION
   run_id: RunID
@@ -132,6 +151,7 @@ export type Summary = {
   pending_tool_parts_interrupted?: number
   incident?: RunIncident.Summary
   recovered_incidents?: RunIncident.Summary[]
+  recovery_decision?: RecoveryDecisionDiagnostics
   lifecycle?: {
     action_id: string
     kind: LifecycleKind
@@ -226,6 +246,21 @@ export type Recorder = {
     watchdog?: { phase: "connect" | "silent_stream" | "unknown" }
     retryable?: boolean
   }): RunIncident.Recovery
+  recordRecoveryDecision(input: {
+    attemptID?: AttemptID
+    at: number
+    monotonicMs: number
+    technical_retryable: boolean
+    technical_retry_blocked_reason?: "not_retryable" | "terminal_classification"
+    safety_gate_decision: RunIncident.Recovery
+    recovery_mode: RecoveryDecisionDiagnostics["recovery_mode"]
+    blocked_reason?: string
+    attempt_kind?: RecoveryDecisionDiagnostics["attempt_kind"]
+    model_stream_attempt: number
+    safe_recovery_attempt: number
+    timeout_policy: RecoveryDecisionDiagnostics["timeout_policy"]
+    presentation: RecoveryDecisionDiagnostics["presentation"]
+  }): void
   recordAutoRetryAttempted(input: { attemptID: AttemptID; at: number; monotonicMs: number }): void
   recordTransportFailure(input: {
     attemptID?: AttemptID

--- a/packages/opencode/src/session/status.test.ts
+++ b/packages/opencode/src/session/status.test.ts
@@ -37,7 +37,24 @@ describe("SessionStatus.Info schema", () => {
     }
   })
 
-  test("parses safe recovery retry with stable reason", () => {
+  test("parses recovery retry with stable reason", () => {
+    const result = SessionStatus.Info.parse({
+      type: "retry",
+      attempt: 1,
+      message: "",
+      next: 1_000,
+      presentation: "recovery",
+      reason: "network_connection_dropped",
+    })
+    expect(result.type).toBe("retry")
+    if (result.type === "retry") {
+      expect(result.message).toBe("")
+      expect(result.presentation).toBe("recovery")
+      expect(result.reason).toBe("network_connection_dropped")
+    }
+  })
+
+  test("parses legacy safe recovery retry presentation", () => {
     const result = SessionStatus.Info.parse({
       type: "retry",
       attempt: 1,
@@ -48,9 +65,7 @@ describe("SessionStatus.Info schema", () => {
     })
     expect(result.type).toBe("retry")
     if (result.type === "retry") {
-      expect(result.message).toBe("")
       expect(result.presentation).toBe("safe_recovery")
-      expect(result.reason).toBe("network_connection_dropped")
     }
   })
 

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -16,7 +16,7 @@ export const Info = z
       attempt: z.number(),
       message: z.string(),
       next: z.number(),
-      presentation: z.union([z.literal("recovery"), z.literal("safe_recovery")]).optional(),
+      presentation: z.enum(["recovery", "safe_recovery"]).optional(),
       reason: z.literal("network_connection_dropped").optional(),
       // optional: populated when the retry is caused by a classifiable rate-limit error
       classification: RetryClassification.optional(),

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -16,7 +16,7 @@ export const Info = z
       attempt: z.number(),
       message: z.string(),
       next: z.number(),
-      presentation: z.literal("safe_recovery").optional(),
+      presentation: z.union([z.literal("recovery"), z.literal("safe_recovery")]).optional(),
       reason: z.literal("network_connection_dropped").optional(),
       // optional: populated when the retry is caused by a classifiable rate-limit error
       classification: RetryClassification.optional(),

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -2104,6 +2104,24 @@ describe("redactPart", () => {
       evidence: ["watchdog_fired", "iterator_error"],
       watchdog: { phase: "connect" },
     })
+    recorder.recordRecoveryDecision({
+      attemptID: first.attemptID,
+      at: 4,
+      monotonicMs: 125,
+      technical_retryable: true,
+      safety_gate_decision: {
+        recommendation: "auto_retry_once",
+        confidence: "high",
+        reason: "no_visible_output_or_tool_execution",
+        safety_scope: "visible_output_and_tool_side_effects",
+      },
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 1,
+      safe_recovery_attempt: 0,
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+    })
     recorder.recordAutoRetryAttempted({ attemptID: first.attemptID, at: 4, monotonicMs: 130 })
     const second = recorder.beginAttempt({ attemptIndex: 2, at: 5, monotonicMs: 140 })
     recorder.recordVisibleOutput({ attemptID: second.attemptID, at: 6, monotonicMs: 150 })
@@ -2146,6 +2164,16 @@ describe("redactPart", () => {
     expect(sanitized.diagnostics.run_observability?.[0]?.recovered_incidents?.[0]?.terminal_cause).toMatchObject({
       category: "watchdog_timeout",
       subcategory: "connect",
+    })
+    expect(sanitized.diagnostics.run_observability?.[0]?.recovery_decision).toMatchObject({
+      technical_retryable: true,
+      safety_gate_recommendation: "auto_retry_once",
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+      retry_attempted: true,
+      outcome: "recovered",
     })
     expect(sanitized.diagnostics.run_incidents?.[0]?.terminal_cause).toMatchObject({
       category: "watchdog_timeout",

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -391,7 +391,7 @@ attemptTimeoutIt.live("reasoning connect watchdog is attempt-scoped for before-p
         expect(retryStatus).toMatchObject({
           type: "retry",
           message: "",
-          presentation: "safe_recovery",
+          presentation: "recovery",
           reason: "network_connection_dropped",
         })
         expect(handle.message.diagnostics?.run_observability?.attempts).toMatchObject([
@@ -1752,7 +1752,7 @@ it.live("reasoning-only retry removes failed reasoning before replaying the assi
         expect(retryStatus).toMatchObject({
           type: "retry",
           message: "",
-          presentation: "safe_recovery",
+          presentation: "recovery",
           reason: "network_connection_dropped",
         })
         expect(parts.some((part) => part.type === "reasoning")).toBe(false)

--- a/packages/opencode/test/session/retry-decision.test.ts
+++ b/packages/opencode/test/session/retry-decision.test.ts
@@ -41,7 +41,7 @@ describe("session.retry-decision", () => {
       modelStreamAttempt: 3,
       safeRecoveryAttempt: 0,
       timeoutPolicy: "reasoning_first_attempt",
-      presentation: "safe_recovery",
+      presentation: "recovery",
     })
     expect(decision.blockedReason).toBeUndefined()
     expect(decision.technicalRetryability.retryable).toBe(true)

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -164,7 +164,7 @@ describe("session.retry.delay", () => {
           type: "retry",
           attempt: 1,
           message: "",
-          presentation: "safe_recovery",
+          presentation: "recovery",
           reason: "network_connection_dropped",
         })
       },
@@ -176,7 +176,7 @@ describe("session.retry.delay", () => {
       attempt: number
       message: string
       next: number
-      presentation: "safe_recovery"
+      presentation: "recovery"
       reason: "network_connection_dropped"
     }> = []
 
@@ -200,7 +200,7 @@ describe("session.retry.delay", () => {
     expect(statuses[0]).toMatchObject({
       attempt: 1,
       message: "",
-      presentation: "safe_recovery",
+      presentation: "recovery",
       reason: "network_connection_dropped",
     })
   })

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -232,8 +232,10 @@ describe("RunObservability", () => {
       presentation: "recovery",
     })
     recorder.recordAutoRetryAttempted({ attemptID: first.attemptID, at: 5, monotonicMs: 140 })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 6, monotonicMs: 150 })
+    recorder.recordProviderProgress({ attemptID: second.attemptID, at: 7, monotonicMs: 160 })
 
-    const summary = recorder.finalize({ completedAt: 6, monotonicMs: 150 })
+    const summary = recorder.finalize({ completedAt: 8, monotonicMs: 170 })
 
     expect(summary.recovery_decision).toMatchObject({
       technical_retryable: true,
@@ -246,8 +248,140 @@ describe("RunObservability", () => {
       timeout_policy: "reasoning_first_attempt",
       presentation: "recovery",
       retry_attempted: true,
-      provider_progress_seen: false,
+      failed_attempt_provider_progress_seen: false,
+      recovery_attempt_id: second.attemptID,
+      recovery_attempt_provider_progress_seen: true,
       outcome: "recovered",
+    })
+  })
+
+  test("does not mark replay recovered before the recovery attempt succeeds", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_recovery_decision_failed_attempt"),
+      traceID: MessageID.make("msg_recovery_decision_failed_attempt"),
+      sessionID: SessionID.make("ses_recovery_decision_failed_attempt"),
+      messageID: MessageID.make("msg_recovery_decision_failed_attempt"),
+      providerID: "test",
+      modelID: "test-model",
+      createdAt: 1,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 2, monotonicMs: 110, connectTimeoutMs: 60_000 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: first.attemptID,
+      at: 2,
+      monotonicMs: 115,
+      snapshot: {
+        exposed_tool_count: 0,
+        unknown_tool_count: 0,
+        unclassified_effect_count: 0,
+        provider_executed_capability_present: false,
+        external_boundary_present: false,
+        proof_result: "complete",
+        proof_reason: "all_boundaries_classified",
+      },
+    })
+    const recovery = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: first.attemptID,
+      at: 3,
+      monotonicMs: 120,
+      error: new Error("LLM stream connection timed out after 60000ms without provider progress"),
+      evidence: ["watchdog_fired", "iterator_error"],
+      watchdog: { phase: "connect" },
+      retryable: true,
+    })
+    recorder.recordRecoveryDecision({
+      attemptID: first.attemptID,
+      at: 4,
+      monotonicMs: 130,
+      technical_retryable: true,
+      safety_gate_decision: recovery,
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 1,
+      safe_recovery_attempt: 0,
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+    })
+    recorder.recordAutoRetryAttempted({ attemptID: first.attemptID, at: 5, monotonicMs: 140 })
+    const second = recorder.beginAttempt({ attemptIndex: 2, at: 6, monotonicMs: 150 })
+    recorder.recordProviderProgress({ attemptID: second.attemptID, at: 7, monotonicMs: 160 })
+    const exhausted = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: second.attemptID,
+      at: 8,
+      monotonicMs: 170,
+      error: new Error("LLM stream connection timed out after 120000ms"),
+      evidence: ["watchdog_fired", "iterator_error"],
+      watchdog: { phase: "silent_stream" },
+      retryable: true,
+    })
+    recorder.recordRecoveryDecision({
+      attemptID: second.attemptID,
+      at: 9,
+      monotonicMs: 180,
+      technical_retryable: true,
+      safety_gate_decision: exhausted,
+      recovery_mode: "auto_replay_blocked",
+      blocked_reason: "safe_recovery_budget_exhausted",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 2,
+      safe_recovery_attempt: 1,
+      timeout_policy: "reasoning_safe_recovery",
+      presentation: "safe_recovery_failed",
+    })
+
+    const summary = recorder.finalize({ completedAt: 10, monotonicMs: 190 })
+
+    expect(summary.recovery_decision).toMatchObject({
+      retry_attempted: true,
+      failed_attempt_provider_progress_seen: false,
+      recovery_attempt_id: second.attemptID,
+      recovery_attempt_provider_progress_seen: true,
+      outcome: "failed",
+    })
+  })
+
+  test("marks replay blocked when recovery was allowed but never attempted", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_recovery_decision_not_attempted"),
+      traceID: MessageID.make("msg_recovery_decision_not_attempted"),
+      sessionID: SessionID.make("ses_recovery_decision_not_attempted"),
+      messageID: MessageID.make("msg_recovery_decision_not_attempted"),
+      providerID: "test",
+      modelID: "test-model",
+      createdAt: 1,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 2, monotonicMs: 110 })
+    const recovery = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: first.attemptID,
+      at: 3,
+      monotonicMs: 120,
+      error: new Error("LLM stream connection timed out after 60000ms without provider progress"),
+      evidence: ["watchdog_fired", "iterator_error"],
+      watchdog: { phase: "connect" },
+      retryable: true,
+    })
+    recorder.recordRecoveryDecision({
+      attemptID: first.attemptID,
+      at: 4,
+      monotonicMs: 130,
+      technical_retryable: true,
+      safety_gate_decision: recovery,
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 1,
+      safe_recovery_attempt: 0,
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+    })
+
+    const summary = recorder.finalize({ completedAt: 5, monotonicMs: 140 })
+
+    expect(summary.recovery_decision).toMatchObject({
+      retry_attempted: false,
+      recovery_attempt_provider_progress_seen: false,
+      outcome: "blocked",
     })
   })
 

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -183,6 +183,74 @@ describe("RunObservability", () => {
     })
   })
 
+  test("records recovery decision diagnostics for automatic replay", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_recovery_decision_diagnostics"),
+      traceID: MessageID.make("msg_recovery_decision_diagnostics"),
+      sessionID: SessionID.make("ses_recovery_decision_diagnostics"),
+      messageID: MessageID.make("msg_recovery_decision_diagnostics"),
+      providerID: "test",
+      modelID: "test-model",
+      createdAt: 1,
+      monotonicStartMs: 100,
+    })
+    const first = recorder.beginAttempt({ attemptIndex: 1, at: 2, monotonicMs: 110, connectTimeoutMs: 60_000 })
+    recorder.recordSideEffectBoundarySnapshot({
+      attemptID: first.attemptID,
+      at: 2,
+      monotonicMs: 115,
+      snapshot: {
+        exposed_tool_count: 0,
+        unknown_tool_count: 0,
+        unclassified_effect_count: 0,
+        provider_executed_capability_present: false,
+        external_boundary_present: false,
+        proof_result: "complete",
+        proof_reason: "all_boundaries_classified",
+      },
+    })
+    const recovery = recorder.recordAttemptFailureAndDeriveRecovery({
+      attemptID: first.attemptID,
+      at: 3,
+      monotonicMs: 120,
+      error: new Error("LLM stream connection timed out after 60000ms without provider progress"),
+      evidence: ["watchdog_fired", "iterator_error"],
+      watchdog: { phase: "connect" },
+      retryable: true,
+    })
+    recorder.recordRecoveryDecision({
+      attemptID: first.attemptID,
+      at: 4,
+      monotonicMs: 130,
+      technical_retryable: true,
+      safety_gate_decision: recovery,
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 1,
+      safe_recovery_attempt: 0,
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+    })
+    recorder.recordAutoRetryAttempted({ attemptID: first.attemptID, at: 5, monotonicMs: 140 })
+
+    const summary = recorder.finalize({ completedAt: 6, monotonicMs: 150 })
+
+    expect(summary.recovery_decision).toMatchObject({
+      technical_retryable: true,
+      safety_gate_recommendation: "auto_retry_once",
+      safety_gate_reason: "no_visible_output_or_tool_execution",
+      recovery_mode: "replay",
+      attempt_kind: "safe_recovery_replay",
+      model_stream_attempt: 1,
+      safe_recovery_attempt: 0,
+      timeout_policy: "reasoning_first_attempt",
+      presentation: "recovery",
+      retry_attempted: true,
+      provider_progress_seen: false,
+      outcome: "recovered",
+    })
+  })
+
   test("classifies completed runs without failure as success", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_success"),

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -471,7 +471,7 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
-      presentation?: "safe_recovery"
+      presentation?: "recovery" | "safe_recovery"
     }
   | {
       type: "busy"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -72,7 +72,7 @@ export type SessionStatus =
       attempt: number
       message: string
       next: number
-      presentation?: "safe_recovery"
+      presentation?: "recovery" | "safe_recovery"
       reason?: "network_connection_dropped"
       classification?: RetryClassification
     }

--- a/packages/ui/src/components/session-retry.tsx
+++ b/packages/ui/src/components/session-retry.tsx
@@ -40,7 +40,7 @@ export function SessionRetry(props: {
   })
   const safeRecoveryRetry = createMemo(() => {
     const current = retry()
-    if (current?.presentation !== "safe_recovery") return
+    if (current?.presentation !== "recovery" && current?.presentation !== "safe_recovery") return
     return current
   })
   const [seconds, setSeconds] = createSignal(0)
@@ -113,7 +113,7 @@ export function SessionRetry(props: {
               <div data-slot="session-turn-safe-retry" class="flex items-center gap-2 text-caption text-fg-weak">
                 <Spinner class="size-3.5" />
                 <div data-slot="session-turn-safe-retry-message">
-                  {i18n.t("ui.sessionTurn.retry.safeRecovery")}
+                  {i18n.t("ui.sessionTurn.retry.recovery")}
                 </div>
               </div>
             )}

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -7,11 +7,11 @@ const en = readFileSync(new URL("../i18n/en.ts", import.meta.url), "utf8")
 const zh = readFileSync(new URL("../i18n/zh.ts", import.meta.url), "utf8")
 const zht = readFileSync(new URL("../i18n/zht.ts", import.meta.url), "utf8")
 
-test("safe recovery retry uses a lightweight status row instead of the error card", () => {
-  expect(retry).toContain('presentation !== "safe_recovery"')
+test("recovery retry uses a lightweight status row instead of the error card", () => {
+  expect(retry).toContain('presentation !== "recovery" && current?.presentation !== "safe_recovery"')
   expect(retry).toContain('data-slot="session-turn-safe-retry"')
   expect(retry).toContain('data-slot="session-turn-safe-retry-message"')
-  expect(retry).toContain('i18n.t("ui.sessionTurn.retry.safeRecovery")')
+  expect(retry).toContain('i18n.t("ui.sessionTurn.retry.recovery")')
   expect(retry).toContain('fallback={')
   expect(retry).toContain('<Card variant="error" class="error-card">')
 })
@@ -23,13 +23,13 @@ test("safe retry failure renders as a dedicated notice part", () => {
   expect(notice).toContain('i18n.t("ui.sessionTurn.notice.safeRetryFailed")')
 })
 
-test("safe retry copy stays short and non-technical in English and Chinese", () => {
-  expect(en).toContain('"ui.sessionTurn.retry.safeRecovery": "No response yet. Retrying..."')
+test("recovery copy stays short and non-technical in English and Chinese", () => {
+  expect(en).toContain('"ui.sessionTurn.retry.recovery": "Recovering..."')
   expect(en).toContain(
-    '"ui.sessionTurn.notice.safeRetryFailed": "The model isn\'t responding right now. Try again later or switch models."',
+    '"ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models."',
   )
-  expect(zh).toContain('"ui.sessionTurn.retry.safeRecovery": "模型暂时没有响应，正在重试…"')
-  expect(zh).toContain('"ui.sessionTurn.notice.safeRetryFailed": "模型暂时没有响应。你可以稍后再试，或换一个模型。"')
-  expect(zht).toContain('"ui.sessionTurn.retry.safeRecovery": "模型暫時沒有回應，正在重試…"')
-  expect(zht).toContain('"ui.sessionTurn.notice.safeRetryFailed": "模型暫時沒有回應。你可以稍後再試，或換一個模型。"')
+  expect(zh).toContain('"ui.sessionTurn.retry.recovery": "正在恢复…"')
+  expect(zh).toContain('"ui.sessionTurn.notice.safeRetryFailed": "恢复失败。你可以稍后再试，或换一个模型。"')
+  expect(zht).toContain('"ui.sessionTurn.retry.recovery": "正在恢復…"')
+  expect(zht).toContain('"ui.sessionTurn.notice.safeRetryFailed": "恢復失敗。你可以稍後再試，或換一個模型。"')
 })

--- a/packages/ui/src/components/session-safe-retry-contract.test.ts
+++ b/packages/ui/src/components/session-safe-retry-contract.test.ts
@@ -1,11 +1,17 @@
 import { expect, test } from "bun:test"
-import { readFileSync } from "node:fs"
+import { readdirSync, readFileSync } from "node:fs"
 
 const retry = readFileSync(new URL("./session-retry.tsx", import.meta.url), "utf8")
 const notice = readFileSync(new URL("./message-part/parts/notice.tsx", import.meta.url), "utf8")
 const en = readFileSync(new URL("../i18n/en.ts", import.meta.url), "utf8")
 const zh = readFileSync(new URL("../i18n/zh.ts", import.meta.url), "utf8")
 const zht = readFileSync(new URL("../i18n/zht.ts", import.meta.url), "utf8")
+const i18nDir = new URL("../i18n/", import.meta.url)
+const localeFiles = Object.fromEntries(
+  readdirSync(i18nDir)
+    .filter((file) => file.endsWith(".ts") && !file.endsWith(".test.ts"))
+    .map((file) => [file, readFileSync(new URL(file, i18nDir), "utf8")]),
+)
 
 test("recovery retry uses a lightweight status row instead of the error card", () => {
   expect(retry).toContain('presentation !== "recovery" && current?.presentation !== "safe_recovery"')
@@ -32,4 +38,12 @@ test("recovery copy stays short and non-technical in English and Chinese", () =>
   expect(zh).toContain('"ui.sessionTurn.notice.safeRetryFailed": "恢复失败。你可以稍后再试，或换一个模型。"')
   expect(zht).toContain('"ui.sessionTurn.retry.recovery": "正在恢復…"')
   expect(zht).toContain('"ui.sessionTurn.notice.safeRetryFailed": "恢復失敗。你可以稍後再試，或換一個模型。"')
+})
+
+test("all locale safe retry failure copy uses recovery wording", () => {
+  for (const [path, source] of Object.entries(localeFiles)) {
+    expect(source, path).toContain('"ui.sessionTurn.notice.safeRetryFailed": "')
+    expect(source, path).toMatch(/Recovery failed|恢复失败|恢復失敗/)
+    expect(source, path).not.toContain("Network connection dropped. Automatic retry did not complete.")
+  }
 })

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - المحاولة رقم {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini مزدحم حاليا",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "تم تجاوز حد الاستخدام المجاني",

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -45,7 +45,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini مزدحم حاليا",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "تم تجاوز حد الاستخدام المجاني",
   "ui.sessionTurn.error.addCredits": "إضافة رصيد",
 

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -45,7 +45,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini está muito sobrecarregado agora",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Adicionar créditos",
 

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentativa #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentativa #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está muito sobrecarregado agora",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite de uso gratuito excedido",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -47,6 +47,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - pokušaj #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini je trenutno preopterećen",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Besplatna upotreba premašena",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -49,7 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini je trenutno preopterećen",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Besplatna upotreba premašena",
   "ui.sessionTurn.error.addCredits": "Dodaj kredite",
 

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "forsøg #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøg #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er meget overbelastet lige nu",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis forbrug overskredet",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -44,7 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini er meget overbelastet lige nu",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis forbrug overskredet",
   "ui.sessionTurn.error.addCredits": "Tilføj kreditter",
 

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -48,6 +48,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "Versuch #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - Versuch #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini ist gerade sehr überlastet",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Kostenloses Nutzungslimit überschritten",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -50,7 +50,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini ist gerade sehr überlastet",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Kostenloses Nutzungslimit überschritten",
   "ui.sessionTurn.error.addCredits": "Guthaben aufladen",
 

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -74,8 +74,9 @@ export const dict: Record<string, string> = {
   "ui.sessionTurn.retry.attempt": "attempt #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - attempt #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini is way too hot right now",
-  "ui.sessionTurn.retry.safeRecovery": "No response yet. Retrying...",
-  "ui.sessionTurn.notice.safeRetryFailed": "The model isn't responding right now. Try again later or switch models.",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
+  "ui.sessionTurn.retry.safeRecovery": "Recovering...",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Free usage exceeded",
   "ui.sessionTurn.error.addCredits": "Add credits",
 

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -45,7 +45,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini está demasiado saturado",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Límite de uso gratuito excedido",
   "ui.sessionTurn.error.addCredits": "Añadir créditos",
 

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "intento #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - intento #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini está demasiado saturado",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Límite de uso gratuito excedido",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "tentative n°{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - tentative n°{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini est en surchauffe",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite d'utilisation gratuite dépassée",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -45,7 +45,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini est en surchauffe",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Limite d'utilisation gratuite dépassée",
   "ui.sessionTurn.error.addCredits": "Ajouter des crédits",
 

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -44,7 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini が混雑しています",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "無料使用制限に達しました",
   "ui.sessionTurn.error.addCredits": "クレジットを追加",
 

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}回目",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}回目",
   "ui.sessionTurn.retry.geminiHot": "gemini が混雑しています",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "無料使用制限に達しました",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -45,7 +45,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini가 현재 과부하 상태입니다",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "무료 사용량 초과",
   "ui.sessionTurn.error.addCredits": "크레딧 추가",
 

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -43,6 +43,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "{{attempt}}번째",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - {{attempt}}번째",
   "ui.sessionTurn.retry.geminiHot": "gemini가 현재 과부하 상태입니다",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "무료 사용량 초과",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -46,6 +46,7 @@ export const dict: Record<Keys, string> = {
   "ui.sessionTurn.retry.attempt": "forsøk #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - forsøk #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini er veldig overbelastet nå",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis bruk overskredet",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -48,7 +48,7 @@ export const dict: Record<Keys, string> = {
   "ui.sessionTurn.retry.geminiHot": "gemini er veldig overbelastet nå",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Gratis bruk overskredet",
   "ui.sessionTurn.error.addCredits": "Legg til kreditt",
 

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -44,7 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini jest teraz mocno przeciążony",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Przekroczono limit darmowego użytkowania",
   "ui.sessionTurn.error.addCredits": "Dodaj kredyty",
 

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "próba #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - próba #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini jest teraz mocno przeciążony",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Przekroczono limit darmowego użytkowania",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -44,7 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini сейчас перегружен",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Лимит бесплатного использования превышен",
   "ui.sessionTurn.error.addCredits": "Добавить кредиты",
 

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -42,6 +42,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "попытка №{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - попытка №{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini сейчас перегружен",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Лимит бесплатного использования превышен",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -46,7 +46,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini กำลังใช้งานหนาแน่นมาก",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "เกินขีดจำกัดการใช้งานฟรี",
   "ui.sessionTurn.error.addCredits": "เพิ่มเครดิต",
 

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -44,6 +44,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - ครั้งที่ {{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini กำลังใช้งานหนาแน่นมาก",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "เกินขีดจำกัดการใช้งานฟรี",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -51,7 +51,7 @@ export const dict = {
   "ui.sessionTurn.retry.geminiHot": "gemini şu anda aşırı yoğun",
   "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
-  "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
+  "ui.sessionTurn.notice.safeRetryFailed": "Recovery failed. Try again later or switch models.",
   "ui.sessionTurn.error.freeUsageExceeded": "Ücretsiz kullanım aşıldı",
   "ui.sessionTurn.error.addCredits": "Kredi ekle",
 

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -49,6 +49,7 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "deneme #{{attempt}}",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - deneme #{{attempt}}",
   "ui.sessionTurn.retry.geminiHot": "gemini şu anda aşırı yoğun",
+  "ui.sessionTurn.retry.recovery": "Recovering...",
   "ui.sessionTurn.retry.safeRecovery": "Network connection dropped, retrying automatically",
   "ui.sessionTurn.notice.safeRetryFailed": "Network connection dropped. Automatic retry did not complete.",
   "ui.sessionTurn.error.freeUsageExceeded": "Ücretsiz kullanım aşıldı",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -77,8 +77,9 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 当前过载",
-  "ui.sessionTurn.retry.safeRecovery": "模型暂时没有响应，正在重试…",
-  "ui.sessionTurn.notice.safeRetryFailed": "模型暂时没有响应。你可以稍后再试，或换一个模型。",
+  "ui.sessionTurn.retry.recovery": "正在恢复…",
+  "ui.sessionTurn.retry.safeRecovery": "正在恢复…",
+  "ui.sessionTurn.notice.safeRetryFailed": "恢复失败。你可以稍后再试，或换一个模型。",
   "ui.sessionTurn.error.freeUsageExceeded": "免费使用额度已用完",
   "ui.sessionTurn.error.addCredits": "添加积分",
 

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -49,8 +49,9 @@ export const dict = {
   "ui.sessionTurn.retry.attempt": "第 {{attempt}} 次",
   "ui.sessionTurn.retry.attemptLine": "{{line}} - 第 {{attempt}} 次",
   "ui.sessionTurn.retry.geminiHot": "gemini 目前過載",
-  "ui.sessionTurn.retry.safeRecovery": "模型暫時沒有回應，正在重試…",
-  "ui.sessionTurn.notice.safeRetryFailed": "模型暫時沒有回應。你可以稍後再試，或換一個模型。",
+  "ui.sessionTurn.retry.recovery": "正在恢復…",
+  "ui.sessionTurn.retry.safeRecovery": "正在恢復…",
+  "ui.sessionTurn.notice.safeRetryFailed": "恢復失敗。你可以稍後再試，或換一個模型。",
   "ui.sessionTurn.error.freeUsageExceeded": "免費使用額度已用完",
   "ui.sessionTurn.error.addCredits": "新增點數",
 


### PR DESCRIPTION
## Summary

Normalizes #925's final recovery presentation layer so automatic replay uses a user-facing recovery state instead of exposing the internal safe-retry mechanism.

This PR:

- changes the retry status presentation value from `safe_recovery` to `recovery`, while keeping legacy `safe_recovery` parsing/rendering compatible;
- updates the safe retry row and failure notice copy to say "recovering" / "recovery failed" in the visible UI;
- records `recovery_decision` diagnostics in run observability and sanitized exports, including technical retryability, safety gate result, recovery mode, attempt metadata, timeout policy, retry-attempted state, provider progress, and final recovery outcome;
- syncs the SDK generated `SessionStatus` types for the new presentation value.

## Why

This is PR 4 for #925. PRs #928, #929, and #931 moved model execution retry mechanics toward one shared retry pipeline. The remaining work was to make UI and diagnostics consume stable recovery-oriented metadata rather than processor-local safe-retry naming.

## Related Issue

Closes #925.

## Human Review Status

Pending

## Review Focus

Please focus on whether the new `recovery_decision` summary answers the intended diagnostics questions without implying broader #927 run-resume support, and whether keeping `safe_retry_failed` as the persisted notice kind is the right compatibility boundary.

## Risk Notes

Behavior risk is intended to be low: retry scheduling, replay budget, #922 timeout behavior, SSE reconnect, and partial-output/tool recovery behavior are unchanged. The visible UI copy changes from "retrying" wording to "recovering" wording. The persisted notice kind remains `safe_retry_failed` to avoid a storage/schema migration.

Skipped conditional checklist items:

- Platform/packaging check: not applicable; no platform, packaging, updater, signing, native path, shell, or permission surface changed.
- Docs/release/dependency/local-file check: SDK generated types were updated for the status contract; no dependencies, release notes, permissions, credentials, deletion behavior, or local-only files were changed. The snap output PNG was generated locally under ignored `docs/` for verification and was not staged.

## How To Verify

```text
TDD RED: bun test src/components/session-safe-retry-contract.test.ts in packages/ui failed on the old safe-retry presentation/copy expectations.
TDD RED: bun test test/session/run-observability.test.ts -t "records recovery decision diagnostics" in packages/opencode failed because recordRecoveryDecision did not exist.
UI contract: bun test src/components/session-safe-retry-contract.test.ts in packages/ui -> 3 passed.
Opencode focused recovery tests: bun test test/session/retry-decision.test.ts test/session/retry.test.ts src/session/status.test.ts test/session/run-observability.test.ts test/session/export.test.ts -t "recovery|retry|status|exports recovered stream incidents" in packages/opencode -> 65 passed, 0 failed.
Review follow-up: added recovery outcome/progress edge tests for retry-not-attempted and retry-attempt-failed cases; all included in the focused recovery test command above.
Processor safe recovery tests: bun test test/session/processor-effect.test.ts -t "safe retry|safe recovery|reasoning-only retry|connect timeout writes a safe retry notice" in packages/opencode -> 6 passed, 0 failed.
Safe retry snap: bun run snap safe-retry -> 1 passed; generated safe-retry grid at docs/design/preview/screenshots/safe-retry.png.
Lint: bun run lint -> passed.
Root typecheck: bun run typecheck -> 8 packages successful.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Safe retry snap was generated and visually checked locally:

```text
docs/design/preview/screenshots/safe-retry.png
```

It shows the running row as "正在恢复…" and the notice as "恢复失败。你可以稍后再试，或换一个模型。" without layout overlap.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

