### PR TITLE
refactor(app): extract layout command registration

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -65,13 +65,13 @@ import { usePortableDraft } from "@/components/prompt-input/portable-draft"
 import { createMigrationStorageIO } from "@/components/prompt-input/homepage-migration-storage"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
-import { useCommand, type CommandOption } from "@/context/command"
+import { useTheme } from "@opencode-ai/ui/theme/context"
+import { useCommand } from "@/context/command"
 import { getDraggableId } from "@/utils/solid-dnd"
 import { DebugBar } from "@/components/debug-bar"
 import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
-import { useLanguage, type Locale } from "@/context/language"
+import { useLanguage } from "@/context/language"
 import {
   displayName,
   effectiveWorkspaceOrder,
@@ -107,6 +107,7 @@ import {
 import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
+import { registerLayoutCommands } from "./layout/layout-commands"
 import {
   buildPawworkSessionWindow,
   nextPawworkSessionWindowLimit,
@@ -175,13 +176,6 @@ export default function Layout(props: ParentProps) {
       dir: globalSync.peek(dir, { bootstrap: false })[0].path.directory || dir,
     }
   })
-  const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]
-  const colorSchemeKey: Record<ColorScheme, "theme.scheme.system" | "theme.scheme.light" | "theme.scheme.dark"> = {
-    system: "theme.scheme.system",
-    light: "theme.scheme.light",
-    dark: "theme.scheme.dark",
-  }
-  const colorSchemeLabel = (scheme: ColorScheme) => language.t(colorSchemeKey[scheme])
   const currentDir = createMemo(() => route().dir)
   const pawworkSidebar = createMemo(() => globalSync.data.project.length <= 1)
 
@@ -235,37 +229,6 @@ export default function Layout(props: ParentProps) {
   const closeEditor = editor.closeEditor
   const setEditor = editor.setEditor
   const InlineEditor = editor.InlineEditor
-
-  function cycleColorScheme(direction = 1) {
-    const current = theme.colorScheme()
-    const currentIndex = colorSchemeOrder.indexOf(current)
-    const nextIndex =
-      currentIndex === -1 ? 0 : (currentIndex + direction + colorSchemeOrder.length) % colorSchemeOrder.length
-    const next = colorSchemeOrder[nextIndex]
-    theme.setColorScheme(next)
-    showToast({
-      title: language.t("toast.scheme.title"),
-      description: colorSchemeLabel(next),
-    })
-  }
-
-  function setLocale(next: Locale) {
-    if (next === language.locale()) return
-    language.setLocale(next)
-    showToast({
-      title: language.t("toast.language.title"),
-      description: language.t("toast.language.description", { language: language.label(next) }),
-    })
-  }
-
-  function cycleLanguage(direction = 1) {
-    const locales = language.locales
-    const currentIndex = locales.indexOf(language.locale())
-    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + direction + locales.length) % locales.length
-    const next = locales[nextIndex]
-    if (!next) return
-    setLocale(next)
-  }
 
   useUpdatePolling({
     platform,
@@ -1264,191 +1227,6 @@ export default function Layout(props: ParentProps) {
     ))
   }
 
