### PR TITLE
chore(release): bump desktop version to v2026.5.29

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.28",
+      "version": "2026.5.29",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.28",
+  "version": "2026.5.29",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary
- Bump PawWork desktop release version to 2026.5.29.

## Changes since v2026.5.28
- feat(settings): move Connections to Integrations + global toast monitor (#975)
- feat(ui): display cache hit rate with one decimal place (#967)
- fix: stabilize session opening state (#969)
- fix(session): repair stale paginated question blockers (#962)
- fix(ui): refit read-file icon into 0-20 viewBox (#964)
- fix: allow running tools to expand
- fix: add run lifecycle diagnostics
- fix: harden Electron repair fallback
- refactor: remove legacy theme choices
- ci: stabilize e2e Playwright install and PR triage paths

## Verification
- `git diff --check`
- Diff scope matches prior release bump (#958): version string in `packages/desktop-electron/package.json` + workspace entry in `bun.lock`.