### PR TITLE
ci: add PR-D hardening audit setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,28 @@
+name: Setup Node and Bun
+description: Install the repository Node and Bun toolchain with the shared Bun dependency cache.
+runs:
+  using: composite
+  steps:
+    # Load-bearing: `bun install` runs `trustedDependencies`
+    # postinstalls from the root package.json (electron, node-pty,
+    # esbuild, tree-sitter at time of writing), which call `node`
+    # explicitly. Do not drop without first patching those scripts.
+    # Source of truth: grep `trustedDependencies` in package.json. (#70)
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+      with:
+        node-version: "24"
+
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+      with:
+        # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
+        bun-version: "1.3.14"
+
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
+    - run: bun install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,30 +110,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -142,8 +127,6 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-typecheck-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
             turbo-${{ runner.os }}-typecheck-
-
-      - run: bun install --frozen-lockfile
 
       - name: typecheck
         run: bun turbo typecheck
@@ -159,31 +142,35 @@ jobs:
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: lint
         run: bun run lint:ci
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        run: |
+          set -euo pipefail
+
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_ARCHIVE}"
+
+          curl --fail --location --show-error --silent "$ACTIONLINT_URL" --output "$ACTIONLINT_ARCHIVE"
+          echo "${ACTIONLINT_SHA256}  ${ACTIONLINT_ARCHIVE}" | sha256sum --check
+          tar -xzf "$ACTIONLINT_ARCHIVE" actionlint
+
+      - name: Run actionlint
+        run: ./actionlint -color -shellcheck=
 
   frontend-architecture:
     needs: changes
@@ -191,6 +178,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           fetch-depth: 0
@@ -247,28 +238,7 @@ jobs:
             } >> "$GITHUB_ENV"
           fi
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: frontend inventory
         run: |
@@ -288,30 +258,15 @@ jobs:
       contents: read
       checks: write
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -320,8 +275,6 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-unit-app-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
             turbo-${{ runner.os }}-unit-app-
-
-      - run: bun install --frozen-lockfile
 
       - name: unit
         run: bun turbo test:ci --filter=@opencode-ai/app
@@ -360,30 +313,15 @@ jobs:
       contents: read
       checks: write
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -392,8 +330,6 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-unit-ui-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
             turbo-${{ runner.os }}-unit-ui-
-
-      - run: bun install --frozen-lockfile
 
       - name: unit
         run: bun turbo test:ci --filter=@opencode-ai/ui
@@ -432,30 +368,15 @@ jobs:
       contents: read
       checks: write
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -464,8 +385,6 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-unit-opencode-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
             turbo-${{ runner.os }}-unit-opencode-
-
-      - run: bun install --frozen-lockfile
 
       - name: unit
         run: bun turbo test:ci --filter=opencode
@@ -504,30 +423,15 @@ jobs:
       contents: read
       checks: write
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false
 
-      # Load-bearing: `bun install` runs `trustedDependencies`
-      # postinstalls from the root package.json (electron, node-pty,
-      # esbuild, tree-sitter at time of writing), which call `node`
-      # explicitly. Do not drop without first patching those scripts.
-      # Source of truth: grep `trustedDependencies` in package.json. (#70)
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
-        with:
-          node-version: "24"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
-        with:
-          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
-          bun-version: "1.3.14"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
         with:
@@ -536,8 +440,6 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-unit-desktop-${{ hashFiles('turbo.json', '**/package.json', 'bun.lock') }}-
             turbo-${{ runner.os }}-unit-desktop-
-
-      - run: bun install --frozen-lockfile
 
       - name: unit
         run: bun turbo test:ci --filter=@opencode-ai/desktop-electron

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # step-security/harden-runner@v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
         with:
           persist-credentials: false

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -6,6 +6,7 @@ import { parseWorkflow, type Workflow } from "./workflow-parser"
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url))
 const workflowsRoot = path.join(repoRoot, ".github", "workflows")