-  command.register("layout", () => {
-    const commands: CommandOption[] = [
-      {
-        id: "sidebar.toggle",
-        title: language.t("command.sidebar.toggle"),
-        category: language.t("command.category.view"),
-        keybind: "mod+b",
-        onSelect: () => layout.sidebar.toggle(),
-      },
-      {
-        id: "project.open",
-        title: language.t("command.project.open"),
-        category: language.t("command.category.project"),
-        keybind: "mod+o",
-        onSelect: () => chooseProject(),
-      },
-      {
-        id: "project.previous",
-        title: language.t("command.project.previous"),
-        category: language.t("command.category.project"),
-        keybind: "mod+alt+arrowup",
-        onSelect: () => navigateProjectByOffset(-1),
-      },
-      {
-        id: "project.next",
-        title: language.t("command.project.next"),
-        category: language.t("command.category.project"),
-        keybind: "mod+alt+arrowdown",
-        onSelect: () => navigateProjectByOffset(1),
-      },
-      {
-        id: "provider.connect",
-        title: language.t("command.provider.connect"),
-        category: language.t("command.category.provider"),
-        onSelect: () => connectProvider(),
-      },
-      {
-        id: "server.switch",
-        title: language.t("command.server.switch"),
-        category: language.t("command.category.server"),
-        onSelect: () => openServer(),
-      },
-      {
-        id: "settings.open",
-        title: language.t("command.settings.open"),
-        category: language.t("command.category.settings"),
-        keybind: "mod+comma",
-        onSelect: () => openSettings(),
-      },
-      {
-        id: "settings.openGlobalConfigFolder",
-        title: language.t("command.settings.openGlobalConfigFolder"),
-        category: language.t("command.category.settings"),
-        disabled: !platform.openPath,
-        onSelect: async () => {
-          const target = await globalSDK.client.path
-            .get({ ensureConfig: true })
-            .then((x) => x.data?.config)
-            .catch((err) => {
-              showToast({
-                title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-                description: errorMessage(err, language.t("common.requestFailed")),
-                variant: "error",
-              })
-              return undefined
-            })
-          if (!target) return
-          await platform.openPath?.(target).catch((err) => {
-            showToast({
-              title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-              description: errorMessage(err, language.t("common.requestFailed")),
-              variant: "error",
-            })
-          })
-        },
-      },
-      {
-        id: "session.previous",
-        title: language.t("command.session.previous"),
-        category: language.t("command.category.session"),
-        keybind: "alt+arrowup",
-        onSelect: () => navigateSessionByOffset(-1),
-      },
-      {
-        id: "session.next",
-        title: language.t("command.session.next"),
-        category: language.t("command.category.session"),
-        keybind: "alt+arrowdown",
-        onSelect: () => navigateSessionByOffset(1),
-      },
-      {
-        id: "session.previous.unseen",
-        title: language.t("command.session.previous.unseen"),
-        category: language.t("command.category.session"),
-        keybind: "shift+alt+arrowup",
-        onSelect: () => navigateSessionByUnseen(-1),
-      },
-      {
-        id: "session.next.unseen",
-        title: language.t("command.session.next.unseen"),
-        category: language.t("command.category.session"),
-        keybind: "shift+alt+arrowdown",
-        onSelect: () => navigateSessionByUnseen(1),
-      },
-      {
-        id: "workspace.new",
-        title: language.t("workspace.new"),
-        category: language.t("command.category.workspace"),
-        keybind: "mod+shift+w",
-        disabled: !workspaceSetting(),
-        onSelect: () => {
-          const project = currentProject()
-          if (!project) return
-          return createWorkspace(project)
-        },
-      },
-      {
-        id: "workspace.toggle",
-        title: language.t("command.workspace.toggle"),
-        description: language.t("command.workspace.toggle.description"),
-        category: language.t("command.category.workspace"),
-        slash: "workspace",
-        disabled: !currentProject() || currentProject()?.vcs !== "git",
-        onSelect: () => {
-          const project = currentProject()
-          if (!project) return
-          if (project.vcs !== "git") return
-          const wasEnabled = layout.sidebar.workspaces(project.worktree)()
-          layout.sidebar.toggleWorkspaces(project.worktree)
-          showToast({
-            title: wasEnabled
-              ? language.t("toast.workspace.disabled.title")
-              : language.t("toast.workspace.enabled.title"),
-            description: wasEnabled
-              ? language.t("toast.workspace.disabled.description")
-              : language.t("toast.workspace.enabled.description"),
-          })
-        },
-      },
-    ]
-
-    // Only register color-scheme commands when the current theme actually
-    // supports switching. The bundled pawwork theme forces light for Phase 1.
-    if (theme.canSwitchColorScheme()) {
-      commands.push({
-        id: "theme.scheme.cycle",
-        title: language.t("command.theme.scheme.cycle"),
-        category: language.t("command.category.theme"),
-        keybind: "mod+shift+s",
-        onSelect: () => cycleColorScheme(1),
-      })
-
-      for (const scheme of colorSchemeOrder) {
-        commands.push({
-          id: `theme.scheme.${scheme}`,
-          title: language.t("command.theme.scheme.set", { scheme: colorSchemeLabel(scheme) }),
-          category: language.t("command.category.theme"),
-          onSelect: () => theme.commitPreview(),
-          onHighlight: () => {
-            theme.previewColorScheme(scheme)
-            return () => theme.cancelPreview()
-          },
-        })
-      }
-    }
-
-    commands.push({
-      id: "language.cycle",
-      title: language.t("command.language.cycle"),
-      category: language.t("command.category.language"),
-      onSelect: () => cycleLanguage(1),
-    })
-
-    for (const locale of language.locales) {
-      commands.push({
-        id: `language.set.${locale}`,
-        title: language.t("command.language.set", { language: language.label(locale) }),
-        category: language.t("command.category.language"),
-        onSelect: () => setLocale(locale),
-      })
-    }
-
-    return commands
-  })
-
   function connectProvider() {
     const run = ++dialogRun
     void import("@/components/dialog-select-provider")
@@ -2231,6 +2009,25 @@ export default function Layout(props: ParentProps) {
     globalSync.child(created.directory)
     navigate(`/${base64Encode(created.directory)}/session`)
   }
+
+  registerLayoutCommands({
+    command,
+    language,
+    layout,
+    theme,
+    platform,
+    globalSDK,
+    currentProject,
+    workspaceSetting,
+    chooseProject,
+    navigateProjectByOffset,
+    connectProvider,
+    openServer,
+    openSettings,
+    navigateSessionByOffset,
+    navigateSessionByUnseen,
+    createWorkspace,
+  })
 
   const workspaceSidebarCtx: WorkspaceSidebarContext = {
     currentDir,

--- a/packages/app/src/pages/layout/layout-commands.ts
+++ b/packages/app/src/pages/layout/layout-commands.ts
@@ -1,0 +1,271 @@
+import type { Accessor } from "solid-js"
+import type { LocalProject, useLayout } from "@/context/layout"
+import type { useCommand, CommandOption } from "@/context/command"
+import type { useGlobalSDK } from "@/context/global-sdk"
+import type { Locale, useLanguage } from "@/context/language"
+import type { usePlatform } from "@/context/platform"
+import type { ColorScheme, useTheme } from "@opencode-ai/ui/theme/context"
+import { showToast } from "@opencode-ai/ui/toast"
+import { errorMessage } from "./helpers"
+
+type LayoutCommandRegistration = {
+  command: ReturnType<typeof useCommand>
+  language: ReturnType<typeof useLanguage>
+  layout: ReturnType<typeof useLayout>
+  theme: ReturnType<typeof useTheme>
+  platform: ReturnType<typeof usePlatform>
+  globalSDK: ReturnType<typeof useGlobalSDK>
+  currentProject: Accessor<LocalProject | undefined>
+  workspaceSetting: Accessor<unknown>
+  chooseProject: () => void
+  navigateProjectByOffset: (offset: number) => void
+  connectProvider: () => void
+  openServer: () => void
+  openSettings: () => void
+  navigateSessionByOffset: (offset: number) => void
+  navigateSessionByUnseen: (offset: number) => void
+  createWorkspace: (project: LocalProject) => unknown
+}
+
+const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]
+const colorSchemeKey: Record<ColorScheme, "theme.scheme.system" | "theme.scheme.light" | "theme.scheme.dark"> = {
+  system: "theme.scheme.system",
+  light: "theme.scheme.light",
+  dark: "theme.scheme.dark",
+}
+
+export function registerLayoutCommands(input: LayoutCommandRegistration) {
+  const {
+    command,
+    language,
+    layout,
+    theme,
+    platform,
+    globalSDK,
+    currentProject,
+    workspaceSetting,
+    chooseProject,
+    navigateProjectByOffset,
+    connectProvider,
+    openServer,
+    openSettings,
+    navigateSessionByOffset,
+    navigateSessionByUnseen,
+    createWorkspace,
+  } = input
+  const colorSchemeLabel = (scheme: ColorScheme) => language.t(colorSchemeKey[scheme])
+
+  function cycleColorScheme(direction = 1) {
+    const current = theme.colorScheme()
+    const currentIndex = colorSchemeOrder.indexOf(current)
+    const nextIndex =
+      currentIndex === -1 ? 0 : (currentIndex + direction + colorSchemeOrder.length) % colorSchemeOrder.length
+    const next = colorSchemeOrder[nextIndex]
+    theme.setColorScheme(next)
+    showToast({
+      title: language.t("toast.scheme.title"),
+      description: colorSchemeLabel(next),
+    })
+  }
+
+  function setLocale(next: Locale) {
+    if (next === language.locale()) return
+    language.setLocale(next)
+    showToast({
+      title: language.t("toast.language.title"),
+      description: language.t("toast.language.description", { language: language.label(next) }),
+    })
+  }
+
+  function cycleLanguage(direction = 1) {
+    const locales = language.locales
+    const currentIndex = locales.indexOf(language.locale())
+    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + direction + locales.length) % locales.length
+    const next = locales[nextIndex]
+    if (!next) return
+    setLocale(next)
+  }
+
+  command.register("layout", () => {
+    const commands: CommandOption[] = [
+      {
+        id: "sidebar.toggle",
+        title: language.t("command.sidebar.toggle"),
+        category: language.t("command.category.view"),
+        keybind: "mod+b",
+        onSelect: () => layout.sidebar.toggle(),
+      },
+      {
+        id: "project.open",
+        title: language.t("command.project.open"),
+        category: language.t("command.category.project"),
+        keybind: "mod+o",
+        onSelect: () => chooseProject(),
+      },
+      {
+        id: "project.previous",
+        title: language.t("command.project.previous"),
+        category: language.t("command.category.project"),
+        keybind: "mod+alt+arrowup",
+        onSelect: () => navigateProjectByOffset(-1),
+      },
+      {
+        id: "project.next",
+        title: language.t("command.project.next"),
+        category: language.t("command.category.project"),
+        keybind: "mod+alt+arrowdown",
+        onSelect: () => navigateProjectByOffset(1),
+      },
+      {
+        id: "provider.connect",
+        title: language.t("command.provider.connect"),
+        category: language.t("command.category.provider"),
+        onSelect: () => connectProvider(),
+      },
+      {
+        id: "server.switch",
+        title: language.t("command.server.switch"),
+        category: language.t("command.category.server"),
+        onSelect: () => openServer(),
+      },
+      {
+        id: "settings.open",
+        title: language.t("command.settings.open"),
+        category: language.t("command.category.settings"),
+        keybind: "mod+comma",
+        onSelect: () => openSettings(),
+      },
+      {
+        id: "settings.openGlobalConfigFolder",
+        title: language.t("command.settings.openGlobalConfigFolder"),
+        category: language.t("command.category.settings"),
+        disabled: !platform.openPath,
+        onSelect: async () => {
+          const target = await globalSDK.client.path
+            .get({ ensureConfig: true })
+            .then((x) => x.data?.config)
+            .catch((err) => {
+              showToast({
+                title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+                description: errorMessage(err, language.t("common.requestFailed")),
+                variant: "error",
+              })
+              return undefined
+            })
+          if (!target) return
+          await platform.openPath?.(target).catch((err) => {
+            showToast({
+              title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+              description: errorMessage(err, language.t("common.requestFailed")),
+              variant: "error",
+            })
+          })
+        },
+      },
+      {
+        id: "session.previous",
+        title: language.t("command.session.previous"),
+        category: language.t("command.category.session"),
+        keybind: "alt+arrowup",
+        onSelect: () => navigateSessionByOffset(-1),
+      },
+      {
+        id: "session.next",
+        title: language.t("command.session.next"),
+        category: language.t("command.category.session"),
+        keybind: "alt+arrowdown",
+        onSelect: () => navigateSessionByOffset(1),
+      },
+      {
+        id: "session.previous.unseen",
+        title: language.t("command.session.previous.unseen"),
+        category: language.t("command.category.session"),
+        keybind: "shift+alt+arrowup",
+        onSelect: () => navigateSessionByUnseen(-1),
+      },
+      {
+        id: "session.next.unseen",
+        title: language.t("command.session.next.unseen"),
+        category: language.t("command.category.session"),
+        keybind: "shift+alt+arrowdown",
+        onSelect: () => navigateSessionByUnseen(1),
+      },
+      {
+        id: "workspace.new",
+        title: language.t("workspace.new"),
+        category: language.t("command.category.workspace"),
+        keybind: "mod+shift+w",
+        disabled: !workspaceSetting(),
+        onSelect: () => {
+          const project = currentProject()
+          if (!project) return
+          return createWorkspace(project)
+        },
+      },
+      {
+        id: "workspace.toggle",
+        title: language.t("command.workspace.toggle"),
+        description: language.t("command.workspace.toggle.description"),
+        category: language.t("command.category.workspace"),
+        slash: "workspace",
+        disabled: !currentProject() || currentProject()?.vcs !== "git",
+        onSelect: () => {
+          const project = currentProject()
+          if (!project) return
+          if (project.vcs !== "git") return
+          const wasEnabled = layout.sidebar.workspaces(project.worktree)()
+          layout.sidebar.toggleWorkspaces(project.worktree)
+          showToast({
+            title: wasEnabled
+              ? language.t("toast.workspace.disabled.title")
+              : language.t("toast.workspace.enabled.title"),
+            description: wasEnabled
+              ? language.t("toast.workspace.disabled.description")
+              : language.t("toast.workspace.enabled.description"),
+          })
+        },
+      },
+    ]
+
+    if (theme.canSwitchColorScheme()) {
+      commands.push({
+        id: "theme.scheme.cycle",
+        title: language.t("command.theme.scheme.cycle"),
+        category: language.t("command.category.theme"),
+        keybind: "mod+shift+s",
+        onSelect: () => cycleColorScheme(1),
+      })
+
+      for (const scheme of colorSchemeOrder) {
+        commands.push({
+          id: `theme.scheme.${scheme}`,
+          title: language.t("command.theme.scheme.set", { scheme: colorSchemeLabel(scheme) }),
+          category: language.t("command.category.theme"),
+          onSelect: () => theme.commitPreview(),
+          onHighlight: () => {
+            theme.previewColorScheme(scheme)
+            return () => theme.cancelPreview()
+          },
+        })
+      }
+    }
+
+    commands.push({
+      id: "language.cycle",
+      title: language.t("command.language.cycle"),
+      category: language.t("command.category.language"),
+      onSelect: () => cycleLanguage(1),
+    })
+
+    for (const locale of language.locales) {
+      commands.push({
+        id: `language.set.${locale}`,
+        title: language.t("command.language.set", { language: language.label(locale) }),
+        category: language.t("command.category.language"),
+        onSelect: () => setLocale(locale),
+      })
+    }
+
+    return commands
+  })
+}


