### PR TITLE
fix(session): unify transport error classification for stream disconnect recovery

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -18,6 +18,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
 import { EffectLogger } from "@/effect"
 import { isMedia } from "@/util/media"
+import { classifyStreamFailure } from "./stream-failure-classifier"
 import { LLMTrace } from "./llm-trace"
 import { RunObservability } from "./run-observability"
 export { isMedia } from "@/util/media"
@@ -1140,19 +1141,20 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case (e as SystemError)?.code === "ECONNRESET":
+    case classifyStreamFailure(e) !== undefined: {
+      const transport = classifyStreamFailure(e)!
       return new APIError(
         {
-          message: "Connection reset by server",
+          message: (e as Error).message ?? "Connection interrupted",
           isRetryable: true,
           metadata: {
-            code: (e as SystemError).code ?? "",
-            syscall: (e as SystemError).syscall ?? "",
-            message: (e as SystemError).message ?? "",
+            code: transport.code,
+            message: (e as Error).message ?? "",
           },
         },
         { cause: e },
       ).toObject()
+    }
     case e instanceof Error && (e as FetchDecompressionError).code === "ZlibError":
       if (ctx.aborted) {
         return new AbortedError({ message: e.message }, { cause: e }).toObject()

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1145,11 +1145,11 @@ export function fromError(
       const transport = classifyStreamFailure(e)!
       return new APIError(
         {
-          message: (e as Error).message ?? "Connection interrupted",
+          message: (e as Error).message || "Connection interrupted",
           isRetryable: true,
           metadata: {
             code: transport.code,
-            message: (e as Error).message ?? "",
+            message: (e as Error).message || "",
           },
         },
         { cause: e },

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -167,24 +167,21 @@ function retryTimeoutPolicyFor(
 
 function recoveryInterruptionMessage(recovery: NonNullable<RunObservability.Summary["incident"]>["recovery"] | undefined) {
   switch (recovery?.reason) {
+    case "no_visible_output_or_tool_execution":
+      return "Connection lost. Retry failed — please resend your message."
     case "visible_output_without_tool_execution":
-      return "The response was interrupted after output started. PawWork did not automatically retry to avoid duplicate text."
+      return "Connection lost during response. Please resend to continue."
     case "partial_tool_input_without_execution":
-      return "The connection broke while PawWork was preparing a tool call. The tool did not run."
     case "tool_call_materialized_without_execution":
-      return "A tool call was prepared before the interruption. Recovery needs confirmation before continuing."
+      return "Connection lost during a tool operation. Please resend — the tool did not complete."
     case "tool_execution_started":
-      return "The connection was interrupted after tool execution started. PawWork did not automatically retry."
     case "unsafe_side_effect_started":
-      return "The connection was interrupted after a side effect may have started. PawWork did not automatically retry."
     case "side_effect_facts_incomplete":
-      return "The connection was interrupted, and PawWork could not prove whether external side effects were possible."
+      return "Connection lost. Please check whether the last operation completed before resending."
     case "local_lifecycle_close":
       return LOCAL_LIFECYCLE_CLOSE_INTERRUPTION_MESSAGE
     case "user_cancel":
       return "The run was cancelled by the user."
-    case "no_visible_output_or_tool_execution":
-      return "The provider connection was interrupted before PawWork produced output or ran tools."
     default:
       return undefined
   }

--- a/packages/opencode/src/session/stream-failure-classifier.test.ts
+++ b/packages/opencode/src/session/stream-failure-classifier.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import { classifyStreamFailure } from "./stream-failure-classifier"
+
+describe("classifyStreamFailure", () => {
+  describe("transport disconnect — retryable", () => {
+    test("ECONNRESET SystemError", () => {
+      const error = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET", syscall: "read" })
+      const result = classifyStreamFailure(error)
+      expect(result).toEqual({
+        kind: "provider_transport_disconnect",
+        retryable: true,
+        code: "ECONNRESET",
+      })
+    })
+
+    test("UND_ERR_SOCKET — TypeError('terminated') with cause.code", () => {
+      const cause = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" })
+      const error = new TypeError("terminated", { cause })
+      const result = classifyStreamFailure(error)
+      expect(result).toEqual({
+        kind: "provider_transport_disconnect",
+        retryable: true,
+        code: "UND_ERR_SOCKET",
+      })
+    })
+
+    test("ECONNREFUSED SystemError", () => {
+      const error = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED", syscall: "connect" })
+      const result = classifyStreamFailure(error)
+      expect(result).toEqual({
+        kind: "provider_transport_disconnect",
+        retryable: true,
+        code: "ECONNREFUSED",
+      })
+    })
+
+    test("ETIMEDOUT SystemError", () => {
+      const error = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT", syscall: "connect" })
+      const result = classifyStreamFailure(error)
+      expect(result).toEqual({
+        kind: "provider_transport_disconnect",
+        retryable: true,
+        code: "ETIMEDOUT",
+      })
+    })
+
+    test("UND_ERR_SOCKET nested in cause chain", () => {
+      const innerCause = Object.assign(new Error("socket hang up"), { code: "UND_ERR_SOCKET" })
+      const midError = new Error("fetch failed", { cause: innerCause })
+      const outerError = new TypeError("terminated", { cause: midError })
+      const result = classifyStreamFailure(outerError)
+      expect(result).toEqual({
+        kind: "provider_transport_disconnect",
+        retryable: true,
+        code: "UND_ERR_SOCKET",
+      })
+    })
+  })
+
+  describe("non-transport errors — not classified", () => {
+    test("generic Error returns undefined", () => {
+      expect(classifyStreamFailure(new Error("something broke"))).toBeUndefined()
+    })
+
+    test("TypeError without transport cause returns undefined", () => {
+      expect(classifyStreamFailure(new TypeError("Cannot read properties of undefined"))).toBeUndefined()
+    })
+
+    test("AbortError returns undefined", () => {
+      const error = new DOMException("The operation was aborted", "AbortError")
+      expect(classifyStreamFailure(error)).toBeUndefined()
+    })
+
+    test("non-Error values return undefined", () => {
+      expect(classifyStreamFailure("string error")).toBeUndefined()
+      expect(classifyStreamFailure(null)).toBeUndefined()
+      expect(classifyStreamFailure(42)).toBeUndefined()
+    })
+
+    test("TypeError('terminated') without UND_ERR_SOCKET cause returns undefined", () => {
+      const error = new TypeError("terminated", { cause: new Error("unrelated") })
+      expect(classifyStreamFailure(error)).toBeUndefined()
+    })
+  })
+})

--- a/packages/opencode/src/session/stream-failure-classifier.ts
+++ b/packages/opencode/src/session/stream-failure-classifier.ts
@@ -24,7 +24,11 @@ export function classifyStreamFailure(error: unknown): TransportDisconnect | und
 
 function findTransportCodeInCause(cause: unknown, depth = 0): string | undefined {
   if (depth > 4 || !cause || typeof cause !== "object") return undefined
-  const code = (cause as { code?: string }).code
-  if (typeof code === "string" && TRANSPORT_CODES.has(code)) return code
-  return findTransportCodeInCause((cause as { cause?: unknown }).cause, depth + 1)
+  try {
+    const code = (cause as { code?: string }).code
+    if (typeof code === "string" && TRANSPORT_CODES.has(code)) return code
+    return findTransportCodeInCause((cause as { cause?: unknown }).cause, depth + 1)
+  } catch {
+    return undefined
+  }
 }

--- a/packages/opencode/src/session/stream-failure-classifier.ts
+++ b/packages/opencode/src/session/stream-failure-classifier.ts
@@ -1,0 +1,30 @@
+export type TransportDisconnect = {
+  kind: "provider_transport_disconnect"
+  retryable: true
+  code: string
+}
+
+const TRANSPORT_CODES = new Set(["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "UND_ERR_SOCKET"])
+
+export function classifyStreamFailure(error: unknown): TransportDisconnect | undefined {
+  if (!(error instanceof Error)) return undefined
+
+  const topCode = (error as { code?: string }).code
+  if (typeof topCode === "string" && TRANSPORT_CODES.has(topCode)) {
+    return { kind: "provider_transport_disconnect", retryable: true, code: topCode }
+  }
+
+  const code = findTransportCodeInCause(error.cause)
+  if (code) {
+    return { kind: "provider_transport_disconnect", retryable: true, code }
+  }
+
+  return undefined
+}
+
+function findTransportCodeInCause(cause: unknown, depth = 0): string | undefined {
+  if (depth > 4 || !cause || typeof cause !== "object") return undefined
+  const code = (cause as { code?: string }).code
+  if (typeof code === "string" && TRANSPORT_CODES.has(code)) return code
+  return findTransportCodeInCause((cause as { cause?: unknown }).cause, depth + 1)
+}

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1566,6 +1566,41 @@ describe("session.message-v2.fromError", () => {
 
     expect(result.name).toBe("MessageAbortedError")
   })
+
+  test("classifies UND_ERR_SOCKET TypeError as retryable APIError", () => {
+    const socketCause = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" })
+    const error = new TypeError("terminated", { cause: socketCause })
+
+    const result = MessageV2.fromError(error, { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.message).toInclude("terminated")
+  })
+
+  test("classifies ECONNREFUSED as retryable APIError", () => {
+    const error = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+      syscall: "connect",
+    })
+
+    const result = MessageV2.fromError(error, { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
+  test("classifies ETIMEDOUT as retryable APIError", () => {
+    const error = Object.assign(new Error("connect ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+      syscall: "connect",
+    })
+
+    const result = MessageV2.fromError(error, { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
 })
 
 describe("session.message-v2.ToolStateError.reason", () => {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -2103,7 +2103,7 @@ it.live("retryable stream error after visible output does not replay the assista
         expect(textParts.map((part) => part.text)).not.toContain("replayed")
         expect(stored?.info.role).toBe("assistant")
         if (stored?.info.role === "assistant") {
-          expect(stored.info.error?.data.message).toContain("interrupted after output started")
+          expect(stored.info.error?.data.message).toContain("Connection lost during response")
           expect(stored.info.error?.data.message).not.toContain("stream terminated")
           expect(stored.info.diagnostics?.run_observability?.incident?.recovery).toMatchObject({
             recommendation: "offer_continue",

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1166,8 +1166,12 @@ it.live("session.processor effect tests reset reasoning state across retries", (
 
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(2)
-        expect(reasoning.some((part) => part.text === "two")).toBe(true)
-        expect(reasoning.some((part) => part.text === "onetwo")).toBe(false)
+        // Bun harness cannot produce Node undici's UND_ERR_SOCKET shape; TCP reset
+        // covers the processor retry/replay chain, classifier unit tests cover the rest.
+        const reasoningTexts = reasoning.map((part) => part.text)
+        expect(reasoningTexts).toContain("two")
+        expect(reasoningTexts).not.toContain("one")
+        expect(reasoningTexts).not.toContain("onetwo")
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -373,9 +373,8 @@ describe("session.message-v2.fromError", () => {
 
       expect(MessageV2.APIError.isInstance(result)).toBe(true)
       expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
-      expect((result as MessageV2.APIError).data.message).toBe("Connection reset by server")
+      expect((result as MessageV2.APIError).data.message).toInclude("socket connection")
       expect((result as MessageV2.APIError).data.metadata?.code).toBe("ECONNRESET")
-      expect((result as MessageV2.APIError).data.metadata?.message).toInclude("socket connection")
     },
     15_000,
   )


### PR DESCRIPTION
## Summary

- Extract a shared `StreamFailureClassifier` module that centralizes transport error recognition (ECONNRESET, UND_ERR_SOCKET, ECONNREFUSED, ETIMEDOUT) in one place
- Replace the inline ECONNRESET case in `fromError()` with classifier delegation so all transport errors produce retryable APIErrors through the same path
- Support cause-chain traversal for undici's `TypeError("terminated")` wrapping pattern
- Update recovery interruption copy to short, actionable user messages

## Why

A prod session hit a `UND_ERR_SOCKET` disconnect during reasoning-only generation. The safety gate correctly classified it as `candidate_safe_auto_retry`, but the technical retryability gate rejected it because `fromError()` only recognized `ECONNRESET`, not undici's `TypeError("terminated")` with `cause.code === "UND_ERR_SOCKET"`. The two classification paths disagreed on the same transport error, so the session stopped instead of auto-recovering.

The root cause was duplicate classification logic: run observability and the processor retry path each classified transport errors independently. This PR eliminates that duplication with a shared classifier.

## Related Issue

Closes #939

## Human Review Status

Pending

## Review Focus

1. The `classifyStreamFailure` function: does the cause-chain traversal (max depth 4) cover the real-world undici error wrapping patterns? Could it misclassify a non-transport error?
2. The `fromError()` change: the old code used a hardcoded `"Connection reset by server"` message; the new code passes through the original error message. Is this safe for all consumers?
3. The copy changes in `recoveryInterruptionMessage`: tool-related cases (`partial_tool_input`, `tool_call_materialized`, `tool_execution_started`, `unsafe_side_effect_started`, `side_effect_facts_incomplete`) are now consolidated into fewer messages. Verify the wording is appropriate for each case.

## Risk Notes

- The `fromError()` change means ECONNRESET errors now carry the original error message instead of `"Connection reset by server"`. This is more accurate but changes the message text that appears in diagnostics exports. No user-visible UI shows this raw message directly.
- The cause-chain depth limit (4) is arbitrary. Real undici errors typically nest 1-2 levels deep. 4 is conservative enough to handle unexpected wrapping without risking infinite traversal.

## How To Verify

```text
Typecheck: bun run typecheck — 0 errors
Classifier unit tests: 10 pass, 0 fail (stream-failure-classifier.test.ts)
fromError unit tests: 13 pass, 0 fail (message-v2.test.ts fromError suite)
Retry unit tests: 98 pass, 0 fail (retry.test.ts + retry-classification.test.ts)
Processor integration tests: 33 pass, 0 fail (processor-effect.test.ts)
Total: 131 pass, 0 fail across 5 test files
```

## Screenshots or Recordings

No visible UI changes. Copy changes are in error messages shown after failed recovery — verified through integration test assertions.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.