### PR TITLE
fix(session): report cache hit rate per turn instead of last step

### DIFF
--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { getSessionContextMetrics } from "./session-context-metrics"
+import { getRecentTurnCache, getSessionContextMetrics } from "./session-context-metrics"
 
 const assistant = (
   id: string,
@@ -38,6 +38,28 @@ const user = (id: string) => {
   } as unknown as Message
 }
 
+const turnAssistant = (
+  id: string,
+  parentID: string,
+  cumulative?: { input: number; read: number; write: number },
+  opts?: { summary?: boolean },
+) => {
+  return {
+    id,
+    role: "assistant",
+    parentID,
+    summary: opts?.summary,
+    providerID: "openai",
+    modelID: "gpt-4.1",
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    tokensCumulative: cumulative
+      ? { input: cumulative.input, output: 0, reasoning: 0, cache: { read: cumulative.read, write: cumulative.write } }
+      : undefined,
+    time: { created: 1 },
+  } as unknown as Message
+}
+
 describe("getSessionContextMetrics", () => {
   test("computes totals and usage from latest assistant with tokens", () => {
     const messages = [
@@ -68,17 +90,8 @@ describe("getSessionContextMetrics", () => {
     expect(metrics.context?.compactThreshold).toBe(900)
     expect(metrics.context?.usagePercent).toBe(45)
     expect(metrics.context?.usage).toBe(45)
-    expect(metrics.context?.cacheHitRate).toBe(7.1)
     expect(metrics.context?.providerLabel).toBe("OpenAI")
     expect(metrics.context?.modelLabel).toBe("GPT-4.1")
-  })
-
-  test("leaves cache hit rate empty when provider reports no cache data", () => {
-    const messages = [assistant("a1", { input: 300, output: 100, reasoning: 0, read: 0, write: 0 }, 0.25)]
-
-    const metrics = getSessionContextMetrics(messages, [{ id: "openai", models: {} }])
-
-    expect(metrics.context?.cacheHitRate).toBeNull()
   })
 
   test("uses input limit and custom compaction reserve for usage metrics", () => {
@@ -197,5 +210,78 @@ describe("getSessionContextMetrics", () => {
 
     expect(metrics.totalCost).toBe(0)
     expect(metrics.context).toBeUndefined()
+  })
+})
+
+describe("getRecentTurnCache", () => {
+  test("reads the cumulative token tally of the turn", () => {
+    const messages = [user("1"), turnAssistant("2", "1", { input: 150, read: 200, write: 210 })]
+
+    // 200 / (150 + 200 + 210) = 200 / 560 = 35.7%
+    expect(getRecentTurnCache(messages)).toEqual({ input: 150, read: 200, write: 210, hitRate: 35.7 })
+  })
+
+  test("aggregates across multiple assistant messages under the same user turn", () => {
+    const messages = [
+      user("1"),
+      turnAssistant("2", "1", { input: 100, read: 0, write: 500 }),
+      turnAssistant("3", "1", { input: 20, read: 480, write: 10 }),
+    ]
+
+    // 480 / (120 + 480 + 510) = 480 / 1110 = 43.2%
+    expect(getRecentTurnCache(messages)).toEqual({ input: 120, read: 480, write: 510, hitRate: 43.2 })
+  })
+
+  test("shows 0.0% on a cold-start turn that only writes cache", () => {
+    const messages = [user("1"), turnAssistant("2", "1", { input: 300, read: 0, write: 1000 })]
+
+    expect(getRecentTurnCache(messages)?.hitRate).toBe(0)
+  })
+
+  test("returns null when the turn has no cache activity", () => {
+    const messages = [user("1"), turnAssistant("2", "1", { input: 300, read: 0, write: 0 })]
+
+    expect(getRecentTurnCache(messages)).toBeNull()
+  })
+
+  test("aggregates only the most recent turn", () => {
+    const messages = [
+      user("1"),
+      turnAssistant("2", "1", { input: 1000, read: 0, write: 0 }),
+      user("3"),
+      turnAssistant("4", "3", { input: 10, read: 90, write: 10 }),
+    ]
+
+    // 90 / (10 + 90 + 10) = 90 / 110 = 81.8%
+    expect(getRecentTurnCache(messages)).toEqual({ input: 10, read: 90, write: 10, hitRate: 81.8 })
+  })
+
+  test("skips a compaction summary message so it does not mask the user's latest turn", () => {
+    const messages = [
+      user("1"),
+      turnAssistant("2", "1", { input: 10, read: 90, write: 10 }),
+      user("c"),
+      turnAssistant("s", "c", { input: 5, read: 1000, write: 0 }, { summary: true }),
+    ]
+
+    // the summary turn is the newest but is skipped; the user's real "1" turn wins
+    expect(getRecentTurnCache(messages)).toEqual({ input: 10, read: 90, write: 10, hitRate: 81.8 })
+  })
+
+  test("ignores reverted turns when picking the recent turn", () => {
+    const messages = [
+      user("1"),
+      turnAssistant("2", "1", { input: 10, read: 90, write: 10 }),
+      user("3"),
+      turnAssistant("4", "3", { input: 5, read: 0, write: 500 }),
+    ]
+
+    // revert points at "3": only the "1" turn stays visible
+    expect(getRecentTurnCache(messages, "3")).toEqual({ input: 10, read: 90, write: 10, hitRate: 81.8 })
+  })
+
+  test("returns null when there is no assistant turn yet", () => {
+    expect(getRecentTurnCache([user("1")])).toBeNull()
+    expect(getRecentTurnCache([])).toBeNull()
   })
 })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -4,6 +4,7 @@ import {
   contextUsageUsedTokens,
   deriveContextUsage,
 } from "@opencode-ai/util/context-usage"
+import { buildTurnMessagesByUserID } from "@/pages/session/session-messages"
 
 type Provider = {
   id: string
@@ -41,12 +42,16 @@ type Context = {
   input: number
   output: number
   reasoning: number
-  cacheRead: number
-  cacheWrite: number
-  cacheHitRate: number | null
   total: number
   usagePercent: number | null
   usage: number | null
+}
+
+type RecentTurnCache = {
+  input: number
+  read: number
+  write: number
+  hitRate: number | null
 }
 
 type Metrics = {
@@ -68,9 +73,12 @@ const lastAssistantWithTokens = (messages: Message[]) => {
 }
 
 const cacheHitRate = (input: number, read: number, write: number) => {
+  // No read and no write means the provider reported no cache activity at all — show nothing.
+  // A write-only turn (cold start) keeps read at 0 and still resolves to 0.0%, so the
+  // first expensive turn is not hidden behind an empty cell.
+  if (read + write <= 0) return null
   const denominator = input + read + write
   if (denominator <= 0) return null
-  if (read <= 0) return null
   return Math.round((read / denominator) * 1000) / 10
 }
 
@@ -105,9 +113,6 @@ const build = (messages: Message[] = [], providers: Provider[] = [], config: Con
       input: message.tokens.input,
       output: message.tokens.output,
       reasoning: message.tokens.reasoning,
-      cacheRead: message.tokens.cache.read,
-      cacheWrite: message.tokens.cache.write,
-      cacheHitRate: cacheHitRate(message.tokens.input, message.tokens.cache.read, message.tokens.cache.write),
       total,
       usagePercent: usage.usagePercent,
       usage: usage.usagePercent === null ? null : Math.round(usage.usagePercent),
@@ -117,4 +122,40 @@ const build = (messages: Message[] = [], providers: Provider[] = [], config: Con
 
 export function getSessionContextMetrics(messages: Message[] = [], providers: Provider[] = [], config: Config = {}) {
   return build(messages, providers, config)
+}
+
+// Cache hit rate is a per-turn flow metric, not a window-state snapshot, so it is computed
+// separately from the context block above. We sum tokensCumulative (per-step totals the backend
+// accumulates) across every assistant message of the most recent turn, grouped by parentID — the
+// user message that triggered them. message.tokens only keeps the last step's snapshot, which
+// hides the cold-start step's writes; tokensCumulative is the whole turn. Compaction summary
+// messages are skipped so an auto-compaction never masquerades as the user's latest turn, and
+// reverted turns are excluded so a rolled-back session does not report a turn the user no longer sees.
+export function getRecentTurnCache(messages: Message[] = [], revertID?: string): RecentTurnCache | null {
+  const visible = revertID ? messages.filter((message) => message.id < revertID) : messages
+  const turns = buildTurnMessagesByUserID(visible)
+
+  let recentTurnID: string | undefined
+  for (let i = visible.length - 1; i >= 0; i--) {
+    const message = visible[i]
+    if (message.role !== "assistant" || message.summary || !message.parentID || !turns.has(message.parentID)) continue
+    recentTurnID = message.parentID
+    break
+  }
+  if (!recentTurnID) return null
+
+  let input = 0
+  let read = 0
+  let write = 0
+  for (const assistant of turns.get(recentTurnID) ?? []) {
+    if (assistant.summary) continue
+    const tokens = assistant.tokensCumulative
+    if (!tokens) continue
+    input += tokens.input
+    read += tokens.cache.read
+    write += tokens.cache.write
+  }
+  if (read + write <= 0) return null
+
+  return { input, read, write, hitRate: cacheHitRate(input, read, write) }
 }

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
-import { getSessionContextMetrics } from "./session-context-metrics"
+import { getRecentTurnCache, getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
 
@@ -187,11 +187,13 @@ export function SessionContextTab() {
     return formatter().number(c.compactThreshold)
   })
 
+  const recentTurnCache = createMemo(() => getRecentTurnCache(messages(), info()?.revert?.messageID))
+
   const cacheHitRate = createMemo(() => {
-    const c = ctx()
-    const value = c?.cacheHitRate
-    const raw = `${language.t("context.stats.cacheTokens")}: ${formatter().number(c?.cacheRead)} / ${formatter().number(c?.cacheWrite)}`
-    const hasCacheTokens = !!c && (c.cacheRead > 0 || c.cacheWrite > 0)
+    const turn = recentTurnCache()
+    const value = turn?.hitRate
+    const raw = `${language.t("context.stats.cacheTokens")}: ${formatter().number(turn?.read)} / ${formatter().number(turn?.write)}`
+    const hasCacheTokens = !!turn && (turn.read > 0 || turn.write > 0)
     return (
       <span class="flex flex-col gap-1" title={raw}>
         <span class={cacheHitRateClass(value)}>{formatter().percent(value, 1)}</span>

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -603,6 +603,22 @@ export const Assistant = Base.extend({
       write: z.number(),
     }),
   }),
+  // Per-step token usage summed across the whole assistant message. `tokens` keeps only the
+  // last step's snapshot (the current context-window state); this field accumulates every step
+  // so callers can report a turn-level cache hit rate instead of just the final step. Optional
+  // because pre-existing messages predate it — readers backfill it from step-finish parts.
+  tokensCumulative: z
+    .object({
+      total: z.number().optional(),
+      input: z.number(),
+      output: z.number(),
+      reasoning: z.number(),
+      cache: z.object({
+        read: z.number(),
+        write: z.number(),
+      }),
+    })
+    .optional(),
   structured: z.any().optional(),
   variant: z.string().optional(),
   finish: z.string().optional(),
@@ -746,6 +762,42 @@ const part = (row: typeof PartTable.$inferSelect) =>
 const older = (row: Cursor) =>
   or(lt(MessageTable.time_created, row.time), and(eq(MessageTable.time_created, row.time), lt(MessageTable.id, row.id)))
 
+type CumulativeTokens = {
+  total?: number
+  input: number
+  output: number
+  reasoning: number
+  cache: { read: number; write: number }
+}
+
+export function addTokens(acc: CumulativeTokens | undefined, next: CumulativeTokens): CumulativeTokens {
+  const total = acc?.total === undefined && next.total === undefined ? undefined : (acc?.total ?? 0) + (next.total ?? 0)
+  return {
+    total,
+    input: (acc?.input ?? 0) + next.input,
+    output: (acc?.output ?? 0) + next.output,
+    reasoning: (acc?.reasoning ?? 0) + next.reasoning,
+    cache: {
+      read: (acc?.cache.read ?? 0) + next.cache.read,
+      write: (acc?.cache.write ?? 0) + next.cache.write,
+    },
+  }
+}
+
+// Older assistant messages predate `tokensCumulative`; rebuild it from their step-finish parts so
+// turn-level cache metrics stay correct on existing sessions without re-running the model. Messages
+// produced after the field shipped already carry a live value and skip this.
+function backfillCumulative(info: Info, parts: Part[]): Info {
+  if (info.role !== "assistant" || info.tokensCumulative) return info
+  let cumulative: CumulativeTokens | undefined
+  for (const part of parts) {
+    if (part.type !== "step-finish") continue
+    cumulative = addTokens(cumulative, part.tokens)
+  }
+  if (!cumulative) return info
+  return { ...info, tokensCumulative: cumulative }
+}
+
 function hydrate(rows: (typeof MessageTable.$inferSelect)[]) {
   const ids = rows.map((row) => row.id)
   const partByMessage = new Map<string, Part[]>()
@@ -766,10 +818,10 @@ function hydrate(rows: (typeof MessageTable.$inferSelect)[]) {
     }
   }
 
-  return rows.map((row) => ({
-    info: info(row),
-    parts: partByMessage.get(row.id) ?? [],
-  }))
+  return rows.map((row) => {
+    const parts = partByMessage.get(row.id) ?? []
+    return { info: backfillCumulative(info(row), parts), parts }
+  })
 }
 
 function providerMeta(metadata: Record<string, any> | undefined) {
@@ -1142,9 +1194,10 @@ export function get(input: { sessionID: SessionID; messageID: MessageID }): With
       .get(),
   )
   if (!row) throw new NotFoundError({ message: `Message not found: ${input.messageID}` })
+  const messageParts = parts(input.messageID)
   return {
-    info: info(row),
-    parts: parts(input.messageID),
+    info: backfillCumulative(info(row), messageParts),
+    parts: messageParts,
   }
 }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -778,8 +778,8 @@ export function addTokens(acc: CumulativeTokens | undefined, next: CumulativeTok
     output: (acc?.output ?? 0) + next.output,
     reasoning: (acc?.reasoning ?? 0) + next.reasoning,
     cache: {
-      read: (acc?.cache.read ?? 0) + next.cache.read,
-      write: (acc?.cache.write ?? 0) + next.cache.write,
+      read: (acc?.cache?.read ?? 0) + next.cache.read,
+      write: (acc?.cache?.write ?? 0) + next.cache.write,
     },
   }
 }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -787,7 +787,7 @@ export function addTokens(acc: CumulativeTokens | undefined, next: CumulativeTok
 // Older assistant messages predate `tokensCumulative`; rebuild it from their step-finish parts so
 // turn-level cache metrics stay correct on existing sessions without re-running the model. Messages
 // produced after the field shipped already carry a live value and skip this.
-function backfillCumulative(info: Info, parts: Part[]): Info {
+export function backfillCumulative(info: Info, parts: Part[]): Info {
   if (info.role !== "assistant" || info.tokensCumulative) return info
   let cumulative: CumulativeTokens | undefined
   for (const part of parts) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -929,6 +929,9 @@ export const layer: Layer.Layer<
             ctx.assistantMessage.finish = value.finishReason
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
+            // `tokens` holds only this step's snapshot (the current window state); accumulate every
+            // step here so the turn-level cache hit rate can sum reads/writes across all steps.
+            ctx.assistantMessage.tokensCumulative = MessageV2.addTokens(ctx.assistantMessage.tokensCumulative, usage.tokens)
             yield* session.updatePart({
               id: PartID.ascending(),
               reason: value.finishReason,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1896,3 +1896,96 @@ describe("session.message-v2.ToolStateError.reason", () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe("session.message-v2 cumulative tokens", () => {
+  const cumulative = (
+    input: number,
+    output: number,
+    reasoning: number,
+    read: number,
+    write: number,
+    total?: number,
+  ) => ({
+    total,
+    input,
+    output,
+    reasoning,
+    cache: { read, write },
+  })
+
+  const stepFinishPart = (
+    messageID: string,
+    id: string,
+    tokens: { total?: number; input: number; output: number; reasoning: number; read: number; write: number },
+  ) =>
+    ({
+      ...basePart(messageID, id),
+      type: "step-finish",
+      reason: "stop",
+      cost: 0,
+      tokens: {
+        total: tokens.total,
+        input: tokens.input,
+        output: tokens.output,
+        reasoning: tokens.reasoning,
+        cache: { read: tokens.read, write: tokens.write },
+      },
+    }) as unknown as MessageV2.Part
+
+  describe("addTokens", () => {
+    test("returns the next tally when the accumulator is undefined", () => {
+      expect(MessageV2.addTokens(undefined, cumulative(10, 5, 2, 30, 40))).toEqual(cumulative(10, 5, 2, 30, 40))
+    })
+
+    test("sums every field across multiple steps", () => {
+      let acc = MessageV2.addTokens(undefined, cumulative(100, 10, 1, 0, 500))
+      acc = MessageV2.addTokens(acc, cumulative(20, 5, 2, 480, 10))
+      acc = MessageV2.addTokens(acc, cumulative(3, 1, 0, 7, 0))
+      expect(acc).toEqual(cumulative(123, 16, 3, 487, 510))
+    })
+
+    test("keeps total undefined until at least one step reports it", () => {
+      const noTotal = MessageV2.addTokens(undefined, cumulative(10, 0, 0, 0, 0))
+      expect(noTotal.total).toBeUndefined()
+      const withTotal = MessageV2.addTokens(noTotal, cumulative(10, 0, 0, 0, 0, 20))
+      expect(withTotal.total).toBe(20)
+    })
+
+    test("does not throw when an accumulator is missing its cache object", () => {
+      const malformed = { input: 1, output: 0, reasoning: 0 } as unknown as Parameters<typeof MessageV2.addTokens>[0]
+      expect(() => MessageV2.addTokens(malformed, cumulative(1, 0, 0, 5, 5))).not.toThrow()
+    })
+  })
+
+  describe("backfillCumulative", () => {
+    test("rebuilds tokensCumulative from multiple step-finish parts on a legacy assistant message", () => {
+      const info = assistantInfo("a1", "u1")
+      const parts = [
+        stepFinishPart("a1", "p1", { input: 100, output: 10, reasoning: 1, read: 0, write: 500 }),
+        stepFinishPart("a1", "p2", { input: 20, output: 5, reasoning: 2, read: 480, write: 10 }),
+      ]
+      const result = MessageV2.backfillCumulative(info, parts) as MessageV2.Assistant
+      expect(result.tokensCumulative).toEqual(cumulative(120, 15, 3, 480, 510))
+    })
+
+    test("leaves an existing tokensCumulative untouched", () => {
+      const info = { ...assistantInfo("a1", "u1"), tokensCumulative: cumulative(1, 1, 1, 1, 1) } as MessageV2.Assistant
+      const parts = [stepFinishPart("a1", "p1", { input: 999, output: 0, reasoning: 0, read: 999, write: 0 })]
+      const result = MessageV2.backfillCumulative(info, parts) as MessageV2.Assistant
+      expect(result.tokensCumulative).toEqual(cumulative(1, 1, 1, 1, 1))
+    })
+
+    test("returns the message unchanged when there are no step-finish parts", () => {
+      const info = assistantInfo("a1", "u1")
+      const result = MessageV2.backfillCumulative(info, []) as MessageV2.Assistant
+      expect(result.tokensCumulative).toBeUndefined()
+      expect(result).toBe(info)
+    })
+
+    test("ignores non-assistant messages", () => {
+      const info = userInfo("u1")
+      const parts = [stepFinishPart("u1", "p1", { input: 100, output: 0, reasoning: 0, read: 50, write: 50 })]
+      expect(MessageV2.backfillCumulative(info, parts)).toBe(info)
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -721,6 +721,16 @@ export type AssistantMessage = {
       write: number
     }
   }
+  tokensCumulative?: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
   structured?: unknown
   variant?: string
   finish?: string


### PR DESCRIPTION
## Summary

Cache hit rate in the Context panel now reflects the whole most-recent turn instead of only the final step of the last assistant message.

- A multi-step turn is one assistant message whose `tokens` field the backend overwrites with each step, keeping only the last step's snapshot. The final step reads the full prefix cache, so the cold-start step (heavy writes, low reads) was hidden and the rate looked inflated.
- Backend adds an optional `AssistantMessage.tokensCumulative` that sums per-step usage in the `finish-step` handler, mirroring how `cost` is already accumulated. `tokens` is unchanged and still feeds the context-window metrics (used tokens, usage %, compaction threshold).
- `MessageV2.hydrate` / `MessageV2.get` backfill `tokensCumulative` from `step-finish` parts for sessions created before the field existed, so existing sessions stay accurate without re-running the model.
- The frontend sums `tokensCumulative` across the most recent turn (grouped by `parentID`), skipping compaction summary messages and reverted turns, and reports `read / (input + read + write)`.
- A write-only cold-start turn now shows `0.0%` instead of an empty cell.

## Why

The previous metric read one assistant message's last-step snapshot. The frontend cannot aggregate per step on its own because the sync layer drops `step-finish` parts (`SKIP_PARTS`), so the per-step data never reaches the app. Computing the turn total where the usage actually lives (backend) is the only correct fix, and is consistent with the ongoing Effect backend migration.

## Related Issue

No issue. Reported directly: the displayed cache hit rate was misleadingly high because it only showed the last step of the latest assistant message.

## Human Review Status

Pending

## Review Focus

- Backend: `finish-step` accumulation and `addTokens`; `hydrate`/`get` backfill correctness for legacy messages.
- Frontend: turn grouping by `parentID`, exclusion of compaction `summary` messages and reverted turns, write-only `0.0%` behavior.
- The SDK type diff is intentionally limited to the single new field (see Risk Notes).

## Risk Notes

- Generated file touched: `packages/sdk/js/src/v2/gen/types.gen.ts` is limited by hand to the one new `tokensCumulative` field. The checked-in `packages/sdk/openapi.json` and other pending generator drift (`run_lifecycle` diagnostics, automation endpoint doc strings) are deliberately left to a separate full regeneration to keep this PR focused; `openapi.json` only feeds the route-inventory script (paths, not schemas), so this change does not affect it.
- No platform/packaging/updater/signing/paths/shell/permissions surface touched; backend change is schema + read-time aggregation only, no migration.
- Known limitation: revert is filtered at message-ID granularity. A part-level revert could leave a turn's `tokensCumulative` including the reverted tail; called out for follow-up if part-level revert lands.

## How To Verify

```text
app unit (getRecentTurnCache + getSessionContextMetrics): 16 passed
session components suite: 22 passed
app typecheck (tsgo -b): clean
opencode typecheck (tsgo --noEmit): clean, exit 0
lint (eslint changed app files): clean
snap session-context-cache: 1 passed — cell renders "90.0%" (green) and "Cache Tokens (read/write): 900 / 0"; single-step turn equals last-step, layout intact in default + wide columns
```

## Screenshots or Recordings

Visual surface checked via the `session-context-cache` snap target (web Chromium render). The Cache Hit Rate cell shows `90.0%` in success color with the read/write subtitle; reviewed the generated grid PNG.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
