### PR TITLE
refactor(server): effectify pty json route handlers

### DIFF
--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -3,6 +3,8 @@ import { describeRoute, validator, resolver } from "hono-openapi"
 import { HTTPException } from "hono/http-exception"
 import type { UpgradeWebSocket } from "hono/ws"
 import z from "zod"
+import { Effect } from "effect"
+import { AppRuntime } from "@/effect/app-runtime"
 import { Pty } from "@/pty"
 import { PtyID } from "@/pty/schema"
 import { ConnectToken, PtyTicket } from "@/pty/ticket"
@@ -48,7 +50,13 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
         },
       }),
       async (c) => {
-        return c.json(await Pty.list())
+        const sessions = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const pty = yield* Pty.Service
+            return yield* pty.list()
+          }),
+        )
+        return c.json(sessions)
       },
     )
     .post(
@@ -71,7 +79,13 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       }),
       validator("json", Pty.CreateInput),
       async (c) => {
-        const info = await Pty.create(c.req.valid("json"))
+        const input = c.req.valid("json")
+        const info = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const pty = yield* Pty.Service
+            return yield* pty.create(input)
+          }),
+        )
         return c.json(info)
       },
     )
@@ -95,7 +109,13 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
-        const info = await Pty.get(c.req.valid("param").ptyID)
+        const id = c.req.valid("param").ptyID
+        const info = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const pty = yield* Pty.Service
+            return yield* pty.get(id)
+          }),
+        )
         if (!info) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -124,7 +144,14 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       validator("json", Pty.UpdateInput),
       async (c) => {
-        const info = await Pty.update(c.req.valid("param").ptyID, c.req.valid("json"))
+        const id = c.req.valid("param").ptyID
+        const input = c.req.valid("json")
+        const info = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const pty = yield* Pty.Service
+            return yield* pty.update(id, input)
+          }),
+        )
         if (!info) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -152,11 +179,18 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
         const id = c.req.valid("param").ptyID
-        const info = await Pty.get(id)
-        if (!info) {
+        const removed = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const pty = yield* Pty.Service
+            const info = yield* pty.get(id)
+            if (!info) return false
+            yield* pty.remove(id)
+            return true
+          }),
+        )
+        if (!removed) {
           throw new NotFoundError({ message: "Session not found" })
         }
-        await Pty.remove(id)
         return c.json(true)
       },
     )


### PR DESCRIPTION
## Summary

Effectify the ordinary JSON PTY route handlers while leaving the WebSocket connection path unchanged:

- route PTY list/create/get/update/remove through `AppRuntime.runPromise(Effect.gen(...))`;
- yield `Pty.Service` from the runtime context instead of calling the async facade helpers;
- preserve route entrypoints, operation IDs, response bodies, not-found mapping, and the existing connect-token/WebSocket behavior.

## Why

Part of #936. The route handler effectification phase should move small, ordinary JSON handlers onto the shared Effect runtime before any larger route-group or HttpApi migration. PTY has focused route coverage and a clear boundary between JSON handlers and the WebSocket connect path.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please review whether the JSON handlers preserve the old PTY service call order and whether the WebSocket/connect-token boundary is truly unchanged.

## Risk Notes

- This is intended as a no-behavior-change route-handler refactor.
- The PTY WebSocket connect route and connect-token route are intentionally left on the existing path for this PR.
- Visible UI/copy check skipped: no visible UI or app copy changed.
- Platform impact considered: PTY behavior is platform-sensitive, but this PR does not change shell spawning, process lifecycle, WebSocket handling, or PTY implementation details.
- No docs, release notes, dependencies, permissions, credentials, generated content, public SDK/API shape, or local file behavior changed.

## How To Verify

```text
Dependency setup: bun install --frozen-lockfile completed in the isolated worktree.
Focused PTY route tests: bun test ./test/server/pty-routes.test.ts in packages/opencode -> passed, 11 tests.
Opencode typecheck: bun run typecheck in packages/opencode -> passed.
Whitespace: git diff --check -> clean.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.