### PR TITLE
fix(session): repair stale paginated question blockers

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1130,7 +1130,7 @@ export const SessionRoutes = lazy(() =>
           return c.json(messages)
         }
 
-        const page = await MessageV2.page({
+        const page = await Session.messagesPage({
           sessionID,
           limit: query.limit,
           before: query.before,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -338,6 +338,11 @@ export const SetRevertInput = z.object({
   summary: Info.shape.summary,
 })
 export const MessagesInput = z.object({ sessionID: SessionID.zod, limit: z.number().optional() })
+export const MessagesPageInput = z.object({
+  sessionID: SessionID.zod,
+  limit: z.number(),
+  before: z.string().optional(),
+})
 const AbsoluteDirectory = z
   .string()
   .min(1, "Expected an absolute directory path")
@@ -524,6 +529,11 @@ export interface Interface {
   readonly findActiveWorktreeBinding: (directory: string) => Effect.Effect<Info | undefined>
   readonly diff: (sessionID: SessionID) => Effect.Effect<Snapshot.FileDiff[]>
   readonly messages: (input: { sessionID: SessionID; limit?: number }) => Effect.Effect<MessageV2.WithParts[]>
+  readonly messagesPage: (input: {
+    sessionID: SessionID
+    limit: number
+    before?: string
+  }) => Effect.Effect<ReturnType<typeof MessageV2.page>>
   readonly children: (parentID: SessionID) => Effect.Effect<Info[]>
   readonly remove: (sessionID: SessionID) => Effect.Effect<void>
   readonly updateMessage: <T extends MessageV2.Info>(msg: T) => Effect.Effect<T>
@@ -1032,6 +1042,20 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       return yield* terminalizeStaleExternalResultQuestions(items)
     })
 
+    const messagesPage = Effect.fn("Session.messagesPage")(function* (input: {
+      sessionID: SessionID
+      limit: number
+      before?: string
+    }) {
+      const page = MessageV2.page({
+        sessionID: input.sessionID,
+        limit: input.limit,
+        before: input.before,
+      })
+      const items = yield* terminalizeStaleExternalResultQuestions(page.items)
+      return { ...page, items }
+    })
+
     const removeMessage = Effect.fn("Session.removeMessage")(function* (input: {
       sessionID: SessionID
       messageID: MessageID
@@ -1096,6 +1120,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       findActiveWorktreeBinding,
       diff,
       messages,
+      messagesPage,
       children,
       remove,
       updateMessage,
@@ -1125,6 +1150,7 @@ export const setTitle = fn(SetTitleInput, (input) => runPromise((svc) => svc.set
 export const setArchived = fn(SetArchivedInput, (input) => runPromise((svc) => svc.setArchived(input)))
 export const setPermission = fn(SetPermissionInput, (input) => runPromise((svc) => svc.setPermission(input)))
 export const messages = fn(MessagesInput, (input) => runPromise((svc) => svc.messages(input)))
+export const messagesPage = fn(MessagesPageInput, (input) => runPromise((svc) => svc.messagesPage(input)))
 export const removePart = fn(RemovePartInput, (input) => runPromise((svc) => svc.removePart(input)))
 export const updateMessage = fn(MessageV2.Info, (input) => runPromise((svc) => svc.updateMessage(input)))
 export const updatePart = fn(MessageV2.Part, (input) => runPromise((svc) => svc.updatePart(input)))

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -74,14 +74,15 @@ async function fill(sessionID: SessionID, count: number, time = (i: number) => D
   return ids
 }
 
-async function createRunningQuestionSession(directory: string, input?: { externalResultReady?: boolean }) {
+async function createRunningQuestionSession(directory: string, input?: { externalResultReady?: boolean; time?: number }) {
   const session = await svc.create({})
   const userID = MessageID.ascending()
+  const time = input?.time ?? Date.now()
   await svc.updateMessage({
     id: userID,
     sessionID: session.id,
     role: "user",
-    time: { created: Date.now() },
+    time: { created: time },
     agent: "user",
     model: { providerID: "test", modelID: "test" },
     tools: {},
@@ -94,7 +95,7 @@ async function createRunningQuestionSession(directory: string, input?: { externa
     sessionID: session.id,
     role: "assistant",
     parentID: userID,
-    time: { created: Date.now() },
+    time: { created: time + 1 },
     agent: "build",
     mode: "build",
     path: { cwd: directory, root: directory },
@@ -130,7 +131,7 @@ async function createRunningQuestionSession(directory: string, input?: { externa
         ],
       },
       raw: "",
-      time: { start: Date.now() },
+      time: { start: time + 2 },
       metadata: { externalResultReady: input?.externalResultReady ?? true },
     },
   } as unknown as MessageV2.Part)
@@ -158,6 +159,47 @@ describe("session messages endpoint", () => {
           const res = await app.request(`/session/${session.id}/message?limit=2`)
           expect(res.status).toBe(200)
           const body = (await res.json()) as MessageV2.WithParts[]
+          const part = expectToolPart(body.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("error")
+          if (part.state.status !== "error") throw new Error("expected error state")
+          expect(part.state.metadata?.interrupted).toBe(true)
+          expect(part.state.metadata?.stale_external_result).toBe(true)
+
+          const persisted = expectToolPart(
+            MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
+              (item) => item.id === partID,
+            ),
+          )
+          expect(persisted.state.status).toBe("error")
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
+  test("terminalizes stale running external-result questions when fetched from an older cursor page", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const time = Date.now()
+          const { session, assistantID, partID } = await createRunningQuestionSession(tmp.path, { time })
+          await fill(session.id, 3, (i) => time + 10 + i)
+          const app = Server.Default().app
+
+          const latest = await app.request(`/session/${session.id}/message?limit=2`)
+          expect(latest.status).toBe(200)
+          const cursor = latest.headers.get("x-next-cursor")
+          expect(cursor).toBeTruthy()
+
+          const older = await app.request(
+            `/session/${session.id}/message?limit=2&before=${encodeURIComponent(cursor!)}`,
+          )
+          expect(older.status).toBe(200)
+          const body = (await older.json()) as MessageV2.WithParts[]
           const part = expectToolPart(body.flatMap((msg) => msg.parts).find((item) => item.id === partID))
           expect(part.state.status).toBe("error")
           if (part.state.status !== "error") throw new Error("expected error state")

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -5,6 +5,7 @@ import { Server } from "../../src/server/server"
 import { Session as SessionNs } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { ExternalResult } from "../../src/tool/external-result"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 
@@ -31,6 +32,7 @@ const svc = {
 }
 
 afterEach(async () => {
+  ExternalResult.__resetForTests()
   await Instance.disposeAll()
 })
 
@@ -72,7 +74,161 @@ async function fill(sessionID: SessionID, count: number, time = (i: number) => D
   return ids
 }
 
+async function createRunningQuestionSession(directory: string, input?: { externalResultReady?: boolean }) {
+  const session = await svc.create({})
+  const userID = MessageID.ascending()
+  await svc.updateMessage({
+    id: userID,
+    sessionID: session.id,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "user",
+    model: { providerID: "test", modelID: "test" },
+    tools: {},
+    mode: "",
+  } as unknown as MessageV2.Info)
+
+  const assistantID = MessageID.ascending()
+  await svc.updateMessage({
+    id: assistantID,
+    sessionID: session.id,
+    role: "assistant",
+    parentID: userID,
+    time: { created: Date.now() },
+    agent: "build",
+    mode: "build",
+    path: { cwd: directory, root: directory },
+    cost: 0,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    modelID: "test",
+    providerID: "test",
+  } as unknown as MessageV2.Info)
+
+  const partID = PartID.ascending()
+  const callID = "call_stale_question"
+  await svc.updatePart({
+    id: partID,
+    sessionID: session.id,
+    messageID: assistantID,
+    type: "tool",
+    tool: "question",
+    callID,
+    state: {
+      status: "running",
+      input: {
+        questions: [
+          {
+            question: "Continue?",
+            options: [{ label: "Yes" }, { label: "No" }],
+          },
+        ],
+      },
+      raw: "",
+      time: { start: Date.now() },
+      metadata: { externalResultReady: input?.externalResultReady ?? true },
+    },
+  } as unknown as MessageV2.Part)
+
+  return { session, assistantID, partID, callID }
+}
+
+function expectToolPart(part: MessageV2.Part | undefined) {
+  expect(part?.type).toBe("tool")
+  if (part?.type !== "tool") throw new Error("expected tool part")
+  return part
+}
+
 describe("session messages endpoint", () => {
+  test("terminalizes stale running external-result questions in paginated responses", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { session, assistantID, partID } = await createRunningQuestionSession(tmp.path)
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/message?limit=2`)
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as MessageV2.WithParts[]
+          const part = expectToolPart(body.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("error")
+          if (part.state.status !== "error") throw new Error("expected error state")
+          expect(part.state.metadata?.interrupted).toBe(true)
+          expect(part.state.metadata?.stale_external_result).toBe(true)
+
+          const persisted = expectToolPart(
+            MessageV2.get({ sessionID: session.id, messageID: assistantID }).parts.find(
+              (item) => item.id === partID,
+            ),
+          )
+          expect(persisted.state.status).toBe("error")
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
+  test("preserves live pending external-result questions in paginated responses", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { session, assistantID, partID, callID } = await createRunningQuestionSession(tmp.path)
+          await Effect.runPromise(
+            ExternalResult.register({
+              sessionID: session.id,
+              messageID: assistantID,
+              callID,
+              inputSnapshot: { questions: ["q1"] },
+            }),
+          )
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/message?limit=2`)
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as MessageV2.WithParts[]
+          const part = expectToolPart(body.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("running")
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
+  test("preserves unready external-result questions in paginated responses", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { session, partID } = await createRunningQuestionSession(tmp.path, { externalResultReady: false })
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/message?limit=2`)
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as MessageV2.WithParts[]
+          const part = expectToolPart(body.flatMap((msg) => msg.parts).find((item) => item.id === partID))
+          expect(part.state.status).toBe("running")
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
   test("returns cursor headers for older pages", async () => {
     await using tmp = await tmpdir({ git: true })
     await withoutWatcher(() =>


### PR DESCRIPTION
## Summary

Repair stale external-result question blockers when session messages are loaded through the paginated message endpoint. This is a follow-up to #947: the full-history path was repaired, but the desktop app uses `GET /session/:sessionID/message?limit=...` and that route still bypassed the repair.

## Why

A session can be reopened after the app is shut down while a question tool is waiting for renderer input. If the in-memory `ExternalResult` is gone, the persisted question part is no longer answerable. The paginated endpoint previously returned that stale part as `running`, so the UI kept showing a question card and every response failed with "session restarted".

## Related Issue

No standalone issue. Follow-up regression from #947.

## Human Review Status

Pending

## Review Focus

Please check that stale-question terminalization stays in the session API layer instead of moving side effects into the low-level `MessageV2.page()` storage reader.

## Risk Notes

Skipped checklist items:

- Visible UI/manual screenshot: no visible UI or copy changed; the affected user-visible state is covered through the server route contract.
- macOS/Windows platform impact: no platform, packaging, updater, signing, shell, or permission surface changed.
- Docs/release/dependencies/generated/local files: none touched.

## How To Verify

```text
Diff check: git diff --check passed
RED: bun test test/server/session-messages.test.ts -t "terminalizes stale running external-result questions in paginated responses" failed before the fix with Expected "error", Received "running"
RED follow-up: bun test test/server/session-messages.test.ts -t "older cursor page" failed when the route was temporarily restored to direct MessageV2.page, with Expected "error", Received "running"
Server route tests: bun test test/server/session-messages.test.ts passed, 9 tests
Session stale-question tests: bun test test/session/session.test.ts -t "messages" passed, 3 tests
Tool response route tests: bun test test/server/tool-respond-route.test.ts passed, 7 tests
Typecheck: bun run typecheck passed
```

## Screenshots or Recordings

Not applicable. No visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
