### PR TITLE
test(server): lock workspace routing guardrails

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -336,7 +336,7 @@ For each service, the migration is roughly:
 ### Migration log
 
 - Workspace routing guardrails — scoped 2026-05-30 as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
-  - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session/*` stays local, a session's bound `workspaceID` wins over `?workspace=`, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
+  - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session` and session-detail GET routes stay local while `/session/status` remains forwarded, a session's bound `workspaceID` wins over `?workspace=`, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
   - Non-goals: no upstream `/sync/*`, workspace adapter/sync-list/warp, v2 `/api/*`, TUI, auth/OAuth, OpenAPI/SDK shape, or proxy internals migration.
   - Follow-ups only when touched: EnterWorktree/ExitWorktree execution-context tests, WebSocket queue/close-code/bidirectional proxy tests, and the actual WorkspaceRouting/InstanceContext Effect middleware design.
 - `SessionStatus` — migrated 2026-04-11. Replaced the last route and retry-policy callers with `AppRuntime.runPromise(SessionStatus.Service.use(...))` and removed the `makeRuntime(...)` facade.

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -335,6 +335,10 @@ For each service, the migration is roughly:
 
 ### Migration log
 
+- Workspace routing guardrails — scoped 2026-05-30 as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
+  - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session/*` stays local, a session's bound `workspaceID` wins over `?workspace=`, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
+  - Non-goals: no upstream `/sync/*`, workspace adapter/sync-list/warp, v2 `/api/*`, TUI, auth/OAuth, OpenAPI/SDK shape, or proxy internals migration.
+  - Follow-ups only when touched: EnterWorktree/ExitWorktree execution-context tests, WebSocket queue/close-code/bidirectional proxy tests, and the actual WorkspaceRouting/InstanceContext Effect middleware design.
 - `SessionStatus` — migrated 2026-04-11. Replaced the last route and retry-policy callers with `AppRuntime.runPromise(SessionStatus.Service.use(...))` and removed the `makeRuntime(...)` facade.
 - `ShareNext` — migrated 2026-04-11. Swapped remaining async callers to `AppRuntime.runPromise(ShareNext.Service.use(...))`, removed the `makeRuntime(...)` facade, and kept instance bootstrap on the shared app runtime.
 - `SessionTodo` — migrated 2026-04-10. Already matched the target service shape in `session/todo.ts`: single namespace, traced Effect methods, and no `makeRuntime(...)` facade remained; checklist updated to reflect the completed migration.

--- a/packages/opencode/test/server/default-directory.test.ts
+++ b/packages/opencode/test/server/default-directory.test.ts
@@ -90,6 +90,7 @@ describe("default directory routing", () => {
       expect(response.status).toBe(200)
       expect(body.config).toBe(expected)
       expect(fs.existsSync(expected)).toBe(true)
+      expect(fs.existsSync(path.join(tmp.path, "legacy-config"))).toBe(false)
     } finally {
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -45,6 +45,10 @@ function wait(ms = 50) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function disableWorkspaceSync() {
+  return spyOn(Workspace, "ensureSync").mockImplementation(() => {})
+}
+
 async function pluginProject() {
   return tmpdir({
     git: true,
@@ -92,7 +96,7 @@ async function pluginProject() {
 }
 
 describe("workspace router", () => {
-  test("keeps GET session detail routes local for remote workspaces", async () => {
+  test("keeps GET session detail routes local while forwarding session status", async () => {
     let remoteHits = 0
     await using remote = Bun.serve({
       port: 0,
@@ -167,15 +171,31 @@ describe("workspace router", () => {
 
     await Instance.disposeAll()
 
-    const app = Server.Default().app
-    const response = await app.request(`/session/ses_missing?workspace=${workspace.id}`, {
-      headers: {
-        "x-opencode-directory": tmp.path,
-      },
-    })
+    const ensureSync = disableWorkspaceSync()
 
-    expect(response.status).toBe(404)
-    expect(remoteHits).toBe(0)
+    try {
+      const app = Server.Default().app
+      const detail = await app.request(`/session/ses_missing?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": tmp.path,
+        },
+      })
+
+      expect(detail.status).toBe(404)
+      expect(remoteHits).toBe(0)
+
+      const status = await app.request(`/session/status?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": tmp.path,
+        },
+      })
+
+      expect(status.status).toBe(200)
+      expect(await status.json()).toEqual({ remote: true })
+      expect(remoteHits).toBe(1)
+    } finally {
+      ensureSync.mockRestore()
+    }
   })
 
   test("uses a session workspace before the workspace query parameter for mutating session routes", async () => {
@@ -307,19 +327,25 @@ describe("workspace router", () => {
 
     await Instance.disposeAll()
 
-    const app = Server.Default().app
-    const response = await app.request(`/session/${session.id}/message?workspace=${localWorkspace.id}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-opencode-directory": first.path,
-      },
-      body: JSON.stringify({}),
-    })
+    const ensureSync = disableWorkspaceSync()
 
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ routed: "session-workspace" })
-    expect(remoteHits).toBe(1)
+    try {
+      const app = Server.Default().app
+      const response = await app.request(`/session/${session.id}/message?workspace=${localWorkspace.id}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-opencode-directory": first.path,
+        },
+        body: JSON.stringify({}),
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ routed: "session-workspace" })
+      expect(remoteHits).toBe(1)
+    } finally {
+      ensureSync.mockRestore()
+    }
   })
 
   test("routes remote workspace websocket upgrades through the websocket proxy", async () => {
@@ -385,6 +411,7 @@ describe("workspace router", () => {
     })
     await Instance.disposeAll()
 
+    const ensureSync = disableWorkspaceSync()
     const websocket = spyOn(ServerProxy, "websocket").mockImplementation(() => new Response("websocket-proxy"))
 
     try {
@@ -401,6 +428,7 @@ describe("workspace router", () => {
       expect(await response.text()).toBe("websocket-proxy")
       expect(websocket).toHaveBeenCalledTimes(1)
     } finally {
+      ensureSync.mockRestore()
       websocket.mockRestore()
     }
   })

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun"
-import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -14,6 +14,8 @@ import { Database } from "../../src/storage/db"
 import { Log } from "@opencode-ai/core/util/log"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
+import { Session } from "../../src/session"
+import { ServerProxy } from "../../src/server/proxy"
 
 Log.init({ print: false })
 
@@ -90,6 +92,319 @@ async function pluginProject() {
 }
 
 describe("workspace router", () => {
+  test("keeps GET session detail routes local for remote workspaces", async () => {
+    let remoteHits = 0
+    await using remote = Bun.serve({
+      port: 0,
+      fetch() {
+        remoteHits++
+        return Response.json({ remote: true })
+      },
+    })
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            "    target() {",
+            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        const id = WorkspaceID.ascending()
+        Database.use((db) =>
+          db.insert(WorkspaceTable)
+            .values({
+              id,
+              type: tmp.extra.type,
+              branch: null,
+              name: "remote",
+              directory: null,
+              owner_directory: tmp.path,
+              extra: null,
+              project_id: Instance.project.id,
+            })
+            .run(),
+        )
+        return { id }
+      },
+    })
+
+    await Instance.disposeAll()
+
+    const app = Server.Default().app
+    const response = await app.request(`/session/ses_missing?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(404)
+    expect(remoteHits).toBe(0)
+  })
+
+  test("uses a session workspace before the workspace query parameter for mutating session routes", async () => {
+    let remoteHits = 0
+    await using remote = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (url.pathname !== "/sync/event") remoteHits++
+        return Response.json({ routed: "session-workspace" })
+      },
+    })
+
+    await using first = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            "    target() {",
+            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
+            "    },",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+    await using second = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "local",',
+            '    description: "local adaptor",',
+            `    configure(input) { return { ...input, name: "local", branch: null, directory: ${JSON.stringify(dir)} } },`,
+            "    async create() {},",
+            "    async remove() {},",
+            "    target(input) { return { type: \"local\", directory: input.directory } }",
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+
+    const remoteWorkspace = await Instance.provide({
+      directory: first.path,
+      fn: async () => {
+        await Plugin.init()
+        const id = WorkspaceID.ascending()
+        Database.use((db) =>
+          db.insert(WorkspaceTable)
+            .values({
+              id,
+              type: first.extra.type,
+              branch: null,
+              name: "remote",
+              directory: null,
+              owner_directory: first.path,
+              extra: null,
+              project_id: Instance.project.id,
+            })
+            .run(),
+        )
+        return { id }
+      },
+    })
+    const localWorkspace = await Instance.provide({
+      directory: second.path,
+      fn: async () => {
+        await Plugin.init()
+        return Workspace.create({
+          type: second.extra.type,
+          branch: null,
+          extra: null,
+          projectID: Instance.project.id,
+        })
+      },
+    })
+    const session = await Instance.provide({
+      directory: first.path,
+      fn: () => Session.create({ workspaceID: remoteWorkspace.id }),
+    })
+
+    await Instance.disposeAll()
+
+    const app = Server.Default().app
+    const response = await app.request(`/session/${session.id}/message?workspace=${localWorkspace.id}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-opencode-directory": first.path,
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ routed: "session-workspace" })
+    expect(remoteHits).toBe(1)
+  })
+
+  test("routes remote workspace websocket upgrades through the websocket proxy", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const type = `plug-${Math.random().toString(36).slice(2)}`
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(
+          file,
+          [
+            "export default async ({ experimental_workspace }) => {",
+            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+            '    name: "remote",',
+            '    description: "remote adaptor",',
+            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
+            "    async create() {},",
+            "    async remove() {},",
+            '    target() { return { type: "remote", url: "http://127.0.0.1:9" } }',
+            "  })",
+            "  return {}",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify(
+            {
+              $schema: "https://opencode.ai/config.json",
+              plugin: [pathToFileURL(file).href],
+            },
+            null,
+            2,
+          ),
+        )
+
+        return { type }
+      },
+    })
+
+    const workspace = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        const id = WorkspaceID.ascending()
+        Database.use((db) =>
+          db.insert(WorkspaceTable)
+            .values({
+              id,
+              type: tmp.extra.type,
+              branch: null,
+              name: "remote",
+              directory: null,
+              owner_directory: tmp.path,
+              extra: null,
+              project_id: Instance.project.id,
+            })
+            .run(),
+        )
+        return { id }
+      },
+    })
+    await Instance.disposeAll()
+
+    const websocket = spyOn(ServerProxy, "websocket").mockImplementation(() => new Response("websocket-proxy"))
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request(`/pty/pty_test/connect?workspace=${workspace.id}`, {
+        headers: {
+          connection: "upgrade",
+          upgrade: "websocket",
+          "x-opencode-directory": tmp.path,
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe("websocket-proxy")
+      expect(websocket).toHaveBeenCalledTimes(1)
+    } finally {
+      websocket.mockRestore()
+    }
+  })
+
   test("bootstraps the owning project before routing a persisted plugin workspace", async () => {
     await using tmp = await pluginProject()
 

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -49,6 +49,115 @@ function disableWorkspaceSync() {
   return spyOn(Workspace, "ensureSync").mockImplementation(() => {})
 }
 
+async function writeOpencodeConfig(dir: string, pluginFile: string) {
+  await Bun.write(
+    path.join(dir, "opencode.json"),
+    JSON.stringify(
+      {
+        $schema: "https://opencode.ai/config.json",
+        plugin: [pathToFileURL(pluginFile).href],
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+async function writeRemoteWorkspacePlugin(input: { dir: string; url: string; branch?: string | null }) {
+  const type = `plug-${Math.random().toString(36).slice(2)}`
+  const file = path.join(input.dir, "plugin.ts")
+  const branch = input.branch === undefined ? null : input.branch
+  await Bun.write(
+    file,
+    [
+      "export default async ({ experimental_workspace }) => {",
+      `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+      '    name: "remote",',
+      '    description: "remote adaptor",',
+      `    configure(input) { return { ...input, name: "remote", branch: ${JSON.stringify(branch)}, directory: null } },`,
+      "    async create() {},",
+      "    async remove() {},",
+      "    target() {",
+      `      return { type: "remote", url: ${JSON.stringify(input.url)} }`,
+      "    },",
+      "  })",
+      "  return {}",
+      "}",
+      "",
+    ].join("\n"),
+  )
+  await writeOpencodeConfig(input.dir, file)
+  return { type }
+}
+
+async function writeLocalWorkspacePlugin(input: { dir: string; name?: string; directory?: string; type?: string }) {
+  const type = input.type ?? `plug-${Math.random().toString(36).slice(2)}`
+  const name = input.name ?? "local"
+  const directory = input.directory ?? input.dir
+  const file = path.join(input.dir, "plugin.ts")
+  await Bun.write(
+    file,
+    [
+      "export default async ({ experimental_workspace }) => {",
+      `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+      `    name: ${JSON.stringify(name)},`,
+      `    description: ${JSON.stringify(`${name} adaptor`)},`,
+      "    configure(input) {",
+      `      return { ...input, name: ${JSON.stringify(name)}, branch: null, directory: ${JSON.stringify(directory)} }`,
+      "    },",
+      "    async create() {},",
+      "    async remove() {},",
+      "    target(input) { return { type: \"local\", directory: input.directory } }",
+      "  })",
+      "  return {}",
+      "}",
+      "",
+    ].join("\n"),
+  )
+  await writeOpencodeConfig(input.dir, file)
+  return { type }
+}
+
+async function persistRemoteWorkspace(input: { directory: string; type: string; branch?: string | null }) {
+  return Instance.provide({
+    directory: input.directory,
+    fn: async () => {
+      await Plugin.init()
+      const id = WorkspaceID.ascending()
+      Database.use((db) =>
+        db.insert(WorkspaceTable)
+          .values({
+            id,
+            type: input.type,
+            branch: input.branch ?? null,
+            name: "remote",
+            directory: null,
+            owner_directory: input.directory,
+            extra: null,
+            project_id: Instance.project.id,
+          })
+          .run(),
+      )
+      return { id }
+    },
+  })
+}
+
+async function createLocalWorkspace(input: { directory: string; type: string }) {
+  return Instance.provide({
+    directory: input.directory,
+    fn: async () => {
+      await Plugin.init()
+      return Workspace.create({
+        type: input.type,
+        branch: null,
+        extra: null,
+        projectID: Instance.project.id,
+      })
+    },
+  })
+}
+
 async function pluginProject() {
   return tmpdir({
     git: true,
@@ -107,67 +216,10 @@ describe("workspace router", () => {
     })
 
     await using tmp = await tmpdir({
-      init: async (dir) => {
-        const type = `plug-${Math.random().toString(36).slice(2)}`
-        const file = path.join(dir, "plugin.ts")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "remote",',
-            '    description: "remote adaptor",',
-            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
-            "    async create() {},",
-            "    async remove() {},",
-            "    target() {",
-            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
-            "    },",
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
-          ),
-        )
-
-        return { type }
-      },
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: remote.url.origin }),
     })
 
-    const workspace = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await Plugin.init()
-        const id = WorkspaceID.ascending()
-        Database.use((db) =>
-          db.insert(WorkspaceTable)
-            .values({
-              id,
-              type: tmp.extra.type,
-              branch: null,
-              name: "remote",
-              directory: null,
-              owner_directory: tmp.path,
-              extra: null,
-              project_id: Instance.project.id,
-            })
-            .run(),
-        )
-        return { id }
-      },
-    })
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type })
 
     await Instance.disposeAll()
 
@@ -210,116 +262,14 @@ describe("workspace router", () => {
     })
 
     await using first = await tmpdir({
-      init: async (dir) => {
-        const type = `plug-${Math.random().toString(36).slice(2)}`
-        const file = path.join(dir, "plugin.ts")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "remote",',
-            '    description: "remote adaptor",',
-            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
-            "    async create() {},",
-            "    async remove() {},",
-            "    target() {",
-            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
-            "    },",
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
-          ),
-        )
-
-        return { type }
-      },
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: remote.url.origin }),
     })
     await using second = await tmpdir({
-      init: async (dir) => {
-        const type = `plug-${Math.random().toString(36).slice(2)}`
-        const file = path.join(dir, "plugin.ts")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "local",',
-            '    description: "local adaptor",',
-            `    configure(input) { return { ...input, name: "local", branch: null, directory: ${JSON.stringify(dir)} } },`,
-            "    async create() {},",
-            "    async remove() {},",
-            "    target(input) { return { type: \"local\", directory: input.directory } }",
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
-          ),
-        )
-
-        return { type }
-      },
+      init: (dir) => writeLocalWorkspacePlugin({ dir }),
     })
 
-    const remoteWorkspace = await Instance.provide({
-      directory: first.path,
-      fn: async () => {
-        await Plugin.init()
-        const id = WorkspaceID.ascending()
-        Database.use((db) =>
-          db.insert(WorkspaceTable)
-            .values({
-              id,
-              type: first.extra.type,
-              branch: null,
-              name: "remote",
-              directory: null,
-              owner_directory: first.path,
-              extra: null,
-              project_id: Instance.project.id,
-            })
-            .run(),
-        )
-        return { id }
-      },
-    })
-    const localWorkspace = await Instance.provide({
-      directory: second.path,
-      fn: async () => {
-        await Plugin.init()
-        return Workspace.create({
-          type: second.extra.type,
-          branch: null,
-          extra: null,
-          projectID: Instance.project.id,
-        })
-      },
-    })
+    const remoteWorkspace = await persistRemoteWorkspace({ directory: first.path, type: first.extra.type })
+    const localWorkspace = await createLocalWorkspace({ directory: second.path, type: second.extra.type })
     const session = await Instance.provide({
       directory: first.path,
       fn: () => Session.create({ workspaceID: remoteWorkspace.id }),
@@ -349,66 +299,11 @@ describe("workspace router", () => {
   })
 
   test("routes remote workspace websocket upgrades through the websocket proxy", async () => {
+    const target = "http://127.0.0.1:9"
     await using tmp = await tmpdir({
-      init: async (dir) => {
-        const type = `plug-${Math.random().toString(36).slice(2)}`
-        const file = path.join(dir, "plugin.ts")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "remote",',
-            '    description: "remote adaptor",',
-            '    configure(input) { return { ...input, name: "remote", branch: null, directory: null } },',
-            "    async create() {},",
-            "    async remove() {},",
-            '    target() { return { type: "remote", url: "http://127.0.0.1:9" } }',
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
-          ),
-        )
-
-        return { type }
-      },
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: target }),
     })
-
-    const workspace = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await Plugin.init()
-        const id = WorkspaceID.ascending()
-        Database.use((db) =>
-          db.insert(WorkspaceTable)
-            .values({
-              id,
-              type: tmp.extra.type,
-              branch: null,
-              name: "remote",
-              directory: null,
-              owner_directory: tmp.path,
-              extra: null,
-              project_id: Instance.project.id,
-            })
-            .run(),
-        )
-        return { id }
-      },
-    })
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type })
     await Instance.disposeAll()
 
     const ensureSync = disableWorkspaceSync()
@@ -427,6 +322,15 @@ describe("workspace router", () => {
       expect(response.status).toBe(200)
       expect(await response.text()).toBe("websocket-proxy")
       expect(websocket).toHaveBeenCalledTimes(1)
+      const call = websocket.mock.calls[0]
+      const proxiedTarget = call[1] as { type?: string; url?: string }
+      const proxiedRequest = call[2] as Request
+      const proxiedURL = new URL(proxiedRequest.url)
+      expect(proxiedTarget).toEqual({ type: "remote", url: target })
+      expect(proxiedURL.pathname).toBe("/pty/pty_test/connect")
+      expect(proxiedURL.searchParams.get("workspace")).toBe(workspace.id)
+      expect(proxiedRequest.headers.get("upgrade")).toBe("websocket")
+      expect(proxiedRequest.headers.get("connection")).toBe("upgrade")
     } finally {
       ensureSync.mockRestore()
       websocket.mockRestore()
@@ -672,88 +576,12 @@ describe("workspace router", () => {
     await using second = await tmpdir()
 
     const type = "shared"
-    const firstPlugin = path.join(first.path, "plugin.ts")
     const firstSpace = path.join(first.path, "first-space")
-    await Bun.write(
-      firstPlugin,
-      [
-        "export default async ({ experimental_workspace }) => {",
-        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-        '    name: "first",',
-        '    description: "first adaptor",',
-        "    configure(input) {",
-        `      return { ...input, name: "first", branch: null, directory: ${JSON.stringify(firstSpace)} }`,
-        "    },",
-        "    async create() {},",
-        "    async remove() {},",
-        "    target() {",
-        `      return { type: "local", directory: ${JSON.stringify(firstSpace)} }`,
-        "    },",
-        "  })",
-        "  return {}",
-        "}",
-        "",
-      ].join("\n"),
-    )
-    await Bun.write(
-      path.join(first.path, "opencode.json"),
-      JSON.stringify(
-        {
-          $schema: "https://opencode.ai/config.json",
-          plugin: [pathToFileURL(firstPlugin).href],
-        },
-        null,
-        2,
-      ),
-    )
-
-    const secondPlugin = path.join(second.path, "plugin.ts")
     const secondSpace = path.join(second.path, "second-space")
-    await Bun.write(
-      secondPlugin,
-      [
-        "export default async ({ experimental_workspace }) => {",
-        `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-        '    name: "second",',
-        '    description: "second adaptor",',
-        "    configure(input) {",
-        `      return { ...input, name: "second", branch: null, directory: ${JSON.stringify(secondSpace)} }`,
-        "    },",
-        "    async create() {},",
-        "    async remove() {},",
-        "    target() {",
-        `      return { type: "local", directory: ${JSON.stringify(secondSpace)} }`,
-        "    },",
-        "  })",
-        "  return {}",
-        "}",
-        "",
-      ].join("\n"),
-    )
-    await Bun.write(
-      path.join(second.path, "opencode.json"),
-      JSON.stringify(
-        {
-          $schema: "https://opencode.ai/config.json",
-          plugin: [pathToFileURL(secondPlugin).href],
-        },
-        null,
-        2,
-      ),
-    )
+    await writeLocalWorkspacePlugin({ dir: first.path, name: "first", directory: firstSpace, type })
+    await writeLocalWorkspacePlugin({ dir: second.path, name: "second", directory: secondSpace, type })
 
-    const workspace = await Instance.provide({
-      directory: first.path,
-      fn: async () => {
-        await Plugin.init()
-        return Workspace.create({
-          type,
-          branch: null,
-          extra: null,
-          projectID: Instance.project.id,
-        })
-      },
-    })
+    const workspace = await createLocalWorkspace({ directory: first.path, type })
 
     await Instance.provide({
       directory: second.path,
@@ -810,67 +638,10 @@ describe("workspace router", () => {
 
     await using tmp = await tmpdir({
       git: true,
-      init: async (dir) => {
-        const type = `plug-${Math.random().toString(36).slice(2)}`
-        const file = path.join(dir, "plugin.ts")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "remote",',
-            '    description: "remote adaptor",',
-            '    configure(input) { return { ...input, name: "remote", branch: "remote/main", directory: null } },',
-            "    async create() {},",
-            "    async remove() {},",
-            "    target() {",
-            `      return { type: "remote", url: ${JSON.stringify(remote.url.origin)} }`,
-            "    },",
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
-          ),
-        )
-
-        return { type }
-      },
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: remote.url.origin, branch: "remote/main" }),
     })
 
-    const workspace = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        await Plugin.init()
-        const id = WorkspaceID.ascending()
-        Database.use((db) =>
-          db.insert(WorkspaceTable)
-            .values({
-              id,
-              type: tmp.extra.type,
-              branch: "remote/main",
-              name: "remote",
-              directory: null,
-              owner_directory: tmp.path,
-              extra: null,
-              project_id: Instance.project.id,
-            })
-            .run(),
-        )
-        return { id }
-      },
-    })
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type, branch: "remote/main" })
 
     const before = syncHits
 

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -322,9 +322,9 @@ describe("workspace router", () => {
       expect(response.status).toBe(200)
       expect(await response.text()).toBe("websocket-proxy")
       expect(websocket).toHaveBeenCalledTimes(1)
-      const call = websocket.mock.calls[0]
-      const proxiedTarget = call[1] as { type?: string; url?: string }
-      const proxiedRequest = call[2] as Request
+      const call = websocket.mock.calls[0] as unknown as [unknown, { type?: string; url?: string }, Request]
+      const proxiedTarget = call[1]
+      const proxiedRequest = call[2]
       const proxiedURL = new URL(proxiedRequest.url)
       expect(proxiedTarget).toEqual({ type: "remote", url: target })
       expect(proxiedURL.pathname).toBe("/pty/pty_test/connect")


### PR DESCRIPTION
## Summary

- Add focused workspace-router guardrails for `GET /session/*` local routing, session workspace priority over `?workspace=`, and remote WebSocket upgrades reaching `ServerProxy.websocket`.
- Lock PawWork `/path?ensureConfig=true` so it creates `.pawwork` but not legacy OpenCode config.
- Record the #936 workspace-routing guardrail slice and non-goals in `packages/opencode/specs/effect-migration.md`.

## Why

This keeps the next #936 Effect migration slice at the route-boundary level before planning the actual WorkspaceRouting / InstanceContext Effect middleware shape. The goal is to preserve current PawWork workspace behavior while making the remaining migration boundary explicit and reviewable.

## Related Issue

Follow-up to #936.

## Human Review Status

- `Pending` — waiting for a human reviewer to approve.

## Review Focus

Please focus on the workspace router fixtures, whether the WebSocket proxy spy is the right contract level, and whether the migration log boundary / non-goals are clear.

## Risk Notes

Tests/planning only; no runtime behavior change intended. Hono remains the default server path, and this PR does not migrate route handlers, workspace adapters, sync-list, warp, v2 `/api/*`, TUI, auth/OAuth, SDK/OpenAPI shape, or proxy internals.

Skipped conditional checklist items:

- Visible UI/copy check: not applicable; no visible UI or product copy changed.
- macOS/Windows platform check: not applicable; no platform, packaging, updater, signing, path, shell, or permissions behavior changed.
- Docs/release/dependency/generated/local-file check: `packages/opencode/specs/effect-migration.md` is intentionally updated; no release notes, dependencies, permissions, credentials, generated content, or local-only files changed.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile in the isolated worktree -> completed successfully
RED: initial workspace-router guardrail run failed due test fixture issues; fixed the invalid session id prefix and sync-event hit counting, then reran
Focused server tests: bun test test/server/workspace-router.test.ts test/server/default-directory.test.ts test/server/proxy.test.ts test/server/route-inventory-harness.test.ts in packages/opencode -> 28 pass, 0 fail
Opencode typecheck: bun run typecheck in packages/opencode -> passed
Whitespace: git diff --check -> clean
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
