### PR TITLE
refactor(server): effectify global config route handlers

### DIFF
--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -392,7 +392,13 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
         },
       }),
       async (c) => {
-        return c.json(await Config.getGlobal())
+        const config = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Config.Service
+            return yield* service.getGlobal()
+          }),
+        )
+        return c.json(config)
       },
     )
     .patch(
@@ -416,7 +422,12 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
       validator("json", Config.Info.zod),
       async (c) => {
         const config = c.req.valid("json")
-        const next = await Config.updateGlobal(config)
+        const next = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Config.Service
+            return yield* service.updateGlobal(config)
+          }),
+        )
         return c.json(next)
       },
     )

--- a/packages/opencode/test/server/global-config-routes.test.ts
+++ b/packages/opencode/test/server/global-config-routes.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Hono } from "hono"
+import { Config } from "../../src/config"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Global } from "../../src/global"
+import { Instance } from "../../src/project/instance"
+import { GlobalRoutes } from "../../src/server/instance/global"
+import { tmpdir } from "../fixture/fixture"
+import { withConfigDepsLock } from "../shared/config-deps-lock"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+async function invalidateConfig() {
+  await AppRuntime.runPromise(Config.Service.use((svc) => svc.invalidate(true)))
+}
+
+async function withIsolatedGlobalConfig<T>(fn: (globalDir: string) => Promise<T>) {
+  await using global = await tmpdir()
+  const previousRuntime = process.env.PAWWORK_RUNTIME_NAMESPACE
+  const previousHome = process.env.PAWWORK_HOME
+  const previousConfigDir = process.env.PAWWORK_CONFIG_DIR
+  const previousConfig = Global.Path.config
+
+  process.env.PAWWORK_RUNTIME_NAMESPACE = "pawwork"
+  process.env.PAWWORK_HOME = global.path
+  delete process.env.PAWWORK_CONFIG_DIR
+  ;(Global.Path as { config: string }).config = global.path
+  await invalidateConfig()
+
+  try {
+    return await fn(global.path)
+  } finally {
+    ;(Global.Path as { config: string }).config = previousConfig
+    if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
+    else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
+    if (previousHome === undefined) delete process.env.PAWWORK_HOME
+    else process.env.PAWWORK_HOME = previousHome
+    if (previousConfigDir === undefined) delete process.env.PAWWORK_CONFIG_DIR
+    else process.env.PAWWORK_CONFIG_DIR = previousConfigDir
+    await invalidateConfig()
+  }
+}
+
+describe("global config routes", () => {
+  test("gets and patches global config through the route runtime", async () => {
+    await withConfigDepsLock(async () => {
+      await withIsolatedGlobalConfig(async (globalDir) => {
+        const app = new Hono().route("/global", GlobalRoutes())
+
+        const before = await app.request("/global/config")
+        expect(before.status).toBe(200)
+
+        const response = await app.request("/global/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: "test/model" }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body.model).toBe("test/model")
+        expect(JSON.parse(await fs.readFile(path.join(globalDir, "pawwork.json"), "utf8")).model).toBe("test/model")
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Effectify the global configuration JSON handlers by resolving `Config.Service` through `AppRuntime`.

## Why

Issue #936 is moving route handlers onto AppRuntime-backed services while preserving the existing HTTP API shape. This keeps `/config` GET and PATCH on the Effect service path without touching global SSE, dispose, or upgrade routes.

## Related Issue

Fixes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether `/config` GET/PATCH preserve their response shape and whether the test isolates global config writes to a temporary PawWork Home.

## Risk Notes

No visible UI or copy changed, so the UI checklist item is not applicable.
No platform, packaging, updater, signing, path, shell, or permissions surface was touched, so the platform checklist item is not applicable.
Global config file writes are covered by an isolated temporary `PAWWORK_HOME` route test.

## How To Verify

```text
Focused route test: cd packages/opencode && bun test ./test/server/global-config-routes.test.ts -> 1 passed, 0 failed
Typecheck: cd packages/opencode && bun run typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.