### PR TITLE
ci: harden dependency audit checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       # Load-bearing: `bun install` runs `trustedDependencies`
       # postinstalls from the root package.json (electron, node-pty,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -169,7 +170,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -256,7 +258,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -300,7 +303,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -371,7 +375,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -442,7 +447,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -513,7 +519,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  review:
+  dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -21,13 +21,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Advisory check: `warn-only: true` surfaces CVE/license findings
-      # in the Actions log but never fails the PR. Paired with `never`
-      # for comment-summary-in-pr so the action needs no write access
-      # and runs on fork PRs too (exactly where advisory coverage is
-      # most useful). Upgrading to fail-on-severity: high is a separate
-      # decision.
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # actions/dependency-review-action@v5.0.0
         with:
           comment-summary-in-pr: never
-          warn-only: true
+          fail-on-severity: high
+          fail-on-scopes: runtime,unknown

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -125,7 +125,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:

--- a/.github/workflows/dev-dep-audit.yml
+++ b/.github/workflows/dev-dep-audit.yml
@@ -1,0 +1,36 @@
+name: dev-dep-audit
+
+on:
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: dev-dep-audit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dev-dep-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Bun audit
+        run: bun audit --audit-level=high

--- a/.github/workflows/dev-dep-audit.yml
+++ b/.github/workflows/dev-dep-audit.yml
@@ -33,5 +33,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run Bun audit
-        continue-on-error: true
         run: bun audit --audit-level=high

--- a/.github/workflows/dev-dep-audit.yml
+++ b/.github/workflows/dev-dep-audit.yml
@@ -33,4 +33,5 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run Bun audit
+        continue-on-error: true
         run: bun audit --audit-level=high

--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -132,7 +132,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:

--- a/.github/workflows/officecli-bump.yml
+++ b/.github/workflows/officecli-bump.yml
@@ -35,7 +35,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -20,9 +20,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
-
 jobs:
   perf-probe-baseline:
     runs-on: ubuntu-latest
