### PR TITLE
ci: assert desktop smoke renderer via CDP

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -170,9 +170,39 @@ jobs:
         run: bun ./scripts/runtime-import-guard.ts
         working-directory: packages/desktop-electron
 
+      - name: Allocate desktop smoke CDP port
+        id: desktop-smoke-cdp-port
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs"
+          import { createServer } from "node:net"
+
+          const server = createServer()
+          server.listen(0, "127.0.0.1", () => {
+            const address = server.address()
+            if (!address || typeof address === "string") {
+              throw new Error("Failed to allocate a TCP port on 127.0.0.1")
+            }
+            console.log(`Allocated desktop smoke CDP port ${address.port}`)
+            appendFileSync(process.env.GITHUB_OUTPUT, `port=${address.port}\n`)
+            server.close(() => {
+              process.exit(0)
+            })
+          })
+
+          server.on("error", (error) => {
+            console.error(error)
+            process.exit(1)
+          })
+          NODE
+        env:
+          NODE_OPTIONS: ""
+
       - name: Launch desktop smoke app
         run: bun run smoke:ci
         working-directory: packages/desktop-electron
+        env:
+          PAWWORK_CI_SMOKE_CDP_PORT: ${{ steps.desktop-smoke-cdp-port.outputs.port }}
 
       - name: Report problem smoke
         run: bun run smoke:report
@@ -247,6 +277,34 @@ jobs:
           grep -q "Signature=adhoc" /tmp/pawwork-codesign.txt
         working-directory: packages/desktop-electron
 
+      - name: Allocate packaged smoke CDP port
+        id: packaged-smoke-cdp-port
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs"
+          import { createServer } from "node:net"
+
+          const server = createServer()
+          server.listen(0, "127.0.0.1", () => {
+            const address = server.address()
+            if (!address || typeof address === "string") {
+              throw new Error("Failed to allocate a TCP port on 127.0.0.1")
+            }
+            console.log(`Allocated packaged smoke CDP port ${address.port}`)
+            appendFileSync(process.env.GITHUB_OUTPUT, `port=${address.port}\n`)
+            server.close(() => {
+              process.exit(0)
+            })
+          })
+
+          server.on("error", (error) => {
+            console.error(error)
+            process.exit(1)
+          })
+          NODE
+        env:
+          NODE_OPTIONS: ""
+
       - name: Launch packaged desktop smoke app
         run: |
           set -euo pipefail
@@ -254,6 +312,8 @@ jobs:
           EXECUTABLE_PATH="dist/mac-arm64/PawWork Dev.app/Contents/MacOS/PawWork Dev"
           bun ./scripts/ci-smoke.ts packaged dev "$EXECUTABLE_PATH"
         working-directory: packages/desktop-electron
+        env:
+          PAWWORK_CI_SMOKE_CDP_PORT: ${{ steps.packaged-smoke-cdp-port.outputs.port }}
 
   # Compatibility aggregator for branch protection setups that require
   # `desktop-smoke / check`. The live dev ruleset currently requires

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -170,39 +170,11 @@ jobs:
         run: bun ./scripts/runtime-import-guard.ts
         working-directory: packages/desktop-electron
 
-      - name: Allocate desktop smoke CDP port
-        id: desktop-smoke-cdp-port
-        run: |
-          node --input-type=module <<'NODE'
-          import { appendFileSync } from "node:fs"
-          import { createServer } from "node:net"
-
-          const server = createServer()
-          server.listen(0, "127.0.0.1", () => {
-            const address = server.address()
-            if (!address || typeof address === "string") {
-              throw new Error("Failed to allocate a TCP port on 127.0.0.1")
-            }
-            console.log(`Allocated desktop smoke CDP port ${address.port}`)
-            appendFileSync(process.env.GITHUB_OUTPUT, `port=${address.port}\n`)
-            server.close(() => {
-              process.exit(0)
-            })
-          })
-
-          server.on("error", (error) => {
-            console.error(error)
-            process.exit(1)
-          })
-          NODE
-        env:
-          NODE_OPTIONS: ""
-
       - name: Launch desktop smoke app
         run: bun run smoke:ci
         working-directory: packages/desktop-electron
         env:
-          PAWWORK_CI_SMOKE_CDP_PORT: ${{ steps.desktop-smoke-cdp-port.outputs.port }}
+          PAWWORK_CI_SMOKE_CDP: "true"
 
       - name: Report problem smoke
         run: bun run smoke:report
@@ -277,34 +249,6 @@ jobs:
           grep -q "Signature=adhoc" /tmp/pawwork-codesign.txt
         working-directory: packages/desktop-electron
 