### PR DESCRIPTION
## Summary

Extracted the layout command registration from `packages/app/src/pages/layout.tsx` into `packages/app/src/pages/layout/layout-commands.ts`.

This PR is the first slice of the `layout.tsx` owner extraction work tracked under #606. The PR keeps the boundary to command registration only.

## Why

`layout.tsx` currently owns too many unrelated responsibilities. Moving command registration into its own owner reduces the main component without changing command IDs, keybinds, labels, disabled states, or callbacks.

## Related Issue

Related: #606

## Human Review Status

Pending

## Review Focus

Confirm that the extracted `registerLayoutCommands` preserves the existing command catalog and only depends on callbacks/state already owned by `layout.tsx`.

## Risk Notes

No intended behavior changes. Conditional checklist items left unticked: no visible UI or copy changed; no platform, packaging, updater, signing, paths, shell, or permissions surface changed; no docs, release notes, dependencies, generated content, credentials, deletion behavior, or local file output changed.

## How To Verify

```text
bun run --cwd packages/app typecheck
Result: passed.

PLAYWRIGHT_VIDEO=off bun run --cwd packages/app test:e2e -- e2e/app/palette.spec.ts
Result: 6 passed. Covers the command palette default view and typed command search for layout/session commands.

git diff --check
Result: passed with no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
