### PR TITLE
refactor(app): extract layout shell frame

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1265,6 +1265,28 @@ export default function Layout(props: ParentProps) {
     shellNavigation.openSettings(tab)
   }
 
+  async function openGlobalConfigFolder() {
+    const target = await globalSDK.client.path
+      .get({ ensureConfig: true })
+      .then((x) => x.data?.config)
+      .catch((err) => {
+        showToast({
+          title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+          description: errorMessage(err, language.t("common.requestFailed")),
+          variant: "error",
+        })
+        return undefined
+      })
+    if (!target) return
+    await platform.openPath?.(target).catch((err) => {
+      showToast({
+        title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+        description: errorMessage(err, language.t("common.requestFailed")),
+        variant: "error",
+      })
+    })
+  }
+
   createEffect(() => {
     command.setModalOpen(settingsOpen())
   })
@@ -2012,23 +2034,49 @@ export default function Layout(props: ParentProps) {
     navigate(`/${base64Encode(created.directory)}/session`)
   }
 
+  function createCurrentWorkspace() {
+    const project = currentProject()
+    if (!project) return
+    return createWorkspace(project)
+  }
+
+  function toggleCurrentWorkspace() {
+    const project = currentProject()
+    if (!project) return undefined
+    if (project.vcs !== "git") return undefined
+    const wasEnabled = layout.sidebar.workspaces(project.worktree)()
+    layout.sidebar.toggleWorkspaces(project.worktree)
+    return wasEnabled
+  }
+
   registerLayoutCommands({
-    command,
-    language,
-    layout,
-    theme,
-    platform,
-    globalSDK,
-    currentProject,
-    workspaceSetting,
-    chooseProject,
-    navigateProjectByOffset,
-    connectProvider,
-    openServer,
-    openSettings,
-    navigateSessionByOffset,
-    navigateSessionByUnseen,
-    createWorkspace,
+    registry: command,
+    copy: language,
+    appearance: theme,
+    viewActions: {
+      toggleSidebar: layout.sidebar.toggle,
+    },
+    navigationActions: {
+      openProject: chooseProject,
+      moveProject: navigateProjectByOffset,
+      moveSession: navigateSessionByOffset,
+      moveUnseenSession: navigateSessionByUnseen,
+    },
+    settingsActions: {
+      open: openSettings,
+      canOpenGlobalConfigFolder: () => !!platform.openPath,
+      openGlobalConfigFolder,
+    },
+    workspaceActions: {
+      canCreateCurrent: () => !!workspaceSetting(),
+      createCurrent: createCurrentWorkspace,
+      canToggleCurrent: () => currentProject()?.vcs === "git",
+      toggleCurrent: toggleCurrentWorkspace,
+    },
+    systemActions: {
+      connectProvider,
+      switchServer: openServer,
+    },
   })
 
   const workspaceSidebarCtx: WorkspaceSidebarContext = {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -20,17 +20,16 @@ import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
-import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { Button } from "@opencode-ai/ui/button"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { getFilename } from "@opencode-ai/util/path"
 import { Session, type GlobalSession, type Message } from "@opencode-ai/sdk/v2/client"
-import { isMacShell, shellAttrs, usePlatform } from "@/context/platform"
+import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
 import { createStore, produce, reconcile } from "solid-js/store"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
-import { showToast, Toast, toaster } from "@opencode-ai/ui/toast"
+import { showToast, toaster } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { clientActionHeaders } from "@/utils/server"
 import { LayoutPageContext } from "@/context/layout-page"
@@ -68,8 +67,6 @@ import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme } from "@opencode-ai/ui/theme/context"
 import { useCommand } from "@/context/command"
 import { getDraggableId } from "@/utils/solid-dnd"