-      - name: Allocate packaged smoke CDP port
-        id: packaged-smoke-cdp-port
-        run: |
-          node --input-type=module <<'NODE'
-          import { appendFileSync } from "node:fs"
-          import { createServer } from "node:net"
-
-          const server = createServer()
-          server.listen(0, "127.0.0.1", () => {
-            const address = server.address()
-            if (!address || typeof address === "string") {
-              throw new Error("Failed to allocate a TCP port on 127.0.0.1")
-            }
-            console.log(`Allocated packaged smoke CDP port ${address.port}`)
-            appendFileSync(process.env.GITHUB_OUTPUT, `port=${address.port}\n`)
-            server.close(() => {
-              process.exit(0)
-            })
-          })
-
-          server.on("error", (error) => {
-            console.error(error)
-            process.exit(1)
-          })
-          NODE
-        env:
-          NODE_OPTIONS: ""
-
       - name: Launch packaged desktop smoke app
         run: |
           set -euo pipefail
@@ -313,7 +257,7 @@ jobs:
           bun ./scripts/ci-smoke.ts packaged dev "$EXECUTABLE_PATH"
         working-directory: packages/desktop-electron
         env:
-          PAWWORK_CI_SMOKE_CDP_PORT: ${{ steps.packaged-smoke-cdp-port.outputs.port }}
+          PAWWORK_CI_SMOKE_CDP: "true"
 
   # Compatibility aggregator for branch protection setups that require
   # `desktop-smoke / check`. The live dev ruleset currently requires

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
 import {
+  allocateCiSmokeCdpPort,
   appIdForSmoke,
   buildSmokeEnv,
   isCiSmokeRendererTarget,
@@ -13,6 +14,7 @@ import {
   probeCiSmokeCdpTarget,
   requiredSelectors,
   resolveCiSmokeReadyFile,
+  resolveCiSmokeCdpPort,
   resolveLaunchCommand,
   resolveMainEntry,
 } from "./ci-smoke"
@@ -77,6 +79,12 @@ describe("ci smoke helpers", () => {
     expect(env.PAWWORK_CI_SMOKE_CDP_PORT).toBe("48291")
   })
 
+  test("buildSmokeEnv injects the harness-allocated CDP port into the child process", () => {
+    const env = buildSmokeEnv("/tmp/pawwork-ci-smoke", "dev", {}, { cdpPort: 48291 })
+
+    expect(env.PAWWORK_CI_SMOKE_CDP_PORT).toBe("48291")
+  })
+
   test("parseSmokeCdpPort accepts only concrete TCP ports", () => {
     expect(parseSmokeCdpPort("48291")).toBe(48291)
     expect(parseSmokeCdpPort(undefined)).toBeUndefined()
@@ -85,6 +93,34 @@ describe("ci smoke helpers", () => {
     for (const value of ["0", "65536", "1.5", "not-a-port"]) {
       expect(() => parseSmokeCdpPort(value)).toThrow("Invalid CI smoke CDP port")
     }
+  })
+
+  test("resolveCiSmokeCdpPort allocates a port only when the CDP probe is enabled", async () => {
+    const allocated: string[] = []
+
+    expect(await resolveCiSmokeCdpPort({}, async () => 48291)).toBeUndefined()
+    expect(
+      await resolveCiSmokeCdpPort({ PAWWORK_CI_SMOKE_CDP: "true" }, async () => {
+        allocated.push("called")
+        return 48291
+      }),
+    ).toBe(48291)
+    expect(allocated).toEqual(["called"])
+  })
+
+  test("resolveCiSmokeCdpPort prefers an explicit port for local smoke debugging", async () => {
+    expect(
+      await resolveCiSmokeCdpPort({ PAWWORK_CI_SMOKE_CDP: "true", PAWWORK_CI_SMOKE_CDP_PORT: "48291" }, async () => {
+        throw new Error("explicit ports should not allocate")
+      }),
+    ).toBe(48291)
+  })
+
+  test("allocateCiSmokeCdpPort returns a concrete loopback TCP port", async () => {
+    const port = await allocateCiSmokeCdpPort()
+
+    expect(port).toBeGreaterThan(0)
+    expect(port).toBeLessThanOrEqual(65_535)
   })
 
   test("isCiSmokeRendererTarget accepts real renderer page URLs only", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -138,6 +138,29 @@ describe("ci smoke helpers", () => {
     ).rejects.toThrow("CDP endpoint on port 48291 did not expose a renderer page target")
   })
 
+  test("probeCiSmokeCdpTarget drains non-OK discovery responses before retrying", async () => {
+    let drained = false
+
+    await expect(
+      probeCiSmokeCdpTarget(48291, {
+        attempts: 1,
+        delayMs: 1,
+        fetch: () =>
+          Promise.resolve({
+            ok: false,
+            status: 403,
+            arrayBuffer: () => {
+              drained = true
+              return Promise.resolve(new ArrayBuffer(0))
+            },
+          } as Response),
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow("CDP endpoint never came up on port 48291: HTTP 403")
+
+    expect(drained).toBe(true)
+  })
+
   test("probeCiSmokeCdpTarget fails clearly when the endpoint never responds", async () => {
     await expect(
       probeCiSmokeCdpTarget(48291, {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -7,7 +7,10 @@ import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer
 import {
   appIdForSmoke,
   buildSmokeEnv,
+  isCiSmokeRendererTarget,
   parseSmokeArgs,
+  parseSmokeCdpPort,
+  probeCiSmokeCdpTarget,
   requiredSelectors,
   resolveCiSmokeReadyFile,
   resolveLaunchCommand,
@@ -66,6 +69,84 @@ describe("ci smoke helpers", () => {
     expect(env.OPENCODE_CHANNEL).toBe("prod")
     expect(env.PAWWORK_CI_SMOKE).toBe("true")
     expect(env.PAWWORK_CI_SMOKE_HOME).toBe("/tmp/pawwork-ci-smoke")
+  })
+
+  test("buildSmokeEnv carries the workflow-scoped CDP port into the child process", () => {
+    const env = buildSmokeEnv("/tmp/pawwork-ci-smoke", "dev", { PAWWORK_CI_SMOKE_CDP_PORT: "48291" })
+
+    expect(env.PAWWORK_CI_SMOKE_CDP_PORT).toBe("48291")
+  })
+
+  test("parseSmokeCdpPort accepts only concrete TCP ports", () => {
+    expect(parseSmokeCdpPort("48291")).toBe(48291)
+    expect(parseSmokeCdpPort(undefined)).toBeUndefined()
+    expect(parseSmokeCdpPort("")).toBeUndefined()
+
+    for (const value of ["0", "65536", "1.5", "not-a-port"]) {
+      expect(() => parseSmokeCdpPort(value)).toThrow("Invalid CI smoke CDP port")
+    }
+  })
+
+  test("isCiSmokeRendererTarget accepts real renderer page URLs only", () => {
+    expect(isCiSmokeRendererTarget({ type: "page", url: "http://127.0.0.1:5173/index.html" })).toBe(true)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "http://localhost:5173/index.html#/chat" })).toBe(true)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "http://[::1]:5173/index.html?debug=1" })).toBe(true)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "pawwork-renderer://renderer/index.html#/session" })).toBe(true)
+
+    expect(isCiSmokeRendererTarget({ type: "page", url: "about:blank" })).toBe(false)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "devtools://devtools/bundled/inspector.html" })).toBe(false)
+    expect(isCiSmokeRendererTarget({ type: "iframe", url: "pawwork-renderer://renderer/index.html" })).toBe(false)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "file:///Applications/PawWork/index.html" })).toBe(false)
+    expect(isCiSmokeRendererTarget({ type: "page", url: "pawwork-renderer://wrong/index.html" })).toBe(false)
+  })
+
+  test("probeCiSmokeCdpTarget retries until the renderer target is discoverable", async () => {
+    const calls: string[] = []
+    const responses = [
+      Promise.reject(new Error("connect ECONNREFUSED")),
+      Promise.resolve(new Response(JSON.stringify([{ type: "page", url: "about:blank" }]))),
+      Promise.resolve(
+        new Response(JSON.stringify([{ type: "page", url: "pawwork-renderer://renderer/index.html" }])),
+      ),
+    ]
+
+    await probeCiSmokeCdpTarget(48291, {
+      attempts: 3,
+      delayMs: 1,
+      fetch: (url) => {
+        calls.push(url)
+        return responses.shift()!
+      },
+      sleep: () => Promise.resolve(),
+    })
+
+    expect(calls).toEqual([
+      "http://127.0.0.1:48291/json/list",
+      "http://127.0.0.1:48291/json/list",
+      "http://127.0.0.1:48291/json/list",
+    ])
+  })
+
+  test("probeCiSmokeCdpTarget fails clearly when no renderer page appears", async () => {
+    await expect(
+      probeCiSmokeCdpTarget(48291, {
+        attempts: 2,
+        delayMs: 1,
+        fetch: () => Promise.resolve(new Response(JSON.stringify([{ type: "page", url: "about:blank" }]))),
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow("CDP endpoint on port 48291 did not expose a renderer page target")
+  })
+
+  test("probeCiSmokeCdpTarget fails clearly when the endpoint never responds", async () => {
+    await expect(
+      probeCiSmokeCdpTarget(48291, {
+        attempts: 2,
+        delayMs: 1,
+        fetch: () => Promise.reject(new Error("connect ECONNREFUSED")),
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow("CDP endpoint never came up on port 48291")
   })
 
   test("parseSmokeArgs defaults to raw dev mode", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import process from "node:process"
 import readline from "node:readline"
+import { rendererOrigin } from "../src/main/renderer-protocol"
 import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
 
 export const requiredSelectors = [titlebarShellSelector, desktopShellMainSelector]
@@ -21,6 +22,18 @@ export type SmokeTarget =
 type LaunchedApp = {
   child: ChildProcessWithoutNullStreams
   spawnError: { current: Error | undefined }
+}
+
+type CdpTarget = {
+  type?: unknown
+  url?: unknown
+}
+
+type ProbeOptions = {
+  attempts?: number
+  delayMs?: number
+  fetch?: typeof fetch
+  sleep?: (ms: number) => Promise<unknown>
 }
 
 const APP_ID_BY_CHANNEL: Record<SmokeChannel, string> = {
@@ -57,9 +70,13 @@ export function resolveMainEntry() {
   return resolve(import.meta.dir, "../out/main/index.js")
 }
 
-export function buildSmokeEnv(homeDir: string, channel: SmokeChannel = "dev") {
+export function buildSmokeEnv(
+  homeDir: string,
+  channel: SmokeChannel = "dev",
+  env: NodeJS.ProcessEnv = process.env,
+) {
   return {
-    ...process.env,
+    ...env,
     CI: "true",
     HOME: homeDir,
     PAWWORK_CI_SMOKE: "true",
@@ -70,6 +87,63 @@ export function buildSmokeEnv(homeDir: string, channel: SmokeChannel = "dev") {
     XDG_STATE_HOME: homeDir,
     OPENCODE_CHANNEL: channel,
   }
+}
+
+export function parseSmokeCdpPort(raw: string | undefined) {
+  if (raw === undefined || raw === "") return undefined
+  if (!/^\d+$/.test(raw)) throw new Error(`Invalid CI smoke CDP port: ${raw}`)
+
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid CI smoke CDP port: ${raw}`)
+  }
+  return port
+}
+
+export function isCiSmokeRendererTarget(target: CdpTarget) {
+  if (target.type !== "page" || typeof target.url !== "string") return false
+  if (target.url === "about:blank" || target.url.startsWith("devtools://")) return false
+
+  return (
+    target.url.startsWith("http://127.0.0.1:") ||
+    target.url.startsWith("http://localhost:") ||
+    target.url.startsWith("http://[::1]:") ||
+    target.url.startsWith(`${rendererOrigin}/`)
+  )
+}
+
+export async function probeCiSmokeCdpTarget(port: number, options: ProbeOptions = {}) {
+  const attempts = options.attempts ?? 50
+  const delayMs = options.delayMs ?? 200
+  const fetcher = options.fetch ?? fetch
+  const sleep = options.sleep ?? Bun.sleep
+  const url = `http://127.0.0.1:${port}/json/list`
+  let lastConnectionError: string | undefined
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetcher(url)
+      if (!response.ok) {
+        lastConnectionError = `HTTP ${response.status}`
+      } else {
+        const targets = (await response.json()) as unknown
+        if (Array.isArray(targets) && targets.some(isCiSmokeRendererTarget)) {
+          console.log(`CI smoke CDP renderer target discovered on port ${port}`)
+          return
+        }
+        lastConnectionError = undefined
+      }
+    } catch (error) {
+      lastConnectionError = error instanceof Error ? error.message : String(error)
+    }
+
+    if (attempt < attempts) await sleep(delayMs)
+  }
+
+  if (lastConnectionError) {
+    throw new Error(`CDP endpoint never came up on port ${port}: ${lastConnectionError}`)
+  }
+  throw new Error(`CDP endpoint on port ${port} did not expose a renderer page target`)
 }
 
 export function resolveCiSmokeReadyFile(homeDir: string, options: { channel?: SmokeChannel; mode?: SmokeMode } = {}) {
@@ -179,6 +253,8 @@ async function main() {
 
   try {
     await waitForCiSmokeReady(homeDir, target, child, spawnError, logs.recent)
+    const cdpPort = parseSmokeCdpPort(process.env.PAWWORK_CI_SMOKE_CDP_PORT)
+    if (cdpPort !== undefined) await probeCiSmokeCdpTarget(cdpPort)
   } finally {
     logs.close()
     await stopChild(child)

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -125,6 +125,7 @@ export async function probeCiSmokeCdpTarget(port: number, options: ProbeOptions 
       const response = await fetcher(url)
       if (!response.ok) {
         lastConnectionError = `HTTP ${response.status}`
+        await response.arrayBuffer().catch(() => undefined)
       } else {
         const targets = (await response.json()) as unknown
         if (Array.isArray(targets) && targets.some(isCiSmokeRendererTarget)) {

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { once } from "node:events"
 import { existsSync, mkdtempSync } from "node:fs"
 import { createRequire } from "node:module"
+import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import process from "node:process"
@@ -34,6 +35,14 @@ type ProbeOptions = {
   delayMs?: number
   fetch?: typeof fetch
   sleep?: (ms: number) => Promise<unknown>
+}
+
+type BuildSmokeEnvOptions = {
+  cdpPort?: number
+}
+
+type LaunchAppOptions = {
+  cdpPort?: number
 }
 
 const APP_ID_BY_CHANNEL: Record<SmokeChannel, string> = {
@@ -74,6 +83,7 @@ export function buildSmokeEnv(
   homeDir: string,
   channel: SmokeChannel = "dev",
   env: NodeJS.ProcessEnv = process.env,
+  options: BuildSmokeEnvOptions = {},
 ) {
   return {
     ...env,
@@ -86,6 +96,7 @@ export function buildSmokeEnv(
     XDG_CONFIG_HOME: homeDir,
     XDG_STATE_HOME: homeDir,
     OPENCODE_CHANNEL: channel,
+    ...(options.cdpPort !== undefined ? { PAWWORK_CI_SMOKE_CDP_PORT: String(options.cdpPort) } : {}),
   }
 }
 
@@ -98,6 +109,39 @@ export function parseSmokeCdpPort(raw: string | undefined) {
     throw new Error(`Invalid CI smoke CDP port: ${raw}`)
   }
   return port
+}
+
+export async function allocateCiSmokeCdpPort() {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer()
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate a TCP port on 127.0.0.1")))
+        return
+      }
+
+      const port = address.port
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve(port)
+      })
+    })
+
+    server.on("error", reject)
+  })
+}
+
+export async function resolveCiSmokeCdpPort(
+  env: Partial<Record<string, string | undefined>> = process.env,
+  allocate: () => Promise<number> = allocateCiSmokeCdpPort,
+) {
+  const explicitPort = parseSmokeCdpPort(env.PAWWORK_CI_SMOKE_CDP_PORT)
+  if (explicitPort !== undefined) return explicitPort
+  if (env.PAWWORK_CI_SMOKE_CDP !== "true") return undefined
+
+  return await allocate()
 }
 
 export function isCiSmokeRendererTarget(target: CdpTarget) {
@@ -216,12 +260,12 @@ async function waitForCiSmokeReady(
   throw new Error(`Timed out waiting for the desktop app to report CI smoke readiness${tail}`)
 }
 
-function launchApp(homeDir: string, target: SmokeTarget): LaunchedApp {
+function launchApp(homeDir: string, target: SmokeTarget, options: LaunchAppOptions = {}): LaunchedApp {
   const launch = resolveLaunchCommand(target)
   const spawnError = { current: undefined as Error | undefined }
   try {
     const child = spawn(launch.command, launch.args, {
-      env: buildSmokeEnv(homeDir, target.channel),
+      env: buildSmokeEnv(homeDir, target.channel, process.env, { cdpPort: options.cdpPort }),
       stdio: ["ignore", "pipe", "pipe"],
     })
     child.on("error", (error) => {
@@ -249,12 +293,12 @@ async function stopChild(child: ChildProcessWithoutNullStreams) {
 async function main() {
   const target = parseSmokeArgs(Bun.argv.slice(2))
   const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
-  const { child, spawnError } = launchApp(homeDir, target)
+  const cdpPort = await resolveCiSmokeCdpPort(process.env)
+  const { child, spawnError } = launchApp(homeDir, target, { cdpPort })
   const logs = watchChildLogs(child)
 
   try {
     await waitForCiSmokeReady(homeDir, target, child, spawnError, logs.recent)
-    const cdpPort = parseSmokeCdpPort(process.env.PAWWORK_CI_SMOKE_CDP_PORT)
     if (cdpPort !== undefined) await probeCiSmokeCdpTarget(cdpPort)
   } finally {
     logs.close()

--- a/packages/desktop-electron/src/main/ci-smoke-cdp.test.ts
+++ b/packages/desktop-electron/src/main/ci-smoke-cdp.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { ciSmokeCdpSwitches } from "./ci-smoke-cdp"
+
+describe("CI smoke CDP switches", () => {
+  test("enables renderer CDP only for CI smoke runs with a valid loopback port", () => {
+    expect(ciSmokeCdpSwitches({ PAWWORK_CI_SMOKE: "true", PAWWORK_CI_SMOKE_CDP_PORT: "48291" })).toEqual([
+      ["remote-debugging-port", "48291"],
+      ["remote-debugging-address", "127.0.0.1"],
+      ["remote-allow-origins", "*"],
+    ])
+  })
+
+  test("keeps normal desktop launches CDP-free", () => {
+    expect(ciSmokeCdpSwitches({ PAWWORK_CI_SMOKE_CDP_PORT: "48291" })).toEqual([])
+    expect(ciSmokeCdpSwitches({ PAWWORK_CI_SMOKE: "true" })).toEqual([])
+    expect(ciSmokeCdpSwitches({ PAWWORK_CI_SMOKE: "true", PAWWORK_CI_SMOKE_CDP_PORT: "0" })).toEqual([])
+    expect(ciSmokeCdpSwitches({ PAWWORK_CI_SMOKE: "true", PAWWORK_CI_SMOKE_CDP_PORT: "not-a-port" })).toEqual([])
+  })
+})

--- a/packages/desktop-electron/src/main/ci-smoke-cdp.ts
+++ b/packages/desktop-electron/src/main/ci-smoke-cdp.ts
@@ -1,0 +1,17 @@
+type Env = Partial<Record<string, string | undefined>>
+
+export function ciSmokeCdpSwitches(env: Env): [string, string][] {
+  if (env.PAWWORK_CI_SMOKE !== "true") return []
+
+  const port = env.PAWWORK_CI_SMOKE_CDP_PORT
+  if (!port || !/^\d+$/.test(port)) return []
+
+  const parsed = Number(port)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) return []
+
+  return [
+    ["remote-debugging-port", String(parsed)],
+    ["remote-debugging-address", "127.0.0.1"],
+    ["remote-allow-origins", "*"],
+  ]
+}

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -52,6 +52,7 @@ const { autoUpdater } = pkg
 
 import type { DesktopContext, InitStep, ServerReadyData, SqliteMigrationProgress, WslConfig } from "../preload/types"
 import { checkAppExists, resolveAppPath, wslPath } from "./apps"
+import { ciSmokeCdpSwitches } from "./ci-smoke-cdp"
 import { CHANNEL, FEEDBACK_FORM_URL, UPDATER_ENABLED } from "./constants"
 import { normalizeDesktopContextPayload, syncWindowTitleForDesktopContext } from "./desktop-context-window"
 import { createDesktopContextStore } from "./desktop-context-store"
@@ -328,6 +329,9 @@ setupApp()
 function setupApp() {
   ensureLoopbackNoProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
+  for (const [name, value] of ciSmokeCdpSwitches(process.env)) {
+    app.commandLine.appendSwitch(name, value)
+  }
   registerRendererScheme()
 
   // CI smoke should not fail just because a local desktop instance already holds

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -25,8 +25,11 @@ describe("desktop smoke workflow", () => {
     const packageStep = smokeSteps.find((step) => step.name === "Package desktop app")
     const smokeStep = smokeSteps.find((step) => step.name === "Smoke check app bundle")
     const runtimeGuardStep = smokeSteps.find((step) => step.name === "Check desktop runtime imports")
+    const desktopCdpPortStep = smokeSteps.find((step) => step.name === "Allocate desktop smoke CDP port")
     const packagedSmokeStep = smokeSteps.find((step) => step.name === "Launch packaged desktop smoke app")
+    const packagedCdpPortStep = smokeSteps.find((step) => step.name === "Allocate packaged smoke CDP port")
     const buildStep = smokeSteps.find((step) => step.name === "Build desktop app")
+    const reportSmokeStep = smokeSteps.find((step) => step.name === "Report problem smoke")
     const prepareOfficeCliStep = smokeSteps.find((step) => step.name === "Prepare OfficeCLI")
     const installStep = smokeSteps.find((step) => step.name === "Install dependencies")
     const repairElectronStep = smokeSteps.find((step) => step.name === "Repair Electron install")
@@ -84,6 +87,12 @@ describe("desktop smoke workflow", () => {
     expect(prepareOfficeCliStep?.["working-directory"]).toBe("packages/desktop-electron")
     expect(workflow).toContain("bun run build")
     expect(appSmokeStep?.run).toBe("bun run smoke:ci")
+    expect(desktopCdpPortStep?.id).toBe("desktop-smoke-cdp-port")
+    expect(desktopCdpPortStep?.run).toContain("server.listen(0, \"127.0.0.1\"")
+    expect(desktopCdpPortStep?.run).toContain("appendFileSync(process.env.GITHUB_OUTPUT")
+    expect(appSmokeStep?.env).toEqual({
+      PAWWORK_CI_SMOKE_CDP_PORT: "${{ steps.desktop-smoke-cdp-port.outputs.port }}",
+    })
     expect(workflow).toContain("Launch desktop smoke app")
     expect(workflow).toContain("bun run smoke:ci")
     expect(packageStep?.run).toContain(
@@ -101,8 +110,15 @@ describe("desktop smoke workflow", () => {
     expect(packagedSmokeStep?.run).toContain(
       'EXECUTABLE_PATH="dist/mac-arm64/PawWork Dev.app/Contents/MacOS/PawWork Dev"',
     )
+    expect(packagedCdpPortStep?.id).toBe("packaged-smoke-cdp-port")
+    expect(packagedCdpPortStep?.run).toContain("server.listen(0, \"127.0.0.1\"")
+    expect(packagedCdpPortStep?.run).toContain("appendFileSync(process.env.GITHUB_OUTPUT")
     expect(packagedSmokeStep?.run).toContain('bun ./scripts/ci-smoke.ts packaged dev "$EXECUTABLE_PATH"')
+    expect(packagedSmokeStep?.env).toEqual({
+      PAWWORK_CI_SMOKE_CDP_PORT: "${{ steps.packaged-smoke-cdp-port.outputs.port }}",
+    })
     expect(packagedSmokeStep?.["working-directory"]).toBe("packages/desktop-electron")
+    expect(reportSmokeStep?.env).not.toHaveProperty("PAWWORK_CI_SMOKE_CDP_PORT")
     expect(buildStep).toBeDefined()
     expect(smokeSteps.indexOf(repairElectronStep!)).toBeGreaterThan(smokeSteps.indexOf(installStep!))
     expect(smokeSteps.indexOf(repairElectronStep!)).toBeLessThan(smokeSteps.indexOf(prepareOfficeCliStep!))
@@ -112,6 +128,8 @@ describe("desktop smoke workflow", () => {
     expect(smokeSteps.indexOf(repairElectronAfterBuildStep!)).toBeLessThan(smokeSteps.indexOf(appSmokeStep!))
     expect(smokeSteps.indexOf(runtimeGuardStep!)).toBeGreaterThan(smokeSteps.indexOf(buildStep!))
     expect(smokeSteps.indexOf(runtimeGuardStep!)).toBeLessThan(smokeSteps.indexOf(appSmokeStep!))
+    expect(smokeSteps.indexOf(desktopCdpPortStep!)).toBe(smokeSteps.indexOf(appSmokeStep!) - 1)
+    expect(smokeSteps.indexOf(packagedCdpPortStep!)).toBe(smokeSteps.indexOf(packagedSmokeStep!) - 1)
     expect(smokeSteps.indexOf(packagedSmokeStep!)).toBeGreaterThan(smokeSteps.indexOf(smokeStep!))
 
     expect(smokeStep?.run).toContain("Expected app bundle at")
@@ -129,6 +147,7 @@ describe("desktop smoke workflow", () => {
 
     expect(workflow).toContain("smoke-macos-arm64.result")
     expect(workflow).toContain("Docs-only change, desktop smoke skipped.")
+    expect(workflow).not.toContain("GITHUB_ENV")
     expect(workflow).not.toContain("codesign --verify --deep --verbose=2")
     expect(workflow).not.toContain("codesign --verify --deep --strict --verbose=2")
     expect(workflow).not.toContain("pull_request_target")

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -25,9 +25,7 @@ describe("desktop smoke workflow", () => {
     const packageStep = smokeSteps.find((step) => step.name === "Package desktop app")
     const smokeStep = smokeSteps.find((step) => step.name === "Smoke check app bundle")
     const runtimeGuardStep = smokeSteps.find((step) => step.name === "Check desktop runtime imports")
-    const desktopCdpPortStep = smokeSteps.find((step) => step.name === "Allocate desktop smoke CDP port")
     const packagedSmokeStep = smokeSteps.find((step) => step.name === "Launch packaged desktop smoke app")
-    const packagedCdpPortStep = smokeSteps.find((step) => step.name === "Allocate packaged smoke CDP port")
     const buildStep = smokeSteps.find((step) => step.name === "Build desktop app")
     const reportSmokeStep = smokeSteps.find((step) => step.name === "Report problem smoke")
     const prepareOfficeCliStep = smokeSteps.find((step) => step.name === "Prepare OfficeCLI")
@@ -87,11 +85,8 @@ describe("desktop smoke workflow", () => {
     expect(prepareOfficeCliStep?.["working-directory"]).toBe("packages/desktop-electron")
     expect(workflow).toContain("bun run build")
     expect(appSmokeStep?.run).toBe("bun run smoke:ci")
-    expect(desktopCdpPortStep?.id).toBe("desktop-smoke-cdp-port")
-    expect(desktopCdpPortStep?.run).toContain("server.listen(0, \"127.0.0.1\"")
-    expect(desktopCdpPortStep?.run).toContain("appendFileSync(process.env.GITHUB_OUTPUT")
     expect(appSmokeStep?.env).toEqual({
-      PAWWORK_CI_SMOKE_CDP_PORT: "${{ steps.desktop-smoke-cdp-port.outputs.port }}",
+      PAWWORK_CI_SMOKE_CDP: "true",
     })
     expect(workflow).toContain("Launch desktop smoke app")
     expect(workflow).toContain("bun run smoke:ci")
@@ -110,12 +105,9 @@ describe("desktop smoke workflow", () => {
     expect(packagedSmokeStep?.run).toContain(
       'EXECUTABLE_PATH="dist/mac-arm64/PawWork Dev.app/Contents/MacOS/PawWork Dev"',
     )
-    expect(packagedCdpPortStep?.id).toBe("packaged-smoke-cdp-port")
-    expect(packagedCdpPortStep?.run).toContain("server.listen(0, \"127.0.0.1\"")
-    expect(packagedCdpPortStep?.run).toContain("appendFileSync(process.env.GITHUB_OUTPUT")
     expect(packagedSmokeStep?.run).toContain('bun ./scripts/ci-smoke.ts packaged dev "$EXECUTABLE_PATH"')
     expect(packagedSmokeStep?.env).toEqual({
-      PAWWORK_CI_SMOKE_CDP_PORT: "${{ steps.packaged-smoke-cdp-port.outputs.port }}",
+      PAWWORK_CI_SMOKE_CDP: "true",
     })
     expect(packagedSmokeStep?.["working-directory"]).toBe("packages/desktop-electron")
     expect(reportSmokeStep?.env).not.toHaveProperty("PAWWORK_CI_SMOKE_CDP_PORT")
@@ -128,8 +120,6 @@ describe("desktop smoke workflow", () => {
     expect(smokeSteps.indexOf(repairElectronAfterBuildStep!)).toBeLessThan(smokeSteps.indexOf(appSmokeStep!))
     expect(smokeSteps.indexOf(runtimeGuardStep!)).toBeGreaterThan(smokeSteps.indexOf(buildStep!))
     expect(smokeSteps.indexOf(runtimeGuardStep!)).toBeLessThan(smokeSteps.indexOf(appSmokeStep!))
-    expect(smokeSteps.indexOf(desktopCdpPortStep!)).toBe(smokeSteps.indexOf(appSmokeStep!) - 1)
-    expect(smokeSteps.indexOf(packagedCdpPortStep!)).toBe(smokeSteps.indexOf(packagedSmokeStep!) - 1)
     expect(smokeSteps.indexOf(packagedSmokeStep!)).toBeGreaterThan(smokeSteps.indexOf(smokeStep!))
 
     expect(smokeStep?.run).toContain("Expected app bundle at")
@@ -147,6 +137,9 @@ describe("desktop smoke workflow", () => {
 
     expect(workflow).toContain("smoke-macos-arm64.result")
     expect(workflow).toContain("Docs-only change, desktop smoke skipped.")
+    expect(workflow).not.toContain("desktop-smoke-cdp-port")
+    expect(workflow).not.toContain("packaged-smoke-cdp-port")
+    expect(workflow).not.toContain("appendFileSync(process.env.GITHUB_OUTPUT")
     expect(workflow).not.toContain("GITHUB_ENV")
     expect(workflow).not.toContain("codesign --verify --deep --verbose=2")
     expect(workflow).not.toContain("codesign --verify --deep --strict --verbose=2")


### PR DESCRIPTION
## Summary

Adds the #977 PR-E desktop smoke hardening slice:

- enables workflow-scoped CDP renderer assertions with `PAWWORK_CI_SMOKE_CDP=true`
- allocates and injects the loopback CDP port inside `ci-smoke.ts` for each raw and packaged desktop smoke launch
- enables Electron renderer CDP only for CI smoke launches with a valid scoped port
- extends `ci-smoke.ts` to assert `/json/list` exposes a real renderer `page` target after the existing file beacon passes
- locks the workflow and smoke harness contracts with focused tests

## Why

The existing desktop smoke file beacon proves renderer-to-main IPC reaches the ready marker, but it does not independently prove the renderer target is discoverable through the gated CDP endpoint. This PR adds that narrow assertion while avoiding `Runtime.evaluate`, because `window.api` lives in the isolated preload world.

## Related Issue

Part of #977.

## Human Review Status

Pending

## Review Focus

Please check the CDP port boundary: `desktop-smoke.yml` only opts each smoke launch into CDP probing, while `ci-smoke.ts` allocates the port immediately before spawning Electron and injects it only into that child process. Also check that packaged renderer matching uses the current `pawwork-renderer://renderer/` origin rather than the stale `file://` wording from the issue.

## Risk Notes

- CDP is opened only during CI smoke launches and is bound to `127.0.0.1`, but this still changes Electron command-line switches for the two desktop-smoke launches.
- `remote-allow-origins=*` is intentionally scoped behind `PAWWORK_CI_SMOKE_CDP_PORT` to avoid Electron/Chromium CDP discovery 403s on CI.
- The port is now selected in the smoke harness instead of a prior workflow step, removing the cross-step released-port reuse window from the review follow-up. It still relies on Electron binding the selected port shortly after the harness spawns the child process.
- `build.yml` release smoke remains CDP-free by design because it does not set `PAWWORK_CI_SMOKE_CDP` or `PAWWORK_CI_SMOKE_CDP_PORT`.
- Ruleset follow-up is still outside this PR: live `dev-merge-gate` still needs `dependency-review` and `dev-dep-audit` added as required contexts after the code PRs finish.
- Checklist conditional skipped: no visible UI or copy changed, so no screenshots or recordings are included.

## How To Verify

```text
bun install --frozen-lockfile: installed dependencies in the isolated worktree without lockfile changes
bun test test/github/desktop-smoke-workflow.test.ts (from packages/opencode): 1 pass, 0 fail
bun test scripts/ci-smoke.test.ts src/main/ci-smoke-cdp.test.ts (from packages/desktop-electron): 26 pass, 0 fail
bun run typecheck (from packages/desktop-electron): passed
bun run build (from packages/desktop-electron): passed
ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/desktop-smoke.yml: ok
git diff --check: passed
PAWWORK_CI_SMOKE_CDP=true bun run smoke:ci (from packages/desktop-electron): raw Electron smoke passed and discovered a CDP renderer target
npx electron-builder --mac dir --arm64 --publish never --config electron-builder.config.ts --config.mac.identity=- --config.mac.notarize=false (from packages/desktop-electron): packaged macOS dir build passed
PAWWORK_CI_SMOKE_CDP=true bun ./scripts/ci-smoke.ts packaged dev "dist/mac-arm64/PawWork Dev.app/Contents/MacOS/PawWork Dev" (from packages/desktop-electron): packaged Electron smoke passed and discovered a CDP renderer target
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
