### PR TITLE
fix: stabilize CI repair paths

### DIFF
--- a/packages/desktop-electron/scripts/repair-electron-install.mjs
+++ b/packages/desktop-electron/scripts/repair-electron-install.mjs
@@ -51,20 +51,44 @@ export function writeElectronPathFileIfInstallComplete(electronDir, platform = p
   return true
 }
 
-export function repairElectronInstall() {
-  const electronDir = join(require.resolve("electron/package.json"), "..")
-  const installScript = join(electronDir, "install.js")
+function resetElectronInstall(electronDir) {
+  rmSync(join(electronDir, "path.txt"), { force: true })
+  rmSync(join(electronDir, "dist"), { recursive: true, force: true })
+}
 
-  if (!writeElectronPathFileIfInstallComplete(electronDir)) {
-    rmSync(join(electronDir, "path.txt"), { force: true })
-    execFileSync(process.execPath, [installScript], { stdio: "inherit" })
+export function repairElectronInstallAt(
+  electronDir,
+  { installScript = join(electronDir, "install.js"), platform = process.platform, runInstall } = {},
+) {
+  const install =
+    runInstall ??
+    ((script, options) => {
+      execFileSync(process.execPath, [script], {
+        stdio: "inherit",
+        env: options.forceNoCache ? { ...process.env, force_no_cache: "true" } : process.env,
+      })
+    })
+
+  if (!writeElectronPathFileIfInstallComplete(electronDir, platform)) {
+    resetElectronInstall(electronDir)
+    install(installScript, { forceNoCache: false })
   }
 
-  if (!writeElectronPathFileIfInstallComplete(electronDir)) {
+  if (!writeElectronPathFileIfInstallComplete(electronDir, platform)) {
+    resetElectronInstall(electronDir)
+    install(installScript, { forceNoCache: true })
+  }
+
+  if (!writeElectronPathFileIfInstallComplete(electronDir, platform)) {
     throw new Error(`Electron install is still incomplete after repair: ${electronDir}`)
   }
 
-  console.log(`Electron install ready: ${join(electronDir, "dist", platformPathForElectron())}`)
+  console.log(`Electron install ready: ${join(electronDir, "dist", platformPathForElectron(platform))}`)
+}
+
+export function repairElectronInstall() {
+  const electronDir = join(require.resolve("electron/package.json"), "..")
+  repairElectronInstallAt(electronDir)
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/desktop-electron/scripts/repair-electron-install.mjs
+++ b/packages/desktop-electron/scripts/repair-electron-install.mjs
@@ -71,7 +71,11 @@ export function repairElectronInstallAt(
 
   if (!writeElectronPathFileIfInstallComplete(electronDir, platform)) {
     resetElectronInstall(electronDir)
-    install(installScript, { forceNoCache: false })
+    try {
+      install(installScript, { forceNoCache: false })
+    } catch {
+      // Fall through to the forced no-cache retry below.
+    }
   }
 
   if (!writeElectronPathFileIfInstallComplete(electronDir, platform)) {

--- a/packages/desktop-electron/scripts/repair-electron-install.mjs
+++ b/packages/desktop-electron/scripts/repair-electron-install.mjs
@@ -62,7 +62,7 @@ export function repairElectronInstallAt(
 ) {
   const install =
     runInstall ??
-    ((script, options) => {
+    ((script, options = {}) => {
       execFileSync(process.execPath, [script], {
         stdio: "inherit",
         env: options.forceNoCache ? { ...process.env, force_no_cache: "true" } : process.env,

--- a/packages/desktop-electron/scripts/repair-electron-install.mjs
+++ b/packages/desktop-electron/scripts/repair-electron-install.mjs
@@ -56,6 +56,17 @@ function resetElectronInstall(electronDir) {
   rmSync(join(electronDir, "dist"), { recursive: true, force: true })
 }
 
+export function electronInstallEnv({ forceNoCache = false } = {}) {
+  const env = { ...process.env }
+  delete env.ELECTRON_SKIP_BINARY_DOWNLOAD
+
+  if (forceNoCache) {
+    env.force_no_cache = "true"
+  }
+
+  return env
+}
+
 export function repairElectronInstallAt(
   electronDir,
   { installScript = join(electronDir, "install.js"), platform = process.platform, runInstall } = {},
@@ -65,7 +76,7 @@ export function repairElectronInstallAt(
     ((script, options = {}) => {
       execFileSync(process.execPath, [script], {
         stdio: "inherit",
-        env: options.forceNoCache ? { ...process.env, force_no_cache: "true" } : process.env,
+        env: electronInstallEnv(options),
       })
     })
 

--- a/packages/desktop-electron/scripts/repair-electron-install.test.ts
+++ b/packages/desktop-electron/scripts/repair-electron-install.test.ts
@@ -112,4 +112,39 @@ describe("repair Electron install", () => {
     expect(attempts).toEqual([false, true])
     expect(isElectronInstallComplete(electronDir, "darwin")).toBe(true)
   })
+
+  test("retries without the Electron artifact cache when the first reinstall fails", () => {
+    const electronDir = mkdtempSync(join(tmpdir(), "pawwork-electron-install-"))
+    const platformPath = platformPathForElectron("darwin")
+    const attempts: boolean[] = []
+
+    repairElectronInstallAt(electronDir, {
+      platform: "darwin",
+      runInstall(_installScript, options) {
+        attempts.push(options.forceNoCache)
+        if (!options.forceNoCache) throw new Error("cached artifact unavailable")
+
+        mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "MacOS"), { recursive: true })
+        mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "Frameworks", "Electron Framework.framework"), {
+          recursive: true,
+        })
+        writeFileSync(join(electronDir, "dist", platformPath), "")
+        writeFileSync(
+          join(
+            electronDir,
+            "dist",
+            "Electron.app",
+            "Contents",
+            "Frameworks",
+            "Electron Framework.framework",
+            "Electron Framework",
+          ),
+          "",
+        )
+      },
+    })
+
+    expect(attempts).toEqual([false, true])
+    expect(isElectronInstallComplete(electronDir, "darwin")).toBe(true)
+  })
 })

--- a/packages/desktop-electron/scripts/repair-electron-install.test.ts
+++ b/packages/desktop-electron/scripts/repair-electron-install.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
+  electronInstallEnv,
   isElectronInstallComplete,
   platformPathForElectron,
   repairElectronInstallAt,
@@ -12,6 +13,23 @@ import {
 describe("repair Electron install", () => {
   test("uses the macOS Electron executable path", () => {
     expect(platformPathForElectron("darwin")).toBe("Electron.app/Contents/MacOS/Electron")
+  })
+
+  test("does not let skip-download leak into repair installs", () => {
+    const previous = process.env.ELECTRON_SKIP_BINARY_DOWNLOAD
+    process.env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1"
+
+    try {
+      const env = electronInstallEnv({ forceNoCache: true })
+      expect(env.ELECTRON_SKIP_BINARY_DOWNLOAD).toBeUndefined()
+      expect(env.force_no_cache).toBe("true")
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ELECTRON_SKIP_BINARY_DOWNLOAD
+      } else {
+        process.env.ELECTRON_SKIP_BINARY_DOWNLOAD = previous
+      }
+    }
   })
 
   test("does not treat a macOS install as complete when the framework is missing", () => {

--- a/packages/desktop-electron/scripts/repair-electron-install.test.ts
+++ b/packages/desktop-electron/scripts/repair-electron-install.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   isElectronInstallComplete,
   platformPathForElectron,
+  repairElectronInstallAt,
   writeElectronPathFileIfInstallComplete,
 } from "./repair-electron-install.mjs"
 
@@ -39,5 +40,76 @@ describe("repair Electron install", () => {
     expect(isElectronInstallComplete(electronDir, "darwin")).toBe(true)
     expect(writeElectronPathFileIfInstallComplete(electronDir, "darwin")).toBe(true)
     expect(readFileSync(join(electronDir, "path.txt"), "utf8")).toBe(platformPath)
+  })
+
+  test("clears an incomplete Electron dist before reinstalling", () => {
+    const electronDir = mkdtempSync(join(tmpdir(), "pawwork-electron-install-"))
+    const platformPath = platformPathForElectron("darwin")
+    mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "MacOS"), { recursive: true })
+    writeFileSync(join(electronDir, "dist", platformPath), "")
+    writeFileSync(join(electronDir, "path.txt"), platformPath)
+
+    repairElectronInstallAt(electronDir, {
+      platform: "darwin",
+      runInstall() {
+        expect(existsSync(join(electronDir, "dist"))).toBe(false)
+        mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "MacOS"), { recursive: true })
+        mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "Frameworks", "Electron Framework.framework"), {
+          recursive: true,
+        })
+        writeFileSync(join(electronDir, "dist", platformPath), "")
+        writeFileSync(
+          join(
+            electronDir,
+            "dist",
+            "Electron.app",
+            "Contents",
+            "Frameworks",
+            "Electron Framework.framework",
+            "Electron Framework",
+          ),
+          "",
+        )
+      },
+    })
+
+    expect(isElectronInstallComplete(electronDir, "darwin")).toBe(true)
+    expect(readFileSync(join(electronDir, "path.txt"), "utf8")).toBe(platformPath)
+  })
+
+  test("retries without the Electron artifact cache when reinstall stays incomplete", () => {
+    const electronDir = mkdtempSync(join(tmpdir(), "pawwork-electron-install-"))
+    const platformPath = platformPathForElectron("darwin")
+    const attempts: boolean[] = []
+
+    repairElectronInstallAt(electronDir, {
+      platform: "darwin",
+      runInstall(_installScript, options) {
+        attempts.push(options.forceNoCache)
+        mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "MacOS"), { recursive: true })
+        writeFileSync(join(electronDir, "dist", platformPath), "")
+
+        if (options.forceNoCache) {
+          mkdirSync(join(electronDir, "dist", "Electron.app", "Contents", "Frameworks", "Electron Framework.framework"), {
+            recursive: true,
+          })
+          writeFileSync(
+            join(
+              electronDir,
+              "dist",
+              "Electron.app",
+              "Contents",
+              "Frameworks",
+              "Electron Framework.framework",
+              "Electron Framework",
+            ),
+            "",
+          )
+        }
+      },
+    })
+
+    expect(attempts).toEqual([false, true])
+    expect(isElectronInstallComplete(electronDir, "darwin")).toBe(true)
   })
 })

--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -166,6 +166,10 @@ function normalizePath(value: string) {
   return canonicalizeParams(pathOnly === "" ? "/" : pathOnly)
 }
 
+function normalizeRouteSourcePath(value: string) {
+  return value.replace(/\\/g, "/")
+}
+
 function canonicalizeParams(routePath: string) {
   return routePath
     .replace(/^\/auth\/:id\b/, "/auth/:providerID")
@@ -203,7 +207,7 @@ async function listTypeScriptFiles(root: string, relative: string): Promise<stri
     if (entry.isDirectory()) {
       files.push(...(await listTypeScriptFiles(root, child)))
     } else if (entry.isFile() && child.endsWith(".ts")) {
-      files.push(child)
+      files.push(normalizeRouteSourcePath(child))
     }
   }
   return files
@@ -230,15 +234,24 @@ async function discoverHonoRouteModules(root: string): Promise<string[]> {
   return routeModules.sort()
 }
 
+export function getMissingHonoRouteSources(expected: string[]): string[] {
+  const covered = [...honoRouteSources.map(([relative]) => relative), ...supplementalHonoRouteSources].map(
+    normalizeRouteSourcePath,
+  )
+  const coveredSet = new Set<string>(covered)
+  return expected.map(normalizeRouteSourcePath).filter((relative) => !coveredSet.has(relative))
+}
+
 export async function getHonoRouteSourceCoverage(rootInput?: string): Promise<HonoRouteSourceCoverage> {
   const root = repoRoot(rootInput)
   const expected = await discoverHonoRouteModules(root)
-  const covered = [...honoRouteSources.map(([relative]) => relative), ...supplementalHonoRouteSources].sort()
-  const coveredSet = new Set<string>(covered)
+  const covered = [...honoRouteSources.map(([relative]) => relative), ...supplementalHonoRouteSources]
+    .map(normalizeRouteSourcePath)
+    .sort()
   return {
     expected,
     covered,
-    missing: expected.filter((relative) => !coveredSet.has(relative)),
+    missing: getMissingHonoRouteSources(expected),
   }
 }
 

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -14,6 +14,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/app/session.spec.ts:@smoke session composer matches home structure without docktray or agent control",
   "packages/app/e2e/app/shell-frame.spec.ts:@smoke shell frame exposes stable desktop hooks",
   "packages/app/e2e/files/file-tree.spec.ts:@smoke review tab no longer renders the legacy file-tree sub-panel",
+  "packages/app/e2e/icon-viewbox-fit.spec.ts:@smoke every chrome icon fits inside the 0..20 viewBox",
   "packages/app/e2e/model-picker-height.spec.ts:@smoke model picker height fits content, no empty bottom space",
   "packages/app/e2e/models/model-picker-thinking.spec.ts:@smoke session re-entry restores thinking variant from the last user message",
   "packages/app/e2e/models/model-picker-thinking.spec.ts:@smoke thinking option click updates variant from nested model picker",

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -3,6 +3,7 @@ import {
   buildRouteInventory,
   findWorkspaceRoot,
   getHonoRouteSourceCoverage,
+  getMissingHonoRouteSources,
   parseHttpApiRoutesFromText,
   parseSdkRoutesFromText,
 } from "../../script/route-inventory"
@@ -139,5 +140,14 @@ describe("route inventory harness", () => {
     const coverage = await getHonoRouteSourceCoverage(root)
 
     expect(coverage.missing).toEqual([])
+  })
+
+  test("matches discovered Hono route modules when Windows uses backslash separators", () => {
+    expect(
+      getMissingHonoRouteSources([
+        "packages\\opencode\\src\\server\\control\\index.ts",
+        "packages\\opencode\\src\\server\\proxy.ts",
+      ]),
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Fixes two CI-only failure modes on `dev`:

- Normalize route inventory source paths before comparing discovered Hono route modules with the checked-in source list, so Windows path separators do not create false missing-source failures.
- Harden the desktop Electron install repair step by clearing incomplete `dist` installs before reinstalling, then retrying once with Electron artifact cache bypassed if the first reinstall is still incomplete.

No related issue; this PR follows up on failing `dev` CI runs for `desktop-smoke` and `windows-advisory`.

## Why

The latest `dev` CI had green `ci` and `codeql`, but `desktop-smoke` failed in `Repair Electron install` and `windows-advisory` failed route inventory on Windows. The Windows failure was deterministic path separator mismatch. The desktop smoke failure showed the repair script could rerun Electron's installer while leaving a partially-restored install in place.

## Related Issue

No issue. Direct CI stabilization for failing `dev` workflows.

## Human Review Status

Pending

## Review Focus

Please focus on whether the Electron repair retry is scoped tightly enough for CI cache corruption cases, and whether the route inventory path normalization preserves POSIX output for reports.

## Risk Notes

Skipped conditional checklist items:

- Visible UI/manual check: not applicable; no UI or copy changed.
- Docs/release/dependency/permission surfaces: not applicable; no docs, dependency, permission, credential, deletion, generated-content, or local-file behavior changed beyond CI repair cleanup of Electron install files.

Platform risk is intentional and covered: the route inventory change targets Windows path separators, and the Electron repair change targets macOS desktop-smoke install integrity.

## How To Verify

```text
RED route inventory: added Windows backslash source-path test; failed before implementation because getMissingHonoRouteSources did not exist.
GREEN opencode harness checks: cd packages/opencode && bun test --timeout 30000 test/config/e2e-smoke-tagging.test.ts test/server/route-inventory-harness.test.ts -> 12 pass, 0 fail.
RED Electron repair dist cleanup: added incomplete-dist repair test; failed before implementation because repairElectronInstallAt did not exist.
GREEN Electron repair: cd packages/desktop-electron && bun test --timeout 30000 scripts/repair-electron-install.test.ts -> 6 pass, 0 fail.
Review follow-up: first cached reinstall can throw; added regression test and no-cache retry fallback -> covered by the same 6-pass Electron repair test.
Typecheck opencode: cd packages/opencode && bun run typecheck -> passed.
Typecheck desktop-electron: cd packages/desktop-electron && bun run typecheck -> passed.
Real repair entrypoint: cd packages/desktop-electron && node ./scripts/repair-electron-install.mjs -> Electron install ready.
Rebased onto latest origin/dev and synced the new icon-viewbox smoke inventory entry introduced by #964.
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Electron installation repair with improved retry logic for failed or incomplete installations
  * Fixed Windows path separator handling in route discovery process

* **Tests**
  * Added tests for Electron reinstall recovery and retry scenarios
  * Added verification for Windows path compatibility in route module handling
  * Added smoke test for icon viewBox fit verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->