### PR TITLE
fix(ui): render tooltip shortcut hints as plain sans glyphs

### DIFF
--- a/packages/app/e2e/snap/keybind-tooltip.snap.ts
+++ b/packages/app/e2e/snap/keybind-tooltip.snap.ts
@@ -1,0 +1,74 @@
+import { expect } from "@playwright/test"
+import { test } from "../fixtures"
+import { applyDarkModeForTests } from "../utils"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 480, height: 200 }, deviceScaleFactor: 2 })
+
+// The keybind tooltip (titlebar / sidebar / composer shortcuts) only appears on
+// hover over a real button, and the shortcut suffix is the same DOM everywhere:
+// <span data-slot="tooltip-keybind-key">. Like worktree-tooltip, we inject that
+// DOM after the global CSS loads instead of standing up the app shell — the
+// shortcut's font/color come entirely from tooltip.css tokens, no Solid state.
+//
+// Guards two things: (1) the suffix renders in the sans stack, never monospace —
+// the mono cell width is what crammed ⇧⌘ into one squished blob; (2) the visual
+// grid lets a human confirm the glyphs read as separate keys, light and dark.
+
+const TOOLTIP_HTML = `
+  <div style="display:flex;align-items:center;justify-content:center;min-height:160px;background:var(--bg-base);">
+    <div data-component="tooltip" data-expanded style="position:static;opacity:1;animation:none;">
+      <div data-slot="tooltip-keybind">
+        <span>新建会话</span>
+        <span data-slot="tooltip-keybind-key">⇧⌘S</span>
+      </div>
+    </div>
+  </div>
+`
+
+async function mountTooltip(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate((html) => {
+    document.body.innerHTML = html
+  }, TOOLTIP_HTML)
+  await page.locator('[data-component="tooltip"][data-expanded]').waitFor({ state: "visible", timeout: 10_000 })
+}
+
+async function waitForThemeBoot(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForFunction(
+    () => getComputedStyle(document.documentElement).getPropertyValue("--bg-base").trim().length > 0,
+    null,
+    { timeout: 30_000 },
+  )
+}
+
+test("keybind-tooltip", async ({ page }) => {
+  test.setTimeout(120_000)
+
+  await page.goto("/")
+  await waitForThemeBoot(page)
+  await mountTooltip(page)
+
+  // Regression lock: the shortcut suffix must use the sans stack, never mono.
+  const fontFamily = await page
+    .locator('[data-slot="tooltip-keybind-key"]')
+    .evaluate((el) => getComputedStyle(el).fontFamily)
+  expect(fontFamily).toContain("system-ui")
+  expect(fontFamily.toLowerCase()).not.toContain("mono")
+
+  const lightShot: Shot = {
+    name: "light",
+    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+  }
+
+  await applyDarkModeForTests(page)
+  await waitForThemeBoot(page)
+  await mountTooltip(page)
+  const darkShot: Shot = {
+    name: "dark",
+    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+  }
+
+  const out = snapOutputPath("keybind-tooltip")
+  await composeGrid([lightShot, darkShot], out)
+  process.stdout.write(`\n[snap] keybind-tooltip grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/keybind-tooltip.snap.ts
+++ b/packages/app/e2e/snap/keybind-tooltip.snap.ts
@@ -3,7 +3,7 @@ import { test } from "../fixtures"
 import { applyDarkModeForTests } from "../utils"
 import { composeGrid, snapOutputPath, type Shot } from "./_compose"
 
-test.use({ viewport: { width: 480, height: 200 }, deviceScaleFactor: 2 })
+test.use({ viewport: { width: 520, height: 240 }, deviceScaleFactor: 2 })
 
 // The keybind tooltip (titlebar / sidebar / composer shortcuts) only appears on
 // hover over a real button, and the shortcut suffix is the same DOM everywhere:
@@ -11,26 +11,38 @@ test.use({ viewport: { width: 480, height: 200 }, deviceScaleFactor: 2 })
 // DOM after the global CSS loads instead of standing up the app shell — the
 // shortcut's font/color come entirely from tooltip.css tokens, no Solid state.
 //
-// Guards two things: (1) the suffix renders in the sans stack, never monospace —
-// the mono cell width is what crammed ⇧⌘ into one squished blob; (2) the visual
-// grid lets a human confirm the glyphs read as separate keys, light and dark.
+// Renders both UI languages (zh + en) stacked, because the chrome ships
+// bilingual: the label font switches by lang while the shortcut glyphs stay the
+// same Latin sans. Guards two things: (1) every suffix renders in the sans
+// stack, never monospace — the mono cell width is what crammed ⇧⌘ into one
+// squished blob; (2) the visual grid lets a human confirm the glyphs read as
+// separate keys across language and light/dark.
 
-const TOOLTIP_HTML = `
-  <div style="display:flex;align-items:center;justify-content:center;min-height:160px;background:var(--bg-base);">
-    <div data-component="tooltip" data-expanded style="position:static;opacity:1;animation:none;">
+const STAGE_HTML = `
+  <div
+    data-snap-stage
+    style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;min-height:200px;padding:20px;background:var(--bg-base);"
+  >
+    <div data-component="tooltip" data-expanded lang="zh" style="position:static;opacity:1;animation:none;">
       <div data-slot="tooltip-keybind">
         <span>新建会话</span>
+        <span data-slot="tooltip-keybind-key">⇧⌘S</span>
+      </div>
+    </div>
+    <div data-component="tooltip" data-expanded lang="en" style="position:static;opacity:1;animation:none;">
+      <div data-slot="tooltip-keybind">
+        <span>New session</span>
         <span data-slot="tooltip-keybind-key">⇧⌘S</span>
       </div>
     </div>
   </div>
 `
 
-async function mountTooltip(page: import("@playwright/test").Page): Promise<void> {
+async function mountStage(page: import("@playwright/test").Page): Promise<void> {
   await page.evaluate((html) => {
     document.body.innerHTML = html
-  }, TOOLTIP_HTML)
-  await page.locator('[data-component="tooltip"][data-expanded]').waitFor({ state: "visible", timeout: 10_000 })
+  }, STAGE_HTML)
+  await page.locator("[data-snap-stage]").waitFor({ state: "visible", timeout: 10_000 })
 }
 
 async function waitForThemeBoot(page: import("@playwright/test").Page): Promise<void> {
@@ -46,26 +58,30 @@ test("keybind-tooltip", async ({ page }) => {
 
   await page.goto("/")
   await waitForThemeBoot(page)
-  await mountTooltip(page)
+  await mountStage(page)
 
-  // Regression lock: the shortcut suffix must use the sans stack, never mono.
-  const fontFamily = await page
+  // Regression lock: every shortcut suffix (zh + en) must use the sans stack,
+  // never mono.
+  const fontFamilies = await page
     .locator('[data-slot="tooltip-keybind-key"]')
-    .evaluate((el) => getComputedStyle(el).fontFamily)
-  expect(fontFamily).toContain("system-ui")
-  expect(fontFamily.toLowerCase()).not.toContain("mono")
+    .evaluateAll((els) => els.map((el) => getComputedStyle(el).fontFamily))
+  expect(fontFamilies.length).toBe(2)
+  for (const family of fontFamilies) {
+    expect(family).toContain("system-ui")
+    expect(family.toLowerCase()).not.toContain("mono")
+  }
 
   const lightShot: Shot = {
     name: "light",
-    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+    buf: await page.locator("[data-snap-stage]").screenshot(),
   }
 
   await applyDarkModeForTests(page)
   await waitForThemeBoot(page)
-  await mountTooltip(page)
+  await mountStage(page)
   const darkShot: Shot = {
     name: "dark",
-    buf: await page.locator('[data-component="tooltip"]').screenshot(),
+    buf: await page.locator("[data-snap-stage]").screenshot(),
   }
 
   const out = snapOutputPath("keybind-tooltip")

--- a/packages/ui/src/components/tooltip.css
+++ b/packages/ui/src/components/tooltip.css
@@ -12,7 +12,7 @@
   /* The shortcut is plain OS-native glyphs (⇧⌘S), not a keycap (see DESIGN.md
      Tooltip). Only two properties are set; size / line-height / color inherit
      the tooltip's 13px cream text:
-       - sans, never mono (--type-kbd) — the monospace cell width crammed the
+       - sans, never the mono keycap font — its fixed cell width crammed the
          modifier glyphs into one squished blob;
        - caption weight (400), one step lighter than the label's 500 emphasis,
          so the shortcut reads as secondary metadata. */

--- a/packages/ui/src/components/tooltip.css
+++ b/packages/ui/src/components/tooltip.css
@@ -9,10 +9,13 @@
 }
 
 [data-slot="tooltip-keybind-key"] {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-kbd);
-  font-weight: var(--font-weight-kbd);
-  line-height: var(--line-height-kbd);
+  /* Plain OS-native glyphs (⇧⌘S), not a keycap — see DESIGN.md Tooltip.
+     Sans, not mono: the monospace cell width crammed the modifier glyphs
+     together, which read as one squished blob. */
+  font-family: var(--font-family-sans);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
   color: var(--bg-cream);
 }
 

--- a/packages/ui/src/components/tooltip.css
+++ b/packages/ui/src/components/tooltip.css
@@ -9,14 +9,15 @@
 }
 
 [data-slot="tooltip-keybind-key"] {
-  /* Plain OS-native glyphs (⇧⌘S), not a keycap — see DESIGN.md Tooltip.
-     Sans, not mono: the monospace cell width crammed the modifier glyphs
-     together, which read as one squished blob. */
+  /* The shortcut is plain OS-native glyphs (⇧⌘S), not a keycap (see DESIGN.md
+     Tooltip). Only two properties are set; size / line-height / color inherit
+     the tooltip's 13px cream text:
+       - sans, never mono (--type-kbd) — the monospace cell width crammed the
+         modifier glyphs into one squished blob;
+       - caption weight (400), one step lighter than the label's 500 emphasis,
+         so the shortcut reads as secondary metadata. */
   font-family: var(--font-family-sans);
-  font-size: 12px;
-  font-weight: var(--font-weight-emphasis);
-  line-height: 1.2;
-  color: var(--bg-cream);
+  font-weight: var(--font-weight-caption);
 }
 
 [data-component="tooltip"] {

--- a/packages/ui/src/components/tooltip.css
+++ b/packages/ui/src/components/tooltip.css
@@ -14,7 +14,7 @@
      together, which read as one squished blob. */
   font-family: var(--font-family-sans);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: var(--font-weight-emphasis);
   line-height: 1.2;
   color: var(--bg-cream);
 }


### PR DESCRIPTION
## Summary

Tooltip shortcut hints (e.g. `新建会话 ⇧⌘S`) rendered the shortcut suffix in `--font-family-mono`. The monospace cell width crammed the modifier glyphs (`⇧⌘`) into one squished blob. Switch `[data-slot="tooltip-keybind-key"]` to the sans stack at 12/500 — the macOS-menu convention (plain glyphs, no keycap). One CSS rule fixes every `TooltipKeybind` site (titlebar, sidebar, composer, session tabs, right-panel review) since they all share the slot.

No linked issue — reported directly from a screenshot of the titlebar tooltip.

## Why

The squish came from forcing a monospace font on the suffix, not from missing spacing or a missing keycap. macOS native menus render shortcuts as bare sans glyphs with no box; that is the user's muscle memory and the lightest treatment for a tertiary hover hint. A `.kbd` keycap was considered (it is the existing design spec) but rejected here as too heavy for a hover hint; the keycap stays for dense scannable surfaces (popover, command palette item-tail). Decision made against real side-by-side variants in the inverse tooltip surface.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

- The font swap on `[data-slot="tooltip-keybind-key"]` (mono → sans, 12/500). This is the whole behavior change.
- Scope: only the tooltip suffix changed. Command palette / popover / sidebar-reorder shortcuts still use the `.kbd` keycap box on purpose (separate surface, separate design rule) — see Risk Notes for the deferred consistency question.

## Risk Notes

- No platform/packaging surface: pure CSS in the web renderer, no `platform.*` / `window.api` branch. `system-ui` resolves to SF on macOS and Segoe on Windows; both render the glyphs cleanly. (macOS/Windows checklist item left unticked for that reason.)
- Local-only doc synced: `docs/DESIGN.md` Tooltip + Kbd sections updated to match (plain sans glyphs, keycap reserved for scannable surfaces). `docs/` is local-only in this repo, so it is not part of this diff.
- Deferred (out of this PR's scope): the same mono-glued shortcut also appears in the command palette item-tail, the sidebar reorder hint, popover shortcut keys, and the keybind editor — all in `.kbd` keycap boxes. Whether to also drop those to plain glyphs is a separate design decision and was not part of the approved scope.

## How To Verify

```text
bun run snap keybind-tooltip
  - asserts the suffix font-family is the sans stack (contains system-ui, not mono)
  - red on the old mono rule (1 failed), green after the fix (1 passed, light+dark grid)
packages/app typecheck (tsgo -b): clean
```

## Screenshots or Recordings

<img width="2152" height="480" alt="image" src="https://github.com/user-attachments/assets/9fc1a5dd-de5d-4f61-8600-1ac25da3731a" />

## Checklist

- [x] **Type label** — `bug`.
- [x] **Routing labels** — `ui`.
- [x] **Priority label** — `P3`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
