### PR TITLE
refactor(server): resolve workspace routes through effect

### DIFF
--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -4,28 +4,15 @@ import { mkdirSync } from "fs"
 import os from "os"
 import path from "path"
 import { WorkspaceID } from "@/control-plane/schema"
-import { Workspace } from "@/control-plane/workspace"
 import { ServerProxy } from "../proxy"
 import { Filesystem } from "@/util/filesystem"
 import { Instance } from "@/project/instance"
-import { Session } from "@/session"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Global } from "@/global"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { requestContextFromHono, withRequestContext, type RequestContextSnapshot } from "@/server/request-context"
-import {
-  classifyWorkspaceRoute,
-  sessionIDForWorkspaceRouting,
-  shouldCreateLegacyConfigBeforeNoWorkspacePath,
-} from "./workspace-routing"
-
-async function getSessionWorkspace(url: URL) {
-  const id = sessionIDForWorkspaceRouting(url.pathname)
-  if (!id) return null
-
-  const session = await Session.get(id).catch(() => undefined)
-  return session?.workspaceID
-}
+import { resolveWorkspaceRoute } from "./workspace-routing"
+import { AppRuntime } from "@/effect/app-runtime"
 
 function provideLocalWorkspaceContext<R>(input: {
   directory: string
@@ -71,18 +58,20 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const directory = Filesystem.resolve(decoded)
 
     const url = new URL(c.req.url)
-    const sessionWorkspaceID = await getSessionWorkspace(url)
-    const workspaceID = sessionWorkspaceID || url.searchParams.get("workspace")
+    const decision = await AppRuntime.runPromise(
+      resolveWorkspaceRoute({
+        method: c.req.method,
+        pathname: url.pathname,
+        directory,
+        workspaceID: url.searchParams.get("workspace"),
+        ensureConfig: url.searchParams.get("ensureConfig") === "true",
+        isPawWork: Runtime.isPawWork(),
+        isWebSocketUpgrade: c.req.header("upgrade")?.toLowerCase() === "websocket",
+      }),
+    )
 
-    // If no workspace is provided we use the project
-    if (!workspaceID) {
-      if (
-        shouldCreateLegacyConfigBeforeNoWorkspacePath({
-          pathname: url.pathname,
-          ensureConfig: url.searchParams.get("ensureConfig") === "true",
-          isPawWork: Runtime.isPawWork(),
-        })
-      ) {
+    if (decision.action === "provide-local-context") {
+      if (decision.createLegacyConfig) {
         try {
           mkdirSync(Global.Path.config, { recursive: true })
         } catch {
@@ -91,69 +80,31 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
       }
 
       return provideLocalWorkspaceContext({
-        directory,
-        request: requestContextFromHono(c, { directory }),
+        directory: decision.directory,
+        workspaceID: decision.workspaceID,
+        request: requestContextFromHono(c, { directory: decision.directory, workspaceID: decision.workspaceID }),
         fn: next,
       })
     }
 
-    const workspace = await Workspace.record(WorkspaceID.make(workspaceID))
-
-    if (!workspace) {
-      const decision = classifyWorkspaceRoute({
-        method: c.req.method,
-        pathname: url.pathname,
-        target: "missing",
-      })
+    if (decision.action === "pass-missing-session-delete") {
       // Special-case deleting a session in case user's data in a
       // weird state. Allow them to forcefully delete a synced session
       // even if the remote workspace is not in their data.
       //
       // The lets the `DELETE /session/:id` endpoint through and we've
       // made sure that it will run without an instance
-      if (decision.action === "pass-missing-session-delete") {
-        return next()
-      }
+      return next()
+    }
 
-      return new Response(`Workspace not found: ${workspaceID}`, {
+    if (decision.action === "missing-workspace-error") {
+      return new Response(`Workspace not found: ${decision.workspaceID}`, {
         status: 500,
         headers: {
           "content-type": "text/plain; charset=utf-8",
         },
       })
     }
-
-    Workspace.ensureSync(workspace, directory)
-
-    const adaptor = await Workspace.resolveAdaptor({
-      ...workspace,
-      hint: directory,
-    })
-    const target = await adaptor.target(workspace)
-
-    if (target.type === "local") {
-      const decision = classifyWorkspaceRoute({
-        method: c.req.method,
-        pathname: url.pathname,
-        target: target.type,
-      })
-      if (decision.action !== "provide-local-workspace") {
-        throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
-      }
-      return provideLocalWorkspaceContext({
-        directory: target.directory,
-        workspaceID: WorkspaceID.make(workspaceID),
-        request: requestContextFromHono(c, { directory: target.directory, workspaceID }),
-        fn: next,
-      })
-    }
-
-    const decision = classifyWorkspaceRoute({
-      method: c.req.method,
-      pathname: url.pathname,
-      target: target.type,
-      isWebSocketUpgrade: c.req.header("upgrade")?.toLowerCase() === "websocket",
-    })
 
     if (decision.action === "serve-local-cache") {
       // No instance provided because we are serving cached data; there
@@ -162,19 +113,19 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     }
 
     if (decision.action === "proxy-websocket") {
-      return ServerProxy.websocket(upgrade, target, c.req.raw, c.env)
+      return ServerProxy.websocket(upgrade, decision.target, c.req.raw, c.env)
     }
 
     const headers = new Headers(c.req.raw.headers)
     headers.delete("x-opencode-workspace")
 
     return ServerProxy.http(
-      target.url,
-      target.headers,
+      decision.target.url,
+      decision.target.headers,
       new Request(c.req.raw, {
         headers,
       }),
-      WorkspaceID.make(workspaceID),
+      decision.workspaceID,
     )
   }
 }

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -72,72 +72,75 @@ export function resolveWorkspaceRoute(input: {
   isPawWork: boolean
   isWebSocketUpgrade?: boolean
 }): Effect.Effect<WorkspaceRouteResolution, unknown> {
-  return Effect.promise(async () => {
-    const sessionWorkspaceID = await getSessionWorkspace(input.pathname)
-    const workspaceID = sessionWorkspaceID || input.workspaceID
+  return Effect.tryPromise({
+    try: async () => {
+      const sessionWorkspaceID = await getSessionWorkspace(input.pathname)
+      const workspaceID = sessionWorkspaceID || input.workspaceID
 
-    if (!workspaceID) {
-      const createLegacyConfig = shouldCreateLegacyConfigBeforeNoWorkspacePath({
-        pathname: input.pathname,
-        ensureConfig: input.ensureConfig,
-        isPawWork: input.isPawWork,
-      })
-      return {
-        action: "provide-local-context",
-        directory: input.directory,
-        createLegacyConfig: createLegacyConfig || undefined,
+      if (!workspaceID) {
+        const createLegacyConfig = shouldCreateLegacyConfigBeforeNoWorkspacePath({
+          pathname: input.pathname,
+          ensureConfig: input.ensureConfig,
+          isPawWork: input.isPawWork,
+        })
+        return {
+          action: "provide-local-context",
+          directory: input.directory,
+          createLegacyConfig: createLegacyConfig || undefined,
+        }
       }
-    }
 
-    const id = WorkspaceID.make(workspaceID)
-    const workspace = await Workspace.record(id)
+      const id = WorkspaceID.make(workspaceID)
+      const workspace = await Workspace.record(id)
 
-    if (!workspace) {
-      const decision = classifyWorkspaceRoute({
-        method: input.method,
-        pathname: input.pathname,
-        target: "missing",
-      })
-      if (decision.action === "pass-missing-session-delete") {
-        return { action: "pass-missing-session-delete" }
+      if (!workspace) {
+        const decision = classifyWorkspaceRoute({
+          method: input.method,
+          pathname: input.pathname,
+          target: "missing",
+        })
+        if (decision.action === "pass-missing-session-delete") {
+          return { action: "pass-missing-session-delete" }
+        }
+        return { action: "missing-workspace-error", workspaceID: id }
       }
-      return { action: "missing-workspace-error", workspaceID: id }
-    }
 
-    Workspace.ensureSync(workspace, input.directory)
+      Workspace.ensureSync(workspace, input.directory)
 
-    const adaptor = await Workspace.resolveAdaptor({
-      ...workspace,
-      hint: input.directory,
-    })
-    const target = await adaptor.target(workspace)
+      const adaptor = await Workspace.resolveAdaptor({
+        ...workspace,
+        hint: input.directory,
+      })
+      const target = await adaptor.target(workspace)
 
-    if (target.type === "local") {
+      if (target.type === "local") {
+        const decision = classifyWorkspaceRoute({
+          method: input.method,
+          pathname: input.pathname,
+          target: target.type,
+        })
+        if (decision.action !== "provide-local-workspace") {
+          throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
+        }
+        return {
+          action: "provide-local-context",
+          directory: target.directory,
+          workspaceID: id,
+        }
+      }
+
       const decision = classifyWorkspaceRoute({
         method: input.method,
         pathname: input.pathname,
         target: target.type,
+        isWebSocketUpgrade: input.isWebSocketUpgrade,
       })
-      if (decision.action !== "provide-local-workspace") {
-        throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
-      }
-      return {
-        action: "provide-local-context",
-        directory: target.directory,
-        workspaceID: id,
-      }
-    }
 
-    const decision = classifyWorkspaceRoute({
-      method: input.method,
-      pathname: input.pathname,
-      target: target.type,
-      isWebSocketUpgrade: input.isWebSocketUpgrade,
-    })
-
-    if (decision.action === "serve-local-cache") return { action: "serve-local-cache" }
-    if (decision.action === "proxy-websocket") return { action: "proxy-websocket", target }
-    return { action: "proxy-http", target, workspaceID: id }
+      if (decision.action === "serve-local-cache") return { action: "serve-local-cache" }
+      if (decision.action === "proxy-websocket") return { action: "proxy-websocket", target }
+      return { action: "proxy-http", target, workspaceID: id }
+    },
+    catch: (error) => error,
   })
 }
 

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -1,3 +1,8 @@
+import { Effect } from "effect"
+import { WorkspaceID } from "@/control-plane/schema"
+import type { Target } from "@/control-plane/types"
+import { Workspace } from "@/control-plane/workspace"
+import { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 
 type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
@@ -14,6 +19,14 @@ export type WorkspaceRouteDecision =
   | { action: "proxy-http" }
   | { action: "pass-missing-session-delete" }
   | { action: "missing-workspace-error" }
+
+export type WorkspaceRouteResolution =
+  | { action: "provide-local-context"; directory: string; workspaceID?: WorkspaceID; createLegacyConfig?: boolean }
+  | { action: "serve-local-cache" }
+  | { action: "proxy-websocket"; target: Extract<Target, { type: "remote" }> }
+  | { action: "proxy-http"; target: Extract<Target, { type: "remote" }>; workspaceID: WorkspaceID }
+  | { action: "pass-missing-session-delete" }
+  | { action: "missing-workspace-error"; workspaceID: WorkspaceID }
 
 export function isLocalCachedRoute(method: string, pathname: string) {
   for (const rule of LOCAL_ROUTE_RULES) {
@@ -40,6 +53,92 @@ export function shouldCreateLegacyConfigBeforeNoWorkspacePath(input: {
   isPawWork: boolean
 }) {
   return input.pathname === "/path" && input.ensureConfig && !input.isPawWork
+}
+
+async function getSessionWorkspace(pathname: string) {
+  const id = sessionIDForWorkspaceRouting(pathname)
+  if (!id) return null
+
+  const session = await Session.get(id).catch(() => undefined)
+  return session?.workspaceID
+}
+
+export function resolveWorkspaceRoute(input: {
+  method: string
+  pathname: string
+  directory: string
+  workspaceID?: string | null
+  ensureConfig: boolean
+  isPawWork: boolean
+  isWebSocketUpgrade?: boolean
+}): Effect.Effect<WorkspaceRouteResolution, unknown> {
+  return Effect.promise(async () => {
+    const sessionWorkspaceID = await getSessionWorkspace(input.pathname)
+    const workspaceID = sessionWorkspaceID || input.workspaceID
+
+    if (!workspaceID) {
+      const createLegacyConfig = shouldCreateLegacyConfigBeforeNoWorkspacePath({
+        pathname: input.pathname,
+        ensureConfig: input.ensureConfig,
+        isPawWork: input.isPawWork,
+      })
+      return {
+        action: "provide-local-context",
+        directory: input.directory,
+        createLegacyConfig: createLegacyConfig || undefined,
+      }
+    }
+
+    const id = WorkspaceID.make(workspaceID)
+    const workspace = await Workspace.record(id)
+
+    if (!workspace) {
+      const decision = classifyWorkspaceRoute({
+        method: input.method,
+        pathname: input.pathname,
+        target: "missing",
+      })
+      if (decision.action === "pass-missing-session-delete") {
+        return { action: "pass-missing-session-delete" }
+      }
+      return { action: "missing-workspace-error", workspaceID: id }
+    }
+
+    Workspace.ensureSync(workspace, input.directory)
+
+    const adaptor = await Workspace.resolveAdaptor({
+      ...workspace,
+      hint: input.directory,
+    })
+    const target = await adaptor.target(workspace)
+
+    if (target.type === "local") {
+      const decision = classifyWorkspaceRoute({
+        method: input.method,
+        pathname: input.pathname,
+        target: target.type,
+      })
+      if (decision.action !== "provide-local-workspace") {
+        throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
+      }
+      return {
+        action: "provide-local-context",
+        directory: target.directory,
+        workspaceID: id,
+      }
+    }
+
+    const decision = classifyWorkspaceRoute({
+      method: input.method,
+      pathname: input.pathname,
+      target: target.type,
+      isWebSocketUpgrade: input.isWebSocketUpgrade,
+    })
+
+    if (decision.action === "serve-local-cache") return { action: "serve-local-cache" }
+    if (decision.action === "proxy-websocket") return { action: "proxy-websocket", target }
+    return { action: "proxy-http", target, workspaceID: id }
+  })
 }
 
 export function classifyWorkspaceRoute(input: {

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test"
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import fs from "fs/promises"
 import { Hono } from "hono"
 import path from "path"
@@ -13,6 +13,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Server } from "../../src/server/server"
 import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
+import { resolveWorkspaceRoute } from "../../src/server/instance/workspace-routing"
 import { WorkspaceID } from "../../src/control-plane/schema"
 import { Workspace } from "../../src/control-plane/workspace"
 import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
@@ -83,7 +84,12 @@ async function writeOpencodeConfig(dir: string, pluginFile: string) {
   )
 }
 
-async function writeRemoteWorkspacePlugin(input: { dir: string; url: string; branch?: string | null }) {
+async function writeRemoteWorkspacePlugin(input: {
+  dir: string
+  url: string
+  branch?: string | null
+  targetError?: string
+}) {
   const type = `plug-${Math.random().toString(36).slice(2)}`
   const file = path.join(input.dir, "plugin.ts")
   const branch = input.branch === undefined ? null : input.branch
@@ -98,7 +104,9 @@ async function writeRemoteWorkspacePlugin(input: { dir: string; url: string; bra
       "    async create() {},",
       "    async remove() {},",
       "    target() {",
-      `      return { type: "remote", url: ${JSON.stringify(input.url)} }`,
+      input.targetError
+        ? `      throw new Error(${JSON.stringify(input.targetError)})`
+        : `      return { type: "remote", url: ${JSON.stringify(input.url)} }`,
       "    },",
       "  })",
       "  return {}",
@@ -514,6 +522,52 @@ describe("workspace router", () => {
     } finally {
       ensureSync.mockRestore()
       websocket.mockRestore()
+    }
+  })
+
+  test("keeps remote target failures in the Effect failure channel and Hono error response", async () => {
+    const message = "workspace target failed"
+    await using tmp = await tmpdir({
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: "http://127.0.0.1:9", targetError: message }),
+    })
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type })
+    await Instance.disposeAll()
+
+    const ensureSync = disableWorkspaceSync()
+
+    try {
+      const exit = await AppRuntime.runPromiseExit(
+        resolveWorkspaceRoute({
+          method: "GET",
+          pathname: "/path",
+          directory: tmp.path,
+          workspaceID: workspace.id,
+          ensureConfig: false,
+          isPawWork: true,
+        }),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasFails(exit.cause)).toBe(true)
+        expect(Cause.hasDies(exit.cause)).toBe(false)
+        const error = Cause.squash(exit.cause)
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain(message)
+      }
+
+      const response = await Server.Default().app.request(`/path?workspace=${workspace.id}`, {
+        headers: {
+          "x-opencode-directory": tmp.path,
+        },
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body.name).toBe("UnknownError")
+      expect(body.data.message).toContain(message)
+    } finally {
+      ensureSync.mockRestore()
     }
   })
 

--- a/packages/opencode/test/server/workspace-routing-decision.test.ts
+++ b/packages/opencode/test/server/workspace-routing-decision.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import {
   classifyWorkspaceRoute,
+  resolveWorkspaceRoute,
   sessionIDForWorkspaceRouting,
   shouldCreateLegacyConfigBeforeNoWorkspacePath,
 } from "../../src/server/instance/workspace-routing"
@@ -93,5 +95,25 @@ describe("workspace routing decisions", () => {
         isPawWork: true,
       }),
     ).toBe(false)
+  })
+
+  test("resolves no-workspace routes through an Effect route decision", async () => {
+    const directory = "/tmp/pawwork-effect-router"
+    const decision = await Effect.runPromise(
+      resolveWorkspaceRoute({
+        method: "GET",
+        pathname: "/path",
+        directory,
+        workspaceID: undefined,
+        ensureConfig: true,
+        isPawWork: false,
+      }),
+    )
+
+    expect(decision).toEqual({
+      action: "provide-local-context",
+      directory,
+      createLegacyConfig: true,
+    })
   })
 })


### PR DESCRIPTION
## Summary

Move the workspace router decision step behind an Effect-backed resolver while keeping the Hono middleware as the execution entrypoint:

- add `resolveWorkspaceRoute` for session/workspace/adaptor route resolution;
- keep local context provisioning, missing-workspace responses, and proxy execution in `WorkspaceRouterMiddleware`;
- add a focused guardrail proving no-workspace route decisions are resolved through the Effect seam.

## Why

This is the remaining PR3 slice for the compressed #936 workspace middleware foundation. PR #1009 extracted the decision table and guardrails; PR #1010 isolated local context injection. This PR moves the workspace router decisions into the Effect boundary without migrating route groups or proxy internals.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please review:

- whether `resolveWorkspaceRoute` preserves the previous session-bound workspace, missing-workspace, local workspace, local-cache, and proxy decision order;
- whether `WorkspaceRouterMiddleware` still owns Hono-specific execution, request context creation, and proxy calls;
- whether `Workspace.resolveAdaptor` still receives the request directory hint for cold-start and ownerless workspace recovery.

## Risk Notes

- This should be a no-behavior-change refactor; the main risk is accidentally moving an execution side effect across the resolver boundary.
- `Workspace.ensureSync` remains in the route resolution path because it already ran before proxy/local target execution and is covered by cold-start sync guardrails.
- Visible UI/copy check skipped: no visible UI or app copy changed.
- Platform impact considered: workspace routing uses filesystem paths, but this PR does not change path resolution, default directory creation, or platform-specific filesystem behavior.
- No dependencies, generated files, release notes, credentials, permissions, public SDK/API shape, route groups, auth/OAuth, upstream sync/warp/v2/TUI surfaces, or #950 automation changes.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in the isolated worktree.
TDD RED: bun test ./test/server/workspace-routing-decision.test.ts in packages/opencode failed because resolveWorkspaceRoute was not exported yet.
Focused decision tests: bun test ./test/server/workspace-routing-decision.test.ts in packages/opencode -> passed, 7 tests.
Workspace router/default-directory/middleware guardrails: bun test ./test/server/workspace-routing-decision.test.ts ./test/server/workspace-router.test.ts ./test/server/default-directory.test.ts ./test/server/middleware.test.ts in packages/opencode -> passed, 36 tests.
PTY/auth/SSE guardrails: bun test ./test/server/workspace-routing-decision.test.ts ./test/server/workspace-router.test.ts ./test/server/default-directory.test.ts ./test/server/middleware.test.ts ./test/server/pty-routes.test.ts ./test/server/auth.test.ts ./test/server/event-stream-routes.test.ts ./test/server/global-event-replay.test.ts in packages/opencode -> passed, 74 tests.
Pre-push xhigh review: PASS, no P1/P2 findings.
Pre-push Claude review: PASS, no P1/P2 findings.
Review follow-up RED: bun test ./test/server/workspace-router.test.ts --test-name-pattern "target failures" in packages/opencode failed because adaptor target failures were Cause.Die instead of Cause.Fail.
Review follow-up focused test: bun test ./test/server/workspace-router.test.ts --test-name-pattern "target failures" in packages/opencode -> passed, 1 test.
Review follow-up target guardrails: bun test ./test/server/workspace-routing-decision.test.ts ./test/server/workspace-router.test.ts ./test/server/default-directory.test.ts ./test/server/middleware.test.ts ./test/server/pty-routes.test.ts ./test/server/auth.test.ts ./test/server/event-stream-routes.test.ts ./test/server/global-event-replay.test.ts in packages/opencode -> passed, 75 tests.
Opencode typecheck: bun run typecheck in packages/opencode -> passed.
Whitespace: git diff --check -> clean.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured workspace routing logic to improve code organization and separation of concerns.

* **Tests**
  * Added test coverage for workspace routing decision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
