### PR TITLE
fix: detach submitted homepage drafts

### DIFF
--- a/packages/app/e2e/projects/workspace-new-session.spec.ts
+++ b/packages/app/e2e/projects/workspace-new-session.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import {
+  cleanupTestProject,
+  createTestProject,
   openSidebar,
   resolveSlug,
   sessionIDFromUrl,
@@ -9,7 +11,12 @@ import {
   waitSession,
   waitSlug,
 } from "../actions"
-import { workspaceItemSelector, workspaceNewSessionSelector } from "../selectors"
+import { promptSelector, workspaceItemSelector, workspaceNewSessionSelector } from "../selectors"
+import { sessionPath } from "../utils"
+
+function clean(value: string | null) {
+  return (value ?? "").replace(/\u200B/g, "").trim()
+}
 
 function item(space: { slug: string; raw: string }) {
   return `${workspaceItemSelector(space.slug)}, ${workspaceItemSelector(space.raw)}`
@@ -75,4 +82,41 @@ test.skip("new sessions from sidebar workspace actions stay in selected workspac
   await createSessionFromWorkspace(project, page, first, `workspace one ${Date.now()}`)
   await createSessionFromWorkspace(project, page, second, `workspace two ${Date.now()}`)
   await createSessionFromWorkspace(project, page, first, `workspace one again ${Date.now()}`)
+})
+
+test("sent homepage prompt does not carry to another project while pending", async ({ page, project, assistant, backend }) => {
+  await page.setViewportSize({ width: 1400, height: 800 })
+
+  const other = await createTestProject({ serverUrl: backend.url })
+  try {
+    await project.open({ extra: [other] })
+
+    let releaseReply!: () => void
+    const replyGate = new Promise<void>((resolve) => {
+      releaseReply = resolve
+    })
+    await assistant.hold("ok", replyGate)
+
+    const text = `already sent ${Date.now()}`
+    const prompt = page.locator(promptSelector).first()
+    await expect(prompt).toBeVisible()
+    await prompt.click()
+    await page.keyboard.type(text)
+    await expect.poll(async () => clean(await prompt.textContent())).toBe(text)
+    await page.keyboard.press("Enter")
+
+    await expect.poll(async () => clean(await prompt.textContent())).toBe("")
+    await expect.poll(() => sessionIDFromUrl(page.url()) ?? "").not.toBe("")
+    project.trackSession(sessionIDFromUrl(page.url())!, project.directory)
+    await expect.poll(() => assistant.calls()).toBe(1)
+
+    await page.goto(sessionPath(other))
+    await waitSession(page, { directory: other, serverUrl: backend.url })
+
+    await expect.poll(async () => clean(await page.locator(promptSelector).first().textContent())).toBe("")
+
+    releaseReply()
+  } finally {
+    await cleanupTestProject(other, { serverUrl: backend.url })
+  }
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -4,6 +4,8 @@ import type {
   createPromptSubmit as createPromptSubmitType,
   sendFollowupDraft as sendFollowupDraftType,
 } from "./submit"
+import { _portableDraftTesting, usePortableDraft } from "./portable-draft"
+import { _pinnedDraftTesting, usePinnedDraft } from "./pinned-draft"
 
 type PromptSubmitInput = Parameters<typeof createPromptSubmitType>[0]
 type PromptSubmit = ReturnType<typeof createPromptSubmitType>
@@ -33,16 +35,19 @@ const commandCalls: Array<Record<string, unknown>> = []
 const commandDefinitions: Array<{ name: string }> = []
 let commandsReady = true
 let promptAsyncFailure: Error | undefined
+let promptAsyncGate: Promise<void> | undefined
 const abortedSessions: Array<{ sessionID: string; source?: string }> = []
 const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
 const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
+const promptContextReplaceAllCalls: unknown[][] = []
 
 let params: { dir?: string; id?: string } = {}
 let navigateImpl = (_path: string): void => {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
+let promptDirty = false
 
 let currentIntl = "zh-Hans"
 let promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
@@ -75,6 +80,7 @@ const clientFor = (directory: string) => {
       prompt: async () => ({ data: undefined }),
       promptAsync: async (input: Record<string, unknown>) => {
         promptAsyncCalls.push(input)
+        await promptAsyncGate
         if (promptAsyncFailure) throw promptAsyncFailure
         return { data: undefined }
       },
@@ -145,6 +151,7 @@ beforeAll(async () => {
   mock.module("@/context/prompt", () => ({
     usePrompt: () => ({
       current: () => promptValue,
+      dirty: () => promptDirty,
       reset: (target?: { dir: string; id?: string }) => {
         promptResetCalls.push({ target })
       },
@@ -155,6 +162,9 @@ beforeAll(async () => {
         add: () => undefined,
         remove: () => undefined,
         items: () => [],
+        replaceAll: (items: unknown[]) => {
+          promptContextReplaceAllCalls.push(items)
+        },
       },
     }),
   }))
@@ -267,19 +277,24 @@ beforeEach(() => {
   commandDefinitions.length = 0
   commandsReady = true
   promptAsyncFailure = undefined
+  promptAsyncGate = undefined
   abortedSessions.length = 0
   globalTodoSets.length = 0
   childTodoSets.length = 0
   promptSetCalls.length = 0
   promptResetCalls.length = 0
+  promptContextReplaceAllCalls.length = 0
   params = {}
   navigateImpl = (_path: string): void => {}
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
+  promptDirty = false
   currentIntl = "zh-Hans"
   promptValue = [{ type: "text", content: "ls", start: 0, end: 2 }]
+  _portableDraftTesting.reset()
+  _pinnedDraftTesting.reset()
   for (const key of Object.keys(storedSessions)) delete storedSessions[key]
 })
 
@@ -806,7 +821,20 @@ describe("prompt submit worktree selection", () => {
       if (match) params.id = match[1]
     }
 
-    const submit = createPromptSubmit({
+    const submit = createHomepageSubmit()
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptResetCalls.length > 0)
+
+    // After navigate(), params.id is now "session-1", but clearInput must reset the
+    // SOURCE scope (home page: dir=/repo/main, no session id) not the final session scope
+    expect(params.id).toBe("session-1") // confirm navigate ran and updated params
+    expect(promptResetCalls.at(-1)?.target?.dir).toBe("/repo/main")
+    expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
+  })
+
+  const createHomepageSubmit = () =>
+    createPromptSubmit({
       navigate: (path) => navigateImpl(path),
       routeParams: () => params,
       info: () => undefined,
@@ -825,14 +853,165 @@ describe("prompt submit worktree selection", () => {
       onSubmit: () => undefined,
     })
 
-    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+  test("detaches submitted portable draft before async prompt settles", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "already sent", start: 0, end: 12 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
     await waitForCall(() => promptResetCalls.length > 0)
 
-    // After navigate(), params.id is now "session-1", but clearInput must reset the
-    // SOURCE scope (home page: dir=/repo/main, no session id) not the final session scope
-    expect(params.id).toBe("session-1") // confirm navigate ran and updated params
-    expect(promptResetCalls.at(-1)?.target?.dir).toBe("/repo/main")
-    expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
+    expect(portable.snapshot()).toBeNull()
+    expect(portable.consumeForHomepage("/repo/other", true)).toBeNull()
+
+    releasePromptAsync()
+    await submitted
+  })
+
+  test("restores submitted portable draft on async prompt failure when no new draft exists", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "restore me", start: 0, end: 10 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptSetCalls.length > 0)
+
+    expect(portable.snapshot()).toBeNull()
+    expect(promptSetCalls.at(-1)).toMatchObject({
+      prompt: promptValue,
+      cursor: 10,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+  })
+
+  test("does not restore submitted portable draft over new draft after async failure", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "old submit", start: 0, end: 10 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptResetCalls.length > 0)
+
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: [{ type: "text", content: "new draft", start: 0, end: 9 }],
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+
+    expect(promptSetCalls).toEqual([])
+    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "new draft" })
+  })
+
+  test("detaches submitted pinned draft before async prompt settles", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "deep link", start: 0, end: 9 }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "deep link" })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptResetCalls.length > 0)
+
+    expect(pinned.current()).toBeNull()
+
+    releasePromptAsync()
+    await submitted
+  })
+
+  test("restores submitted pinned draft on async prompt failure when no new draft exists", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "restore pin", start: 0, end: 11 }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "restore pin" })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptSetCalls.length > 0)
+
+    expect(pinned.current()).toBeNull()
+    expect(promptSetCalls.at(-1)).toMatchObject({
+      prompt: promptValue,
+      cursor: 11,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+  })
+
+  test("does not restore submitted pinned draft over new pinned draft after async failure", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "old pin", start: 0, end: 7 }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "old pin" })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptResetCalls.length > 0)
+
+    pinned.adopt({ directory: "/repo/main", prompt: "new pin" })
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+
+    expect(promptSetCalls).toEqual([])
+    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "new pin" })
   })
 })
 

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -1055,6 +1055,41 @@ describe("prompt submit worktree selection", () => {
     expect(promptSetCalls).toEqual([])
   })
 
