### PR TITLE
refactor(server): effectify session message route handlers

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1119,25 +1119,41 @@ export const SessionRoutes = lazy(() =>
         const query = c.req.valid("query")
         const sessionID = c.req.valid("param").sessionID
         if (query.limit === undefined) {
-          await Session.get(sessionID)
-          const messages = await Session.messages({ sessionID })
+          const messages = await AppRuntime.runPromise(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              yield* sessions.get(sessionID)
+              return yield* sessions.messages({ sessionID })
+            }),
+          )
           return c.json(messages)
         }
 
         if (query.limit === 0) {
-          await Session.get(sessionID)
-          const messages = await Session.messages({ sessionID })
+          const messages = await AppRuntime.runPromise(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              yield* sessions.get(sessionID)
+              return yield* sessions.messages({ sessionID })
+            }),
+          )
           return c.json(messages)
         }
 
-        const page = await Session.messagesPage({
-          sessionID,
-          limit: query.limit,
-          before: query.before,
-        })
+        const limit = query.limit
+        const page = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.messagesPage({
+              sessionID,
+              limit,
+              before: query.before,
+            })
+          }),
+        )
         if (page.cursor) {
           const url = new URL(c.req.url)
-          url.searchParams.set("limit", query.limit.toString())
+          url.searchParams.set("limit", limit.toString())
           url.searchParams.set("before", page.cursor)
           c.header("Access-Control-Expose-Headers", "Link, X-Next-Cursor")
           c.header("Link", `<${url.toString()}>; rel=\"next\"`)
@@ -1254,11 +1270,16 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const params = c.req.valid("param")
-        await Session.removePart({
-          sessionID: params.sessionID,
-          messageID: params.messageID,
-          partID: params.partID,
-        })
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            yield* sessions.removePart({
+              sessionID: params.sessionID,
+              messageID: params.messageID,
+              partID: params.partID,
+            })
+          }),
+        )
         return c.json(true)
       },
     )
@@ -1296,7 +1317,12 @@ export const SessionRoutes = lazy(() =>
             `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
           )
         }
-        const part = await Session.updatePart(body)
+        const part = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.updatePart(body)
+          }),
+        )
         return c.json(part)
       },
     )

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -29,6 +29,9 @@ const svc = {
   updatePart<T extends MessageV2.Part>(part: T) {
     return run(SessionNs.Service.use((svc) => svc.updatePart(part)))
   },
+  messages(input: Parameters<typeof SessionNs.messages>[0]) {
+    return run(SessionNs.Service.use((svc) => svc.messages(input)))
+  },
 }
 
 afterEach(async () => {
@@ -356,6 +359,62 @@ describe("session messages endpoint", () => {
           expect(res.status).toBe(200)
           const body = (await res.json()) as MessageV2.WithParts[]
           expect(body).toHaveLength(510)
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
+  test("updates and deletes message parts through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await svc.create({})
+          const messageID = MessageID.ascending()
+          const partID = PartID.ascending()
+          await svc.updateMessage({
+            id: messageID,
+            sessionID: session.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "test",
+            model: { providerID: "test", modelID: "test" },
+            tools: {},
+            mode: "",
+          } as unknown as MessageV2.Info)
+          await svc.updatePart({
+            id: partID,
+            sessionID: session.id,
+            messageID,
+            type: "text",
+            text: "before",
+          })
+          const app = Server.Default().app
+
+          const update = await app.request(`/session/${session.id}/message/${messageID}/part/${partID}`, {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              id: partID,
+              sessionID: session.id,
+              messageID,
+              type: "text",
+              text: "after",
+            }),
+          })
+          const updated = await update.json()
+          expect(update.status).toBe(200)
+          expect(updated.text).toBe("after")
+
+          const remove = await app.request(`/session/${session.id}/message/${messageID}/part/${partID}`, {
+            method: "DELETE",
+          })
+          expect(remove.status).toBe(200)
+          expect(await remove.json()).toBe(true)
+          expect((await svc.messages({ sessionID: session.id }))[0].parts).toHaveLength(0)
 
           await svc.remove(session.id)
         },


### PR DESCRIPTION
## Summary

Effectify the session message-list and message-part JSON handlers.

## Why

Issue #936 is moving route handlers onto AppRuntime-backed services while preserving the existing HTTP API shape. This keeps message list/page and part delete/update routes on `Session.Service` without touching prompt streaming, prompt_async, single-message `MessageV2.get`, or SDK/OpenAPI shapes.

## Related Issue

Fixes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether message pagination headers and part update/delete response shapes remain unchanged.

## Risk Notes

No visible UI or copy changed, so the UI checklist item is not applicable.
No platform, packaging, updater, signing, path, shell, or permissions surface was touched, so the platform checklist item is not applicable.
No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surface changed beyond the focused route test update.

## How To Verify

```text
Focused route tests: cd packages/opencode && bun test ./test/server/session-messages.test.ts -> 10 passed, 0 failed
Typecheck: cd packages/opencode && bun run typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.