### PR TITLE
test(server): lock workspace routing planning guardrails

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -357,7 +357,7 @@ Decision table for the design:
 | Local workspace target | Run in the adaptor target directory. | `InstanceRef` for target directory; `WorkspaceRef` for the selected workspace. |
 | Remote workspace target, normal forwarded route | Forward through `ServerProxy.http` after stripping proxy-only workspace headers. | No local instance context for the route body. |
 | Remote workspace target, WebSocket upgrade | Forward through `ServerProxy.websocket`. | No local instance context for the route body. |
-| Remote workspace target, local cached route | Keep local for `GET /session` and session-detail GET routes. | No instance context today; preserve current route behavior unless explicitly changed. |
+| Remote workspace target, local cached route | Keep local for `GET /session` and session-detail GET routes, rather than forwarding them to the remote target. `GET /session` currently has no instance context and returns the current local error; making it return a usable list is a behavior change that needs an explicit decision. | No instance context today; preserve current route behavior unless explicitly changed. |
 | `/session/status` with workspace | Forward to the remote target. | No local instance context for the route body. |
 | Session route with a bound `workspaceID` and a conflicting query `workspace` | Use the session-bound workspace. | Same context as the selected workspace target. |
 | Missing workspace record, normal route | Return `500` text response with `Workspace not found: <id>`. | No instance context. |

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -335,10 +335,35 @@ For each service, the migration is roughly:
 
 ### Migration log
 
-- Workspace routing guardrails — scoped 2026-05-30 as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
-  - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session` and session-detail GET routes stay local while `/session/status` remains forwarded, a session's bound `workspaceID` wins over `?workspace=`, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
+- Workspace routing guardrails - completed 2026-05-30 as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
+  - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session`, session-detail GET routes, and missing-workspace session deletes stay local while `/session/status` remains forwarded, a session's bound `workspaceID` wins over `?workspace=`, missing workspace records return an explicit `Workspace not found` error for normal routes, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
   - Non-goals: no upstream `/sync/*`, workspace adapter/sync-list/warp, v2 `/api/*`, TUI, auth/OAuth, OpenAPI/SDK shape, or proxy internals migration.
-  - Follow-ups only when touched: EnterWorktree/ExitWorktree execution-context tests, WebSocket queue/close-code/bidirectional proxy tests, and the actual WorkspaceRouting/InstanceContext Effect middleware design.
+  - Next follow-up: design the actual WorkspaceRouting / Effect instance context middleware split before replacing Hono middleware. Follow-ups only when touched: EnterWorktree/ExitWorktree execution-context tests and WebSocket queue/close-code/bidirectional proxy tests.
+
+### Workspace routing / instance context planning
+
+The future Effect middleware should preserve the existing Hono split rather than copying upstream semantics wholesale:
+
+- `WorkspaceRouterMiddleware` is the router. It decides whether a request runs locally, forwards to a remote workspace, uses a local workspace target, or fails because the workspace record is missing.
+- `InstanceMiddleware` is a thin provider for `/experimental/workspace`. It resolves the request directory and provides `Instance` / `WorkspaceContext`; it does not own proxy or forwarding decisions.
+- The Effect design should bind request context through the existing bridge primitives: `InstanceRef`, `WorkspaceRef`, `attachWith`, `EffectBridge`, and the existing ALS-backed `Instance` / `WorkspaceContext`. Do not invent a parallel context model.
+- Avoid naming the new provider simply `InstanceContext` unless the existing `project/instance-context.ts` type is intentionally overloaded; prefer a middleware-specific name in the implementation plan.
+
+Decision table for the design:
+
+| Case | Workspace routing decision | Context to provide |
+| --- | --- | --- |
+| No `workspace` and no session-bound workspace | Run in the request/default directory. Best-effort create `~/PawWork` when no directory is supplied. | `InstanceRef` for the resolved directory; no `WorkspaceRef`. |
+| Local workspace target | Run in the adaptor target directory. | `InstanceRef` for target directory; `WorkspaceRef` for the selected workspace. |
+| Remote workspace target, normal forwarded route | Forward through `ServerProxy.http` after stripping proxy-only workspace headers. | No local instance context for the route body. |
+| Remote workspace target, WebSocket upgrade | Forward through `ServerProxy.websocket`. | No local instance context for the route body. |
+| Remote workspace target, local cached route | Keep local for `GET /session` and session-detail GET routes. | No instance context today; preserve current route behavior unless explicitly changed. |
+| `/session/status` with workspace | Forward to the remote target. | No local instance context for the route body. |
+| Session route with a bound `workspaceID` and a conflicting query `workspace` | Use the session-bound workspace. | Same context as the selected workspace target. |
+| Missing workspace record, normal route | Return `500` text response with `Workspace not found: <id>`. | No instance context. |
+| Missing workspace record, `DELETE /session/:id` | Let the session route run so broken synced sessions remain deletable. | No instance context. |
+| `/path?ensureConfig=true` in PawWork runtime | Return PawWork primary config path without creating the legacy OpenCode config directory. | Same context as the selected local path case. |
+
 - `SessionStatus` — migrated 2026-04-11. Replaced the last route and retry-policy callers with `AppRuntime.runPromise(SessionStatus.Service.use(...))` and removed the `makeRuntime(...)` facade.
 - `ShareNext` — migrated 2026-04-11. Swapped remaining async callers to `AppRuntime.runPromise(ShareNext.Service.use(...))`, removed the `makeRuntime(...)` facade, and kept instance bootstrap on the shared app runtime.
 - `SessionTodo` — migrated 2026-04-10. Already matched the target service shape in `session/todo.ts`: single namespace, traced Effect methods, and no `makeRuntime(...)` facade remained; checklist updated to reflect the completed migration.

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -335,7 +335,7 @@ For each service, the migration is roughly:
 
 ### Migration log
 