+  test("does not restore submitted portable draft over context-only active target route", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "same route context", start: 0, end: 18 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/main", id: "session-1" }
+    promptDirty = false
+    promptContextItems = [{ key: "new", type: "file", path: "/repo/main/new.ts", comment: "new note" }]
+    releasePromptAsync()
+    await submitted
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(promptSetCalls).toEqual([])
+    expect(promptContextReplaceAllCalls).toEqual([])
+  })
+
   test("detaches submitted pinned draft before async prompt settles", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "deep link", start: 0, end: 9 }]
@@ -1160,6 +1195,35 @@ describe("prompt submit worktree selection", () => {
 
     expect(promptSetCalls).toEqual([])
     expect(pinned.current()?.prompt[0]).toMatchObject({ content: "new pin" })
+  })
+
+  test("does not restore submitted pinned draft over context-only active target route", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "old pin", start: 0, end: 7 }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "old pin" })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/main", id: "session-1" }
+    promptDirty = false
+    promptContextItems = [{ key: "new", type: "file", path: "/repo/main/new-pin.ts", comment: "new pin note" }]
+    releasePromptAsync()
+    await submitted
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(promptSetCalls).toEqual([])
+    expect(promptContextReplaceAllCalls).toEqual([])
   })
 })
 

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -921,7 +921,7 @@ describe("prompt submit worktree selection", () => {
     })
   })
 
