### PR TITLE
fix(watcher): isolate macOS workspace roots

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -23,7 +23,8 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
-  const WORKSPACE_IGNORE_ENTRIES = [".worktrees"]
+  const LOCAL_ARTIFACT_ENTRIES = new Set([".worktrees", ".claude", ".claire", ".superpowers"])
+  const WORKSPACE_IGNORE_ENTRIES = [...LOCAL_ARTIFACT_ENTRIES]
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
   const VCS_REFRESH_FILES = new Set(["HEAD", "index", "packed-refs"])
   const VCS_REFRESH_PREFIXES = ["refs/heads/", "refs/remotes/"]
@@ -77,6 +78,24 @@ export namespace FileWatcher {
   }
 
   export type WatchScope = "workspace" | "vcs"
+  export type WatchPlanExcludeReason = "default-ignore" | "local-artifact" | "user-config" | "protected-path"
+  export type WorkspaceWatchPlanEntry = { name: string; type: "directory" | "file" | "other" }
+  export type WorkspaceWatchPlanRoot = {
+    directory: string
+    ignore: string[]
+    reason: "workspace-child"
+  }
+  export type WorkspaceWatchPlanExcluded = {
+    path: string
+    reason: WatchPlanExcludeReason
+  }
+  export type WorkspaceWatchPlan = {
+    roots: WorkspaceWatchPlanRoot[]
+    excluded: WorkspaceWatchPlanExcluded[]
+    rootFiles: string[]
+    rootFilesStrategy: "poll-root-entries"
+    refreshStrategy: "refresh-plan-on-top-level-entry-change"
+  }
   export type RescanIncidentSummary = {
     directory: string
     request_count: number
@@ -185,6 +204,93 @@ export namespace FileWatcher {
 
   export function workspaceWatcherIgnoreEntries(input: { config: string[]; protected: string[] }) {
     return [...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_IGNORE_ENTRIES, ...input.config, ...input.protected])]
+  }
+
+  function hasGlobSyntax(value: string) {
+    return /[*?[\]{}]/.test(value)
+  }
+
+  function normalizePathKey(value: string) {
+    return value.replaceAll("\\", "/").replace(/\/+$/, "")
+  }
+
+  function ignoreReason(input: {
+    entry: string
+    fullPath: string
+    ignore: string[]
+    userConfig?: string[]
+    protectedPaths?: string[]
+  }): WatchPlanExcludeReason | undefined {
+    const entryKey = normalizePathKey(input.entry)
+    if (LOCAL_ARTIFACT_ENTRIES.has(entryKey)) return "local-artifact"
+
+    const protectedSet = new Set(input.protectedPaths?.map((item) => normalizePathKey(item)) ?? [])
+    if (protectedSet.has(normalizePathKey(input.fullPath)) || protectedSet.has(entryKey)) return "protected-path"
+
+    const configSet = new Set(input.userConfig?.map((item) => normalizePathKey(item)) ?? [])
+    if (configSet.has(entryKey) || configSet.has(normalizePathKey(input.fullPath))) return "user-config"
+
+    if (input.ignore.some((item) => !hasGlobSyntax(item) && normalizePathKey(item) === entryKey)) return "default-ignore"
+    return undefined
+  }
+
+  export function subscriptionIgnoreEntries(input: { workspace: string; subscription: string; ignore: string[] }) {
+    return input.ignore.map((entry) => {
+      if (path.isAbsolute(entry)) return entry
+      if (hasGlobSyntax(entry)) return entry
+      return path.resolve(input.workspace, entry)
+    })
+  }
+
+  export function workspaceWatchPlan(input: {
+    directory: string
+    backend: string
+    entries: WorkspaceWatchPlanEntry[]
+    ignore: string[]
+    userConfig?: string[]
+    protectedPaths?: string[]
+  }): WorkspaceWatchPlan {
+    const roots: WorkspaceWatchPlanRoot[] = []
+    const excluded: WorkspaceWatchPlanExcluded[] = []
+    const rootFiles: string[] = []
+
+    for (const entry of input.entries) {
+      const fullPath = path.join(input.directory, entry.name)
+      const reason = ignoreReason({
+        entry: entry.name,
+        fullPath,
+        ignore: input.ignore,
+        userConfig: input.userConfig,
+        protectedPaths: input.protectedPaths,
+      })
+      if (reason) {
+        excluded.push({ path: fullPath, reason })
+        continue
+      }
+
+      if (entry.type === "directory") {
+        roots.push({
+          directory: fullPath,
+          ignore: subscriptionIgnoreEntries({
+            workspace: input.directory,
+            subscription: fullPath,
+            ignore: input.ignore,
+          }),
+          reason: "workspace-child",
+        })
+        continue
+      }
+
+      if (entry.type === "file") rootFiles.push(fullPath)
+    }
+
+    return {
+      roots,
+      excluded,
+      rootFiles,
+      rootFilesStrategy: "poll-root-entries",
+      refreshStrategy: "refresh-plan-on-top-level-entry-change",
+    }
   }
 
   export function watcherSubscriptionDiagnostics(input: {

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -12,6 +12,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Git } from "@/git"
 import { Instance } from "@/project/instance"
 import { lazy } from "@/util/lazy"
+import { Glob } from "@/util/glob"
 import { Config } from "../config/config"
 import { FileIgnore } from "./ignore"
 import { Protected } from "./protected"
@@ -232,6 +233,11 @@ export namespace FileWatcher {
     return value.replaceAll("\\", "/").replace(/\/+$/, "")
   }
 
+  function globTargetsRootEntry(pattern: string, entry: string) {
+    if (!hasGlobSyntax(pattern)) return false
+    return Glob.match(pattern, `${entry}/__pawwork_watch_plan_probe__`)
+  }
+
   function ignoreReason(input: {
     entry: string
     fullPath: string
@@ -247,8 +253,15 @@ export namespace FileWatcher {
 
     const configSet = new Set(input.userConfig?.map((item) => normalizePathKey(item)) ?? [])
     if (configSet.has(entryKey) || configSet.has(normalizePathKey(input.fullPath))) return "user-config"
+    if (input.userConfig?.some((item) => globTargetsRootEntry(normalizePathKey(item), entryKey))) return "user-config"
 
-    if (input.ignore.some((item) => !hasGlobSyntax(item) && normalizePathKey(item) === entryKey)) return "default-ignore"
+    if (
+      input.ignore.some((item) => {
+        const pattern = normalizePathKey(item)
+        return (!hasGlobSyntax(pattern) && pattern === entryKey) || globTargetsRootEntry(pattern, entryKey)
+      })
+    )
+      return "default-ignore"
     return undefined
   }
 
@@ -313,18 +326,21 @@ export namespace FileWatcher {
 
   async function rootEntrySnapshot(directory: string) {
     const entries = new Map<string, RootEntryState>()
-    for (const item of await readdir(directory, { withFileTypes: true }).catch(() => [])) {
-      const fullPath = path.join(directory, item.name)
-      const type = item.isDirectory() ? "directory" : item.isFile() ? "file" : "other"
-      const info = await stat(fullPath).catch(() => undefined)
-      entries.set(item.name, {
-        name: item.name,
-        path: fullPath,
-        type,
-        size: info?.size ?? 0,
-        mtimeMs: info?.mtimeMs ?? 0,
-      })
-    }
+    const items = await readdir(directory, { withFileTypes: true })
+    await Promise.all(
+      items.map(async (item) => {
+        const fullPath = path.join(directory, item.name)
+        const type = item.isDirectory() ? "directory" : item.isFile() ? "file" : "other"
+        const info = type === "file" ? await stat(fullPath).catch(() => undefined) : undefined
+        entries.set(item.name, {
+          name: item.name,
+          path: fullPath,
+          type,
+          size: info?.size ?? 0,
+          mtimeMs: info?.mtimeMs ?? 0,
+        })
+      }),
+    )
     return entries
   }
 
@@ -423,9 +439,9 @@ export namespace FileWatcher {
 
             log.info("watcher backend", { directory: ctx.directory, platform: process.platform, backend })
 
-            const subs: ParcelWatcher.AsyncSubscription[] = []
+            const subs = new Set<ParcelWatcher.AsyncSubscription>()
             yield* Effect.addFinalizer(() =>
-              Effect.promise(() => Promise.allSettled(subs.map((sub) => sub.unsubscribe()))),
+              Effect.promise(() => Promise.allSettled([...subs].map((sub) => sub.unsubscribe()))),
             )
 
             const requestRescan = createRescanScheduler({
@@ -492,7 +508,7 @@ export namespace FileWatcher {
               const pending = w.subscribe(dir, createCallback(dir, shouldPublish, options), { ignore, backend })
               return Effect.gen(function* () {
                 const sub = yield* Effect.promise(() => pending)
-                subs.push(sub)
+                subs.add(sub)
                 return sub
               }).pipe(
                 Effect.timeout(SUBSCRIBE_TIMEOUT_MS),
@@ -548,6 +564,7 @@ export namespace FileWatcher {
                   for (const [dir, sub] of active) {
                     if (nextRoots.has(dir)) continue
                     active.delete(dir)
+                    subs.delete(sub)
                     yield* Effect.promise(() => sub.unsubscribe().catch(() => undefined))
                     log.info("watcher subscription removed", {
                       dir,
@@ -581,7 +598,11 @@ export namespace FileWatcher {
                 })
 
                 yield* applyPlan()
+                let polling = false
+                let pollingDisposed = false
                 const timer = setInterval(() => {
+                  if (polling || pollingDisposed) return
+                  polling = true
                   Instance.restore(ctx, () => {
                     rootEntrySnapshot(ctx.directory)
                       .then((next) => {
@@ -648,10 +669,14 @@ export namespace FileWatcher {
                           .catch((error) => log.warn("failed to refresh watcher plan", { dir: ctx.directory, error }))
                       })
                       .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))
+                      .finally(() => {
+                        polling = false
+                      })
                   })
                 }, ROOT_DISCOVERY_INTERVAL_MS)
                 yield* Effect.addFinalizer(() =>
                   Effect.sync(() => {
+                    pollingDisposed = true
                     clearInterval(timer)
                   }),
                 )

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -25,6 +25,7 @@ export namespace FileWatcher {
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
   const ROOT_DISCOVERY_INTERVAL_MS = 500
+  const FALLBACK_RESCAN_INTERVAL_MS = 5_000
   export const MAX_WORKSPACE_WATCH_ROOTS = 128
   const LOCAL_ARTIFACT_ENTRIES = new Set([".worktrees", ".claude", ".claire", ".superpowers"])
   const WORKSPACE_IGNORE_ENTRIES = [...LOCAL_ARTIFACT_ENTRIES]
@@ -111,7 +112,7 @@ export namespace FileWatcher {
     rootFiles: string[]
     rootCount: number
     maxRootCount: number
-    fallbackStrategy?: "root-polling-only"
+    fallbackStrategy?: "limited-child-watchers"
     rootFilesStrategy: "poll-root-entries"
     refreshStrategy: "refresh-plan-on-top-level-entry-change"
   }
@@ -332,10 +333,10 @@ export namespace FileWatcher {
     }
 
     const rootCount = roots.length
-    const fallbackStrategy = rootCount > MAX_WORKSPACE_WATCH_ROOTS ? "root-polling-only" : undefined
+    const fallbackStrategy = rootCount > MAX_WORKSPACE_WATCH_ROOTS ? "limited-child-watchers" : undefined
 
     return {
-      roots: fallbackStrategy ? [] : roots,
+      roots: fallbackStrategy ? roots.slice(0, MAX_WORKSPACE_WATCH_ROOTS) : roots,
       excluded,
       rootFiles,
       rootCount,
@@ -613,7 +614,12 @@ export namespace FileWatcher {
                 let snapshot = yield* Effect.promise(() => rootEntrySnapshot(ctx.directory))
                 const active = new Map<string, ParcelWatcher.AsyncSubscription>()
                 let watchPlanDisposed = false
-                let rootPollingOnly = false
+                let limitedChildWatchers = false
+                let lastFallbackRescan = 0
+                const publishWorkspaceRescan = () =>
+                  Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
+                    log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
+                  )
                 const applyPlan = Effect.fn("FileWatcher.applyWorkspaceWatchPlan")(function* (
                   planSnapshot: Map<string, RootEntryState>,
                 ) {
@@ -645,17 +651,14 @@ export namespace FileWatcher {
                     })),
                   })
 
-                  if (plan.fallbackStrategy === "root-polling-only") {
-                    if (!rootPollingOnly) {
-                      rootPollingOnly = true
-                      yield* Effect.promise(() =>
-                        Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
-                          log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
-                        ),
-                      )
+                  if (plan.fallbackStrategy === "limited-child-watchers") {
+                    if (!limitedChildWatchers) {
+                      limitedChildWatchers = true
+                      lastFallbackRescan = Date.now()
+                      yield* Effect.promise(publishWorkspaceRescan)
                     }
                   } else {
-                    rootPollingOnly = false
+                    limitedChildWatchers = false
                   }
 
                   const nextRoots = new Set(plan.roots.map((root) => root.directory))
@@ -727,6 +730,11 @@ export namespace FileWatcher {
                       )
                       .then((next) => {
                         snapshot = next
+                        if (!limitedChildWatchers || watchPlanDisposed) return
+                        const now = Date.now()
+                        if (now - lastFallbackRescan < FALLBACK_RESCAN_INTERVAL_MS) return
+                        lastFallbackRescan = now
+                        return publishWorkspaceRescan()
                       })
                       .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))
                       .finally(() => {

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -25,6 +25,7 @@ export namespace FileWatcher {
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
   const ROOT_DISCOVERY_INTERVAL_MS = 500
+  export const MAX_WORKSPACE_WATCH_ROOTS = 128
   const LOCAL_ARTIFACT_ENTRIES = new Set([".worktrees", ".claude", ".claire", ".superpowers"])
   const WORKSPACE_IGNORE_ENTRIES = [...LOCAL_ARTIFACT_ENTRIES]
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
@@ -108,6 +109,9 @@ export namespace FileWatcher {
     roots: WorkspaceWatchPlanRoot[]
     excluded: WorkspaceWatchPlanExcluded[]
     rootFiles: string[]
+    rootCount: number
+    maxRootCount: number
+    fallbackStrategy?: "root-polling-only"
     rootFilesStrategy: "poll-root-entries"
     refreshStrategy: "refresh-plan-on-top-level-entry-change"
   }
@@ -327,10 +331,16 @@ export namespace FileWatcher {
       if (entry.type === "file") rootFiles.push(fullPath)
     }
 
+    const rootCount = roots.length
+    const fallbackStrategy = rootCount > MAX_WORKSPACE_WATCH_ROOTS ? "root-polling-only" : undefined
+
     return {
-      roots,
+      roots: fallbackStrategy ? [] : roots,
       excluded,
       rootFiles,
+      rootCount,
+      maxRootCount: MAX_WORKSPACE_WATCH_ROOTS,
+      fallbackStrategy,
       rootFilesStrategy: "poll-root-entries",
       refreshStrategy: "refresh-plan-on-top-level-entry-change",
     }
@@ -603,6 +613,7 @@ export namespace FileWatcher {
                 let snapshot = yield* Effect.promise(() => rootEntrySnapshot(ctx.directory))
                 const active = new Map<string, ParcelWatcher.AsyncSubscription>()
                 let watchPlanDisposed = false
+                let rootPollingOnly = false
                 const applyPlan = Effect.fn("FileWatcher.applyWorkspaceWatchPlan")(function* (
                   planSnapshot: Map<string, RootEntryState>,
                 ) {
@@ -621,7 +632,10 @@ export namespace FileWatcher {
                     backend,
                     watch_scope: "workspace",
                     plan_version: planVersion,
-                    root_count: plan.roots.length,
+                    root_count: plan.rootCount,
+                    subscribed_root_count: plan.roots.length,
+                    max_root_count: plan.maxRootCount,
+                    fallback_strategy: plan.fallbackStrategy,
                     excluded_count: plan.excluded.length,
                     root_files_strategy: plan.rootFilesStrategy,
                     refresh_strategy: plan.refreshStrategy,
@@ -630,6 +644,19 @@ export namespace FileWatcher {
                       reason: item.reason,
                     })),
                   })
+
+                  if (plan.fallbackStrategy === "root-polling-only") {
+                    if (!rootPollingOnly) {
+                      rootPollingOnly = true
+                      yield* Effect.promise(() =>
+                        Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
+                          log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
+                        ),
+                      )
+                    }
+                  } else {
+                    rootPollingOnly = false
+                  }
 
                   const nextRoots = new Set(plan.roots.map((root) => root.directory))
                   for (const [dir, sub] of active) {

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -606,6 +606,7 @@ export namespace FileWatcher {
                   Instance.restore(ctx, () => {
                     rootEntrySnapshot(ctx.directory)
                       .then((next) => {
+                        if (pollingDisposed) return
                         const prev = snapshot
                         snapshot = next
                         const nextNames = new Set(next.keys())
@@ -661,11 +662,12 @@ export namespace FileWatcher {
 
                         if (!refreshPlan) return
                         Effect.runPromise(applyPlan())
-                          .then(() =>
-                            Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
+                          .then(() => {
+                            if (pollingDisposed) return
+                            return Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
                               log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
-                            ),
-                          )
+                            )
+                          })
                           .catch((error) => log.warn("failed to refresh watcher plan", { dir: ctx.directory, error }))
                       })
                       .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -230,6 +230,30 @@ export namespace FileWatcher {
     return [...new Set([...FileIgnore.PATTERNS, ...WORKSPACE_IGNORE_ENTRIES, ...input.config, ...input.protected])]
   }
 
+  export function createFallbackRescanThrottle(input: { now?: () => number } = {}) {
+    let active = false
+    let lastRescan = 0
+    return {
+      now: input.now ?? (() => Date.now()),
+      enter() {
+        if (active) return false
+        active = true
+        lastRescan = this.now()
+        return true
+      },
+      tick() {
+        if (!active) return false
+        const now = this.now()
+        if (now - lastRescan < FALLBACK_RESCAN_INTERVAL_MS) return false
+        lastRescan = now
+        return true
+      },
+      exit() {
+        active = false
+      },
+    }
+  }
+
   function hasGlobSyntax(value: string) {
     return /[*?[\]{}]/.test(value)
   }
@@ -614,8 +638,7 @@ export namespace FileWatcher {
                 let snapshot = yield* Effect.promise(() => rootEntrySnapshot(ctx.directory))
                 const active = new Map<string, ParcelWatcher.AsyncSubscription>()
                 let watchPlanDisposed = false
-                let limitedChildWatchers = false
-                let lastFallbackRescan = 0
+                const fallbackRescan = createFallbackRescanThrottle()
                 const publishWorkspaceRescan = () =>
                   Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
                     log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
@@ -652,13 +675,9 @@ export namespace FileWatcher {
                   })
 
                   if (plan.fallbackStrategy === "limited-child-watchers") {
-                    if (!limitedChildWatchers) {
-                      limitedChildWatchers = true
-                      lastFallbackRescan = Date.now()
-                      yield* Effect.promise(publishWorkspaceRescan)
-                    }
+                    if (fallbackRescan.enter()) yield* Effect.promise(publishWorkspaceRescan)
                   } else {
-                    limitedChildWatchers = false
+                    fallbackRescan.exit()
                   }
 
                   const nextRoots = new Set(plan.roots.map((root) => root.directory))
@@ -730,10 +749,7 @@ export namespace FileWatcher {
                       )
                       .then((next) => {
                         snapshot = next
-                        if (!limitedChildWatchers || watchPlanDisposed) return
-                        const now = Date.now()
-                        if (now - lastFallbackRescan < FALLBACK_RESCAN_INTERVAL_MS) return
-                        lastFallbackRescan = now
+                        if (watchPlanDisposed || !fallbackRescan.tick()) return
                         return publishWorkspaceRescan()
                       })
                       .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -81,7 +81,7 @@ export namespace FileWatcher {
 
   export type WatchScope = "workspace" | "vcs"
   type RuntimeWatchScope = WatchScope | "workspace-child" | "root-discovery"
-  type RootEntryState = {
+  export type RootEntryState = {
     name: string
     path: string
     type: WorkspaceWatchPlanEntry["type"]
@@ -265,10 +265,22 @@ export namespace FileWatcher {
     return undefined
   }
 
+  function subscriptionGlobIgnoreEntry(input: { workspace: string; subscription: string; pattern: string }) {
+    const pattern = normalizePathKey(input.pattern)
+    if (!hasGlobSyntax(pattern)) return pattern
+    if (pattern.startsWith("**/")) return pattern
+
+    const subscription = normalizePathKey(path.relative(input.workspace, input.subscription))
+    if (!subscription || subscription.startsWith("..") || path.isAbsolute(subscription)) return undefined
+    if (!pattern.includes("/")) return undefined
+    if (!pattern.startsWith(`${subscription}/`)) return undefined
+    return pattern.slice(subscription.length + 1)
+  }
+
   export function subscriptionIgnoreEntries(input: { workspace: string; subscription: string; ignore: string[] }) {
-    return input.ignore.map((entry) => {
+    return input.ignore.flatMap((entry) => {
       if (path.isAbsolute(entry)) return entry
-      if (hasGlobSyntax(entry)) return entry
+      if (hasGlobSyntax(entry)) return subscriptionGlobIgnoreEntry({ ...input, pattern: entry }) ?? []
       return path.resolve(input.workspace, entry)
     })
   }
@@ -362,6 +374,55 @@ export namespace FileWatcher {
       if (!rel || (!rel.startsWith("..") && !path.isAbsolute(rel))) return false
     }
     return !FileIgnore.match(relative, { extra: ignore })
+  }
+
+  export async function runWorkspaceRootPoll(input: {
+    previous: Map<string, RootEntryState>
+    next: Map<string, RootEntryState>
+    workspace: string
+    ignore: string[]
+    isDisposed: () => boolean
+    applyPlan: (next: Map<string, RootEntryState>) => Promise<void>
+    publishUpdate: (event: { file: string; event: "add" | "change" | "unlink" }) => void
+    publishRescan: (directory: string) => void | Promise<void>
+  }) {
+    if (input.isDisposed()) return input.previous
+
+    const nextNames = new Set(input.next.keys())
+    let refreshPlan = false
+
+    for (const [name, value] of input.next) {
+      if (input.isDisposed()) return input.previous
+      const before = input.previous.get(name)
+      const publishable = shouldPublishWorkspacePath(value.path, input.workspace, input.ignore)
+      if (!before) {
+        if (value.type === "file" && publishable) input.publishUpdate({ file: value.path, event: "add" })
+        if (value.type === "directory" && publishable) {
+          refreshPlan = true
+          input.publishUpdate({ file: value.path, event: "add" })
+        }
+        continue
+      }
+      if (rootFileChanged(before, value) && publishable) input.publishUpdate({ file: value.path, event: "change" })
+      if (before.type !== value.type && publishable) refreshPlan = true
+    }
+
+    for (const [name, value] of input.previous) {
+      if (input.isDisposed()) return input.previous
+      if (nextNames.has(name)) continue
+      const publishable = shouldPublishWorkspacePath(value.path, input.workspace, input.ignore)
+      if (value.type === "file" && publishable) input.publishUpdate({ file: value.path, event: "unlink" })
+      if (value.type === "directory" && publishable) {
+        refreshPlan = true
+        input.publishUpdate({ file: value.path, event: "unlink" })
+      }
+    }
+
+    if (!refreshPlan) return input.next
+    await input.applyPlan(input.next)
+    if (input.isDisposed()) return input.previous
+    await input.publishRescan(input.workspace)
+    return input.next
   }
 
   export function watcherSubscriptionDiagnostics(input: {
@@ -472,6 +533,7 @@ export namespace FileWatcher {
                 options?: {
                   rescanDirectory?: string
                   watchScope?: RuntimeWatchScope
+                  isDisposed?: () => boolean
                 },
               ): ParcelWatcher.SubscribeCallback =>
               (err, evts) =>
@@ -503,11 +565,16 @@ export namespace FileWatcher {
               options?: {
                 rescanDirectory?: string
                 watchScope?: RuntimeWatchScope
+                isDisposed?: () => boolean
               },
             ) => {
               const pending = w.subscribe(dir, createCallback(dir, shouldPublish, options), { ignore, backend })
               return Effect.gen(function* () {
                 const sub = yield* Effect.promise(() => pending)
+                if (options?.isDisposed?.()) {
+                  yield* Effect.promise(() => sub.unsubscribe().catch(() => undefined))
+                  return undefined
+                }
                 subs.add(sub)
                 return sub
               }).pipe(
@@ -535,11 +602,15 @@ export namespace FileWatcher {
                 let planVersion = 0
                 let snapshot = yield* Effect.promise(() => rootEntrySnapshot(ctx.directory))
                 const active = new Map<string, ParcelWatcher.AsyncSubscription>()
-                const applyPlan = Effect.fn("FileWatcher.applyWorkspaceWatchPlan")(function* () {
+                let watchPlanDisposed = false
+                const applyPlan = Effect.fn("FileWatcher.applyWorkspaceWatchPlan")(function* (
+                  planSnapshot: Map<string, RootEntryState>,
+                ) {
+                  if (watchPlanDisposed) return
                   const plan = workspaceWatchPlan({
                     directory: ctx.directory,
                     backend,
-                    entries: watchPlanEntries(snapshot),
+                    entries: watchPlanEntries(planSnapshot),
                     ignore: workspaceSubscription.ignore,
                     userConfig: cfgIgnores,
                     protectedPaths: protecteds(ctx.directory),
@@ -572,8 +643,8 @@ export namespace FileWatcher {
                       plan_version: planVersion,
                     })
                   }
-
                   for (const root of plan.roots) {
+                    if (watchPlanDisposed) return
                     if (active.has(root.directory)) continue
                     log.info("watcher subscription configured", {
                       dir: root.directory,
@@ -590,85 +661,45 @@ export namespace FileWatcher {
                       {
                         rescanDirectory: ctx.directory,
                         watchScope: "workspace-child",
+                        isDisposed: () => watchPlanDisposed,
                       },
                     )
                     if (!sub) continue
+                    if (watchPlanDisposed) {
+                      subs.delete(sub)
+                      yield* Effect.promise(() => sub.unsubscribe().catch(() => undefined))
+                      return
+                    }
                     active.set(root.directory, sub)
                   }
                 })
 
-                yield* applyPlan()
+                yield* applyPlan(snapshot)
                 let polling = false
-                let pollingDisposed = false
                 const timer = setInterval(() => {
-                  if (polling || pollingDisposed) return
+                  if (polling || watchPlanDisposed) return
                   polling = true
                   Instance.restore(ctx, () => {
                     rootEntrySnapshot(ctx.directory)
+                      .then((next) =>
+                        runWorkspaceRootPoll({
+                          previous: snapshot,
+                          next,
+                          workspace: ctx.directory,
+                          ignore: workspaceSubscription.ignore,
+                          isDisposed: () => watchPlanDisposed,
+                          applyPlan: (planSnapshot) => Effect.runPromise(applyPlan(planSnapshot)),
+                          publishUpdate: (event) => {
+                            Bus.publish(Event.Updated, event)
+                          },
+                          publishRescan: (directory) =>
+                            Bus.publish(Event.Rescan, { directory }).catch((error) =>
+                              log.warn("failed to publish watcher rescan", { dir: directory, error }),
+                            ),
+                        }),
+                      )
                       .then((next) => {
-                        if (pollingDisposed) return
-                        const prev = snapshot
                         snapshot = next
-                        const nextNames = new Set(next.keys())
-                        let refreshPlan = false
-
-                        for (const [name, value] of next) {
-                          const before = prev.get(name)
-                          if (!before) {
-                            const publishable = shouldPublishWorkspacePath(
-                              value.path,
-                              ctx.directory,
-                              workspaceSubscription.ignore,
-                            )
-                            if (value.type === "file" && publishable)
-                              Bus.publish(Event.Updated, { file: value.path, event: "add" })
-                            if (value.type === "directory") {
-                              if (publishable) {
-                                refreshPlan = true
-                                Bus.publish(Event.Updated, { file: value.path, event: "add" })
-                              }
-                            }
-                            continue
-                          }
-                          if (
-                            rootFileChanged(before, value) &&
-                            shouldPublishWorkspacePath(value.path, ctx.directory, workspaceSubscription.ignore)
-                          ) {
-                            Bus.publish(Event.Updated, { file: value.path, event: "change" })
-                          }
-                          if (
-                            before.type !== value.type &&
-                            shouldPublishWorkspacePath(value.path, ctx.directory, workspaceSubscription.ignore)
-                          )
-                            refreshPlan = true
-                        }
-
-                        for (const [name, value] of prev) {
-                          if (nextNames.has(name)) continue
-                          const publishable = shouldPublishWorkspacePath(
-                            value.path,
-                            ctx.directory,
-                            workspaceSubscription.ignore,
-                          )
-                          if (value.type === "file" && publishable)
-                            Bus.publish(Event.Updated, { file: value.path, event: "unlink" })
-                          if (value.type === "directory") {
-                            if (publishable) {
-                              refreshPlan = true
-                              Bus.publish(Event.Updated, { file: value.path, event: "unlink" })
-                            }
-                          }
-                        }
-
-                        if (!refreshPlan) return
-                        Effect.runPromise(applyPlan())
-                          .then(() => {
-                            if (pollingDisposed) return
-                            return Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
-                              log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
-                            )
-                          })
-                          .catch((error) => log.warn("failed to refresh watcher plan", { dir: ctx.directory, error }))
                       })
                       .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))
                       .finally(() => {
@@ -678,7 +709,7 @@ export namespace FileWatcher {
                 }, ROOT_DISCOVERY_INTERVAL_MS)
                 yield* Effect.addFinalizer(() =>
                   Effect.sync(() => {
-                    pollingDisposed = true
+                    watchPlanDisposed = true
                     clearInterval(timer)
                   }),
                 )

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -2,7 +2,7 @@ import { Cause, Effect, Layer, Scope, Context } from "effect"
 // @ts-ignore
 import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
-import { readdir } from "fs/promises"
+import { readdir, stat } from "fs/promises"
 import path from "path"
 import z from "zod"
 import { Bus } from "@/bus"
@@ -23,6 +23,7 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const SUBSCRIBE_TIMEOUT_MS = 10_000
   const RESCAN_QUIET_MS = 1_000
+  const ROOT_DISCOVERY_INTERVAL_MS = 500
   const LOCAL_ARTIFACT_ENTRIES = new Set([".worktrees", ".claude", ".claire", ".superpowers"])
   const WORKSPACE_IGNORE_ENTRIES = [...LOCAL_ARTIFACT_ENTRIES]
   const VCS_SUBSCRIBE_ENTRIES = new Set(["HEAD", "index", "packed-refs", "refs"])
@@ -78,6 +79,19 @@ export namespace FileWatcher {
   }
 
   export type WatchScope = "workspace" | "vcs"
+  type RuntimeWatchScope = WatchScope | "workspace-child" | "root-discovery"
+  type RootEntryState = {
+    name: string
+    path: string
+    type: WorkspaceWatchPlanEntry["type"]
+    size: number
+    mtimeMs: number
+  }
+  type RescanRequest = {
+    directory: string
+    subscriptionDirectory?: string
+    watchScope?: RuntimeWatchScope
+  }
   export type WatchPlanExcludeReason = "default-ignore" | "local-artifact" | "user-config" | "protected-path"
   export type WorkspaceWatchPlanEntry = { name: string; type: "directory" | "file" | "other" }
   export type WorkspaceWatchPlanRoot = {
@@ -107,7 +121,7 @@ export namespace FileWatcher {
   }
 
   export function createRescanScheduler(input: {
-    publish: (directory: string) => void
+    publish: (request: RescanRequest) => void
     schedule?: (callback: () => void) => (() => void) | void
     now?: () => number
     onIncidentSettled?: (summary: RescanIncidentSummary) => void
@@ -120,6 +134,7 @@ export namespace FileWatcher {
       requestCount: number
       leadingPublished: boolean
       trailingPublished: boolean
+      request: RescanRequest
     }
     const pending = new Map<string, RescanState>()
     const schedule = (callback: () => void) => {
@@ -156,7 +171,7 @@ export namespace FileWatcher {
           state.needsTrailing = false
           state.trailingPublished = true
           pending.delete(directory)
-          input.publish(directory)
+          input.publish(state.request)
           settle(directory, state)
           return
         }
@@ -166,8 +181,10 @@ export namespace FileWatcher {
     }
 
     return {
-      request(directory: string) {
+      request(inputRequest: string | RescanRequest) {
         if (disposed) return
+        const request = typeof inputRequest === "string" ? { directory: inputRequest } : inputRequest
+        const directory = request.directory
         const state = pending.get(directory)
         if (state) {
           state.dirty = true
@@ -183,9 +200,10 @@ export namespace FileWatcher {
           requestCount: 1,
           leadingPublished: true,
           trailingPublished: false,
+          request,
         }
         pending.set(directory, next)
-        input.publish(directory)
+        input.publish(request)
         arm(directory, next)
       },
       dispose() {
@@ -293,6 +311,43 @@ export namespace FileWatcher {
     }
   }
 
+  async function rootEntrySnapshot(directory: string) {
+    const entries = new Map<string, RootEntryState>()
+    for (const item of await readdir(directory, { withFileTypes: true }).catch(() => [])) {
+      const fullPath = path.join(directory, item.name)
+      const type = item.isDirectory() ? "directory" : item.isFile() ? "file" : "other"
+      const info = await stat(fullPath).catch(() => undefined)
+      entries.set(item.name, {
+        name: item.name,
+        path: fullPath,
+        type,
+        size: info?.size ?? 0,
+        mtimeMs: info?.mtimeMs ?? 0,
+      })
+    }
+    return entries
+  }
+
+  function watchPlanEntries(snapshot: Map<string, RootEntryState>): WorkspaceWatchPlanEntry[] {
+    return [...snapshot.values()].map((item) => ({ name: item.name, type: item.type }))
+  }
+
+  function rootFileChanged(prev: RootEntryState | undefined, next: RootEntryState | undefined) {
+    if (!prev || !next) return false
+    return prev.type === "file" && next.type === "file" && (prev.size !== next.size || prev.mtimeMs !== next.mtimeMs)
+  }
+
+  function shouldPublishWorkspacePath(file: string, workspace: string, ignore: string[]) {
+    const relative = path.relative(workspace, file)
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return false
+    for (const entry of ignore) {
+      if (!path.isAbsolute(entry) || hasGlobSyntax(entry)) continue
+      const rel = path.relative(entry, file)
+      if (!rel || (!rel.startsWith("..") && !path.isAbsolute(rel))) return false
+    }
+    return !FileIgnore.match(relative, { extra: ignore })
+  }
+
   export function watcherSubscriptionDiagnostics(input: {
     directory: string
     backend: string
@@ -374,10 +429,15 @@ export namespace FileWatcher {
             )
 
             const requestRescan = createRescanScheduler({
-              publish: (dir) => {
-                log.warn("watcher events dropped, requesting rescan", { dir })
-                Bus.publish(Event.Rescan, { directory: dir }).catch((error) =>
-                  log.warn("failed to publish watcher rescan", { dir, error }),
+              publish: (request) => {
+                log.warn("watcher events dropped, requesting rescan", {
+                  dir: request.directory,
+                  rescan_directory: request.directory,
+                  subscription_dir: request.subscriptionDirectory ?? request.directory,
+                  watch_scope: request.watchScope,
+                })
+                Bus.publish(Event.Rescan, { directory: request.directory }).catch((error) =>
+                  log.warn("failed to publish watcher rescan", { dir: request.directory, error }),
                 )
               },
               onIncidentSettled: (summary) => {
@@ -390,12 +450,23 @@ export namespace FileWatcher {
             })
             yield* Effect.addFinalizer(() => Effect.sync(() => requestRescan.dispose()))
             const createCallback =
-              (dir: string, shouldPublish = (_file: string) => true): ParcelWatcher.SubscribeCallback =>
+              (
+                dir: string,
+                shouldPublish = (_file: string) => true,
+                options?: {
+                  rescanDirectory?: string
+                  watchScope?: RuntimeWatchScope
+                },
+              ): ParcelWatcher.SubscribeCallback =>
               (err, evts) =>
               Instance.restore(ctx, () => {
                 if (err) {
                   if (isDroppedEventsError(err)) {
-                    requestRescan.request(dir)
+                    requestRescan.request({
+                      directory: options?.rescanDirectory ?? dir,
+                      subscriptionDirectory: dir,
+                      watchScope: options?.watchScope,
+                    })
                     return
                   }
                   log.error("watcher callback error", { err })
@@ -409,17 +480,26 @@ export namespace FileWatcher {
                 }
               })
 
-            const subscribe = (dir: string, ignore: string[], shouldPublish?: (file: string) => boolean) => {
-              const pending = w.subscribe(dir, createCallback(dir, shouldPublish), { ignore, backend })
+            const subscribe = (
+              dir: string,
+              ignore: string[],
+              shouldPublish?: (file: string) => boolean,
+              options?: {
+                rescanDirectory?: string
+                watchScope?: RuntimeWatchScope
+              },
+            ) => {
+              const pending = w.subscribe(dir, createCallback(dir, shouldPublish, options), { ignore, backend })
               return Effect.gen(function* () {
                 const sub = yield* Effect.promise(() => pending)
                 subs.push(sub)
+                return sub
               }).pipe(
                 Effect.timeout(SUBSCRIBE_TIMEOUT_MS),
                 Effect.catchCause((cause) => {
                   log.error("failed to subscribe", { dir, cause: Cause.pretty(cause) })
                   pending.then((s) => s.unsubscribe()).catch(() => {})
-                  return Effect.void
+                  return Effect.succeed(undefined)
                 }),
               )
             }
@@ -435,10 +515,149 @@ export namespace FileWatcher {
                 protectedPaths: protecteds(ctx.directory),
               })
               log.info("watcher subscription configured", workspaceSubscription.diagnostics)
-              yield* subscribe(
-                ctx.directory,
-                workspaceSubscription.ignore,
-              )
+              if (backend === "fs-events") {
+                let planVersion = 0
+                let snapshot = yield* Effect.promise(() => rootEntrySnapshot(ctx.directory))
+                const active = new Map<string, ParcelWatcher.AsyncSubscription>()
+                const applyPlan = Effect.fn("FileWatcher.applyWorkspaceWatchPlan")(function* () {
+                  const plan = workspaceWatchPlan({
+                    directory: ctx.directory,
+                    backend,
+                    entries: watchPlanEntries(snapshot),
+                    ignore: workspaceSubscription.ignore,
+                    userConfig: cfgIgnores,
+                    protectedPaths: protecteds(ctx.directory),
+                  })
+                  planVersion++
+                  log.info("watcher plan configured", {
+                    dir: ctx.directory,
+                    backend,
+                    watch_scope: "workspace",
+                    plan_version: planVersion,
+                    root_count: plan.roots.length,
+                    excluded_count: plan.excluded.length,
+                    root_files_strategy: plan.rootFilesStrategy,
+                    refresh_strategy: plan.refreshStrategy,
+                    excluded: plan.excluded.map((item) => ({
+                      path: item.path,
+                      reason: item.reason,
+                    })),
+                  })
+
+                  const nextRoots = new Set(plan.roots.map((root) => root.directory))
+                  for (const [dir, sub] of active) {
+                    if (nextRoots.has(dir)) continue
+                    active.delete(dir)
+                    yield* Effect.promise(() => sub.unsubscribe().catch(() => undefined))
+                    log.info("watcher subscription removed", {
+                      dir,
+                      watch_scope: "workspace-child",
+                      plan_version: planVersion,
+                    })
+                  }
+
+                  for (const root of plan.roots) {
+                    if (active.has(root.directory)) continue
+                    log.info("watcher subscription configured", {
+                      dir: root.directory,
+                      backend,
+                      watch_scope: "workspace-child",
+                      plan_version: planVersion,
+                      ignore_count: root.ignore.length,
+                      rescan_directory: ctx.directory,
+                    })
+                    const sub = yield* subscribe(
+                      root.directory,
+                      root.ignore,
+                      (file) => shouldPublishWorkspacePath(file, ctx.directory, workspaceSubscription.ignore),
+                      {
+                        rescanDirectory: ctx.directory,
+                        watchScope: "workspace-child",
+                      },
+                    )
+                    if (!sub) continue
+                    active.set(root.directory, sub)
+                  }
+                })
+
+                yield* applyPlan()
+                const timer = setInterval(() => {
+                  Instance.restore(ctx, () => {
+                    rootEntrySnapshot(ctx.directory)
+                      .then((next) => {
+                        const prev = snapshot
+                        snapshot = next
+                        const nextNames = new Set(next.keys())
+                        let refreshPlan = false
+
+                        for (const [name, value] of next) {
+                          const before = prev.get(name)
+                          if (!before) {
+                            const publishable = shouldPublishWorkspacePath(
+                              value.path,
+                              ctx.directory,
+                              workspaceSubscription.ignore,
+                            )
+                            if (value.type === "file" && publishable)
+                              Bus.publish(Event.Updated, { file: value.path, event: "add" })
+                            if (value.type === "directory") {
+                              if (publishable) {
+                                refreshPlan = true
+                                Bus.publish(Event.Updated, { file: value.path, event: "add" })
+                              }
+                            }
+                            continue
+                          }
+                          if (
+                            rootFileChanged(before, value) &&
+                            shouldPublishWorkspacePath(value.path, ctx.directory, workspaceSubscription.ignore)
+                          ) {
+                            Bus.publish(Event.Updated, { file: value.path, event: "change" })
+                          }
+                          if (
+                            before.type !== value.type &&
+                            shouldPublishWorkspacePath(value.path, ctx.directory, workspaceSubscription.ignore)
+                          )
+                            refreshPlan = true
+                        }
+
+                        for (const [name, value] of prev) {
+                          if (nextNames.has(name)) continue
+                          const publishable = shouldPublishWorkspacePath(
+                            value.path,
+                            ctx.directory,
+                            workspaceSubscription.ignore,
+                          )
+                          if (value.type === "file" && publishable)
+                            Bus.publish(Event.Updated, { file: value.path, event: "unlink" })
+                          if (value.type === "directory") {
+                            if (publishable) {
+                              refreshPlan = true
+                              Bus.publish(Event.Updated, { file: value.path, event: "unlink" })
+                            }
+                          }
+                        }
+
+                        if (!refreshPlan) return
+                        Effect.runPromise(applyPlan())
+                          .then(() =>
+                            Bus.publish(Event.Rescan, { directory: ctx.directory }).catch((error) =>
+                              log.warn("failed to publish watcher rescan", { dir: ctx.directory, error }),
+                            ),
+                          )
+                          .catch((error) => log.warn("failed to refresh watcher plan", { dir: ctx.directory, error }))
+                      })
+                      .catch((error) => log.warn("failed to poll workspace root", { dir: ctx.directory, error }))
+                  })
+                }, ROOT_DISCOVERY_INTERVAL_MS)
+                yield* Effect.addFinalizer(() =>
+                  Effect.sync(() => {
+                    clearInterval(timer)
+                  }),
+                )
+              } else {
+                yield* subscribe(ctx.directory, workspaceSubscription.ignore)
+              }
             }
 
             if (ctx.project.vcs === "git") {

--- a/packages/opencode/test/file/watcher-error.test.ts
+++ b/packages/opencode/test/file/watcher-error.test.ts
@@ -17,8 +17,8 @@ describe("FileWatcher error handling", () => {
     const settled: FileWatcher.RescanIncidentSummary[] = []
     let now = 100
     const scheduler = FileWatcher.createRescanScheduler({
-      publish: (directory) => {
-        published.push(directory)
+      publish: (request) => {
+        published.push(request.directory)
       },
       now: () => now,
       onIncidentSettled: (summary) => {
@@ -63,8 +63,8 @@ describe("FileWatcher error handling", () => {
     const published: string[] = []
     const scheduled: Array<() => void> = []
     const scheduler = FileWatcher.createRescanScheduler({
-      publish: (directory) => {
-        published.push(directory)
+      publish: (request) => {
+        published.push(request.directory)
       },
       schedule: (callback) => {
         scheduled.push(callback)
@@ -88,9 +88,9 @@ describe("FileWatcher error handling", () => {
     const scheduled: Array<() => void> = []
     let scheduler: ReturnType<typeof FileWatcher.createRescanScheduler>
     scheduler = FileWatcher.createRescanScheduler({
-      publish: (directory) => {
-        published.push(directory)
-        if (published.length === 2) scheduler.request(directory)
+      publish: (request) => {
+        published.push(request.directory)
+        if (published.length === 2) scheduler.request(request)
       },
       schedule: (callback) => {
         scheduled.push(callback)
@@ -111,8 +111,8 @@ describe("FileWatcher error handling", () => {
     const published: string[] = []
     const scheduled: Array<() => void> = []
     const scheduler = FileWatcher.createRescanScheduler({
-      publish: (directory) => {
-        published.push(directory)
+      publish: (request) => {
+        published.push(request.directory)
       },
       schedule: (callback) => {
         scheduled.push(callback)
@@ -126,5 +126,26 @@ describe("FileWatcher error handling", () => {
     scheduled[0]?.()
 
     expect(published).toEqual(["/repo"])
+  })
+
+  test("keeps child watcher dropped-event recovery mapped to the workspace root", () => {
+    const published: Array<{ directory: string; subscriptionDirectory?: string }> = []
+    const scheduler = FileWatcher.createRescanScheduler({
+      publish: (request) => {
+        published.push({
+          directory: request.directory,
+          subscriptionDirectory: request.subscriptionDirectory,
+        })
+      },
+      schedule: () => undefined,
+    })
+
+    scheduler.request({
+      directory: "/repo",
+      subscriptionDirectory: "/repo/packages",
+      watchScope: "workspace-child",
+    })
+
+    expect(published).toEqual([{ directory: "/repo", subscriptionDirectory: "/repo/packages" }])
   })
 })

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -237,13 +237,120 @@ describe("FileWatcher git metadata filtering", () => {
     const ignore = FileWatcher.subscriptionIgnoreEntries({
       workspace: repo,
       subscription: child,
-      ignore: ["custom-cache", "packages/generated", "**/*.log", path.join(repo, "secret")],
+      ignore: [
+        "custom-cache",
+        "packages/generated",
+        "*.md",
+        "logs/**",
+        "packages/generated/**",
+        "packages/*.snap",
+        "**/*.log",
+        path.join(repo, "secret"),
+      ],
     })
 
     expect(ignore).toContain(path.join(repo, "custom-cache"))
     expect(ignore).toContain(path.join(repo, "packages", "generated"))
+    expect(ignore).not.toContain("*.md")
+    expect(ignore).not.toContain("logs/**")
+    expect(ignore).toContain("generated/**")
+    expect(ignore).toContain("*.snap")
     expect(ignore).toContain("**/*.log")
     expect(ignore).toContain(path.join(repo, "secret"))
+  })
+
+  test("waits for root poll plan refresh before publishing rescan", async () => {
+    const repo = path.join("/tmp", "repo")
+    const prev = new Map()
+    const next = new Map([
+      [
+        "generated",
+        {
+          name: "generated",
+          path: path.join(repo, "generated"),
+          type: "directory" as const,
+          size: 0,
+          mtimeMs: 0,
+        },
+      ],
+    ])
+    let releaseApply!: () => void
+    const applied = new Promise<void>((resolve) => {
+      releaseApply = resolve
+    })
+    let settled = false
+    const updates: WatcherEvent[] = []
+    const rescans: string[] = []
+
+    const running = FileWatcher.runWorkspaceRootPoll({
+      previous: prev,
+      next,
+      workspace: repo,
+      ignore: [],
+      isDisposed: () => false,
+      applyPlan: () => applied,
+      publishUpdate: (event) => {
+        updates.push(event)
+      },
+      publishRescan: (directory) => {
+        rescans.push(directory)
+      },
+    }).then(() => {
+      settled = true
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(settled).toBe(false)
+    expect(rescans).toEqual([])
+
+    releaseApply()
+    await running
+
+    expect(updates).toEqual([{ file: path.join(repo, "generated"), event: "add" }])
+    expect(rescans).toEqual([repo])
+  })
+
+  test("does not publish root poll rescan after disposal", async () => {
+    const repo = path.join("/tmp", "repo")
+    const prev = new Map()
+    const next = new Map([
+      [
+        "generated",
+        {
+          name: "generated",
+          path: path.join(repo, "generated"),
+          type: "directory" as const,
+          size: 0,
+          mtimeMs: 0,
+        },
+      ],
+    ])
+    let disposed = false
+    let releaseApply!: () => void
+    const applied = new Promise<void>((resolve) => {
+      releaseApply = resolve
+    })
+    const rescans: string[] = []
+
+    const running = FileWatcher.runWorkspaceRootPoll({
+      previous: prev,
+      next,
+      workspace: repo,
+      ignore: [],
+      isDisposed: () => disposed,
+      applyPlan: () => applied,
+      publishUpdate: () => {},
+      publishRescan: (directory) => {
+        rescans.push(directory)
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    disposed = true
+    releaseApply()
+    await running
+
+    expect(rescans).toEqual([])
   })
 
   test("ignores nested PawWork worktree roots from the workspace watcher", () => {

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -512,21 +512,32 @@ describeWatcher("FileWatcher", () => {
     })
   })
 
-  test("ignores local artifact roots from workspace updates", async () => {
+  test("ignores high-churn local artifact roots from workspace updates", async () => {
     await using tmp = await tmpdir({ git: true })
-    const artifact = path.join(tmp.path, ".claude")
-    const file = path.join(artifact, "settings.local.json")
+    const artifacts = [".worktrees", ".claude", ".claire", ".superpowers", "node_modules", ".turbo"]
 
     await withWatcher(
       tmp.path,
       noUpdate(
         tmp.path,
-        (evt) => evt.file === file,
+        (evt) => artifacts.some((artifact) => evt.file.startsWith(path.join(tmp.path, artifact) + path.sep)),
         noRescan(
           (evt) => evt.directory === tmp.path,
           Effect.promise(async () => {
-            await fs.mkdir(artifact)
-            await fs.writeFile(file, "{}")
+            for (const artifact of artifacts) {
+              const artifactDir = path.join(tmp.path, artifact)
+              await fs.mkdir(artifactDir)
+              await Promise.all(
+                Array.from({ length: 100 }, (_, index) =>
+                  fs.writeFile(path.join(artifactDir, `artifact-${index}.txt`), `first ${index}`),
+                ),
+              )
+              await Promise.all(
+                Array.from({ length: 100 }, (_, index) =>
+                  fs.writeFile(path.join(artifactDir, `artifact-${index}.txt`), `second ${index}`),
+                ),
+              )
+            }
           }),
           1_000,
         ),

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -146,6 +146,54 @@ function ready(directory: string) {
 // ---------------------------------------------------------------------------
 
 describe("FileWatcher git metadata filtering", () => {
+  test("builds an explainable macOS workspace watch plan", () => {
+    const repo = path.join("/tmp", "repo")
+    const plan = FileWatcher.workspaceWatchPlan({
+      directory: repo,
+      backend: "fs-events",
+      entries: [
+        { name: ".claude", type: "directory" },
+        { name: ".claire", type: "directory" },
+        { name: ".superpowers", type: "directory" },
+        { name: ".turbo", type: "directory" },
+        { name: ".worktrees", type: "directory" },
+        { name: "node_modules", type: "directory" },
+        { name: "packages", type: "directory" },
+        { name: "src", type: "directory" },
+        { name: "README.md", type: "file" },
+      ],
+      ignore: FileWatcher.workspaceWatcherIgnoreEntries({ config: ["custom-cache"], protected: [] }),
+    })
+
+    expect(plan.rootFilesStrategy).toBe("poll-root-entries")
+    expect(plan.refreshStrategy).toBe("refresh-plan-on-top-level-entry-change")
+    expect(plan.roots.map((root) => path.basename(root.directory)).sort()).toEqual(["packages", "src"])
+    expect(plan.excluded.map((item) => [path.basename(item.path), item.reason]).sort()).toEqual([
+      [".claire", "local-artifact"],
+      [".claude", "local-artifact"],
+      [".superpowers", "local-artifact"],
+      [".turbo", "default-ignore"],
+      [".worktrees", "local-artifact"],
+      ["node_modules", "default-ignore"],
+    ])
+    expect(plan.rootFiles).toEqual([path.join(repo, "README.md")])
+  })
+
+  test("keeps workspace ignore semantics for child subscriptions", () => {
+    const repo = path.join("/tmp", "repo")
+    const child = path.join(repo, "packages")
+    const ignore = FileWatcher.subscriptionIgnoreEntries({
+      workspace: repo,
+      subscription: child,
+      ignore: ["custom-cache", "packages/generated", "**/*.log", path.join(repo, "secret")],
+    })
+
+    expect(ignore).toContain(path.join(repo, "custom-cache"))
+    expect(ignore).toContain(path.join(repo, "packages", "generated"))
+    expect(ignore).toContain("**/*.log")
+    expect(ignore).toContain(path.join(repo, "secret"))
+  })
+
   test("ignores nested PawWork worktree roots from the workspace watcher", () => {
     const entries = FileWatcher.workspaceWatcherIgnoreEntries({
       config: ["custom-cache"],

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -259,6 +259,26 @@ describe("FileWatcher git metadata filtering", () => {
     expect(ignore).toContain(path.join(repo, "secret"))
   })
 
+  test("falls back to root polling when the workspace has too many top-level roots", () => {
+    const repo = path.join("/tmp", "repo")
+    const entries = Array.from({ length: FileWatcher.MAX_WORKSPACE_WATCH_ROOTS + 1 }, (_, index) => ({
+      name: `pkg-${index}`,
+      type: "directory" as const,
+    }))
+
+    const plan = FileWatcher.workspaceWatchPlan({
+      directory: repo,
+      backend: "fs-events",
+      entries,
+      ignore: FileWatcher.workspaceWatcherIgnoreEntries({ config: [], protected: [] }),
+    })
+
+    expect(plan.roots).toEqual([])
+    expect(plan.fallbackStrategy).toBe("root-polling-only")
+    expect(plan.rootCount).toBe(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS + 1)
+    expect(plan.maxRootCount).toBe(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS)
+  })
+
   test("waits for root poll plan refresh before publishing rescan", async () => {
     const repo = path.join("/tmp", "repo")
     const prev = new Map()

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -204,12 +204,15 @@ describe("FileWatcher git metadata filtering", () => {
         { name: ".superpowers", type: "directory" },
         { name: ".turbo", type: "directory" },
         { name: ".worktrees", type: "directory" },
+        { name: "logs", type: "directory" },
+        { name: "local-cache", type: "directory" },
         { name: "node_modules", type: "directory" },
         { name: "packages", type: "directory" },
         { name: "src", type: "directory" },
         { name: "README.md", type: "file" },
       ],
-      ignore: FileWatcher.workspaceWatcherIgnoreEntries({ config: ["custom-cache"], protected: [] }),
+      ignore: FileWatcher.workspaceWatcherIgnoreEntries({ config: ["local-cache/**"], protected: [] }),
+      userConfig: ["local-cache/**"],
     })
 
     expect(plan.rootFilesStrategy).toBe("poll-root-entries")
@@ -221,6 +224,8 @@ describe("FileWatcher git metadata filtering", () => {
       [".superpowers", "local-artifact"],
       [".turbo", "default-ignore"],
       [".worktrees", "local-artifact"],
+      ["local-cache", "user-config"],
+      ["logs", "default-ignore"],
       ["node_modules", "default-ignore"],
     ])
     expect(plan.rootFiles).toEqual([path.join(repo, "README.md")])

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -281,6 +281,25 @@ describe("FileWatcher git metadata filtering", () => {
     expect(plan.maxRootCount).toBe(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS)
   })
 
+  test("throttles fallback workspace rescans while child subscriptions are capped", () => {
+    const fallback = FileWatcher.createFallbackRescanThrottle({ now: () => 1_000 })
+
+    expect(fallback.enter()).toBe(true)
+    expect(fallback.tick()).toBe(false)
+
+    fallback.now = () => 5_999
+    expect(fallback.tick()).toBe(false)
+
+    fallback.now = () => 6_000
+    expect(fallback.tick()).toBe(true)
+    expect(fallback.tick()).toBe(false)
+
+    fallback.exit()
+    fallback.now = () => 6_001
+    expect(fallback.tick()).toBe(false)
+    expect(fallback.enter()).toBe(true)
+  })
+
   test("waits for root poll plan refresh before publishing rescan", async () => {
     const repo = path.join("/tmp", "repo")
     const prev = new Map()

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -25,6 +25,7 @@ const watcherConfigLayer = ConfigProvider.layer(
 )
 
 type WatcherEvent = { file: string; event: "add" | "change" | "unlink" }
+type RescanEvent = { directory: string }
 
 /** Run `body` with a live FileWatcher service. */
 function withWatcher<E>(directory: string, body: Effect.Effect<void, E>) {
@@ -79,6 +80,28 @@ function wait(directory: string, check: (evt: WatcherEvent) => boolean) {
   })
 }
 
+function waitRescan(check: (evt: RescanEvent) => boolean) {
+  return Effect.gen(function* () {
+    const deferred = yield* Deferred.make<RescanEvent>()
+    const cleanup = yield* Effect.sync(() => {
+      let done = false
+      const unsub = Bus.subscribe(FileWatcher.Event.Rescan, (evt) => {
+        if (done) return
+        if (!check(evt.properties)) return
+        done = true
+        unsub()
+        Deferred.doneUnsafe(deferred, Effect.succeed(evt.properties))
+      })
+      return () => {
+        if (done) return
+        done = true
+        unsub()
+      }
+    })
+    return { cleanup, deferred }
+  })
+}
+
 function nextUpdate<E>(directory: string, check: (evt: WatcherEvent) => boolean, trigger: Effect.Effect<void, E>) {
   return Effect.acquireUseRelease(
     wait(directory, check),
@@ -86,6 +109,30 @@ function nextUpdate<E>(directory: string, check: (evt: WatcherEvent) => boolean,
       Effect.gen(function* () {
         yield* trigger
         return yield* Deferred.await(deferred).pipe(Effect.timeout("5 seconds"))
+      }),
+    ({ cleanup }) => Effect.sync(cleanup),
+  )
+}
+
+function nextRescan<E>(check: (evt: RescanEvent) => boolean, trigger: Effect.Effect<void, E>) {
+  return Effect.acquireUseRelease(
+    waitRescan(check),
+    ({ deferred }) =>
+      Effect.gen(function* () {
+        yield* trigger
+        return yield* Deferred.await(deferred).pipe(Effect.timeout("5 seconds"))
+      }),
+    ({ cleanup }) => Effect.sync(cleanup),
+  )
+}
+
+function noRescan<E>(check: (evt: RescanEvent) => boolean, trigger: Effect.Effect<void, E>, ms = 500) {
+  return Effect.acquireUseRelease(
+    waitRescan(check),
+    ({ deferred }) =>
+      Effect.gen(function* () {
+        yield* trigger
+        expect(yield* Deferred.await(deferred).pipe(Effect.timeoutOption(`${ms} millis`))).toEqual(Option.none())
       }),
     ({ cleanup }) => Effect.sync(cleanup),
   )
@@ -310,6 +357,54 @@ describeWatcher("FileWatcher", () => {
           ),
         ),
     })
+  })
+
+  test("ignores local artifact roots from workspace updates", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const artifact = path.join(tmp.path, ".claude")
+    const file = path.join(artifact, "settings.local.json")
+
+    await withWatcher(
+      tmp.path,
+      noUpdate(
+        tmp.path,
+        (evt) => evt.file === file,
+        noRescan(
+          (evt) => evt.directory === tmp.path,
+          Effect.promise(async () => {
+            await fs.mkdir(artifact)
+            await fs.writeFile(file, "{}")
+          }),
+          1_000,
+        ),
+        1_000,
+      ),
+    )
+  })
+
+  test("refreshes the watch plan for new top-level directories", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = path.join(tmp.path, "generated")
+    const first = path.join(dir, "first.txt")
+    const second = path.join(dir, "second.txt")
+
+    await withWatcher(
+      tmp.path,
+      Effect.gen(function* () {
+        yield* nextRescan(
+          (evt) => evt.directory === tmp.path,
+          Effect.promise(async () => {
+            await fs.mkdir(dir)
+            await fs.writeFile(first, "first")
+          }),
+        )
+        yield* nextUpdate(
+          tmp.path,
+          (evt) => evt.file === second && evt.event === "add",
+          Effect.promise(() => fs.writeFile(second, "second")),
+        )
+      }),
+    )
   })
 
   test("publishes .git/index changes", async () => {

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -259,7 +259,7 @@ describe("FileWatcher git metadata filtering", () => {
     expect(ignore).toContain(path.join(repo, "secret"))
   })
 
-  test("falls back to root polling when the workspace has too many top-level roots", () => {
+  test("caps child subscriptions when the workspace has too many top-level roots", () => {
     const repo = path.join("/tmp", "repo")
     const entries = Array.from({ length: FileWatcher.MAX_WORKSPACE_WATCH_ROOTS + 1 }, (_, index) => ({
       name: `pkg-${index}`,
@@ -273,8 +273,10 @@ describe("FileWatcher git metadata filtering", () => {
       ignore: FileWatcher.workspaceWatcherIgnoreEntries({ config: [], protected: [] }),
     })
 
-    expect(plan.roots).toEqual([])
-    expect(plan.fallbackStrategy).toBe("root-polling-only")
+    expect(plan.roots).toHaveLength(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS)
+    expect(plan.roots[0]?.directory).toBe(path.join(repo, "pkg-0"))
+    expect(plan.roots.at(-1)?.directory).toBe(path.join(repo, `pkg-${FileWatcher.MAX_WORKSPACE_WATCH_ROOTS - 1}`))
+    expect(plan.fallbackStrategy).toBe("limited-child-watchers")
     expect(plan.rootCount).toBe(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS + 1)
     expect(plan.maxRootCount).toBe(FileWatcher.MAX_WORKSPACE_WATCH_ROOTS)
   })


### PR DESCRIPTION
## Summary

Implements the macOS watcher isolation plan for recurring dropped-event rescans:

- Adds an explainable `workspaceWatchPlan` that excludes local artifact roots by default.
- Uses macOS child workspace subscriptions instead of one recursive repo-root FSEvents stream.
- Adds root-level discovery via first-level polling so root files and new top-level directories remain observable.
- Keeps dropped-event recovery mapped to the workspace root for child subscriptions.

## Why

The recurring `service=file.watcher ... watcher events dropped, requesting rescan` incidents were not caused by the rescan quiet-window scheduler. On macOS, FSEvents can report dropped events at the stream level before ignored paths are filtered, so a recursive repo-root watcher can still be pressured by high-churn local artifact roots such as `.worktrees/`, `.claude/`, `.claire/`, `.superpowers/`, `node_modules/`, and `.turbo/`.

This PR narrows the macOS stream scope so those top-level local artifacts do not share the workspace file stream while preserving the existing recovery path for real dropped events.

## Related Issue

Fixes #942.

## Human Review Status

Pending

## Review Focus

Please focus on:

- The macOS-only branch in `FileWatcher.layer` and whether Linux/Windows correctly keep the existing root watcher behavior.
- The `workspaceWatchPlan` exclusions and per-subscription ignore normalization.
- The root-level discovery polling path for root files and newly-created top-level directories.
- The rescan contract: child workspace subscriptions must publish `file.watcher.rescan` with the workspace root directory.

## Risk Notes

- Platform behavior: this intentionally changes macOS watcher registration only. Linux and Windows keep the existing root watcher path.
- Root-level files are discovered by a first-level poll every 500ms on macOS, so root file updates are not strictly instant. Child source directories still use native watcher events.
- Workspaces with more than 128 non-ignored top-level roots keep the first 128 child watchers live and use a throttled 5s workspace rescan fallback for uncovered roots. This preserves eventual correctness but can reduce realtime freshness for very large repositories.
- This fixes top-level local artifact isolation. Nested ignored high-churn directories under watched child roots, for example `packages/foo/node_modules/`, can still share that child stream; if they cause dropped events, recovery still maps to workspace-root rescan.
- No visible UI or copy changed, so no screenshot was taken.

## How To Verify

```text
macOS high-churn artifact probe: cd packages/opencode && bun test test/file/watcher.test.ts test/file/watcher-error.test.ts
Result: 25 pass, 0 fail, 74 expect() calls on Darwin with native @parcel/watcher enabled. The live test `ignores high-churn local artifact roots from workspace updates` churns .worktrees/, .claude/, .claire/, .superpowers/, node_modules/, and .turbo/ with 200 writes per root and asserts 0 workspace update/rescan events from those roots.

Normal source update coverage: same macOS live watcher suite.
Result: passed. Covers root file create/update/delete, non-git source updates, newly-created top-level directory plan refresh, and VCS metadata events.

Dropped-event recovery coverage: same watcher-error suite.
Result: passed. Covers FSEvents dropped-event recognition, quiet-window rescan coalescing, disposal, and child workspace watcher dropped-event mapping back to the workspace root.

Typecheck: cd packages/opencode && bun run typecheck
Result: passed.

Diff check: git diff --check
Result: passed with no output.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved file-watching: periodic root discovery, dynamic root subscriptions, and plan-driven workspace watch behavior for more reliable detection of adds/changes/removals and better handling of dropped events.
  * Smarter ignore and exclusion handling, plus throttled/coalesced rescan scheduling to reduce duplicate rescans under load.

* **Tests**
  * Expanded tests covering rescan delivery, workspace watch-plan logic, exclusion reasons, throttling, and root-poll behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
