### PR TITLE
chore(release): bump desktop version to v2026.5.28

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.27",
+      "version": "2026.5.28",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.27",
+  "version": "2026.5.28",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary
- Bump PawWork desktop release version to 2026.5.28.

## Changes since v2026.5.27
- feat(ui): fold reasoning into trow block (#948)
- feat: align outbound HTTP headers with canonical OpenCode desktop (#940)
- feat(app): collapse notification settings to single tri-state control (#938)
- fix(ui): track List header surface via --list-surface (#954)
- fix(ui): render tooltip shortcut hints as plain sans glyphs (#955)
- fix(watcher): isolate macOS workspace roots
- fix(session): terminalize stale question blockers
- fix(session): unify transport error classification for stream disconnect recovery (#941)
- test: add route inventory guardrails
- ci: repair electron desktop build + install

## Verification
- `bun install --frozen-lockfile`
- `git diff --check`