-  test("does not restore submitted portable draft over new draft after async failure", async () => {
+  test("restores submitted portable draft while preserving a different homepage owner draft", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "old submit", start: 0, end: 10 }]
     const portable = usePortableDraft()
@@ -944,19 +944,28 @@ describe("prompt submit worktree selection", () => {
     const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
     await waitForCall(() => promptResetCalls.length > 0)
 
+    params = { dir: "/repo/other" }
+    const otherDraft = [{ type: "text" as const, content: "new draft", start: 0, end: 9 }]
     portable.record({
-      sourceFilesystemDirectory: "/repo/main",
-      prompt: [{ type: "text", content: "new draft", start: 0, end: 9 }],
+      sourceFilesystemDirectory: "/repo/other",
+      prompt: otherDraft,
       context: [],
       images: [],
       resolvedMentions: {},
     })
-    promptDirty = true
     releasePromptAsync()
     await submitted
+    await waitForAsyncSubmitSettled()
 
-    expect(promptSetCalls).toEqual([])
-    expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "new draft" })
+    expect(promptSetCalls.at(-1)).toMatchObject({
+      prompt: promptValue,
+      cursor: 10,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+    expect(portable.snapshot()).toMatchObject({
+      sourceFilesystemDirectory: "/repo/other",
+      prompt: otherDraft,
+    })
   })
 
   test("restores submitted portable draft when a different active route is dirty", async () => {
@@ -1217,7 +1226,7 @@ describe("prompt submit worktree selection", () => {
     })
   })
 
-  test("does not restore submitted pinned draft over new pinned draft after async failure", async () => {
+  test("restores submitted pinned draft while preserving a different homepage owner draft", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "old pin", start: 0, end: 7 }]
     const pinned = usePinnedDraft()
@@ -1234,13 +1243,21 @@ describe("prompt submit worktree selection", () => {
     const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
     await waitForCall(() => promptResetCalls.length > 0)
 
-    pinned.adopt({ directory: "/repo/main", prompt: "new pin" })
-    promptDirty = true
+    params = { dir: "/repo/other" }
+    pinned.adopt({ directory: "/repo/other", prompt: "new pin" })
     releasePromptAsync()
     await submitted
+    await waitForAsyncSubmitSettled()
 
-    expect(promptSetCalls).toEqual([])
-    expect(pinned.current()?.prompt[0]).toMatchObject({ content: "new pin" })
+    expect(promptSetCalls.at(-1)).toMatchObject({
+      prompt: promptValue,
+      cursor: 7,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+    expect(pinned.current()).toMatchObject({
+      directory: "/repo/other",
+      prompt: [{ type: "text", content: "new pin", start: 0, end: 7 }],
+    })
   })
 
   test("does not restore submitted pinned draft over context-only active target route", async () => {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -43,6 +43,10 @@ const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: s
 const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
 const promptContextReplaceAllCalls: Array<{ items: unknown[]; target?: { dir: string; id?: string } }> = []
 const promptHasDraftCalls: Array<{ target?: { dir: string; id?: string } }> = []
+const uiSetModeCalls: Array<"normal" | "shell"> = []
+const uiSetPopoverCalls: Array<"at" | "slash" | null> = []
+const uiQueueScrollCalls: string[] = []
+const uiFocusCalls: string[] = []
 let promptContextItems: Array<{ key: string; type: "file"; path: string; comment?: string }> = []
 
 let params: { dir?: string; id?: string } = {}
@@ -295,6 +299,10 @@ beforeEach(() => {
   promptResetCalls.length = 0
   promptContextReplaceAllCalls.length = 0
   promptHasDraftCalls.length = 0
+  uiSetModeCalls.length = 0
+  uiSetPopoverCalls.length = 0
+  uiQueueScrollCalls.length = 0
+  uiFocusCalls.length = 0
   promptContextItems = []
   params = {}
   navigateImpl = (_path: string): void => {}
@@ -846,7 +854,7 @@ describe("prompt submit worktree selection", () => {
     expect(promptResetCalls.at(-1)?.target?.id).toBeUndefined()
   })
 
-  const createHomepageSubmit = () =>
+  const createHomepageSubmit = (overrides: Partial<PromptSubmitInput> = {}) =>
     createPromptSubmit({
       navigate: (path) => navigateImpl(path),
       routeParams: () => params,
@@ -857,13 +865,14 @@ describe("prompt submit worktree selection", () => {
       mode: () => "normal",
       working: () => false,
       editor: () => undefined,
-      queueScroll: () => undefined,
+      queueScroll: () => uiQueueScrollCalls.push("queue"),
       promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
-      setMode: () => undefined,
-      setPopover: () => undefined,
+      setMode: (nextMode) => uiSetModeCalls.push(nextMode),
+      setPopover: (popover) => uiSetPopoverCalls.push(popover),
       onSubmit: () => undefined,
+      ...overrides,
     })
 
   test("detaches submitted portable draft before async prompt settles", async () => {
@@ -1002,6 +1011,62 @@ describe("prompt submit worktree selection", () => {
       cursor: 15,
       target: { dir: "/repo/main", id: "session-1" },
     })
+  })
+
+  test("restores submitted portable draft in background without changing active composer UI", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    }) as typeof requestAnimationFrame
+    try {
+      params = { dir: "/repo/main" }
+      promptValue = [{ type: "text", content: "background ui", start: 0, end: 13 }]
+      const portable = usePortableDraft()
+      portable.record({
+        sourceFilesystemDirectory: "/repo/main",
+        prompt: promptValue,
+        context: [],
+        images: [],
+        resolvedMentions: {},
+      })
+
+      const editor = document.createElement("div")
+      editor.textContent = "active composer"
+      Object.defineProperty(editor, "focus", { value: () => uiFocusCalls.push("focus") })
+
+      let releasePromptAsync!: () => void
+      promptAsyncGate = new Promise<void>((resolve) => {
+        releasePromptAsync = resolve
+      })
+      promptAsyncFailure = new Error("network down")
+
+      const submit = createHomepageSubmit({ editor: () => editor })
+
+      const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+      await waitForCall(() => promptResetCalls.length > 0)
+      const modeCallsAfterClear = uiSetModeCalls.length
+      const popoverCallsAfterClear = uiSetPopoverCalls.length
+      const focusCallsAfterClear = uiFocusCalls.length
+      const queueScrollCallsAfterClear = uiQueueScrollCalls.length
+
+      params = { dir: "/repo/other", id: "session-other" }
+      releasePromptAsync()
+      await submitted
+      await waitForAsyncSubmitSettled()
+
+      expect(promptSetCalls.at(-1)).toMatchObject({
+        prompt: promptValue,
+        cursor: 13,
+        target: { dir: "/repo/main", id: "session-1" },
+      })
+      expect(uiSetModeCalls).toHaveLength(modeCallsAfterClear)
+      expect(uiSetPopoverCalls).toHaveLength(popoverCallsAfterClear)
+      expect(uiFocusCalls).toHaveLength(focusCallsAfterClear)
+      expect(uiQueueScrollCalls).toHaveLength(queueScrollCallsAfterClear)
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame
+    }
   })
 
   test("restores submitted portable context to target scope when a different active route is dirty", async () => {
@@ -1258,6 +1323,56 @@ describe("prompt submit worktree selection", () => {
       directory: "/repo/other",
       prompt: [{ type: "text", content: "new pin", start: 0, end: 7 }],
     })
+  })
+
+  test("restores submitted pinned draft in background without changing active composer UI", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    }) as typeof requestAnimationFrame
+    try {
+      params = { dir: "/repo/main" }
+      promptValue = [{ type: "text", content: "pin background", start: 0, end: 14 }]
+      const pinned = usePinnedDraft()
+      pinned.adopt({ directory: "/repo/main", prompt: "pin background" })
+
+      const editor = document.createElement("div")
+      editor.textContent = "active composer"
+      Object.defineProperty(editor, "focus", { value: () => uiFocusCalls.push("focus") })
+
+      let releasePromptAsync!: () => void
+      promptAsyncGate = new Promise<void>((resolve) => {
+        releasePromptAsync = resolve
+      })
+      promptAsyncFailure = new Error("network down")
+
+      const submit = createHomepageSubmit({ editor: () => editor })
+
+      const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+      await waitForCall(() => promptResetCalls.length > 0)
+      const modeCallsAfterClear = uiSetModeCalls.length
+      const popoverCallsAfterClear = uiSetPopoverCalls.length
+      const focusCallsAfterClear = uiFocusCalls.length
+      const queueScrollCallsAfterClear = uiQueueScrollCalls.length
+
+      params = { dir: "/repo/other", id: "session-other" }
+      releasePromptAsync()
+      await submitted
+      await waitForAsyncSubmitSettled()
+
+      expect(promptSetCalls.at(-1)).toMatchObject({
+        prompt: promptValue,
+        cursor: 14,
+        target: { dir: "/repo/main", id: "session-1" },
+      })
+      expect(uiSetModeCalls).toHaveLength(modeCallsAfterClear)
+      expect(uiSetPopoverCalls).toHaveLength(popoverCallsAfterClear)
+      expect(uiFocusCalls).toHaveLength(focusCallsAfterClear)
+      expect(uiQueueScrollCalls).toHaveLength(queueScrollCallsAfterClear)
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame
+    }
   })
 
   test("does not restore submitted pinned draft over context-only active target route", async () => {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -42,6 +42,7 @@ const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknow
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
 const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
 const promptContextReplaceAllCalls: Array<{ items: unknown[]; target?: { dir: string; id?: string } }> = []
+const promptHasDraftCalls: Array<{ target?: { dir: string; id?: string } }> = []
 let promptContextItems: Array<{ key: string; type: "file"; path: string; comment?: string }> = []
 
 let params: { dir?: string; id?: string } = {}
@@ -49,6 +50,7 @@ let navigateImpl = (_path: string): void => {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
 let promptDirty = false
+let promptHasDraft = false
 
 let currentIntl = "zh-Hans"
 let promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
@@ -60,6 +62,8 @@ const waitForCall = async (check: () => boolean) => {
   }
   throw new Error("timed out waiting for async request")
 }
+
+const waitForAsyncSubmitSettled = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 const clientFor = (directory: string) => {
   createdClients.push(directory)
@@ -153,6 +157,11 @@ beforeAll(async () => {
     usePrompt: () => ({
       current: () => promptValue,
       dirty: () => promptDirty,
+      hasDraft: (target?: { dir: string; id?: string }) => {
+        promptHasDraftCalls.push({ target })
+        const targetIsActive = target && params.dir === target.dir && params.id === target.id
+        return promptHasDraft || (!!targetIsActive && (promptDirty || promptContextItems.length > 0))
+      },
       reset: (target?: { dir: string; id?: string }) => {
         promptResetCalls.push({ target })
       },
@@ -285,6 +294,7 @@ beforeEach(() => {
   promptSetCalls.length = 0
   promptResetCalls.length = 0
   promptContextReplaceAllCalls.length = 0
+  promptHasDraftCalls.length = 0
   promptContextItems = []
   params = {}
   navigateImpl = (_path: string): void => {}
@@ -293,6 +303,7 @@ beforeEach(() => {
   selected = "/repo/worktree-a"
   variant = undefined
   promptDirty = false
+  promptHasDraft = false
   currentIntl = "zh-Hans"
   promptValue = [{ type: "text", content: "ls", start: 0, end: 2 }]
   _portableDraftTesting.reset()
@@ -1083,11 +1094,46 @@ describe("prompt submit worktree selection", () => {
     promptContextItems = [{ key: "new", type: "file", path: "/repo/main/new.ts", comment: "new note" }]
     releasePromptAsync()
     await submitted
-    await Promise.resolve()
-    await Promise.resolve()
+    await waitForAsyncSubmitSettled()
 
     expect(promptSetCalls).toEqual([])
     expect(promptContextReplaceAllCalls).toEqual([])
+    expect(promptHasDraftCalls.at(-1)?.target).toEqual({ dir: "/repo/main", id: "session-1" })
+  })
+
+  test("does not restore submitted portable draft over inactive target route with a newer draft", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "old submit", start: 0, end: 10 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/main", id: "session-1" }
+    promptHasDraft = true
+    params = { dir: "/repo/other", id: "session-other" }
+    releasePromptAsync()
+    await submitted
+    await waitForAsyncSubmitSettled()
+
+    expect(promptSetCalls).toEqual([])
+    expect(promptContextReplaceAllCalls).toEqual([])
+    expect(promptHasDraftCalls.at(-1)?.target).toEqual({ dir: "/repo/main", id: "session-1" })
   })
 
   test("detaches submitted pinned draft before async prompt settles", async () => {
@@ -1224,6 +1270,35 @@ describe("prompt submit worktree selection", () => {
 
     expect(promptSetCalls).toEqual([])
     expect(promptContextReplaceAllCalls).toEqual([])
+  })
+
+  test("does not restore submitted pinned draft over inactive target route with a newer draft", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "old pin", start: 0, end: 7 }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "old pin" })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/main", id: "session-1" }
+    promptHasDraft = true
+    params = { dir: "/repo/other", id: "session-other" }
+    releasePromptAsync()
+    await submitted
+    await waitForAsyncSubmitSettled()
+
+    expect(promptSetCalls).toEqual([])
+    expect(promptContextReplaceAllCalls).toEqual([])
+    expect(promptHasDraftCalls.at(-1)?.target).toEqual({ dir: "/repo/main", id: "session-1" })
   })
 })
 

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -41,7 +41,8 @@ const globalTodoSets: Array<{ sessionID: string; todos: unknown }> = []
 const childTodoSets: Array<{ directory: string; sessionID: string; todos: unknown }> = []
 const promptSetCalls: Array<{ prompt: Prompt; cursor?: number; target?: { dir: string; id?: string } }> = []
 const promptResetCalls: Array<{ target?: { dir: string; id?: string } }> = []
-const promptContextReplaceAllCalls: unknown[][] = []
+const promptContextReplaceAllCalls: Array<{ items: unknown[]; target?: { dir: string; id?: string } }> = []
+let promptContextItems: Array<{ key: string; type: "file"; path: string; comment?: string }> = []
 
 let params: { dir?: string; id?: string } = {}
 let navigateImpl = (_path: string): void => {}
@@ -161,9 +162,9 @@ beforeAll(async () => {
       context: {
         add: () => undefined,
         remove: () => undefined,
-        items: () => [],
-        replaceAll: (items: unknown[]) => {
-          promptContextReplaceAllCalls.push(items)
+        items: () => promptContextItems,
+        replaceAll: (items: unknown[], target?: { dir: string; id?: string }) => {
+          promptContextReplaceAllCalls.push({ items, target })
         },
       },
     }),
@@ -284,6 +285,7 @@ beforeEach(() => {
   promptSetCalls.length = 0
   promptResetCalls.length = 0
   promptContextReplaceAllCalls.length = 0
+  promptContextItems = []
   params = {}
   navigateImpl = (_path: string): void => {}
   sentShell.length = 0
@@ -982,6 +984,44 @@ describe("prompt submit worktree selection", () => {
     })
   })
 
+  test("restores submitted portable context to target scope when a different active route is dirty", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "background context", start: 0, end: 18 }]
+    const submittedContext = [{ key: "old", type: "file" as const, path: "/repo/main/old.ts", comment: "old note" }]
+    promptContextItems = submittedContext
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: submittedContext,
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/other", id: "session-other" }
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+    await waitForCall(() => promptContextReplaceAllCalls.length > 0)
+
+    expect(promptSetCalls.at(-1)?.target).toEqual({ dir: "/repo/main", id: "session-1" })
+    expect(promptContextReplaceAllCalls.at(-1)).toEqual({
+      items: [{ type: "file", path: "/repo/main/old.ts", comment: "old note" }],
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+  })
+
   test("does not restore submitted portable draft over dirty active target route", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "same route fail", start: 0, end: 15 }]
@@ -1040,6 +1080,7 @@ describe("prompt submit worktree selection", () => {
   test("restores submitted pinned draft on async prompt failure when no new draft exists", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "restore pin", start: 0, end: 11 }]
+    promptContextItems = [{ key: "pin", type: "file", path: "/repo/main/pin.ts", comment: "pin note" }]
     const pinned = usePinnedDraft()
     pinned.adopt({ directory: "/repo/main", prompt: "restore pin" })
     promptAsyncFailure = new Error("network down")
@@ -1053,6 +1094,44 @@ describe("prompt submit worktree selection", () => {
     expect(promptSetCalls.at(-1)).toMatchObject({
       prompt: promptValue,
       cursor: 11,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+  })
+
+  test("restores submitted pinned context to target scope when a different active route is dirty", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "restore pin", start: 0, end: 11 }]
+    promptContextItems = [{ key: "pin", type: "file", path: "/repo/main/pin.ts", comment: "pin note" }]
+    const pinned = usePinnedDraft()
+    pinned.adopt({ directory: "/repo/main", prompt: "restore pin" })
+    pinned.recordEdit({
+      directory: "/repo/main",
+      prompt: promptValue,
+      context: promptContextItems,
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/other", id: "session-other" }
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+    await waitForCall(() => promptContextReplaceAllCalls.length > 0)
+
+    expect(promptSetCalls.at(-1)?.target).toEqual({ dir: "/repo/main", id: "session-1" })
+    expect(promptContextReplaceAllCalls.at(-1)).toEqual({
+      items: [{ type: "file", path: "/repo/main/pin.ts", comment: "pin note" }],
       target: { dir: "/repo/main", id: "session-1" },
     })
   })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -946,6 +946,75 @@ describe("prompt submit worktree selection", () => {
     expect(portable.snapshot()?.prompt[0]).toMatchObject({ content: "new draft" })
   })
 
+  test("restores submitted portable draft when a different active route is dirty", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "background fail", start: 0, end: 15 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/other", id: "session-other" }
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+    await waitForCall(() => promptSetCalls.length > 0)
+
+    expect(promptSetCalls.at(-1)).toMatchObject({
+      prompt: promptValue,
+      cursor: 15,
+      target: { dir: "/repo/main", id: "session-1" },
+    })
+  })
+
+  test("does not restore submitted portable draft over dirty active target route", async () => {
+    params = { dir: "/repo/main" }
+    promptValue = [{ type: "text", content: "same route fail", start: 0, end: 15 }]
+    const portable = usePortableDraft()
+    portable.record({
+      sourceFilesystemDirectory: "/repo/main",
+      prompt: promptValue,
+      context: [],
+      images: [],
+      resolvedMentions: {},
+    })
+
+    let releasePromptAsync!: () => void
+    promptAsyncGate = new Promise<void>((resolve) => {
+      releasePromptAsync = resolve
+    })
+    promptAsyncFailure = new Error("network down")
+
+    const submit = createHomepageSubmit()
+
+    const submitted = submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    params = { dir: "/repo/main", id: "session-1" }
+    promptDirty = true
+    releasePromptAsync()
+    await submitted
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(promptSetCalls).toEqual([])
+  })
+
   test("detaches submitted pinned draft before async prompt settles", async () => {
     params = { dir: "/repo/main" }
     promptValue = [{ type: "text", content: "deep link", start: 0, end: 9 }]

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -622,6 +622,25 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return !prompt.hasDraft(promptScope)
     }
 
+    const isActivePromptScope = (scope: PromptRouteScope) => {
+      const active = params()
+      return active.dir === scope.dir && active.id === scope.id
+    }
+
+    const restoreVisibleEditor = (owned: SubmitOwnership) => {
+      if (!isActivePromptScope(promptScope)) return
+      input.setMode(mode)
+      input.setPopover(null)
+      requestAnimationFrame(() => {
+        const editor = input.editor()
+        if (!editor) return
+        editor.focus()
+        const cursorPrompt = owned.kind === "route" ? currentPrompt : prompt.current()
+        setCursorPosition(editor, input.promptLength(cursorPrompt))
+        input.queueScroll()
+      })
+    }
+
     const restoreInput = (owned: SubmitOwnership) => {
       switch (owned.kind) {
         case "portable":
@@ -640,16 +659,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
           break
         }
       }
-      input.setMode(mode)
-      input.setPopover(null)
-      requestAnimationFrame(() => {
-        const editor = input.editor()
-        if (!editor) return
-        editor.focus()
-        const cursorPrompt = owned.kind === "route" ? currentPrompt : prompt.current()
-        setCursorPosition(editor, input.promptLength(cursorPrompt))
-        input.queueScroll()
-      })
+      restoreVisibleEditor(owned)
     }
 
     // commentItems is referenced by restoreInput (route case) and by the prompt

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -634,12 +634,12 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         case "portable":
           if (!shouldRestoreOwnerDraft(portable.snapshot() !== null)) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
-          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
+          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest), promptScope)
           break
         case "pinned":
           if (!shouldRestoreOwnerDraft(pinned.current() !== null)) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
-          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
+          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest), promptScope)
           break
         case "route": {
           prompt.set(currentPrompt, input.promptLength(currentPrompt), promptScope)

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -618,15 +618,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       }
     }
 
-    const isActivePromptScope = (scope: PromptRouteScope) => {
-      const active = params()
-      return active.dir === scope.dir && active.id === scope.id
-    }
-
     const shouldRestoreOwnerDraft = (ownerHasNewDraft: boolean) => {
       if (ownerHasNewDraft) return false
-      if (!isActivePromptScope(promptScope)) return true
-      return !prompt.dirty() && prompt.context.items().length === 0
+      return !prompt.hasDraft(promptScope)
     }
 
     const restoreInput = (owned: SubmitOwnership) => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -578,21 +578,23 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       sessionID: session.id,
     })
 
-    // Two-phase clear (Bug 2):
-    //   1) clearInput(owned) runs SYNCHRONOUSLY before the await. It resets the
-    //      visible UI only; the owner snapshot is intentionally preserved so
-    //      restoreInput() can push it back on async failure.
-    //   2) confirmOwnerCleared(owned) runs in each success path AFTER the await
-    //      resolves. It tears down the owner snapshot under the captured revision
-    //      so a user who typed during the await is never trampled.
-    //   restoreInput(owned) (failure path) reads from the still-intact owner.
+    const submittedDraft = {
+      prompt: currentPrompt,
+      context,
+    }
+
+    // Submitted owner-backed drafts leave the live draft owner before the async
+    // send settles. The owner only represents editable unsent draft state;
+    // failure recovery uses submittedDraft captured above.
     const clearInput = (owned: SubmitOwnership) => {
       switch (owned.kind) {
-        case "portable":
         case "pinned":
-          // Reset the visible UI to homepage source scope. The owner snapshot
-          // stays put for now; confirmOwnerCleared/restoreInput own its fate.
           prompt.reset(sourcePromptScope)
+          pinned.clearAll(owned.revision)
+          break
+        case "portable":
+          prompt.reset(sourcePromptScope)
+          portable.clear(owned.revision)
           break
         case "route":
           prompt.reset(owned.scope)
@@ -603,9 +605,6 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     const confirmOwnerCleared = (owned: SubmitOwnership) => {
-      // Owner-backed cases: clear under the captured revision. If the user typed
-      // during the await the revision diverged and clear() returns false; we
-      // leave their fresh content in place.
       switch (owned.kind) {
         case "portable":
           portable.clear(owned.revision)
@@ -620,26 +619,17 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     const restoreInput = (owned: SubmitOwnership) => {
-      // Revision-guarded restore: only push the captured draft back if the user
-      // has not typed new content since submit. For owner-backed cases this means
-      // the owner's current revision still matches the captured revision (the
-      // owner is the source of truth). For route, the prompt store is a UI
-      // mirror with no separate owner, so we always re-push the captured value.
       switch (owned.kind) {
-        case "portable": {
-          const current = portable.snapshot()
-          if (!current || current.revision !== owned.revision) return
-          prompt.set(current.prompt, input.promptLength(current.prompt), promptScope)
-          prompt.context.replaceAll(current.context.map(({ key: _omit, ...rest }) => rest))
+        case "portable":
+          if (portable.snapshot() !== null || prompt.dirty()) return
+          prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
+          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
           break
-        }
-        case "pinned": {
-          const current = pinned.current()
-          if (!current || current.revision !== owned.revision) return
-          prompt.set(current.prompt, input.promptLength(current.prompt), promptScope)
-          prompt.context.replaceAll(current.context.map(({ key: _omit, ...rest }) => rest))
+        case "pinned":
+          if (pinned.current() !== null || prompt.dirty()) return
+          prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
+          prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
           break
-        }
         case "route": {
           prompt.set(currentPrompt, input.promptLength(currentPrompt), promptScope)
           restoreCommentItems(commentItems)

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -618,20 +618,19 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       }
     }
 
-    const shouldRestoreOwnerDraft = (ownerHasNewDraft: boolean) => {
-      if (ownerHasNewDraft) return false
+    const shouldRestoreOwnerDraft = () => {
       return !prompt.hasDraft(promptScope)
     }
 
     const restoreInput = (owned: SubmitOwnership) => {
       switch (owned.kind) {
         case "portable":
-          if (!shouldRestoreOwnerDraft(portable.snapshot() !== null)) return
+          if (!shouldRestoreOwnerDraft()) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
           prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest), promptScope)
           break
         case "pinned":
-          if (!shouldRestoreOwnerDraft(pinned.current() !== null)) return
+          if (!shouldRestoreOwnerDraft()) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
           prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest), promptScope)
           break

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -626,7 +626,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const shouldRestoreOwnerDraft = (ownerHasNewDraft: boolean) => {
       if (ownerHasNewDraft) return false
       if (!isActivePromptScope(promptScope)) return true
-      return !prompt.dirty()
+      return !prompt.dirty() && prompt.context.items().length === 0
     }
 
     const restoreInput = (owned: SubmitOwnership) => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -618,15 +618,26 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       }
     }
 
+    const isActivePromptScope = (scope: PromptRouteScope) => {
+      const active = params()
+      return active.dir === scope.dir && active.id === scope.id
+    }
+
+    const shouldRestoreOwnerDraft = (ownerHasNewDraft: boolean) => {
+      if (ownerHasNewDraft) return false
+      if (!isActivePromptScope(promptScope)) return true
+      return !prompt.dirty()
+    }
+
     const restoreInput = (owned: SubmitOwnership) => {
       switch (owned.kind) {
         case "portable":
-          if (portable.snapshot() !== null || prompt.dirty()) return
+          if (!shouldRestoreOwnerDraft(portable.snapshot() !== null)) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
           prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
           break
         case "pinned":
-          if (pinned.current() !== null || prompt.dirty()) return
+          if (!shouldRestoreOwnerDraft(pinned.current() !== null)) return
           prompt.set(submittedDraft.prompt, input.promptLength(submittedDraft.prompt), promptScope)
           prompt.context.replaceAll(submittedDraft.context.map(({ key: _omit, ...rest }) => rest))
           break

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -54,7 +54,10 @@ function promptSession() {
       removeComment: () => markDirty(),
       updateComment: () => markDirty(),
       replaceComments: () => markDirty(),
-      replaceAll: () => markDirty(),
+      replaceAll: (next: ContextItem[]) => {
+        items.splice(0, items.length, ...next.map((item) => ({ key: item.type, ...item })))
+        markDirty()
+      },
     },
     set: (next: Prompt, nextCursor?: number) => {
       prompt = next
@@ -133,6 +136,27 @@ describe("createPromptBinding", () => {
     expect(target.current()).toEqual(DEFAULT_PROMPT)
     expect(target.cursor()).toBe(0)
     expect(current.current()).toEqual([{ type: "text", content: "hello", start: 0, end: 5 }])
+  })
+
+  test("replaces context on an explicit target session", () => {
+    const current = promptSession()
+    const target = promptSession()
+    const binding = createPromptBinding(
+      () => ({ dir: "repo", id: "current" }),
+      (dir, id) => {
+        expect(dir).toBe("repo")
+        return id === "fork" ? target : current
+      },
+    )
+
+    binding.context.add({ type: "file", path: "current.ts" })
+    binding.context.replaceAll([{ type: "file", path: "target.ts", comment: "restore me" }], {
+      dir: "repo",
+      id: "fork",
+    })
+
+    expect(current.context.items().map((item) => item.path)).toEqual(["current.ts"])
+    expect(target.context.items()).toMatchObject([{ type: "file", path: "target.ts", comment: "restore me" }])
   })
 })
 

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -38,6 +38,7 @@ function promptSession() {
     current: () => prompt,
     cursor: () => cursor,
     dirty: () => dirty,
+    hasDraft: () => !isStructurallyEmpty(prompt, items, []),
     context: {
       items: () => items,
       add: (item: ContextItem) => {
@@ -110,6 +111,30 @@ describe("createPromptBinding", () => {
     expect(binding.cursor()).toBe(5)
     expect(binding.dirty()).toBe(true)
     expect(binding.context.items().map((item) => item.path)).toEqual(["a.ts"])
+  })
+
+  test("checks whether an explicit target session has a structural draft", () => {
+    const current = promptSession()
+    const target = promptSession()
+    const binding = createPromptBinding(
+      () => ({ dir: "repo", id: "current" }),
+      (dir, id) => {
+        expect(dir).toBe("repo")
+        return id === "fork" ? target : current
+      },
+    )
+
+    current.reset()
+    target.reset()
+    target.context.add({ type: "file", path: "target.ts" })
+
+    expect(binding.hasDraft()).toBe(false)
+    expect(binding.hasDraft({ dir: "repo", id: "fork" })).toBe(true)
+
+    target.context.replaceAll([])
+    target.set([{ type: "image", id: "img", filename: "shot.png", mime: "image/png", dataUrl: "data:" }], 0)
+
+    expect(binding.hasDraft({ dir: "repo", id: "fork" })).toBe(true)
   })
 
   test("writes to an explicit target session", () => {

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -196,6 +196,7 @@ type PromptBindingSession = {
   current: () => Prompt
   cursor: () => number | undefined
   dirty: () => boolean
+  hasDraft: () => boolean
   context: {
     items: () => (ContextItem & { key: string })[]
     add: (item: ContextItem) => void
@@ -226,6 +227,7 @@ export function createPromptBinding(
     current: () => session()?.current() ?? clonePrompt(DEFAULT_PROMPT),
     cursor: () => session()?.cursor(),
     dirty: () => session()?.dirty() ?? false,
+    hasDraft: (target?: Scope) => pick(target)?.hasDraft() ?? false,
     context: {
       items: () => session()?.context.items() ?? [],
       add: (item: ContextItem) => session()?.context.add(item),
@@ -268,6 +270,7 @@ function createPromptSession(dir: string, id: string | undefined) {
     current: createMemo(() => store.prompt),
     cursor: createMemo(() => store.cursor),
     dirty: createMemo(() => !isPromptEqual(store.prompt, DEFAULT_PROMPT)),
+    hasDraft: createMemo(() => !isStructurallyEmpty(store.prompt, store.context.items, [])),
     context: {
       items: createMemo(() => store.context.items),
       add(item: ContextItem) {

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -203,7 +203,7 @@ type PromptBindingSession = {
     removeComment: (path: string, commentID: string) => void
     updateComment: (path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) => void
     replaceComments: (items: FileContextItem[]) => void
-    /** Atomic full-replace: swaps ALL context items at once. Used by carry hydration. */
+    /** Atomic full-replace: swaps ALL context items at once. Used by carry hydration and failure restore. */
     replaceAll: (items: ContextItem[]) => void
   }
   set: (prompt: Prompt, cursorPosition?: number) => void
@@ -234,7 +234,7 @@ export function createPromptBinding(
       updateComment: (path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) =>
         session()?.context.updateComment(path, commentID, next),
       replaceComments: (items: FileContextItem[]) => session()?.context.replaceComments(items),
-      replaceAll: (items: ContextItem[]) => session()?.context.replaceAll(items),
+      replaceAll: (items: ContextItem[], target?: Scope) => pick(target)?.context.replaceAll(items),
     },
     set: (prompt: Prompt, cursorPosition?: number, target?: Scope) => pick(target)?.set(prompt, cursorPosition),
     reset: (target?: Scope) => pick(target)?.reset(),


### PR DESCRIPTION
## Summary

Detach submitted homepage drafts from portable and pinned draft owners as soon as submit clears the visible editor. Keep the submitted payload in the submit closure for failure recovery instead of leaving it in the live draft owner.

## Why

A sent homepage prompt could reappear after switching to another project or workspace while the async send was still settling. The live portable owner could be consumed by the new empty homepage before the old success cleanup ran, causing the submitted prompt to look like an unsent draft again.

## Related Issue

Fixes #1041

## Human Review Status

Pending

## Review Focus

Please focus on the submit lifecycle around `clearInput`, async failure restore, and whether owner-backed drafts now correctly represent only editable unsent state.

## Risk Notes

No storage schema, dependency, docs, release notes, permissions, generated content, or platform packaging surface changed.

Skipped conditional checklist items:

- Platform impact: not applicable because this is renderer prompt-state logic only.
- Docs/release/dependency/local-file surface: not applicable.

## How To Verify

```text
Diff check: git diff --check passed
Related unit tests: bun test --preload ./happydom.ts src/components/prompt-input/submit.test.ts src/context/prompt.test.ts src/components/prompt-input/portable-draft.test.ts src/components/prompt-input/pinned-draft.test.ts src/components/prompt-input/draft-isolation.integration.test.ts src/components/prompt-input/submit-ownership.test.ts passed, 115 tests
App typecheck: bun run typecheck passed
Visible user path: bunx playwright test e2e/projects/workspace-new-session.spec.ts --grep "sent homepage prompt" passed, 1 Chromium test
```

## Screenshots or Recordings

The visible behavior is covered by the Playwright test above: type a homepage prompt, submit while the assistant response is held pending, navigate to another project homepage, and assert the destination composer remains empty. No static screenshot is attached because the expected visual state is an empty editor after navigation.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Homepage prompts no longer persist or carry over between projects while replies are pending.
  * Improved restoration of drafts and prompt context when asynchronous submissions fail.
  * Stronger isolation of prompt context between sessions to prevent unintended carry-over.

* **Tests**
  * Added end-to-end and unit tests to ensure deterministic async submit and draft lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


