### PR TITLE
test(session): stabilize force dispose lifecycle test

### DIFF
--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -162,7 +162,8 @@ describe("Worktree", () => {
     test("restores .gitignore when git worktree add fails", async () => {
       await using tmp = await tmpdir({ git: true })
       const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("bad-branch"))
-      await $`git branch ${info.branch}`.cwd(tmp.path).quiet()
+      await fs.mkdir(info.directory, { recursive: true })
+      await Bun.write(path.join(info.directory, "blocker"), "already here\n")
 
       await expect(withInstance(tmp.path, () => Worktree.createFromInfo(info))).rejects.toThrow(
         "WorktreeCreateFailedError",

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -116,6 +116,7 @@ describe("SessionRunState", () => {
       (directory) =>
         Effect.gen(function* () {
           const run = yield* SessionRunState.Service
+          const started = yield* Deferred.make<void>()
           const fiber = yield* run
             .ensureRunning(
               SessionID.make("ses_run_state_scope"),
@@ -124,11 +125,11 @@ describe("SessionRunState", () => {
                   captured = meta
                   return {} as never
                 }),
-              Effect.never,
+              Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
             )
             .pipe(Effect.forkChild)
 
-          yield* Effect.sleep("10 millis")
+          yield* Deferred.await(started)
           yield* Effect.promise(() => Instance.dispose({ mode: "force" }))
 
           const exit = yield* Fiber.await(fiber)


### PR DESCRIPTION
## Summary

Stabilizes two Windows advisory timing-sensitive tests exposed while closing out PR #995 post-merge CI. There is no related issue; this is a follow-up to the post-merge `windows-advisory` failures.

## Why

The `SessionRunState` force-dispose lifecycle test used a fixed 10ms sleep as a startup barrier before calling `Instance.dispose({ mode: "force" })`. On the Windows runner, that was not a reliable guarantee that the run had actually entered its active `Effect.never` work, so the fiber could wait until the 30s test timeout.

The worktree rollback test used a pre-existing branch to make `git worktree add -b` fail. A manual Windows advisory run showed that failure path can hang on Windows. The test only needs any deterministic setup failure after `.gitignore` is updated, so it now uses a non-empty target directory failure path instead.

## Related Issue

No issue. Follow-up to PR #995 post-merge CI.

## Human Review Status

Pending

## Review Focus

Confirm that the tests still cover the same contracts while avoiding scheduler- or Git-platform-dependent failure paths:

- force disposal interrupt provenance waits for the run body to start with `Deferred` instead of relying on scheduler timing
- `.gitignore` rollback after worktree setup failure uses a non-empty target directory instead of an existing branch failure

## Risk Notes

No product behavior changes. No visible UI or copy changes, no docs, dependencies, permissions, generated content, or local file behavior changes. Platform impact considered because this specifically addresses Windows CI timing failures.

## How To Verify

```text
cd packages/opencode && bun test test/session/run-state.test.ts -t "annotates runner interrupts caused by force instance disposal"
Result: 1 pass, 0 fail

cd packages/opencode && bun test test/session/run-state.test.ts
Result: 22 pass, 0 fail

cd packages/opencode && bun test test/project/worktree.test.ts -t "restores .gitignore when git worktree add fails"
Result: 1 pass, 0 fail

cd packages/opencode && bun test test/project/worktree.test.ts
Result: 15 pass, 0 fail

cd packages/opencode && bun test --timeout 30000 test/config test/project test/worktree test/file/ test/github test/settings test/settings.test.ts
Result: 456 pass, 3 skip, 0 fail
```

## Screenshots or Recordings

Not needed. No visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.