### PR TITLE
feat: execute automation run now

### DIFF
--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -7,6 +7,7 @@ import { ProjectID } from "@/project/schema"
 import { PermissionID } from "@/permission/schema"
 import { SessionID } from "@/session/schema"
 import { NotFoundError } from "@/storage/db"
+import type { AutomationRunAttendance, AutomationRunBlocker } from "./run-context"
 
 export const AutomationID = {
   Definition: {
@@ -232,8 +233,16 @@ export namespace Automation {
   type State = {
     definitions: Map<string, Definition>
     runs: Map<string, Run[]>
+    activeRuns: Set<string>
   }
-  const state = Instance.state<State>(() => ({ definitions: new Map(), runs: new Map() }))
+  const state = Instance.state<State>(() => ({ definitions: new Map(), runs: new Map(), activeRuns: new Set() }))
+
+  export type RunExecutor = (input: {
+    definition: Definition
+    run: Run
+    attendance: AutomationRunAttendance
+    signal: AbortSignal
+  }) => Promise<{ sessionID: SessionID; result: string | null; cost?: number | null }>
 
   const COMMON_CREATE_FIELDS = new Set([
     "kind",
@@ -460,6 +469,66 @@ export namespace Automation {
     return { id: previous.id, deleted: true, revision: previous.revision + 1 }
   }
 
+  function replaceRun(run: Run) {
+    const current = state().runs.get(run.automationID) ?? []
+    state().runs.set(
+      run.automationID,
+      current.map((item) => (item.id === run.id ? run : item)),
+    )
+    return run
+  }
+
+  function reviseRun(run: Run, patch: Record<string, unknown>): Run {
+    const next = {
+      ...run,
+      ...patch,
+      revision: run.revision + 1,
+    }
+    for (const [key, value] of Object.entries(next)) {
+      if (value === undefined) delete (next as Record<string, unknown>)[key]
+    }
+    return replaceRun(Run.parse(next))
+  }
+
+  export function markRunStarted(run: Run, sessionID: SessionID, options?: { now?: number }): Run {
+    return reviseRun(run, {
+      state: "running",
+      sessionID,
+      startedAt: options?.now ?? Date.now(),
+      completedAt: null,
+      result: null,
+      error: null,
+    })
+  }
+
+  function setDefinitionAutomationSession(definition: Definition, sessionID: SessionID) {
+    if (definition.automationSessionID === sessionID) return definition
+    const next = Definition.parse({
+      ...definition,
+      automationSessionID: sessionID,
+      revision: definition.revision + 1,
+      updatedAt: Date.now(),
+    })
+    state().definitions.set(definition.id, next)
+    return next
+  }
+
+  export function markRunBlocked(run: Run, blocker: AutomationRunBlocker): Run {
+    if (run.state !== "running" && run.state !== "awaiting_input") return run
+    return reviseRun(run, {
+      state: "awaiting_input",
+      blocker,
+    })
+  }
+
+  export function clearRunBlocker(run: Run): Run {
+    if (run.state !== "awaiting_input") return run
+    return reviseRun(run, {
+      state: "running",
+      blocker: undefined,
+    })
+  }
+
   export function runNow(id: string, options?: { now?: number }): Run {
     const definition = get(id)
     const current = state().runs.get(id) ?? []
@@ -479,6 +548,72 @@ export namespace Automation {
     })
     state().runs.set(id, [run, ...current])
     return run
+  }
+
+  export function runNowExecuting(
+    id: string,
+    options: { executor: RunExecutor; attendance?: AutomationRunAttendance; now?: number },
+  ): Run {
+    const initial = runNow(id, { now: options.now })
+    void executeRun(initial, options.executor, options.attendance ?? "attended")
+    return initial
+  }
+
+  async function executeRun(initial: Run, executor: RunExecutor, attendance: AutomationRunAttendance) {
+    const data = state()
+    if (data.activeRuns.has(initial.automationID)) {
+      const stopped = reviseRun(initial, {
+        state: "stopped",
+        completedAt: Date.now(),
+        stopReason: "previous_run_awaiting_input",
+      })
+      await publishRunUpdated(stopped)
+      return
+    }
+    data.activeRuns.add(initial.automationID)
+    const controller = new AbortController()
+    let current = initial
+    try {
+      const definition = get(initial.automationID)
+      const prepared = await executor({ definition, run: initial, attendance, signal: controller.signal })
+      const latest = state().runs.get(initial.automationID)?.find((item) => item.id === initial.id) ?? initial
+      const running = latest.state === "scheduled" ? markRunStarted(latest, prepared.sessionID) : latest
+      current = running
+      await publishRunUpdated(running)
+      if (definition.context === "continue") setDefinitionAutomationSession(definition, prepared.sessionID)
+      const succeeded = reviseRun(running, {
+        state: "succeeded",
+        completedAt: Date.now(),
+        result: prepared.result,
+        error: null,
+        cost: prepared.cost ?? null,
+      })
+      current = succeeded
+      await publishRunUpdated(succeeded)
+    } catch (error) {
+      current = state().runs.get(initial.automationID)?.find((item) => item.id === initial.id) ?? current
+      if (current.state === "scheduled") {
+        const stopped = reviseRun(current, {
+          state: "stopped",
+          completedAt: Date.now(),
+          stopReason: "cancelled",
+        })
+        await publishRunUpdated(stopped)
+        return
+      }
+      const isStepCap = error instanceof globalThis.Error && error.name === "AutomationStepCapError"
+      const failed = reviseRun(current, {
+        state: "failed",
+        completedAt: Date.now(),
+        error: {
+          code: isStepCap ? "step_cap" : "execution_failed",
+          message: error instanceof globalThis.Error ? error.message : String(error),
+        },
+      })
+      await publishRunUpdated(failed)
+    } finally {
+      data.activeRuns.delete(initial.automationID)
+    }
   }
 
   export function runs(input: { automationID: string; limit?: number; cursor?: string }) {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -233,9 +233,9 @@ export namespace Automation {
   type State = {
     definitions: Map<string, Definition>
     runs: Map<string, Run[]>
-    activeRuns: Set<string>
+    activeWriters: Set<string>
   }
-  const state = Instance.state<State>(() => ({ definitions: new Map(), runs: new Map(), activeRuns: new Set() }))
+  const state = Instance.state<State>(() => ({ definitions: new Map(), runs: new Map(), activeWriters: new Set() }))
 
   export type RunExecutor = (input: {
     definition: Definition
@@ -425,6 +425,10 @@ export namespace Automation {
     return definition
   }
 
+  function getOptional(id: string): Definition | undefined {
+    return state().definitions.get(id)
+  }
+
   function isSameValue(left: unknown, right: unknown): boolean {
     if (Object.is(left, right)) return true
     if (Array.isArray(left) || Array.isArray(right)) {
@@ -563,7 +567,9 @@ export namespace Automation {
 
   async function executeRun(initial: Run, executor: RunExecutor, attendance: AutomationRunAttendance) {
     const data = state()
-    if (data.activeRuns.has(initial.automationID)) {
+    const definition = get(initial.automationID)
+    const writerKey = definition.where.worktree ?? definition.where.projectID
+    if (data.activeWriters.has(writerKey)) {
       const stopped = reviseRun(initial, {
         state: "stopped",
         completedAt: Date.now(),
@@ -572,18 +578,17 @@ export namespace Automation {
       await publishRunUpdated(stopped)
       return
     }
-    data.activeRuns.add(initial.automationID)
+    data.activeWriters.add(writerKey)
     const controller = new AbortController()
     let current = initial
     try {
-      const definition = get(initial.automationID)
       const prepared = await executor({ definition, run: initial, attendance, signal: controller.signal })
       const latest = state().runs.get(initial.automationID)?.find((item) => item.id === initial.id) ?? initial
       const running = latest.state === "scheduled" ? markRunStarted(latest, prepared.sessionID) : latest
       current = running
       await publishRunUpdated(running)
-      const latestDefinition = get(initial.automationID)
-      if (latestDefinition.context === "continue") {
+      const latestDefinition = getOptional(initial.automationID)
+      if (latestDefinition?.context === "continue") {
         const updatedDefinition = setDefinitionAutomationSession(latestDefinition, prepared.sessionID)
         if (updatedDefinition !== latestDefinition) await publishDefinitionUpdated(updatedDefinition)
       }
@@ -618,7 +623,7 @@ export namespace Automation {
       })
       await publishRunUpdated(failed)
     } finally {
-      data.activeRuns.delete(initial.automationID)
+      data.activeWriters.delete(writerKey)
     }
   }
 

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -621,7 +621,7 @@ export namespace Automation {
       }
       const running = latest.state === "scheduled" ? markRunStarted(latest, prepared.sessionID) : latest
       current = running
-      await publishRunUpdated(running)
+      if (running !== latest) await publishRunUpdated(running)
       const latestDefinition = getOptional(initial.automationID)
       if (latestDefinition?.context === "continue") {
         const updatedDefinition = setDefinitionAutomationSession(latestDefinition, prepared.sessionID)

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -484,6 +484,8 @@ export namespace Automation {
       ...patch,
       revision: run.revision + 1,
     }
+    if (next.state !== "awaiting_input") delete (next as Record<string, unknown>).blocker
+    if (next.state !== "stopped") delete (next as Record<string, unknown>).stopReason
     for (const [key, value] of Object.entries(next)) {
       if (value === undefined) delete (next as Record<string, unknown>)[key]
     }
@@ -580,7 +582,11 @@ export namespace Automation {
       const running = latest.state === "scheduled" ? markRunStarted(latest, prepared.sessionID) : latest
       current = running
       await publishRunUpdated(running)
-      if (definition.context === "continue") setDefinitionAutomationSession(definition, prepared.sessionID)
+      const latestDefinition = get(initial.automationID)
+      if (latestDefinition.context === "continue") {
+        const updatedDefinition = setDefinitionAutomationSession(latestDefinition, prepared.sessionID)
+        if (updatedDefinition !== latestDefinition) await publishDefinitionUpdated(updatedDefinition)
+      }
       const succeeded = reviseRun(running, {
         state: "succeeded",
         completedAt: Date.now(),

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -234,8 +234,14 @@ export namespace Automation {
     definitions: Map<string, Definition>
     runs: Map<string, Run[]>
     activeWriters: Set<string>
+    activeRuns: Map<string, { writerKey: string; controller: AbortController }>
   }
-  const state = Instance.state<State>(() => ({ definitions: new Map(), runs: new Map(), activeWriters: new Set() }))
+  const state = Instance.state<State>(() => ({
+    definitions: new Map(),
+    runs: new Map(),
+    activeWriters: new Set(),
+    activeRuns: new Map(),
+  }))
 
   export type RunExecutor = (input: {
     definition: Definition
@@ -466,11 +472,12 @@ export namespace Automation {
     return next
   }
 
-  export function remove(id: string): Tombstone {
+  export function remove(id: string): { tombstone: Tombstone; stoppedRun?: Run } {
     const previous = get(id)
+    const stoppedRun = stopActiveRun(id)
     state().definitions.delete(id)
-    state().runs.delete(id)
-    return { id: previous.id, deleted: true, revision: previous.revision + 1 }
+    if (!stoppedRun) state().runs.delete(id)
+    return { tombstone: { id: previous.id, deleted: true, revision: previous.revision + 1 }, stoppedRun }
   }
 
   function replaceRun(run: Run) {
@@ -494,6 +501,27 @@ export namespace Automation {
       if (value === undefined) delete (next as Record<string, unknown>)[key]
     }
     return replaceRun(Run.parse(next))
+  }
+
+  function stopRun(run: Run, stopReason: Extract<Run, { state: "stopped" }>["stopReason"]): Run {
+    if (run.state === "stopped" || run.state === "succeeded" || run.state === "failed") return run
+    return reviseRun(run, {
+      state: "stopped",
+      completedAt: Date.now(),
+      result: null,
+      error: null,
+      stopReason,
+    })
+  }
+
+  function stopActiveRun(automationID: string) {
+    const active = state().activeRuns.get(automationID)
+    if (!active) return undefined
+    active.controller.abort()
+    const current = state().runs.get(automationID)?.find((run) => (
+      run.state === "scheduled" || run.state === "running" || run.state === "awaiting_input"
+    ))
+    return current ? stopRun(current, "cancelled") : undefined
   }
 
   export function markRunStarted(run: Run, sessionID: SessionID, options?: { now?: number }): Run {
@@ -580,10 +608,17 @@ export namespace Automation {
     }
     data.activeWriters.add(writerKey)
     const controller = new AbortController()
+    data.activeRuns.set(initial.automationID, { writerKey, controller })
     let current = initial
     try {
       const prepared = await executor({ definition, run: initial, attendance, signal: controller.signal })
       const latest = state().runs.get(initial.automationID)?.find((item) => item.id === initial.id) ?? initial
+      if (controller.signal.aborted) {
+        const stopped = stopRun(latest, "cancelled")
+        current = stopped
+        if (stopped !== latest) await publishRunUpdated(stopped)
+        return
+      }
       const running = latest.state === "scheduled" ? markRunStarted(latest, prepared.sessionID) : latest
       current = running
       await publishRunUpdated(running)
@@ -603,6 +638,11 @@ export namespace Automation {
       await publishRunUpdated(succeeded)
     } catch (error) {
       current = state().runs.get(initial.automationID)?.find((item) => item.id === initial.id) ?? current
+      if (controller.signal.aborted) {
+        const stopped = stopRun(current, "cancelled")
+        if (stopped !== current) await publishRunUpdated(stopped)
+        return
+      }
       if (current.state === "scheduled") {
         const stopped = reviseRun(current, {
           state: "stopped",
@@ -623,6 +663,7 @@ export namespace Automation {
       })
       await publishRunUpdated(failed)
     } finally {
+      data.activeRuns.delete(initial.automationID)
       data.activeWriters.delete(writerKey)
     }
   }

--- a/packages/opencode/src/automation/run-context.ts
+++ b/packages/opencode/src/automation/run-context.ts
@@ -1,0 +1,47 @@
+import { Context, Effect } from "effect"
+import type { Permission } from "@/permission"
+import type { PermissionID } from "@/permission/schema"
+
+export type AutomationRunAttendance = "attended" | "unattended"
+
+export type AutomationRunBlocker =
+  | { kind: "permission"; requestID: PermissionID }
+  | { kind: "question"; callID: string }
+
+export interface AutomationRunContext {
+  readonly attendance: AutomationRunAttendance
+  readonly stepCap?: number
+  readonly block: (blocker: AutomationRunBlocker) => Effect.Effect<void>
+  readonly clear: () => Effect.Effect<void>
+}
+
+export class AutomationStepCapError extends Error {
+  readonly _tag = "AutomationStepCapError"
+  constructor(readonly stepCap: number) {
+    super(`Automation run exceeded the hard step cap (${stepCap}).`)
+    this.name = "AutomationStepCapError"
+  }
+}
+
+export const AutomationRunContextService: Context.Reference<AutomationRunContext | undefined> = Context.Reference<
+  AutomationRunContext | undefined
+>("@opencode/AutomationRunContext", {
+  defaultValue: () => undefined,
+})
+
+export const AutomationRunContext = {
+  service: AutomationRunContextService,
+  current: AutomationRunContextService,
+  attended(input: Pick<AutomationRunContext, "block" | "clear" | "stepCap">): AutomationRunContext {
+    return { attendance: "attended", ...input }
+  },
+  unattended(input: Pick<AutomationRunContext, "block" | "clear" | "stepCap">): AutomationRunContext {
+    return { attendance: "unattended", ...input }
+  },
+  permissionOnPending(
+    context: AutomationRunContext | undefined,
+  ): ((request: Permission.Request) => Effect.Effect<void>) | undefined {
+    if (!context) return undefined
+    return (request) => context.block({ kind: "permission", requestID: request.id })
+  },
+}

--- a/packages/opencode/src/automation/run-context.ts
+++ b/packages/opencode/src/automation/run-context.ts
@@ -33,10 +33,10 @@ export const AutomationRunContext = {
   service: AutomationRunContextService,
   current: AutomationRunContextService,
   attended(input: Pick<AutomationRunContext, "block" | "clear" | "stepCap">): AutomationRunContext {
-    return { attendance: "attended", ...input }
+    return { ...input, attendance: "attended" }
   },
   unattended(input: Pick<AutomationRunContext, "block" | "clear" | "stepCap">): AutomationRunContext {
-    return { attendance: "unattended", ...input }
+    return { ...input, attendance: "unattended" }
   },
   permissionOnPending(
     context: AutomationRunContext | undefined,

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import { Automation } from "."
 import { Session } from "@/session"
 import { SessionPrompt } from "@/session/prompt"
-import { AutomationRunContext } from "./run-context"
+import { AutomationRunContext, type AutomationRunBlocker } from "./run-context"
 
 export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition, run, attendance, signal }) => {
   const sessionID =
@@ -11,18 +11,23 @@ export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition
       : (await Session.create({ title: `Automation: ${definition.title}` })).id
   let currentRun = Automation.markRunStarted(run, sessionID)
   await Automation.publishRunUpdated(currentRun)
-  const context = AutomationRunContext.attended({
+  const handlers = {
     stepCap: 50,
-    block: (blocker) =>
-      Effect.sync(() => {
+    block: (blocker: AutomationRunBlocker) =>
+      Effect.gen(function* () {
+        const previous = currentRun
         currentRun = Automation.markRunBlocked(currentRun, blocker)
-      }).pipe(Effect.flatMap(() => Effect.promise(() => Automation.publishRunUpdated(currentRun)))),
+        if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
+      }),
     clear: () =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
+        const previous = currentRun
         currentRun = Automation.clearRunBlocker(currentRun)
-      }).pipe(Effect.flatMap(() => Effect.promise(() => Automation.publishRunUpdated(currentRun)))),
-  })
-  const scoped = attendance === "attended" ? context : AutomationRunContext.unattended(context)
+        if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
+      }),
+  }
+  const scoped =
+    attendance === "attended" ? AutomationRunContext.attended(handlers) : AutomationRunContext.unattended(handlers)
   const message = await SessionPrompt.promptWithAutomationContext(
     {
       sessionID,

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -5,40 +5,51 @@ import { SessionPrompt } from "@/session/prompt"
 import { AutomationRunContext, type AutomationRunBlocker } from "./run-context"
 
 export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition, run, attendance, signal }) => {
+  signal.throwIfAborted()
   const sessionID =
     definition.context === "continue" && definition.automationSessionID
       ? definition.automationSessionID
       : (await Session.create({ title: `Automation: ${definition.title}` })).id
-  let currentRun = Automation.markRunStarted(run, sessionID)
-  await Automation.publishRunUpdated(currentRun)
-  const handlers = {
-    stepCap: 50,
-    block: (blocker: AutomationRunBlocker) =>
-      Effect.gen(function* () {
-        const previous = currentRun
-        currentRun = Automation.markRunBlocked(currentRun, blocker)
-        if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
-      }),
-    clear: () =>
-      Effect.gen(function* () {
-        const previous = currentRun
-        currentRun = Automation.clearRunBlocker(currentRun)
-        if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
-      }),
+  const cancelPrompt = () => {
+    void SessionPrompt.cancel(sessionID, { source: "automation.cancel" }).catch(() => undefined)
   }
-  const scoped =
-    attendance === "attended" ? AutomationRunContext.attended(handlers) : AutomationRunContext.unattended(handlers)
-  const message = await SessionPrompt.promptWithAutomationContext(
-    {
+  if (signal.aborted) cancelPrompt()
+  else signal.addEventListener("abort", cancelPrompt, { once: true })
+  try {
+    signal.throwIfAborted()
+    let currentRun = Automation.markRunStarted(run, sessionID)
+    await Automation.publishRunUpdated(currentRun)
+    const handlers = {
+      stepCap: 50,
+      block: (blocker: AutomationRunBlocker) =>
+        Effect.gen(function* () {
+          const previous = currentRun
+          currentRun = Automation.markRunBlocked(currentRun, blocker)
+          if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
+        }),
+      clear: () =>
+        Effect.gen(function* () {
+          const previous = currentRun
+          currentRun = Automation.clearRunBlocker(currentRun)
+          if (currentRun !== previous) yield* Effect.promise(() => Automation.publishRunUpdated(currentRun))
+        }),
+    }
+    const scoped =
+      attendance === "attended" ? AutomationRunContext.attended(handlers) : AutomationRunContext.unattended(handlers)
+    const message = await SessionPrompt.promptWithAutomationContext(
+      {
+        sessionID,
+        parts: [{ type: "text", text: definition.prompt }],
+      },
+      scoped,
+    )
+    signal.throwIfAborted()
+    return {
       sessionID,
-      parts: [{ type: "text", text: definition.prompt }],
-    },
-    scoped,
-  )
-  signal.throwIfAborted()
-  return {
-    sessionID,
-    result: message.parts.find((part) => part.type === "text")?.text ?? null,
-    cost: message.info.role === "assistant" ? message.info.cost : null,
+      result: message.parts.find((part) => part.type === "text")?.text ?? null,
+      cost: message.info.role === "assistant" ? message.info.cost : null,
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelPrompt)
   }
 }

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -1,0 +1,39 @@
+import { Effect } from "effect"
+import { Automation } from "."
+import { Session } from "@/session"
+import { SessionPrompt } from "@/session/prompt"
+import { AutomationRunContext } from "./run-context"
+
+export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition, run, attendance, signal }) => {
+  const sessionID =
+    definition.context === "continue" && definition.automationSessionID
+      ? definition.automationSessionID
+      : (await Session.create({ title: `Automation: ${definition.title}` })).id
+  let currentRun = Automation.markRunStarted(run, sessionID)
+  await Automation.publishRunUpdated(currentRun)
+  const context = AutomationRunContext.attended({
+    stepCap: 50,
+    block: (blocker) =>
+      Effect.sync(() => {
+        currentRun = Automation.markRunBlocked(currentRun, blocker)
+      }).pipe(Effect.flatMap(() => Effect.promise(() => Automation.publishRunUpdated(currentRun)))),
+    clear: () =>
+      Effect.sync(() => {
+        currentRun = Automation.clearRunBlocker(currentRun)
+      }).pipe(Effect.flatMap(() => Effect.promise(() => Automation.publishRunUpdated(currentRun)))),
+  })
+  const scoped = attendance === "attended" ? context : AutomationRunContext.unattended(context)
+  const message = await SessionPrompt.promptWithAutomationContext(
+    {
+      sessionID,
+      parts: [{ type: "text", text: definition.prompt }],
+    },
+    scoped,
+  )
+  signal.throwIfAborted()
+  return {
+    sessionID,
+    result: message.parts.find((part) => part.type === "text")?.text ?? null,
+    cost: message.info.role === "assistant" ? message.info.cost : null,
+  }
+}

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -42,6 +42,7 @@ export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition
         parts: [{ type: "text", text: definition.prompt }],
       },
       scoped,
+      { abortSignal: signal },
     )
     signal.throwIfAborted()
     return {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -117,8 +117,12 @@ export namespace Permission {
     message: z.string().optional(),
   })
 
+  export type AskOptions = z.infer<typeof AskInput> & {
+    onPending?: (request: Request) => Effect.Effect<void>
+  }
+
   export interface Interface {
-    readonly ask: (input: z.infer<typeof AskInput>) => Effect.Effect<void, Error>
+    readonly ask: (input: AskOptions) => Effect.Effect<void, Error>
     readonly reply: (input: z.infer<typeof ReplyInput>) => Effect.Effect<void>
     readonly clearSession: (
       sessionID: SessionID,
@@ -171,9 +175,9 @@ export namespace Permission {
         }),
       )
 
-      const ask = Effect.fn("Permission.ask")(function* (input: z.infer<typeof AskInput>) {
+      const ask = Effect.fn("Permission.ask")(function* (input: AskOptions) {
         const { approved, pending } = yield* InstanceState.get(state)
-        const { ruleset, ...request } = input
+        const { ruleset, onPending, ...request } = input
         let needsAsk = false
         const denied: Array<{ pattern: string; rule: Rule }> = []
 
@@ -222,6 +226,7 @@ export namespace Permission {
 
         const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()
         pending.set(id, { info, deferred })
+        if (onPending) yield* onPending(info)
         yield* bus.publish(Event.Asked, info)
         return yield* Effect.ensuring(
           Deferred.await(deferred),

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -230,7 +230,7 @@ export const AutomationRoutes = (): Hono =>
       "/:automationID/run",
       describeRoute({
         summary: "Run automation now",
-        description: "Create a scheduled automation run record and start execution in the background.",
+        description: "Create a queued automation run, start execution in the background, and return the queued run immediately.",
         operationId: "automation.runNow",
         responses: {
           200: {

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
 import { Automation, AutomationID, ValidationError } from "@/automation"
+import { sessionPromptExecutor } from "@/automation/runner"
 import { errors } from "../error"
 
 function validationError(error: ValidationError) {
@@ -241,7 +242,9 @@ export const AutomationRoutes = (): Hono =>
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
       async (c) => {
-        const run = Automation.runNow(c.req.valid("param").automationID)
+        const run = Automation.runNowExecuting(c.req.valid("param").automationID, {
+          executor: sessionPromptExecutor,
+        })
         await Automation.publishRunUpdated(run)
         return c.json(run)
       },

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -209,7 +209,8 @@ export const AutomationRoutes = (): Hono =>
       "/:automationID",
       describeRoute({
         summary: "Delete automation",
-        description: "Delete an automation definition and return a tombstone.",
+        description:
+          "Delete an automation definition and return a tombstone. If a run is active, stop it and publish the stopped run before publishing the tombstone.",
         operationId: "automation.delete",
         responses: {
           200: {

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -221,9 +221,10 @@ export const AutomationRoutes = (): Hono =>
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
       async (c) => {
-        const tombstone = Automation.remove(c.req.valid("param").automationID)
-        await Automation.publishDefinitionDeleted(tombstone)
-        return c.json(tombstone)
+        const removed = Automation.remove(c.req.valid("param").automationID)
+        if (removed.stoppedRun) await Automation.publishRunUpdated(removed.stoppedRun)
+        await Automation.publishDefinitionDeleted(removed.tombstone)
+        return c.json(removed.tombstone)
       },
     )
     .post(

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -230,7 +230,7 @@ export const AutomationRoutes = (): Hono =>
       "/:automationID/run",
       describeRoute({
         summary: "Run automation now",
-        description: "Create a scheduled automation run record. Execution lands in a later PR.",
+        description: "Create a scheduled automation run record and start execution in the background.",
         operationId: "automation.runNow",
         responses: {
           200: {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -87,6 +87,10 @@ type TitleGenerationProgress = {
   completedAt?: number
 }
 
+type PromptRuntimeOptions = {
+  abortSignal?: AbortSignal
+}
+
 export function titleGenerationStateAtAbort(
   progress: TitleGenerationProgress | undefined,
   abortRecordedAt: number,
@@ -266,8 +270,8 @@ function modelCanReadMedia(model: Provider.Model, kind: MediaInputKind) {
 
 export interface Interface {
   readonly cancel: (sessionID: SessionID, options?: { source?: string }) => Effect.Effect<boolean>
-  readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
-  readonly loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts>
+  readonly prompt: (input: PromptInput, options?: PromptRuntimeOptions) => Effect.Effect<MessageV2.WithParts>
+  readonly loop: (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
@@ -303,6 +307,9 @@ export const layer = Layer.effect(
     const llm = yield* LLM.Service
     const runner = Effect.fn("SessionPrompt.runner")(function* () {
       return yield* EffectBridge.make()
+    })
+    const throwIfAborted = Effect.fn("SessionPrompt.throwIfAborted")(function* (options?: PromptRuntimeOptions) {
+      options?.abortSignal?.throwIfAborted()
     })
     // Tracks subagent sessions whose runner.onInterrupt fired during the most recent prompt run.
     // Reset at the start of each prompt() call; written when loop()'s onInterrupt arg fires; read
@@ -1837,27 +1844,29 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return { info, parts }
     }, Effect.scoped)
 
-    const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.prompt")(
-      function* (input: PromptInput) {
-        interruptedSessions.delete(input.sessionID)
-        const session = yield* sessions.get(input.sessionID)
-        yield* revert.cleanup(session)
-        const message = yield* createUserMessage(input)
-        yield* sessions.touch(input.sessionID)
+    const prompt: (input: PromptInput, options?: PromptRuntimeOptions) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
+      "SessionPrompt.prompt",
+    )(function* (input: PromptInput, options?: PromptRuntimeOptions) {
+      yield* throwIfAborted(options)
+      interruptedSessions.delete(input.sessionID)
+      const session = yield* sessions.get(input.sessionID)
+      yield* revert.cleanup(session)
+      const message = yield* createUserMessage(input)
+      yield* sessions.touch(input.sessionID)
 
-        const permissions: Permission.Ruleset = []
-        for (const [t, enabled] of Object.entries(input.tools ?? {})) {
-          permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
-        }
-        if (permissions.length > 0) {
-          session.permission = permissions
-          yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
-        }
+      const permissions: Permission.Ruleset = []
+      for (const [t, enabled] of Object.entries(input.tools ?? {})) {
+        permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
+      }
+      if (permissions.length > 0) {
+        session.permission = permissions
+        yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+      }
 
-        if (input.noReply === true) return message
-        return yield* loop({ sessionID: input.sessionID, traceMessageID: message.info.id })
-      },
-    )
+      yield* throwIfAborted(options)
+      if (input.noReply === true) return message
+      return yield* loop({ sessionID: input.sessionID, traceMessageID: message.info.id }, options)
+    })
 
     const appendRunLifecycleEvent = Effect.fn("SessionPrompt.appendRunLifecycleEvent")(function* (
       sessionID: SessionID,
@@ -2269,9 +2278,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     )
 
-    const loop: (input: z.infer<typeof LoopInput>) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
+    const loop: (
+      input: z.infer<typeof LoopInput>,
+      options?: PromptRuntimeOptions,
+    ) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.loop",
-    )(function* (input: z.infer<typeof LoopInput>) {
+    )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
       const onInterrupt = (meta?: {
         source?: string
         reason?: string
@@ -2409,6 +2421,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return assistant
         })
       const work = Effect.gen(function* () {
+        yield* throwIfAborted(options)
         // Two reasons busy goes first. (1) The compaction part event must
         // not race ahead of `session.status: busy` — the divider's
         // "no summary + not working" branch would otherwise flash the
@@ -2469,6 +2482,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               appendRunLifecycleEvent(input.sessionID, input.traceMessageID!, event),
           }
         : undefined
+      yield* throwIfAborted(options)
       return yield* state.ensureRunning(input.sessionID, onInterrupt, work, {
         rejectIfBusy: input.prelude !== undefined,
         runLifecycle,
@@ -2752,10 +2766,11 @@ export async function prompt(input: PromptInput) {
 export async function promptWithAutomationContext(
   input: PromptInput,
   context: import("@/automation/run-context").AutomationRunContext,
+  options?: PromptRuntimeOptions,
 ) {
   return runPromise((svc) =>
     svc
-      .prompt(PromptInput.parse(input))
+      .prompt(PromptInput.parse(input), options)
       .pipe(Effect.provideService(AutomationRunContext.service, context)),
   )
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -62,6 +62,7 @@ import { attachWith, makeRuntime } from "@/effect/run-service"
 import { Instance } from "@/project/instance"
 import { MemoryFile } from "@/memory/memory"
 import { MemoryService } from "@/memory/service"
+import { AutomationRunContext, AutomationStepCapError } from "@/automation/run-context"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -676,6 +677,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const run = yield* runner()
       const promptOps = yield* ops()
       const effectContext = yield* Effect.context()
+      const automation = yield* AutomationRunContext.current
       const runInSessionContext = <A>(effect: Effect.Effect<A, any, any>): Effect.Effect<A> =>
         Effect.gen(function* () {
           const session = yield* sessions.get(input.session.id)
@@ -739,13 +741,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID: input.session.id,
               tool: { messageID: input.processor.message.id, callID: options.toolCallId },
               ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+              onPending: AutomationRunContext.permissionOnPending(automation),
             })
-            .pipe(Effect.orDie),
+            .pipe(Effect.ensuring(automation ? automation.clear() : Effect.void), Effect.orDie),
         externalResult: ({ inputSnapshot, decoder }) =>
           Effect.gen(function* () {
+            if (automation?.attendance === "unattended") {
+              return yield* Effect.fail(new ExternalResult.Error({ reason: "aborted" }))
+            }
             const sessionID = input.session.id
             const messageID = input.processor.message.id
             const callID = options.toolCallId
+            if (automation) {
+              yield* automation.block({ kind: "question", callID })
+            }
             const deferred = yield* ExternalResult.register({
               sessionID,
               messageID,
@@ -814,6 +823,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return result as Tool.ExternalResultOutcome
             } finally {
               if (signal) signal.removeEventListener("abort", abortHandler)
+              if (automation) yield* automation.clear()
             }
           }),
       })
@@ -1939,6 +1949,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
+        const automation = yield* AutomationRunContext.current
         const slog = elog.with({ sessionID })
         let structured: unknown | undefined
         let step = 0
@@ -2054,6 +2065,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             throw error
           }
           const maxSteps = agent.steps ?? Infinity
+          const automationHardStepCap = automation?.stepCap ?? 50
+          if (automation && step > automationHardStepCap) {
+            throw new AutomationStepCapError(automationHardStepCap)
+          }
           const isLastStep = step >= maxSteps
           msgs = yield* insertReminders({ messages: msgs, agent, session })
           const diagnostics = SessionDiagnostics.consumeReminders({ messages: msgs, parentID: lastUser.id })
@@ -2732,6 +2747,17 @@ export type PromptInput = z.infer<typeof PromptInput>
 
 export async function prompt(input: PromptInput) {
   return runPromise((svc) => svc.prompt(PromptInput.parse(input)))
+}
+
+export async function promptWithAutomationContext(
+  input: PromptInput,
+  context: import("@/automation/run-context").AutomationRunContext,
+) {
+  return runPromise((svc) =>
+    svc
+      .prompt(PromptInput.parse(input))
+      .pipe(Effect.provideService(AutomationRunContext.service, context)),
+  )
 }
 
 export async function resolvePromptParts(template: string) {

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -471,7 +471,7 @@ describe("automation routes", () => {
     expect(spec.components?.schemas).toHaveProperty("AutomationValidationError")
   })
 
-  test("runNow is a contract stub before PR2 execution", async () => {
+  test("runNow returns the queued run before background execution updates it", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
       const created = await json(app, "/automation", {
           method: "POST",

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -471,6 +471,16 @@ describe("automation routes", () => {
     expect(spec.components?.schemas).toHaveProperty("AutomationValidationError")
   })
 
+  test("openapi describes delete active-run stop side effect", async () => {
+    const { Server } = await import("../../src/server/server")
+    const spec = await Server.openapi()
+    const paths = spec.paths as Record<string, any>
+    const description = paths["/automation/{automationID}"].delete.description
+
+    expect(description).toContain("If a run is active")
+    expect(description).toContain("publish the stopped run")
+  })
+
   test("runNow returns the queued run before background execution updates it", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
       const created = await json(app, "/automation", {

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -126,6 +126,29 @@ describe("automation runNow execution", () => {
     })
   })
 
+  test("does not publish duplicate running events when the executor already started the run", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+      const sessionID = SessionID.descending()
+      const runEvents: Automation.Run[] = []
+      const unsubscribeRun = Bus.subscribe(Automation.Event.RunUpdated, (event) => {
+        if (event.properties.automationID === definition.id) runEvents.push(event.properties)
+      })
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async ({ run }) => {
+          const started = Automation.markRunStarted(run, sessionID, { now: run.triggeredAt })
+          await Automation.publishRunUpdated(started)
+          return { sessionID, result: "done", cost: 0 }
+        },
+      })
+
+      await waitForRun(definition.id, "succeeded")
+      unsubscribeRun()
+      expect(runEvents.map((event) => event.state)).toEqual(["running", "succeeded"])
+    })
+  })
+
   test("keeps one active writer per project", async () => {
     await withAutomation(async (projectID) => {
       const first = Automation.create(input(projectID, { title: "First automation" }))

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -366,6 +366,81 @@ describe("automation runNow execution", () => {
     }
   })
 
+  test("deleting after run start but before prompt runner is busy does not call the provider", async () => {
+    let providerCalls = 0
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+        providerCalls++
+        return new Response(hangingChat(() => undefined), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const definition = Automation.create(input(Instance.project.id, { title: "Cancel before runner busy" }))
+          const removed = Promise.withResolvers<ReturnType<typeof Automation.remove>>()
+          const unsubscribe = Bus.subscribe(Automation.Event.RunUpdated, (event) => {
+            if (event.properties.automationID !== definition.id || event.properties.state !== "running") return
+            removed.resolve(Automation.remove(definition.id))
+          })
+
+          Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
+          const result = await Promise.race([
+            removed.promise,
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error("timed out waiting for running run")), 1_000),
+            ),
+          ])
+          unsubscribe()
+
+          expect(result.stoppedRun).toMatchObject({ state: "stopped", stopReason: "cancelled" })
+          await Bun.sleep(50)
+          expect(providerCalls).toBe(0)
+          if (result.stoppedRun?.sessionID) {
+            const messages = await Session.messages({ sessionID: result.stoppedRun.sessionID })
+            expect(messages.some((message) => message.info.role === "assistant")).toBe(false)
+          }
+        },
+      })
+    } finally {
+      void server.stop(true)
+    }
+  })
+
   test("unattended context construction overrides any existing attendance tag", async () => {
     const handlers = {
       stepCap: 50,

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 
 async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
   await using tmp = await tmpdir({ git: true })
-  return Instance.provide({
+  return await Instance.provide({
     directory: tmp.path,
     fn: () => fn(Instance.project.id),
   })

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -189,30 +189,58 @@ describe("automation runNow execution", () => {
     await withAutomation(async (projectID) => {
       const definition = Automation.create(input(projectID, { context: "continue" }))
       const definitionEvents: Automation.Definition[] = []
-      const terminalRun = new Promise<Automation.Run>((resolve) => {
-        const unsubscribe = Bus.subscribe(Automation.Event.RunUpdated, (event) => {
-          const run = event.properties
-          if (run.automationID !== definition.id) return
-          if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return
-          unsubscribe()
-          resolve(run)
-        })
-      })
       const unsubscribeDefinition = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
         definitionEvents.push(event.properties)
       })
+      let removed!: ReturnType<typeof Automation.remove>
 
       Automation.runNowExecuting(definition.id, {
         executor: async () => {
-          Automation.remove(definition.id)
+          removed = Automation.remove(definition.id)
           return { sessionID: SessionID.descending(), result: "done", cost: 0 }
         },
       })
 
-      await terminalRun
+      await Bun.sleep(20)
       unsubscribeDefinition()
+      expect(removed.stoppedRun).toMatchObject({ state: "stopped", stopReason: "cancelled" })
       expect(() => Automation.get(definition.id)).toThrow()
       expect(definitionEvents).toHaveLength(0)
+    })
+  })
+
+  test("aborts an active run when its automation is deleted", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+      const sessionID = SessionID.descending()
+      let sawAbort = false
+      const started = Promise.withResolvers<void>()
+      const release = Promise.withResolvers<void>()
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async ({ run, signal }) => {
+          Automation.markRunStarted(run, sessionID, { now: run.triggeredAt })
+          signal.addEventListener("abort", () => {
+            sawAbort = true
+            release.resolve()
+          })
+          started.resolve()
+          await release.promise
+          return { sessionID, result: "should not succeed", cost: 0 }
+        },
+      })
+
+      await started.promise
+      const removed = Automation.remove(definition.id)
+
+      expect(sawAbort).toBe(true)
+      expect(removed.stoppedRun).toMatchObject({
+        state: "stopped",
+        sessionID,
+        stopReason: "cancelled",
+      })
+      await Bun.sleep(20)
+      expect(removed.stoppedRun).not.toMatchObject({ state: "succeeded" })
     })
   })
 

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -1,9 +1,12 @@
+import path from "path"
 import { afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Automation } from "../../src/automation"
+import { sessionPromptExecutor } from "../../src/automation/runner"
 import { Bus } from "../../src/bus"
 import { Instance } from "../../src/project/instance"
 import { ProjectID } from "../../src/project/schema"
+import { Session } from "../../src/session"
 import { SessionID } from "../../src/session/schema"
 import { AutomationRunContext, AutomationStepCapError } from "../../src/automation/run-context"
 import { tmpdir } from "../fixture/fixture"
@@ -42,6 +45,63 @@ async function waitForRun(automationID: string, state: Automation.Run["state"]) 
     await Bun.sleep(10)
   }
   throw new Error(`Timed out waiting for ${state}`)
+}
+
+function defer<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function hangingChat(ready: () => void) {
+  const encoder = new TextEncoder()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const first = `data: ${JSON.stringify({
+    id: "chatcmpl-1",
+    object: "chat.completion.chunk",
+    choices: [{ delta: { role: "assistant" } }],
+  })}\n\n`
+  const rest =
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { content: "late" } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(encoder.encode(first))
+      ready()
+      timer = setTimeout(() => {
+        ctrl.enqueue(encoder.encode(rest))
+        ctrl.close()
+      }, 10_000)
+    },
+    cancel() {
+      if (timer) clearTimeout(timer)
+    },
+  })
+}
+
+async function waitForAbortedAssistant(sessionID: SessionID) {
+  const deadline = Date.now() + 1_000
+  while (Date.now() < deadline) {
+    const messages = await Session.messages({ sessionID })
+    const assistant = messages.findLast((message) => message.info.role === "assistant")
+    if (assistant?.info.role === "assistant" && assistant.info.error?.name === "MessageAbortedError") return assistant
+    await Bun.sleep(10)
+  }
+  throw new Error("Timed out waiting for aborted assistant message")
 }
 
 describe("automation runNow execution", () => {
@@ -242,6 +302,68 @@ describe("automation runNow execution", () => {
       await Bun.sleep(20)
       expect(removed.stoppedRun).not.toMatchObject({ state: "succeeded" })
     })
+  })
+
+  test("deleting an active automation cancels the real session prompt", async () => {
+    const ready = defer<void>()
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+        return new Response(hangingChat(() => ready.resolve()), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const definition = Automation.create(input(Instance.project.id, { title: "Cancel real prompt" }))
+
+          Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
+          await ready.promise
+
+          const removed = Automation.remove(definition.id)
+          const stoppedRun = removed.stoppedRun
+          expect(stoppedRun).toMatchObject({ state: "stopped", stopReason: "cancelled" })
+          if (!stoppedRun?.sessionID) throw new Error("expected stopped run to keep its sessionID")
+
+          await waitForAbortedAssistant(stoppedRun.sessionID)
+        },
+      })
+    } finally {
+      void server.stop(true)
+    }
   })
 
   test("unattended context construction overrides any existing attendance tag", async () => {

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import { Automation } from "../../src/automation"
+import { Bus } from "../../src/bus"
 import { Instance } from "../../src/project/instance"
 import { ProjectID } from "../../src/project/schema"
 import { SessionID } from "../../src/session/schema"
-import { AutomationStepCapError } from "../../src/automation/run-context"
+import { AutomationRunContext, AutomationStepCapError } from "../../src/automation/run-context"
 import { tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
@@ -18,7 +20,7 @@ async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
   })
 }
 
-function input(projectID: ProjectID): Automation.CreateInput {
+function input(projectID: ProjectID, overrides: Partial<Extract<Automation.CreateInput, { kind: "recurring" }>> = {}): Automation.CreateInput {
   return {
     kind: "recurring",
     title: "Repo brief",
@@ -28,6 +30,7 @@ function input(projectID: ProjectID): Automation.CreateInput {
     timezone: "Asia/Shanghai",
     rhythm: { kind: "interval", everyMs: 60_000 },
     stop: { kind: "count", count: 3 },
+    ...overrides,
   }
 }
 
@@ -104,7 +107,86 @@ describe("automation runNow execution", () => {
       })
       expect(cleared.state).toBe("running")
       expect(cleared).not.toHaveProperty("blocker")
+      expect(Automation.clearRunBlocker(cleared)).toBe(cleared)
     })
+  })
+
+  test("drops state-specific fields when a run transitions out of that state", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async ({ run }) => {
+          const started = Automation.markRunStarted(run, SessionID.descending(), { now: run.triggeredAt })
+          Automation.markRunBlocked(started, { kind: "question", callID: "call_1" })
+          throw new Error("boom")
+        },
+      })
+
+      const failed = await waitForRun(definition.id, "failed")
+      expect(failed).not.toHaveProperty("blocker")
+
+      let release!: () => void
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => {
+          await held
+          return { sessionID: SessionID.descending(), result: "first", cost: 0 }
+        },
+      })
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => ({ sessionID: SessionID.descending(), result: "second", cost: 0 }),
+      })
+      const stopped = await waitForRun(definition.id, "stopped")
+      if (stopped.completedAt === null) throw new Error("expected stopped run to have completedAt")
+      const restarted = Automation.markRunStarted(stopped, SessionID.descending(), { now: stopped.completedAt })
+      expect(restarted).not.toHaveProperty("stopReason")
+      release()
+    })
+  })
+
+  test("publishes continue-session definition updates from the latest definition", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID, { context: "continue" }))
+      const sessionID = SessionID.descending()
+      const definitionEvents: Automation.Definition[] = []
+      const unsubscribe = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
+        definitionEvents.push(event.properties)
+      })
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => {
+          Automation.update(definition.id, { title: "Updated repo brief" })
+          return { sessionID, result: "done", cost: 0 }
+        },
+      })
+
+      await waitForRun(definition.id, "succeeded")
+      unsubscribe()
+      const updated = Automation.get(definition.id)
+      expect(updated.title).toBe("Updated repo brief")
+      expect(updated.automationSessionID).toBe(sessionID)
+      expect(definitionEvents.at(-1)).toMatchObject({
+        id: definition.id,
+        title: "Updated repo brief",
+        automationSessionID: sessionID,
+      })
+    })
+  })
+
+  test("unattended context construction overrides any existing attendance tag", async () => {
+    const handlers = {
+      stepCap: 50,
+      block: () => Effect.void,
+      clear: () => Effect.void,
+    }
+    const attended = AutomationRunContext.attended(handlers)
+    const unattended = AutomationRunContext.unattended(attended)
+
+    expect(attended.attendance).toBe("attended")
+    expect(unattended.attendance).toBe("unattended")
   })
 
   test("records hard step-cap failures with the frozen stop code", async () => {

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -66,29 +66,36 @@ describe("automation runNow execution", () => {
     })
   })
 
-  test("keeps one active writer per automation", async () => {
+  test("keeps one active writer per project", async () => {
     await withAutomation(async (projectID) => {
-      const definition = Automation.create(input(projectID))
+      const first = Automation.create(input(projectID, { title: "First automation" }))
+      const second = Automation.create(input(projectID, { title: "Second automation" }))
       let release!: () => void
       const held = new Promise<void>((resolve) => {
         release = resolve
       })
+      let entered = 0
 
-      Automation.runNowExecuting(definition.id, {
+      Automation.runNowExecuting(first.id, {
         executor: async () => {
+          entered++
           await held
           return { sessionID: SessionID.descending(), result: "first", cost: 0 }
         },
       })
-      Automation.runNowExecuting(definition.id, {
-        executor: async () => ({ sessionID: SessionID.descending(), result: "second", cost: 0 }),
+      Automation.runNowExecuting(second.id, {
+        executor: async () => {
+          entered++
+          return { sessionID: SessionID.descending(), result: "second", cost: 0 }
+        },
       })
 
-      const stopped = await waitForRun(definition.id, "stopped")
+      const stopped = await waitForRun(second.id, "stopped")
       if (stopped.state !== "stopped") throw new Error("expected stopped run")
       expect(stopped.stopReason).toBe("previous_run_awaiting_input")
+      expect(entered).toBe(1)
       release()
-      const succeeded = await waitForRun(definition.id, "succeeded")
+      const succeeded = await waitForRun(first.id, "succeeded")
       expect(succeeded.result).toBe("first")
     })
   })
@@ -158,7 +165,7 @@ describe("automation runNow execution", () => {
 
       Automation.runNowExecuting(definition.id, {
         executor: async () => {
-          Automation.update(definition.id, { title: "Updated repo brief" })
+          Automation.update(definition.id, { title: "Updated repo brief", prompt: "Use the latest prompt." })
           return { sessionID, result: "done", cost: 0 }
         },
       })
@@ -167,12 +174,45 @@ describe("automation runNow execution", () => {
       unsubscribe()
       const updated = Automation.get(definition.id)
       expect(updated.title).toBe("Updated repo brief")
+      expect(updated.prompt).toBe("Use the latest prompt.")
       expect(updated.automationSessionID).toBe(sessionID)
       expect(definitionEvents.at(-1)).toMatchObject({
         id: definition.id,
         title: "Updated repo brief",
+        prompt: "Use the latest prompt.",
         automationSessionID: sessionID,
       })
+    })
+  })
+
+  test("does not revive a continue automation deleted during execution", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID, { context: "continue" }))
+      const definitionEvents: Automation.Definition[] = []
+      const terminalRun = new Promise<Automation.Run>((resolve) => {
+        const unsubscribe = Bus.subscribe(Automation.Event.RunUpdated, (event) => {
+          const run = event.properties
+          if (run.automationID !== definition.id) return
+          if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return
+          unsubscribe()
+          resolve(run)
+        })
+      })
+      const unsubscribeDefinition = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
+        definitionEvents.push(event.properties)
+      })
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => {
+          Automation.remove(definition.id)
+          return { sessionID: SessionID.descending(), result: "done", cost: 0 }
+        },
+      })
+
+      await terminalRun
+      unsubscribeDefinition()
+      expect(() => Automation.get(definition.id)).toThrow()
+      expect(definitionEvents).toHaveLength(0)
     })
   })
 

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Automation } from "../../src/automation"
+import { Instance } from "../../src/project/instance"
+import { ProjectID } from "../../src/project/schema"
+import { SessionID } from "../../src/session/schema"
+import { AutomationStepCapError } from "../../src/automation/run-context"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
+  await using tmp = await tmpdir({ git: true })
+  return Instance.provide({
+    directory: tmp.path,
+    fn: () => fn(Instance.project.id),
+  })
+}
+
+function input(projectID: ProjectID): Automation.CreateInput {
+  return {
+    kind: "recurring",
+    title: "Repo brief",
+    prompt: "Summarize repo changes.",
+    context: "fresh",
+    where: { projectID },
+    timezone: "Asia/Shanghai",
+    rhythm: { kind: "interval", everyMs: 60_000 },
+    stop: { kind: "count", count: 3 },
+  }
+}
+
+async function waitForRun(automationID: string, state: Automation.Run["state"]) {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    const run = Automation.runs({ automationID }).items.find((item) => item.state === state)
+    if (run?.state === state) return run
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${state}`)
+}
+
+describe("automation runNow execution", () => {
+  test("executes a run and records the terminal result", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+      const sessionID = SessionID.descending()
+
+      const initial = Automation.runNowExecuting(definition.id, {
+        executor: async () => ({ sessionID, result: "done", cost: 0 }),
+      })
+      expect(initial.state).toBe("scheduled")
+
+      const completed = await waitForRun(definition.id, "succeeded")
+      expect(completed).toMatchObject({
+        state: "succeeded",
+        sessionID,
+        result: "done",
+        error: null,
+      })
+      expect(completed.revision).toBeGreaterThan(initial.revision)
+    })
+  })
+
+  test("keeps one active writer per automation", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+      let release!: () => void
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => {
+          await held
+          return { sessionID: SessionID.descending(), result: "first", cost: 0 }
+        },
+      })
+      Automation.runNowExecuting(definition.id, {
+        executor: async () => ({ sessionID: SessionID.descending(), result: "second", cost: 0 }),
+      })
+
+      const stopped = await waitForRun(definition.id, "stopped")
+      if (stopped.state !== "stopped") throw new Error("expected stopped run")
+      expect(stopped.stopReason).toBe("previous_run_awaiting_input")
+      release()
+      const succeeded = await waitForRun(definition.id, "succeeded")
+      expect(succeeded.result).toBe("first")
+    })
+  })
+
+  test("records and clears blocker state on the run ledger", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+      const run = Automation.runNow(definition.id)
+      const started = Automation.markRunStarted(run, SessionID.descending(), { now: run.triggeredAt })
+      const blocked = Automation.markRunBlocked(started, { kind: "question", callID: "call_1" })
+      const cleared = Automation.clearRunBlocker(blocked)
+
+      expect(blocked).toMatchObject({
+        state: "awaiting_input",
+        blocker: { kind: "question", callID: "call_1" },
+      })
+      expect(cleared.state).toBe("running")
+      expect(cleared).not.toHaveProperty("blocker")
+    })
+  })
+
+  test("records hard step-cap failures with the frozen stop code", async () => {
+    await withAutomation(async (projectID) => {
+      const definition = Automation.create(input(projectID))
+
+      Automation.runNowExecuting(definition.id, {
+        executor: async ({ run }) => {
+          Automation.markRunStarted(run, SessionID.descending(), { now: run.triggeredAt })
+          throw new AutomationStepCapError(50)
+        },
+      })
+
+      const failed = await waitForRun(definition.id, "failed")
+      expect(failed.error).toEqual({
+        code: "step_cap",
+        message: "Automation run exceeded the hard step cap (50).",
+      })
+    })
+  })
+})

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -447,13 +447,17 @@ describe("automation runNow execution", () => {
           })
 
           Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
-          const result = await Promise.race([
-            removed.promise,
-            new Promise<never>((_, reject) =>
-              setTimeout(() => reject(new Error("timed out waiting for running run")), 1_000),
-            ),
-          ])
-          unsubscribe()
+          let result: ReturnType<typeof Automation.remove>
+          try {
+            result = await Promise.race([
+              removed.promise,
+              new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error("timed out waiting for running run")), 1_000),
+              ),
+            ])
+          } finally {
+            unsubscribe()
+          }
 
           expect(result.stoppedRun).toMatchObject({ state: "stopped", stopReason: "cancelled" })
           await Bun.sleep(50)

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -276,6 +276,10 @@ describe("automation runNow execution", () => {
       let sawAbort = false
       const started = Promise.withResolvers<void>()
       const release = Promise.withResolvers<void>()
+      const runEvents: Automation.Run[] = []
+      const unsubscribeRun = Bus.subscribe(Automation.Event.RunUpdated, (event) => {
+        if (event.properties.automationID === definition.id) runEvents.push(event.properties)
+      })
 
       Automation.runNowExecuting(definition.id, {
         executor: async ({ run, signal }) => {
@@ -300,7 +304,8 @@ describe("automation runNow execution", () => {
         stopReason: "cancelled",
       })
       await Bun.sleep(20)
-      expect(removed.stoppedRun).not.toMatchObject({ state: "succeeded" })
+      unsubscribeRun()
+      expect(runEvents.some((event) => event.state === "succeeded")).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

Adds the PR2 backend execution slice for issue #950: manual `automation.runNow` now queues a run and starts background execution through the session prompt runner, with run-ledger updates for running, success, blocker, and hard-stop states.

## Why

PR1 froze the automation contract and in-memory store but intentionally left execution stubbed. This PR keeps the next slice narrow: it proves manual Run now execution while the user is present, adds the shared blocker seam, and leaves scheduler, persistence, frontend UI, and worktree placement for later PRs.

## Related Issue

Closes part of #950. This is PR2 in the agreed 7-PR breakdown.

## Human Review Status

Pending

## Review Focus

Please focus on the `AutomationRunContext` seam through `SessionPrompt`, the narrow `Permission.ask onPending` hook, and the run ledger transitions in `packages/opencode/src/automation/index.ts`.

## Risk Notes

No scheduler, persistence, frontend, generated SDK, or worktree behavior is included. The run store remains in-memory from PR1. Visible UI/copy, platform/packaging, and docs/release-note surfaces were not touched.

## How To Verify

```text
bun run typecheck: passed
bun test ./test/server/automation-runner.test.ts ./test/server/automation-routes.test.ts ./test/permission-cleanup.test.ts ./test/permission-agent.test.ts: 50 passed, 0 failed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run endpoint queues a run and starts background execution immediately; runs now execute with prompt sessions that record session results and costs.
  * Permission requests support an on-pending callback during approval flow.

* **Improvements**
  * Prevents concurrent execution for the same work area; overlapping runs are stopped with a clear stop reason.
  * Runs can block for permissions/questions and resume; enforces a step cap (default 50).
  * Deleting an automation stops any active run and returns info about the stopped run.

* **Tests**
  * Expanded coverage for execution, concurrency, blockers, lifecycle, deletion, and cancellation timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->