### PR TITLE
fix(app): show startup state during root redirect

### DIFF
--- a/packages/app/e2e/app/root-redirect.spec.ts
+++ b/packages/app/e2e/app/root-redirect.spec.ts
@@ -1,18 +1,58 @@
 import { test, expect } from "../fixtures"
+import type { Page, Route } from "@playwright/test"
 
-test("@smoke root route falls back to backend project when local store is empty", async ({ page, project }) => {
-  await project.open()
-
-  await page.evaluate(() => {
+async function seedServerWithoutProjects(page: Page, serverUrl: string) {
+  await page.addInitScript((serverUrl) => {
     const key = "pawwork.global.dat:server"
-    const raw = localStorage.getItem(key)
-    if (!raw) return
-    const parsed = JSON.parse(raw) as { projects?: Record<string, unknown> }
-    parsed.projects = {}
-    localStorage.setItem(key, JSON.stringify(parsed))
+    localStorage.setItem(key, JSON.stringify({ list: [serverUrl], projects: {}, lastProject: {} }))
+    localStorage.setItem("pawwork.settings.dat:defaultServerUrl", serverUrl)
+  }, serverUrl)
+}
+
+async function delayProjectDiscovery(page: Page) {
+  let releaseStartup!: () => void
+  const startupPending = new Promise<void>((resolve) => {
+    releaseStartup = resolve
   })
+  const delayDiscovery = async (route: Route) => {
+    await startupPending
+    await route.continue()
+  }
+  await page.route("**/path", delayDiscovery)
+  await page.route("**/project", delayDiscovery)
+  return releaseStartup
+}
+
+test("@smoke root route falls back to backend project when local store is empty", async ({ page, backend }) => {
+  await seedServerWithoutProjects(page, backend.url)
 
   await page.goto("/")
 
   await expect(page).toHaveURL(/\/[A-Za-z0-9_-]+\/session/)
+})
+
+test("root route shows startup state while backend project discovery is pending", async ({ page, backend }) => {
+  await seedServerWithoutProjects(page, backend.url)
+  const releaseStartup = await delayProjectDiscovery(page)
+
+  await page.goto("/")
+
+  const main = page.locator('[data-component="desktop-shell-main"]')
+  await expect(main).toBeVisible()
+  await expect(main.locator('[data-component="app-startup-pending"]')).toBeVisible()
+
+  releaseStartup()
+  await expect(page).toHaveURL(/\/[A-Za-z0-9_-]+\/session/)
+})
+
+test("direct session route does not wait for startup autoselect discovery", async ({ page, backend, slug }) => {
+  await seedServerWithoutProjects(page, backend.url)
+  const releaseStartup = await delayProjectDiscovery(page)
+
+  await page.goto(`/${slug}/session`)
+
+  await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
+  await expect(page.locator('[data-component="app-startup-pending"]')).toHaveCount(0)
+
+  releaseStartup()
 })

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -43,6 +43,7 @@ import { PromptProvider } from "@/context/prompt"
 import { ServerConnection, ServerProvider, serverName, useServer } from "@/context/server"
 import { SettingsProvider } from "@/context/settings"
 import { TerminalProvider } from "@/context/terminal"
+import { AppStartupPending } from "@/components/app-startup-pending"
 import { AboutModal, type AboutInfo } from "@/components/about-modal"
 import DirectoryLayout from "@/pages/directory-layout"
 import Layout from "@/pages/layout"
@@ -54,7 +55,7 @@ import { base64Encode } from "@opencode-ai/util/encode"
 
 const loadSession = () => import("@/pages/session")
 const Session = lazy(loadSession)
-const Loading = () => <div class="size-full" />
+const Loading = () => <AppStartupPending />
 
 if (typeof location === "object" && /\/session(?:\/|$)/.test(location.pathname)) {
   void loadSession()
@@ -80,7 +81,7 @@ const HomeRedirectRoute = () => {
   return (
     <Show
       when={target()}
-      fallback={<div data-component="home-redirect-pending" class="size-full" aria-hidden="true" />}
+      fallback={<AppStartupPending />}
     >
       {(directory) => <Navigate href={`/${base64Encode(directory())}/session`} />}
     </Show>

--- a/packages/app/src/components/app-startup-pending.test.ts
+++ b/packages/app/src/components/app-startup-pending.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
+
+const browserCheck = String.raw`
+import { render } from "solid-js/web"
+import { createComponent } from "solid-js"
+import { mock } from "bun:test"
+
+mock.module("./src/context/language.tsx", () => ({
+  useLanguage: () => ({
+    t: (key) => {
+      if (key === "app.startup.opening") return "正在打开爪印"
+      return key
+    },
+  }),
+}))
+
+import { AppStartupPending } from "./src/components/app-startup-pending.tsx"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+globalThis.React = {
+  createElement(type, props, ...children) {
+    if (typeof type === "function") return type({ ...(props ?? {}), children })
+
+    const node = document.createElement(type)
+    const classNames = []
+    for (const [key, value] of Object.entries(props ?? {})) {
+      if (value === undefined || value === null || value === false) continue
+      if (key === "class" || key === "className") {
+        classNames.push(String(value))
+        continue
+      }
+      node.setAttribute(key, String(value))
+    }
+    if (classNames.length > 0) node.setAttribute("class", classNames.join(" "))
+
+    const append = (child) => {
+      if (Array.isArray(child)) {
+        for (const item of child) append(item)
+        return
+      }
+      if (child === undefined || child === null || child === false) return
+      node.append(child instanceof Node ? child : document.createTextNode(String(child)))
+    }
+    for (const child of children) append(child)
+    return node
+  },
+}
+
+const root = document.createElement("div")
+document.body.append(root)
+const dispose = render(() => createComponent(AppStartupPending, {}), root)
+
+const state = root.querySelector('[data-component="app-startup-pending"]')
+assert(state, "startup pending state should render")
+assert(state.getAttribute("role") === "status", "startup pending state should expose status semantics")
+assert(state.getAttribute("aria-label") === "正在打开爪印", "startup pending aria-label should follow the active locale")
+
+dispose()
+root.remove()
+`
+
+describe("AppStartupPending", () => {
+  test("uses the active locale for its status label", () => {
+    runBrowserCheck(browserCheck)
+  })
+})

--- a/packages/app/src/components/app-startup-pending.tsx
+++ b/packages/app/src/components/app-startup-pending.tsx
@@ -1,0 +1,14 @@
+import { Splash } from "@opencode-ai/ui/logo"
+
+export function AppStartupPending() {
+  return (
+    <div
+      data-component="app-startup-pending"
+      role="status"
+      aria-label="Opening PawWork"
+      class="size-full bg-bg-base flex items-center justify-center"
+    >
+      <Splash class="w-12 h-15 opacity-50 animate-pulse" />
+    </div>
+  )
+}

--- a/packages/app/src/components/app-startup-pending.tsx
+++ b/packages/app/src/components/app-startup-pending.tsx
@@ -1,11 +1,14 @@
 import { Splash } from "@opencode-ai/ui/logo"
+import { useLanguage } from "@/context/language"
 
 export function AppStartupPending() {
+  const language = useLanguage()
+
   return (
     <div
       data-component="app-startup-pending"
       role="status"
-      aria-label="Opening PawWork"
+      aria-label={language.t("app.startup.opening")}
       class="size-full bg-bg-base flex items-center justify-center"
     >
       <Splash class="w-12 h-15 opacity-50 animate-pulse" />

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -324,6 +324,7 @@ export const dict = {
   "app.server.unreachable": "Could not reach {{server}}",
   "app.server.retrying": "Retrying automatically...",
   "app.server.otherServers": "Other servers",
+  "app.startup.opening": "Opening PawWork",
 
   "dialog.server.title": "Servers",
   "dialog.server.description": "Switch which PawWork server this app connects to.",

--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -6,6 +6,7 @@ const locales = [zh]
 const keys = [
   "command.session.previous.unseen",
   "command.session.next.unseen",
+  "app.startup.opening",
   "home.hero.title",
   "session.panel.addTab",
   "session.panel.utility",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -983,6 +983,7 @@ export const dict = {
   "app.server.unreachable": "无法连接到 {{server}}",
   "app.server.retrying": "正在自动重试...",
   "app.server.otherServers": "其他服务器",
+  "app.startup.opening": "正在打开爪印",
   "dialog.server.add.usernamePlaceholder": "用户名",
   "dialog.server.add.passwordPlaceholder": "密码",
   "server.row.noUsername": "无用户名",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -121,6 +121,7 @@ import { PawworkTitlebar } from "./layout/pawwork-titlebar"
 import { createDefaultLayoutPageState, createLayoutPagePersistTarget, removePinnedSessionIDs } from "./layout/layout-page-store"
 import { SettingsContent, SettingsNav, isSettingsTab, type SettingsTab } from "@/pages/settings/settings-shell"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
+import { AppStartupPending } from "@/components/app-startup-pending"
 import { sessionTitle } from "@/utils/session-title"
 import { sizingStopEvents } from "@/pages/session/helpers"
 
@@ -359,6 +360,7 @@ export default function Layout(props: ParentProps) {
     if (!dir) return
     await openProject(dir, true)
   })
+  const startupAutoselectPending = () => state.autoselect && autoselecting.loading
 
   const workspaceName = (directory: string, projectId?: string, branch?: string) => {
     const key = workspaceKey(directory)
@@ -2429,7 +2431,7 @@ export default function Layout(props: ParentProps) {
                       aria-hidden={settingsOpen() || undefined}
                       classList={{ "size-full": true, invisible: settingsOpen() }}
                     >
-                      <Show when={!autoselecting.loading} fallback={<div class="size-full" />}>
+                      <Show when={!startupAutoselectPending()} fallback={<AppStartupPending />}>
                         {props.children}
                       </Show>
                     </div>


### PR DESCRIPTION
## Summary

Show a visible PawWork startup state while the root route is waiting for backend project discovery, so first-open startup does not look like a blank main pane.

## Why

A renderer diagnostics export for a first-open blank-screen report showed the captured session state only after the UI had recovered. A focused delayed-backend probe reproduced the visible symptom: the shell could render while the main pane stayed empty until `/path` and `/project` discovery finished and the app navigated into `/:dir/session`.

The root cause is that startup autoselect blocked the layout main slot with an empty fallback. Root redirect and lazy session fallback also used empty placeholders.

## Related Issue

No GitHub issue. This is a maintainer-reported first-open renderer diagnostics investigation.

## Human Review Status

Pending

## Review Focus

Please focus on the startup routing conditions in `Layout`: direct `/:dir/session` routes should render immediately and should not wait for startup autoselect discovery, while `/` still shows a non-empty startup state while backend project discovery is pending.

## Risk Notes

Low UI-state risk. The change does not alter backend discovery, project selection, persistence schemas, permissions, packaging, or platform-specific paths. It only replaces blank fallbacks with a visible startup state and narrows the layout blocking condition to true startup autoselect.

Conditional checklist notes:
- Platform/packaging impact: not applicable; no native, packaging, updater, signing, path, shell, or permission code changed.
- Docs/release/dependencies/permissions/generated/local-file surfaces: not applicable.

## How To Verify

```text
RED check: the new root-route pending E2E failed before the fix because app-startup-pending was missing.
Focused E2E: bun --cwd packages/app playwright test e2e/app/root-redirect.spec.ts -> 3 passed.
Typecheck: bun run typecheck in packages/app -> passed.
Lint: bun run lint -> passed.
Whitespace: git diff --check -> passed.
Visual check: delayed fake backend root route showed a centered PawWork startup splash instead of a blank main pane.
```

## Screenshots or Recordings

Visible UI was checked locally with a delayed fake backend. The captured pending state shows the PawWork splash centered in the main pane instead of an empty white surface. Local screenshot path: `/tmp/pawwork-startup-pending.png`.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

