### PR TITLE
refactor(server): effectify file json route handlers

### DIFF
--- a/packages/opencode/src/server/instance/file.ts
+++ b/packages/opencode/src/server/instance/file.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import { Effect } from "effect"
 import z from "zod"
 import { File } from "../../file"
 import { Ripgrep } from "../../file/ripgrep"
@@ -42,13 +43,14 @@ export const FileRoutes = lazy(() =>
       async (c) => {
         const pattern = c.req.valid("query").pattern
         const result = await AppRuntime.runPromise(
-          Ripgrep.Service.use((rg) =>
-            rg.search({
+          Effect.gen(function* () {
+            const rg = yield* Ripgrep.Service
+            return yield* rg.search({
               cwd: Instance.directory,
               pattern,
               limit: 10,
-            }),
-          ),
+            })
+          }),
         )
         return c.json(result)
       },
@@ -84,12 +86,17 @@ export const FileRoutes = lazy(() =>
         const dirs = c.req.valid("query").dirs
         const type = c.req.valid("query").type
         const limit = c.req.valid("query").limit
-        const results = await File.search({
-          query,
-          limit: limit ?? 10,
-          dirs: dirs !== "false",
-          type,
-        })
+        const results = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const file = yield* File.Service
+            return yield* file.search({
+              query,
+              limit: limit ?? 10,
+              dirs: dirs !== "false",
+              type,
+            })
+          }),
+        )
         return c.json(results)
       },
     )
@@ -150,7 +157,12 @@ export const FileRoutes = lazy(() =>
       ),
       async (c) => {
         const path = c.req.valid("query").path
-        const content = await File.list(path)
+        const content = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const file = yield* File.Service
+            return yield* file.list(path)
+          }),
+        )
         return c.json(content)
       },
     )
@@ -179,7 +191,12 @@ export const FileRoutes = lazy(() =>
       ),
       async (c) => {
         const path = c.req.valid("query").path
-        const content = await File.read(path)
+        const content = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const file = yield* File.Service
+            return yield* file.read(path)
+          }),
+        )
         return c.json(content)
       },
     )
@@ -201,7 +218,12 @@ export const FileRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const content = await File.status()
+        const content = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const file = yield* File.Service
+            return yield* file.status()
+          }),
+        )
         return c.json(content)
       },
     ),

--- a/packages/opencode/test/server/file-routes.test.ts
+++ b/packages/opencode/test/server/file-routes.test.ts
@@ -1,0 +1,60 @@
+import { $ } from "bun"
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Hono } from "hono"
+import { Log } from "@opencode-ai/core/util/log"
+import { Instance } from "../../src/project/instance"
+import { FileRoutes } from "../../src/server/instance/file"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("file routes", () => {
+  function app() {
+    return new Hono().route("/", FileRoutes())
+  }
+
+  test("finds, lists, and reads files through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await fs.writeFile(path.join(tmp.path, "sample.txt"), "hello\n", "utf-8")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const found = await app().request("/find/file?query=sample&dirs=false")
+        expect(found.status).toBe(200)
+        expect(await found.json()).toContain("sample.txt")
+
+        const listed = await app().request("/file?path=.")
+        expect(listed.status).toBe(200)
+        expect((await listed.json()).map((item: { name: string }) => item.name)).toContain("sample.txt")
+
+        const read = await app().request("/file/content?path=sample.txt")
+        expect(read.status).toBe(200)
+        expect(await read.json()).toMatchObject({ type: "text", content: "hello" })
+      },
+    })
+  })
+
+  test("returns file status through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await fs.writeFile(path.join(tmp.path, "tracked.txt"), "original\n", "utf-8")
+    await $`git add tracked.txt`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "add file"`.cwd(tmp.path).quiet()
+    await fs.writeFile(path.join(tmp.path, "tracked.txt"), "changed\n", "utf-8")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/file/status")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual([{ path: "tracked.txt", added: 1, removed: 1, status: "modified" }])
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Migrate the ordinary file JSON route handlers to the existing `AppRuntime.runPromise(Effect.gen(...))` route runtime pattern.

## Why

This continues the #936 ordinary JSON route migration while preserving the current file search, list, read, and status contracts. Streaming, auth, workspace sync, v2, and SDK/OpenAPI source generation are not touched.

## Related Issue

Refs #936

## Human Review Status

Pending

## Review Focus

Please check that the route handlers only delegate through the Effect services and keep existing JSON responses unchanged for file search/list/read/status.

## Risk Notes

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; server-only route refactor.
- Platform/packaging check: not applicable; no platform or packaging surface touched.
- Docs/release/dependency/local file check: not applicable; no docs, dependencies, generated content, credentials, or local-only files changed.

## How To Verify

```text
Focused route tests: bun test test/server/file-routes.test.ts -> 2 pass, 0 fail
Diff check: git diff --cached --check -> passed before commit
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.