### PR TITLE
chore(release): bump desktop version to v2026.5.27

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.26",
+      "version": "2026.5.27",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.26",
+  "version": "2026.5.27",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

- Bump the desktop release version to 2026.5.27.
- Keep the release diff scoped to `packages/desktop-electron/package.json` and `bun.lock`.

## Verification

- `bun install --frozen-lockfile`
- `git diff --check`
- Confirmed `v2026.5.27` does not already exist on GitHub Releases.

## Release Notes

- Not required: this PR only prepares the version metadata for the release workflow. The public GitHub Release notes will be written before publishing the release.

## Checklist

- [x] I ran the relevant targeted verification.
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version number incremented for the desktop application package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->