-- Workspace routing guardrails - completed 2026-05-30 as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
+- Workspace routing guardrails (completed 2026-05-30) as the next #936 slice after VCS, PTY connect-token, and SSE guardrails. This slice is planning + tests only; it does not migrate Hono routes to Effect HttpApi.
   - PR scope: lock the current workspace routing decisions before any middleware migration. `GET /session`, session-detail GET routes, and missing-workspace session deletes stay local while `/session/status` remains forwarded, a session's bound `workspaceID` wins over `?workspace=`, missing workspace records return an explicit `Workspace not found` error for normal routes, PawWork `/path?ensureConfig=true` must not create the legacy OpenCode config directory, and remote workspace WebSocket upgrades must reach `ServerProxy.websocket`.
   - Non-goals: no upstream `/sync/*`, workspace adapter/sync-list/warp, v2 `/api/*`, TUI, auth/OAuth, OpenAPI/SDK shape, or proxy internals migration.
   - Next follow-up: design the actual WorkspaceRouting / Effect instance context middleware split before replacing Hono middleware. Follow-ups only when touched: EnterWorktree/ExitWorktree execution-context tests and WebSocket queue/close-code/bidirectional proxy tests.

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -250,6 +250,76 @@ describe("workspace router", () => {
     }
   })
 
+  test("keeps GET session list local for remote workspaces", async () => {
+    let remoteHits = 0
+    await using remote = Bun.serve({
+      port: 0,
+      fetch() {
+        remoteHits++
+        return Response.json({ remote: true })
+      },
+    })
+
+    await using tmp = await tmpdir({
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: remote.url.origin }),
+    })
+
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type })
+
+    await Instance.disposeAll()
+
+    const ensureSync = disableWorkspaceSync()
+
+    try {
+      const app = Server.Default().app
+      const response = await app.request(`/session?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": tmp.path,
+        },
+      })
+
+      await response.text()
+      expect(remoteHits).toBe(0)
+    } finally {
+      ensureSync.mockRestore()
+    }
+  })
+
+  test("returns an explicit error when a workspace record is missing", async () => {
+    await using tmp = await tmpdir()
+
+    const app = Server.Default().app
+    const response = await app.request(`/path?workspace=${WorkspaceID.ascending()}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8")
+    expect(await response.text()).toStartWith("Workspace not found: wrk_")
+  })
+
+  test("routes session delete past a missing workspace record", async () => {
+    await using tmp = await tmpdir()
+
+    const app = Server.Default().app
+    const response = await app.request(`/session/ses_missing?workspace=${WorkspaceID.ascending()}`, {
+      method: "DELETE",
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toMatchObject({
+      name: "NotFoundError",
+      data: {
+        message: "Session not found: ses_missing",
+      },
+    })
+  })
+
   test("uses a session workspace before the workspace query parameter for mutating session routes", async () => {
     let remoteHits = 0
     await using remote = Bun.serve({

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -250,7 +250,7 @@ describe("workspace router", () => {
     }
   })
 
-  test("keeps GET session list local for remote workspaces", async () => {
+  test("keeps GET session list on the current local route for remote workspaces", async () => {
     let remoteHits = 0
     await using remote = Bun.serve({
       port: 0,
@@ -278,7 +278,10 @@ describe("workspace router", () => {
         },
       })
 
-      await response.text()
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.name).toBe("UnknownError")
+      expect(body.data.message).toContain("No context found for instance")
       expect(remoteHits).toBe(0)
     } finally {
       ensureSync.mockRestore()


### PR DESCRIPTION
## Summary

Adds workspace routing guardrails and records the next WorkspaceRouting / Effect instance context planning boundary for #936.

## Why

PR #999 locked the first workspace routing guardrails after VCS, PTY connect-token, and SSE parity work. This follow-up makes the remaining edge behavior explicit before any Hono middleware is replaced by Effect HttpApi infrastructure.

## Related Issue

Closes nothing; follows #936.

## Human Review Status

Pending

## Review Focus

Please check that the new workspace routing tests lock the current behavior without implying a route migration, especially the remote-workspace `GET /session` local error path and missing-workspace session delete escape hatch.

## Risk Notes

This PR intentionally locks current behavior, including the remote-workspace `GET /session` local `500 UnknownError` caused by missing instance context. Making that route return a usable list should be a separate behavior decision during the actual middleware migration.

Skipped conditional checklist items:

- Visible UI check: not applicable; no UI or copy changed.
- macOS / Windows platform check: not applicable; no platform, packaging, updater, signing, shell, or permissions surface changed.

## How To Verify

```text
bun test test/server/workspace-router.test.ts
Result: 14 pass, 0 fail

bun test test/server/default-directory.test.ts
Result: 5 pass, 0 fail

git diff --check dev...HEAD
Result: no whitespace errors

Claude fresh-eye review
Result: no P0/P1/P2/P3 findings after the P3 style fix

xhigh subagent fresh-eye review
Result: no P0/P1/P2/P3 findings after the remote session-list guardrail fix
```

## Screenshots or Recordings

N/A - no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
