### PR TITLE
feat(ui): display cache hit rate with one decimal place

### DIFF
--- a/packages/app/e2e/snap/session-context-cache.snap.ts
+++ b/packages/app/e2e/snap/session-context-cache.snap.ts
@@ -39,7 +39,7 @@ test("session-context-cache", async ({ page, llm, project }) => {
   await page.getByRole("tab", { name: "Context" }).click()
 
   await expect(panel.getByText("Cache Hit Rate")).toBeVisible()
-  await expect(panel.getByText("90%")).toBeVisible()
+  await expect(panel.getByText("90.0%")).toBeVisible()
   await expect(panel.getByText("Cache Tokens (read/write): 900 / 0")).toBeVisible()
 
   const toastCloseButtons = page.locator('[data-component="toast"] [data-slot="toast-close-button"]')

--- a/packages/app/src/components/session/session-context-format.ts
+++ b/packages/app/src/components/session/session-context-format.ts
@@ -7,10 +7,14 @@ export function createSessionContextFormatter(locale: string) {
       if (value === null) return "—"
       return value.toLocaleString(locale)
     },
-    percent(value: number | null | undefined) {
+    percent(value: number | null | undefined, fractionDigits?: number) {
       if (value === undefined) return "—"
       if (value === null) return "—"
-      return value.toLocaleString(locale) + "%"
+      const options =
+        fractionDigits === undefined
+          ? undefined
+          : { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }
+      return value.toLocaleString(locale, options) + "%"
     },
     time(value: number | undefined) {
       if (!value) return "—"

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -68,7 +68,7 @@ describe("getSessionContextMetrics", () => {
     expect(metrics.context?.compactThreshold).toBe(900)
     expect(metrics.context?.usagePercent).toBe(45)
     expect(metrics.context?.usage).toBe(45)
-    expect(metrics.context?.cacheHitRate).toBe(Math.round((25 / (300 + 25 + 25)) * 100))
+    expect(metrics.context?.cacheHitRate).toBe(7.1)
     expect(metrics.context?.providerLabel).toBe("OpenAI")
     expect(metrics.context?.modelLabel).toBe("GPT-4.1")
   })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -71,7 +71,7 @@ const cacheHitRate = (input: number, read: number, write: number) => {
   const denominator = input + read + write
   if (denominator <= 0) return null
   if (read <= 0) return null
-  return Math.round((read / denominator) * 100)
+  return Math.round((read / denominator) * 1000) / 10
 }
 
 const build = (messages: Message[] = [], providers: Provider[] = [], config: Config = {}): Metrics => {

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -194,7 +194,7 @@ export function SessionContextTab() {
     const hasCacheTokens = !!c && (c.cacheRead > 0 || c.cacheWrite > 0)
     return (
       <span class="flex flex-col gap-1" title={raw}>
-        <span class={cacheHitRateClass(value)}>{formatter().percent(value)}</span>
+        <span class={cacheHitRateClass(value)}>{formatter().percent(value, 1)}</span>
         <Show when={hasCacheTokens}>
           <span class="text-body text-fg-weak">{raw}</span>
         </Show>


### PR DESCRIPTION
## Summary

Round cache hit rate in session context panel to one decimal place instead of integer. Add optional `fractionDigits` parameter to `percent()` formatter so other percentage displays (e.g. context usage) remain unchanged. No related issue — this is a small self-contained enhancement.

## Why

The current integer display loses precision on small hit rates (e.g. 7.1% shows as 7%). One decimal place gives a meaningful improvement without visual noise.

## Related Issue

None.

## Human Review Status

Approved by @Astro-Han

## Review Focus

- The `percent()` formatter now takes an optional second argument; verify only cache hit rate passes it (line 197 in tab.tsx), not the usage stat (line 238).
- The formatter uses `toLocaleString(locale, { minimumFractionDigits, maximumFractionDigits })` instead of `toFixed` to preserve locale-aware decimal separators.

## Risk Notes

None. The change is backward-compatible: `percent(value)` without the second argument behaves identically to before.

## How To Verify

```text
bun test src/components/session/session-context-metrics.test.ts
  9 pass, 0 fail

bun x tsc --noEmit
  clean, no errors

PLAYWRIGHT_SNAP=1 bun run test:e2e:local -- e2e/snap/session-context-cache.snap.ts
  1 passed
```

## Screenshots or Recordings

E2E snap grid generated at `docs/design/preview/screenshots/session-context-cache.png` — visually confirmed by @Astro-Han: cache hit rate displays `90.0%` with one decimal place.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Cache hit rate metric now displays with one decimal place for improved precision (e.g., "90.0%" instead of "90%").
  * Enhanced cache hit rate calculation algorithm for more granular percentage accuracy in reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->