### PR TITLE
refactor(server): effectify permission reply route

### DIFF
--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -79,11 +79,16 @@ export const PermissionRoutes = lazy(() =>
       async (c) => {
         const params = c.req.valid("param")
         const json = c.req.valid("json")
-        await Permission.reply({
-          requestID: params.requestID,
-          reply: json.reply,
-          message: json.message,
-        })
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const permission = yield* Permission.Service
+            yield* permission.reply({
+              requestID: params.requestID,
+              reply: json.reply,
+              message: json.message,
+            })
+          }),
+        )
         return c.json(true)
       },
     )

--- a/packages/opencode/test/server/permission-routes.test.ts
+++ b/packages/opencode/test/server/permission-routes.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Deferred } from "effect"
+import { Hono } from "hono"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Permission } from "../../src/permission"
+import { PermissionID } from "../../src/permission/schema"
+import { Instance } from "../../src/project/instance"
+import { PermissionRoutes } from "../../src/server/instance/permission"
+import { SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("permission routes", () => {
+  function app() {
+    return new Hono().route("/permission", PermissionRoutes())
+  }
+
+  test("replies to a pending permission through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const requestID = PermissionID.ascending()
+        const pending = await AppRuntime.runPromise(Deferred.make<void>())
+        const asked = AppRuntime.runPromise(
+          Permission.Service.use((permission) =>
+            permission.ask({
+              id: requestID,
+              sessionID: SessionID.descending(),
+              permission: "bash",
+              patterns: ["echo ok"],
+              metadata: {},
+              always: ["echo ok"],
+              ruleset: [{ permission: "bash", pattern: "echo ok", action: "ask" }],
+              onPending: () => Deferred.succeed(pending, undefined),
+            }),
+          ),
+        )
+
+        await AppRuntime.runPromise(Deferred.await(pending))
+
+        const response = await app().request(`/permission/${requestID}/reply`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reply: "once" }),
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toBe(true)
+        await expect(asked).resolves.toBeUndefined()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Migrate `POST /permission/:requestID/reply` to the existing `AppRuntime.runPromise(Effect.gen(...))` route runtime pattern.

## Why

This continues the #936 ordinary JSON route migration for a narrow permission JSON route without changing permission semantics or touching auth, streaming, automation, workspace sync, v2, or SDK/OpenAPI source areas.

## Related Issue

Refs #936

## Human Review Status

Pending

## Review Focus

Please check that the route still forwards the same request ID, reply, and optional message to `Permission.Service.reply`.

## Risk Notes

This PR does not change the e2e permission seed route or permission list pruning behavior.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; server-only route refactor.
- Platform/packaging check: not applicable; no platform or packaging surface touched.
- Docs/release/dependency/local file check: not applicable; no docs, dependencies, generated content, credentials, or local-only files changed.

## How To Verify

```text
Focused route tests: bun test test/server/permission-routes.test.ts -> 1 pass, 0 fail
Diff check: git diff --cached --check -> passed before commit
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal permission request handling logic.

* **Tests**
  * Added comprehensive test coverage for permission request routes to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->