### PR TITLE
refactor(server): extract workspace routing decisions

### DIFF
--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -16,7 +16,7 @@ import { requestContextFromHono, withRequestContext } from "@/server/request-con
 import {
   classifyWorkspaceRoute,
   sessionIDForWorkspaceRouting,
-  shouldCreateLegacyConfigBeforePath,
+  shouldCreateLegacyConfigBeforeNoWorkspacePath,
 } from "./workspace-routing"
 
 async function getSessionWorkspace(url: URL) {
@@ -56,10 +56,9 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     // If no workspace is provided we use the project
     if (!workspaceID) {
       if (
-        shouldCreateLegacyConfigBeforePath({
+        shouldCreateLegacyConfigBeforeNoWorkspacePath({
           pathname: url.pathname,
           ensureConfig: url.searchParams.get("ensureConfig") === "true",
-          hasWorkspace: false,
           isPawWork: Runtime.isPawWork(),
         })
       ) {

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -9,40 +9,18 @@ import { ServerProxy } from "../proxy"
 import { Filesystem } from "@/util/filesystem"
 import { Instance } from "@/project/instance"
 import { Session } from "@/session"
-import { SessionID } from "@/session/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Global } from "@/global"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { requestContextFromHono, withRequestContext } from "@/server/request-context"
-
-type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
-
-const RULES: Array<Rule> = [
-  { path: "/session/status", action: "forward" },
-  { method: "GET", path: "/session", action: "local" },
-]
-
-function local(method: string, path: string) {
-  for (const rule of RULES) {
-    if (rule.method && rule.method !== method) continue
-    const match = rule.exact ? path === rule.path : path === rule.path || path.startsWith(rule.path + "/")
-    if (match) return rule.action === "local"
-  }
-  return false
-}
-
-function getSessionID(url: URL) {
-  if (url.pathname === "/session/status") return null
-  if (url.pathname.startsWith("/session/__e2e/")) return null
-
-  const id = url.pathname.match(/^\/session\/([^/]+)(?:\/|$)/)?.[1]
-  if (!id) return null
-
-  return SessionID.make(id)
-}
+import {
+  classifyWorkspaceRoute,
+  sessionIDForWorkspaceRouting,
+  shouldCreateLegacyConfigBeforePath,
+} from "./workspace-routing"
 
 async function getSessionWorkspace(url: URL) {
-  const id = getSessionID(url)
+  const id = sessionIDForWorkspaceRouting(url.pathname)
   if (!id) return null
 
   const session = await Session.get(id).catch(() => undefined)
@@ -77,7 +55,14 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
 
     // If no workspace is provided we use the project
     if (!workspaceID) {
-      if (url.pathname === "/path" && url.searchParams.get("ensureConfig") === "true" && !Runtime.isPawWork()) {
+      if (
+        shouldCreateLegacyConfigBeforePath({
+          pathname: url.pathname,
+          ensureConfig: url.searchParams.get("ensureConfig") === "true",
+          hasWorkspace: false,
+          isPawWork: Runtime.isPawWork(),
+        })
+      ) {
         try {
           mkdirSync(Global.Path.config, { recursive: true })
         } catch {
@@ -99,13 +84,18 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const workspace = await Workspace.record(WorkspaceID.make(workspaceID))
 
     if (!workspace) {
+      const decision = classifyWorkspaceRoute({
+        method: c.req.method,
+        pathname: url.pathname,
+        target: "missing",
+      })
       // Special-case deleting a session in case user's data in a
       // weird state. Allow them to forcefully delete a synced session
       // even if the remote workspace is not in their data.
       //
       // The lets the `DELETE /session/:id` endpoint through and we've
       // made sure that it will run without an instance
-      if (url.pathname.match(/\/session\/[^/]+$/) && c.req.method === "DELETE") {
+      if (decision.action === "pass-missing-session-delete") {
         return next()
       }
 
@@ -126,6 +116,14 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const target = await adaptor.target(workspace)
 
     if (target.type === "local") {
+      const decision = classifyWorkspaceRoute({
+        method: c.req.method,
+        pathname: url.pathname,
+        target: target.type,
+      })
+      if (decision.action !== "provide-local-workspace") {
+        throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
+      }
       const snapshot = requestContextFromHono(c, { directory: target.directory, workspaceID })
       return WorkspaceContext.provide({
         workspaceID: WorkspaceID.make(workspaceID),
@@ -141,13 +139,20 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       })
     }
 
-    if (local(c.req.method, url.pathname)) {
+    const decision = classifyWorkspaceRoute({
+      method: c.req.method,
+      pathname: url.pathname,
+      target: target.type,
+      isWebSocketUpgrade: c.req.header("upgrade")?.toLowerCase() === "websocket",
+    })
+
+    if (decision.action === "serve-local-cache") {
       // No instance provided because we are serving cached data; there
       // is no instance to work with
       return next()
     }
 
-    if (c.req.header("upgrade")?.toLowerCase() === "websocket") {
+    if (decision.action === "proxy-websocket") {
       return ServerProxy.websocket(upgrade, target, c.req.raw, c.env)
     }
 

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -34,13 +34,12 @@ export function sessionIDForWorkspaceRouting(pathname: string) {
   return SessionID.make(id)
 }
 
-export function shouldCreateLegacyConfigBeforePath(input: {
+export function shouldCreateLegacyConfigBeforeNoWorkspacePath(input: {
   pathname: string
   ensureConfig: boolean
-  hasWorkspace: boolean
   isPawWork: boolean
 }) {
-  return input.pathname === "/path" && input.ensureConfig && !input.hasWorkspace && !input.isPawWork
+  return input.pathname === "/path" && input.ensureConfig && !input.isPawWork
 }
 
 export function classifyWorkspaceRoute(input: {

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -1,0 +1,63 @@
+import { SessionID } from "@/session/schema"
+
+type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
+
+const LOCAL_ROUTE_RULES: Array<Rule> = [
+  { path: "/session/status", action: "forward" },
+  { method: "GET", path: "/session", action: "local" },
+]
+
+export type WorkspaceRouteDecision =
+  | { action: "provide-local-workspace" }
+  | { action: "serve-local-cache" }
+  | { action: "proxy-websocket" }
+  | { action: "proxy-http" }
+  | { action: "pass-missing-session-delete" }
+  | { action: "missing-workspace-error" }
+
+export function isLocalCachedRoute(method: string, pathname: string) {
+  for (const rule of LOCAL_ROUTE_RULES) {
+    if (rule.method && rule.method !== method) continue
+    const match = rule.exact ? pathname === rule.path : pathname === rule.path || pathname.startsWith(rule.path + "/")
+    if (match) return rule.action === "local"
+  }
+  return false
+}
+
+export function sessionIDForWorkspaceRouting(pathname: string) {
+  if (pathname === "/session/status") return undefined
+  if (pathname.startsWith("/session/__e2e/")) return undefined
+
+  const id = pathname.match(/^\/session\/([^/]+)(?:\/|$)/)?.[1]
+  if (!id) return undefined
+
+  return SessionID.make(id)
+}
+
+export function shouldCreateLegacyConfigBeforePath(input: {
+  pathname: string
+  ensureConfig: boolean
+  hasWorkspace: boolean
+  isPawWork: boolean
+}) {
+  return input.pathname === "/path" && input.ensureConfig && !input.hasWorkspace && !input.isPawWork
+}
+
+export function classifyWorkspaceRoute(input: {
+  method: string
+  pathname: string
+  target: "missing" | "local" | "remote"
+  isWebSocketUpgrade?: boolean
+}): WorkspaceRouteDecision {
+  if (input.target === "missing") {
+    if (input.method === "DELETE" && /\/session\/[^/]+$/.test(input.pathname)) {
+      return { action: "pass-missing-session-delete" }
+    }
+    return { action: "missing-workspace-error" }
+  }
+
+  if (input.target === "local") return { action: "provide-local-workspace" }
+  if (isLocalCachedRoute(input.method, input.pathname)) return { action: "serve-local-cache" }
+  if (input.isWebSocketUpgrade) return { action: "proxy-websocket" }
+  return { action: "proxy-http" }
+}

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -1,17 +1,22 @@
 import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test"
 import { Effect } from "effect"
+import fs from "fs/promises"
+import { Hono } from "hono"
 import path from "path"
 import { pathToFileURL } from "url"
 import { eq } from "../../src/storage/db"
+import { WorkspaceContext } from "../../src/control-plane/workspace-context"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Server } from "../../src/server/server"
+import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
 import { WorkspaceID } from "../../src/control-plane/schema"
 import { Workspace } from "../../src/control-plane/workspace"
 import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
 import { Database } from "../../src/storage/db"
 import { Log } from "@opencode-ai/core/util/log"
+import { currentRequestContext } from "../../src/server/request-context"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
@@ -205,6 +210,81 @@ async function pluginProject() {
 }
 
 describe("workspace router", () => {
+  test("provides instance and request context for no-workspace local routes", async () => {
+    await using tmp = await tmpdir()
+    const app = new Hono()
+    app.use(WorkspaceRouterMiddleware(() => undefined as never))
+    app.get("/context", (c) =>
+      c.json({
+        directory: Instance.current.directory,
+        request: currentRequestContext(),
+      }),
+    )
+
+    const response = await app.request(`/context?directory=${encodeURIComponent(tmp.path)}`, {
+      headers: {
+        "x-pawwork-client-action-id": "client-action-workspace-router",
+        "x-pawwork-client-action-kind": "project.git.init",
+      },
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.directory).toBe(tmp.path)
+    expect(body.request).toMatchObject({
+      method: "GET",
+      path: "/context",
+      client_action: {
+        id: "client-action-workspace-router",
+        kind: "project.git.init",
+      },
+    })
+    expect(JSON.stringify(body.request)).not.toContain(tmp.path)
+  })
+
+  test("provides target instance, workspace, and request context for local workspace routes", async () => {
+    await using tmp = await tmpdir()
+    const space = path.join(tmp.path, "space")
+    await fs.mkdir(space, { recursive: true })
+    const plugin = await writeLocalWorkspacePlugin({ dir: tmp.path, directory: space })
+    const workspace = await createLocalWorkspace({ directory: tmp.path, type: plugin.type })
+    await Instance.disposeAll()
+
+    const app = new Hono()
+    app.use(WorkspaceRouterMiddleware(() => undefined as never))
+    app.get("/context", (c) =>
+      c.json({
+        directory: Instance.current.directory,
+        workspaceID: WorkspaceContext.workspaceID,
+        request: currentRequestContext(),
+      }),
+    )
+
+    const response = await app.request(`/context?workspace=${workspace.id}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+        "x-pawwork-client-action-id": "client-action-local-workspace",
+        "x-pawwork-client-action-kind": "project.git.init",
+      },
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.directory).toBe(space)
+    expect(body.workspaceID).toBe(workspace.id)
+    expect(body.request).toMatchObject({
+      method: "GET",
+      path: "/context",
+      workspace_id: workspace.id,
+      client_action: {
+        id: "client-action-local-workspace",
+        kind: "project.git.init",
+      },
+    })
+    expect(JSON.stringify(body.request)).not.toContain(tmp.path)
+    expect(JSON.stringify(body.request)).not.toContain(space)
+  })
+
   test("keeps GET session detail routes local while forwarding session status", async () => {
     let remoteHits = 0
     await using remote = Bun.serve({

--- a/packages/opencode/test/server/workspace-routing-decision.test.ts
+++ b/packages/opencode/test/server/workspace-routing-decision.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import {
+  classifyWorkspaceRoute,
+  sessionIDForWorkspaceRouting,
+  shouldCreateLegacyConfigBeforePath,
+} from "../../src/server/instance/workspace-routing"
+
+describe("workspace routing decisions", () => {
+  test("keeps session status remote while treating GET session routes as local cached routes", () => {
+    expect(classifyWorkspaceRoute({ method: "GET", pathname: "/session/status", target: "remote" })).toEqual({
+      action: "proxy-http",
+    })
+    expect(classifyWorkspaceRoute({ method: "GET", pathname: "/session", target: "remote" })).toEqual({
+      action: "serve-local-cache",
+    })
+    expect(classifyWorkspaceRoute({ method: "GET", pathname: "/session/ses_1", target: "remote" })).toEqual({
+      action: "serve-local-cache",
+    })
+    expect(classifyWorkspaceRoute({ method: "POST", pathname: "/session/ses_1/message", target: "remote" })).toEqual(
+      {
+        action: "proxy-http",
+      },
+    )
+  })
+
+  test("routes missing workspace deletes through while other missing records fail explicitly", () => {
+    expect(classifyWorkspaceRoute({ method: "DELETE", pathname: "/session/ses_missing", target: "missing" })).toEqual({
+      action: "pass-missing-session-delete",
+    })
+    expect(classifyWorkspaceRoute({ method: "GET", pathname: "/path", target: "missing" })).toEqual({
+      action: "missing-workspace-error",
+    })
+  })
+
+  test("provides local workspace targets and keeps remote websocket upgrades on the proxy path", () => {
+    expect(classifyWorkspaceRoute({ method: "GET", pathname: "/path", target: "local" })).toEqual({
+      action: "provide-local-workspace",
+    })
+    expect(
+      classifyWorkspaceRoute({
+        method: "GET",
+        pathname: "/pty/pty_1/connect",
+        target: "remote",
+        isWebSocketUpgrade: true,
+      }),
+    ).toEqual({
+      action: "proxy-websocket",
+    })
+  })
+
+  test("detects workspace session ids without treating status or e2e routes as session-bound", () => {
+    expect(sessionIDForWorkspaceRouting("/session/ses_1/message")?.toString()).toBe("ses_1")
+    expect(sessionIDForWorkspaceRouting("/session/status")).toBeUndefined()
+    expect(sessionIDForWorkspaceRouting("/session/__e2e/create")).toBeUndefined()
+    expect(sessionIDForWorkspaceRouting("/path")).toBeUndefined()
+  })
+
+  test("keeps legacy config precreation scoped to OpenCode no-workspace path requests", () => {
+    expect(
+      shouldCreateLegacyConfigBeforePath({
+        pathname: "/path",
+        ensureConfig: true,
+        hasWorkspace: false,
+        isPawWork: false,
+      }),
+    ).toBe(true)
+    expect(
+      shouldCreateLegacyConfigBeforePath({
+        pathname: "/path",
+        ensureConfig: true,
+        hasWorkspace: true,
+        isPawWork: false,
+      }),
+    ).toBe(false)
+    expect(
+      shouldCreateLegacyConfigBeforePath({
+        pathname: "/path",
+        ensureConfig: true,
+        hasWorkspace: false,
+        isPawWork: true,
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/server/workspace-routing-decision.test.ts
+++ b/packages/opencode/test/server/workspace-routing-decision.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   classifyWorkspaceRoute,
   sessionIDForWorkspaceRouting,
-  shouldCreateLegacyConfigBeforePath,
+  shouldCreateLegacyConfigBeforeNoWorkspacePath,
 } from "../../src/server/instance/workspace-routing"
 
 describe("workspace routing decisions", () => {
@@ -48,6 +48,29 @@ describe("workspace routing decisions", () => {
     })
   })
 
+  test("keeps cached remote GET session routes before websocket proxy routing", () => {
+    expect(
+      classifyWorkspaceRoute({
+        method: "GET",
+        pathname: "/session",
+        target: "remote",
+        isWebSocketUpgrade: true,
+      }),
+    ).toEqual({
+      action: "serve-local-cache",
+    })
+    expect(
+      classifyWorkspaceRoute({
+        method: "GET",
+        pathname: "/session/ses_1",
+        target: "remote",
+        isWebSocketUpgrade: true,
+      }),
+    ).toEqual({
+      action: "serve-local-cache",
+    })
+  })
+
   test("detects workspace session ids without treating status or e2e routes as session-bound", () => {
     expect(sessionIDForWorkspaceRouting("/session/ses_1/message")?.toString()).toBe("ses_1")
     expect(sessionIDForWorkspaceRouting("/session/status")).toBeUndefined()
@@ -57,26 +80,16 @@ describe("workspace routing decisions", () => {
 
   test("keeps legacy config precreation scoped to OpenCode no-workspace path requests", () => {
     expect(
-      shouldCreateLegacyConfigBeforePath({
+      shouldCreateLegacyConfigBeforeNoWorkspacePath({
         pathname: "/path",
         ensureConfig: true,
-        hasWorkspace: false,
         isPawWork: false,
       }),
     ).toBe(true)
     expect(
-      shouldCreateLegacyConfigBeforePath({
+      shouldCreateLegacyConfigBeforeNoWorkspacePath({
         pathname: "/path",
         ensureConfig: true,
-        hasWorkspace: true,
-        isPawWork: false,
-      }),
-    ).toBe(false)
-    expect(
-      shouldCreateLegacyConfigBeforePath({
-        pathname: "/path",
-        ensureConfig: true,
-        hasWorkspace: false,
         isPawWork: true,
       }),
     ).toBe(false)


### PR DESCRIPTION
## Summary

Extract the workspace routing decision rules behind the current Hono middleware and add guardrails for the local context paths that the next Effect provider PR will need:

- move route classification into `workspace-routing.ts` while preserving the existing Hono middleware entrypoint;
- pin the decision table for session status forwarding, cached GET session routes, missing-workspace deletes, WebSocket proxying, and legacy config precreation;
- add characterization tests proving no-workspace and local-workspace routes still provide instance, workspace, and request context.

## Why

Issue #936 is moving the remaining Effect migration through small, reviewable PRs. This is PR1 of the compressed workspace middleware sequence: it makes the current routing decisions explicit and testable before any Effect provider replacement or router migration.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please review:

- whether `workspace-routing.ts` preserves the old middleware decision order;
- whether local cached routes, missing-workspace session deletes, and WebSocket proxy routing remain unchanged;
- whether the new context characterization tests cover the local provider paths needed by the next PR.

## Risk Notes

- This should be a no-behavior-change extraction; the main risk is accidentally reordering workspace routing decisions.
- Missing-workspace `DELETE /session/:id` behavior is intentionally preserved so broken synced sessions remain deletable.
- XHigh read-only review before PR found no blocking findings; one matcher was adjusted back to the old unanchored behavior before opening this PR.
- Review follow-up: removed the pseudo-general `hasWorkspace` helper parameter and added cached GET session + WebSocket upgrade precedence coverage.
- Visible UI/copy check skipped: no visible UI or app copy changed.
- Platform impact considered: workspace routing uses filesystem paths, but this PR does not change path resolution or platform-specific filesystem behavior.
- No dependencies, generated files, release notes, credentials, or public SDK/API shape changes.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in the isolated worktree.
TDD RED: bun test ./test/server/workspace-routing-decision.test.ts in packages/opencode failed because the new decision helper module did not exist.
Decision tests: bun test ./test/server/workspace-routing-decision.test.ts in packages/opencode -> passed, 6 tests.
Workspace router/default-directory/middleware guardrails: bun test ./test/server/workspace-routing-decision.test.ts ./test/server/workspace-router.test.ts ./test/server/default-directory.test.ts ./test/server/middleware.test.ts in packages/opencode -> passed, 35 tests.
PTY/auth/SSE guardrails: bun test ./test/server/pty-routes.test.ts ./test/server/auth.test.ts ./test/server/event-stream-routes.test.ts ./test/server/global-event-replay.test.ts in packages/opencode -> passed, 38 tests.
Opencode typecheck: bun run typecheck in packages/opencode -> passed.
Whitespace: git diff --check -> clean.
Pre-PR review: XHigh read-only reviewer reported no blocking findings.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
