### PR TITLE
ci: relax e2e Playwright install timeout

### DIFF
--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -140,7 +140,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        timeout-minutes: 5
+        timeout-minutes: 10
         working-directory: packages/app
         run: bunx playwright install --with-deps chromium
 

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -67,7 +67,7 @@ describe("e2e artifacts workflow", () => {
       "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(5)
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
     expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)


### PR DESCRIPTION
## Summary

Increase the `e2e-artifacts` Playwright browser install step timeout from 5 minutes to 10 minutes.

There is no separate issue for this tiny CI follow-up. It follows PR #974, where the 5-minute timeout made install hangs observable but proved too tight for a cold Playwright cache path.

## Why

PR #970 picked up the #974 workflow fix and exposed the cold-cache path: the Playwright browser cache missed, Chromium downloaded to 100%, and the install step was killed at exactly 5 minutes before it could finish. This keeps the install bounded while avoiding false failures on normal cold installs.

## Related Issue

Follow-up to #974; helps unblock #970.

## Human Review Status

Pending

## Review Focus

Confirm that 10 minutes is still a bounded install step but less aggressive for cold-cache Playwright installs.

## Risk Notes

No product behavior changes. This only affects CI runtime. The visible UI/copy checklist item is left unticked because no visible UI or copy changed. The platform checklist item is left unticked because this is Linux GitHub Actions CI only, not app platform behavior.

## How To Verify

```text
bun test test/config/e2e-artifacts-workflow.test.ts -> 1 pass, 0 fail.
bun run typecheck in packages/opencode -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

