### PR TITLE
refactor(server): effectify session summary route handlers

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -662,10 +662,15 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const query = c.req.valid("query")
         const params = c.req.valid("param")
-        const result = await SessionSummary.diff({
-          sessionID: params.sessionID,
-          messageID: query.messageID,
-        })
+        const result = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const summary = yield* SessionSummary.Service
+            return yield* summary.diff({
+              sessionID: params.sessionID,
+              messageID: query.messageID,
+            })
+          }),
+        )
         return c.json(result)
       },
     )
@@ -926,9 +931,14 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const params = c.req.valid("param")
-        const result = await SessionSummary.artifacts({
-          sessionID: params.sessionID,
-        })
+        const result = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const summary = yield* SessionSummary.Service
+            return yield* summary.artifacts({
+              sessionID: params.sessionID,
+            })
+          }),
+        )
         return c.json(result)
       },
     )

--- a/packages/opencode/test/server/session-runtime-routes.test.ts
+++ b/packages/opencode/test/server/session-runtime-routes.test.ts
@@ -30,7 +30,7 @@ afterEach(async () => {
 })
 
 describe("session runtime routes", () => {
-  test("share, unshare, artifacts, command, and shell routes are wired through the instance router", async () => {
+  test("share, unshare, diff, artifacts, command, and shell routes are wired through the instance router", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
       directory: tmp.path,
@@ -69,6 +69,10 @@ describe("session runtime routes", () => {
         const artifactsRes = await app.request(`/session/${session.id}/artifacts`)
         expect(artifactsRes.status).toBe(200)
         expect(Array.isArray(await artifactsRes.json())).toBe(true)
+
+        const diffRes = await app.request(`/session/${session.id}/diff`)
+        expect(diffRes.status).toBe(200)
+        expect(await diffRes.json()).toHaveProperty("kind")
 
         const commandRes = await app.request(`/session/${session.id}/command`, {
           method: "POST",


### PR DESCRIPTION
## Summary

Effectify the session diff and artifacts JSON handlers.

## Why

Issue #936 is moving route handlers onto AppRuntime-backed services while preserving the existing HTTP API shape. This keeps the read-only session summary routes on `SessionSummary.Service` without touching summarize, prompt, share, revert, or permission behavior.

## Related Issue

Fixes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether `/:sessionID/diff` and `/:sessionID/artifacts` preserve their existing response shape and remain limited to read-only summary routes.

## Risk Notes

No visible UI or copy changed, so the UI checklist item is not applicable.
No platform, packaging, updater, signing, path, shell, or permissions surface was touched, so the platform checklist item is not applicable.
No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surface changed beyond the focused route test update.

## How To Verify

```text
Focused route test: cd packages/opencode && bun test ./test/server/session-runtime-routes.test.ts -> 1 passed, 0 failed
Typecheck: cd packages/opencode && bun run typecheck -> passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.