### PR TITLE
test: decouple ci smoke launcher test from electron install

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -128,6 +128,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Repair Electron install
+        run: node node_modules/electron/install.js
+        working-directory: packages/desktop-electron
+
       - name: Prepare OfficeCLI
         run: bun ./scripts/prepare-officecli.ts --platform darwin --arch arm64
         working-directory: packages/desktop-electron

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -106,11 +106,18 @@ describe("ci smoke helpers", () => {
     expect(raw.args).toEqual([resolveMainEntry()])
     expect(raw.command).toBe("/tmp/pawwork-electron/electron")
 
-    const packaged = resolveLaunchCommand({
-      mode: "packaged",
-      channel: "dev",
-      executablePath: "/tmp/PawWork Dev.app/Contents/MacOS/PawWork Dev",
-    })
+    const packaged = resolveLaunchCommand(
+      {
+        mode: "packaged",
+        channel: "dev",
+        executablePath: "/tmp/PawWork Dev.app/Contents/MacOS/PawWork Dev",
+      },
+      {
+        electronBinary: () => {
+          throw new Error("packaged mode should not resolve electron binary")
+        },
+      },
+    )
     expect(packaged).toEqual({
       command: "/tmp/PawWork Dev.app/Contents/MacOS/PawWork Dev",
       args: [],

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -99,9 +99,12 @@ describe("ci smoke helpers", () => {
   })
 
   test("resolveLaunchCommand uses Electron for raw runs and the app executable for packaged runs", () => {
-    const raw = resolveLaunchCommand({ mode: "raw", channel: "dev" })
+    const raw = resolveLaunchCommand(
+      { mode: "raw", channel: "dev" },
+      { electronBinary: () => "/tmp/pawwork-electron/electron" },
+    )
     expect(raw.args).toEqual([resolveMainEntry()])
-    expect(raw.command).toContain("electron")
+    expect(raw.command).toBe("/tmp/pawwork-electron/electron")
 
     const packaged = resolveLaunchCommand({
       mode: "packaged",

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -82,11 +82,15 @@ function resolveElectronBinary() {
   return require("electron/index.js") as string
 }
 
-export function resolveLaunchCommand(target: SmokeTarget) {
+type LaunchCommandOptions = {
+  electronBinary?: () => string
+}
+
+export function resolveLaunchCommand(target: SmokeTarget, options: LaunchCommandOptions = {}) {
   if (target.mode === "packaged") {
     return { command: target.executablePath, args: [] as string[] }
   }
-  return { command: resolveElectronBinary(), args: [resolveMainEntry()] }
+  return { command: (options.electronBinary ?? resolveElectronBinary)(), args: [resolveMainEntry()] }
 }
 
 function watchChildLogs(child: ChildProcessWithoutNullStreams) {

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -25,6 +25,8 @@ describe("desktop smoke workflow", () => {
     const packagedSmokeStep = smokeSteps.find((step) => step.name === "Launch packaged desktop smoke app")
     const buildStep = smokeSteps.find((step) => step.name === "Build desktop app")
     const prepareOfficeCliStep = smokeSteps.find((step) => step.name === "Prepare OfficeCLI")
+    const installStep = smokeSteps.find((step) => step.name === "Install dependencies")
+    const repairElectronStep = smokeSteps.find((step) => step.name === "Repair Electron install")
 
     expect(parsed.name).toBe("desktop-smoke")
     expect(parsed.on?.push).toEqual({ branches: ["dev"] })
@@ -58,7 +60,9 @@ describe("desktop smoke workflow", () => {
 
     expect(smokeCheckoutStep?.with).toEqual({ "persist-credentials": false })
     expect(smokeBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
-    expect(workflow).toContain("bun install --frozen-lockfile")
+    expect(installStep?.run).toBe("bun install --frozen-lockfile")
+    expect(repairElectronStep?.run).toBe("node node_modules/electron/install.js")
+    expect(repairElectronStep?.["working-directory"]).toBe("packages/desktop-electron")
     expect(prepareOfficeCliStep).toBeDefined()
     expect(prepareOfficeCliStep?.run).toBe("bun ./scripts/prepare-officecli.ts --platform darwin --arch arm64")
     expect(prepareOfficeCliStep?.["working-directory"]).toBe("packages/desktop-electron")
@@ -84,6 +88,8 @@ describe("desktop smoke workflow", () => {
     expect(packagedSmokeStep?.run).toContain('bun ./scripts/ci-smoke.ts packaged dev "$EXECUTABLE_PATH"')
     expect(packagedSmokeStep?.["working-directory"]).toBe("packages/desktop-electron")
     expect(buildStep).toBeDefined()
+    expect(smokeSteps.indexOf(repairElectronStep!)).toBeGreaterThan(smokeSteps.indexOf(installStep!))
+    expect(smokeSteps.indexOf(repairElectronStep!)).toBeLessThan(smokeSteps.indexOf(prepareOfficeCliStep!))
     expect(smokeSteps.indexOf(prepareOfficeCliStep!)).toBeGreaterThan(smokeSteps.indexOf(smokeBunStep!))
     expect(smokeSteps.indexOf(prepareOfficeCliStep!)).toBeLessThan(smokeSteps.indexOf(buildStep!))
     expect(smokeSteps.indexOf(runtimeGuardStep!)).toBeGreaterThan(smokeSteps.indexOf(buildStep!))


### PR DESCRIPTION
## Summary

Decouple the desktop CI smoke launcher unit test from the real Electron package install artifact, and repair Electron explicitly before the macOS desktop smoke workflow launches the raw app. There is no related issue; this fixes the flaky CI rerun failure observed on an already-merged dev commit and the follow-up PR smoke failure.

## Why

The helper test asserted that raw smoke runs launch Electron, but it did so by resolving `require("electron/index.js")`. When a CI rerun has an incomplete Electron install artifact, such as a missing `path.txt`, the unit test fails before it can assert the launcher behavior.

After the unit test was decoupled, the PR desktop-smoke workflow showed the same underlying install issue in the real raw smoke launch. The workflow now runs Electron's install repair script from the desktop package workspace after `bun install`, before any smoke launch.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that the injected resolver is only used by tests, that packaged smoke launch behavior is unchanged, and that the desktop-smoke workflow repairs Electron before launching the raw app.

## Risk Notes

No product runtime behavior changes. The workflow adds one explicit Electron install repair step in CI before smoke launch. Skipped visible UI/manual screenshot check because no UI or copy changed. No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes apply.

## How To Verify

```text
TDD red: workflow contract expected Repair Electron install before smoke launch and failed before the workflow step existed.
TDD red: launcher test injected a fake Electron binary and failed against the previous implementation because resolveLaunchCommand still resolved the real Electron package.
Focused workflow test: bun --cwd packages/opencode test test/github/desktop-smoke-workflow.test.ts -> 1 passed, 0 failed.
Focused launcher test: bun --cwd packages/desktop-electron test scripts/ci-smoke.test.ts -> 13 passed, 0 failed.
Repair command: node node_modules/electron/install.js from packages/desktop-electron -> exit 0.
Package CI test: bun turbo test:ci --filter=@opencode-ai/desktop-electron -> 397 passed, 0 failed.
Typecheck: bun turbo typecheck --filter=@opencode-ai/desktop-electron -> 6 successful tasks.
Scope search: rg "resolveLaunchCommand\(|resolveElectronBinary|electron/index\.js|ELECTRON_OVERRIDE_DIST_PATH" packages/desktop-electron -> ci-smoke uses the helper under test; report-problem-smoke remains a real smoke script.
Diff check: git diff --check -> no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.