### PR TITLE
refactor(server): effectify session core route handlers

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -193,7 +193,12 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const session = await Session.get(sessionID)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.get(sessionID)
+          }),
+        )
         return c.json(session)
       },
     )
@@ -224,7 +229,12 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const session = await Session.children(sessionID)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.children(sessionID)
+          }),
+        )
         return c.json(session)
       },
     )
@@ -309,7 +319,12 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        await Session.remove(sessionID)
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            yield* sessions.remove(sessionID)
+          }),
+        )
         return c.json(true)
       },
     )
@@ -352,22 +367,27 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         const updates = c.req.valid("json")
-        const current = await Session.get(sessionID)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            const current = yield* sessions.get(sessionID)
 
-        if (updates.title !== undefined) {
-          await Session.setTitle({ sessionID, title: updates.title })
-        }
-        if (updates.permission !== undefined) {
-          await Session.setPermission({
-            sessionID,
-            permission: Permission.merge(current.permission ?? [], updates.permission),
-          })
-        }
-        if (updates.time?.archived !== undefined) {
-          await Session.setArchived({ sessionID, time: updates.time.archived })
-        }
+            if (updates.title !== undefined) {
+              yield* sessions.setTitle({ sessionID, title: updates.title })
+            }
+            if (updates.permission !== undefined) {
+              yield* sessions.setPermission({
+                sessionID,
+                permission: Permission.merge(current.permission ?? [], updates.permission),
+              })
+            }
+            if (updates.time?.archived !== undefined) {
+              yield* sessions.setArchived({ sessionID, time: updates.time.archived })
+            }
 
-        const session = await Session.get(sessionID)
+            return yield* sessions.get(sessionID)
+          }),
+        )
         return c.json(session)
       },
     )
@@ -445,7 +465,12 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         const body = c.req.valid("json")
-        const result = await Session.fork({ ...body, sessionID })
+        const result = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.fork({ ...body, sessionID })
+          }),
+        )
         return c.json(result)
       },
     )

--- a/packages/opencode/test/server/session-core-routes.test.ts
+++ b/packages/opencode/test/server/session-core-routes.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session as SessionNs } from "../../src/session"
+import type { SessionID } from "../../src/session/schema"
+import { Log } from "../../src/util"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
+  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
+}
+
+const svc = {
+  ...SessionNs,
+  create(input?: Parameters<typeof SessionNs.create>[0]) {
+    return run(SessionNs.Service.use((svc) => svc.create(input)))
+  },
+  remove(id: SessionID) {
+    return run(SessionNs.Service.use((svc) => svc.remove(id)))
+  },
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("session core routes", () => {
+  test("get, children, update, fork, and delete use the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const root = await svc.create({ title: "root-session" })
+        const child = await svc.create({ title: "child-session", parentID: root.id })
+        let forkID: SessionID | undefined
+
+        try {
+          const app = Server.Default().app
+
+          const getRes = await app.request(`/session/${root.id}`)
+          expect(getRes.status).toBe(200)
+          expect((await getRes.json()).id).toBe(root.id)
+
+          const childrenRes = await app.request(`/session/${root.id}/children`)
+          const children = await childrenRes.json()
+          expect(childrenRes.status).toBe(200)
+          expect(children.map((session: { id: string }) => session.id)).toContain(child.id)
+
+          const updateRes = await app.request(`/session/${root.id}`, {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ title: "renamed-session" }),
+          })
+          const updated = await updateRes.json()
+          expect(updateRes.status).toBe(200)
+          expect(updated.title).toBe("renamed-session")
+
+          const forkRes = await app.request(`/session/${root.id}/fork`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({}),
+          })
+          const fork = await forkRes.json()
+          forkID = fork.id
+          expect(forkRes.status).toBe(200)
+          expect(typeof fork.id).toBe("string")
+          expect(fork.id).not.toBe(root.id)
+
+          const deleteRes = await app.request(`/session/${fork.id}`, { method: "DELETE" })
+          forkID = undefined
+          expect(deleteRes.status).toBe(200)
+          expect(await deleteRes.json()).toBe(true)
+        } finally {
+          if (forkID) await svc.remove(forkID).catch(() => undefined)
+          await svc.remove(child.id).catch(() => undefined)
+          await svc.remove(root.id).catch(() => undefined)
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Effectify the core session JSON handlers for get, children, delete, update, and fork.

## Why

Issue #936 is moving route handlers onto AppRuntime-backed services while preserving the existing HTTP API shape. This keeps the small session CRUD/fork routes on `Session.Service` without touching prompt, share, message streaming, revert, permission, or route shape behavior.

## Related Issue

Fixes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the migrated handlers preserve their existing response shape and whether the PR stays limited to core session JSON routes.

## Risk Notes

No visible UI or copy changed, so the UI checklist item is not applicable.
No platform, packaging, updater, signing, path, shell, or permissions surface was touched, so the platform checklist item is not applicable.
No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surface changed beyond the focused route test.

## How To Verify

```text
Focused route test: cd packages/opencode && bun test ./test/server/session-core-routes.test.ts -> 1 passed, 0 failed
Typecheck: cd packages/opencode && bun run typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.