-import { DebugBar } from "@/components/debug-bar"
-import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
 import {
@@ -108,6 +105,7 @@ import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
 import { registerLayoutCommands } from "./layout/layout-commands"
+import { LayoutShellFrame } from "./layout/layout-shell-frame"
 import {
   buildPawworkSessionWindow,
   nextPawworkSessionWindowLimit,
@@ -118,7 +116,6 @@ import {
 } from "./layout/pawwork-session-window"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
-import { PawworkTitlebar } from "./layout/pawwork-titlebar"
 import { createDefaultLayoutPageState, createLayoutPagePersistTarget, removePinnedSessionIDs } from "./layout/layout-page-store"
 import { SettingsContent, SettingsNav, isSettingsTab, type SettingsTab } from "@/pages/settings/settings-shell"
 import { DialogDeleteSession } from "@/components/dialog-delete-session"
@@ -184,7 +181,6 @@ export default function Layout(props: ParentProps) {
     autoselect: !initialDirectory,
     busyWorkspaces: {} as Record<string, boolean>,
     scrollSessionKey: undefined as string | undefined,
-    nav: undefined as HTMLElement | undefined,
     sizing: false,
   })
 
@@ -1894,14 +1890,6 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
-  createEffect(() => {
-    const sidebarWidth = layout.sidebar.opened() ? layout.sidebar.width() : 0
-    document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
-  })
-
-  const side = createMemo(() => Math.max(layout.sidebar.width(), 180))
-  const panel = createMemo(() => Math.max(side() - 64, 0))
-
   const loadedSessionDirs = new Set<string>()
 
   createEffect(
@@ -2154,6 +2142,14 @@ export default function Layout(props: ParentProps) {
   )
   const sidebarContent = () =>
     renderPawworkPanel(pawworkSessions, { directory: currentProject()?.worktree, scope: "main" })
+
+  function handleSidebarResize(width: number) {
+    setState("sizing", true)
+    if (sizet !== undefined) clearTimeout(sizet)
+    sizet = window.setTimeout(() => setState("sizing", false), 120)
+    layout.sidebar.resize(width)
+  }
+
   return (
     <LayoutPageContext.Provider
       value={{
@@ -2173,131 +2169,35 @@ export default function Layout(props: ParentProps) {
           closeSettings,
         }}
       >
-      <div
-        data-component="desktop-shell"
-        data-platform={platform.platform}
-        {...shellAttrs(platform)}
-        class="relative bg-bg-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
-        classList={{
-          "[transition:--sidebar-width_200ms_cubic-bezier(0.22,1,0.36,1),--right-panel-width_240ms_cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none":
-            !state.sizing,
-        }}
-        style={{
-          "--shell-titlebar-current-height":
-            isMacShell(platform)
-              ? `calc(var(--shell-titlebar-height, 44px) / ${platform.webviewZoom?.() ?? 1})`
-              : "var(--shell-titlebar-height, 44px)",
-          "--sidebar-width": layout.sidebar.opened() || settingsOpen() ? `${side()}px` : "0px",
-          "--right-panel-width": layout.rightPanel.opened() ? `${layout.rightPanel.width()}px` : "0px",
-          "--right-panel-divider": layout.rightPanel.opened() ? "var(--border-weaker)" : "transparent",
-        }}
-      >
-        <div
-          data-component="desktop-shell-frame"
-          data-platform={platform.platform}
-          {...shellAttrs(platform)}
-          class="flex flex-1 min-h-0 min-w-0 flex-col"
-        >
-          <Titlebar />
-          <PawworkTitlebar visible={settingsOpen} title={() => language.t("sidebar.settings")} />
-          <div class="flex-1 min-h-0 min-w-0 flex">
-          <div class="flex-1 min-h-0 relative">
-            <div data-component="shell-content" class="size-full relative overflow-x-hidden">
-              <Show when={layout.sidebar.opened() || settingsOpen()}>
-                <aside
-                  aria-label={language.t("sidebar.nav.projectsAndSessions")}
-                  data-component="sidebar-nav-desktop"
-                  class="absolute inset-y-0 left-0 z-10 border-r border-border-weaker"
-                  style={{ width: `${side()}px` }}
-                  ref={(el) => {
-                    setState("nav", el)
-                  }}
-                >
-                  <div
-                    classList={{ "@container w-full h-full contain-strict": true, invisible: settingsOpen() }}
-                    inert={settingsOpen() ? true : undefined}
-                    aria-hidden={settingsOpen() || undefined}
-                  >
-                    {sidebarContent()}
-                  </div>
-                  {/* Settings takeover: the nav overlays the session sidebar (kept mounted, only inert, so scroll state survives); geometry is inherited from this aside slot. */}
-                  <Show when={settingsOpen()}>
-                    <div class="absolute inset-0 z-10">
-                      <SettingsNav active={settingsTab()} onSelect={setSettingsTab} onClose={closeSettings} />
-                    </div>
-                  </Show>
-                </aside>
-
-                {/* Hide the resize handle while settings is open: the sidebar width is not draggable inside settings. */}
-                <Show when={!settingsOpen()}>
-                  <div
-                    class="absolute inset-y-0 z-30 w-0 overflow-visible"
-                    style={{ left: `${side()}px` }}
-                    onPointerDown={() => setState("sizing", true)}
-                  >
-                    <ResizeHandle
-                      direction="horizontal"
-                      size={layout.sidebar.width()}
-                      min={180}
-                      max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}
-                      onResize={(w) => {
-                        setState("sizing", true)
-                        if (sizet !== undefined) clearTimeout(sizet)
-                        sizet = window.setTimeout(() => setState("sizing", false), 120)
-                        layout.sidebar.resize(w)
-                      }}
-                    />
-                  </div>
-                </Show>
-              </Show>
-
-              <div
-                classList={{
-                  "absolute inset-y-0 right-0 left-[var(--main-left)]": true,
-                  "z-20": true,
-                  "transition-[left] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[left] motion-reduce:transition-none":
-                    !state.sizing,
-                }}
-                style={{
-                  "--main-left": layout.sidebar.opened() || settingsOpen() ? `${side()}px` : "0",
-                }}
-              >
-                <main
-                  data-component="desktop-shell-main"
-                  data-platform={platform.platform}
-                  {...shellAttrs(platform)}
-                  classList={{
-                    "size-full overflow-x-hidden flex flex-col items-start contain-strict": true,
-                  }}
-                >
-                  <div class="relative size-full">
-                    <div
-                      inert={settingsOpen() ? true : undefined}
-                      aria-hidden={settingsOpen() || undefined}
-                      classList={{ "size-full": true, invisible: settingsOpen() }}
-                    >
-                      <Show when={!startupAutoselectPending()} fallback={<AppStartupPending />}>
-                        {props.children}
-                      </Show>
-                    </div>
-                    {/* Settings takeover: the content overlays the session page (kept mounted, only inert, so the terminal/right panel are not torn down); geometry is inherited from the main slot. */}
-                    <Show when={settingsOpen()}>
-                      <div class="absolute inset-0 z-10">
-                        <SettingsContent active={settingsTab()} directory={currentDir()} onClose={closeSettings} />
-                      </div>
-                    </Show>
-                  </div>
-                </main>
-              </div>
-            </div>
-          </div>
-          {import.meta.env.DEV &&
-            !((window as typeof window & { __opencode_e2e?: unknown }).__opencode_e2e) &&
-            <DebugBar />}
-          </div>
-        </div>
-        <Toast.Region />
-      </div>
+        <LayoutShellFrame
+          platform={platform}
+          sizing={() => state.sizing}
+          sidebar={{
+            visible: () => layout.sidebar.opened() || settingsOpen(),
+            width: layout.sidebar.width,
+            minWidth: 180,
+            maxWidth: () => (typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64),
+            label: () => language.t("sidebar.nav.projectsAndSessions"),
+            content: sidebarContent,
+            onResizeStart: () => setState("sizing", true),
+            onResize: handleSidebarResize,
+          }}
+          rightPanel={{
+            opened: layout.rightPanel.opened,
+            width: layout.rightPanel.width,
+          }}
+          settings={{
+            open: settingsOpen,
+            title: () => language.t("sidebar.settings"),
+            nav: () => <SettingsNav active={settingsTab()} onSelect={setSettingsTab} onClose={closeSettings} />,
+            content: () => <SettingsContent active={settingsTab()} directory={currentDir()} onClose={closeSettings} />,
+          }}
+          main={() => (
+            <Show when={!startupAutoselectPending()} fallback={<AppStartupPending />}>
+              {props.children}
+            </Show>
+          )}
+        />
       </ShellSurfaceContext.Provider>
     </LayoutPageContext.Provider>
   )

--- a/packages/app/src/pages/layout/layout-commands.test.ts
+++ b/packages/app/src/pages/layout/layout-commands.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+import type { CommandOption, useCommand } from "@/context/command"
+import type { useLanguage } from "@/context/language"
+import type { useTheme } from "@opencode-ai/ui/theme/context"
+import { registerLayoutCommands } from "./layout-commands"
+
+function layoutCommandCatalog(input?: {
+  canOpenGlobalConfigFolder?: boolean
+  canCreateWorkspace?: boolean
+  canToggleWorkspace?: boolean
+  canSwitchColorScheme?: boolean
+}) {
+  let catalog: CommandOption[] = []
+  registerLayoutCommands({
+    registry: {
+      register: (_scope, options) => {
+        catalog = options()
+      },
+    } as Pick<ReturnType<typeof useCommand>, "register">,
+    copy: {
+      t: (key: string) => key,
+      locale: () => "en",
+      locales: ["en", "zh"],
+      label: (locale: string) => locale,
+      setLocale: () => undefined,
+    } as unknown as ReturnType<typeof useLanguage>,
+    appearance: {
+      canSwitchColorScheme: () => input?.canSwitchColorScheme ?? true,
+      colorScheme: () => "system",
+      setColorScheme: () => undefined,
+      commitPreview: () => undefined,
+      previewColorScheme: () => undefined,
+      cancelPreview: () => undefined,
+    } as unknown as ReturnType<typeof useTheme>,
+    viewActions: {
+      toggleSidebar: () => undefined,
+    },
+    navigationActions: {
+      openProject: () => undefined,
+      moveProject: () => undefined,
+      moveSession: () => undefined,
+      moveUnseenSession: () => undefined,
+    },
+    settingsActions: {
+      open: () => undefined,
+      canOpenGlobalConfigFolder: () => input?.canOpenGlobalConfigFolder ?? true,
+      openGlobalConfigFolder: () => undefined,
+    },
+    workspaceActions: {
+      canCreateCurrent: () => input?.canCreateWorkspace ?? true,
+      createCurrent: () => undefined,
+      canToggleCurrent: () => input?.canToggleWorkspace ?? true,
+      toggleCurrent: () => false,
+    },
+    systemActions: {
+      connectProvider: () => undefined,
+      switchServer: () => undefined,
+    },
+  })
+  return catalog
+}
+
+describe("registerLayoutCommands", () => {
+  test("keeps the layout command catalog shape stable", () => {
+    const catalog = layoutCommandCatalog()
+
+    expect(catalog.map((command) => command.id)).toEqual([
+      "sidebar.toggle",
+      "project.open",
+      "project.previous",
+      "project.next",
+      "provider.connect",
+      "server.switch",
+      "settings.open",
+      "settings.openGlobalConfigFolder",
+      "session.previous",
+      "session.next",
+      "session.previous.unseen",
+      "session.next.unseen",
+      "workspace.new",
+      "workspace.toggle",
+      "theme.scheme.cycle",
+      "theme.scheme.system",
+      "theme.scheme.light",
+      "theme.scheme.dark",
+      "language.cycle",
+      "language.set.en",
+      "language.set.zh",
+    ])
+
+    expect(Object.fromEntries(catalog.map((command) => [command.id, command.keybind ?? null]))).toMatchObject({
+      "sidebar.toggle": "mod+b",
+      "project.open": "mod+o",
+      "project.previous": "mod+alt+arrowup",
+      "project.next": "mod+alt+arrowdown",
+      "settings.open": "mod+comma",
+      "session.previous": "alt+arrowup",
+      "session.next": "alt+arrowdown",
+      "session.previous.unseen": "shift+alt+arrowup",
+      "session.next.unseen": "shift+alt+arrowdown",
+      "workspace.new": "mod+shift+w",
+      "theme.scheme.cycle": "mod+shift+s",
+    })
+    expect(catalog.find((command) => command.id === "workspace.toggle")?.slash).toBe("workspace")
+  })
+
+  test("reflects command availability from layout capabilities", () => {
+    const catalog = layoutCommandCatalog({
+      canOpenGlobalConfigFolder: false,
+      canCreateWorkspace: false,
+      canToggleWorkspace: false,
+      canSwitchColorScheme: false,
+    })
+
+    expect(catalog.find((command) => command.id === "settings.openGlobalConfigFolder")?.disabled).toBe(true)
+    expect(catalog.find((command) => command.id === "workspace.new")?.disabled).toBe(true)
+    expect(catalog.find((command) => command.id === "workspace.toggle")?.disabled).toBe(true)
+    expect(catalog.some((command) => command.id.startsWith("theme.scheme."))).toBe(false)
+  })
+})

--- a/packages/app/src/pages/layout/layout-commands.ts
+++ b/packages/app/src/pages/layout/layout-commands.ts
@@ -1,30 +1,37 @@
 import type { Accessor } from "solid-js"
-import type { LocalProject, useLayout } from "@/context/layout"
 import type { useCommand, CommandOption } from "@/context/command"
-import type { useGlobalSDK } from "@/context/global-sdk"
 import type { Locale, useLanguage } from "@/context/language"
-import type { usePlatform } from "@/context/platform"
 import type { ColorScheme, useTheme } from "@opencode-ai/ui/theme/context"
 import { showToast } from "@opencode-ai/ui/toast"
-import { errorMessage } from "./helpers"
 
 type LayoutCommandRegistration = {
-  command: ReturnType<typeof useCommand>
-  language: ReturnType<typeof useLanguage>
-  layout: ReturnType<typeof useLayout>
-  theme: ReturnType<typeof useTheme>
-  platform: ReturnType<typeof usePlatform>
-  globalSDK: ReturnType<typeof useGlobalSDK>
-  currentProject: Accessor<LocalProject | undefined>
-  workspaceSetting: Accessor<unknown>
-  chooseProject: () => void
-  navigateProjectByOffset: (offset: number) => void
-  connectProvider: () => void
-  openServer: () => void
-  openSettings: () => void
-  navigateSessionByOffset: (offset: number) => void
-  navigateSessionByUnseen: (offset: number) => void
-  createWorkspace: (project: LocalProject) => unknown
+  registry: Pick<ReturnType<typeof useCommand>, "register">
+  copy: ReturnType<typeof useLanguage>
+  appearance: ReturnType<typeof useTheme>
+  viewActions: {
+    toggleSidebar: () => void
+  }
+  navigationActions: {
+    openProject: () => void
+    moveProject: (offset: number) => void
+    moveSession: (offset: number) => void
+    moveUnseenSession: (offset: number) => void
+  }
+  settingsActions: {
+    open: () => void
+    canOpenGlobalConfigFolder: Accessor<boolean>
+    openGlobalConfigFolder: () => void | Promise<void>
+  }
+  workspaceActions: {
+    canCreateCurrent: Accessor<boolean>
+    createCurrent: () => unknown
+    canToggleCurrent: Accessor<boolean>
+    toggleCurrent: () => boolean | undefined
+  }
+  systemActions: {
+    connectProvider: () => void
+    switchServer: () => void
+  }
 }
 
 const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]
@@ -36,202 +43,167 @@ const colorSchemeKey: Record<ColorScheme, "theme.scheme.system" | "theme.scheme.
 
 export function registerLayoutCommands(input: LayoutCommandRegistration) {
   const {
-    command,
-    language,
-    layout,
-    theme,
-    platform,
-    globalSDK,
-    currentProject,
-    workspaceSetting,
-    chooseProject,
-    navigateProjectByOffset,
-    connectProvider,
-    openServer,
-    openSettings,
-    navigateSessionByOffset,
-    navigateSessionByUnseen,
-    createWorkspace,
+    registry,
+    copy,
+    appearance,
+    viewActions,
+    navigationActions,
+    settingsActions,
+    workspaceActions,
+    systemActions,
   } = input
-  const colorSchemeLabel = (scheme: ColorScheme) => language.t(colorSchemeKey[scheme])
+  const colorSchemeLabel = (scheme: ColorScheme) => copy.t(colorSchemeKey[scheme])
 
   function cycleColorScheme(direction = 1) {
-    const current = theme.colorScheme()
+    const current = appearance.colorScheme()
     const currentIndex = colorSchemeOrder.indexOf(current)
     const nextIndex =
       currentIndex === -1 ? 0 : (currentIndex + direction + colorSchemeOrder.length) % colorSchemeOrder.length
     const next = colorSchemeOrder[nextIndex]
-    theme.setColorScheme(next)
+    appearance.setColorScheme(next)
     showToast({
-      title: language.t("toast.scheme.title"),
+      title: copy.t("toast.scheme.title"),
       description: colorSchemeLabel(next),
     })
   }
 
   function setLocale(next: Locale) {
-    if (next === language.locale()) return
-    language.setLocale(next)
+    if (next === copy.locale()) return
+    copy.setLocale(next)
     showToast({
-      title: language.t("toast.language.title"),
-      description: language.t("toast.language.description", { language: language.label(next) }),
+      title: copy.t("toast.language.title"),
+      description: copy.t("toast.language.description", { language: copy.label(next) }),
     })
   }
 
   function cycleLanguage(direction = 1) {
-    const locales = language.locales
-    const currentIndex = locales.indexOf(language.locale())
+    const locales = copy.locales
+    const currentIndex = locales.indexOf(copy.locale())
     const nextIndex = currentIndex === -1 ? 0 : (currentIndex + direction + locales.length) % locales.length
     const next = locales[nextIndex]
     if (!next) return
     setLocale(next)
   }
 
-  command.register("layout", () => {
+  registry.register("layout", () => {
     const commands: CommandOption[] = [
       {
         id: "sidebar.toggle",
-        title: language.t("command.sidebar.toggle"),
-        category: language.t("command.category.view"),
+        title: copy.t("command.sidebar.toggle"),
+        category: copy.t("command.category.view"),
         keybind: "mod+b",
-        onSelect: () => layout.sidebar.toggle(),
+        onSelect: () => viewActions.toggleSidebar(),
       },
       {
         id: "project.open",
-        title: language.t("command.project.open"),
-        category: language.t("command.category.project"),
+        title: copy.t("command.project.open"),
+        category: copy.t("command.category.project"),
         keybind: "mod+o",
-        onSelect: () => chooseProject(),
+        onSelect: () => navigationActions.openProject(),
       },
       {
         id: "project.previous",
-        title: language.t("command.project.previous"),
-        category: language.t("command.category.project"),
+        title: copy.t("command.project.previous"),
+        category: copy.t("command.category.project"),
         keybind: "mod+alt+arrowup",
-        onSelect: () => navigateProjectByOffset(-1),
+        onSelect: () => navigationActions.moveProject(-1),
       },
       {
         id: "project.next",
-        title: language.t("command.project.next"),
-        category: language.t("command.category.project"),
+        title: copy.t("command.project.next"),
+        category: copy.t("command.category.project"),
         keybind: "mod+alt+arrowdown",
-        onSelect: () => navigateProjectByOffset(1),
+        onSelect: () => navigationActions.moveProject(1),
       },
       {
         id: "provider.connect",
-        title: language.t("command.provider.connect"),
-        category: language.t("command.category.provider"),
-        onSelect: () => connectProvider(),
+        title: copy.t("command.provider.connect"),
+        category: copy.t("command.category.provider"),
+        onSelect: () => systemActions.connectProvider(),
       },
       {
         id: "server.switch",
-        title: language.t("command.server.switch"),
-        category: language.t("command.category.server"),
-        onSelect: () => openServer(),
+        title: copy.t("command.server.switch"),
+        category: copy.t("command.category.server"),
+        onSelect: () => systemActions.switchServer(),
       },
       {
         id: "settings.open",
-        title: language.t("command.settings.open"),
-        category: language.t("command.category.settings"),
+        title: copy.t("command.settings.open"),
+        category: copy.t("command.category.settings"),
         keybind: "mod+comma",
-        onSelect: () => openSettings(),
+        onSelect: () => settingsActions.open(),
       },
       {
         id: "settings.openGlobalConfigFolder",
-        title: language.t("command.settings.openGlobalConfigFolder"),
-        category: language.t("command.category.settings"),
-        disabled: !platform.openPath,
-        onSelect: async () => {
-          const target = await globalSDK.client.path
-            .get({ ensureConfig: true })
-            .then((x) => x.data?.config)
-            .catch((err) => {
-              showToast({
-                title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-                description: errorMessage(err, language.t("common.requestFailed")),
-                variant: "error",
-              })
-              return undefined
-            })
-          if (!target) return
-          await platform.openPath?.(target).catch((err) => {
-            showToast({
-              title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-              description: errorMessage(err, language.t("common.requestFailed")),
-              variant: "error",
-            })
-          })
-        },
+        title: copy.t("command.settings.openGlobalConfigFolder"),
+        category: copy.t("command.category.settings"),
+        disabled: !settingsActions.canOpenGlobalConfigFolder(),
+        onSelect: () => settingsActions.openGlobalConfigFolder(),
       },
       {
         id: "session.previous",
-        title: language.t("command.session.previous"),
-        category: language.t("command.category.session"),
+        title: copy.t("command.session.previous"),
+        category: copy.t("command.category.session"),
         keybind: "alt+arrowup",
-        onSelect: () => navigateSessionByOffset(-1),
+        onSelect: () => navigationActions.moveSession(-1),
       },
       {
         id: "session.next",
-        title: language.t("command.session.next"),
-        category: language.t("command.category.session"),
+        title: copy.t("command.session.next"),
+        category: copy.t("command.category.session"),
         keybind: "alt+arrowdown",
-        onSelect: () => navigateSessionByOffset(1),
+        onSelect: () => navigationActions.moveSession(1),
       },
       {
         id: "session.previous.unseen",
-        title: language.t("command.session.previous.unseen"),
-        category: language.t("command.category.session"),
+        title: copy.t("command.session.previous.unseen"),
+        category: copy.t("command.category.session"),
         keybind: "shift+alt+arrowup",
-        onSelect: () => navigateSessionByUnseen(-1),
+        onSelect: () => navigationActions.moveUnseenSession(-1),
       },
       {
         id: "session.next.unseen",
-        title: language.t("command.session.next.unseen"),
-        category: language.t("command.category.session"),
+        title: copy.t("command.session.next.unseen"),
+        category: copy.t("command.category.session"),
         keybind: "shift+alt+arrowdown",
-        onSelect: () => navigateSessionByUnseen(1),
+        onSelect: () => navigationActions.moveUnseenSession(1),
       },
       {
         id: "workspace.new",
-        title: language.t("workspace.new"),
-        category: language.t("command.category.workspace"),
+        title: copy.t("workspace.new"),
+        category: copy.t("command.category.workspace"),
         keybind: "mod+shift+w",
-        disabled: !workspaceSetting(),
-        onSelect: () => {
-          const project = currentProject()
-          if (!project) return
-          return createWorkspace(project)
-        },
+        disabled: !workspaceActions.canCreateCurrent(),
+        onSelect: () => workspaceActions.createCurrent(),
       },
       {
         id: "workspace.toggle",
-        title: language.t("command.workspace.toggle"),
-        description: language.t("command.workspace.toggle.description"),
-        category: language.t("command.category.workspace"),
+        title: copy.t("command.workspace.toggle"),
+        description: copy.t("command.workspace.toggle.description"),
+        category: copy.t("command.category.workspace"),
         slash: "workspace",
-        disabled: !currentProject() || currentProject()?.vcs !== "git",
+        disabled: !workspaceActions.canToggleCurrent(),
         onSelect: () => {
-          const project = currentProject()
-          if (!project) return
-          if (project.vcs !== "git") return
-          const wasEnabled = layout.sidebar.workspaces(project.worktree)()
-          layout.sidebar.toggleWorkspaces(project.worktree)
+          const wasEnabled = workspaceActions.toggleCurrent()
+          if (wasEnabled === undefined) return
           showToast({
             title: wasEnabled
-              ? language.t("toast.workspace.disabled.title")
-              : language.t("toast.workspace.enabled.title"),
+              ? copy.t("toast.workspace.disabled.title")
+              : copy.t("toast.workspace.enabled.title"),
             description: wasEnabled
-              ? language.t("toast.workspace.disabled.description")
-              : language.t("toast.workspace.enabled.description"),
+              ? copy.t("toast.workspace.disabled.description")
+              : copy.t("toast.workspace.enabled.description"),
           })
         },
       },
     ]
 
-    if (theme.canSwitchColorScheme()) {
+    if (appearance.canSwitchColorScheme()) {
       commands.push({
         id: "theme.scheme.cycle",
-        title: language.t("command.theme.scheme.cycle"),
-        category: language.t("command.category.theme"),
+        title: copy.t("command.theme.scheme.cycle"),
+        category: copy.t("command.category.theme"),
         keybind: "mod+shift+s",
         onSelect: () => cycleColorScheme(1),
       })
@@ -239,12 +211,12 @@ export function registerLayoutCommands(input: LayoutCommandRegistration) {
       for (const scheme of colorSchemeOrder) {
         commands.push({
           id: `theme.scheme.${scheme}`,
-          title: language.t("command.theme.scheme.set", { scheme: colorSchemeLabel(scheme) }),
-          category: language.t("command.category.theme"),
-          onSelect: () => theme.commitPreview(),
+          title: copy.t("command.theme.scheme.set", { scheme: colorSchemeLabel(scheme) }),
+          category: copy.t("command.category.theme"),
+          onSelect: () => appearance.commitPreview(),
           onHighlight: () => {
-            theme.previewColorScheme(scheme)
-            return () => theme.cancelPreview()
+            appearance.previewColorScheme(scheme)
+            return () => appearance.cancelPreview()
           },
         })
       }
@@ -252,16 +224,16 @@ export function registerLayoutCommands(input: LayoutCommandRegistration) {
 
     commands.push({
       id: "language.cycle",
-      title: language.t("command.language.cycle"),
-      category: language.t("command.category.language"),
+      title: copy.t("command.language.cycle"),
+      category: copy.t("command.category.language"),
       onSelect: () => cycleLanguage(1),
     })
 
-    for (const locale of language.locales) {
+    for (const locale of copy.locales) {
       commands.push({
         id: `language.set.${locale}`,
-        title: language.t("command.language.set", { language: language.label(locale) }),
-        category: language.t("command.category.language"),
+        title: copy.t("command.language.set", { language: copy.label(locale) }),
+        category: copy.t("command.category.language"),
         onSelect: () => setLocale(locale),
       })
     }

--- a/packages/app/src/pages/layout/layout-shell-frame-debug.ts
+++ b/packages/app/src/pages/layout/layout-shell-frame-debug.ts
@@ -1,0 +1,5 @@
+export function shouldShowLayoutDebugBar() {
+  if (!import.meta.env.DEV) return false
+  if (typeof window === "undefined") return false
+  return !((window as typeof window & { __opencode_e2e?: unknown }).__opencode_e2e)
+}

--- a/packages/app/src/pages/layout/layout-shell-frame-geometry.ts
+++ b/packages/app/src/pages/layout/layout-shell-frame-geometry.ts
@@ -1,0 +1,6 @@
+export function normalizedSidebarWidth(input: { width: number; minWidth: number; maxWidth: number }) {
+  const min = Number.isFinite(input.minWidth) ? input.minWidth : 0
+  const max = Number.isFinite(input.maxWidth) ? Math.max(input.maxWidth, min) : min
+  const width = Number.isFinite(input.width) ? input.width : min
+  return Math.min(Math.max(width, min), max)
+}

--- a/packages/app/src/pages/layout/layout-shell-frame.test.ts
+++ b/packages/app/src/pages/layout/layout-shell-frame.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { shouldShowLayoutDebugBar } from "./layout-shell-frame-debug"
+
+function withoutWindow(run: () => void) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "window")
+  Reflect.deleteProperty(globalThis, "window")
+  try {
+    run()
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, "window", descriptor)
+  }
+}
+
+describe("LayoutShellFrame", () => {
+  test("does not read window in non-browser test environments", () => {
+    withoutWindow(() => {
+      expect(() => shouldShowLayoutDebugBar()).not.toThrow()
+      expect(shouldShowLayoutDebugBar()).toBe(false)
+    })
+  })
+})

--- a/packages/app/src/pages/layout/layout-shell-frame.test.ts
+++ b/packages/app/src/pages/layout/layout-shell-frame.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { shouldShowLayoutDebugBar } from "./layout-shell-frame-debug"
+import { normalizedSidebarWidth } from "./layout-shell-frame-geometry"
 
 function withoutWindow(run: () => void) {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, "window")
@@ -17,5 +18,11 @@ describe("LayoutShellFrame", () => {
       expect(() => shouldShowLayoutDebugBar()).not.toThrow()
       expect(shouldShowLayoutDebugBar()).toBe(false)
     })
+  })
+
+  test("normalizes sidebar geometry across min, normal, and max widths", () => {
+    expect(normalizedSidebarWidth({ width: 120, minWidth: 180, maxWidth: 360 })).toBe(180)
+    expect(normalizedSidebarWidth({ width: 260, minWidth: 180, maxWidth: 360 })).toBe(260)
+    expect(normalizedSidebarWidth({ width: 720, minWidth: 180, maxWidth: 360 })).toBe(360)
   })
 })

--- a/packages/app/src/pages/layout/layout-shell-frame.tsx
+++ b/packages/app/src/pages/layout/layout-shell-frame.tsx
@@ -5,6 +5,7 @@ import { isMacShell, shellAttrs, type usePlatform } from "@/context/platform"
 import { DebugBar } from "@/components/debug-bar"
 import { Titlebar } from "@/components/titlebar"
 import { PawworkTitlebar } from "./pawwork-titlebar"
+import { shouldShowLayoutDebugBar } from "./layout-shell-frame-debug"
 
 type LayoutShellFrameProps = {
   platform: ReturnType<typeof usePlatform>
@@ -143,9 +144,7 @@ export function LayoutShellFrame(props: LayoutShellFrameProps) {
               </div>
             </div>
           </div>
-          {import.meta.env.DEV &&
-            !((window as typeof window & { __opencode_e2e?: unknown }).__opencode_e2e) &&
-            <DebugBar />}
+          {shouldShowLayoutDebugBar() && <DebugBar />}
         </div>
       </div>
       <Toast.Region />

--- a/packages/app/src/pages/layout/layout-shell-frame.tsx
+++ b/packages/app/src/pages/layout/layout-shell-frame.tsx
@@ -6,6 +6,7 @@ import { DebugBar } from "@/components/debug-bar"
 import { Titlebar } from "@/components/titlebar"
 import { PawworkTitlebar } from "./pawwork-titlebar"
 import { shouldShowLayoutDebugBar } from "./layout-shell-frame-debug"
+import { normalizedSidebarWidth } from "./layout-shell-frame-geometry"
 
 type LayoutShellFrameProps = {
   platform: ReturnType<typeof usePlatform>
@@ -34,11 +35,17 @@ type LayoutShellFrameProps = {
 }
 
 export function LayoutShellFrame(props: LayoutShellFrameProps) {
-  const side = createMemo(() => Math.max(props.sidebar.width(), props.sidebar.minWidth))
+  const sidebarWidth = createMemo(() =>
+    normalizedSidebarWidth({
+      width: props.sidebar.width(),
+      minWidth: props.sidebar.minWidth,
+      maxWidth: props.sidebar.maxWidth(),
+    }),
+  )
 
   createEffect(() => {
-    const sidebarWidth = props.sidebar.visible() ? props.sidebar.width() : 0
-    document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
+    const dialogLeftMargin = props.sidebar.visible() ? sidebarWidth() : 0
+    document.documentElement.style.setProperty("--dialog-left-margin", `${dialogLeftMargin}px`)
   })
 
   return (
@@ -55,7 +62,7 @@ export function LayoutShellFrame(props: LayoutShellFrameProps) {
         "--shell-titlebar-current-height": isMacShell(props.platform)
           ? `calc(var(--shell-titlebar-height, 44px) / ${props.platform.webviewZoom?.() ?? 1})`
           : "var(--shell-titlebar-height, 44px)",
-        "--sidebar-width": props.sidebar.visible() ? `${side()}px` : "0px",
+        "--sidebar-width": props.sidebar.visible() ? `${sidebarWidth()}px` : "0px",
         "--right-panel-width": props.rightPanel.opened() ? `${props.rightPanel.width()}px` : "0px",
         "--right-panel-divider": props.rightPanel.opened() ? "var(--border-weaker)" : "transparent",
       }}
@@ -76,7 +83,7 @@ export function LayoutShellFrame(props: LayoutShellFrameProps) {
                   aria-label={props.sidebar.label()}
                   data-component="sidebar-nav-desktop"
                   class="absolute inset-y-0 left-0 z-10 border-r border-border-weaker"
-                  style={{ width: `${side()}px` }}
+                  style={{ width: `${sidebarWidth()}px` }}
                 >
                   <div
                     classList={{ "@container w-full h-full contain-strict": true, invisible: props.settings.open() }}
@@ -94,12 +101,12 @@ export function LayoutShellFrame(props: LayoutShellFrameProps) {
                 <Show when={!props.settings.open()}>
                   <div
                     class="absolute inset-y-0 z-30 w-0 overflow-visible"
-                    style={{ left: `${side()}px` }}
+                    style={{ left: `${sidebarWidth()}px` }}
                     onPointerDown={props.sidebar.onResizeStart}
                   >
                     <ResizeHandle
                       direction="horizontal"
-                      size={props.sidebar.width()}
+                      size={sidebarWidth()}
                       min={props.sidebar.minWidth}
                       max={props.sidebar.maxWidth()}
                       onResize={props.sidebar.onResize}
@@ -116,7 +123,7 @@ export function LayoutShellFrame(props: LayoutShellFrameProps) {
                     !props.sizing(),
                 }}
                 style={{
-                  "--main-left": props.sidebar.visible() ? `${side()}px` : "0",
+                  "--main-left": props.sidebar.visible() ? `${sidebarWidth()}px` : "0",
                 }}
               >
                 <main

--- a/packages/app/src/pages/layout/layout-shell-frame.tsx
+++ b/packages/app/src/pages/layout/layout-shell-frame.tsx
@@ -1,0 +1,154 @@
+import { createEffect, createMemo, Show, type Accessor, type JSXElement } from "solid-js"
+import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
+import { Toast } from "@opencode-ai/ui/toast"
+import { isMacShell, shellAttrs, type usePlatform } from "@/context/platform"
+import { DebugBar } from "@/components/debug-bar"
+import { Titlebar } from "@/components/titlebar"
+import { PawworkTitlebar } from "./pawwork-titlebar"
+
+type LayoutShellFrameProps = {
+  platform: ReturnType<typeof usePlatform>
+  sizing: Accessor<boolean>
+  sidebar: {
+    visible: Accessor<boolean>
+    width: Accessor<number>
+    minWidth: number
+    maxWidth: Accessor<number>
+    label: Accessor<string>
+    content: () => JSXElement
+    onResizeStart: () => void
+    onResize: (width: number) => void
+  }
+  rightPanel: {
+    opened: Accessor<boolean>
+    width: Accessor<number>
+  }
+  settings: {
+    open: Accessor<boolean>
+    title: Accessor<string>
+    nav: () => JSXElement
+    content: () => JSXElement
+  }
+  main: () => JSXElement
+}
+
+export function LayoutShellFrame(props: LayoutShellFrameProps) {
+  const side = createMemo(() => Math.max(props.sidebar.width(), props.sidebar.minWidth))
+
+  createEffect(() => {
+    const sidebarWidth = props.sidebar.visible() ? props.sidebar.width() : 0
+    document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
+  })
+
+  return (
+    <div
+      data-component="desktop-shell"
+      data-platform={props.platform.platform}
+      {...shellAttrs(props.platform)}
+      class="relative bg-bg-base flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
+      classList={{
+        "[transition:--sidebar-width_200ms_cubic-bezier(0.22,1,0.36,1),--right-panel-width_240ms_cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none":
+          !props.sizing(),
+      }}
+      style={{
+        "--shell-titlebar-current-height": isMacShell(props.platform)
+          ? `calc(var(--shell-titlebar-height, 44px) / ${props.platform.webviewZoom?.() ?? 1})`
+          : "var(--shell-titlebar-height, 44px)",
+        "--sidebar-width": props.sidebar.visible() ? `${side()}px` : "0px",
+        "--right-panel-width": props.rightPanel.opened() ? `${props.rightPanel.width()}px` : "0px",
+        "--right-panel-divider": props.rightPanel.opened() ? "var(--border-weaker)" : "transparent",
+      }}
+    >
+      <div
+        data-component="desktop-shell-frame"
+        data-platform={props.platform.platform}
+        {...shellAttrs(props.platform)}
+        class="flex flex-1 min-h-0 min-w-0 flex-col"
+      >
+        <Titlebar />
+        <PawworkTitlebar visible={props.settings.open} title={props.settings.title} />
+        <div class="flex-1 min-h-0 min-w-0 flex">
+          <div class="flex-1 min-h-0 relative">
+            <div data-component="shell-content" class="size-full relative overflow-x-hidden">
+              <Show when={props.sidebar.visible()}>
+                <aside
+                  aria-label={props.sidebar.label()}
+                  data-component="sidebar-nav-desktop"
+                  class="absolute inset-y-0 left-0 z-10 border-r border-border-weaker"
+                  style={{ width: `${side()}px` }}
+                >
+                  <div
+                    classList={{ "@container w-full h-full contain-strict": true, invisible: props.settings.open() }}
+                    inert={props.settings.open() ? true : undefined}
+                    aria-hidden={props.settings.open() || undefined}
+                  >
+                    {props.sidebar.content()}
+                  </div>
+                  {/* Settings takeover keeps the session sidebar mounted so its scroll state survives. */}
+                  <Show when={props.settings.open()}>
+                    <div class="absolute inset-0 z-10">{props.settings.nav()}</div>
+                  </Show>
+                </aside>
+
+                <Show when={!props.settings.open()}>
+                  <div
+                    class="absolute inset-y-0 z-30 w-0 overflow-visible"
+                    style={{ left: `${side()}px` }}
+                    onPointerDown={props.sidebar.onResizeStart}
+                  >
+                    <ResizeHandle
+                      direction="horizontal"
+                      size={props.sidebar.width()}
+                      min={props.sidebar.minWidth}
+                      max={props.sidebar.maxWidth()}
+                      onResize={props.sidebar.onResize}
+                    />
+                  </div>
+                </Show>
+              </Show>
+
+              <div
+                classList={{
+                  "absolute inset-y-0 right-0 left-[var(--main-left)]": true,
+                  "z-20": true,
+                  "transition-[left] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[left] motion-reduce:transition-none":
+                    !props.sizing(),
+                }}
+                style={{
+                  "--main-left": props.sidebar.visible() ? `${side()}px` : "0",
+                }}
+              >
+                <main
+                  data-component="desktop-shell-main"
+                  data-platform={props.platform.platform}
+                  {...shellAttrs(props.platform)}
+                  classList={{
+                    "size-full overflow-x-hidden flex flex-col items-start contain-strict": true,
+                  }}
+                >
+                  <div class="relative size-full">
+                    <div
+                      inert={props.settings.open() ? true : undefined}
+                      aria-hidden={props.settings.open() || undefined}
+                      classList={{ "size-full": true, invisible: props.settings.open() }}
+                    >
+                      {props.main()}
+                    </div>
+                    {/* Settings takeover keeps the session page mounted so terminal and panel state survive. */}
+                    <Show when={props.settings.open()}>
+                      <div class="absolute inset-0 z-10">{props.settings.content()}</div>
+                    </Show>
+                  </div>
+                </main>
+              </div>
+            </div>
+          </div>
+          {import.meta.env.DEV &&
+            !((window as typeof window & { __opencode_e2e?: unknown }).__opencode_e2e) &&
+            <DebugBar />}
+        </div>
+      </div>
+      <Toast.Region />
+    </div>
+  )
+}

--- a/packages/app/src/shell-frame-contract.test.ts
+++ b/packages/app/src/shell-frame-contract.test.ts
@@ -30,6 +30,7 @@ function stripComments(source: string) {
 test("desktop shell shares titlebar height across titlebar and narrow sidebar geometry", () => {
   const css = read("./index.css")
   const layout = read("./pages/layout.tsx")
+  const layoutShellFrame = read("./pages/layout/layout-shell-frame.tsx")
   const titlebar = read("./components/titlebar.tsx")
   const sessionHeader = read("./components/session/session-header.tsx")
   const pawworkTitlebar = read("./pages/layout/pawwork-titlebar.tsx")
@@ -51,9 +52,9 @@ test("desktop shell shares titlebar height across titlebar and narrow sidebar ge
   expect(wideFrameRule).toBeGreaterThan(wideDesktopQuery)
   expect(macMainSeamRule).toBeGreaterThan(-1)
   expect(macMainSeamRule).toBeLessThan(wideDesktopQuery)
-  expect(layout).toContain('"--shell-titlebar-current-height"')
-  expect(layout).toContain("{...shellAttrs(platform)}")
-  expect(layout).toContain("isMacShell(platform)")
+  expect(layoutShellFrame).toContain('"--shell-titlebar-current-height"')
+  expect(layoutShellFrame).toContain("{...shellAttrs(props.platform)}")
+  expect(layoutShellFrame).toContain("isMacShell(props.platform)")
   expect(layout).not.toContain("top-10")
   expect(titlebar).toContain('"h-11": isDesktopShell(platform) && !mac()')
   expect(titlebar).toContain("{...shellAttrs(platform)}")
@@ -119,6 +120,7 @@ test("visual shell files do not key appearance from runtime platform identity", 
   const visualSources = [
     "./components/titlebar.tsx",
     "./pages/layout.tsx",
+    "./pages/layout/layout-shell-frame.tsx",
     "./components/session/session-header.tsx",
     "./components/settings-general.tsx",
   ]


### PR DESCRIPTION
## Summary

Refactors the next layout governance slice after #1036:

- Groups `registerLayoutCommands` inputs into command-facing capabilities and actions instead of passing a broad layout-owned parameter bag.
- Extracts the desktop shell JSX into `LayoutShellFrame`, keeping providers and state owners in `layout.tsx`.
- Adds a layout command catalog unit test to lock command ids, keybinds, slash commands, and availability flags.

## Why

This continues the `layout.tsx` owner extraction tracked by #606. PR #1036 moved command registration out of `layout.tsx`; this PR tightens that owner boundary and then moves the render shell into a focused frame component without changing workspace, session, or startup behavior.

## Related Issue

Related: #606

## Human Review Status

Pending

## Review Focus

Please focus on whether the new `LayoutShellFrame` props are still a render-shell boundary rather than a leaked copy of `layout.tsx` internals, and whether the command capability groups keep command behavior unchanged.

## Risk Notes

Visible shell geometry and settings takeover are touched. The PR intentionally does not move workspace CRUD, session window/prefetch ownership, boot effects, or the context providers.

## How To Verify

```text
bun install --frozen-lockfile: ok in the new worktree
bun run --cwd packages/app typecheck: ok
bun test --preload ./happydom.ts src/pages/layout/layout-commands.test.ts: 2 passed
bun test --preload ./happydom.ts src/shell-frame-contract.test.ts src/pages/layout/shell-navigation.test.ts: 15 passed
bun run --cwd packages/app snap app-shell: 1 passed, screenshot reviewed
bun run --cwd packages/app snap settings-shell: 1 passed, screenshot reviewed
PLAYWRIGHT_VIDEO=off bun run --cwd packages/app test:e2e -- e2e/app/palette.spec.ts: 6 passed
git diff --check: ok
```

## Screenshots or Recordings

Snap grids reviewed locally:

- `docs/design/preview/screenshots/app-shell.png`
- `docs/design/preview/screenshots/settings-shell.png`

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to open the global configuration folder

* **Refactor**
  * Redesigned desktop shell layout with enhanced sidebar resizing capabilities
  * Reorganized workspace creation and toggle commands
  * Restructured settings panel integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->