### PR TITLE
feat(pty): add websocket connect tickets

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -93,6 +93,7 @@ const specialSurfaces: Array<[RegExp, string]> = [
   [/^GET \/global\/(?:sync-)?event$/, "SSE/event"],
   [/^GET \/event$/, "SSE/event"],
   [/^GET \/pty\/:ptyID\/connect$/, "PTY websocket"],
+  [/^POST \/pty\/:ptyID\/connect-token$/, "PTY websocket"],
   [/^GET \/__workspace_ws$/, "workspace websocket proxy"],
   [/^ALL \/\*$/, "UI static route"],
   [/^GET \/doc$/, "OpenAPI source"],

--- a/packages/opencode/src/pty/ticket.ts
+++ b/packages/opencode/src/pty/ticket.ts
@@ -36,6 +36,7 @@ export class PtyTicketStore {
   }
 
   issue(input: { ptyID: PtyID }): ConnectToken {
+    this.cleanupExpired()
     const ticket = this.random()
     this.tickets.set(ticket, {
       ptyID: input.ptyID,
@@ -50,13 +51,17 @@ export class PtyTicketStore {
   consume(input: { ptyID: PtyID; ticket: string }) {
     const record = this.tickets.get(input.ticket)
     if (!record) return false
-    if (record.expiresAt <= this.now()) {
-      this.tickets.delete(input.ticket)
-      return false
-    }
-    if (record.ptyID !== input.ptyID) return false
     this.tickets.delete(input.ticket)
+    if (record.expiresAt <= this.now()) return false
+    if (record.ptyID !== input.ptyID) return false
     return true
+  }
+
+  private cleanupExpired() {
+    const now = this.now()
+    for (const [ticket, record] of this.tickets) {
+      if (record.expiresAt <= now) this.tickets.delete(ticket)
+    }
   }
 }
 

--- a/packages/opencode/src/pty/ticket.ts
+++ b/packages/opencode/src/pty/ticket.ts
@@ -1,0 +1,63 @@
+import z from "zod"
+import type { PtyID } from "./schema"
+
+const DEFAULT_TTL_MS = 60_000
+
+export const ConnectToken = z
+  .object({
+    ticket: z.string(),
+    expires_in: z.number().int().positive(),
+  })
+  .meta({ ref: "PtyConnectToken" })
+
+export type ConnectToken = z.infer<typeof ConnectToken>
+
+type TicketRecord = {
+  ptyID: PtyID
+  expiresAt: number
+}
+
+type StoreOptions = {
+  ttlMs?: number
+  now?: () => number
+  random?: () => string
+}
+
+export class PtyTicketStore {
+  private readonly ttlMs: number
+  private readonly now: () => number
+  private readonly random: () => string
+  private readonly tickets = new Map<string, TicketRecord>()
+
+  constructor(options: StoreOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+    this.now = options.now ?? Date.now
+    this.random = options.random ?? (() => crypto.randomUUID())
+  }
+
+  issue(input: { ptyID: PtyID }): ConnectToken {
+    const ticket = this.random()
+    this.tickets.set(ticket, {
+      ptyID: input.ptyID,
+      expiresAt: this.now() + this.ttlMs,
+    })
+    return {
+      ticket,
+      expires_in: Math.max(1, Math.round(this.ttlMs / 1000)),
+    }
+  }
+
+  consume(input: { ptyID: PtyID; ticket: string }) {
+    const record = this.tickets.get(input.ticket)
+    if (!record) return false
+    if (record.expiresAt <= this.now()) {
+      this.tickets.delete(input.ticket)
+      return false
+    }
+    if (record.ptyID !== input.ptyID) return false
+    this.tickets.delete(input.ticket)
+    return true
+  }
+}
+
+export const PtyTicket = new PtyTicketStore()

--- a/packages/opencode/src/pty/ticket.ts
+++ b/packages/opencode/src/pty/ticket.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import type { PtyID } from "./schema"
 
 const DEFAULT_TTL_MS = 60_000
+const DEFAULT_MAX_TICKETS = 1024
 
 export const ConnectToken = z
   .object({
@@ -19,24 +20,28 @@ type TicketRecord = {
 
 type StoreOptions = {
   ttlMs?: number
+  maxTickets?: number
   now?: () => number
   random?: () => string
 }
 
 export class PtyTicketStore {
   private readonly ttlMs: number
+  private readonly maxTickets: number
   private readonly now: () => number
   private readonly random: () => string
   private readonly tickets = new Map<string, TicketRecord>()
 
   constructor(options: StoreOptions = {}) {
     this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+    this.maxTickets = Math.max(1, options.maxTickets ?? DEFAULT_MAX_TICKETS)
     this.now = options.now ?? Date.now
     this.random = options.random ?? (() => crypto.randomUUID())
   }
 
   issue(input: { ptyID: PtyID }): ConnectToken {
     this.cleanupExpired()
+    this.trimToCapacity()
     const ticket = this.random()
     this.tickets.set(ticket, {
       ptyID: input.ptyID,
@@ -61,6 +66,14 @@ export class PtyTicketStore {
     const now = this.now()
     for (const [ticket, record] of this.tickets) {
       if (record.expiresAt <= now) this.tickets.delete(ticket)
+    }
+  }
+
+  private trimToCapacity() {
+    while (this.tickets.size >= this.maxTickets) {
+      const oldest = this.tickets.keys().next().value
+      if (!oldest) return
+      this.tickets.delete(oldest)
     }
   }
 }

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -1,9 +1,11 @@
 import { Hono, type MiddlewareHandler } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import { HTTPException } from "hono/http-exception"
 import type { UpgradeWebSocket } from "hono/ws"
 import z from "zod"
 import { Pty } from "@/pty"
 import { PtyID } from "@/pty/schema"
+import { ConnectToken, PtyTicket } from "@/pty/ticket"
 import { NotFoundError } from "../../storage/db"
 import { errors } from "../error"
 
@@ -11,6 +13,12 @@ export function assertPtyConnectTarget(info: unknown) {
   if (!info) {
     throw new NotFoundError({ message: "PTY session not found" })
   }
+}
+
+function assertPtyConnectTicket(input: { ptyID: PtyID; ticket?: string }) {
+  if (!input.ticket) return
+  if (PtyTicket.consume({ ptyID: input.ptyID, ticket: input.ticket })) return
+  throw new HTTPException(401, { message: "Invalid PTY connect ticket" })
 }
 
 export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
@@ -145,6 +153,31 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
         return c.json(true)
       },
     )
+    .post(
+      "/:ptyID/connect-token",
+      describeRoute({
+        summary: "Create PTY WebSocket token",
+        description: "Create a short-lived ticket for opening a PTY WebSocket connection.",
+        operationId: "pty.connectToken",
+        responses: {
+          200: {
+            description: "WebSocket connect token",
+            content: {
+              "application/json": {
+                schema: resolver(ConnectToken),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      validator("param", z.object({ ptyID: PtyID.zod })),
+      async (c) => {
+        const id = c.req.valid("param").ptyID
+        assertPtyConnectTarget(await Pty.get(id))
+        return c.json(PtyTicket.issue({ ptyID: id }))
+      },
+    )
     .get(
       "/:ptyID/connect",
       describeRoute({
@@ -164,8 +197,10 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
         },
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
+      validator("query", z.object({ cursor: z.string().optional(), ticket: z.string().optional() })),
       upgradeWebSocket(async (c) => {
         const id = PtyID.zod.parse(c.req.param("ptyID"))
+        assertPtyConnectTicket({ ptyID: id, ticket: c.req.query("ticket") })
         const cursor = (() => {
           const value = c.req.query("cursor")
           if (!value) return

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -21,6 +21,13 @@ function assertPtyConnectTicket(input: { ptyID: PtyID; ticket?: string }) {
   throw new HTTPException(401, { message: "Invalid PTY connect ticket" })
 }
 
+const PtyConnectQuery = z.object({ cursor: z.string().optional(), ticket: z.string().optional() })
+type PtyConnectQuery = z.infer<typeof PtyConnectQuery>
+type PtyConnectRequest = {
+  valid(target: "param"): { ptyID: PtyID }
+  valid(target: "query"): PtyConnectQuery
+}
+
 export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
   return new Hono()
     .get(
@@ -197,12 +204,14 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
         },
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
-      validator("query", z.object({ cursor: z.string().optional(), ticket: z.string().optional() })),
+      validator("query", PtyConnectQuery),
       upgradeWebSocket(async (c) => {
-        const id = PtyID.zod.parse(c.req.param("ptyID"))
-        assertPtyConnectTicket({ ptyID: id, ticket: c.req.query("ticket") })
+        const request = c.req as unknown as PtyConnectRequest
+        const id = request.valid("param").ptyID
+        const query = request.valid("query")
+        assertPtyConnectTicket({ ptyID: id, ticket: query.ticket })
         const cursor = (() => {
-          const value = c.req.query("cursor")
+          const value = query.cursor
           if (!value) return
           const parsed = Number(value)
           if (!Number.isSafeInteger(parsed) || parsed < -1) return

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -13,6 +13,7 @@ import { Option, Redacted } from "effect"
 import { ServerAuth } from "./auth"
 
 const log = Log.create({ service: "server" })
+const PTY_CONNECT_PATH = /^\/pty\/[^/]+\/connect$/
 
 export const ErrorMiddleware: ErrorHandler = (err, c) => {
   if (err instanceof NamedError) {
@@ -54,6 +55,8 @@ export const AuthMiddleware: MiddlewareHandler = async (c, next) => {
 
   const password = Flag.OPENCODE_SERVER_PASSWORD
   if (!password) return next()
+
+  if (c.req.method === "GET" && PTY_CONNECT_PATH.test(c.req.path) && c.req.query("ticket")) return next()
 
   const queryToken = c.req.query("auth_token")
   const authHeader = c.req.header("authorization")

--- a/packages/opencode/src/server/proxy.ts
+++ b/packages/opencode/src/server/proxy.ts
@@ -103,6 +103,15 @@ const app = (upgrade: UpgradeWebSocket) =>
   )
 
 const log = Log.Default.clone().tag("service", "server-proxy")
+const SENSITIVE_QUERY_KEYS = new Set(["auth_token", "ticket"])
+
+export function redactProxyURL(input: string | URL) {
+  const url = new URL(input)
+  for (const key of SENSITIVE_QUERY_KEYS) {
+    if (url.searchParams.has(key)) url.searchParams.set(key, "REDACTED")
+  }
+  return url.toString()
+}
 
 function isLegacyTarget(value: unknown): value is Extract<Target, { type: "remote" }> {
   return Boolean(value && typeof value === "object" && "type" in value && (value as { type?: unknown }).type === "remote")
@@ -222,8 +231,8 @@ export function websocket(
     next.set(key, value)
   }
   log.info("proxy websocket", {
-    request: req.url,
-    target: String(target),
+    request: redactProxyURL(req.url),
+    target: redactProxyURL(target),
   })
   return app(upgrade).fetch(
     new Request(proxy, {

--- a/packages/opencode/test/pty/pty-ticket.test.ts
+++ b/packages/opencode/test/pty/pty-ticket.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { PtyTicketStore } from "../../src/pty/ticket"
+import { PtyID } from "../../src/pty/schema"
+
+describe("PtyTicketStore", () => {
+  test("issues one-use tickets scoped to a PTY id", () => {
+    const store = new PtyTicketStore({ ttlMs: 60_000, now: () => 1_000, random: () => "ticket-1" })
+    const ptyID = PtyID.ascending()
+    const otherPtyID = PtyID.ascending()
+
+    const issued = store.issue({ ptyID })
+
+    expect(issued).toEqual({ ticket: "ticket-1", expires_in: 60 })
+    expect(store.consume({ ptyID: otherPtyID, ticket: issued.ticket })).toBe(false)
+    expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(true)
+    expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(false)
+  })
+
+  test("rejects expired tickets", () => {
+    let now = 1_000
+    const store = new PtyTicketStore({ ttlMs: 100, now: () => now, random: () => "ticket-1" })
+    const ptyID = PtyID.ascending()
+
+    const issued = store.issue({ ptyID })
+    now = 1_101
+
+    expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(false)
+  })
+})

--- a/packages/opencode/test/pty/pty-ticket.test.ts
+++ b/packages/opencode/test/pty/pty-ticket.test.ts
@@ -45,4 +45,22 @@ describe("PtyTicketStore", () => {
 
     expect(tickets.size).toBe(1)
   })
+
+  test("evicts the oldest unused ticket when capacity is reached", () => {
+    let next = 0
+    const store = new PtyTicketStore({
+      maxTickets: 2,
+      now: () => 1_000,
+      random: () => `ticket-${++next}`,
+    })
+    const ptyID = PtyID.ascending()
+
+    const first = store.issue({ ptyID })
+    const second = store.issue({ ptyID })
+    const third = store.issue({ ptyID })
+
+    expect(store.consume({ ptyID, ticket: first.ticket })).toBe(false)
+    expect(store.consume({ ptyID, ticket: second.ticket })).toBe(true)
+    expect(store.consume({ ptyID, ticket: third.ticket })).toBe(true)
+  })
 })

--- a/packages/opencode/test/pty/pty-ticket.test.ts
+++ b/packages/opencode/test/pty/pty-ticket.test.ts
@@ -12,7 +12,7 @@ describe("PtyTicketStore", () => {
 
     expect(issued).toEqual({ ticket: "ticket-1", expires_in: 60 })
     expect(store.consume({ ptyID: otherPtyID, ticket: issued.ticket })).toBe(false)
-    expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(true)
+    expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(false)
     expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(false)
   })
 
@@ -25,5 +25,24 @@ describe("PtyTicketStore", () => {
     now = 1_101
 
     expect(store.consume({ ptyID, ticket: issued.ticket })).toBe(false)
+  })
+
+  test("cleans expired tickets when issuing a new ticket", () => {
+    let now = 1_000
+    let next = 0
+    const store = new PtyTicketStore({
+      ttlMs: 100,
+      now: () => now,
+      random: () => `ticket-${++next}`,
+    })
+    const ptyID = PtyID.ascending()
+    const tickets = (store as unknown as { tickets: Map<string, unknown> }).tickets
+
+    store.issue({ ptyID })
+    store.issue({ ptyID })
+    now = 1_101
+    store.issue({ ptyID })
+
+    expect(tickets.size).toBe(1)
   })
 })

--- a/packages/opencode/test/server/auth.test.ts
+++ b/packages/opencode/test/server/auth.test.ts
@@ -121,4 +121,27 @@ describe("AuthMiddleware", () => {
     expect(response.status).toBe(401)
     expect(response.headers.get("www-authenticate")).toBe('Basic realm="opencode"')
   })
+
+  test("lets PTY websocket ticket requests reach the PTY connect route", async () => {
+    mutableFlag.OPENCODE_SERVER_PASSWORD = "secret"
+    mutableFlag.OPENCODE_SERVER_USERNAME = "alice"
+    const app = new Hono()
+    app.use(AuthMiddleware)
+    app.get("/pty/:ptyID/connect", (c) => c.text(c.req.query("ticket") ?? "missing"))
+
+    const response = await app.request("/pty/pty_test/connect?ticket=one-use")
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("one-use")
+  })
+
+  test("does not treat PTY websocket tickets as general API auth", async () => {
+    mutableFlag.OPENCODE_SERVER_PASSWORD = "secret"
+    mutableFlag.OPENCODE_SERVER_USERNAME = "alice"
+
+    const response = await app().request("/?ticket=one-use")
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe('Basic realm="opencode"')
+  })
 })

--- a/packages/opencode/test/server/proxy.test.ts
+++ b/packages/opencode/test/server/proxy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { redactProxyURL } from "../../src/server/proxy"
+
+describe("server proxy logging", () => {
+  test("redacts sensitive websocket query credentials", () => {
+    const request = redactProxyURL(
+      "http://127.0.0.1:4096/pty/pty_test/connect?ticket=connect-ticket&auth_token=basic-token&cursor=12",
+    )
+    const target = redactProxyURL(
+      "ws://remote.example/pty/pty_test/connect?ticket=remote-ticket&auth_token=remote-token&cursor=12",
+    )
+
+    expect(request).toBe(
+      "http://127.0.0.1:4096/pty/pty_test/connect?ticket=REDACTED&auth_token=REDACTED&cursor=12",
+    )
+    expect(target).toBe(
+      "ws://remote.example/pty/pty_test/connect?ticket=REDACTED&auth_token=REDACTED&cursor=12",
+    )
+    expect(request).not.toContain("connect-ticket")
+    expect(request).not.toContain("basic-token")
+    expect(target).not.toContain("remote-ticket")
+    expect(target).not.toContain("remote-token")
+  })
+})

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -9,6 +9,7 @@ import { Pty } from "../../src/pty"
 import { PtyID } from "../../src/pty/schema"
 import { PtyTicket } from "../../src/pty/ticket"
 import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -140,6 +141,21 @@ describe("pty routes", () => {
         expect(replay.status).toBe(401)
       },
     })
+  })
+
+  test("openapi documents connect tokens and websocket query parameters", async () => {
+    const spec = await Server.openapi()
+    const tokenResponse = spec.paths?.["/pty/{ptyID}/connect-token"]?.post?.responses?.["200"] as
+      | { content?: unknown }
+      | undefined
+
+    expect(tokenResponse?.content).toBeTruthy()
+
+    const parameters = spec.paths?.["/pty/{ptyID}/connect"]?.get?.parameters ?? []
+    const names = parameters.map((parameter) => ("name" in parameter ? parameter.name : undefined))
+
+    expect(names).toContain("cursor")
+    expect(names).toContain("ticket")
   })
 
   test("maps missing update targets as not found", async () => {

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -5,7 +5,9 @@ import { Log } from "@opencode-ai/core/util/log"
 import { assertPtyConnectTarget, PtyRoutes } from "../../src/server/instance/pty"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { NotFoundError } from "../../src/storage/db"
+import { Pty } from "../../src/pty"
 import { PtyID } from "../../src/pty/schema"
+import { PtyTicket } from "../../src/pty/ticket"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -44,6 +46,98 @@ describe("pty routes", () => {
 
         expect(response.status).toBe(404)
         expect(body.name).toBe("NotFoundError")
+      },
+    })
+  })
+
+  test("issues a connect token for an existing PTY", async () => {
+    if (process.platform === "win32") return
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const info = await Pty.create({
+          command: "/bin/sh",
+          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+          title: "ticket",
+        })
+        try {
+          const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+          app.onError(ErrorMiddleware)
+
+          const response = await app.request(`/pty/${info.id}/connect-token`, { method: "POST" })
+          const body = await response.json()
+
+          expect(response.status).toBe(200)
+          expect(body.ticket).toBeString()
+          expect(body.expires_in).toBe(60)
+          expect(PtyTicket.consume({ ptyID: info.id, ticket: body.ticket })).toBe(true)
+        } finally {
+          await Pty.remove(info.id)
+        }
+      },
+    })
+  })
+
+  test("rejects invalid connect tickets before checking PTY existence", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+        app.onError(ErrorMiddleware)
+
+        const response = await app.request(`/pty/${PtyID.ascending()}/connect?ticket=missing`)
+
+        expect(response.status).toBe(401)
+      },
+    })
+  })
+
+  test("accepts a valid connect ticket once", async () => {
+    if (process.platform === "win32") return
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const info = await Pty.create({
+          command: "/bin/sh",
+          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+          title: "ticket-connect",
+        })
+        try {
+          const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+          app.onError(ErrorMiddleware)
+          const issued = PtyTicket.issue({ ptyID: info.id })
+
+          const first = await app.request(`/pty/${info.id}/connect?ticket=${encodeURIComponent(issued.ticket)}`)
+          const second = await app.request(`/pty/${info.id}/connect?ticket=${encodeURIComponent(issued.ticket)}`)
+
+          expect(first.status).toBe(200)
+          expect(await first.text()).toBe("upgraded")
+          expect(second.status).toBe(401)
+        } finally {
+          await Pty.remove(info.id)
+        }
+      },
+    })
+  })
+
+  test("consumes a valid ticket before reporting a deleted PTY target", async () => {
+    const ptyID = PtyID.ascending()
+    const issued = PtyTicket.issue({ ptyID })
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+        app.onError(ErrorMiddleware)
+
+        const missing = await app.request(`/pty/${ptyID}/connect?ticket=${encodeURIComponent(issued.ticket)}`)
+        const replay = await app.request(`/pty/${ptyID}/connect?ticket=${encodeURIComponent(issued.ticket)}`)
+
+        expect(missing.status).toBe(404)
+        expect(replay.status).toBe(401)
       },
     })
   })

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -124,6 +124,36 @@ describe("pty routes", () => {
     })
   })
 
+  test("consumes a valid ticket when it is presented for the wrong PTY", async () => {
+    if (process.platform === "win32") return
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const info = await Pty.create({
+          command: "/bin/sh",
+          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+          title: "ticket-wrong-pty",
+        })
+        try {
+          const app = new Hono().route("/pty", PtyRoutes(testUpgradeWebSocket))
+          app.onError(ErrorMiddleware)
+          const issued = PtyTicket.issue({ ptyID: info.id })
+
+          const wrong = await app.request(
+            `/pty/${PtyID.ascending()}/connect?ticket=${encodeURIComponent(issued.ticket)}`,
+          )
+          const replay = await app.request(`/pty/${info.id}/connect?ticket=${encodeURIComponent(issued.ticket)}`)
+
+          expect(wrong.status).toBe(401)
+          expect(replay.status).toBe(401)
+        } finally {
+          await Pty.remove(info.id)
+        }
+      },
+    })
+  })
+
   test("consumes a valid ticket before reporting a deleted PTY target", async () => {
     const ptyID = PtyID.ascending()
     const issued = PtyTicket.issue({ ptyID })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -120,6 +120,18 @@ describe("route inventory harness", () => {
     ).toMatchObject({ hono: true, openapi: false, v2Sdk: true, classification: "hono-v2-sdk" })
   })
 
+  test("keeps the PTY connect-token route in the public OpenAPI and v2 SDK surfaces", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    expect(inventory.rows.find((row) => row.method === "POST" && row.path === "/pty/:ptyID/connect-token")).toMatchObject({
+      hono: true,
+      openapi: true,
+      v2Sdk: true,
+      classification: "openapi-v2-sdk",
+      specialSurface: "PTY websocket",
+    })
+  })
+
   test("fails when the upstream HttpApi ref is unavailable", async () => {
     await expect(
       buildRouteInventory({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -122,6 +122,8 @@ import type {
   ProviderOauthCallbackResponses,
   PtyConnectErrors,
   PtyConnectResponses,
+  PtyConnectTokenErrors,
+  PtyConnectTokenResponses,
   PtyCreateErrors,
   PtyCreateResponses,
   PtyGetErrors,
@@ -1225,11 +1227,11 @@ export class Pty extends HeyApiClient {
   }
 
   /**
-   * Connect to PTY session
+   * Create PTY WebSocket token
    *
-   * Establish a WebSocket connection to interact with a pseudo-terminal (PTY) session in real-time.
+   * Create a short-lived ticket for opening a PTY WebSocket connection.
    */
-  public connect<ThrowOnError extends boolean = false>(
+  public connectToken<ThrowOnError extends boolean = false>(
     parameters: {
       ptyID: string
       directory?: string
@@ -1245,6 +1247,42 @@ export class Pty extends HeyApiClient {
             { in: "path", key: "ptyID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PtyConnectTokenResponses, PtyConnectTokenErrors, ThrowOnError>({
+      url: "/pty/{ptyID}/connect-token",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Connect to PTY session
+   *
+   * Establish a WebSocket connection to interact with a pseudo-terminal (PTY) session in real-time.
+   */
+  public connect<ThrowOnError extends boolean = false>(
+    parameters: {
+      ptyID: string
+      directory?: string
+      workspace?: string
+      cursor?: string
+      ticket?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "ptyID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "cursor" },
+            { in: "query", key: "ticket" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2019,6 +2019,11 @@ export type NotFoundError = {
   }
 }
 
+export type PtyConnectToken = {
+  ticket: string
+  expires_in: number
+}
+
 export type Model = {
   id: string
   providerID: string
@@ -3207,6 +3212,36 @@ export type PtyUpdateResponses = {
 
 export type PtyUpdateResponse = PtyUpdateResponses[keyof PtyUpdateResponses]
 
+export type PtyConnectTokenData = {
+  body?: never
+  path: {
+    ptyID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/pty/{ptyID}/connect-token"
+}
+
+export type PtyConnectTokenErrors = {
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type PtyConnectTokenError = PtyConnectTokenErrors[keyof PtyConnectTokenErrors]
+
+export type PtyConnectTokenResponses = {
+  /**
+   * WebSocket connect token
+   */
+  200: PtyConnectToken
+}
+
+export type PtyConnectTokenResponse = PtyConnectTokenResponses[keyof PtyConnectTokenResponses]
+
 export type PtyConnectData = {
   body?: never
   path: {
@@ -3215,6 +3250,8 @@ export type PtyConnectData = {
   query?: {
     directory?: string
     workspace?: string
+    cursor?: string
+    ticket?: string
   }
   url: "/pty/{ptyID}/connect"
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1309,6 +1309,20 @@
               "pattern": "^pty.*"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ticket",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "summary": "Connect to PTY session",
@@ -6792,6 +6806,66 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.formatter.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/pty/{ptyID}/connect-token": {
+      "post": {
+        "operationId": "pty.connectToken",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "ptyID",
+            "schema": {
+              "type": "string",
+              "pattern": "^pty.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Create PTY WebSocket token",
+        "description": "Create a short-lived ticket for opening a PTY WebSocket connection.",
+        "responses": {
+          "200": {
+            "description": "WebSocket connect token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PtyConnectToken"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.pty.connectToken({\n  ...\n})"
           }
         ]
       }
@@ -14186,6 +14260,23 @@
           "name",
           "extensions",
           "enabled"
+        ]
+      },
+      "PtyConnectToken": {
+        "type": "object",
+        "properties": {
+          "ticket": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "ticket",
+          "expires_in"
         ]
       }
     }


### PR DESCRIPTION
## Summary

Add a narrow PTY websocket connect-token contract as the next #936 migration slice:

- `POST /pty/:ptyID/connect-token` issues a short-lived one-use ticket for an existing PTY.
- `GET /pty/:ptyID/connect?ticket=...` accepts the ticket as a PTY-connect-only credential while preserving the existing no-ticket connect path.
- The ticket is scoped to the target `ptyID`; directory/workspace scoping is intentionally deferred to the later workspace routing / instance-context migration.
- OpenAPI, v2 SDK, and route-inventory guardrails now include the connect-token route plus `cursor` and `ticket` query parameters on the websocket connect route.

## Why

Issue #936 identified PTY connect-token parity as the next small backend slice after route inventory and VCS parity. This PR prepares the PTY websocket boundary for future Effect HttpApi migration without switching the default Hono server path or changing frontend terminal adoption.

## Related Issue

Follow-up to #936.

## Human Review Status

Pending

## Review Focus

Please review:

- The auth boundary: ticket issuance still requires existing server auth, while a valid ticket only bypasses auth for `GET /pty/:ptyID/connect` and no other API.
- One-use ticket semantics: ptyID binding, invalid/reused/deleted-target behavior, and the decision not to bind directory/workspace in this slice.
- OpenAPI / v2 SDK / route-inventory changes are limited to PTY connect-token and websocket query contract surfaces.

## Risk Notes

- This changes an auth-adjacent websocket path. The ticket is intentionally narrow: it only authorizes one PTY websocket connect and does not authorize general HTTP API access.
- The old no-ticket terminal websocket path remains supported to avoid changing current frontend behavior in this backend migration slice.
- Generated content included: `packages/sdk/openapi.json` and v2 SDK generated files were updated only for the PTY connect-token and websocket query contract.
- Visible UI/copy check skipped: no visible UI or copy changed.
- Platform impact considered: PTY is desktop/platform-sensitive; route tests that create real PTYs skip Windows-only execution where appropriate, while auth and inventory tests remain platform-neutral.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in the isolated worktree.
Focused tests: bun test test/pty/pty-ticket.test.ts test/server/pty-routes.test.ts test/server/auth.test.ts test/server/route-inventory-harness.test.ts in packages/opencode -> passed, 34 tests.
Opencode typecheck: bun run typecheck in packages/opencode -> passed.
SDK typecheck: bun run typecheck in packages/sdk/js -> passed.
Whitespace: git diff --check -> clean.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
