### PR TITLE
fix(session): terminalize stale question blockers

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -972,11 +972,64 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         .pipe(Effect.orElseSucceed((): Snapshot.FileDiff[] => []))
     })
 
+    const terminalizeStaleExternalResultQuestions = Effect.fn("Session.terminalizeStaleExternalResultQuestions")(
+      function* (messages: MessageV2.WithParts[]) {
+        const now = Date.now()
+        const next: MessageV2.WithParts[] = []
+        for (const message of messages) {
+          let changed = false
+          const parts: MessageV2.Part[] = []
+          for (const part of message.parts) {
+            if (
+              part.type !== "tool" ||
+              part.tool !== "question" ||
+              part.state.status !== "running" ||
+              part.state.metadata?.externalResultReady !== true
+            ) {
+              parts.push(part)
+              continue
+            }
+
+            const lookup = ExternalResult.lookup({
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              callID: part.callID,
+            })
+            if (lookup.state !== "not_found") {
+              parts.push(part)
+              continue
+            }
+
+            changed = true
+            parts.push(
+              yield* updatePart({
+                ...part,
+                state: {
+                  status: "error",
+                  input: part.state.input,
+                  error: "Question cancelled before the user answered it.",
+                  reason: "shutdown",
+                  metadata: {
+                    ...part.state.metadata,
+                    interrupted: true,
+                    stale_external_result: true,
+                  },
+                  time: { start: part.state.time.start, end: now },
+                },
+              }),
+            )
+          }
+          next.push(changed ? { ...message, parts } : message)
+        }
+        return next
+      },
+    )
+
     const messages = Effect.fn("Session.messages")(function* (input: { sessionID: SessionID; limit?: number }) {
-      if (input.limit) {
-        return MessageV2.page({ sessionID: input.sessionID, limit: input.limit }).items
-      }
-      return Array.from(MessageV2.stream(input.sessionID)).reverse()
+      const items = input.limit
+        ? MessageV2.page({ sessionID: input.sessionID, limit: input.limit }).items
+        : Array.from(MessageV2.stream(input.sessionID)).reverse()
+      return yield* terminalizeStaleExternalResultQuestions(items)
     })
 
     const removeMessage = Effect.fn("Session.removeMessage")(function* (input: {

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -8,6 +8,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { Instance } from "../../src/project/instance"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID } from "../../src/session/schema"
+import { ExternalResult } from "../../src/tool/external-result"
 import { tmpdir } from "../fixture/fixture"
 import { Database, eq } from "../../src/storage/db"
 import { MessageTable, SessionTable } from "../../src/session/session.sql"
@@ -734,6 +735,95 @@ describe("step-finish token propagation via Bus event", () => {
 })
 
 describe("Session", () => {
+  test("messages terminalizes stale running external-result questions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await SessionNs.create({})
+        const userID = MessageID.ascending()
+        await SessionNs.updateMessage({
+          id: userID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "user",
+          model: { providerID: "test", modelID: "test" },
+          tools: {},
+          mode: "",
+        } as unknown as MessageV2.Info)
+
+        const assistantID = MessageID.ascending()
+        await SessionNs.updateMessage({
+          id: assistantID,
+          sessionID: session.id,
+          role: "assistant",
+          parentID: userID,
+          time: { created: Date.now() },
+          agent: "build",
+          mode: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: "test",
+          providerID: "test",
+        } as unknown as MessageV2.Info)
+
+        const partID = PartID.ascending()
+        await SessionNs.updatePart({
+          id: partID,
+          sessionID: session.id,
+          messageID: assistantID,
+          type: "tool",
+          tool: "question",
+          callID: "call_stale_question",
+          state: {
+            status: "running",
+            input: {
+              questions: [
+                {
+                  question: "Continue?",
+                  options: [{ label: "Yes" }, { label: "No" }],
+                },
+              ],
+            },
+            raw: "",
+            time: { start: Date.now() },
+            metadata: { externalResultReady: true },
+          },
+        } as unknown as MessageV2.Part)
+
+        const messages = await SessionNs.messages({ sessionID: session.id })
+        const part = messages.flatMap((msg) => msg.parts).find((item) => item.id === partID)
+        expect(part?.type).toBe("tool")
+        if (part?.type !== "tool") throw new Error("expected tool part")
+        expect(part.state.status).toBe("error")
+        if (part.state.status !== "error") throw new Error("expected error state")
+        expect(part.state.metadata?.interrupted).toBe(true)
+        expect(part.state.metadata?.stale_external_result).toBe(true)
+
+        const persisted = MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
+          (item) => item.id === partID,
+        )
+        expect(persisted?.type).toBe("tool")
+        if (persisted?.type !== "tool") throw new Error("expected persisted tool part")
+        expect(persisted.state.status).toBe("error")
+
+        await SessionNs.remove(session.id)
+      },
+    })
+
+    ExternalResult.__resetForTests()
+  })
+
   test("remove works without an instance", async () => {
     await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -739,89 +739,91 @@ describe("Session", () => {
     await using tmp = await tmpdir({ git: true })
     ExternalResult.__resetForTests()
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await SessionNs.create({})
-        const userID = MessageID.ascending()
-        await SessionNs.updateMessage({
-          id: userID,
-          sessionID: session.id,
-          role: "user",
-          time: { created: Date.now() },
-          agent: "user",
-          model: { providerID: "test", modelID: "test" },
-          tools: {},
-          mode: "",
-        } as unknown as MessageV2.Info)
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await SessionNs.create({})
+          const userID = MessageID.ascending()
+          await SessionNs.updateMessage({
+            id: userID,
+            sessionID: session.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "user",
+            model: { providerID: "test", modelID: "test" },
+            tools: {},
+            mode: "",
+          } as unknown as MessageV2.Info)
 
-        const assistantID = MessageID.ascending()
-        await SessionNs.updateMessage({
-          id: assistantID,
-          sessionID: session.id,
-          role: "assistant",
-          parentID: userID,
-          time: { created: Date.now() },
-          agent: "build",
-          mode: "build",
-          path: { cwd: tmp.path, root: tmp.path },
-          cost: 0,
-          tokens: {
-            total: 0,
-            input: 0,
-            output: 0,
-            reasoning: 0,
-            cache: { read: 0, write: 0 },
-          },
-          modelID: "test",
-          providerID: "test",
-        } as unknown as MessageV2.Info)
-
-        const partID = PartID.ascending()
-        await SessionNs.updatePart({
-          id: partID,
-          sessionID: session.id,
-          messageID: assistantID,
-          type: "tool",
-          tool: "question",
-          callID: "call_stale_question",
-          state: {
-            status: "running",
-            input: {
-              questions: [
-                {
-                  question: "Continue?",
-                  options: [{ label: "Yes" }, { label: "No" }],
-                },
-              ],
+          const assistantID = MessageID.ascending()
+          await SessionNs.updateMessage({
+            id: assistantID,
+            sessionID: session.id,
+            role: "assistant",
+            parentID: userID,
+            time: { created: Date.now() },
+            agent: "build",
+            mode: "build",
+            path: { cwd: tmp.path, root: tmp.path },
+            cost: 0,
+            tokens: {
+              total: 0,
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
             },
-            raw: "",
-            time: { start: Date.now() },
-            metadata: { externalResultReady: true },
-          },
-        } as unknown as MessageV2.Part)
+            modelID: "test",
+            providerID: "test",
+          } as unknown as MessageV2.Info)
 
-        const messages = await SessionNs.messages({ sessionID: session.id })
-        const part = messages.flatMap((msg) => msg.parts).find((item) => item.id === partID)
-        expect(part?.type).toBe("tool")
-        if (part?.type !== "tool") throw new Error("expected tool part")
-        expect(part.state.status).toBe("error")
-        if (part.state.status !== "error") throw new Error("expected error state")
-        expect(part.state.metadata?.interrupted).toBe(true)
-        expect(part.state.metadata?.stale_external_result).toBe(true)
+          const partID = PartID.ascending()
+          await SessionNs.updatePart({
+            id: partID,
+            sessionID: session.id,
+            messageID: assistantID,
+            type: "tool",
+            tool: "question",
+            callID: "call_stale_question",
+            state: {
+              status: "running",
+              input: {
+                questions: [
+                  {
+                    question: "Continue?",
+                    options: [{ label: "Yes" }, { label: "No" }],
+                  },
+                ],
+              },
+              raw: "",
+              time: { start: Date.now() },
+              metadata: { externalResultReady: true },
+            },
+          } as unknown as MessageV2.Part)
 
-        const persisted = MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
-          (item) => item.id === partID,
-        )
-        expect(persisted?.type).toBe("tool")
-        if (persisted?.type !== "tool") throw new Error("expected persisted tool part")
-        expect(persisted.state.status).toBe("error")
+          const messages = await SessionNs.messages({ sessionID: session.id })
+          const part = messages.flatMap((msg) => msg.parts).find((item) => item.id === partID)
+          expect(part?.type).toBe("tool")
+          if (part?.type !== "tool") throw new Error("expected tool part")
+          expect(part.state.status).toBe("error")
+          if (part.state.status !== "error") throw new Error("expected error state")
+          expect(part.state.metadata?.interrupted).toBe(true)
+          expect(part.state.metadata?.stale_external_result).toBe(true)
 
-        await SessionNs.remove(session.id)
-      },
-    })
+          const persisted = MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
+            (item) => item.id === partID,
+          )
+          expect(persisted?.type).toBe("tool")
+          if (persisted?.type !== "tool") throw new Error("expected persisted tool part")
+          expect(persisted.state.status).toBe("error")
 
