### PR TITLE
refactor(server): effectify experimental json route handlers

### DIFF
--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -205,7 +205,13 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(await ToolRegistry.ids())
+        const ids = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const registry = yield* ToolRegistry.Service
+            return yield* registry.ids()
+          }),
+        )
+        return c.json(ids)
       },
     )
     .get(
@@ -248,11 +254,18 @@ export const ExperimentalRoutes = lazy(() =>
       ),
       async (c) => {
         const { provider, model } = c.req.valid("query")
-        const tools = await ToolRegistry.tools({
-          providerID: ProviderID.make(provider),
-          modelID: ModelID.make(model),
-          agent: await Agent.get(await Agent.defaultAgent()),
-        })
+        const tools = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const registry = yield* ToolRegistry.Service
+            const agents = yield* Agent.Service
+            const agent = yield* agents.get(yield* agents.defaultAgent())
+            return yield* registry.tools({
+              providerID: ProviderID.make(provider),
+              modelID: ModelID.make(model),
+              agent,
+            })
+          }),
+        )
         return c.json(
           tools.map((t) => ({
             id: t.id,
@@ -285,7 +298,12 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", Worktree.CreateInput.optional()),
       async (c) => {
         const body = c.req.valid("json")
-        const worktree = await Worktree.create(body)
+        const worktree = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const worktrees = yield* Worktree.Service
+            return yield* worktrees.create(body)
+          }),
+        )
         return c.json(worktree)
       },
     )
@@ -307,7 +325,12 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const worktrees = await Worktree.list()
+        const worktrees = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Worktree.Service
+            return yield* service.list()
+          }),
+        )
         return c.json(worktrees)
       },
     )
@@ -332,11 +355,21 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", Worktree.RemoveInput),
       async (c) => {
         const body = c.req.valid("json")
-        const session = await Session.findActiveWorktreeBinding(body.directory)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.findActiveWorktreeBinding(body.directory)
+          }),
+        )
         if (session) {
           throw new Error(`Worktree is in use by session "${session.title}". Call ExitWorktree from that session first.`)
         }
-        await Worktree.remove(body)
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const worktrees = yield* Worktree.Service
+            yield* worktrees.remove(body)
+          }),
+        )
         return c.json(true)
       },
     )
@@ -361,7 +394,12 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", Worktree.ResetInput),
       async (c) => {
         const body = c.req.valid("json")
-        await Worktree.reset(body)
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const worktrees = yield* Worktree.Service
+            yield* worktrees.reset(body)
+          }),
+        )
         return c.json(true)
       },
     )
@@ -463,7 +501,13 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(await MCP.resources())
+        const resources = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const mcp = yield* MCP.Service
+            return yield* mcp.resources()
+          }),
+        )
+        return c.json(resources)
       },
     ),
 )

--- a/packages/opencode/test/server/experimental-routes.test.ts
+++ b/packages/opencode/test/server/experimental-routes.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { Log } from "@opencode-ai/core/util/log"
+import { Instance } from "../../src/project/instance"
+import { ExperimentalRoutes } from "../../src/server/instance/experimental"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("experimental routes", () => {
+  function app() {
+    return new Hono().route("/experimental", ExperimentalRoutes())
+  }
+
+  test("lists tool IDs through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/experimental/tool/ids")
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toBeArray()
+      },
+    })
+  })
+
+  test("lists worktrees through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/experimental/worktree")
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toBeArray()
+      },
+    })
+  })
+
+  test("lists MCP resources through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/experimental/resource")
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toBeObject()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Effectify the ordinary JSON handlers in the experimental route for tool, worktree, and MCP resource endpoints.

## Why

Issue #936 is moving route handlers onto AppRuntime-backed services while preserving the existing HTTP API shape. This keeps the experimental JSON route handlers on the Effect service path without touching the workspace sub-router or session pagination generator.

## Related Issue

Fixes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the migrated handlers preserve the same response shape and avoid crossing into `/experimental/workspace` or `/experimental/session` behavior.

## Risk Notes

No visible UI or copy changed, so the UI checklist item is not applicable.
No platform, packaging, updater, signing, path, shell, or permissions surface was touched, so the platform checklist item is not applicable.
No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surface changed beyond the focused route test.

## How To Verify

```text
Focused route test: cd packages/opencode && bun test ./test/server/experimental-routes.test.ts -> 3 passed, 0 failed
Typecheck: cd packages/opencode && bun run typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.