### PR TITLE
fix: set repository explicitly in electron-builder config

### DIFF
--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -139,14 +139,10 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # Avoid Playwright's browser download path here; on this runner it can
-      # hang after reaching 100%. Use the GitHub-hosted Chrome install instead.
-      - name: Install Playwright system dependencies
+      - name: Install Playwright browsers
         timeout-minutes: 10
         working-directory: packages/app
-        run: |
-          bunx playwright install-deps chromium
-          google-chrome --version
+        run: bunx playwright install --with-deps chromium
 
       - name: Run e2e
         id: run_e2e
@@ -155,8 +151,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           E2E_SUITE: ${{ inputs.suite || '' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
-          PLAYWRIGHT_BROWSER_CHANNEL: chrome
-          PLAYWRIGHT_VIDEO: "off"
         run: |
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
             bun --cwd packages/app test:e2e:local:smoke

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -156,6 +156,7 @@ jobs:
           E2E_SUITE: ${{ inputs.suite || '' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
           PLAYWRIGHT_BROWSER_CHANNEL: chrome
+          PLAYWRIGHT_VIDEO: "off"
         run: |
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
             bun --cwd packages/app test:e2e:local:smoke

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -133,16 +133,16 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: ${{ github.workspace }}/.playwright-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
           restore-keys: |-
             playwright-${{ runner.os }}-
 
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        timeout-minutes: 20
+        timeout-minutes: 10
         working-directory: packages/app
-        run: ./node_modules/.bin/playwright install --with-deps chromium
+        run: bunx playwright install --with-deps chromium
 
       - name: Run e2e
         id: run_e2e

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -139,10 +139,14 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Install Playwright browsers
+      # Avoid Playwright's browser download path here; on this runner it can
+      # hang after reaching 100%. Use the GitHub-hosted Chrome install instead.
+      - name: Install Playwright system dependencies
         timeout-minutes: 10
         working-directory: packages/app
-        run: bunx playwright install --with-deps chromium
+        run: |
+          bunx playwright install-deps chromium
+          google-chrome --version
 
       - name: Run e2e
         id: run_e2e
@@ -151,6 +155,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           E2E_SUITE: ${{ inputs.suite || '' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
+          PLAYWRIGHT_BROWSER_CHANNEL: chrome
+          PLAYWRIGHT_VIDEO: "off"
         run: |
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
             bun --cwd packages/app test:e2e:local:smoke

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
           path: ${{ github.workspace }}/.playwright-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json') }}
           restore-keys: |-
             playwright-${{ runner.os }}-
 
@@ -142,7 +142,7 @@ jobs:
       - name: Install Playwright browsers
         timeout-minutes: 10
         working-directory: packages/app
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps --only-shell chromium
 
       - name: Run e2e
         id: run_e2e

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -139,26 +139,14 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # The browser download intermittently hangs at 100% on the runner,
-      # so retry it with a short per-attempt timeout instead of a single
-      # long wait. System deps are installed once up front. (#979)
-      - name: Install Playwright browsers
-        timeout-minutes: 15
+      # Avoid Playwright's browser download path here; on this runner it can
+      # hang after reaching 100%. Use the GitHub-hosted Chrome install instead.
+      - name: Install Playwright system dependencies
+        timeout-minutes: 10
         working-directory: packages/app
         run: |
           bunx playwright install-deps chromium
-          for attempt in 1 2 3 4; do
-            echo "::group::Install chromium (attempt $attempt)"
-            if timeout --kill-after=10 180 bunx playwright install chromium; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "::warning::Playwright chromium install attempt $attempt failed or timed out; retrying"
-            sleep 5
-          done
-          echo "::error::Playwright chromium install failed after 4 attempts"
-          exit 1
+          google-chrome --version
 
       - name: Run e2e
         id: run_e2e
@@ -167,6 +155,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           E2E_SUITE: ${{ inputs.suite || '' }}
           PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-linux.xml
+          PLAYWRIGHT_BROWSER_CHANNEL: chrome
         run: |
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$E2E_SUITE" = "smoke" ]; then
             bun --cwd packages/app test:e2e:local:smoke

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -140,7 +140,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        timeout-minutes: 10
+        timeout-minutes: 20
         working-directory: packages/app
         run: bunx playwright install --with-deps --only-shell chromium
 

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -139,10 +139,26 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # The browser download intermittently hangs at 100% on the runner,
+      # so retry it with a short per-attempt timeout instead of a single
+      # long wait. System deps are installed once up front. (#979)
       - name: Install Playwright browsers
-        timeout-minutes: 10
+        timeout-minutes: 15
         working-directory: packages/app
-        run: bunx playwright install --with-deps chromium
+        run: |
+          bunx playwright install-deps chromium
+          for attempt in 1 2 3 4; do
+            echo "::group::Install chromium (attempt $attempt)"
+            if timeout --kill-after=10 180 bunx playwright install chromium; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::Playwright chromium install attempt $attempt failed or timed out; retrying"
+            sleep 5
+          done
+          echo "::error::Playwright chromium install failed after 4 attempts"
+          exit 1
 
       - name: Run e2e
         id: run_e2e

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Install Playwright browsers
         timeout-minutes: 20
         working-directory: packages/app
-        run: bunx playwright install --with-deps --only-shell chromium
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Run e2e
         id: run_e2e

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -8,8 +8,10 @@ const command = process.env.PLAYWRIGHT_WEB_COMMAND ?? `bun run dev -- --host 0.0
 const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1"
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
+const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
 const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
 const trace = process.env.PAWWORK_PERF_TRACE === "1" ? "on" : "on-first-retry"
+const video = process.env.PLAYWRIGHT_VIDEO === "off" ? "off" : "retain-on-failure"
 
 if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
   reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
@@ -52,12 +54,12 @@ export default defineConfig({
     baseURL,
     trace,
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video,
   },
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], ...(browserChannel ? { channel: browserChannel } : {}) },
     },
   ],
 })

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -8,6 +8,7 @@ const command = process.env.PLAYWRIGHT_WEB_COMMAND ?? `bun run dev -- --host 0.0
 const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1"
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
+const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
 const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
 const trace = process.env.PAWWORK_PERF_TRACE === "1" ? "on" : "on-first-retry"
 
@@ -57,7 +58,7 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], ...(browserChannel ? { channel: browserChannel } : {}) },
     },
   ],
 })

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -11,6 +11,7 @@ const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0
 const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
 const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
 const trace = process.env.PAWWORK_PERF_TRACE === "1" ? "on" : "on-first-retry"
