### PR TITLE
fix: set repository via extraMetadata in electron-builder config

### DIFF
--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -80,6 +80,18 @@ describe("electron builder app-update config", () => {
     expect(createConfig("prod").artifactName).toBe("pawwork-${os}-${arch}-${version}.${ext}")
   })
 
+  test("packaged repository metadata follows the release channel", () => {
+    expect(createConfig("dev").extraMetadata).toMatchObject({
+      repository: { type: "git", url: "https://github.com/Astro-Han/pawwork" },
+    })
+    expect(createConfig("prod").extraMetadata).toMatchObject({
+      repository: { type: "git", url: "https://github.com/Astro-Han/pawwork" },
+    })
+    expect(createConfig("beta").extraMetadata).toMatchObject({
+      repository: { type: "git", url: "https://github.com/Astro-Han/pawwork-beta" },
+    })
+  })
+
   test("packages third-party notices into app resources", () => {
     const config = createConfig("prod")
     expect(config.extraResources).toEqual(

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -101,7 +101,9 @@ async function writeLocalizedMacDisplayName(resourcesDir: string, channel: Chann
   }
 }
 
-const getBase = (): Configuration => ({
+const repositoryUrl = (channel: Channel) => `https://github.com/Astro-Han/${getPublishConfig(channel)?.repo ?? "pawwork"}`
+
+const getBase = (channel: Channel): Configuration => ({
   artifactName: "pawwork-${os}-${arch}-${version}.${ext}",
   directories: {
     output: "dist",
@@ -112,7 +114,7 @@ const getBase = (): Configuration => ({
   // CI runners with persist-credentials: false. Set explicitly via
   // extraMetadata to avoid "Cannot detect repository by .git/config".
   extraMetadata: {
-    repository: { type: "git", url: "https://github.com/Astro-Han/pawwork" },
+    repository: { type: "git", url: repositoryUrl(channel) },
   },
   extraResources: [
     ...nativeWatcherFileSets(),
@@ -181,7 +183,7 @@ const getBase = (): Configuration => ({
 })
 
 export function createConfig(channel: Channel = currentChannel(), baseOverrides: Partial<Configuration> = {}) {
-  const base = { ...getBase(), ...baseOverrides }
+  const base = { ...getBase(channel), ...baseOverrides }
   const publish = getPublishConfig(channel)
 
   const withAppUpdateConfig = (configuration: Configuration): Configuration => ({

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -108,6 +108,12 @@ const getBase = (): Configuration => ({
     buildResources: "resources",
   },
   files: ["out/**/*", "resources/**/*"],
+  // electron-builder reads .git/config for repository info, which fails on
+  // CI runners with persist-credentials: false. Set explicitly via
+  // extraMetadata to avoid "Cannot detect repository by .git/config".
+  extraMetadata: {
+    repository: { type: "git", url: "https://github.com/Astro-Han/pawwork" },
+  },
   extraResources: [
     ...nativeWatcherFileSets(),
     {


### PR DESCRIPTION
## Summary

Set `repository` via `extraMetadata` in electron-builder config so packaging does not depend on `.git/config`.

## Why

Windows `full` release build (run 26608667785) fails at the `Package app` step with:
```
Cannot detect repository by .git/config. Please specify "repository" in the package.json
```

The build workflow uses `persist-credentials: false` on checkout, so `.git/config` has no remote URL. electron-builder's `PublishManager.getInfo()` reads `.git/config` to detect the repository even when an explicit `publish` config is provided. `extraMetadata.repository` injects the field into package metadata before build, so `repositoryInfo.js` resolves it from metadata instead of falling back to `.git/config`.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Whether `extraMetadata.repository` is the right mechanism vs adding `repository` directly to `packages/desktop-electron/package.json`. Both work; `extraMetadata` avoids changing the published package metadata source.

## Risk Notes

- `extraMetadata` writes `repository` into the packaged app's `package.json` inside the asar. This is cosmetic and has no functional impact.
- Dev channel has `publish: undefined`. With this fix, CI with `GITHUB_TOKEN` will auto-detect `Astro-Han/pawwork` as the publish target. This matches the current behavior on macOS (which never hit this code path because finalize skips packaging). No change in release intent.

## How To Verify

```text
electron-builder.config.ts: extraMetadata.repository added after files field
Typecheck: passes (npm run typecheck or CI typecheck check)
Release verification: re-run workflow_dispatch release full windows x64 after merge
```

## Screenshots or Recordings

Not applicable — no visible UI change.

## Checklist

- [x] **Type label** — `bug`
- [ ] **Routing labels** — waiting for labeler bot
- [ ] **Priority label** — waiting for priority-triage bot
- [x] Human Review Status above is set to `Pending`
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed — not applicable, no UI change.
- [x] **(conditional)** I considered macOS and Windows impact — this is a platform/packaging fix for Windows CI.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant — none of those surfaces touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.