@@ -111,14 +108,6 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('head/bun.lock', 'base/bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
-
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        if: steps.compute-range.outputs.skipped != 'true'
-        with:
-          path: ${{ github.workspace }}/.playwright-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('head/packages/app/package.json', 'head/bun.lock', 'base/packages/app/package.json', 'base/bun.lock') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
 
       - name: Install head dependencies
         if: steps.compute-range.outputs.skipped != 'true'

--- a/.github/workflows/perf-probe-baseline.yml
+++ b/.github/workflows/perf-probe-baseline.yml
@@ -99,7 +99,8 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         if: steps.compute-range.outputs.skipped != 'true'
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         if: steps.compute-range.outputs.skipped != 'true'

--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -225,7 +225,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+          bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Desktop AI workstation for knowledge workers",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "bun run dev:desktop",
     "dev:desktop": "bun --cwd packages/desktop-electron dev",

--- a/packages/app/src/testing/perf-workflow.test.ts
+++ b/packages/app/src/testing/perf-workflow.test.ts
@@ -5,9 +5,9 @@ const normalizeLineEndings = (text: string) => text.replace(/\r\n?/g, "\n")
 
 describe("perf workflow contract", () => {
   test("matches workflow snippets after Windows line-ending checkout", () => {
-    const workflow = normalizeLineEndings("restore-keys: |\r\n            playwright-${{ runner.os }}-")
+    const workflow = normalizeLineEndings("restore-keys: |\r\n            bun-${{ runner.os }}-")
 
-    expect(workflow).toContain("restore-keys: |\n            playwright-${{ runner.os }}-")
+    expect(workflow).toContain("restore-keys: |\n            bun-${{ runner.os }}-")
   })
 
   test("keeps default gate broad and low-end gate scoped", async () => {
@@ -28,7 +28,8 @@ describe("perf workflow contract", () => {
     expect(workflow).toContain('PLAYWRIGHT_VIDEO: "off"')
     expect(workflow).not.toContain("playwright install --with-deps chromium")
     expect(workflow).toContain("actions/cache/restore@")
-    expect(workflow).toContain("restore-keys: |\n            playwright-${{ runner.os }}-")
+    expect(workflow).not.toContain("PLAYWRIGHT_BROWSERS_PATH")
+    expect(workflow).not.toContain(".playwright-browsers")
     expect(workflow).toContain("perf-base-combined.json")
     expect(workflow).toContain("perf-head-combined.json")
     expect(workflow).toContain("perf-comment.md")

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url))
+const workflowsRoot = path.join(repoRoot, ".github", "workflows")
+const expectedBunVersion = "1.3.14"
+const auditComment = "Load-bearing for `bun audit` exit semantics"
+
+describe("GitHub workflow Bun version pin", () => {
+  test("keeps every setup-bun runtime on the audit-verified Bun version", () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+      packageManager?: string
+    }
+    expect(packageJson.packageManager).toBe(`bun@${expectedBunVersion}`)
+
+    const workflowFiles = fs
+      .readdirSync(workflowsRoot)
+      .filter((name) => name.endsWith(".yml"))
+      .sort()
+      .map((name) => path.join(workflowsRoot, name))
+
+    const setupBunPins: string[] = []
+    const missingComments: string[] = []
+
+    for (const workflowPath of workflowFiles) {
+      const lines = fs.readFileSync(workflowPath, "utf8").split(/\r?\n/)
+      for (const [index, line] of lines.entries()) {
+        if (!line.includes("bun-version:")) continue
+
+        const relativePath = path.relative(repoRoot, workflowPath)
+        setupBunPins.push(`${relativePath}:${index + 1}:${line.trim()}`)
+        const previousLines = lines.slice(Math.max(0, index - 3), index).join("\n")
+        if (!previousLines.includes(auditComment)) {
+          missingComments.push(`${relativePath}:${index + 1}`)
+        }
+      }
+    }
+
+    expect(setupBunPins.map((entry) => entry.replace(/:\d+:/, ":line:"))).toEqual([
+      ".github/workflows/build.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/desktop-smoke.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/dev-dep-audit.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/e2e-artifacts.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/officecli-bump.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/perf-probe-baseline.yml:line:bun-version: \"1.3.14\"",
+      ".github/workflows/windows-advisory.yml:line:bun-version: \"1.3.14\"",
+    ])
+    expect(missingComments).toEqual([])
+  })
+})

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -2,13 +2,43 @@ import { describe, expect, test } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseWorkflow, type Workflow } from "./workflow-parser"
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url))
 const workflowsRoot = path.join(repoRoot, ".github", "workflows")
 const expectedBunVersion = "1.3.14"
 const auditComment = "Load-bearing for `bun audit` exit semantics"
 
