### PR TITLE
refactor(server): effectify provider list route

### DIFF
--- a/packages/opencode/src/server/instance/provider.ts
+++ b/packages/opencode/src/server/instance/provider.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import { Effect } from "effect"
 import z from "zod"
 import { Config } from "../../config/config"
 import { Provider } from "../../provider/provider"
@@ -40,11 +41,18 @@ export const ProviderRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const config = await Config.get()
+        const [config, allProviders, connected] = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const config = yield* Config.Service
+            const provider = yield* Provider.Service
+            return yield* Effect.all([config.get(), Effect.promise(() => ModelsDev.get()), provider.list()], {
+              concurrency: 3,
+            })
+          }),
+        )
         const disabled = new Set(config.disabled_providers ?? [])
         const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
 
-        const allProviders = await ModelsDev.get()
         const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
         for (const [key, value] of Object.entries(allProviders)) {
           if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
@@ -52,7 +60,6 @@ export const ProviderRoutes = lazy(() =>
           }
         }
 
-        const connected = await Provider.list()
         const providers = Object.assign(
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { Instance } from "../../src/project/instance"
+import { ProviderRoutes } from "../../src/server/instance/provider"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("provider routes", () => {
+  function app() {
+    return new Hono().route("/provider", ProviderRoutes())
+  }
+
+  test("lists providers through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/provider")
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body.all).toBeArray()
+        expect(body.default).toBeObject()
+        expect(body.connected).toBeArray()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- migrate the ordinary `GET /provider` JSON route to `AppRuntime.runPromise(Effect.gen(...))`
- keep provider auth and OAuth routes unchanged
- add focused route coverage for the provider list response shape

Refs #936

## Verification
- `bun test test/server/provider-routes.test.ts`

## Risk
- Full CI not run locally; this PR only changes the provider list JSON handler and its focused route test.