+const video = process.env.PLAYWRIGHT_VIDEO === "off" ? "off" : "retain-on-failure"
 
 if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
   reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
@@ -53,7 +54,7 @@ export default defineConfig({
     baseURL,
     trace,
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video,
   },
   projects: [
     {

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -8,10 +8,8 @@ const command = process.env.PLAYWRIGHT_WEB_COMMAND ?? `bun run dev -- --host 0.0
 const skipWebServer = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1"
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
-const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
 const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
 const trace = process.env.PAWWORK_PERF_TRACE === "1" ? "on" : "on-first-retry"
-const video = process.env.PLAYWRIGHT_VIDEO === "off" ? "off" : "retain-on-failure"
 
 if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
   reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
@@ -54,12 +52,12 @@ export default defineConfig({
     baseURL,
     trace,
     screenshot: "only-on-failure",
-    video,
+    video: "retain-on-failure",
   },
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"], ...(browserChannel ? { channel: browserChannel } : {}) },
+      use: { ...devices["Desktop Chrome"] },
     },
   ],
 })

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -103,6 +103,10 @@ async function writeLocalizedMacDisplayName(resourcesDir: string, channel: Chann
 
 const getBase = (): Configuration => ({
   artifactName: "pawwork-${os}-${arch}-${version}.${ext}",
+  // electron-builder reads .git/config for repository info, which fails on
+  // CI runners with persist-credentials: false. Set explicitly to avoid
+  // "Cannot detect repository by .git/config" on Windows.
+  repository: { owner: "Astro-Han", repo: "pawwork" },
   directories: {
     output: "dist",
     buildResources: "resources",

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -103,15 +103,18 @@ async function writeLocalizedMacDisplayName(resourcesDir: string, channel: Chann
 
 const getBase = (): Configuration => ({
   artifactName: "pawwork-${os}-${arch}-${version}.${ext}",
-  // electron-builder reads .git/config for repository info, which fails on
-  // CI runners with persist-credentials: false. Set explicitly to avoid
-  // "Cannot detect repository by .git/config" on Windows.
-  repository: { owner: "Astro-Han", repo: "pawwork" },
+
   directories: {
     output: "dist",
     buildResources: "resources",
   },
   files: ["out/**/*", "resources/**/*"],
+  // electron-builder reads .git/config for repository info, which fails on
+  // CI runners with persist-credentials: false. Set explicitly via
+  // extraMetadata to avoid "Cannot detect repository by .git/config".
+  extraMetadata: {
+    repository: { type: "git", url: "https://github.com/Astro-Han/pawwork" },
+  },
   extraResources: [
     ...nativeWatcherFileSets(),
     {

--- a/packages/desktop-electron/scripts/finalize-latest-yml.ts
+++ b/packages/desktop-electron/scripts/finalize-latest-yml.ts
@@ -115,7 +115,9 @@ function shellErrorText(error: unknown) {
 function isMissingAssetError(message: string) {
   // `gh release download` does not expose an asset-missing exit code, so keep this
   // narrow and let generic 404/release/repo/auth failures propagate.
-  return /no assets to download|no matches found|could not find any assets|release not found/i.test(message)
+  return /no assets to download|no matches found|no assets match|could not find any assets|release not found/i.test(
+    message,
+  )
 }
 
 function assertSameVersion(source: string, filename: string, data: LatestYml | undefined) {

--- a/packages/desktop-electron/scripts/finalize-latest-yml.ts
+++ b/packages/desktop-electron/scripts/finalize-latest-yml.ts
@@ -115,7 +115,7 @@ function shellErrorText(error: unknown) {
 function isMissingAssetError(message: string) {
   // `gh release download` does not expose an asset-missing exit code, so keep this
   // narrow and let generic 404/release/repo/auth failures propagate.
-  return /no assets to download|no matches found|could not find any assets/i.test(message)
+  return /no assets to download|no matches found|could not find any assets|release not found/i.test(message)
 }
 
 function assertSameVersion(source: string, filename: string, data: LatestYml | undefined) {

--- a/packages/desktop-electron/scripts/release-metadata-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-metadata-contract.test.ts
@@ -191,6 +191,29 @@ describe("release metadata finalizer", () => {
     expect(latestMac).toContain("PawWork-snapshot-x64.zip")
   })
 
+  test("uses predownloaded metadata when live download returns release not found", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
+    roots.push(root)
+    const latestDir = join(root, "latest-yml")
+    const runnerTemp = join(root, "runner")
+    const binDir = join(root, "bin")
+    const snapshotDir = join(root, "snapshot")
+    mkdirSync(runnerTemp, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(snapshotDir, { recursive: true })
+    writeFakeGh(binDir, {}, "release not found")
+    writeLatest(snapshotDir, "latest-mac.yml", "PawWork-snapshot-x64.zip")
+
+    writeLatest(join(latestDir, "latest-yml-aarch64-apple-darwin"), "latest-mac.yml", "PawWork-new-arm64.zip")
+
+    const proc = spawnFinalizer(binDir, latestDir, runnerTemp, { EXISTING_LATEST_YML_DIR: snapshotDir })
+
+    expect(await proc.exited).toBe(0)
+    const latestMac = readFileSync(join(runnerTemp, "latest-mac.yml"), "utf8")
+    expect(latestMac).toContain("PawWork-new-arm64.zip")
+    expect(latestMac).toContain("PawWork-snapshot-x64.zip")
+  })
+
   test("fails when existing metadata download has a non-missing error", async () => {
     const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
     roots.push(root)
@@ -350,7 +373,11 @@ function writeFakeGh(binDir: string, downloads: Record<string, string | FixtureF
   }
 
   const script = join(binDir, "gh")
-  writeFileSync(script, `#!/usr/bin/env bash\nexec ${shellQuote(process.execPath)} ${shellQuote(helper)} "$@"\n`, "utf8")
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash\nexec ${shellQuote(process.execPath)} ${shellQuote(helper)} "$@"\n`,
+    "utf8",
+  )
   chmodSync(script, 0o755)
 }
 

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -68,7 +68,7 @@ describe("e2e artifacts workflow", () => {
       "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(20)
     expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps --only-shell chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -22,7 +22,7 @@ describe("e2e artifacts workflow", () => {
     const playwrightCacheStep = steps.find(
       (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
-    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
+    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright system dependencies")
     const runStep = steps.find((step) => step.name === "Run e2e")
     const warnStep = steps.find((step) => step.name === "Warn on E2E failure")
     const uploadStep = steps.find((step) => step.name === "Upload e2e artifacts")
@@ -67,10 +67,10 @@ describe("e2e artifacts workflow", () => {
       "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(15)
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
     expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
-    expect(installBrowsersStep?.run).toContain("timeout --kill-after=10 180 bunx playwright install chromium")
-    expect(installBrowsersStep?.run).toContain("attempt")
+    expect(installBrowsersStep?.run).not.toContain("playwright install chromium")
+    expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -22,7 +22,7 @@ describe("e2e artifacts workflow", () => {
     const playwrightCacheStep = steps.find(
       (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
-    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
+    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright system dependencies")
     const runStep = steps.find((step) => step.name === "Run e2e")
     const warnStep = steps.find((step) => step.name === "Warn on E2E failure")
     const uploadStep = steps.find((step) => step.name === "Upload e2e artifacts")
@@ -68,7 +68,10 @@ describe("e2e artifacts workflow", () => {
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
     expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
-    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
+    expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
+    expect(installBrowsersStep?.run).not.toContain("playwright install chromium")
+    expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
+    expect(runStep?.env?.PLAYWRIGHT_VIDEO).toBe("off")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -20,7 +20,8 @@ describe("e2e artifacts workflow", () => {
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
     const bunStep = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
     const playwrightCacheStep = steps.find(
-      (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
+      (step) =>
+        step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
     const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
     const runStep = steps.find((step) => step.name === "Run e2e")
@@ -64,11 +65,11 @@ describe("e2e artifacts workflow", () => {
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(bunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
     expect(playwrightCacheStep?.with?.key).toBe(
-      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
+      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
     expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
-    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
+    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps --only-shell chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")
@@ -85,8 +86,8 @@ describe("e2e artifacts workflow", () => {
     expect(checkJob?.["runs-on"]).toBe("ubuntu-latest")
     expect(validateStep?.env?.DOCS_ONLY).toBe("${{ needs.changes.outputs.docs_only }}")
     expect(validateStep?.env?.E2E_RESULT).toBe("${{ needs.e2e-artifacts.result }}")
-    expect(validateStep?.run).toContain("if [ \"$DOCS_ONLY\" = \"true\" ]")
-    expect(validateStep?.run).toContain("if [ \"$E2E_RESULT\" != \"success\" ]")
+    expect(validateStep?.run).toContain('if [ "$DOCS_ONLY" = "true" ]')
+    expect(validateStep?.run).toContain('if [ "$E2E_RESULT" != "success" ]')
     expect(workflow).not.toContain("pull_request_target:")
     expect(workflow).not.toMatch(/\/Users\/[^/]+\//)
     expect(workflow).not.toMatch(/\/home\/[^/]+\//)

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -69,7 +69,7 @@ describe("e2e artifacts workflow", () => {
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
     expect(installBrowsersStep?.["timeout-minutes"]).toBe(20)
-    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps --only-shell chromium")
+    expect(installBrowsersStep?.run).toBe("./node_modules/.bin/playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -20,8 +20,7 @@ describe("e2e artifacts workflow", () => {
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
     const bunStep = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
     const playwrightCacheStep = steps.find(
-      (step) =>
-        step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
+      (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
     const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
     const runStep = steps.find((step) => step.name === "Run e2e")
@@ -65,11 +64,11 @@ describe("e2e artifacts workflow", () => {
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(bunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
     expect(playwrightCacheStep?.with?.key).toBe(
-      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json') }}",
+      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(20)
-    expect(installBrowsersStep?.run).toBe("./node_modules/.bin/playwright install --with-deps chromium")
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
+    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")
@@ -86,8 +85,8 @@ describe("e2e artifacts workflow", () => {
     expect(checkJob?.["runs-on"]).toBe("ubuntu-latest")
     expect(validateStep?.env?.DOCS_ONLY).toBe("${{ needs.changes.outputs.docs_only }}")
     expect(validateStep?.env?.E2E_RESULT).toBe("${{ needs.e2e-artifacts.result }}")
-    expect(validateStep?.run).toContain('if [ "$DOCS_ONLY" = "true" ]')
-    expect(validateStep?.run).toContain('if [ "$E2E_RESULT" != "success" ]')
+    expect(validateStep?.run).toContain("if [ \"$DOCS_ONLY\" = \"true\" ]")
+    expect(validateStep?.run).toContain("if [ \"$E2E_RESULT\" != \"success\" ]")
     expect(workflow).not.toContain("pull_request_target:")
     expect(workflow).not.toMatch(/\/Users\/[^/]+\//)
     expect(workflow).not.toMatch(/\/home\/[^/]+\//)

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -67,8 +67,10 @@ describe("e2e artifacts workflow", () => {
       "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
-    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
+    expect(installBrowsersStep?.["timeout-minutes"]).toBe(15)
+    expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
+    expect(installBrowsersStep?.run).toContain("timeout --kill-after=10 180 bunx playwright install chromium")
+    expect(installBrowsersStep?.run).toContain("attempt")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -71,6 +71,7 @@ describe("e2e artifacts workflow", () => {
     expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
     expect(installBrowsersStep?.run).not.toContain("playwright install chromium")
     expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
+    expect(runStep?.env?.PLAYWRIGHT_VIDEO).toBe("off")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -22,7 +22,7 @@ describe("e2e artifacts workflow", () => {
     const playwrightCacheStep = steps.find(
       (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
-    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright system dependencies")
+    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright browsers")
     const runStep = steps.find((step) => step.name === "Run e2e")
     const warnStep = steps.find((step) => step.name === "Warn on E2E failure")
     const uploadStep = steps.find((step) => step.name === "Upload e2e artifacts")
@@ -68,10 +68,7 @@ describe("e2e artifacts workflow", () => {
     )
     expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
     expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
-    expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
-    expect(installBrowsersStep?.run).not.toContain("playwright install chromium")
-    expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
-    expect(runStep?.env?.PLAYWRIGHT_VIDEO).toBe("off")
+    expect(installBrowsersStep?.run).toBe("bunx playwright install --with-deps chromium")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")
     expect(runStep?.["continue-on-error"]).not.toBe(true)
     expect(warnStep?.if).toBe("failure()")


### PR DESCRIPTION
electron-builder reads .git/config for repository info during packaging. On CI runners with persist-credentials: false (all build jobs), the remote URL is absent, causing 'Cannot detect repository by .git/config' on Windows builds. Set the repository field explicitly so electron-builder skips .git/config lookup.

Fixes Windows full build failure (run 26608667785).