### PR TITLE
fix: wait for worktree start command launch

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -11,7 +11,7 @@ import { errorMessage } from "../util/error"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
 import { Git } from "@/git"
-import { Effect, Layer, Path, Scope, Context, Stream, Semaphore } from "effect"
+import { Deferred, Effect, Layer, Path, Scope, Context, Stream, Semaphore } from "effect"
 import { ensureWorktreesIgnored, restoreWorktreesIgnored } from "./gitignore-guard"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
@@ -446,10 +446,7 @@ export namespace Worktree {
           },
         })
 
-        yield* runStartScripts(info.directory, { projectID, extra }).pipe(
-          Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),
-          Effect.forkIn(scope),
-        )
+        yield* launchStartScripts(info.directory, { projectID, extra })
       })
 
       const createFromInfo = Effect.fn("Worktree.createFromInfo")(function* (info: Info, startCommand?: string) {
@@ -608,28 +605,42 @@ export namespace Worktree {
         return result
       })
 
+      const signalStartLaunch = (launch: Deferred.Deferred<void> | undefined) => {
+        if (!launch) return Effect.void
+        return Deferred.succeed(launch, undefined).pipe(Effect.ignore)
+      }
+
       const runStartCommand = Effect.fnUntraced(
-        function* (directory: string, cmd: string) {
-          const [shell, args] = process.platform === "win32" ? ["cmd", ["/c", cmd]] : ["bash", ["-lc", cmd]]
-          const handle = yield* spawner.spawn(
-            ChildProcess.make(shell, args, { cwd: directory, extendEnv: true, stdin: "ignore" }),
+        function* (directory: string, cmd: string, launch?: Deferred.Deferred<void>) {
+          return yield* Effect.gen(function* () {
+            const [shell, args] = process.platform === "win32" ? ["cmd", ["/c", cmd]] : ["bash", ["-lc", cmd]]
+            const handle = yield* spawner.spawn(
+              ChildProcess.make(shell, args, { cwd: directory, extendEnv: true, stdin: "ignore" }),
+            )
+            yield* signalStartLaunch(launch)
+            // Drain stdout, capture stderr for error reporting
+            const [, stderr] = yield* Effect.all(
+              [Stream.runDrain(handle.stdout), Stream.mkString(Stream.decodeText(handle.stderr))],
+              { concurrency: 2 },
+            ).pipe(Effect.orDie)
+            const code = yield* handle.exitCode
+            return { code, stderr }
+          }).pipe(
+            Effect.scoped,
+            Effect.catch(() => signalStartLaunch(launch).pipe(Effect.as({ code: 1, stderr: "" }))),
           )
-          // Drain stdout, capture stderr for error reporting
-          const [, stderr] = yield* Effect.all(
-            [Stream.runDrain(handle.stdout), Stream.mkString(Stream.decodeText(handle.stderr))],
-            { concurrency: 2 },
-          ).pipe(Effect.orDie)
-          const code = yield* handle.exitCode
-          return { code, stderr }
         },
-        Effect.scoped,
-        Effect.catch(() => Effect.succeed({ code: 1, stderr: "" })),
       )
 
-      const runStartScript = Effect.fnUntraced(function* (directory: string, cmd: string, kind: string) {
+      const runStartScript = Effect.fnUntraced(function* (
+        directory: string,
+        cmd: string,
+        kind: string,
+        launch?: Deferred.Deferred<void>,
+      ) {
         const text = cmd.trim()
         if (!text) return true
-        const result = yield* runStartCommand(directory, text)
+        const result = yield* runStartCommand(directory, text, launch)
         if (result.code === 0) return true
         log.error("worktree start command failed", { kind, directory, message: result.stderr })
         return false
@@ -638,16 +649,38 @@ export namespace Worktree {
       const runStartScripts = Effect.fnUntraced(function* (
         directory: string,
         input: { projectID: ProjectID; extra?: string },
+        launch?: Deferred.Deferred<void>,
       ) {
         const row = yield* Effect.sync(() =>
           Database.use((db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, input.projectID)).get()),
         )
         const project = row ? Project.fromRow(row) : undefined
         const startup = project?.commands?.start?.trim() ?? ""
-        const ok = yield* runStartScript(directory, startup, "project")
+        const extra = input.extra?.trim() ?? ""
+        if (!startup && !extra) {
+          yield* signalStartLaunch(launch)
+          return true
+        }
+        const ok = yield* runStartScript(directory, startup, "project", startup ? launch : undefined)
         if (!ok) return false
-        yield* runStartScript(directory, input.extra ?? "", "worktree")
+        yield* runStartScript(directory, extra, "worktree", startup ? undefined : launch)
         return true
+      })
+
+      const launchStartScripts = Effect.fnUntraced(function* (
+        directory: string,
+        input: { projectID: ProjectID; extra?: string },
+      ) {
+        const launch = yield* Deferred.make<void>()
+        yield* runStartScripts(directory, input, launch).pipe(
+          Effect.catchCause((cause) =>
+            signalStartLaunch(launch).pipe(
+              Effect.andThen(Effect.sync(() => log.error("worktree start task failed", { cause }))),
+            ),
+          ),
+          Effect.forkIn(scope),
+        )
+        return yield* Deferred.await(launch)
       })
 
       const prune = Effect.fnUntraced(function* (root: string, entries: string[]) {
@@ -766,10 +799,7 @@ export namespace Worktree {
           yield* upsertRegistry(Info.parse({ ...registered, branch }))
         }
 
-        yield* runStartScripts(worktreePath, { projectID: Instance.project.id }).pipe(
-          Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),
-          Effect.forkIn(scope),
-        )
+        yield* launchStartScripts(worktreePath, { projectID: Instance.project.id })
 
         return true
       })

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -18,12 +18,13 @@ import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
 
 const encoder = new TextEncoder()
+type StartCommandProbe = { spawned: boolean; released: boolean; release?: () => void }
 
 function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
 }
 
-function startCommandSpawnProbe(probe: { spawned: boolean; release?: () => void }) {
+function startCommandSpawnProbe(probe: StartCommandProbe) {
   return Layer.effect(
     ChildProcessSpawner.ChildProcessSpawner,
     Effect.gen(function* () {
@@ -42,6 +43,7 @@ function startCommandSpawnProbe(probe: { spawned: boolean; release?: () => void 
             probe.release = () => {
               if (released) return
               released = true
+              probe.released = true
               finish(ChildProcessSpawner.ExitCode(0))
             }
             return ChildProcessSpawner.makeHandle({
@@ -65,7 +67,7 @@ function startCommandSpawnProbe(probe: { spawned: boolean; release?: () => void 
   ).pipe(Layer.provide(CrossSpawnSpawner.defaultLayer))
 }
 
-function worktreeLayerWithStartCommandProbe(probe: { spawned: boolean; release?: () => void }) {
+function worktreeLayerWithStartCommandProbe(probe: StartCommandProbe) {
   return Worktree.layer.pipe(
     Layer.provide(Git.defaultLayer),
     Layer.provide(Project.defaultLayer),
@@ -290,43 +292,9 @@ describe("Worktree", () => {
   })
 
   describe("reset", () => {
-    test("starts project start command without waiting for it to exit", async () => {
+    test("starts project start command before returning without waiting for it to exit", async () => {
       await using tmp = await tmpdir({ git: true })
-
-      await withInstance(tmp.path, async () => {
-        const info = await Worktree.createReady({ name: "reset-start-command" })
-        await Project.update({
-          projectID: Instance.project.id,
-          commands: {
-            start:
-              "bun -e \"await Bun.write('.reset-start-began', 'ready'); while (!(await Bun.file('.reset-start-release').exists())) await Bun.sleep(20)\"",
-          },
-        })
-
-        const reset = Worktree.reset({ directory: info.directory })
-        const result = await Promise.race([
-          reset.then(() => "done" as const),
-          Bun.sleep(2_000).then(() => "timeout" as const),
-        ])
-        if (result === "timeout") {
-          await Bun.write(path.join(info.directory, ".reset-start-release"), "done")
-          await reset.catch(() => undefined)
-          throw new Error("Worktree.reset waited for the project start command to exit")
-        }
-
-        const deadline = Date.now() + 1_000
-        while (!(await Bun.file(path.join(info.directory, ".reset-start-began")).exists()) && Date.now() < deadline) {
-          await Bun.sleep(20)
-        }
-        expect(await Bun.file(path.join(info.directory, ".reset-start-began")).text()).toBe("ready")
-        await Bun.write(path.join(info.directory, ".reset-start-release"), "done")
-        await Worktree.remove({ directory: info.directory })
-      })
-    })
-
-    test("returns only after the project start command has spawned", async () => {
-      await using tmp = await tmpdir({ git: true })
-      const probe = { spawned: false, release: undefined as (() => void) | undefined }
+      const probe: StartCommandProbe = { spawned: false, released: false }
 
       await withInstance(tmp.path, async () => {
         const info = await Worktree.createReady({ name: "reset-start-spawn-probe" })
@@ -338,11 +306,21 @@ describe("Worktree", () => {
         })
 
         const layer = worktreeLayerWithStartCommandProbe(probe)
-        await Effect.runPromise(
+        const reset = Effect.runPromise(
           Worktree.Service.use((svc) => svc.reset({ directory: info.directory })).pipe(Effect.provide(layer)),
         )
+        const result = await Promise.race([
+          reset.then(() => "done" as const),
+          Bun.sleep(10_000).then(() => "timeout" as const),
+        ])
+        if (result === "timeout") {
+          probe.release?.()
+          await reset.catch(() => undefined)
+          throw new Error("Worktree.reset waited for the project start command to exit")
+        }
 
         expect(probe.spawned).toBe(true)
+        expect(probe.released).toBe(false)
         probe.release?.()
         await Worktree.remove({ directory: info.directory })
       })

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -2,8 +2,14 @@ import { $ } from "bun"
 import { afterEach, describe, expect, test } from "bun:test"
 
 const wintest = process.platform !== "win32" ? test : test.skip
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { NodePath } from "@effect/platform-node"
+import { Effect, Layer, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import fs from "fs/promises"
 import path from "path"
+import { Git } from "../../src/git"
 import { Instance } from "../../src/project/instance"
 import { Project } from "../../src/project/project"
 import { ProjectTable } from "../../src/project/project.sql"
@@ -11,8 +17,62 @@ import { Database, eq } from "../../src/storage/db"
 import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
 
+const encoder = new TextEncoder()
+
 function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
+}
+
+function startCommandSpawnProbe(probe: { spawned: boolean; release?: () => void }) {
+  return Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.gen(function* () {
+      const real = yield* ChildProcessSpawner.ChildProcessSpawner
+      return ChildProcessSpawner.make(
+        Effect.fnUntraced(function* (command) {
+          const std = ChildProcess.isStandardCommand(command) ? command : undefined
+          const text = std ? [std.command, ...std.args].join(" ") : ""
+          if (text.includes("start-spawn-probe")) {
+            probe.spawned = true
+            let released = false
+            let finish: (code: ChildProcessSpawner.ExitCode) => void = () => undefined
+            const exit = new Promise<ChildProcessSpawner.ExitCode>((resolve) => {
+              finish = resolve
+            })
+            probe.release = () => {
+              if (released) return
+              released = true
+              finish(ChildProcessSpawner.ExitCode(0))
+            }
+            return ChildProcessSpawner.makeHandle({
+              pid: ChildProcessSpawner.ProcessId(0),
+              exitCode: Effect.promise(() => exit),
+              isRunning: Effect.sync(() => !released),
+              kill: () => Effect.sync(() => probe.release?.()),
+              stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+              stdout: Stream.empty,
+              stderr: Stream.make(encoder.encode("")),
+              all: Stream.empty,
+              getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+              getOutputFd: () => Stream.empty,
+              unref: Effect.succeed(Effect.void),
+            })
+          }
+          return yield* real.spawn(command)
+        }),
+      )
+    }),
+  ).pipe(Layer.provide(CrossSpawnSpawner.defaultLayer))
+}
+
+function worktreeLayerWithStartCommandProbe(probe: { spawned: boolean; release?: () => void }) {
+  return Worktree.layer.pipe(
+    Layer.provide(Git.defaultLayer),
+    Layer.provide(Project.defaultLayer),
+    Layer.provide(startCommandSpawnProbe(probe)),
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(NodePath.layer),
+  )
 }
 
 function normalize(input: string) {
@@ -260,6 +320,30 @@ describe("Worktree", () => {
         }
         expect(await Bun.file(path.join(info.directory, ".reset-start-began")).text()).toBe("ready")
         await Bun.write(path.join(info.directory, ".reset-start-release"), "done")
+        await Worktree.remove({ directory: info.directory })
+      })
+    })
+
+    test("returns only after the project start command has spawned", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const probe = { spawned: false, release: undefined as (() => void) | undefined }
+
+      await withInstance(tmp.path, async () => {
+        const info = await Worktree.createReady({ name: "reset-start-spawn-probe" })
+        await Project.update({
+          projectID: Instance.project.id,
+          commands: {
+            start: "start-spawn-probe",
+          },
+        })
+
+        const layer = worktreeLayerWithStartCommandProbe(probe)
+        await Effect.runPromise(
+          Worktree.Service.use((svc) => svc.reset({ directory: info.directory })).pipe(Effect.provide(layer)),
+        )
+
+        expect(probe.spawned).toBe(true)
+        probe.release?.()
         await Worktree.remove({ directory: info.directory })
       })
     })

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -686,14 +686,6 @@ describe("automation runNow execution", () => {
           expect(providerCalls).toBe(1)
           const worktree = await Worktree.lookupBySlug("long-start")
           if (!worktree) throw new Error("expected worktree placement")
-          const deadline = Date.now() + 1_000
-          while (
-            !(await Bun.file(path.join(worktree.directory, ".automation-start-began")).exists()) &&
-            Date.now() < deadline
-          ) {
-            await Bun.sleep(20)
-          }
-          expect(await Bun.file(path.join(worktree.directory, ".automation-start-began")).text()).toBe("ready")
           await Bun.write(path.join(worktree.directory, ".automation-start-release"), "done")
         },
       })

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -19,6 +19,8 @@ import { Flock } from "../../src/util/flock"
 import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
 
+const RUN_WAIT_TIMEOUT_MS = 10_000
+
 afterEach(async () => {
   await Instance.disposeAll()
 })
@@ -46,7 +48,7 @@ function input(projectID: ProjectID, overrides: Partial<Extract<Automation.Creat
 }
 
 async function waitForRun(automationID: string, state: Automation.Run["state"]) {
-  const deadline = Date.now() + 2_000
+  const deadline = Date.now() + RUN_WAIT_TIMEOUT_MS
   while (Date.now() < deadline) {
     const run = Automation.runs({ automationID }).items.find((item) => item.state === state)
     if (run?.state === state) return run
@@ -56,7 +58,7 @@ async function waitForRun(automationID: string, state: Automation.Run["state"]) 
 }
 
 async function waitForRunCount(automationID: string, count: number) {
-  const deadline = Date.now() + 2_000
+  const deadline = Date.now() + RUN_WAIT_TIMEOUT_MS
   while (Date.now() < deadline) {
     const items = Automation.runs({ automationID, limit: 100 }).items
     if (items.length >= count) return items
@@ -66,7 +68,7 @@ async function waitForRunCount(automationID: string, count: number) {
 }
 
 async function waitForSucceededRunCount(automationID: string, count: number) {
-  const deadline = Date.now() + 2_000
+  const deadline = Date.now() + RUN_WAIT_TIMEOUT_MS
   while (Date.now() < deadline) {
     const items = Automation.runs({ automationID, limit: 100 }).items
     const succeeded = items.filter((run) => run.state === "succeeded")
@@ -77,7 +79,7 @@ async function waitForSucceededRunCount(automationID: string, count: number) {
 }
 
 async function waitForTerminalRun(automationID: string) {
-  const deadline = Date.now() + 2_000
+  const deadline = Date.now() + RUN_WAIT_TIMEOUT_MS
   while (Date.now() < deadline) {
     const run = Automation.runs({ automationID }).items.find((item) =>
       item.state === "succeeded" || item.state === "failed" || item.state === "stopped"
@@ -671,7 +673,7 @@ describe("automation runNow execution", () => {
           await Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
           const result = await Promise.race([
             waitForRun(definition.id, "succeeded").then((run) => ({ state: "succeeded" as const, run })),
-            Bun.sleep(2_000).then(() => ({ state: "timeout" as const })),
+            Bun.sleep(RUN_WAIT_TIMEOUT_MS).then(() => ({ state: "timeout" as const })),
           ])
           if (result.state === "timeout") {
             const worktree = await Worktree.lookupBySlug("long-start")


### PR DESCRIPTION
## Summary

Fixes the worktree start-command launch race exposed by the merged `windows-advisory` run after PR #1004.

- waits for a configured worktree start command to reach the process-spawn boundary before `createReady` / `reset` continue
- keeps stdout/stderr draining and process exit tracking in the background, so long-lived start commands still do not block prompt execution
- adds a deterministic regression test for the launch boundary and removes a Windows-sensitive shell marker assertion from the automation runner coverage

## Why

The merged `dev` run for commit `f9219cce6f58c54fd8191d9b2385d5530c037fa4` failed in `windows-advisory` on both `unit-windows-opencode-config-project` and `unit-windows-opencode-server-tools`.

PR #1004 correctly moved long-running worktree start commands out of the foreground path, but it forked the whole start-script task. That left no handshake for the middle state: the command has started, but has not exited. Windows scheduling exposed both sides of that race: callers could continue before the command had spawned, and tests with short wall-clock waits could misclassify slow Windows setup as waiting on command exit.

## Related Issue

No separate issue. Follow-up fix for the merged PR #1004 CI failure: https://github.com/Astro-Han/pawwork/actions/runs/26709693626

## Human Review Status

Pending

## Review Focus

Please focus on the `Worktree` start-script launch boundary:

- the new `Deferred<void>` barrier should wait only until the first configured start command spawns
- long-lived start commands should still drain and exit in the background
- project start commands should still run before per-worktree extra start commands
- start-command failures should preserve the existing best-effort logging behavior

## Risk Notes

Platform/CI: this targets a Windows CI failure in worktree start-command timing. The final branch was verified with both normal PR CI and a manual `windows-advisory` dispatch on the PR head.

Visible UI check skipped: no visible UI or copy changed.

Docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, and local-only docs were not changed.

XHigh review: a read-only reviewer found no blocking issues and judged the fix clean/elegant at the lowest correct layer. I applied its optional cleanup to make the launch barrier `Deferred<void>` because the barrier value is intentionally not consumed.

## How To Verify

```text
Diff whitespace check: git diff --check -> passed
Worktree regression suite: bun --cwd packages/opencode test test/project/worktree.test.ts --timeout 30000 -> 20 passed, 0 failed
Automation runner regression suite: OPENCODE_DB=:memory: bun --cwd packages/opencode test test/server/automation-runner.test.ts --timeout 30000 -> 22 passed, 0 failed
Worktree reset/remove adjacency suite: bun --cwd packages/opencode test test/project/worktree-remove.test.ts --timeout 30000 -> 4 passed, 1 skipped, 0 failed
Opencode typecheck: OPENCODE_DB=:memory: bun --cwd packages/opencode typecheck -> passed
PR checks: https://github.com/Astro-Han/pawwork/pull/1012/checks -> all required checks passed, including unit-opencode
Manual windows-advisory: https://github.com/Astro-Han/pawwork/actions/runs/26711660621 -> passed, including unit-windows-opencode-config-project and unit-windows-opencode-server-tools
XHigh reviewer: read-only review found no P0/P1/P2 issues
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
