### PR TITLE
refactor(server): provide workspace context through effect

### DIFF
--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -27,7 +27,7 @@ async function getSessionWorkspace(url: URL) {
   return session?.workspaceID
 }
 
-async function provideLocalWorkspaceContext<R>(input: {
+function provideLocalWorkspaceContext<R>(input: {
   directory: string
   workspaceID?: WorkspaceID
   request: RequestContextSnapshot

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -12,7 +12,7 @@ import { Session } from "@/session"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Global } from "@/global"
 import { Runtime } from "@opencode-ai/core/runtime"
-import { requestContextFromHono, withRequestContext } from "@/server/request-context"
+import { requestContextFromHono, withRequestContext, type RequestContextSnapshot } from "@/server/request-context"
 import {
   classifyWorkspaceRoute,
   sessionIDForWorkspaceRouting,
@@ -25,6 +25,27 @@ async function getSessionWorkspace(url: URL) {
 
   const session = await Session.get(id).catch(() => undefined)
   return session?.workspaceID
+}
+
+async function provideLocalWorkspaceContext<R>(input: {
+  directory: string
+  workspaceID?: WorkspaceID
+  request: RequestContextSnapshot
+  fn: () => R
+}) {
+  const run = () =>
+    withRequestContext(input.request, () =>
+      Instance.provide({
+        directory: input.directory,
+        fn: input.fn,
+      }),
+    )
+
+  if (!input.workspaceID) return run()
+  return WorkspaceContext.provide({
+    workspaceID: input.workspaceID,
+    fn: run,
+  })
 }
 
 export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): MiddlewareHandler {
@@ -69,15 +90,11 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
         }
       }
 
-      const snapshot = requestContextFromHono(c, { directory })
-      return withRequestContext(snapshot, () =>
-        Instance.provide({
-          directory,
-          async fn() {
-            return next()
-          },
-        }),
-      )
+      return provideLocalWorkspaceContext({
+        directory,
+        request: requestContextFromHono(c, { directory }),
+        fn: next,
+      })
     }
 
     const workspace = await Workspace.record(WorkspaceID.make(workspaceID))
@@ -123,18 +140,11 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       if (decision.action !== "provide-local-workspace") {
         throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
       }
-      const snapshot = requestContextFromHono(c, { directory: target.directory, workspaceID })
-      return WorkspaceContext.provide({
+      return provideLocalWorkspaceContext({
+        directory: target.directory,
         workspaceID: WorkspaceID.make(workspaceID),
-        fn: () =>
-          withRequestContext(snapshot, () =>
-            Instance.provide({
-              directory: target.directory,
-              async fn() {
-                return next()
-              },
-            }),
-          ),
+        request: requestContextFromHono(c, { directory: target.directory, workspaceID }),
+        fn: next,
       })
     }
 

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -5,6 +5,8 @@ import fs from "fs/promises"
 import { Hono } from "hono"
 import path from "path"
 import { pathToFileURL } from "url"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
 import { eq } from "../../src/storage/db"
 import { WorkspaceContext } from "../../src/control-plane/workspace-context"
 import { Instance } from "../../src/project/instance"
@@ -52,6 +54,19 @@ function wait(ms = 50) {
 
 function disableWorkspaceSync() {
   return spyOn(Workspace, "ensureSync").mockImplementation(() => {})
+}
+
+async function readEffectContext() {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const instance = yield* InstanceRef
+      const workspaceID = yield* WorkspaceRef
+      return {
+        directory: instance?.directory,
+        workspaceID: workspaceID ?? null,
+      }
+    }),
+  )
 }
 
 async function writeOpencodeConfig(dir: string, pluginFile: string) {
@@ -214,9 +229,10 @@ describe("workspace router", () => {
     await using tmp = await tmpdir()
     const app = new Hono()
     app.use(WorkspaceRouterMiddleware(() => undefined as never))
-    app.get("/context", (c) =>
+    app.get("/context", async (c) =>
       c.json({
         directory: Instance.current.directory,
+        effect: await readEffectContext(),
         request: currentRequestContext(),
       }),
     )
@@ -231,6 +247,11 @@ describe("workspace router", () => {
 
     expect(response.status).toBe(200)
     expect(body.directory).toBe(tmp.path)
+    expect(body.effect).toEqual({
+      directory: tmp.path,
+      workspaceID: null,
+    })
+    expect(Instance.directories()).toContain(tmp.path)
     expect(body.request).toMatchObject({
       method: "GET",
       path: "/context",
@@ -252,10 +273,11 @@ describe("workspace router", () => {
 
     const app = new Hono()
     app.use(WorkspaceRouterMiddleware(() => undefined as never))
-    app.get("/context", (c) =>
+    app.get("/context", async (c) =>
       c.json({
         directory: Instance.current.directory,
         workspaceID: WorkspaceContext.workspaceID,
+        effect: await readEffectContext(),
         request: currentRequestContext(),
       }),
     )
@@ -272,6 +294,11 @@ describe("workspace router", () => {
     expect(response.status).toBe(200)
     expect(body.directory).toBe(space)
     expect(body.workspaceID).toBe(workspace.id)
+    expect(body.effect).toEqual({
+      directory: space,
+      workspaceID: workspace.id,
+    })
+    expect(Instance.directories()).toContain(space)
     expect(body.request).toMatchObject({
       method: "GET",
       path: "/context",


### PR DESCRIPTION
## Summary

Extract the local workspace context provider path behind `WorkspaceRouterMiddleware` while preserving the existing Hono routing entrypoint:

- add an internal helper for no-workspace and local-workspace context injection;
- keep `WorkspaceContext`, request context, and `Instance.provide` ordering intact;
- add guardrails proving handlers can still read legacy ALS context and Effect `InstanceRef` / `WorkspaceRef` through `AppRuntime`.

## Why

Issue #936 is moving the remaining Effect migration through small workspace middleware slices. PR #1009 made routing decisions explicit; this PR keeps those decisions unchanged and narrows the local context provider path so the next slice can move routing decisions toward Effect without mixing in proxy or route migration behavior.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please review:

- whether `provideLocalWorkspaceContext` preserves the previous no-workspace and local-workspace nesting order;
- whether `Instance.provide` remains the right lowest-risk bridge because it preserves instance directory tracking;
- whether the new Effect context guardrails cover the intended Hono-to-Effect bridge without implying that raw `Effect.runPromise` has ambient refs.

## Risk Notes

- This should be a no-behavior-change refactor; the main risk is changing context ordering around request provenance, workspace IDs, or instance directory tracking.
- The implementation intentionally keeps `Instance.provide` rather than calling `InstanceStore` directly, because `Instance.provide` also maintains `Instance.directories()`.
- Remote proxy routing, WebSocket lifecycle, route groups, OpenAPI/SDK shape, auth/OAuth, upstream sync/warp/v2/TUI surfaces, and #950 automation are unchanged.
- Read-only xhigh and Claude design reviews agreed on the boundary. Claude recommended relying on existing `AppRuntime.attach()` bridge instead of manually providing Effect services in the middleware.
- Visible UI/copy check skipped: no visible UI or app copy changed.
- Platform impact considered: workspace routing uses filesystem paths, but this PR does not change path resolution, default-directory behavior, or platform-specific filesystem behavior.
- No dependencies, generated files, release notes, credentials, permissions, or public SDK/API shape changes.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in the isolated worktree.
Context characterization before refactor: bun test ./test/server/workspace-router.test.ts in packages/opencode -> passed, 16 tests.
Workspace middleware guardrails: bun test ./test/server/workspace-routing-decision.test.ts ./test/server/workspace-router.test.ts ./test/server/default-directory.test.ts ./test/server/middleware.test.ts in packages/opencode -> passed, 35 tests.
Opencode typecheck: bun run typecheck in packages/opencode -> passed.
Whitespace: git diff --check -> clean.
Design review: xhigh read-only reviewer and Claude read-only consult agreed with the PR2 boundary; their implementation constraints are reflected in the helper order and tests.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated workspace context provisioning to eliminate duplicate request handling code patterns and improve overall code reusability across multiple request paths within the application.

* **Tests**
  * Enhanced workspace router tests with improved effect context validation, including detailed assertions for directory information and workspace ID associations to ensure proper context initialization and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->