### PR TITLE
ci: stabilize e2e Playwright install

### DIFF
--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.playwright-browsers
           key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
-          restore-keys: |
+          restore-keys: |-
             playwright-${{ runner.os }}-
 
       - run: bun install --frozen-lockfile

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -134,10 +134,13 @@ jobs:
         with:
           path: ${{ github.workspace }}/.playwright-browsers
           key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
+        timeout-minutes: 5
         working-directory: packages/app
         run: bunx playwright install --with-deps chromium
 

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -19,6 +19,9 @@ describe("e2e artifacts workflow", () => {
     const filterStep = changesSteps.find((step) => step.id === "filter")
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
     const bunStep = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const playwrightCacheStep = steps.find(
+      (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
+    )
     const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
     const runStep = steps.find((step) => step.name === "Run e2e")
     const warnStep = steps.find((step) => step.name === "Warn on E2E failure")
@@ -60,6 +63,11 @@ describe("e2e artifacts workflow", () => {
     expect(checkoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(bunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
+    expect(playwrightCacheStep?.with?.key).toBe(
+      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
+    )
+    expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-\n")
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(5)
     expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -66,7 +66,7 @@ describe("e2e artifacts workflow", () => {
     expect(playwrightCacheStep?.with?.key).toBe(
       "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
     )
-    expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-\n")
+    expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
     expect(installBrowsersStep?.["timeout-minutes"]).toBe(5)
     expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -10,6 +10,7 @@ export type WorkflowStep = {
   name?: string
   run?: string
   shell?: string
+  "timeout-minutes"?: number
   uses?: string
   with?: Record<string, unknown>
   env?: Record<string, string>


### PR DESCRIPTION
## Summary

Stabilize the `e2e-artifacts` Playwright browser install step.

## Why

Recent PR runs repeatedly hung before tests started, inside `Install Playwright browsers`. Other e2e runs completed quickly when the Playwright browser cache was usable, but this workflow had no fallback restore key and allowed the install step to consume the whole 30-minute job timeout.

## Related Issue

No issue; this is a CI reliability follow-up discovered while validating PR #970.

## Human Review Status

Pending

## Review Focus

Please check whether the Playwright cache fallback is aligned with the existing perf workflow and whether the 5-minute browser install timeout is the right failure boundary.

## Risk Notes

No product behavior changes. This only affects the PR e2e workflow. Conditional checklist items left unticked: no visible UI/copy changed; no platform/packaging runtime surface changed; no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file artifacts are changed.

## How To Verify

```text
RED: bun test test/config/e2e-artifacts-workflow.test.ts failed because Playwright cache restore-keys was missing.
GREEN: bun test test/config/e2e-artifacts-workflow.test.ts -> 1 pass, 0 fail.
Related workflow tests: bun test test/config/e2e-artifacts-workflow.test.ts test/github/pr-triage-workflow.test.ts test/github/ci-workflow.test.ts -> 22 pass, 0 fail.
Diff hygiene: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
