### PR TITLE
refactor(server): effectify mcp status route

### DIFF
--- a/packages/opencode/src/server/instance/mcp.ts
+++ b/packages/opencode/src/server/instance/mcp.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import { Effect } from "effect"
 import z from "zod"
 import { MCP } from "../../mcp"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { AppRuntime } from "../../effect/app-runtime"
 
 export const McpRoutes = lazy(() =>
   new Hono()
@@ -26,7 +28,13 @@ export const McpRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(await MCP.status())
+        const status = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const mcp = yield* MCP.Service
+            return yield* mcp.status()
+          }),
+        )
+        return c.json(status)
       },
     )
     .post(

--- a/packages/opencode/test/server/mcp-routes.test.ts
+++ b/packages/opencode/test/server/mcp-routes.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { Instance } from "../../src/project/instance"
+import { McpRoutes } from "../../src/server/instance/mcp"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("MCP routes", () => {
+  function app() {
+    return new Hono().route("/mcp", McpRoutes())
+  }
+
+  test("returns MCP status through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/mcp")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toBeObject()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Migrate `GET /mcp` to the existing `AppRuntime.runPromise(Effect.gen(...))` route runtime pattern.

## Why

This continues the #936 ordinary JSON route migration for the safe MCP status read path. OAuth/auth routes and connect/disconnect/add routes are intentionally left unchanged.

## Related Issue

Refs #936

## Human Review Status

Pending

## Review Focus

Please check that this PR only moves the MCP status read through `MCP.Service.status` and does not touch OAuth or MCP connection behavior.

## Risk Notes

Remaining MCP routes are skipped because they involve OAuth, config mutation, or external MCP connection side effects.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; server-only route refactor.
- Platform/packaging check: not applicable; no platform or packaging surface touched.
- Docs/release/dependency/local file check: not applicable; no docs, dependencies, generated content, credentials, or local-only files changed.

## How To Verify

```text
Focused route tests: bun test test/server/mcp-routes.test.ts -> 1 pass, 0 fail
Diff check: git diff --cached --check -> passed before commit
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.