### PR TITLE
fix(app): avoid stale session context reads

### DIFF
--- a/packages/app/src/components/session-context-usage.test.ts
+++ b/packages/app/src/components/session-context-usage.test.ts
@@ -1,9 +1,68 @@
 import { describe, expect, test } from "bun:test"
-import * as fs from "node:fs/promises"
-import { fileURLToPath } from "node:url"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
 import { contextUsageRingPercent, contextUsageTone } from "./session-context-usage-state"
 
-const SOURCE_PATH = fileURLToPath(new URL("session-context-usage.tsx", import.meta.url))
+const showAccessorBehaviorCheck = String.raw`
+import { batch, createComponent, createSignal } from "solid-js"
+import { render } from "solid-js/web"
+import { Show } from "solid-js"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const unsafeRoot = document.createElement("div")
+let staleAccessor
+let clearContext
+const disposeUnsafe = render(
+  () => {
+    const [context, setContext] = createSignal({ label: "Context usage" })
+    clearContext = () => batch(() => setContext(undefined))
+    return createComponent(Show, {
+      get when() {
+        return context()
+      },
+      children: (current) => {
+        staleAccessor = current
+        return document.createTextNode(current().label)
+      },
+    })
+  },
+  unsafeRoot,
+)
+
+assert(staleAccessor().label === "Context usage", "callback-form Show accessor should expose the current context first")
+clearContext()
+let staleError
+try {
+  staleAccessor()
+} catch (error) {
+  staleError = error
+}
+assert(String(staleError) === "Stale read from <Show>.", "callback-form Show accessor should throw after the when value disappears")
+disposeUnsafe()
+
+const safeRoot = document.createElement("div")
+let clearContextUsedLabel
+const disposeSafe = render(
+  () => {
+    const [contextUsedLabel, setContextUsedLabel] = createSignal("Context usage")
+    clearContextUsedLabel = () => batch(() => setContextUsedLabel(undefined))
+    return createComponent(Show, {
+      get when() {
+        return contextUsedLabel()
+      },
+      get children() {
+        return document.createTextNode(contextUsedLabel() ?? "")
+      },
+    })
+  },
+  safeRoot,
+)
+
+clearContextUsedLabel()
+disposeSafe()
+`
 
 describe("session context usage indicator helpers", () => {
   test("uses normal tone for unknown usage and usage below warning", () => {
@@ -25,11 +84,8 @@ describe("session context usage indicator helpers", () => {
   })
 })
 
-describe("SessionContextUsage render contract", () => {
-  test("does not pass volatile context accessors through non-keyed Show children", async () => {
-    const source = await fs.readFile(SOURCE_PATH, "utf8")
-
-    expect(source).not.toContain("<Show when={context()}>")
-    expect(source).not.toContain("<Show when={compactStatus()}>{(status)")
+describe("Solid Show context usage behavior", () => {
+  test("avoids stale callback accessors when context metrics disappear", () => {
+    runBrowserCheck(showAccessorBehaviorCheck)
   })
 })

--- a/packages/app/src/components/session-context-usage.test.ts
+++ b/packages/app/src/components/session-context-usage.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import * as fs from "node:fs/promises"
-import * as path from "node:path"
+import { fileURLToPath } from "node:url"
 import { contextUsageRingPercent, contextUsageTone } from "./session-context-usage-state"
 
-const SOURCE_PATH = path.join(__dirname, "session-context-usage.tsx")
+const SOURCE_PATH = fileURLToPath(new URL("session-context-usage.tsx", import.meta.url))
 
 describe("session context usage indicator helpers", () => {
   test("uses normal tone for unknown usage and usage below warning", () => {

--- a/packages/app/src/components/session-context-usage.test.ts
+++ b/packages/app/src/components/session-context-usage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
 import { contextUsageRingPercent, contextUsageTone } from "./session-context-usage-state"
+
+const SOURCE_PATH = path.join(__dirname, "session-context-usage.tsx")
 
 describe("session context usage indicator helpers", () => {
   test("uses normal tone for unknown usage and usage below warning", () => {
@@ -18,5 +22,14 @@ describe("session context usage indicator helpers", () => {
     expect(contextUsageRingPercent(-1)).toBe(0)
     expect(contextUsageRingPercent(42.5)).toBe(42.5)
     expect(contextUsageRingPercent(120)).toBe(100)
+  })
+})
+
+describe("SessionContextUsage render contract", () => {
+  test("does not pass volatile context accessors through non-keyed Show children", async () => {
+    const source = await fs.readFile(SOURCE_PATH, "utf8")
+
+    expect(source).not.toContain("<Show when={context()}>")
+    expect(source).not.toContain("<Show when={compactStatus()}>{(status)")
   })
 })

--- a/packages/app/src/components/session-context-usage.test.ts
+++ b/packages/app/src/components/session-context-usage.test.ts
@@ -2,66 +2,118 @@ import { describe, expect, test } from "bun:test"
 import { runBrowserCheck } from "@/testing/browser-subprocess"
 import { contextUsageRingPercent, contextUsageTone } from "./session-context-usage-state"
 
-const showAccessorBehaviorCheck = String.raw`
+const sessionContextUsageBehaviorCheck = String.raw`
+import { mock } from "bun:test"
 import { batch, createComponent, createSignal } from "solid-js"
 import { render } from "solid-js/web"
-import { Show } from "solid-js"
 
 const assert = (condition, message) => {
   if (!condition) throw new Error(message)
 }
 
-const unsafeRoot = document.createElement("div")
-let staleAccessor
-let clearContext
-const disposeUnsafe = render(
-  () => {
-    const [context, setContext] = createSignal({ label: "Context usage" })
-    clearContext = () => batch(() => setContext(undefined))
-    return createComponent(Show, {
-      get when() {
-        return context()
-      },
-      children: (current) => {
-        staleAccessor = current
-        return document.createTextNode(current().label)
-      },
-    })
+globalThis.React = {
+  createElement(type, props, ...children) {
+    if (typeof type === "function") return type({ ...(props ?? {}), children })
+    return children
   },
-  unsafeRoot,
-)
-
-assert(staleAccessor().label === "Context usage", "callback-form Show accessor should expose the current context first")
-clearContext()
-let staleError
-try {
-  staleAccessor()
-} catch (error) {
-  staleError = error
 }
-assert(String(staleError) === "Stale read from <Show>.", "callback-form Show accessor should throw after the when value disappears")
-disposeUnsafe()
 
-const safeRoot = document.createElement("div")
-let clearContextUsedLabel
-const disposeSafe = render(
-  () => {
-    const [contextUsedLabel, setContextUsedLabel] = createSignal("Context usage")
-    clearContextUsedLabel = () => batch(() => setContextUsedLabel(undefined))
-    return createComponent(Show, {
-      get when() {
-        return contextUsedLabel()
+const [messageList, setMessageList] = createSignal([])
+
+mock.module("@opencode-ai/ui/tooltip", () => ({
+  Tooltip: (props) => [props.value, props.children],
+}))
+mock.module("@opencode-ai/ui/progress-circle", () => ({
+  ProgressCircle: () => document.createTextNode("progress"),
+}))
+mock.module("@opencode-ai/ui/button", () => ({
+  Button: (props) => props.children,
+}))
+mock.module("@/context/sync", () => ({
+  useSync: () => ({
+    data: {
+      get message() {
+        return { session_a: messageList() }
       },
-      get children() {
-        return document.createTextNode(contextUsedLabel() ?? "")
+      config: {
+        compaction: {
+          auto: true,
+          reserved: 1000,
+        },
       },
-    })
+    },
+  }),
+}))
+mock.module("@/context/language", () => ({
+  useLanguage: () => ({
+    intl: () => "en-US",
+    t: (key, values) => (values ? key + JSON.stringify(values) : key),
+  }),
+}))
+mock.module("@/hooks/use-providers", () => ({
+  useProviders: () => ({
+    all: () => [
+      {
+        id: "provider",
+        name: "Provider",
+        models: {
+          model: {
+            name: "Model",
+            limit: {
+              context: 10000,
+              input: 10000,
+              output: 1000,
+            },
+          },
+        },
+      },
+    ],
+  }),
+}))
+mock.module("@/pages/session/session-layout", () => ({
+  useSessionLayout: () => ({
+    params: { id: "session_a" },
+    view: () => ({
+      sidePanel: {
+        toggleTab: () => undefined,
+      },
+    }),
+  }),
+}))
+
+const { SessionContextUsage } = await import("./src/components/session-context-usage.tsx")
+
+setMessageList([
+  {
+    id: "msg_a",
+    role: "assistant",
+    providerID: "provider",
+    modelID: "model",
+    cost: 0.25,
+    tokens: {
+      total: 2100,
+      input: 2000,
+      output: 100,
+      reasoning: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+    time: {
+      created: 1,
+    },
   },
-  safeRoot,
-)
+])
 
-clearContextUsedLabel()
-disposeSafe()
+const root = document.createElement("div")
+const dispose = render(() => createComponent(SessionContextUsage, {}), root)
+
+assert(root.textContent.includes("context.usage.title"), "context usage details should render before metrics disappear")
+batch(() => setMessageList([]))
+assert(root.textContent.includes("context.usage.cost"), "cost row should remain visible without context metrics")
+
+dispose()
 `
 
 describe("session context usage indicator helpers", () => {
@@ -84,8 +136,8 @@ describe("session context usage indicator helpers", () => {
   })
 })
 
-describe("Solid Show context usage behavior", () => {
-  test("avoids stale callback accessors when context metrics disappear", () => {
-    runBrowserCheck(showAccessorBehaviorCheck)
+describe("SessionContextUsage render behavior", () => {
+  test("does not read stale Show accessors when context metrics disappear", () => {
+    runBrowserCheck(sessionContextUsageBehaviorCheck)
   })
 })

--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -15,6 +15,36 @@ interface SessionContextUsageProps {
   placement?: TooltipProps["placement"]
 }
 
+interface SessionContextUsageTooltipContentProps {
+  title: () => string
+  contextUsedLabel: () => string | undefined
+  compactStatus: () => string | undefined
+  cost: () => string
+  costLabel: () => string
+}
+
+function SessionContextUsageTooltipContent(props: SessionContextUsageTooltipContentProps) {
+  return (
+    <div>
+      <Show when={props.contextUsedLabel()}>
+        <div class="flex items-center gap-2">
+          <span>{props.title()}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span>{props.contextUsedLabel()}</span>
+        </div>
+        <Show when={props.compactStatus()}>
+          <div>{props.compactStatus()}</div>
+        </Show>
+      </Show>
+      <div class="flex items-center gap-2">
+        <span>{props.cost()}</span>
+        <span>{props.costLabel()}</span>
+      </div>
+    </div>
+  )
+}
+
 export function SessionContextUsage(props: SessionContextUsageProps) {
   const sync = useSync()
   const language = useLanguage()
@@ -78,23 +108,13 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   })
 
   const tooltipValue = () => (
-    <div>
-      <Show when={contextUsedLabel()}>
-        <div class="flex items-center gap-2">
-          <span>{language.t("context.usage.title")}</span>
-        </div>
-        <div class="flex items-center gap-2">
-          <span>{contextUsedLabel()}</span>
-        </div>
-        <Show when={compactStatus()}>
-          <div>{compactStatus()}</div>
-        </Show>
-      </Show>
-      <div class="flex items-center gap-2">
-        <span>{cost()}</span>
-        <span>{language.t("context.usage.cost")}</span>
-      </div>
-    </div>
+    <SessionContextUsageTooltipContent
+      title={() => language.t("context.usage.title")}
+      contextUsedLabel={contextUsedLabel}
+      compactStatus={compactStatus}
+      cost={cost}
+      costLabel={() => language.t("context.usage.cost")}
+    />
   )
 
   return (

--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -72,21 +72,23 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
       limit: limit.toLocaleString(language.intl()),
     })
   }
+  const contextUsedLabel = createMemo(() => {
+    const ctx = context()
+    return ctx ? contextUsedText(ctx) : undefined
+  })
 
   const tooltipValue = () => (
     <div>
-      <Show when={context()}>
-        {(ctx) => (
-          <>
-            <div class="flex items-center gap-2">
-              <span>{language.t("context.usage.title")}</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <span>{contextUsedText(ctx())}</span>
-            </div>
-            <Show when={compactStatus()}>{(status) => <div>{status()}</div>}</Show>
-          </>
-        )}
+      <Show when={contextUsedLabel()}>
+        <div class="flex items-center gap-2">
+          <span>{language.t("context.usage.title")}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span>{contextUsedLabel()}</span>
+        </div>
+        <Show when={compactStatus()}>
+          <div>{compactStatus()}</div>
+        </Show>
       </Show>
       <div class="flex items-center gap-2">
         <span>{cost()}</span>


### PR DESCRIPTION
## Summary

Fixes a Solid stale `<Show>` accessor read in `SessionContextUsage` by avoiding callback accessors for context usage tooltip content.

## Why

Production v2026.5.29 can throw `Stale read from <Show>` while switching sessions. The issue was first filed as #985. The release regression was exposed by PR #969 keeping the composer mounted during session opening; Claude's read-only review agreed that restoring the composer guard would be a symptom fix that regresses #969, and that the smaller root fix is to stop passing volatile context accessors through non-keyed `<Show>` children inside the composer subtree.

## Related Issue

Fixes #985

## Human Review Status

Pending

## Review Focus

Please check that the tooltip still renders the same context/cost information while no longer using callback-form `<Show>` accessors for values that can disappear during session transitions.

## Risk Notes

Low risk. This keeps the #969 composer mount behavior intact and only changes the render shape inside the context usage tooltip. Review follow-up replaced the brittle source-string render contract with a browser-condition test that renders SessionContextUsage itself and clears the mocked session messages so context metrics disappear. Platform/packaging surfaces were not touched. Docs, dependencies, permissions, generated files, and local file behavior were not touched.

## How To Verify

```text
Diff check: git diff --check passed
Focused tests: bun test --preload ./happydom.ts ./src/components/session/session-context-metrics.test.ts ./src/components/session-context-usage.test.ts passed, 13 tests, including a SessionContextUsage render regression for disappearing context metrics
Typecheck: bun run typecheck passed in packages/app
Visual check: bun run snap session-context-cache passed; reviewed docs/design/preview/screenshots/session-context-cache.png
```

## Screenshots or Recordings

Visual snap checked locally: `docs/design/preview/screenshots/session-context-cache.png` (`session-context-cache`).

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