+function collectSetupBunPins(workflow: Workflow, relativePath: string) {
+  const pins: string[] = []
+
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+      if (!step.uses?.startsWith("oven-sh/setup-bun@")) continue
+
+      const bunVersion = step.with?.["bun-version"] ?? "<missing>"
+      pins.push(`${relativePath}:${jobName}:step-${stepIndex + 1}:bun-version: ${JSON.stringify(bunVersion)}`)
+    }
+  }
+
+  return pins
+}
+
 describe("GitHub workflow Bun version pin", () => {
+  test("detects setup-bun steps that omit bun-version", () => {
+    const workflow: Workflow = {
+      jobs: {
+        unpinned: {
+          steps: [{ uses: "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6" }],
+        },
+      },
+    }
+
+    expect(collectSetupBunPins(workflow, "synthetic.yml")).toEqual([
+      "synthetic.yml:unpinned:step-1:bun-version: \"<missing>\"",
+    ])
+  })
+
   test("keeps every setup-bun runtime on the audit-verified Bun version", () => {
     const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
       packageManager?: string
@@ -25,12 +55,13 @@ describe("GitHub workflow Bun version pin", () => {
     const missingComments: string[] = []
 
     for (const workflowPath of workflowFiles) {
+      const relativePath = path.relative(repoRoot, workflowPath)
+      setupBunPins.push(...collectSetupBunPins(parseWorkflow(workflowPath), relativePath))
+
       const lines = fs.readFileSync(workflowPath, "utf8").split(/\r?\n/)
       for (const [index, line] of lines.entries()) {
         if (!line.includes("bun-version:")) continue
 
-        const relativePath = path.relative(repoRoot, workflowPath)
-        setupBunPins.push(`${relativePath}:${index + 1}:${line.trim()}`)
         const previousLines = lines.slice(Math.max(0, index - 3), index).join("\n")
         if (!previousLines.includes(auditComment)) {
           missingComments.push(`${relativePath}:${index + 1}`)
@@ -38,21 +69,21 @@ describe("GitHub workflow Bun version pin", () => {
       }
     }
 
-    expect(setupBunPins.map((entry) => entry.replace(/:\d+:/, ":line:"))).toEqual([
-      ".github/workflows/build.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/desktop-smoke.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/dev-dep-audit.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/e2e-artifacts.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/officecli-bump.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/perf-probe-baseline.yml:line:bun-version: \"1.3.14\"",
-      ".github/workflows/windows-advisory.yml:line:bun-version: \"1.3.14\"",
+    expect(setupBunPins).toEqual([
+      ".github/workflows/build.yml:build-electron:step-5:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:typecheck:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:lint:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:frontend-architecture:step-5:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:unit-app:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:unit-ui:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:unit-opencode:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/ci.yml:unit-desktop:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/desktop-smoke.yml:smoke-macos-arm64:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/dev-dep-audit.yml:dev-dep-audit:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/e2e-artifacts.yml:e2e-artifacts:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/officecli-bump.yml:officecli-bump:step-3:bun-version: \"1.3.14\"",
+      ".github/workflows/perf-probe-baseline.yml:perf-probe-baseline:step-7:bun-version: \"1.3.14\"",
+      ".github/workflows/windows-advisory.yml:unit-windows:step-3:bun-version: \"1.3.14\"",
     ])
     expect(missingComments).toEqual([])
   })

--- a/packages/opencode/test/github/dependency-review-workflow.test.ts
+++ b/packages/opencode/test/github/dependency-review-workflow.test.ts
@@ -59,6 +59,7 @@ describe("dependency review workflow", () => {
     expect(setupBun?.uses).toBe(pinned.setupBun)
     expect(setupBun?.with).toEqual({ "bun-version": "1.3.14" })
     expect(install?.run).toBe("bun install --frozen-lockfile")
+    expect(audit?.["continue-on-error"]).toBe(true)
     expect(audit?.run).toBe("bun audit --audit-level=high")
   })
 })

--- a/packages/opencode/test/github/dependency-review-workflow.test.ts
+++ b/packages/opencode/test/github/dependency-review-workflow.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseWorkflow } from "./workflow-parser"
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url))
+const workflowsRoot = path.join(repoRoot, ".github", "workflows")
+
+const pinned = {
+  checkout: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+  dependencyReview: "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294",
+  setupBun: "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+  setupNode: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+}
+
+describe("dependency review workflow", () => {
+  test("uses the required dependency-review check name and fails high runtime advisories", () => {
+    const parsed = parseWorkflow(path.join(workflowsRoot, "dependency-review.yml"))
+    const job = parsed.jobs?.["dependency-review"]
+    const steps = job?.steps ?? []
+    const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
+    const review = steps.find((step) => step.uses?.startsWith("actions/dependency-review-action@"))
+
+    expect(parsed.name).toBe("dependency-review")
+    expect(parsed.permissions).toEqual({ contents: "read", "pull-requests": "read" })
+    expect(Object.keys(parsed.jobs ?? {})).toEqual(["dependency-review"])
+    expect(job?.["runs-on"]).toBe("ubuntu-latest")
+    expect(job?.["timeout-minutes"]).toBe(10)
+    expect(checkout?.uses).toBe(pinned.checkout)
+    expect(checkout?.with?.["persist-credentials"]).toBe(false)
+    expect(review?.uses).toBe(pinned.dependencyReview)
+    expect(review?.with).toEqual({
+      "comment-summary-in-pr": "never",
+      "fail-on-scopes": "runtime,unknown",
+      "fail-on-severity": "high",
+    })
+  })
+
+  test("runs the dev dependency audit check on every pull request", () => {
+    const parsed = parseWorkflow(path.join(workflowsRoot, "dev-dep-audit.yml"))
+    const job = parsed.jobs?.["dev-dep-audit"]
+    const steps = job?.steps ?? []
+    const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"))
+    const setupNode = steps.find((step) => step.uses?.startsWith("actions/setup-node@"))
+    const setupBun = steps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const install = steps.find((step) => step.name === "Install dependencies")
+    const audit = steps.find((step) => step.name === "Run Bun audit")
+
+    expect(parsed.name).toBe("dev-dep-audit")
+    expect(parsed.on?.pull_request).toEqual({ branches: ["dev"] })
+    expect(parsed.permissions).toEqual({ contents: "read" })
+    expect(Object.keys(parsed.jobs ?? {})).toEqual(["dev-dep-audit"])
+    expect(job?.["runs-on"]).toBe("ubuntu-latest")
+    expect(job?.["timeout-minutes"]).toBe(10)
+    expect(checkout?.uses).toBe(pinned.checkout)
+    expect(checkout?.with?.["persist-credentials"]).toBe(false)
+    expect(setupNode?.uses).toBe(pinned.setupNode)
+    expect(setupNode?.with).toEqual({ "node-version": "24" })
+    expect(setupBun?.uses).toBe(pinned.setupBun)
+    expect(setupBun?.with).toEqual({ "bun-version": "1.3.14" })
+    expect(install?.run).toBe("bun install --frozen-lockfile")
+    expect(audit?.run).toBe("bun audit --audit-level=high")
+  })
+})

--- a/packages/opencode/test/github/dependency-review-workflow.test.ts
+++ b/packages/opencode/test/github/dependency-review-workflow.test.ts
@@ -59,7 +59,7 @@ describe("dependency review workflow", () => {
     expect(setupBun?.uses).toBe(pinned.setupBun)
     expect(setupBun?.with).toEqual({ "bun-version": "1.3.14" })
     expect(install?.run).toBe("bun install --frozen-lockfile")
-    expect(audit?.["continue-on-error"]).toBe(true)
+    expect(audit?.["continue-on-error"]).toBeUndefined()
     expect(audit?.run).toBe("bun audit --audit-level=high")
   })
 })

--- a/packages/opencode/test/github/officecli-bump-workflow.test.ts
+++ b/packages/opencode/test/github/officecli-bump-workflow.test.ts
@@ -37,7 +37,7 @@ describe("officecli bump workflow", () => {
     expect(setupNode?.uses).toBe("actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e")
     expect(setupNode?.with).toEqual({ "node-version": "24" })
     expect(setupBun?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
-    expect(setupBun?.with).toEqual({ "bun-version": "1.3.13" })
+    expect(setupBun?.with).toEqual({ "bun-version": "1.3.14" })
 
     expect(workflow).not.toContain("persist-credentials: true")
     expect(workflow).toContain("gh api repos/iOfficeAI/OfficeCLI/releases/latest")

--- a/packages/opencode/test/github/perf-probe-workflow.test.ts
+++ b/packages/opencode/test/github/perf-probe-workflow.test.ts
@@ -21,11 +21,10 @@ describe("perf probe baseline workflow", () => {
 
     expect(parsed.name).toBe("perf-probe-baseline")
     expect(parsed.permissions).toEqual({ contents: "read" })
-    expect(cacheSteps.map((step) => step.uses)).toEqual([pinned.cacheRestore, pinned.cacheRestore])
-    expect(cacheSteps.map((step) => step.with?.path)).toEqual([
-      "~/.bun/install/cache",
-      "${{ github.workspace }}/.playwright-browsers",
-    ])
+    expect(cacheSteps.map((step) => step.uses)).toEqual([pinned.cacheRestore])
+    expect(cacheSteps.map((step) => step.with?.path)).toEqual(["~/.bun/install/cache"])
+    expect(parsed.env).not.toHaveProperty("PLAYWRIGHT_BROWSERS_PATH")
+    expect(workflow).not.toContain(".playwright-browsers")
     expect(workflow).not.toContain("issues: write")
     expect(workflow).not.toContain("pull-requests: write")
     expect(workflow).not.toContain("actions/github-script")

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -49,6 +49,7 @@ export type Workflow = {
     group?: string
     "cancel-in-progress"?: boolean | string
   }
+  env?: Record<string, string>
   on?: Record<string, unknown>
   permissions?: Record<string, string>
   jobs?: Record<string, WorkflowJob>


### PR DESCRIPTION
## Summary

Harden the second #977 CI slice: remove the now-unused perf Playwright browser cache, tighten dependency-review, add a non-required Bun audit visibility check, and pin workflow Bun runtimes to the audit-verified `1.3.14`.

## Why

PR #988 moved `perf-probe-baseline` to system Chrome with Playwright video disabled, leaving the `.playwright-browsers` restore cache unused. The dependency review workflow was still advisory-only and its job name did not match the planned required context. `bun audit` is useful signal, but current `dev` already has high/critical advisories, so this PR adds it as a visible non-required check rather than a merge gate.

## Related Issue

Closes part of #977.

## Human Review Status

Pending

## Review Focus

Please focus on the GitHub Actions semantics: `dependency-review` now emits the required check name, `dev-dep-audit` is intentionally not a required context, and every `setup-bun` workflow pin is on `1.3.14` with a contract test covering the scan.

## Risk Notes

- `dev-dep-audit` currently fails on the existing lockfile advisories: `34 vulnerabilities (1 critical, 33 high)`. It is intentionally a non-required visibility check until those are fixed or baselined.
- Do not add `dev-dep-audit` to `dev-merge-gate` from this PR. It would block unrelated PRs.
- `dependency-review` can become required after this workflow shape lands on `dev`, because the job now emits the `dependency-review` check name.
- Screenshots/recordings skipped: no visible UI changed.

## How To Verify

```text
Workflow contract tests: 21 passed
Command: bun test test/github/perf-probe-workflow.test.ts test/github/dependency-review-workflow.test.ts test/github/bun-version-workflow.test.ts test/github/officecli-bump-workflow.test.ts test/github/ci-workflow.test.ts test/github/desktop-smoke-workflow.test.ts test/config/e2e-artifacts-workflow.test.ts

App perf workflow contract: 2 passed
Command: bun test src/testing/perf-workflow.test.ts

Root typecheck: passed
Command: bun turbo typecheck

Whitespace check: passed
Command: git diff --check origin/dev...HEAD

Perf cache sanity: passed
Command: rg -n 'PLAYWRIGHT_BROWSERS_PATH|path: \$\{\{ github\.workspace \}\}/\.playwright-browsers|playwright-\$\{\{ runner\.os \}\}-' .github/workflows/perf-probe-baseline.yml
Result: no matches

Bun pin sanity: passed
Command: rg -n 'bun-version:|packageManager' .github/workflows package.json
Result: root packageManager and all setup-bun workflow inputs are 1.3.14

Bun audit visibility check: expected failure on current lockfile
Command: bun audit --audit-level=high
Result: exits 1 with 34 vulnerabilities (1 critical, 33 high)

Ruleset readback: current dev-merge-gate remains at 8 required contexts and does not include dev-dep-audit
Command: gh api repos/Astro-Han/pawwork/rulesets/15292177 --jq '{name,enforcement,required: [.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[]?.context]}'
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bun runtime version from 1.3.13 to 1.3.14 across all CI/CD workflows and project configuration.
  * Removed Playwright browser caching optimization from performance baseline workflow.

* **New Features**
  * Added automated dependency audit workflow for the dev branch to detect high-severity vulnerabilities.

* **Bug Fixes**
  * Enhanced dependency review to actively fail PRs on high-severity security issues instead of warning only.

* **Tests**
  * Added test coverage for Bun version pin consistency and GitHub Actions workflow validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
