### PR TITLE
refactor(server): effectify project json route handlers

### DIFF
--- a/packages/opencode/src/server/instance/project.ts
+++ b/packages/opencode/src/server/instance/project.ts
@@ -1,12 +1,14 @@
 import { Hono } from "hono"
 import { describeRoute, validator } from "hono-openapi"
 import { resolver } from "hono-openapi"
+import { Effect } from "effect"
 import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
 import z from "zod"
 import { ProjectID } from "../../project/schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { AppRuntime } from "../../effect/app-runtime"
 
 export const ProjectRoutes = lazy(() =>
   new Hono()
@@ -28,7 +30,12 @@ export const ProjectRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const projects = Project.list()
+        const projects = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Project.Service
+            return yield* service.list()
+          }),
+        )
         return c.json(projects)
       },
     )
@@ -50,7 +57,12 @@ export const ProjectRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(Instance.project)
+        const project = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            return Instance.project
+          }),
+        )
+        return c.json(project)
       },
     )
     .post(
@@ -73,16 +85,24 @@ export const ProjectRoutes = lazy(() =>
       async (c) => {
         const dir = Instance.directory
         const prev = Instance.project
-        const next = await Project.initGit({
-          directory: dir,
-          project: prev,
-        })
-        if (next.id === prev.id && next.vcs === prev.vcs && next.worktree === prev.worktree) return c.json(next)
-        await Instance.reload({
-          directory: dir,
-          worktree: dir,
-          project: next,
-        })
+        const next = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Project.Service
+            const project = yield* service.initGit({
+              directory: dir,
+              project: prev,
+            })
+            if (project.id === prev.id && project.vcs === prev.vcs && project.worktree === prev.worktree) return project
+            yield* Effect.promise(() =>
+              Instance.reload({
+                directory: dir,
+                worktree: dir,
+                project,
+              }),
+            )
+            return project
+          }),
+        )
         return c.json(next)
       },
     )
@@ -109,7 +129,12 @@ export const ProjectRoutes = lazy(() =>
       async (c) => {
         const projectID = c.req.valid("param").projectID
         const body = c.req.valid("json")
-        const project = await Project.update({ ...body, projectID })
+        const project = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const service = yield* Project.Service
+            return yield* service.update({ ...body, projectID })
+          }),
+        )
         return c.json(project)
       },
     ),

--- a/packages/opencode/src/server/instance/project.ts
+++ b/packages/opencode/src/server/instance/project.ts
@@ -57,12 +57,7 @@ export const ProjectRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const project = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            return Instance.project
-          }),
-        )
-        return c.json(project)
+        return c.json(Instance.project)
       },
     )
     .post(

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -17,6 +17,25 @@ afterEach(async () => {
 })
 
 describe("project.initGit endpoint", () => {
+  test("lists and reads projects through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const app = Server.Default().app
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const headers = { "x-opencode-directory": tmp.path }
+        const list = await app.request("/project", { headers })
+        expect(list.status).toBe(200)
+        expect(await list.json()).toBeArray()
+
+        const current = await app.request("/project/current", { headers })
+        expect(current.status).toBe(200)
+        expect(await current.json()).toMatchObject({ vcs: "git", worktree: tmp.path })
+      },
+    })
+  })
+
   test("initializes git and reloads immediately", async () => {
     await using tmp = await tmpdir()
     const app = Server.Default().app


### PR DESCRIPTION
## Summary

Migrate the project JSON route handlers to the existing `AppRuntime.runPromise(Effect.gen(...))` route runtime pattern.

## Why

This continues the #936 ordinary JSON route migration for the project route group without changing public route contracts or touching forbidden streaming, auth, workspace sync, v2, or SDK/OpenAPI source areas.

## Related Issue

Refs #936

## Human Review Status

Pending

## Review Focus

Please check that project list/current/init/update still delegate to the same project/instance behavior while route service access moves through the Effect runtime.

## Risk Notes

`PATCH /project/:projectID` is migrated through the same `Project.Service.update` path; the focused local route coverage exercises list/current/init because the simple fixture does not create an updateable project row without broadening into product setup.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; server-only route refactor.
- Platform/packaging check: not applicable; no platform or packaging surface touched.
- Docs/release/dependency/local file check: not applicable; no docs, dependencies, generated content, credentials, or local-only files changed.

## How To Verify

```text
Focused route tests: bun test test/server/project-init-git.test.ts -> 3 pass, 0 fail
Diff check: git diff --cached --check -> passed before commit
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.