### PR TITLE
refactor(server): effectify external result route

### DIFF
--- a/packages/opencode/src/server/instance/external-result.ts
+++ b/packages/opencode/src/server/instance/external-result.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
+import { Effect } from "effect"
 import z from "zod"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
@@ -7,6 +8,7 @@ import { SessionID, MessageID } from "@/session/schema"
 import { ExternalResult } from "@/tool/external-result"
 import { lazy } from "../../util/lazy"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "@/effect/app-runtime"
 
 const log = Log.create({ service: "server" })
 
@@ -52,7 +54,12 @@ export const ExternalResultRoutes = lazy(() =>
           // schema), so we coerce here using the canonical brand maker.
           const sessionID = SessionID.make(snap.sessionID)
           const messageID = MessageID.make(snap.messageID)
-          const session = await Session.get(sessionID)
+          const session = await AppRuntime.runPromise(
+            Effect.gen(function* () {
+              const sessions = yield* Session.Service
+              return yield* sessions.get(sessionID)
+            }),
+          )
           // Brief retry for the register → updateToolCall race: ExternalResult
           // entry is set before processor.updateToolCall flushes the part row
           // to DB. Without the retry a reload that hits this millisecond
@@ -60,11 +67,11 @@ export const ExternalResultRoutes = lazy(() =>
           // message.part.updated either because the child session/message
           // never made it into the store (part.updated reducer does not
           // upsert session info).
-          let message = await MessageV2.get({ sessionID, messageID })
+          let message = MessageV2.get({ sessionID, messageID })
           let part = message.parts.find((p) => p.type === "tool" && p.callID === snap.callID)
           for (let attempt = 0; !part && attempt < 3; attempt++) {
             await new Promise((resolve) => setTimeout(resolve, 50))
-            message = await MessageV2.get({ sessionID, messageID })
+            message = MessageV2.get({ sessionID, messageID })
             part = message.parts.find((p) => p.type === "tool" && p.callID === snap.callID)
           }
           if (!part) continue

--- a/packages/opencode/test/server/external-result-routes.test.ts
+++ b/packages/opencode/test/server/external-result-routes.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Hono } from "hono"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Instance } from "../../src/project/instance"
+import { ExternalResultRoutes } from "../../src/server/instance/external-result"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ExternalResult } from "../../src/tool/external-result"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  ExternalResult.__resetForTests()
+  await Instance.disposeAll()
+})
+
+describe("external-result routes", () => {
+  function app() {
+    return new Hono().route("/external-result", ExternalResultRoutes())
+  }
+
+  test("skips stale pending external-result entries through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Effect.runPromise(
+          ExternalResult.register({
+            sessionID: SessionID.descending(),
+            messageID: MessageID.ascending(),
+            callID: "call_stale_external_result_route",
+            inputSnapshot: { questions: ["q1"] },
+          }),
+        )
+
+        const response = await app().request("/external-result")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual([])
+      },
+    })
+  })
+
+  test("hydrates pending external-result tool calls through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await AppRuntime.runPromise(Session.Service.use((service) => service.create({})))
+        const userID = MessageID.ascending()
+        await AppRuntime.runPromise(
+          Session.Service.use((service) =>
+            service.updateMessage({
+              id: userID,
+              sessionID: session.id,
+              role: "user",
+              time: { created: 1 },
+              agent: "user",
+              model: { providerID: "test", modelID: "test" },
+              tools: {},
+              mode: "",
+            } as unknown as MessageV2.Info),
+          ),
+        )
+
+        const assistantID = MessageID.ascending()
+        await AppRuntime.runPromise(
+          Session.Service.use((service) =>
+            service.updateMessage({
+              id: assistantID,
+              sessionID: session.id,
+              role: "assistant",
+              parentID: userID,
+              time: { created: 2 },
+              agent: "build",
+              mode: "build",
+              path: { cwd: tmp.path, root: tmp.path },
+              cost: 0,
+              tokens: {
+                total: 0,
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+              modelID: "test",
+              providerID: "test",
+            } as unknown as MessageV2.Info),
+          ),
+        )
+
+        const callID = "call_external_result_route"
+        const partID = PartID.ascending()
+        await AppRuntime.runPromise(
+          Session.Service.use((service) =>
+            service.updatePart({
+              id: partID,
+              sessionID: session.id,
+              messageID: assistantID,
+              type: "tool",
+              tool: "question",
+              callID,
+              state: {
+                status: "running",
+                input: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] },
+                raw: "",
+                time: { start: 3 },
+                metadata: { externalResultReady: true },
+              },
+            } as unknown as MessageV2.Part),
+          ),
+        )
+
+        await Effect.runPromise(
+          ExternalResult.register({
+            sessionID: session.id,
+            messageID: assistantID,
+            callID,
+            inputSnapshot: { questions: ["q1"] },
+          }),
+        )
+
+        const response = await app().request("/external-result")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual([
+          expect.objectContaining({
+            session: expect.objectContaining({ id: session.id }),
+            message: expect.objectContaining({ id: assistantID }),
+            part: expect.objectContaining({ id: partID, callID }),
+          }),
+        ])
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Migrate `GET /external-result` to use the existing `AppRuntime.runPromise(Effect.gen(...))` route runtime pattern for session lookup.

## Why

This continues the #936 ordinary JSON route migration for a PawWork-owned hydration route while preserving the existing stale-entry skip behavior and pending tool-call response shape.

## Related Issue

Refs #936

## Human Review Status

Pending

## Review Focus

Please check that stale session/message entries are still skipped and that successful pending external-result hydration returns the same session/message/part trio.

## Risk Notes

This route has race-sensitive recovery behavior. The focused test covers both stale pending entries and a live pending external-result tool part.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; server-only route refactor.
- Platform/packaging check: not applicable; no platform or packaging surface touched.
- Docs/release/dependency/local file check: not applicable; no docs, dependencies, generated content, credentials, or local-only files changed.

## How To Verify

```text
Focused route tests: bun test test/server/external-result-routes.test.ts -> 2 pass, 0 fail
Diff check: git diff --cached --check -> passed before commit
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.