### PR TITLE
fix(ci): stabilize windows advisory checks

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -176,7 +176,7 @@ jobs:
               test/question
               test/effect
               test/agent
-              test/git
+              test/git/git.test.ts
               test/storage
               test/provider
               test/pty

--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -155,7 +155,7 @@ jobs:
               test/config
               test/project
               test/worktree
-              test/file
+              test/file/
               test/github
               test/settings
               test/settings.test.ts
@@ -176,11 +176,11 @@ jobs:
               test/question
               test/effect
               test/agent
-              test/git/git.test.ts
+              test/git/
               test/storage
               test/provider
               test/pty
-              test/share
+              test/share/
               test/script
               test/memory
               test/lsp

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -9,6 +9,14 @@ const workflowsRoot = path.join(repoRoot, ".github", "workflows")
 const expectedBunVersion = "1.3.14"
 const auditComment = "Load-bearing for `bun audit` exit semantics"
 
+function repoRelativeWorkflowPath(workflowPath: string) {
+  return normalizeWorkflowPath(path.relative(repoRoot, workflowPath))
+}
+
+function normalizeWorkflowPath(relativePath: string) {
+  return relativePath.replaceAll("\\", "/")
+}
+
 function collectSetupBunPins(workflow: Workflow, relativePath: string) {
   const pins: string[] = []
 
@@ -25,6 +33,10 @@ function collectSetupBunPins(workflow: Workflow, relativePath: string) {
 }
 
 describe("GitHub workflow Bun version pin", () => {
+  test("normalizes workflow paths for cross-platform assertions", () => {
+    expect(normalizeWorkflowPath(".github\\workflows\\ci.yml")).toBe(".github/workflows/ci.yml")
+  })
+
   test("detects setup-bun steps that omit bun-version", () => {
     const workflow: Workflow = {
       jobs: {
@@ -55,7 +67,7 @@ describe("GitHub workflow Bun version pin", () => {
     const missingComments: string[] = []
 
     for (const workflowPath of workflowFiles) {
-      const relativePath = path.relative(repoRoot, workflowPath)
+      const relativePath = repoRelativeWorkflowPath(workflowPath)
       setupBunPins.push(...collectSetupBunPins(parseWorkflow(workflowPath), relativePath))
 
       const lines = fs.readFileSync(workflowPath, "utf8").split(/\r?\n/)

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -73,7 +73,7 @@ const windowsOpencodeShards = [
     suffix: "opencode-server-tools",
     usesTurbo: false,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git test/storage test/provider test/pty test/share test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/git.test.ts test/storage test/provider test/pty test/share test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
   },
 ] as const
@@ -599,6 +599,16 @@ describe("ci workflow", () => {
       extra: [],
       missing: [],
     })
+  })
+
+  test("keeps Windows opencode shard paths from prefix-matching sibling test directories", () => {
+    const parsed = parseWorkflow(windowsAdvisoryWorkflowPath)
+    const matrixIncludes = parsed.jobs?.[windowsUnitJobName]?.strategy?.matrix?.include ?? []
+    const opencodeShards = matrixIncludes.filter(isWindowsOpencodeShard)
+    const shardArgs = opencodeShards.flatMap((item) => testPathArgs(item.command))
+    const ambiguousArgs = shardArgs.filter((arg) => arg === "test/git")
+
+    expect(ambiguousArgs).toEqual([])
   })
 
   test("keeps docs-only behavior and excludes Windows from the blocking aggregate", () => {

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -66,14 +66,14 @@ const windowsOpencodeShards = [
     suffix: "opencode-config-project",
     usesTurbo: false,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-config-project.xml test/config test/project test/worktree test/file test/github test/settings test/settings.test.ts",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-config-project.xml test/config test/project test/worktree test/file/ test/github test/settings test/settings.test.ts",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-config-project.xml",
   },
   {
     suffix: "opencode-server-tools",
     usesTurbo: false,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/git.test.ts test/storage test/provider test/pty test/share test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
   },
 ] as const
@@ -147,6 +147,19 @@ function expandOpencodeTestPath(testPath: string): string[] {
     return listOpencodeTestFiles(fullPath)
   }
   return [testPath]
+}
+
+function ambiguousDirectoryShardArgs(testPaths: string[]) {
+  const testRootEntries = readdirSync(opencodeTestRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `test/${entry.name}`)
+  const testRootEntrySet = new Set(testRootEntries)
+
+  return testPaths.filter((testPath) => {
+    if (testPath.endsWith("/")) return false
+    if (!testRootEntrySet.has(testPath)) return false
+    return testRootEntries.some((entry) => entry !== testPath && entry.startsWith(testPath))
+  })
 }
 
 function testPathArgs(command: string) {
@@ -606,9 +619,8 @@ describe("ci workflow", () => {
     const matrixIncludes = parsed.jobs?.[windowsUnitJobName]?.strategy?.matrix?.include ?? []
     const opencodeShards = matrixIncludes.filter(isWindowsOpencodeShard)
     const shardArgs = opencodeShards.flatMap((item) => testPathArgs(item.command))
-    const ambiguousArgs = shardArgs.filter((arg) => arg === "test/git")
 
-    expect(ambiguousArgs).toEqual([])
+    expect(ambiguousDirectoryShardArgs(shardArgs)).toEqual([])
   })
 
   test("keeps docs-only behavior and excludes Windows from the blocking aggregate", () => {

--- a/packages/opencode/test/server/global-session-activity-list.test.ts
+++ b/packages/opencode/test/server/global-session-activity-list.test.ts
@@ -281,7 +281,10 @@ describe("session.listGlobal activity order", () => {
 
       await Instance.provide({
         directory: tmp.path,
-        fn: async () => userMessageWithSyntheticReminder(oldMixedUser.id, 4_000),
+        fn: async () => {
+          now = 4_000
+          return userMessageWithSyntheticReminder(oldMixedUser.id, 4_000)
+        },
       })
 
       const sessions = [

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1645,7 +1645,7 @@ it.live("disabled unknown tools do not block safe connect-timeout auto retry", (
               inputSchema: z.object({}),
             }),
           },
-          connectTimeoutMs: 20,
+          connectTimeoutMs: 250,
           streamTimeoutMs: 1_000,
         })
 

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { LLM } from "../../src/session/llm"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { RunIncident } from "../../src/session/run-incident"
 import { RunObservability } from "../../src/session/run-observability"
@@ -1276,6 +1277,36 @@ describe("RunObservability", () => {
       reason: "no_visible_output_or_tool_execution",
     })
     expect(summary.incident?.recovery).toMatchObject({
+      recommendation: "auto_retry_once",
+      reason: "no_visible_output_or_tool_execution",
+    })
+  })
+
+  test("disabled unknown tools are absent from before-progress retry boundary proof", () => {
+    const tools = LLM.resolveTools({
+      agent: { permission: [] } as never,
+      permission: [],
+      user: { tools: { mcp_write: false } } as never,
+      tools: {
+        read: {},
+        mcp_write: {},
+      } as never,
+    })
+    const snapshot = RunObservability.sideEffectBoundarySnapshot(tools)
+    const decision = recoveryForBeforeProgress({
+      side_effect_facts_complete: true,
+      side_effect_boundary_snapshot: snapshot,
+    })
+
+    expect(Object.keys(tools)).toEqual(["read"])
+    expect(snapshot).toMatchObject({
+      exposed_tool_count: 1,
+      unknown_tool_count: 0,
+      unclassified_effect_count: 0,
+      proof_result: "complete",
+      proof_reason: "all_boundaries_classified",
+    })
+    expect(decision).toMatchObject({
       recommendation: "auto_retry_once",
       reason: "no_visible_output_or_tool_execution",
     })


### PR DESCRIPTION
## Summary

Stabilize the merged-dev `windows-advisory` failures introduced around PR #990. There is no dedicated issue; this follows up the red `windows-advisory` run on dev SHA `6eb8585008ceb95ec12cc3928c3f829d43862809`.

## Why

The Windows advisory run failed in three opencode shards:

- workflow Bun pin assertions compared POSIX expected paths with Windows `path.relative()` output
- Windows shard path args such as `test/git`, `test/file`, and `test/share` could prefix-match sibling directories such as `test/github`, `test/filesystem`, and `test/shared`
- the disabled-tool connect-timeout retry test coupled the core retry assertion to a very tight 20ms live HTTP timing window on Windows runners

The first PR CI pass also exposed a Linux `unit-opencode` timing fixture issue in `global-session-activity-list.test.ts`, where the fake `Date.now()` could be earlier than the synthetic reminder timestamp.

## Related Issue

No issue. This is a narrow CI follow-up to the failed merged-dev `windows-advisory` run after PR #990.

## Human Review Status

Pending

## Review Focus

Please check the Windows advisory shard command change and the retry test boundary. The intent is to fix deterministic Windows test failures without changing production retry behavior.

## Risk Notes

No visible UI or copy changed, so the UI check item is left unticked. Platform impact is limited to the Windows advisory workflow and Windows CI timing sensitivity. No dependency, docs, credential, deletion, or generated-file surface changed.

## How To Verify

```text
cd packages/opencode && bun test test/github/bun-version-workflow.test.ts test/github/ci-workflow.test.ts
Result: 16 pass, 0 fail

cd packages/opencode && bun test test/session/run-observability.test.ts
Result: 67 pass, 0 fail

cd packages/opencode && bun test test/session/run-observability.test.ts test/session/processor-effect.test.ts -t "disabled unknown tools"
Result: 2 pass, 0 fail

cd packages/opencode && bun test test/server/global-session-activity-list.test.ts
Result: 6 pass, 0 fail
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.