+const setupActionPath = path.join(repoRoot, ".github", "actions", "setup", "action.yml")
 const expectedBunVersion = "1.3.14"
 const auditComment = "Load-bearing for `bun audit` exit semantics"
 
@@ -83,13 +84,6 @@ describe("GitHub workflow Bun version pin", () => {
 
     expect(setupBunPins).toEqual([
       ".github/workflows/build.yml:build-electron:step-5:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:typecheck:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:lint:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:frontend-architecture:step-5:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:unit-app:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:unit-ui:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:unit-opencode:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/ci.yml:unit-desktop:step-3:bun-version: \"1.3.14\"",
       ".github/workflows/desktop-smoke.yml:smoke-macos-arm64:step-3:bun-version: \"1.3.14\"",
       ".github/workflows/dev-dep-audit.yml:dev-dep-audit:step-3:bun-version: \"1.3.14\"",
       ".github/workflows/e2e-artifacts.yml:e2e-artifacts:step-3:bun-version: \"1.3.14\"",
@@ -98,5 +92,9 @@ describe("GitHub workflow Bun version pin", () => {
       ".github/workflows/windows-advisory.yml:unit-windows:step-3:bun-version: \"1.3.14\"",
     ])
     expect(missingComments).toEqual([])
+
+    const setupAction = fs.readFileSync(setupActionPath, "utf8")
+    expect(setupAction).toContain(`bun-version: "${expectedBunVersion}"`)
+    expect(setupAction).toContain(auditComment)
   })
 })

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import path from "node:path"
-import { parseWorkflow, readWorkflow } from "./workflow-parser"
+import { parseWorkflow, parseYamlFile, readWorkflow, type WorkflowStep } from "./workflow-parser"
 
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const ciWorkflowPath = path.join(repoRoot, ".github", "workflows", "ci.yml")
@@ -33,12 +33,20 @@ const actionlintVersion = "1.7.12"
 const actionlintLinuxAmd64Sha = "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
 const hardenRunnerJobs = [
   "typecheck",
+  lintJobName,
   frontendArchitectureJobName,
   "unit-ui",
   "unit-app",
   "unit-opencode",
   "unit-desktop",
 ] as const
+
+type CompositeActionMetadata = {
+  runs?: {
+    using?: string
+    steps?: WorkflowStep[]
+  }
+}
 
 // Suffixes drive readable job and artifact names; commands use package.json names verbatim.
 // `opencode` is intentionally unscoped because that is its actual package name.