-    ExternalResult.__resetForTests()
+          await SessionNs.remove(session.id)
+        },
+      })
+    } finally {
+      ExternalResult.__resetForTests()
+    }
   })
 
   test("remove works without an instance", async () => {

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -735,6 +735,76 @@ describe("step-finish token propagation via Bus event", () => {
 })
 
 describe("Session", () => {
+  async function createRunningQuestionSession(directory: string, input?: { externalResultReady?: boolean }) {
+    const session = await SessionNs.create({})
+    const userID = MessageID.ascending()
+    await SessionNs.updateMessage({
+      id: userID,
+      sessionID: session.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "user",
+      model: { providerID: "test", modelID: "test" },
+      tools: {},
+      mode: "",
+    } as unknown as MessageV2.Info)
+
+    const assistantID = MessageID.ascending()
+    await SessionNs.updateMessage({
+      id: assistantID,
+      sessionID: session.id,
+      role: "assistant",
+      parentID: userID,
+      time: { created: Date.now() },
+      agent: "build",
+      mode: "build",
+      path: { cwd: directory, root: directory },
+      cost: 0,
+      tokens: {
+        total: 0,
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: "test",
+      providerID: "test",
+    } as unknown as MessageV2.Info)
+
+    const partID = PartID.ascending()
+    const callID = "call_stale_question"
+    await SessionNs.updatePart({
+      id: partID,
+      sessionID: session.id,
+      messageID: assistantID,
+      type: "tool",
+      tool: "question",
+      callID,
+      state: {
+        status: "running",
+        input: {
+          questions: [
+            {
+              question: "Continue?",
+              options: [{ label: "Yes" }, { label: "No" }],
+            },
+          ],
+        },
+        raw: "",
+        time: { start: Date.now() },
+        metadata: { externalResultReady: input?.externalResultReady ?? true },
+      },
+    } as unknown as MessageV2.Part)
+
+    return { session, assistantID, partID, callID }
+  }
+
+  function expectToolPart(part: MessageV2.Part | undefined) {
+    expect(part?.type).toBe("tool")
+    if (part?.type !== "tool") throw new Error("expected tool part")
+    return part
+  }
+
   test("messages terminalizes stale running external-result questions", async () => {
     await using tmp = await tmpdir({ git: true })
     ExternalResult.__resetForTests()
@@ -743,80 +813,73 @@ describe("Session", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const session = await SessionNs.create({})
-          const userID = MessageID.ascending()
-          await SessionNs.updateMessage({
-            id: userID,
-            sessionID: session.id,
-            role: "user",
-            time: { created: Date.now() },
-            agent: "user",
-            model: { providerID: "test", modelID: "test" },
-            tools: {},
-            mode: "",
-          } as unknown as MessageV2.Info)
-
-          const assistantID = MessageID.ascending()
-          await SessionNs.updateMessage({
-            id: assistantID,
-            sessionID: session.id,
-            role: "assistant",
-            parentID: userID,
-            time: { created: Date.now() },
-            agent: "build",
-            mode: "build",
-            path: { cwd: tmp.path, root: tmp.path },
-            cost: 0,
-            tokens: {
-              total: 0,
-              input: 0,
-              output: 0,
-              reasoning: 0,
-              cache: { read: 0, write: 0 },
-            },
-            modelID: "test",
-            providerID: "test",
-          } as unknown as MessageV2.Info)
-
-          const partID = PartID.ascending()
-          await SessionNs.updatePart({
-            id: partID,
-            sessionID: session.id,
-            messageID: assistantID,
-            type: "tool",
-            tool: "question",
-            callID: "call_stale_question",
-            state: {
-              status: "running",
-              input: {
-                questions: [
-                  {
-                    question: "Continue?",
-                    options: [{ label: "Yes" }, { label: "No" }],
-                  },
-                ],
-              },
-              raw: "",
-              time: { start: Date.now() },
-              metadata: { externalResultReady: true },
-            },
-          } as unknown as MessageV2.Part)
+          const { session, assistantID, partID } = await createRunningQuestionSession(tmp.path)
 
           const messages = await SessionNs.messages({ sessionID: session.id })
-          const part = messages.flatMap((msg) => msg.parts).find((item) => item.id === partID)
-          expect(part?.type).toBe("tool")
-          if (part?.type !== "tool") throw new Error("expected tool part")
+          const part = expectToolPart(messages.flatMap((msg) => msg.parts).find((item) => item.id === partID))
           expect(part.state.status).toBe("error")
           if (part.state.status !== "error") throw new Error("expected error state")
           expect(part.state.metadata?.interrupted).toBe(true)
           expect(part.state.metadata?.stale_external_result).toBe(true)
 
-          const persisted = MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
-            (item) => item.id === partID,
+          const persisted = expectToolPart(
+            MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
+              (item) => item.id === partID,
+            ),
           )
-          expect(persisted?.type).toBe("tool")
-          if (persisted?.type !== "tool") throw new Error("expected persisted tool part")
           expect(persisted.state.status).toBe("error")
+
+          await SessionNs.remove(session.id)
+        },
+      })
+    } finally {
+      ExternalResult.__resetForTests()
+    }
+  })
+
+  test("messages preserves live pending external-result questions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { session, assistantID, partID, callID } = await createRunningQuestionSession(tmp.path)
+          await Effect.runPromise(
+            ExternalResult.register({
+              sessionID: session.id,
+              messageID: assistantID,
+              callID,
+              inputSnapshot: { questions: ["q1"] },
+            }),
+          )
+
+          const messages = await SessionNs.messages({ sessionID: session.id })
+          const part = expectToolPart(messages.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("running")
+
+          await SessionNs.remove(session.id)
+        },
+      })
+    } finally {
+      ExternalResult.__resetForTests()
+    }
+  })
+
+  test("messages preserves unready external-result questions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { session, partID } = await createRunningQuestionSession(tmp.path, { externalResultReady: false })
+
+          const messages = await SessionNs.messages({ sessionID: session.id })
+          const part = expectToolPart(messages.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("running")
 
           await SessionNs.remove(session.id)
         },


### PR DESCRIPTION
## Summary

Terminalize stale question blockers when session history is read, so a persisted `running` question whose in-memory external-result Deferred was lost during restart no longer reopens as an active dock. There is no linked issue; this came from a user-provided exported session that reproduced a blocked conversation after app restart.

## Why

External-result question prompts depend on an in-memory Deferred. After a full app/server restart, that Deferred is gone, but the persisted tool part can still say `running` with `externalResultReady: true`. The app then renders a submit-ready question dock that can only fail with `no_pending_tool_call`, leaving the session stuck.

The fix reconciles durable session history with the live external-result registry at the backend session-read boundary. If the registry no longer has a pending entry for a ready running question, PawWork persists the part as `error` with interrupted metadata instead of exposing it as a live blocker.

## Related Issue

No GitHub issue yet. This PR is scoped to the exported-session bug report where a question dock survived restart and blocked the session from continuing.

## Human Review Status

Pending

## Review Focus

Please focus on whether `Session.messages()` is the right reconciliation boundary and whether the stale check is narrow enough: it only terminalizes `question` tool parts that are `running`, `externalResultReady === true`, and missing from `ExternalResult.lookup()`.

## Risk Notes

- The change mutates stale session parts during message reads. That is intentional so all consumers see the same terminal state, but reviewers should check that live pending questions remain untouched.
- Skipped visible UI/copy check: no visible UI or copy files changed; existing question interrupted rendering is reused.
- Skipped platform check: no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Skipped docs/release/dependency check: no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file behavior changed.

## How To Verify

```text
RED: bun test test/session/session.test.ts --test-name-pattern "messages terminalizes stale running external-result questions" initially failed with running != error.
Focused backend: bun test test/session/session.test.ts passed, 25 tests, including stale terminalization plus live pending and unready preservation coverage.
Tool route regression: bun test test/server/tool-respond-route.test.ts passed, 7 tests.
Backend typecheck: bun run typecheck passed.
Related app unit tests: bun test src/pages/session/blockers/use-session-blockers.test.ts src/pages/session/composer/session-question-dock.test.ts passed, 25 tests.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of unresolved questions by automatically marking stale external-result questions as errors with clear status indicators and interruption metadata.

* **Tests**
  * Added test coverage for stale question terminalization behavior during session message retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