@@ -269,19 +277,26 @@ describe("ci workflow", () => {
       expect(jobSteps[1]?.uses).toBe(pinned.checkout)
     }
 
-    expect(steps(lintJobName)[0]?.uses).toBe(pinned.checkout)
     expect(steps("check").some((step) => step.uses === pinned.hardenRunner)).toBe(false)
   })
 
   test("uses a local setup composite for shared CI Node and Bun setup", () => {
     const setupActionContent = readWorkflow(setupActionPath)
+    const setupActionMetadata = parseYamlFile<CompositeActionMetadata>(setupActionPath)
+    const setupSteps = setupActionMetadata.runs?.steps ?? []
+    const setupNode = setupSteps.find((step) => step.uses?.startsWith("actions/setup-node@"))
+    const setupBun = setupSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    const cache = setupSteps.find((step) => step.uses?.startsWith("actions/cache@"))
+    const install = setupSteps.find((step) => step.run === "bun install --frozen-lockfile")
 
-    expect(setupActionContent).toContain(pinned.setupNode)
-    expect(setupActionContent).toContain('node-version: "24"')
-    expect(setupActionContent).toContain(pinned.setupBun)
-    expect(setupActionContent).toContain('bun-version: "1.3.14"')
-    expect(setupActionContent).toContain(pinned.cache)
-    expect(setupActionContent).toContain("bun install --frozen-lockfile")
+    expect(setupActionMetadata.runs?.using).toBe("composite")
+    expect(setupNode?.uses).toBe(pinned.setupNode)
+    expect(setupNode?.with?.["node-version"]).toBe("24")
+    expect(setupBun?.uses).toBe(pinned.setupBun)
+    expect(setupBun?.with?.["bun-version"]).toBe("1.3.14")
+    expect(cache?.uses).toBe(pinned.cache)
+    expect(cache?.with?.path).toBe("~/.bun/install/cache")
+    expect(install?.shell).toBe("bash")
     expect(setupActionContent).toContain("Load-bearing: `bun install` runs `trustedDependencies`")
     expect(setupActionContent).toContain("Load-bearing for `bun audit` exit semantics")
 

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -5,6 +5,7 @@ import { parseWorkflow, readWorkflow } from "./workflow-parser"
 
 const repoRoot = path.join(import.meta.dir, "../../../..")
 const ciWorkflowPath = path.join(repoRoot, ".github", "workflows", "ci.yml")
+const setupActionPath = path.join(repoRoot, ".github", "actions", "setup", "action.yml")
 const windowsAdvisoryWorkflowPath = path.join(repoRoot, ".github", "workflows", "windows-advisory.yml")
 const turboJsonPath = path.join(repoRoot, "turbo.json")
 const uiPackageJsonPath = path.join(repoRoot, "packages", "ui", "package.json")
@@ -16,6 +17,7 @@ const pinned = {
   setupNode: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
   setupBun: "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
   cache: "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
+  hardenRunner: "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411",
   junit: "mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d",
   artifact: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
 }
@@ -25,6 +27,18 @@ const githubSha = "${{ github.sha }}"
 const lintJobName = "lint"
 const frontendArchitectureJobName = "frontend-architecture"
 const windowsUnitJobName = "unit-windows"
+const setupAction = "./.github/actions/setup"
+const actionlintJobName = "actionlint"
+const actionlintVersion = "1.7.12"
+const actionlintLinuxAmd64Sha = "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+const hardenRunnerJobs = [
+  "typecheck",
+  frontendArchitectureJobName,
+  "unit-ui",
+  "unit-app",
+  "unit-opencode",
+  "unit-desktop",
+] as const
 
 // Suffixes drive readable job and artifact names; commands use package.json names verbatim.
 // `opencode` is intentionally unscoped because that is its actual package name.
@@ -222,20 +236,15 @@ describe("ci workflow", () => {
     expect(checkoutStep("changes")?.with?.["fetch-depth"]).toBe(0)
 
     for (const job of ["typecheck", ...linuxUnitJobNames]) {
-      expect(steps(job).find((step) => step.uses?.startsWith("actions/setup-node@"))?.uses).toBe(pinned.setupNode)
-      expect(steps(job).find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))?.uses).toBe(pinned.setupBun)
+      expect(steps(job).find((step) => step.uses === setupAction)?.uses).toBe(setupAction)
       expect(steps(job).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual([
-        pinned.cache,
         pinned.cache,
       ])
     }
 
-    expect(steps(lintJobName).find((step) => step.uses?.startsWith("actions/setup-node@"))?.uses).toBe(
-      pinned.setupNode,
-    )
-    expect(steps(lintJobName).find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))?.uses).toBe(pinned.setupBun)
+    expect(steps(lintJobName).find((step) => step.uses === setupAction)?.uses).toBe(setupAction)
     expect(steps(lintJobName).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual(
-      [pinned.cache],
+      [],
     )
 
     for (const job of linuxUnitJobNames) {
@@ -249,6 +258,65 @@ describe("ci workflow", () => {
     expect(workflow).not.toContain("pull_request_target")
     expect(workflow).not.toContain("persist-credentials: true")
     expect(parsed.jobs?.[windowsUnitJobName]).toBeUndefined()
+  })
+
+  test("audits required dependency-installing jobs before checkout", () => {
+    for (const job of hardenRunnerJobs) {
+      const jobSteps = steps(job)
+
+      expect(jobSteps[0]?.uses).toBe(pinned.hardenRunner)
+      expect(jobSteps[0]?.with?.["egress-policy"]).toBe("audit")
+      expect(jobSteps[1]?.uses).toBe(pinned.checkout)
+    }
+
+    expect(steps(lintJobName)[0]?.uses).toBe(pinned.checkout)
+    expect(steps("check").some((step) => step.uses === pinned.hardenRunner)).toBe(false)
+  })
+
+  test("uses a local setup composite for shared CI Node and Bun setup", () => {
+    const setupActionContent = readWorkflow(setupActionPath)
+
+    expect(setupActionContent).toContain(pinned.setupNode)
+    expect(setupActionContent).toContain('node-version: "24"')
+    expect(setupActionContent).toContain(pinned.setupBun)
+    expect(setupActionContent).toContain('bun-version: "1.3.14"')
+    expect(setupActionContent).toContain(pinned.cache)
+    expect(setupActionContent).toContain("bun install --frozen-lockfile")
+    expect(setupActionContent).toContain("Load-bearing: `bun install` runs `trustedDependencies`")
+    expect(setupActionContent).toContain("Load-bearing for `bun audit` exit semantics")
+
+    const setupActionJobs = [
+      "typecheck",
+      lintJobName,
+      frontendArchitectureJobName,
+      ...linuxUnitJobs.map((item) => item.jobName),
+    ]
+
+    for (const job of setupActionJobs) {
+      expect(steps(job).some((step) => step.uses === setupAction)).toBe(true)
+    }
+
+    for (const workflowStep of steps(frontendArchitectureJobName).slice(0, 4)) {
+      expect(workflowStep.uses).not.toBe(setupAction)
+    }
+  })
+
+  test("runs actionlint as a non-blocking pinned advisory check", () => {
+    const workflow = readWorkflow(ciWorkflowPath)
+    const actionlint = parseWorkflow(ciWorkflowPath).jobs?.[actionlintJobName]
+    const actionlintSteps = steps(actionlintJobName)
+
+    expect(actionlint?.["continue-on-error"]).toBe(true)
+    expect(actionlint?.needs).toBeUndefined()
+    expect(actionlintSteps[0]?.uses).toBe(pinned.checkout)
+    expect(actionlintSteps[1]?.name).toBe("Download actionlint")
+    expect(actionlintSteps[1]?.run).toContain(`ACTIONLINT_VERSION="${actionlintVersion}"`)
+    expect(actionlintSteps[1]?.run).toContain(`ACTIONLINT_SHA256="${actionlintLinuxAmd64Sha}"`)
+    expect(actionlintSteps[1]?.run).toContain("sha256sum --check")
+    expect(actionlintSteps[2]?.name).toBe("Run actionlint")
+    expect(actionlintSteps[2]?.run).toBe("./actionlint -color -shellcheck=")
+    expect(workflow).not.toContain("rhysd/actionlint@")
+    expect(parseWorkflow(ciWorkflowPath).jobs?.check?.needs).not.toContain(actionlintJobName)
   })
 
   test("keeps dev runs and cancels stale pull request runs", () => {
@@ -415,15 +483,8 @@ describe("ci workflow", () => {
     expect(computeRange?.run).toContain("BASE_SHA=")
     expect(computeRange?.run).toContain("HEAD_SHA=")
     expect(computeRange?.run).toContain("skipped=true")
-    expect(steps(frontendArchitectureJobName).find((step) => step.uses?.startsWith("actions/setup-node@"))?.uses).toBe(
-      pinned.setupNode,
-    )
-    expect(steps(frontendArchitectureJobName).find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))?.uses).toBe(
-      pinned.setupBun,
-    )
-    expect(steps(frontendArchitectureJobName).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual([
-      pinned.cache,
-    ])
+    expect(steps(frontendArchitectureJobName).find((step) => step.uses === setupAction)?.uses).toBe(setupAction)
+    expect(steps(frontendArchitectureJobName).filter((step) => step.uses?.startsWith("actions/cache@")).map((step) => step.uses)).toEqual([])
     expect(inventory?.run).toContain("node script/frontend-inventory.mjs --format json")
     expect(inventory?.run).toContain(".artifacts/frontend-architecture/frontend-inventory.json")
     expect(ratchet?.if).toBe("steps.compute-range.outputs.skipped != 'true'")

--- a/packages/opencode/test/github/workflow-parser.ts
+++ b/packages/opencode/test/github/workflow-parser.ts
@@ -63,8 +63,8 @@ export function readWorkflow(workflowPath: string) {
   return fs.readFileSync(workflowPath, "utf8")
 }
 
-/** Parses workflow YAML with Ruby, preserving GitHub's `on` key for assertions. */
-export function parseWorkflow(workflowPath: string) {
+/** Parses YAML with Ruby, preserving GitHub's workflow `on` key for assertions. */
+export function parseYamlFile<T>(yamlPath: string) {
   const parsed = execFileSync(
     "ruby",
     [
@@ -77,10 +77,15 @@ export function parseWorkflow(workflowPath: string) {
         data["on"] = data.delete(true) if data.key?(true)
         puts JSON.generate(data)
       `,
-      workflowPath,
+      yamlPath,
     ],
     { encoding: "utf8" },
   )
 
-  return JSON.parse(parsed) as Workflow
+  return JSON.parse(parsed) as T
+}
+
+/** Parses workflow YAML with Ruby, preserving GitHub's `on` key for assertions. */
+export function parseWorkflow(workflowPath: string) {
+  return parseYamlFile<Workflow>(workflowPath)
 }


### PR DESCRIPTION
## Summary

Adds the #977 PR-D CI hardening slice:

- starts the required CI dependency-installing jobs with `step-security/harden-runner` in audit mode
- extracts the shared `ci.yml` Node/Bun install preamble into `.github/actions/setup`
- adds an advisory `actionlint` job using the pinned v1.7.12 release binary and SHA256 verification
- updates workflow contract tests for the new CI shape and Bun pin location

## Why

This prepares CI for an eventual egress allowlist without switching to block mode yet, and keeps the repeated CI setup in one pinned local action. The issue text mentioned `rhysd/actionlint@<sha>`, but the upstream `rhysd/actionlint` repository is a CLI repository, not a GitHub Action with root `action.yml`. This PR uses the official release binary plus digest verification instead, preserving the pinning/security intent without adding a wrapper dependency.

## Related Issue

Part of #977.

## Human Review Status

Pending

## Review Focus

Please check the CI job ordering: `harden-runner` is intentionally before checkout for the audited dependency-installing jobs, including `lint`, while the `check` aggregator stays outside the audit scope. Also check that the setup composite is limited to `ci.yml`; other workflows keep their current setup because their OS, cache, or install ordering differs.

## Risk Notes

- `harden-runner` is added to required CI jobs, so a GitHub Actions regression or StepSecurity outage could affect required checks even though the policy is only `audit`.
- `actionlint` runs with `-shellcheck=` because existing workflows have unrelated ShellCheck findings; this PR scopes the new advisory job to workflow/action syntax first.
- PR-B's manual ruleset follow-up is still outstanding: live `dev-merge-gate` did not list `dependency-review` or `dev-dep-audit` as required contexts during implementation. This PR does not change rulesets.
- Checklist conditional skipped: no visible UI or copy changed, so no screenshots or recordings are included.
- Checklist conditional skipped: no desktop platform, packaging, updater, signing, paths, shell, or permission behavior changed.

## How To Verify

```text
bun install --frozen-lockfile: installed dependencies in the isolated worktree without lockfile changes
bun test test/github/ci-workflow.test.ts test/github/bun-version-workflow.test.ts (from packages/opencode): 19 pass, 0 fail
ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/*.yml .github/actions/setup/action.yml: all workflow/action YAML parsed successfully
actionlint v1.7.12 darwin_arm64 with verified SHA256, run as `actionlint -color -shellcheck= .github/workflows/*.yml`: passed
git diff --check: passed
bun run lint:ci: passed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.