### PR TITLE
feat(automation): close PR1-5 backend gaps before frontend slice

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -204,6 +204,7 @@ jobs:
               test/ide
               test/installation
               test/auth
+              test/automation
             report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
           - package: desktop
             uses_turbo: true

--- a/packages/opencode/migration/20260601100000_automation_model_required/migration.sql
+++ b/packages/opencode/migration/20260601100000_automation_model_required/migration.sql
@@ -1,0 +1,7 @@
+-- Automation definitions and runs persisted before PR5.5 lack the now-required
+-- `model` field on AutomationDefinition. Since automations are still gated
+-- behind the env-flagged `automate` tool and no UI entry exists yet, any rows
+-- in these tables are pre-release dev/QA data. Drop them so the new schema
+-- parses cleanly without per-row backfill.
+DELETE FROM `automation_run`;--> statement-breakpoint
+DELETE FROM `automation_definition`;

--- a/packages/opencode/src/automation/__test_hooks.ts
+++ b/packages/opencode/src/automation/__test_hooks.ts
@@ -1,0 +1,17 @@
+import type { Automation } from "./index"
+
+/**
+ * @internal Test-only injection points for the automation module.
+ *
+ * Production code MUST NOT import or write to this module — the only reader
+ * is `recordRunOutcome` in `./index`, which checks `beforeReplaceDefinition`
+ * to support a deterministic ConflictError retry test. By living outside the
+ * `Automation` namespace, this seam is invisible to anyone consuming the
+ * public `Automation.*` API surface.
+ *
+ * Tests assign hooks here and MUST clear them in a `finally` block so a
+ * failing test cannot leak state to a sibling test.
+ */
+export const internalTestHooks: {
+  beforeReplaceDefinition?: (previous: Automation.Definition) => void
+} = {}

--- a/packages/opencode/src/automation/cron.ts
+++ b/packages/opencode/src/automation/cron.ts
@@ -46,6 +46,42 @@ export function parseCronSchedule(expression: string): CronSchedule {
   }
 }
 
+const monthMaxDays = new Map([
+  [1, 31],
+  [2, 29],
+  [3, 31],
+  [4, 30],
+  [5, 31],
+  [6, 30],
+  [7, 31],
+  [8, 31],
+  [9, 30],
+  [10, 31],
+  [11, 30],
+  [12, 31],
+])
+
+function hasReachableDayMonth(schedule: CronSchedule) {
+  for (const month of schedule.months) {
+    const maxDay = monthMaxDays.get(month)
+    if (maxDay === undefined) continue
+    for (const day of schedule.days) {
+      if (day <= maxDay) return true
+    }
+  }
+  return false
+}
+
+export function isValidCronExpression(expression: string): boolean {
+  try {
+    const schedule = parseCronSchedule(expression)
+    if (!schedule.weekdayRestricted && !hasReachableDayMonth(schedule)) return false
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function cronMatches(schedule: CronSchedule, time: DateTime) {
   const weekday = time.weekday === 7 ? 0 : time.weekday
   const dayMatches = schedule.days.has(time.day)

--- a/packages/opencode/src/automation/cron.ts
+++ b/packages/opencode/src/automation/cron.ts
@@ -1,0 +1,61 @@
+import { DateTime } from "luxon"
+
+export type CronSchedule = {
+  minutes: Set<number>
+  hours: Set<number>
+  days: Set<number>
+  months: Set<number>
+  weekdays: Set<number>
+  dayRestricted: boolean
+  weekdayRestricted: boolean
+}
+
+function cronValues(field: string, min: number, max: number, options?: { sundayAlias?: boolean }) {
+  const values = new Set<number>()
+  for (const item of field.split(",")) {
+    const [base, stepRaw] = item.split("/")
+    if (!base || item.split("/").length > 2) throw new Error(`Invalid cron field: ${item}`)
+    const step = stepRaw === undefined ? 1 : Number(stepRaw)
+    if (!Number.isInteger(step) || step <= 0) throw new Error(`Invalid cron step: ${item}`)
+    const range = base === "*" ? [min, max] : base.split("-").map(Number)
+    if (range.length === 0 || range.length > 2 || range.some((value) => !Number.isInteger(value))) {
+      throw new Error(`Invalid cron field: ${item}`)
+    }
+    const start = range[0]
+    const end = base === "*" || (range.length === 1 && stepRaw !== undefined) ? max : range.length === 1 ? range[0] : range[1]
+    if (start < min || end > max || start > end) throw new Error(`Invalid cron range: ${item}`)
+    for (let value = start; value <= end; value += step) {
+      values.add(options?.sundayAlias && value === 7 ? 0 : value)
+    }
+  }
+  return values
+}
+
+export function parseCronSchedule(expression: string): CronSchedule {
+  const fields = expression.trim().split(/\s+/)
+  if (fields.length !== 5) throw new Error(`Invalid cron expression: ${expression}`)
+  const [minuteField, hourField, dayField, monthField, weekdayField] = fields
+  return {
+    minutes: cronValues(minuteField, 0, 59),
+    hours: cronValues(hourField, 0, 23),
+    days: cronValues(dayField, 1, 31),
+    months: cronValues(monthField, 1, 12),
+    weekdays: cronValues(weekdayField, 0, 7, { sundayAlias: true }),
+    dayRestricted: dayField !== "*",
+    weekdayRestricted: weekdayField !== "*",
+  }
+}
+
+export function cronMatches(schedule: CronSchedule, time: DateTime) {
+  const weekday = time.weekday === 7 ? 0 : time.weekday
+  const dayMatches = schedule.days.has(time.day)
+  const weekdayMatches = schedule.weekdays.has(weekday)
+  const calendarMatches =
+    schedule.dayRestricted && schedule.weekdayRestricted ? dayMatches || weekdayMatches : dayMatches && weekdayMatches
+  return (
+    schedule.minutes.has(time.minute) &&
+    schedule.hours.has(time.hour) &&
+    schedule.months.has(time.month) &&
+    calendarMatches
+  )
+}

--- a/packages/opencode/src/automation/derived.ts
+++ b/packages/opencode/src/automation/derived.ts
@@ -66,6 +66,11 @@ export function cronMatches(schedule: CronSchedule, time: DateTime) {
   )
 }
 
+const PLUS_ONE_MONTH = { months: 1 }
+const PLUS_ONE_DAY = { days: 1 }
+const PLUS_ONE_HOUR = { hours: 1 }
+const PLUS_ONE_MINUTE = { minutes: 1 }
+
 function nextCronFires(definition: RecurringDefinition, from: number, count: number): number[] {
   if (definition.rhythm.kind !== "cron" || count <= 0) return []
   let schedule: CronSchedule
@@ -75,10 +80,28 @@ function nextCronFires(definition: RecurringDefinition, from: number, count: num
     return []
   }
   const fires: number[] = []
-  let cursor = DateTime.fromMillis(from, { zone: definition.timezone }).plus({ minutes: 1 }).startOf("minute")
-  for (let attempts = 0; attempts < CRON_LOOKAHEAD_MINUTES && fires.length < count; attempts++) {
-    if (cronMatches(schedule, cursor)) fires.push(cursor.toMillis())
-    cursor = cursor.plus({ minutes: 1 })
+  const maxTimestamp = from + CRON_LOOKAHEAD_MINUTES * 60 * 1000
+  let cursor = DateTime.fromMillis(from, { zone: definition.timezone }).plus(PLUS_ONE_MINUTE).startOf("minute")
+  while (cursor.toMillis() < maxTimestamp && fires.length < count) {
+    if (!schedule.months.has(cursor.month)) {
+      cursor = cursor.plus(PLUS_ONE_MONTH).startOf("month")
+      continue
+    }
+    const weekday = cursor.weekday === 7 ? 0 : cursor.weekday
+    const dayMatches = schedule.days.has(cursor.day)
+    const weekdayMatches = schedule.weekdays.has(weekday)
+    const calendarMatches =
+      schedule.dayRestricted && schedule.weekdayRestricted ? dayMatches || weekdayMatches : dayMatches && weekdayMatches
+    if (!calendarMatches) {
+      cursor = cursor.plus(PLUS_ONE_DAY).startOf("day")
+      continue
+    }
+    if (!schedule.hours.has(cursor.hour)) {
+      cursor = cursor.plus(PLUS_ONE_HOUR).startOf("hour")
+      continue
+    }
+    if (schedule.minutes.has(cursor.minute)) fires.push(cursor.toMillis())
+    cursor = cursor.plus(PLUS_ONE_MINUTE)
   }
   return fires
 }

--- a/packages/opencode/src/automation/derived.ts
+++ b/packages/opencode/src/automation/derived.ts
@@ -1,70 +1,11 @@
 import { DateTime } from "luxon"
 import type { Automation } from "."
+import { type CronSchedule, parseCronSchedule } from "./cron"
 
 const CRON_LOOKAHEAD_MINUTES = 527_040 * 5
 const NEXT_FIRES_PREVIEW = 5
 
 type RecurringDefinition = Extract<Automation.Definition, { kind: "recurring" }>
-
-type CronSchedule = {
-  minutes: Set<number>
-  hours: Set<number>
-  days: Set<number>
-  months: Set<number>
-  weekdays: Set<number>
-  dayRestricted: boolean
-  weekdayRestricted: boolean
-}
-
-function cronValues(field: string, min: number, max: number, options?: { sundayAlias?: boolean }) {
-  const values = new Set<number>()
-  for (const item of field.split(",")) {
-    const [base, stepRaw] = item.split("/")
-    if (!base || item.split("/").length > 2) throw new Error(`Invalid cron field: ${item}`)
-    const step = stepRaw === undefined ? 1 : Number(stepRaw)
-    if (!Number.isInteger(step) || step <= 0) throw new Error(`Invalid cron step: ${item}`)
-    const range = base === "*" ? [min, max] : base.split("-").map(Number)
-    if (range.length === 0 || range.length > 2 || range.some((value) => !Number.isInteger(value))) {
-      throw new Error(`Invalid cron field: ${item}`)
-    }
-    const start = range[0]
-    const end = base === "*" || (range.length === 1 && stepRaw !== undefined) ? max : range.length === 1 ? range[0] : range[1]
-    if (start < min || end > max || start > end) throw new Error(`Invalid cron range: ${item}`)
-    for (let value = start; value <= end; value += step) {
-      values.add(options?.sundayAlias && value === 7 ? 0 : value)
-    }
-  }
-  return values
-}
-
-export function parseCronSchedule(expression: string): CronSchedule {
-  const fields = expression.trim().split(/\s+/)
-  if (fields.length !== 5) throw new Error(`Invalid cron expression: ${expression}`)
-  const [minuteField, hourField, dayField, monthField, weekdayField] = fields
-  return {
-    minutes: cronValues(minuteField, 0, 59),
-    hours: cronValues(hourField, 0, 23),
-    days: cronValues(dayField, 1, 31),
-    months: cronValues(monthField, 1, 12),
-    weekdays: cronValues(weekdayField, 0, 7, { sundayAlias: true }),
-    dayRestricted: dayField !== "*",
-    weekdayRestricted: weekdayField !== "*",
-  }
-}
-
-export function cronMatches(schedule: CronSchedule, time: DateTime) {
-  const weekday = time.weekday === 7 ? 0 : time.weekday
-  const dayMatches = schedule.days.has(time.day)
-  const weekdayMatches = schedule.weekdays.has(weekday)
-  const calendarMatches =
-    schedule.dayRestricted && schedule.weekdayRestricted ? dayMatches || weekdayMatches : dayMatches && weekdayMatches
-  return (
-    schedule.minutes.has(time.minute) &&
-    schedule.hours.has(time.hour) &&
-    schedule.months.has(time.month) &&
-    calendarMatches
-  )
-}
 
 const PLUS_ONE_MONTH = { months: 1 }
 const PLUS_ONE_DAY = { days: 1 }

--- a/packages/opencode/src/automation/derived.ts
+++ b/packages/opencode/src/automation/derived.ts
@@ -1,0 +1,111 @@
+import { DateTime } from "luxon"
+import type { Automation } from "."
+
+const CRON_LOOKAHEAD_MINUTES = 527_040 * 5
+const NEXT_FIRES_PREVIEW = 5
+
+type RecurringDefinition = Extract<Automation.Definition, { kind: "recurring" }>
+
+type CronSchedule = {
+  minutes: Set<number>
+  hours: Set<number>
+  days: Set<number>
+  months: Set<number>
+  weekdays: Set<number>
+  dayRestricted: boolean
+  weekdayRestricted: boolean
+}
+
+function cronValues(field: string, min: number, max: number, options?: { sundayAlias?: boolean }) {
+  const values = new Set<number>()
+  for (const item of field.split(",")) {
+    const [base, stepRaw] = item.split("/")
+    if (!base || item.split("/").length > 2) throw new Error(`Invalid cron field: ${item}`)
+    const step = stepRaw === undefined ? 1 : Number(stepRaw)
+    if (!Number.isInteger(step) || step <= 0) throw new Error(`Invalid cron step: ${item}`)
+    const range = base === "*" ? [min, max] : base.split("-").map(Number)
+    if (range.length === 0 || range.length > 2 || range.some((value) => !Number.isInteger(value))) {
+      throw new Error(`Invalid cron field: ${item}`)
+    }
+    const start = range[0]
+    const end = base === "*" || (range.length === 1 && stepRaw !== undefined) ? max : range.length === 1 ? range[0] : range[1]
+    if (start < min || end > max || start > end) throw new Error(`Invalid cron range: ${item}`)
+    for (let value = start; value <= end; value += step) {
+      values.add(options?.sundayAlias && value === 7 ? 0 : value)
+    }
+  }
+  return values
+}
+
+export function parseCronSchedule(expression: string): CronSchedule {
+  const fields = expression.trim().split(/\s+/)
+  if (fields.length !== 5) throw new Error(`Invalid cron expression: ${expression}`)
+  const [minuteField, hourField, dayField, monthField, weekdayField] = fields
+  return {
+    minutes: cronValues(minuteField, 0, 59),
+    hours: cronValues(hourField, 0, 23),
+    days: cronValues(dayField, 1, 31),
+    months: cronValues(monthField, 1, 12),
+    weekdays: cronValues(weekdayField, 0, 7, { sundayAlias: true }),
+    dayRestricted: dayField !== "*",
+    weekdayRestricted: weekdayField !== "*",
+  }
+}
+
+export function cronMatches(schedule: CronSchedule, time: DateTime) {
+  const weekday = time.weekday === 7 ? 0 : time.weekday
+  const dayMatches = schedule.days.has(time.day)
+  const weekdayMatches = schedule.weekdays.has(weekday)
+  const calendarMatches =
+    schedule.dayRestricted && schedule.weekdayRestricted ? dayMatches || weekdayMatches : dayMatches && weekdayMatches
+  return (
+    schedule.minutes.has(time.minute) &&
+    schedule.hours.has(time.hour) &&
+    schedule.months.has(time.month) &&
+    calendarMatches
+  )
+}
+
+function nextCronFires(definition: RecurringDefinition, from: number, count: number): number[] {
+  if (definition.rhythm.kind !== "cron" || count <= 0) return []
+  let schedule: CronSchedule
+  try {
+    schedule = parseCronSchedule(definition.rhythm.expression)
+  } catch {
+    return []
+  }
+  const fires: number[] = []
+  let cursor = DateTime.fromMillis(from, { zone: definition.timezone }).plus({ minutes: 1 }).startOf("minute")
+  for (let attempts = 0; attempts < CRON_LOOKAHEAD_MINUTES && fires.length < count; attempts++) {
+    if (cronMatches(schedule, cursor)) fires.push(cursor.toMillis())
+    cursor = cursor.plus({ minutes: 1 })
+  }
+  return fires
+}
+
+function nextIntervalFires(definition: RecurringDefinition, from: number, count: number): number[] {
+  if (definition.rhythm.kind !== "interval" || count <= 0) return []
+  const fires: number[] = []
+  let cursor = from + definition.rhythm.everyMs
+  for (let index = 0; index < count; index++) {
+    fires.push(cursor)
+    cursor += definition.rhythm.everyMs
+  }
+  return fires
+}
+
+export function computeDerivedFields(
+  definition: RecurringDefinition,
+  from: number,
+  completedRunCount: number,
+): { nextFireAt: number | null; nextFires: number[] } {
+  if (definition.paused) return { nextFireAt: null, nextFires: [] }
+  if (definition.stop.kind === "condition") return { nextFireAt: null, nextFires: [] }
+  const remaining =
+    definition.stop.kind === "count" ? Math.max(0, definition.stop.count - completedRunCount) : NEXT_FIRES_PREVIEW
+  if (remaining <= 0) return { nextFireAt: null, nextFires: [] }
+  const count = Math.min(NEXT_FIRES_PREVIEW, remaining)
+  const fires =
+    definition.rhythm.kind === "cron" ? nextCronFires(definition, from, count) : nextIntervalFires(definition, from, count)
+  return { nextFireAt: fires[0] ?? null, nextFires: fires }
+}

--- a/packages/opencode/src/automation/fixtures.ts
+++ b/packages/opencode/src/automation/fixtures.ts
@@ -13,10 +13,18 @@ export const automationDefinitionFixture = Automation.Definition.parse({
   updatedAt: 1_800_000_030_000,
   timezone: "UTC",
   normalizationWarnings: [],
+  model: Automation.Model.parse({ providerID: "anthropic", modelID: "claude-sonnet-4-6" }),
+  variant: "high",
   rhythm: { kind: "interval", everyMs: 3_600_000 },
   stop: { kind: "never" },
-  nextFireAt: null,
-  nextFires: [],
+  nextFireAt: 1_800_003_600_000,
+  nextFires: [
+    1_800_003_600_000,
+    1_800_007_200_000,
+    1_800_010_800_000,
+    1_800_014_400_000,
+    1_800_018_000_000,
+  ],
   failureStreak: 0,
 })
 

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -64,6 +64,10 @@ export namespace Automation {
     .object({ error: z.literal("active_run_still_running"), runID: RunID })
     .strict()
     .meta({ ref: "AutomationActiveRunStillRunningError" })
+  // Stop accepts all three kinds at the schema layer so create/update can
+  // return a structured `unsupported_stop_condition` error for `kind: "condition"`
+  // (rejected by validateCreateInput / validateUpdateInput). The agent-facing
+  // `automate` tool schema separately omits condition from its input surface.
   export const Stop = z
     .discriminatedUnion("kind", [
       z.object({ kind: z.literal("count"), count: z.number().int().positive() }).strict(),
@@ -71,15 +75,6 @@ export namespace Automation {
       z.object({ kind: z.literal("never") }).strict(),
     ])
     .meta({ ref: "AutomationStop" })
-  // Input-only Stop: condition is persisted (Definition.stop can be `condition`)
-  // but cannot be supplied via create/update yet. Keep the two schemas separate
-  // so the public contract doesn't advertise a kind we reject at runtime.
-  export const SupportedCreateStop = z
-    .discriminatedUnion("kind", [
-      z.object({ kind: z.literal("count"), count: z.number().int().positive() }).strict(),
-      z.object({ kind: z.literal("never") }).strict(),
-    ])
-    .meta({ ref: "AutomationSupportedCreateStop" })
   export const Rhythm = z
     .discriminatedUnion("kind", [
       z.object({ kind: z.literal("interval"), everyMs: z.number().int().min(MIN_INTERVAL_MS, `interval_below_minimum_${MIN_INTERVAL_MS}ms`) }).strict(),
@@ -100,7 +95,7 @@ export namespace Automation {
   export const CreateInput = z
     .discriminatedUnion("kind", [
       z.object({ kind: z.literal("oneshot"), ...CommonCreate, fireAt: z.number().int().nonnegative() }).strict(),
-      z.object({ kind: z.literal("recurring"), ...CommonCreate, rhythm: Rhythm, stop: SupportedCreateStop }).strict(),
+      z.object({ kind: z.literal("recurring"), ...CommonCreate, rhythm: Rhythm, stop: Stop }).strict(),
     ])
     .meta({ ref: "AutomationCreateInput" })
   export type CreateInput = z.infer<typeof CreateInput>
@@ -115,7 +110,7 @@ export namespace Automation {
       timezone: z.string().min(1).optional(),
       fireAt: z.number().int().nonnegative().optional(),
       rhythm: Rhythm.optional(),
-      stop: SupportedCreateStop.optional(),
+      stop: Stop.optional(),
       model: Model.optional(),
       variant: z.string().min(1).nullable().optional(),
     })
@@ -398,6 +393,9 @@ export namespace Automation {
     if (input.where.worktree && Instance.project.vcs !== "git") {
       addDetail(details, "where.worktree", "unsupported_where_worktree_not_git")
     }
+    if (input.kind === "recurring" && input.stop.kind === "condition") {
+      addDetail(details, "stop", "unsupported_stop_condition")
+    }
     details.push(...validateScheduleFields(input))
     return details
   }
@@ -421,6 +419,9 @@ export namespace Automation {
     }
     if (patch.rhythm?.kind === "cron" && !isValidCronExpression(patch.rhythm.expression)) {
       addDetail(details, "rhythm.expression", "invalid_cron_expression")
+    }
+    if (patch.stop?.kind === "condition") {
+      addDetail(details, "stop", "unsupported_stop_condition")
     }
     return details
   }
@@ -634,7 +635,14 @@ export namespace Automation {
 
   export function recordRunOutcome(
     run: Run,
-    options?: { now?: number; refreshOnStopped?: boolean },
+    options?: {
+      now?: number
+      refreshOnStopped?: boolean
+      /** @internal Test-only hook fired between reading `previous` and calling
+       * `replaceDefinition`. Used to deterministically inject a concurrent write
+       * so the ConflictError retry path can be covered. */
+      __testBeforeReplace?: (previous: Definition) => void
+    },
   ): Definition | undefined {
     if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return undefined
     const now = options?.now ?? Date.now()
@@ -667,6 +675,7 @@ export namespace Automation {
         revision: previous.revision + 1,
         updatedAt: now,
       })
+      options?.__testBeforeReplace?.(previous)
       try {
         return replaceDefinition(previous, next)
       } catch (error) {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -638,10 +638,6 @@ export namespace Automation {
     options?: {
       now?: number
       refreshOnStopped?: boolean
-      /** @internal Test-only hook fired between reading `previous` and calling
-       * `replaceDefinition`. Used to deterministically inject a concurrent write
-       * so the ConflictError retry path can be covered. */
-      __testBeforeReplace?: (previous: Definition) => void
     },
   ): Definition | undefined {
     if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return undefined
@@ -675,7 +671,7 @@ export namespace Automation {
         revision: previous.revision + 1,
         updatedAt: now,
       })
-      options?.__testBeforeReplace?.(previous)
+      __testHooks.beforeReplaceDefinition?.(previous)
       try {
         return replaceDefinition(previous, next)
       } catch (error) {
@@ -685,6 +681,17 @@ export namespace Automation {
     }
     return undefined
   }
+
+  /**
+   * @internal Test-only seam. Production code MUST NOT read or write this.
+   * Tests assign `beforeReplaceDefinition` to deterministically inject a
+   * concurrent write between `recordRunOutcome`'s read and its replace, so
+   * the ConflictError retry path can be exercised end-to-end. Reset to `{}`
+   * after each test (or scope assignments with try/finally).
+   */
+  export const __testHooks: {
+    beforeReplaceDefinition?: (previous: Definition) => void
+  } = {}
 
   function sameArray(left: readonly number[], right: readonly number[]) {
     if (left.length !== right.length) return false

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -13,6 +13,7 @@ import type { AutomationRunAttendance, AutomationRunBlocker } from "./run-contex
 import { AutomationDefinitionTable, AutomationRunTable } from "./automation.sql"
 import { isValidCronExpression as cronIsValidExpression } from "./cron"
 import { computeDerivedFields } from "./derived"
+import { internalTestHooks } from "./__test_hooks"
 
 export const AutomationID = {
   Definition: {
@@ -671,7 +672,7 @@ export namespace Automation {
         revision: previous.revision + 1,
         updatedAt: now,
       })
-      __testHooks.beforeReplaceDefinition?.(previous)
+      internalTestHooks.beforeReplaceDefinition?.(previous)
       try {
         return replaceDefinition(previous, next)
       } catch (error) {
@@ -681,17 +682,6 @@ export namespace Automation {
     }
     return undefined
   }
-
-  /**
-   * @internal Test-only seam. Production code MUST NOT read or write this.
-   * Tests assign `beforeReplaceDefinition` to deterministically inject a
-   * concurrent write between `recordRunOutcome`'s read and its replace, so
-   * the ConflictError retry path can be exercised end-to-end. Reset to `{}`
-   * after each test (or scope assignments with try/finally).
-   */
-  export const __testHooks: {
-    beforeReplaceDefinition?: (previous: Definition) => void
-  } = {}
 
   function sameArray(left: readonly number[], right: readonly number[]) {
     if (left.length !== right.length) return false

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -107,7 +107,7 @@ export namespace Automation {
       rhythm: Rhythm.optional(),
       stop: Stop.optional(),
       model: Model.optional(),
-      variant: z.string().min(1).optional(),
+      variant: z.string().min(1).nullable().optional(),
     })
     .strict()
     .meta({ ref: "AutomationUpdateInput" })
@@ -675,17 +675,25 @@ export namespace Automation {
     const updateDetails = validateUpdateInput(previous, patch, now)
     if (updateDetails.length) throw new ValidationError(updateDetails)
     if (!hasChanges(previous, patch)) return previous
+    const merged: Record<string, unknown> = { ...previous, ...patch }
+    if (patch.variant === null) delete merged.variant
     let next = Definition.parse({
-      ...previous,
-      ...patch,
+      ...merged,
       revision: previous.revision + 1,
       updatedAt: now,
     })
     const details = validateCreateInput(next)
     if (details.length) throw new ValidationError(details)
-    if (next.kind === "recurring") {
-      const derived = computeDerivedFields(next, now, completedRunCount(next.id))
-      next = { ...next, nextFireAt: derived.nextFireAt, nextFires: derived.nextFires }
+    if (next.kind === "recurring" && previous.kind === "recurring") {
+      const scheduleChanged =
+        !isSameValue(previous.rhythm, next.rhythm) ||
+        !isSameValue(previous.stop, next.stop) ||
+        previous.timezone !== next.timezone ||
+        previous.paused !== next.paused
+      if (scheduleChanged) {
+        const derived = computeDerivedFields(next, now, completedRunCount(next.id))
+        next = { ...next, nextFireAt: derived.nextFireAt, nextFires: derived.nextFires }
+      }
     }
     return replaceDefinition(previous, next)
   }

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -705,7 +705,10 @@ export namespace Automation {
     const now = options?.now ?? Date.now()
     const failureStreak =
       run.state === "succeeded" ? 0 : run.state === "failed" ? previous.failureStreak + 1 : previous.failureStreak
-    const derived = computeDerivedFields(previous, now, completedRunCount(previous.id))
+    const derived =
+      run.state === "stopped"
+        ? { nextFireAt: previous.nextFireAt, nextFires: previous.nextFires }
+        : computeDerivedFields(previous, now, completedRunCount(previous.id))
     if (
       previous.failureStreak === failureStreak &&
       previous.nextFireAt === derived.nextFireAt &&

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -5,11 +5,13 @@ import { Identifier } from "@/id/id"
 import { Instance } from "@/project/instance"
 import { ProjectID } from "@/project/schema"
 import { PermissionID } from "@/permission/schema"
+import { ModelID, ProviderID } from "@/provider/schema"
 import { SessionID } from "@/session/schema"
 import { and, Database, desc, eq, gte, inArray, lt, NotFoundError, or, sql } from "@/storage/db"
 import { Flock } from "@/util/flock"
 import type { AutomationRunAttendance, AutomationRunBlocker } from "./run-context"
 import { AutomationDefinitionTable, AutomationRunTable } from "./automation.sql"
+import { computeDerivedFields } from "./derived"
 
 export const AutomationID = {
   Definition: {
@@ -38,11 +40,17 @@ export namespace Automation {
     .meta({
       ref: "AutomationWhere",
     })
+  export const Model = z
+    .object({ providerID: ProviderID.zod, modelID: ModelID.zod })
+    .strict()
+    .meta({ ref: "AutomationModel" })
+  export type Model = z.infer<typeof Model>
   export const ValidationErrorDetail = z
     .object({ field: z.string(), message: z.string() })
     .strict()
     .meta({ ref: "AutomationValidationErrorDetail" })
   export type ValidationErrorDetail = z.infer<typeof ValidationErrorDetail>
+  export type ValidationErrorDetailType = ValidationErrorDetail
   export const ValidationErrorResponse = z
     .object({ error: z.literal("invalid_automation"), details: z.array(ValidationErrorDetail) })
     .strict()
@@ -75,6 +83,8 @@ export namespace Automation {
     context: Context,
     where: Where,
     timezone: z.string().min(1),
+    model: Model,
+    variant: z.string().min(1).optional(),
   }
 
   export const CreateInput = z
@@ -96,6 +106,8 @@ export namespace Automation {
       fireAt: z.number().int().nonnegative().optional(),
       rhythm: Rhythm.optional(),
       stop: Stop.optional(),
+      model: Model.optional(),
+      variant: z.string().min(1).optional(),
     })
     .strict()
     .meta({ ref: "AutomationUpdateInput" })
@@ -115,6 +127,8 @@ export namespace Automation {
     sourceSessionID: SessionID.zod.optional(),
     automationSessionID: SessionID.zod.optional(),
     normalizationWarnings: z.array(z.string()),
+    model: Model,
+    variant: z.string().min(1).optional(),
   }
 
   export const Definition = z
@@ -263,6 +277,8 @@ export namespace Automation {
     "context",
     "where",
     "timezone",
+    "model",
+    "variant",
   ])
   const ONESHOT_CREATE_FIELDS = new Set([...COMMON_CREATE_FIELDS, "fireAt"])
   const RECURRING_CREATE_FIELDS = new Set([...COMMON_CREATE_FIELDS, "rhythm", "stop"])
@@ -276,6 +292,8 @@ export namespace Automation {
     "fireAt",
     "rhythm",
     "stop",
+    "model",
+    "variant",
   ])
 
   function addDetail(details: ValidationErrorDetail[], field: string, message: string) {
@@ -443,6 +461,9 @@ export namespace Automation {
     if (input.where.worktree && Instance.project.vcs !== "git") {
       addDetail(details, "where.worktree", "unsupported_where_worktree_not_git")
     }
+    if (input.kind === "recurring" && input.stop.kind === "condition") {
+      addDetail(details, "stop", "unsupported_stop_condition")
+    }
     details.push(...validateScheduleFields(input))
     return details
   }
@@ -467,6 +488,9 @@ export namespace Automation {
     if (patch.rhythm?.kind === "cron" && !isValidCronExpression(patch.rhythm.expression)) {
       addDetail(details, "rhythm.expression", "invalid_cron_expression")
     }
+    if (patch.stop?.kind === "condition") {
+      addDetail(details, "stop", "unsupported_stop_condition")
+    }
     return details
   }
 
@@ -487,9 +511,11 @@ export namespace Automation {
       updatedAt: now,
       timezone: input.timezone,
       normalizationWarnings: [],
+      model: input.model,
+      ...(input.variant ? { variant: input.variant } : {}),
       ...(options?.sourceSessionID ? { sourceSessionID: options.sourceSessionID } : {}),
     }
-    const definition: Definition =
+    let definition: Definition =
       input.kind === "oneshot"
         ? { kind: "oneshot", ...base, fireAt: input.fireAt }
         : {
@@ -501,6 +527,10 @@ export namespace Automation {
             nextFires: [],
             failureStreak: 0,
           }
+    if (definition.kind === "recurring") {
+      const derived = computeDerivedFields(definition, now, 0)
+      definition = { ...definition, nextFireAt: derived.nextFireAt, nextFires: derived.nextFires }
+    }
     writeDefinition(definition)
     return definition
   }
@@ -645,7 +675,7 @@ export namespace Automation {
     const updateDetails = validateUpdateInput(previous, patch, now)
     if (updateDetails.length) throw new ValidationError(updateDetails)
     if (!hasChanges(previous, patch)) return previous
-    const next = Definition.parse({
+    let next = Definition.parse({
       ...previous,
       ...patch,
       revision: previous.revision + 1,
@@ -653,7 +683,50 @@ export namespace Automation {
     })
     const details = validateCreateInput(next)
     if (details.length) throw new ValidationError(details)
+    if (next.kind === "recurring") {
+      const derived = computeDerivedFields(next, now, completedRunCount(next.id))
+      next = { ...next, nextFireAt: derived.nextFireAt, nextFires: derived.nextFires }
+    }
     return replaceDefinition(previous, next)
+  }
+
+  export function recordRunOutcome(run: Run, options?: { now?: number }): Definition | undefined {
+    if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return undefined
+    const previous = getOptional(run.automationID)
+    if (!previous || previous.kind !== "recurring") return undefined
+    const now = options?.now ?? Date.now()
+    const failureStreak =
+      run.state === "succeeded" ? 0 : run.state === "failed" ? previous.failureStreak + 1 : previous.failureStreak
+    const derived = computeDerivedFields(previous, now, completedRunCount(previous.id))
+    if (
+      previous.failureStreak === failureStreak &&
+      previous.nextFireAt === derived.nextFireAt &&
+      sameArray(previous.nextFires, derived.nextFires)
+    ) {
+      return undefined
+    }
+    const next = Definition.parse({
+      ...previous,
+      failureStreak,
+      nextFireAt: derived.nextFireAt,
+      nextFires: derived.nextFires,
+      revision: previous.revision + 1,
+      updatedAt: now,
+    })
+    try {
+      return replaceDefinition(previous, next)
+    } catch (error) {
+      if (error instanceof ConflictError) return undefined
+      throw error
+    }
+  }
+
+  function sameArray(left: readonly number[], right: readonly number[]) {
+    if (left.length !== right.length) return false
+    for (let index = 0; index < left.length; index++) {
+      if (left[index] !== right[index]) return false
+    }
+    return true
   }
 
   export async function remove(id: string): Promise<{ tombstone: Tombstone; stoppedRun?: Run }> {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -698,7 +698,10 @@ export namespace Automation {
     return replaceDefinition(previous, next)
   }
 
-  export function recordRunOutcome(run: Run, options?: { now?: number }): Definition | undefined {
+  export function recordRunOutcome(
+    run: Run,
+    options?: { now?: number; refreshOnStopped?: boolean },
+  ): Definition | undefined {
     if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return undefined
     const previous = getOptional(run.automationID)
     if (!previous || previous.kind !== "recurring") return undefined
@@ -706,7 +709,7 @@ export namespace Automation {
     const failureStreak =
       run.state === "succeeded" ? 0 : run.state === "failed" ? previous.failureStreak + 1 : previous.failureStreak
     const derived =
-      run.state === "stopped"
+      run.state === "stopped" && !options?.refreshOnStopped
         ? { nextFireAt: previous.nextFireAt, nextFires: previous.nextFires }
         : computeDerivedFields(previous, now, completedRunCount(previous.id))
     if (

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -637,36 +637,44 @@ export namespace Automation {
     options?: { now?: number; refreshOnStopped?: boolean },
   ): Definition | undefined {
     if (run.state !== "succeeded" && run.state !== "failed" && run.state !== "stopped") return undefined
-    const previous = getOptional(run.automationID)
-    if (!previous || previous.kind !== "recurring") return undefined
     const now = options?.now ?? Date.now()
-    const failureStreak =
-      run.state === "succeeded" ? 0 : run.state === "failed" ? previous.failureStreak + 1 : previous.failureStreak
-    const derived =
-      run.state === "stopped" && !options?.refreshOnStopped
-        ? { nextFireAt: previous.nextFireAt, nextFires: previous.nextFires }
-        : computeDerivedFields(previous, now, completedRunCount(previous.id))
-    if (
-      previous.failureStreak === failureStreak &&
-      previous.nextFireAt === derived.nextFireAt &&
-      sameArray(previous.nextFires, derived.nextFires)
-    ) {
-      return undefined
+    // Retry on revision conflict: a concurrent write (e.g. pause/update) may
+    // have advanced the row between our read and our update. Re-read the
+    // latest definition and recompute failureStreak + derived fields against
+    // it, otherwise we silently drop the run's outcome and the user sees a
+    // stale nextFireAt / failureStreak.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const previous = getOptional(run.automationID)
+      if (!previous || previous.kind !== "recurring") return undefined
+      const failureStreak =
+        run.state === "succeeded" ? 0 : run.state === "failed" ? previous.failureStreak + 1 : previous.failureStreak
+      const derived =
+        run.state === "stopped" && !options?.refreshOnStopped
+          ? { nextFireAt: previous.nextFireAt, nextFires: previous.nextFires }
+          : computeDerivedFields(previous, now, completedRunCount(previous.id))
+      if (
+        previous.failureStreak === failureStreak &&
+        previous.nextFireAt === derived.nextFireAt &&
+        sameArray(previous.nextFires, derived.nextFires)
+      ) {
+        return undefined
+      }
+      const next = Definition.parse({
+        ...previous,
+        failureStreak,
+        nextFireAt: derived.nextFireAt,
+        nextFires: derived.nextFires,
+        revision: previous.revision + 1,
+        updatedAt: now,
+      })
+      try {
+        return replaceDefinition(previous, next)
+      } catch (error) {
+        if (!(error instanceof ConflictError)) throw error
+        // retry: read latest and recompute
+      }
     }
-    const next = Definition.parse({
-      ...previous,
-      failureStreak,
-      nextFireAt: derived.nextFireAt,
-      nextFires: derived.nextFires,
-      revision: previous.revision + 1,
-      updatedAt: now,
-    })
-    try {
-      return replaceDefinition(previous, next)
-    } catch (error) {
-      if (error instanceof ConflictError) return undefined
-      throw error
-    }
+    return undefined
   }
 
   function sameArray(left: readonly number[], right: readonly number[]) {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -11,6 +11,7 @@ import { and, Database, desc, eq, gte, inArray, lt, NotFoundError, or, sql } fro
 import { Flock } from "@/util/flock"
 import type { AutomationRunAttendance, AutomationRunBlocker } from "./run-context"
 import { AutomationDefinitionTable, AutomationRunTable } from "./automation.sql"
+import { isValidCronExpression as cronIsValidExpression } from "./cron"
 import { computeDerivedFields } from "./derived"
 
 export const AutomationID = {
@@ -70,6 +71,15 @@ export namespace Automation {
       z.object({ kind: z.literal("never") }).strict(),
     ])
     .meta({ ref: "AutomationStop" })
+  // Input-only Stop: condition is persisted (Definition.stop can be `condition`)
+  // but cannot be supplied via create/update yet. Keep the two schemas separate
+  // so the public contract doesn't advertise a kind we reject at runtime.
+  export const SupportedCreateStop = z
+    .discriminatedUnion("kind", [
+      z.object({ kind: z.literal("count"), count: z.number().int().positive() }).strict(),
+      z.object({ kind: z.literal("never") }).strict(),
+    ])
+    .meta({ ref: "AutomationSupportedCreateStop" })
   export const Rhythm = z
     .discriminatedUnion("kind", [
       z.object({ kind: z.literal("interval"), everyMs: z.number().int().min(MIN_INTERVAL_MS, `interval_below_minimum_${MIN_INTERVAL_MS}ms`) }).strict(),
@@ -90,7 +100,7 @@ export namespace Automation {
   export const CreateInput = z
     .discriminatedUnion("kind", [
       z.object({ kind: z.literal("oneshot"), ...CommonCreate, fireAt: z.number().int().nonnegative() }).strict(),
-      z.object({ kind: z.literal("recurring"), ...CommonCreate, rhythm: Rhythm, stop: Stop }).strict(),
+      z.object({ kind: z.literal("recurring"), ...CommonCreate, rhythm: Rhythm, stop: SupportedCreateStop }).strict(),
     ])
     .meta({ ref: "AutomationCreateInput" })
   export type CreateInput = z.infer<typeof CreateInput>
@@ -105,7 +115,7 @@ export namespace Automation {
       timezone: z.string().min(1).optional(),
       fireAt: z.number().int().nonnegative().optional(),
       rhythm: Rhythm.optional(),
-      stop: Stop.optional(),
+      stop: SupportedCreateStop.optional(),
       model: Model.optional(),
       variant: z.string().min(1).nullable().optional(),
     })
@@ -351,80 +361,7 @@ export namespace Automation {
     }
   }
 
-  function isValidCronInteger(input: string, min: number, max: number) {
-    if (!/^\d+$/.test(input)) return false
-    const value = Number(input)
-    return value >= min && value <= max
-  }
-
-  function isValidCronField(input: string, min: number, max: number) {
-    if (!input) return false
-    return input.split(",").every((item) => {
-      const [base, step, extra] = item.split("/")
-      if (extra !== undefined) return false
-      if (step !== undefined && !isValidCronInteger(step, 1, max)) return false
-      if (base === "*") return true
-      const range = base.split("-")
-      if (range.length === 2) {
-        const [start, end] = range
-        if (!isValidCronInteger(start, min, max) || !isValidCronInteger(end, min, max)) return false
-        return Number(start) <= Number(end)
-      }
-      if (range.length !== 1) return false
-      return isValidCronInteger(base, min, max)
-    })
-  }
-
-  function cronFieldValues(field: string, min: number, max: number) {
-    const values = new Set<number>()
-    for (const item of field.split(",")) {
-      const [base, stepRaw] = item.split("/")
-      const step = stepRaw === undefined ? 1 : Number(stepRaw)
-      const range = base === "*" ? [min, max] : base.split("-").map(Number)
-      const start = range[0]
-      const end = base === "*" || (range.length === 1 && stepRaw !== undefined) ? max : range.length === 1 ? range[0] : range[1]
-      for (let value = start; value <= end; value += step) values.add(value)
-    }
-    return values
-  }
-
-  function hasPossibleCronDayMonth(dayField: string, monthField: string) {
-    const maxDays = new Map([
-      [1, 31],
-      [2, 29],
-      [3, 31],
-      [4, 30],
-      [5, 31],
-      [6, 30],
-      [7, 31],
-      [8, 31],
-      [9, 30],
-      [10, 31],
-      [11, 30],
-      [12, 31],
-    ])
-    for (const month of cronFieldValues(monthField, 1, 12)) {
-      const maxDay = maxDays.get(month)
-      if (maxDay === undefined) continue
-      for (const day of cronFieldValues(dayField, 1, 31)) {
-        if (day <= maxDay) return true
-      }
-    }
-    return false
-  }
-
-  export function isValidCronExpression(expression: string) {
-    const fields = expression.trim().split(/\s+/)
-    if (fields.length !== 5) return false
-    return (
-      isValidCronField(fields[0], 0, 59) &&
-      isValidCronField(fields[1], 0, 23) &&
-      isValidCronField(fields[2], 1, 31) &&
-      isValidCronField(fields[3], 1, 12) &&
-      isValidCronField(fields[4], 0, 7) &&
-      (fields[4] !== "*" || hasPossibleCronDayMonth(fields[2], fields[3]))
-    )
-  }
+  export const isValidCronExpression = cronIsValidExpression
 
   function validateScheduleFields(input: CreateInput | Definition) {
     const details: ValidationErrorDetail[] = []
@@ -461,9 +398,6 @@ export namespace Automation {
     if (input.where.worktree && Instance.project.vcs !== "git") {
       addDetail(details, "where.worktree", "unsupported_where_worktree_not_git")
     }
-    if (input.kind === "recurring" && input.stop.kind === "condition") {
-      addDetail(details, "stop", "unsupported_stop_condition")
-    }
     details.push(...validateScheduleFields(input))
     return details
   }
@@ -487,9 +421,6 @@ export namespace Automation {
     }
     if (patch.rhythm?.kind === "cron" && !isValidCronExpression(patch.rhythm.expression)) {
       addDetail(details, "rhythm.expression", "invalid_cron_expression")
-    }
-    if (patch.stop?.kind === "condition") {
-      addDetail(details, "stop", "unsupported_stop_condition")
     }
     return details
   }
@@ -665,7 +596,10 @@ export namespace Automation {
   }
 
   function hasChanges(previous: Definition, patch: UpdateInput) {
-    return Object.entries(patch).some(([field, value]) => !isSameValue(previous[field as keyof Definition], value))
+    return Object.entries(patch).some(([field, value]) => {
+      if (field === "variant" && value === null && previous.variant === undefined) return false
+      return !isSameValue(previous[field as keyof Definition], value)
+    })
   }
 
   export function update(id: string, patch: UpdateInput, options?: { now?: number }): Definition {

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -96,6 +96,8 @@ export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition
     const message = await SessionPrompt.promptWithAutomationContext(
       {
         sessionID,
+        model: definition.model,
+        ...(definition.variant ? { variant: definition.variant } : {}),
         parts: [{ type: "text", text: definition.prompt }],
       },
       scoped,

--- a/packages/opencode/src/automation/scheduler.ts
+++ b/packages/opencode/src/automation/scheduler.ts
@@ -166,8 +166,11 @@ export namespace AutomationScheduler {
     // Marks DefinitionUpdated events that the scheduler emits itself after a
     // stopped-run refresh, so its own DefinitionUpdated subscriber can skip
     // reschedule() — preventing a missed_schedule → refresh → publish → reschedule
-    // self-loop when the clock keeps oversleeping.
+    // self-loop when the clock keeps oversleeping. Keyed by id:revision so a real
+    // update that races ahead of the self event isn't swallowed by id alone.
     const selfPublishedDefinitionUpdates = new Set<string>()
+    const selfUpdateKey = (definition: { id: string; revision: number }) =>
+      `${definition.id}:${definition.revision}`
     let ownsTimers = !ownerKey
     let ownerLease: Flock.Lease | undefined
     let ownerAttempt: Promise<void> | undefined
@@ -341,8 +344,12 @@ export namespace AutomationScheduler {
             refreshOnStopped: wasOwned || wasSchedulerStopped,
           })
           if (refreshed) {
-            selfPublishedDefinitionUpdates.add(refreshed.id)
-            void Automation.publishDefinitionUpdated(refreshed)
+            const key = selfUpdateKey(refreshed)
+            selfPublishedDefinitionUpdates.add(key)
+            void Automation.publishDefinitionUpdated(refreshed).catch((error) => {
+              selfPublishedDefinitionUpdates.delete(key)
+              log.error("automation derived field publish failed", { error, automationID: refreshed.id })
+            })
           }
         } catch (error) {
           if (!NotFoundError.isInstance(error)) log.error("automation derived field update failed", { error, automationID: run.automationID })
@@ -352,7 +359,7 @@ export namespace AutomationScheduler {
     })
     const unsubscribeDefinitionUpdates = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
       if (!running) return
-      if (selfPublishedDefinitionUpdates.delete(event.properties.id)) return
+      if (selfPublishedDefinitionUpdates.delete(selfUpdateKey(event.properties))) return
       reschedule(event.properties)
     })
     const unsubscribeDefinitionDeletes = Bus.subscribe(Automation.Event.DefinitionDeleted, (event) => {

--- a/packages/opencode/src/automation/scheduler.ts
+++ b/packages/opencode/src/automation/scheduler.ts
@@ -331,7 +331,10 @@ export namespace AutomationScheduler {
       if (run.state === "stopped" && !wasOwned && !wasSchedulerStopped) return
       if (ownsTimers) {
         try {
-          const refreshed = Automation.recordRunOutcome(run, { now: clock.now() })
+          const refreshed = Automation.recordRunOutcome(run, {
+            now: clock.now(),
+            refreshOnStopped: wasOwned || wasSchedulerStopped,
+          })
           if (refreshed) void Automation.publishDefinitionUpdated(refreshed)
         } catch (error) {
           if (!NotFoundError.isInstance(error)) log.error("automation derived field update failed", { error, automationID: run.automationID })

--- a/packages/opencode/src/automation/scheduler.ts
+++ b/packages/opencode/src/automation/scheduler.ts
@@ -388,6 +388,14 @@ export namespace AutomationScheduler {
       const wasOwned = ownedRuns.delete(run.id)
       const wasSchedulerStopped = schedulerStoppedRuns.delete(run.id)
       if (run.state === "stopped" && !wasOwned && !wasSchedulerStopped) return
+      if (ownsTimers) {
+        try {
+          const refreshed = Automation.recordRunOutcome(run, { now: clock.now() })
+          if (refreshed) void Automation.publishDefinitionUpdated(refreshed)
+        } catch (error) {
+          if (!NotFoundError.isInstance(error)) log.error("automation derived field update failed", { error, automationID: run.automationID })
+        }
+      }
       scheduleNextInterval(run.automationID)
     })
     const unsubscribeDefinitionUpdates = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {

--- a/packages/opencode/src/automation/scheduler.ts
+++ b/packages/opencode/src/automation/scheduler.ts
@@ -163,6 +163,11 @@ export namespace AutomationScheduler {
     const unschedulable = new Map<string, Automation.Definition>()
     const ownedRuns = new Map<string, string>()
     const schedulerStoppedRuns = new Set<string>()
+    // Marks DefinitionUpdated events that the scheduler emits itself after a
+    // stopped-run refresh, so its own DefinitionUpdated subscriber can skip
+    // reschedule() — preventing a missed_schedule → refresh → publish → reschedule
+    // self-loop when the clock keeps oversleeping.
+    const selfPublishedDefinitionUpdates = new Set<string>()
     let ownsTimers = !ownerKey
     let ownerLease: Flock.Lease | undefined
     let ownerAttempt: Promise<void> | undefined
@@ -335,7 +340,10 @@ export namespace AutomationScheduler {
             now: clock.now(),
             refreshOnStopped: wasOwned || wasSchedulerStopped,
           })
-          if (refreshed) void Automation.publishDefinitionUpdated(refreshed)
+          if (refreshed) {
+            selfPublishedDefinitionUpdates.add(refreshed.id)
+            void Automation.publishDefinitionUpdated(refreshed)
+          }
         } catch (error) {
           if (!NotFoundError.isInstance(error)) log.error("automation derived field update failed", { error, automationID: run.automationID })
         }
@@ -344,6 +352,7 @@ export namespace AutomationScheduler {
     })
     const unsubscribeDefinitionUpdates = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
       if (!running) return
+      if (selfPublishedDefinitionUpdates.delete(event.properties.id)) return
       reschedule(event.properties)
     })
     const unsubscribeDefinitionDeletes = Bus.subscribe(Automation.Event.DefinitionDeleted, (event) => {

--- a/packages/opencode/src/automation/scheduler.ts
+++ b/packages/opencode/src/automation/scheduler.ts
@@ -6,6 +6,7 @@ import { Bus } from "@/bus"
 import { Instance, type InstanceContext } from "@/project/instance"
 import { NotFoundError } from "@/storage/db"
 import { Flock } from "@/util/flock"
+import { cronMatches, parseCronSchedule } from "./cron"
 import { sessionPromptExecutor } from "./runner"
 
 export namespace AutomationScheduler {
@@ -50,16 +51,6 @@ export namespace AutomationScheduler {
     fireAt: number
     token: symbol
     definition: Automation.Definition
-  }
-
-  type CronSchedule = {
-    minutes: Set<number>
-    hours: Set<number>
-    days: Set<number>
-    months: Set<number>
-    weekdays: Set<number>
-    dayRestricted: boolean
-    weekdayRestricted: boolean
   }
 
   export const liveClock: Clock = {
@@ -118,56 +109,6 @@ export namespace AutomationScheduler {
     if (!canScheduleRecurring(definition)) return null
     if (definition.rhythm.kind === "cron") return computeNextCronFireAt(definition, from)
     return from + definition.rhythm.everyMs
-  }
-
-  function cronValues(field: string, min: number, max: number, options?: { sundayAlias?: boolean }) {
-    const values = new Set<number>()
-    for (const item of field.split(",")) {
-      const [base, stepRaw] = item.split("/")
-      if (!base || item.split("/").length > 2) throw new Error(`Invalid cron field: ${item}`)
-      const step = stepRaw === undefined ? 1 : Number(stepRaw)
-      if (!Number.isInteger(step) || step <= 0) throw new Error(`Invalid cron step: ${item}`)
-      const range = base === "*" ? [min, max] : base.split("-").map(Number)
-      if (range.length === 0 || range.length > 2 || range.some((value) => !Number.isInteger(value))) {
-        throw new Error(`Invalid cron field: ${item}`)
-      }
-      const start = range[0]
-      const end = base === "*" || (range.length === 1 && stepRaw !== undefined) ? max : range.length === 1 ? range[0] : range[1]
-      if (start < min || end > max || start > end) throw new Error(`Invalid cron range: ${item}`)
-      for (let value = start; value <= end; value += step) {
-        values.add(options?.sundayAlias && value === 7 ? 0 : value)
-      }
-    }
-    return values
-  }
-
-  function parseCronSchedule(expression: string): CronSchedule {
-    const fields = expression.trim().split(/\s+/)
-    if (fields.length !== 5) throw new Error(`Invalid cron expression: ${expression}`)
-    const [minuteField, hourField, dayField, monthField, weekdayField] = fields
-    return {
-      minutes: cronValues(minuteField, 0, 59),
-      hours: cronValues(hourField, 0, 23),
-      days: cronValues(dayField, 1, 31),
-      months: cronValues(monthField, 1, 12),
-      weekdays: cronValues(weekdayField, 0, 7, { sundayAlias: true }),
-      dayRestricted: dayField !== "*",
-      weekdayRestricted: weekdayField !== "*",
-    }
-  }
-
-  function cronMatches(schedule: CronSchedule, time: DateTime) {
-    const weekday = time.weekday === 7 ? 0 : time.weekday
-    const dayMatches = schedule.days.has(time.day)
-    const weekdayMatches = schedule.weekdays.has(weekday)
-    const calendarMatches =
-      schedule.dayRestricted && schedule.weekdayRestricted ? dayMatches || weekdayMatches : dayMatches && weekdayMatches
-    return (
-      schedule.minutes.has(time.minute) &&
-      schedule.hours.has(time.hour) &&
-      schedule.months.has(time.month) &&
-      calendarMatches
-    )
   }
 
   function computeNextCronFireAt(definition: Extract<Automation.Definition, { kind: "recurring" }>, from: number) {

--- a/packages/opencode/src/automation/validation.ts
+++ b/packages/opencode/src/automation/validation.ts
@@ -1,0 +1,47 @@
+import { Cause, Effect, Exit, Result } from "effect"
+import { ModelNotFoundError, Provider } from "@/provider/provider"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { ProviderTransform } from "@/provider/transform"
+import type { Automation } from "."
+
+function isModelNotFound(cause: Cause.Cause<unknown>): boolean {
+  const errorResult = Cause.findError(cause)
+  if (Result.isSuccess(errorResult) && ModelNotFoundError.isInstance(errorResult.success)) return true
+  const defectResult = Cause.findDefect(cause)
+  if (Result.isSuccess(defectResult) && ModelNotFoundError.isInstance(defectResult.success)) return true
+  return false
+}
+
+type ValidationErrorDetail = Automation.ValidationErrorDetailType
+
+type ModelLike = { providerID: string; modelID: string }
+
+export const validateModelAndVariantWith = (
+  provider: Provider.Interface,
+  model: ModelLike,
+  variant: string | undefined,
+): Effect.Effect<ValidationErrorDetail[]> =>
+  Effect.gen(function* () {
+    const providerID = ProviderID.make(model.providerID)
+    const modelID = ModelID.make(model.modelID)
+    const exit = yield* provider.getModel(providerID, modelID).pipe(Effect.exit)
+    if (Exit.isFailure(exit)) {
+      const message = isModelNotFound(exit.cause) ? "model_not_found" : "model_lookup_failed"
+      return [{ field: "model", message }]
+    }
+    if (variant === undefined) return []
+    const variants = ProviderTransform.variants(exit.value)
+    if (!Object.hasOwn(variants, variant)) {
+      return [{ field: "variant", message: "invalid_variant_for_model" }]
+    }
+    return []
+  })
+
+export const validateModelAndVariant = (
+  model: Automation.Model,
+  variant: string | undefined,
+): Effect.Effect<ValidationErrorDetail[], never, Provider.Service> =>
+  Effect.gen(function* () {
+    const provider = yield* Provider.Service
+    return yield* validateModelAndVariantWith(provider, model, variant)
+  })

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -196,7 +196,7 @@ export const AutomationRoutes = (): Hono =>
           const patch = c.req.valid("json")
           if (patch.model !== undefined || patch.variant !== undefined) {
             const effectiveModel = patch.model ?? previous.model
-            const effectiveVariant = patch.variant ?? previous.variant
+            const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
             const modelDetails = await modelValidationDetails(effectiveModel, effectiveVariant)
             if (modelDetails.length) {
               return c.json(

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -5,6 +5,8 @@ import z from "zod"
 import { ActiveRunStillRunningError, Automation, AutomationID, ConflictError, ValidationError } from "@/automation"
 import { sessionPromptExecutor } from "@/automation/runner"
 import { AutomationScheduler } from "@/automation/scheduler"
+import { validateModelAndVariant } from "@/automation/validation"
+import { AppRuntime } from "@/effect/app-runtime"
 import { errors } from "../error"
 
 function validationError(error: ValidationError) {
@@ -29,6 +31,11 @@ async function publishIfChanged(previous: Automation.Definition, definition: Aut
 
 async function settleAutomationScheduler() {
   await AutomationScheduler.current().settleOwner()
+}
+
+async function modelValidationDetails(model: Automation.Model, variant?: string) {
+  if (process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION === "1") return []
+  return AppRuntime.runPromise(validateModelAndVariant(model, variant))
 }
 
 function validationIssuePath(issue: unknown) {
@@ -120,7 +127,15 @@ export const AutomationRoutes = (): Hono =>
       async (c) => {
         try {
           await settleAutomationScheduler()
-          const definition = Automation.create(c.req.valid("json"))
+          const input = c.req.valid("json")
+          const modelDetails = await modelValidationDetails(input.model, input.variant)
+          if (modelDetails.length) {
+            return c.json(
+              Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
+              422,
+            )
+          }
+          const definition = Automation.create(input)
           await Automation.publishDefinitionUpdated(definition)
           return c.json(definition)
         } catch (error) {
@@ -178,7 +193,19 @@ export const AutomationRoutes = (): Hono =>
           const automationID = c.req.valid("param").automationID
           await settleAutomationScheduler()
           const previous = Automation.get(automationID)
-          const definition = Automation.update(automationID, c.req.valid("json"))
+          const patch = c.req.valid("json")
+          if (patch.model !== undefined || patch.variant !== undefined) {
+            const effectiveModel = patch.model ?? previous.model
+            const effectiveVariant = patch.variant ?? previous.variant
+            const modelDetails = await modelValidationDetails(effectiveModel, effectiveVariant)
+            if (modelDetails.length) {
+              return c.json(
+                Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
+                422,
+              )
+            }
+          }
+          const definition = Automation.update(automationID, patch)
           await publishIfChanged(previous, definition)
           return c.json(definition)
         } catch (error) {

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -25,8 +25,6 @@ const CronExpression = Schema.NonEmptyString.check(
 )
 const Title = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_TITLE_CHARS))
 const Prompt = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_PROMPT_CHARS))
-const Condition = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_CONDITION_CHARS))
-
 const Common = {
   title: Title,
   prompt: Prompt,
@@ -41,9 +39,11 @@ const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0))
 const IntervalMs = Schema.Int.check(Schema.isGreaterThanOrEqualTo(Automation.MIN_INTERVAL_MS))
 
+// `condition` is part of the persisted Stop union but not yet supported as
+// input; keep this in lockstep with Automation.SupportedCreateStop so the tool
+// signature doesn't advertise a kind we reject.
 const Stop = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("count"), count: PositiveInt }),
-  Schema.Struct({ kind: Schema.Literal("condition"), condition: Condition }),
   Schema.Struct({ kind: Schema.Literal("never") }),
 ])
 

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -25,6 +25,8 @@ const CronExpression = Schema.NonEmptyString.check(
 )
 const Title = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_TITLE_CHARS))
 const Prompt = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_PROMPT_CHARS))
+const Condition = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_CONDITION_CHARS))
+
 const Common = {
   title: Title,
   prompt: Prompt,
@@ -39,11 +41,13 @@ const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0))
 const IntervalMs = Schema.Int.check(Schema.isGreaterThanOrEqualTo(Automation.MIN_INTERVAL_MS))
 
-// `condition` is part of the persisted Stop union but not yet supported as
-// input; keep this in lockstep with Automation.SupportedCreateStop so the tool
-// signature doesn't advertise a kind we reject.
+// Mirrors Automation.Stop. `kind: "condition"` is currently rejected at
+// validate time with { field: "stop", message: "unsupported_stop_condition" };
+// kept in the schema so the structured error contract matches HTTP routes.
+// The tool description below points the LLM away from condition.
 const Stop = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("count"), count: PositiveInt }),
+  Schema.Struct({ kind: Schema.Literal("condition"), condition: Condition }),
   Schema.Struct({ kind: Schema.Literal("never") }),
 ])
 
@@ -75,6 +79,7 @@ export function formatAutomateValidationError(error: unknown) {
     "Invalid automate input.",
     "Expected shape: oneshot { kind, title, prompt, context, where, timezone, model, variant?, fireAt } or recurring { kind, title, prompt, context, where, timezone, model, variant?, rhythm, stop }.",
     "model is required as { providerID, modelID }; variant is optional and must be a valid effort key for that model (omit for models without reasoning).",
+    "stop only supports { kind: \"count\", count } or { kind: \"never\" } today; { kind: \"condition\" } is reserved and currently rejected.",
     "Example: { kind: \"recurring\", title: \"Daily repo brief\", prompt: \"Summarize repo changes.\", context: \"fresh\", where: { projectID: \"current-project\" }, timezone: \"UTC\", model: { providerID: \"anthropic\", modelID: \"claude-sonnet-4-6\" }, variant: \"high\", rhythm: { kind: \"interval\", everyMs: 3600000 }, stop: { kind: \"never\" } }.",
     detail,
   ].join("\n")

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -1,11 +1,18 @@
 import { Effect, Schema } from "effect"
 import { Automation, ValidationError } from "@/automation"
 import { AutomationScheduler } from "@/automation/scheduler"
+import { validateModelAndVariantWith } from "@/automation/validation"
+import { Provider } from "@/provider/provider"
 import * as Tool from "./tool"
 
 const Where = Schema.Struct({
   projectID: Schema.String,
   worktree: Schema.optional(Schema.NonEmptyString),
+})
+
+const Model = Schema.Struct({
+  providerID: Schema.NonEmptyString,
+  modelID: Schema.NonEmptyString,
 })
 
 const Timezone = Schema.NonEmptyString.check(
@@ -26,6 +33,8 @@ const Common = {
   context: Schema.Union([Schema.Literal("continue"), Schema.Literal("fresh")]),
   where: Where,
   timezone: Timezone,
+  model: Model,
+  variant: Schema.optional(Schema.NonEmptyString),
 }
 
 const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
@@ -64,8 +73,9 @@ export function formatAutomateValidationError(error: unknown) {
       : String(error)
   return [
     "Invalid automate input.",
-    "Expected shape: oneshot { kind, title, prompt, context, where, timezone, fireAt } or recurring { kind, title, prompt, context, where, timezone, rhythm, stop }.",
-    "Example: { kind: \"recurring\", title: \"Daily repo brief\", prompt: \"Summarize repo changes.\", context: \"fresh\", where: { projectID: \"current-project\" }, timezone: \"UTC\", rhythm: { kind: \"interval\", everyMs: 3600000 }, stop: { kind: \"never\" } }.",
+    "Expected shape: oneshot { kind, title, prompt, context, where, timezone, model, variant?, fireAt } or recurring { kind, title, prompt, context, where, timezone, model, variant?, rhythm, stop }.",
+    "model is required as { providerID, modelID }; variant is optional and must be a valid effort key for that model (omit for models without reasoning).",
+    "Example: { kind: \"recurring\", title: \"Daily repo brief\", prompt: \"Summarize repo changes.\", context: \"fresh\", where: { projectID: \"current-project\" }, timezone: \"UTC\", model: { providerID: \"anthropic\", modelID: \"claude-sonnet-4-6\" }, variant: \"high\", rhythm: { kind: \"interval\", everyMs: 3600000 }, stop: { kind: \"never\" } }.",
     detail,
   ].join("\n")
 }
@@ -75,7 +85,7 @@ function readableAutomationError(error: unknown) {
   return error
 }
 
-export function createAutomateDefinition(): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
+export function createAutomateDefinition(provider: Provider.Interface): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
     description:
       "Create an Automation definition for later execution. The automation is not executed by this tool; it only stores the definition and echoes the resolved contract.",
@@ -83,12 +93,20 @@ export function createAutomateDefinition(): Tool.DefWithoutID<typeof AutomatePar
     formatValidationError: formatAutomateValidationError,
     execute: (params, ctx) =>
       Effect.gen(function* () {
+        const { sourceSessionID: _ignoredSourceSessionID, ...input } = params as typeof params & { sourceSessionID?: unknown }
+        if (Object.hasOwn(input, "automationSessionID")) {
+          return yield* Effect.fail(
+            readableAutomationError(
+              new ValidationError([{ field: "automationSessionID", message: "unsupported_automation_field" }]),
+            ),
+          )
+        }
+        const modelDetails = yield* validateModelAndVariantWith(provider, input.model, input.variant)
+        if (modelDetails.length) {
+          return yield* Effect.fail(readableAutomationError(new ValidationError(modelDetails)))
+        }
         const definition = yield* Effect.try({
           try: () => {
-            if (Object.hasOwn(params as object, "automationSessionID")) {
-              throw new ValidationError([{ field: "automationSessionID", message: "unsupported_automation_field" }])
-            }
-            const { sourceSessionID: _ignoredSourceSessionID, ...input } = params as typeof params & { sourceSessionID?: unknown }
             const parsed = Automation.CreateInput.parse(input)
             AutomationScheduler.current()
             return Automation.create(parsed, { sourceSessionID: ctx.sessionID })
@@ -105,4 +123,10 @@ export function createAutomateDefinition(): Tool.DefWithoutID<typeof AutomatePar
   }
 }
 
-export const AutomateTool = Tool.define("automate", Effect.succeed(createAutomateDefinition()))
+export const AutomateTool = Tool.define(
+  "automate",
+  Effect.gen(function* () {
+    const provider = yield* Provider.Service
+    return createAutomateDefinition(provider)
+  }),
+)

--- a/packages/opencode/test/automation/cron.test.ts
+++ b/packages/opencode/test/automation/cron.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { isValidCronExpression as cronIsValid, parseCronSchedule } from "../../src/automation/cron"
+import { Automation } from "../../src/automation"
+
+describe("automation cron validation — single source of truth", () => {
+  const cases: Array<[string, boolean]> = [
+    ["* * * * *", true],
+    ["0 0 1 * *", true],
+    ["0 0 1-5 * *", true],
+    ["*/15 * * * *", true],
+    ["0 0 * * 1-5", true],
+    ["0 0 31 2 1", true],
+    ["0 0 31 2 *", false],
+    ["0 0 30 2 *", false],
+    ["60 * * * *", false],
+    ["* 24 * * *", false],
+    ["* * 0 * *", false],
+    ["* * 32 * *", false],
+    ["* * * 0 *", false],
+    ["* * * 13 *", false],
+    ["* * * * 8", false],
+    ["bad", false],
+    ["* * * *", false],
+    ["* * * * * *", false],
+    ["5-3 * * * *", false],
+  ]
+
+  test("Automation.isValidCronExpression delegates to cron module", () => {
+    for (const [expr, expected] of cases) {
+      expect(Automation.isValidCronExpression(expr)).toBe(expected)
+      expect(cronIsValid(expr)).toBe(expected)
+    }
+  })
+
+  test("valid expressions parse without throwing; invalid ones either throw or fail reachability", () => {
+    for (const [expr, expected] of cases) {
+      if (expected) {
+        expect(() => parseCronSchedule(expr)).not.toThrow()
+      } else {
+        let threw = false
+        try {
+          parseCronSchedule(expr)
+        } catch {
+          threw = true
+        }
+        const reachable = !threw && cronIsValid(expr)
+        expect(threw || !reachable).toBe(true)
+      }
+    }
+  })
+})

--- a/packages/opencode/test/automation/validation.test.ts
+++ b/packages/opencode/test/automation/validation.test.ts
@@ -35,8 +35,8 @@ describe("automation validation — matches HTTP route 422 details payload", () 
     Effect.gen(function* () {
       const provider: Provider.Interface = {
         ...fakeAutomationProvider().interface,
-        getModel: ((pId, mId) =>
-          Effect.fail(new ModelNotFoundError({ providerID: pId, modelID: mId }))) as Provider.Interface["getModel"],
+        getModel: (pId, mId) =>
+          Effect.fail(new ModelNotFoundError({ providerID: pId, modelID: mId })) as never,
       }
       const details = yield* validateModelAndVariantWith(provider, { providerID: "anthropic", modelID: "claude-bogus" }, undefined)
       expect(details).toEqual([{ field: "model", message: "model_not_found" }])
@@ -47,7 +47,7 @@ describe("automation validation — matches HTTP route 422 details payload", () 
     Effect.gen(function* () {
       const provider: Provider.Interface = {
         ...fakeAutomationProvider().interface,
-        getModel: (() => Effect.die(new Error("provider exploded"))) as Provider.Interface["getModel"],
+        getModel: () => Effect.die(new Error("provider exploded")) as never,
       }
       const details = yield* validateModelAndVariantWith(provider, { providerID: "x", modelID: "y" }, undefined)
       expect(details).toEqual([{ field: "model", message: "model_lookup_failed" }])
@@ -71,7 +71,7 @@ describe("automation validation — matches HTTP route 422 details payload", () 
       })
       const provider: Provider.Interface = {
         ...fakeAutomationProvider().interface,
-        getModel: (() => Effect.succeed(nonReasoning)) as Provider.Interface["getModel"],
+        getModel: () => Effect.succeed(nonReasoning) as never,
       }
       const details = yield* validateModelAndVariantWith(provider, { providerID: "openai", modelID: "plain-model" }, "high")
       expect(details).toEqual([{ field: "variant", message: "invalid_variant_for_model" }])

--- a/packages/opencode/test/automation/validation.test.ts
+++ b/packages/opencode/test/automation/validation.test.ts
@@ -1,73 +1,80 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { validateModelAndVariantWith } from "../../src/automation/validation"
 import { ModelNotFoundError, type Provider } from "../../src/provider/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { fakeAutomationProvider, ProviderTest } from "../fake/provider"
-
-function runDetails(provider: Provider.Interface, model: { providerID: string; modelID: string }, variant?: string) {
-  return Effect.runPromise(validateModelAndVariantWith(provider, model, variant))
-}
+import { it } from "../lib/effect"
 
 describe("automation validation — matches HTTP route 422 details payload", () => {
-  test("returns empty details when model exists and variant is supported", async () => {
-    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
-    expect(await runDetails(provider, { providerID, modelID }, "high")).toEqual([])
-  })
+  it.effect("returns empty details when model exists and variant is supported", () =>
+    Effect.gen(function* () {
+      const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+      const details = yield* validateModelAndVariantWith(provider, { providerID, modelID }, "high")
+      expect(details).toEqual([])
+    }),
+  )
 
-  test("returns empty details when variant is omitted", async () => {
-    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
-    expect(await runDetails(provider, { providerID, modelID })).toEqual([])
-  })
+  it.effect("returns empty details when variant is omitted", () =>
+    Effect.gen(function* () {
+      const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+      const details = yield* validateModelAndVariantWith(provider, { providerID, modelID }, undefined)
+      expect(details).toEqual([])
+    }),
+  )
 
-  test("rejects unsupported variant for the given model with invalid_variant_for_model", async () => {
-    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
-    expect(await runDetails(provider, { providerID, modelID }, "xhigh")).toEqual([
-      { field: "variant", message: "invalid_variant_for_model" },
-    ])
-  })
+  it.effect("rejects unsupported variant for the given model with invalid_variant_for_model", () =>
+    Effect.gen(function* () {
+      const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+      const details = yield* validateModelAndVariantWith(provider, { providerID, modelID }, "xhigh")
+      expect(details).toEqual([{ field: "variant", message: "invalid_variant_for_model" }])
+    }),
+  )
 
-  test("maps ModelNotFoundError to model_not_found", async () => {
-    const provider: Provider.Interface = {
-      ...fakeAutomationProvider().interface,
-      getModel: (pId, mId) =>
-        Effect.fail(new ModelNotFoundError({ providerID: pId, modelID: mId })) as never,
-    }
-    expect(await runDetails(provider, { providerID: "anthropic", modelID: "claude-bogus" })).toEqual([
-      { field: "model", message: "model_not_found" },
-    ])
-  })
+  it.effect("maps ModelNotFoundError to model_not_found", () =>
+    Effect.gen(function* () {
+      const provider: Provider.Interface = {
+        ...fakeAutomationProvider().interface,
+        getModel: ((pId, mId) =>
+          Effect.fail(new ModelNotFoundError({ providerID: pId, modelID: mId }))) as Provider.Interface["getModel"],
+      }
+      const details = yield* validateModelAndVariantWith(provider, { providerID: "anthropic", modelID: "claude-bogus" }, undefined)
+      expect(details).toEqual([{ field: "model", message: "model_not_found" }])
+    }),
+  )
 
-  test("maps unknown provider failures to model_lookup_failed", async () => {
-    const provider: Provider.Interface = {
-      ...fakeAutomationProvider().interface,
-      getModel: () => Effect.die(new Error("provider exploded")) as never,
-    }
-    expect(await runDetails(provider, { providerID: "x", modelID: "y" })).toEqual([
-      { field: "model", message: "model_lookup_failed" },
-    ])
-  })
+  it.effect("maps unknown provider failures to model_lookup_failed", () =>
+    Effect.gen(function* () {
+      const provider: Provider.Interface = {
+        ...fakeAutomationProvider().interface,
+        getModel: (() => Effect.die(new Error("provider exploded"))) as Provider.Interface["getModel"],
+      }
+      const details = yield* validateModelAndVariantWith(provider, { providerID: "x", modelID: "y" }, undefined)
+      expect(details).toEqual([{ field: "model", message: "model_lookup_failed" }])
+    }),
+  )
 
-  test("rejects unsupported variant against a non-reasoning model", async () => {
-    const nonReasoning = ProviderTest.model({
-      id: ModelID.make("plain-model"),
-      providerID: ProviderID.make("openai"),
-      capabilities: {
-        toolcall: true,
-        attachment: false,
-        reasoning: false,
-        temperature: true,
-        interleaved: false,
-        input: { text: true, image: false, audio: false, video: false, pdf: false },
-        output: { text: true, image: false, audio: false, video: false, pdf: false },
-      },
-    })
-    const provider: Provider.Interface = {
-      ...fakeAutomationProvider().interface,
-      getModel: () => Effect.succeed(nonReasoning) as never,
-    }
-    expect(await runDetails(provider, { providerID: "openai", modelID: "plain-model" }, "high")).toEqual([
-      { field: "variant", message: "invalid_variant_for_model" },
-    ])
-  })
+  it.effect("rejects unsupported variant against a non-reasoning model", () =>
+    Effect.gen(function* () {
+      const nonReasoning = ProviderTest.model({
+        id: ModelID.make("plain-model"),
+        providerID: ProviderID.make("openai"),
+        capabilities: {
+          toolcall: true,
+          attachment: false,
+          reasoning: false,
+          temperature: true,
+          interleaved: false,
+          input: { text: true, image: false, audio: false, video: false, pdf: false },
+          output: { text: true, image: false, audio: false, video: false, pdf: false },
+        },
+      })
+      const provider: Provider.Interface = {
+        ...fakeAutomationProvider().interface,
+        getModel: (() => Effect.succeed(nonReasoning)) as Provider.Interface["getModel"],
+      }
+      const details = yield* validateModelAndVariantWith(provider, { providerID: "openai", modelID: "plain-model" }, "high")
+      expect(details).toEqual([{ field: "variant", message: "invalid_variant_for_model" }])
+    }),
+  )
 })

--- a/packages/opencode/test/automation/validation.test.ts
+++ b/packages/opencode/test/automation/validation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { validateModelAndVariantWith } from "../../src/automation/validation"
+import { ModelNotFoundError, type Provider } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { fakeAutomationProvider, ProviderTest } from "../fake/provider"
+
+function runDetails(provider: Provider.Interface, model: { providerID: string; modelID: string }, variant?: string) {
+  return Effect.runPromise(validateModelAndVariantWith(provider, model, variant))
+}
+
+describe("automation validation — matches HTTP route 422 details payload", () => {
+  test("returns empty details when model exists and variant is supported", async () => {
+    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+    expect(await runDetails(provider, { providerID, modelID }, "high")).toEqual([])
+  })
+
+  test("returns empty details when variant is omitted", async () => {
+    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+    expect(await runDetails(provider, { providerID, modelID })).toEqual([])
+  })
+
+  test("rejects unsupported variant for the given model with invalid_variant_for_model", async () => {
+    const { providerID, modelID, interface: provider } = fakeAutomationProvider()
+    expect(await runDetails(provider, { providerID, modelID }, "xhigh")).toEqual([
+      { field: "variant", message: "invalid_variant_for_model" },
+    ])
+  })
+
+  test("maps ModelNotFoundError to model_not_found", async () => {
+    const provider: Provider.Interface = {
+      ...fakeAutomationProvider().interface,
+      getModel: (pId, mId) =>
+        Effect.fail(new ModelNotFoundError({ providerID: pId, modelID: mId })) as never,
+    }
+    expect(await runDetails(provider, { providerID: "anthropic", modelID: "claude-bogus" })).toEqual([
+      { field: "model", message: "model_not_found" },
+    ])
+  })
+
+  test("maps unknown provider failures to model_lookup_failed", async () => {
+    const provider: Provider.Interface = {
+      ...fakeAutomationProvider().interface,
+      getModel: () => Effect.die(new Error("provider exploded")) as never,
+    }
+    expect(await runDetails(provider, { providerID: "x", modelID: "y" })).toEqual([
+      { field: "model", message: "model_lookup_failed" },
+    ])
+  })
+
+  test("rejects unsupported variant against a non-reasoning model", async () => {
+    const nonReasoning = ProviderTest.model({
+      id: ModelID.make("plain-model"),
+      providerID: ProviderID.make("openai"),
+      capabilities: {
+        toolcall: true,
+        attachment: false,
+        reasoning: false,
+        temperature: true,
+        interleaved: false,
+        input: { text: true, image: false, audio: false, video: false, pdf: false },
+        output: { text: true, image: false, audio: false, video: false, pdf: false },
+      },
+    })
+    const provider: Provider.Interface = {
+      ...fakeAutomationProvider().interface,
+      getModel: () => Effect.succeed(nonReasoning) as never,
+    }
+    expect(await runDetails(provider, { providerID: "openai", modelID: "plain-model" }, "high")).toEqual([
+      { field: "variant", message: "invalid_variant_for_model" },
+    ])
+  })
+})

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -28,15 +28,23 @@ export function fakeAutomationProvider(): {
   // Sanity check: variants include 'high' so tests can use it.
   void ProviderTransform.variants(mdl)
   const iface: Provider.Interface = {
-    list: () => Effect.succeed({ [providerID]: info }),
-    getProvider: (id) =>
+    list: Effect.fn("Provider.list")(() => Effect.succeed({ [providerID]: info })),
+    getProvider: Effect.fn("Provider.getProvider")((id) =>
       id === providerID ? Effect.succeed(info) : Effect.die(new Error(`Unknown provider: ${id}`)),
-    getModel: (pId, mId) =>
-      pId === providerID && mId === modelID ? Effect.succeed(mdl) : Effect.die(new Error(`Unknown model: ${pId}/${mId}`)),
-    getLanguage: () => Effect.die(new Error("getLanguage not configured")),
-    closest: (pId) => Effect.succeed(pId === providerID ? { providerID, modelID } : undefined),
-    getSmallModel: (pId) => Effect.succeed(pId === providerID ? mdl : undefined),
-    defaultModel: () => Effect.succeed({ providerID, modelID }),
+    ),
+    getModel: Effect.fn("Provider.getModel")((pId, mId) =>
+      pId === providerID && mId === modelID
+        ? Effect.succeed(mdl)
+        : Effect.die(new Error(`Unknown model: ${pId}/${mId}`)),
+    ),
+    getLanguage: Effect.fn("Provider.getLanguage")(() => Effect.die(new Error("getLanguage not configured"))),
+    closest: Effect.fn("Provider.closest")((pId) =>
+      Effect.succeed(pId === providerID ? { providerID, modelID } : undefined),
+    ),
+    getSmallModel: Effect.fn("Provider.getSmallModel")((pId) =>
+      Effect.succeed(pId === providerID ? mdl : undefined),
+    ),
+    defaultModel: Effect.fn("Provider.defaultModel")(() => Effect.succeed({ providerID, modelID })),
   }
   return { providerID, modelID, interface: iface }
 }

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -1,6 +1,45 @@
 import { Effect, Layer } from "effect"
 import { Provider } from "../../src/provider/provider"
+import { ProviderTransform } from "../../src/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+
+export function fakeAutomationProvider(): {
+  providerID: ProviderID
+  modelID: ModelID
+  interface: Provider.Interface
+} {
+  const providerID = ProviderID.make("openai")
+  const modelID = ModelID.make("test-reasoning-model")
+  const mdl = ProviderTest.model({
+    id: modelID,
+    providerID,
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: true,
+      temperature: true,
+      interleaved: false,
+      input: { text: true, image: false, audio: false, video: false, pdf: false },
+      output: { text: true, image: false, audio: false, video: false, pdf: false },
+    },
+    api: { id: modelID, url: "https://example.com", npm: "ai-gateway-provider" },
+  })
+  const info = ProviderTest.info({ id: providerID }, mdl)
+  // Sanity check: variants include 'high' so tests can use it.
+  void ProviderTransform.variants(mdl)
+  const iface: Provider.Interface = {
+    list: () => Effect.succeed({ [providerID]: info }),
+    getProvider: (id) =>
+      id === providerID ? Effect.succeed(info) : Effect.die(new Error(`Unknown provider: ${id}`)),
+    getModel: (pId, mId) =>
+      pId === providerID && mId === modelID ? Effect.succeed(mdl) : Effect.die(new Error(`Unknown model: ${pId}/${mId}`)),
+    getLanguage: () => Effect.die(new Error("getLanguage not configured")),
+    closest: (pId) => Effect.succeed(pId === providerID ? { providerID, modelID } : undefined),
+    getSmallModel: (pId) => Effect.succeed(pId === providerID ? mdl : undefined),
+    defaultModel: () => Effect.succeed({ providerID, modelID }),
+  }
+  return { providerID, modelID, interface: iface }
+}
 
 export namespace ProviderTest {
   export function model(override: Partial<Provider.Model> = {}): Provider.Model {

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -95,7 +95,7 @@ const windowsOpencodeShards = [
     suffix: "opencode-server-tools",
     usesTurbo: false,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth test/automation",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
   },
 ] as const

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -608,6 +608,16 @@ describe("automation routes", () => {
           [{ field: "prompt", message: "prompt_too_long_20000" }],
         ],
         [
+          "stop kind condition rejected with structured detail",
+          recurringInput(projectID, { stop: { kind: "condition", condition: "repo is ready" } }),
+          [{ field: "stop", message: "unsupported_stop_condition" }],
+        ],
+        [
+          "condition above replay-safe limit",
+          recurringInput(projectID, { stop: { kind: "condition", condition: "x".repeat(4_001) } }),
+          [{ field: "stop.condition", message: "condition_too_long_4000" }],
+        ],
+        [
           "externally supplied automation session",
           { ...recurringInput(projectID), automationSessionID: SessionID.descending() },
           [{ field: "automationSessionID", message: "unsupported_automation_field" }],
@@ -655,35 +665,23 @@ describe("automation routes", () => {
     })
   })
 
-  test("rejects stop kind 'condition' at the create/update route as unsupported input", async () => {
+  test("PUT rejects stop kind 'condition' with structured unsupported_stop_condition detail", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
-      const createResponse = await app.request("/automation", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          ...recurringInput(projectID),
-          stop: { kind: "condition", condition: "repo is ready" },
-        }),
-      })
-      expect(createResponse.status).toBe(422)
-      const createBody = (await createResponse.json()) as { error: string; details: { field: string }[] }
-      expect(createBody.error).toBe("invalid_automation")
-      expect(createBody.details.some((d) => d.field.startsWith("stop"))).toBe(true)
-
       const created = await json(app, "/automation", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(recurringInput(projectID)),
       })
-      const updateResponse = await app.request(`/automation/${created.id}`, {
+      const response = await app.request(`/automation/${created.id}`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ stop: { kind: "condition", condition: "repo is ready" } }),
       })
-      expect(updateResponse.status).toBe(422)
-      const updateBody = (await updateResponse.json()) as { error: string; details: { field: string }[] }
-      expect(updateBody.error).toBe("invalid_automation")
-      expect(updateBody.details.some((d) => d.field.startsWith("stop"))).toBe(true)
+      expect(response.status).toBe(422)
+      expect(await response.json()).toEqual({
+        error: "invalid_automation",
+        details: [{ field: "stop", message: "unsupported_stop_condition" }],
+      })
     })
   })
 

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -130,6 +130,69 @@ function run(overrides: Record<string, unknown> = {}) {
   }
 }
 
+describe("automation route 422 wiring with provider validation enabled", () => {
+  // These tests deliberately bypass the suite-wide skip flag to exercise the
+  // real modelValidationDetails -> AppRuntime path that production hits.
+  let restoreBypass: string | undefined
+  const enableValidation = () => {
+    restoreBypass = process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION
+    delete process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION
+  }
+  const restoreBypassEnv = () => {
+    if (restoreBypass === undefined) delete process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION
+    else process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION = restoreBypass
+  }
+
+  test("create rejects with 422 invalid_automation details when provider lookup fails", async () => {
+    await withAutomationApp(async ({ app, projectID }) => {
+      enableValidation()
+      try {
+        const response = await app.request("/automation", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(recurringInput(projectID)),
+        })
+        expect(response.status).toBe(422)
+        const body = await response.json()
+        expect(body.error).toBe("invalid_automation")
+        expect(body.details).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ field: "model" }),
+          ]),
+        )
+        expect(["model_not_found", "model_lookup_failed"]).toContain(body.details[0].message)
+      } finally {
+        restoreBypassEnv()
+      }
+    })
+  })
+
+  test("update rejects with 422 invalid_automation details when model patch fails provider lookup", async () => {
+    await withAutomationApp(async ({ app, projectID }) => {
+      const created = await json(app, "/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID)),
+      })
+      enableValidation()
+      try {
+        const response = await app.request(`/automation/${created.id}`, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: { providerID: "nonexistent", modelID: "missing-model" } }),
+        })
+        expect(response.status).toBe(422)
+        const body = await response.json()
+        expect(body.error).toBe("invalid_automation")
+        expect(body.details[0].field).toBe("model")
+        expect(["model_not_found", "model_lookup_failed"]).toContain(body.details[0].message)
+      } finally {
+        restoreBypassEnv()
+      }
+    })
+  })
+})
+
 describe("automation routes", () => {
   test("reloads definitions and runs from durable storage after instance restart", async () => {
     await using tmp = await tmpdir({ git: true })

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -727,6 +727,51 @@ describe("automation routes", () => {
     })
   })
 
+  test("metadata-only update preserves pending nextFireAt and nextFires", async () => {
+    await withAutomationApp(async ({ projectID }) => {
+      const created = Automation.create(recurringInput(projectID), { now: 100 })
+      expect(created.kind).toBe("recurring")
+      if (created.kind !== "recurring") throw new Error("recurring")
+      const updated = Automation.update(created.id, { title: "Renamed" }, { now: 200 })
+      expect(updated).toMatchObject({
+        title: "Renamed",
+        nextFireAt: created.nextFireAt,
+        nextFires: created.nextFires,
+      })
+    })
+  })
+
+  test("rhythm change recomputes nextFireAt from the update timestamp", async () => {
+    await withAutomationApp(async ({ projectID }) => {
+      const created = Automation.create(recurringInput(projectID), { now: 100 })
+      const updated = Automation.update(
+        created.id,
+        { rhythm: { kind: "interval", everyMs: 120_000 } },
+        { now: 300 },
+      )
+      if (updated.kind !== "recurring") throw new Error("recurring")
+      expect(updated.nextFireAt).toBe(300 + 120_000)
+    })
+  })
+
+  test("update accepts variant: null to clear a previously set effort", async () => {
+    await withAutomationApp(async ({ app, projectID }) => {
+      const created = await json(app, "/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID, { variant: "high" } as Partial<RecurringCreateInput>)),
+      })
+      expect(created.variant).toBe("high")
+      const cleared = await json(app, `/automation/${created.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ variant: null }),
+      })
+      expect(cleared).not.toHaveProperty("variant")
+      expect(Automation.get(created.id)).not.toHaveProperty("variant")
+    })
+  })
+
   test("pause and resume only revise when paused state changes", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
       const created = await json(app, "/automation", {

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { Automation, AutomationID } from "../../src/automation"
@@ -13,8 +13,18 @@ import { SessionID } from "../../src/session/schema"
 import { Flock } from "../../src/util/flock"
 import { tmpdir } from "../fixture/fixture"
 
-process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION = "1"
 void Log.init({ print: false })
+
+const previousSkipAutomationModelValidation = process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION
+
+beforeAll(() => {
+  process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION = "1"
+})
+
+afterAll(() => {
+  if (previousSkipAutomationModelValidation === undefined) delete process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION
+  else process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION = previousSkipAutomationModelValidation
+})
 
 afterEach(async () => {
   await Instance.disposeAll()

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -150,7 +150,11 @@ describe("automation route 422 wiring with provider validation enabled", () => {
         const response = await app.request("/automation", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify(recurringInput(projectID)),
+          body: JSON.stringify(
+            recurringInput(projectID, {
+              model: Automation.Model.parse({ providerID: "nonexistent", modelID: "missing-model" }),
+            }),
+          ),
         })
         expect(response.status).toBe(422)
         const body = await response.json()

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -13,6 +13,7 @@ import { SessionID } from "../../src/session/schema"
 import { Flock } from "../../src/util/flock"
 import { tmpdir } from "../fixture/fixture"
 
+process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION = "1"
 void Log.init({ print: false })
 
 afterEach(async () => {
@@ -70,6 +71,8 @@ function deferred<T>() {
 type RecurringCreateInput = Extract<Automation.CreateInput, { kind: "recurring" }>
 type OneshotCreateInput = Extract<Automation.CreateInput, { kind: "oneshot" }>
 
+const fixtureModel = Automation.Model.parse({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+
 function recurringInput(projectID: ProjectID, overrides: Partial<RecurringCreateInput> = {}): RecurringCreateInput {
   return {
     kind: "recurring",
@@ -78,6 +81,7 @@ function recurringInput(projectID: ProjectID, overrides: Partial<RecurringCreate
     context: "fresh",
     where: { projectID },
     timezone: "Asia/Shanghai",
+    model: fixtureModel,
     rhythm: { kind: "interval", everyMs: 60_000 },
     stop: { kind: "count", count: 3 },
     ...overrides,
@@ -92,6 +96,7 @@ function oneshotInput(projectID: ProjectID, overrides: Partial<OneshotCreateInpu
     context: "fresh",
     where: { projectID },
     timezone: "Asia/Shanghai",
+    model: fixtureModel,
     fireAt: 1_800_000_000_000,
     ...overrides,
   }
@@ -387,8 +392,10 @@ describe("automation routes", () => {
       expect(body.id).toMatch(/^automation_/)
       expect(body.createdAt).toBeNumber()
       expect(body.updatedAt).toBe(body.createdAt)
-      expect(body.nextFireAt).toBeNull()
-      expect(body.nextFires).toEqual([])
+      expect(body.model).toEqual(fixtureModel)
+      expect(body.nextFireAt).toBeNumber()
+      expect(body.nextFires).toHaveLength(3)
+      expect(body.failureStreak).toBe(0)
     })
   })
 

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -608,11 +608,6 @@ describe("automation routes", () => {
           [{ field: "prompt", message: "prompt_too_long_20000" }],
         ],
         [
-          "condition above replay-safe limit",
-          recurringInput(projectID, { stop: { kind: "condition", condition: "x".repeat(4_001) } }),
-          [{ field: "stop.condition", message: "condition_too_long_4000" }],
-        ],
-        [
           "externally supplied automation session",
           { ...recurringInput(projectID), automationSessionID: SessionID.descending() },
           [{ field: "automationSessionID", message: "unsupported_automation_field" }],
@@ -657,6 +652,38 @@ describe("automation routes", () => {
         expect(response.status).toBe(422)
         expect(await response.json()).toEqual({ error: "invalid_automation", details })
       }
+    })
+  })
+
+  test("rejects stop kind 'condition' at the create/update route as unsupported input", async () => {
+    await withAutomationApp(async ({ app, projectID }) => {
+      const createResponse = await app.request("/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...recurringInput(projectID),
+          stop: { kind: "condition", condition: "repo is ready" },
+        }),
+      })
+      expect(createResponse.status).toBe(422)
+      const createBody = (await createResponse.json()) as { error: string; details: { field: string }[] }
+      expect(createBody.error).toBe("invalid_automation")
+      expect(createBody.details.some((d) => d.field.startsWith("stop"))).toBe(true)
+
+      const created = await json(app, "/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID)),
+      })
+      const updateResponse = await app.request(`/automation/${created.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stop: { kind: "condition", condition: "repo is ready" } }),
+      })
+      expect(updateResponse.status).toBe(422)
+      const updateBody = (await updateResponse.json()) as { error: string; details: { field: string }[] }
+      expect(updateBody.error).toBe("invalid_automation")
+      expect(updateBody.details.some((d) => d.field.startsWith("stop"))).toBe(true)
     })
   })
 
@@ -842,6 +869,31 @@ describe("automation routes", () => {
       })
       expect(cleared).not.toHaveProperty("variant")
       expect(Automation.get(created.id)).not.toHaveProperty("variant")
+    })
+  })
+
+  test("update with variant: null on an unset variant is a no-op (no revision bump, no event)", async () => {
+    await withAutomationApp(async ({ app, projectID }) => {
+      const created = await json(app, "/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID)),
+      })
+      expect(created).not.toHaveProperty("variant")
+      const updates: number[] = []
+      const unsubscribe = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
+        if (event.properties.id === created.id) updates.push(event.properties.revision)
+      })
+      const noop = await json(app, `/automation/${created.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ variant: null }),
+      })
+      await Bun.sleep(10)
+      unsubscribe()
+      expect(noop.revision).toBe(created.revision)
+      expect(noop.updatedAt).toBe(created.updatedAt)
+      expect(updates).toEqual([])
     })
   })
 

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -33,6 +33,8 @@ async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
   })
 }
 
+const fixtureModel = Automation.Model.parse({ providerID: "alibaba", modelID: "qwen-plus" })
+
 function input(projectID: ProjectID, overrides: Partial<Extract<Automation.CreateInput, { kind: "recurring" }>> = {}): Automation.CreateInput {
   return {
     kind: "recurring",
@@ -41,6 +43,7 @@ function input(projectID: ProjectID, overrides: Partial<Extract<Automation.Creat
     context: "fresh",
     where: { projectID },
     timezone: "Asia/Shanghai",
+    model: fixtureModel,
     rhythm: { kind: "interval", everyMs: 60_000 },
     stop: { kind: "count", count: 3 },
     ...overrides,

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -995,6 +995,46 @@ describe("automation scheduler", () => {
     })
   })
 
+  test("recordRunOutcome retries on real ConflictError and merges with the racing edit", async () => {
+    await withAutomation(async (projectID) => {
+      const created = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
+      if (created.kind !== "recurring") throw new Error("recurring")
+
+      const sessionID = SessionID.descending()
+      await Automation.runNowExecuting(created.id, {
+        now: 1_000,
+        executor: async ({ run }) => {
+          const running = Automation.markRunStarted(run, sessionID, { now: 1_000 })
+          await Automation.publishRunUpdated(running)
+          throw new Error("kaboom")
+        },
+      }).catch(() => undefined)
+      await Bun.sleep(10)
+      const failed = Automation.runs({ automationID: created.id }).items.find((r) => r.state === "failed")
+      if (!failed) throw new Error("failed missing")
+
+      // Force a real ConflictError: __testBeforeReplace fires after record
+      // reads `previous` but before it writes, so the unrelated update bumps
+      // the row's revision and the first replaceDefinition hits ConflictError.
+      let hookFires = 0
+      const refreshed = Automation.recordRunOutcome(failed, {
+        now: 1_500,
+        __testBeforeReplace: (previous) => {
+          if (hookFires === 0) {
+            hookFires += 1
+            Automation.update(previous.id, { title: "raced edit" }, { now: 1_400 })
+          }
+        },
+      })
+      expect(hookFires).toBe(1)
+      if (!refreshed || refreshed.kind !== "recurring") throw new Error("refreshed missing")
+      // The retry must preserve the racing edit AND apply the run's contribution.
+      expect(refreshed.title).toBe("raced edit")
+      expect(refreshed.failureStreak).toBe(1)
+      expect(refreshed.nextFireAt).not.toBe(created.nextFireAt)
+    })
+  })
+
   test("recordRunOutcome stays consistent across concurrent revision bumps", async () => {
     await withAutomation(async (projectID) => {
       const created = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
@@ -1039,16 +1079,20 @@ describe("automation scheduler", () => {
     })
   })
 
-  test("CreateInput schema rejects stop kind 'condition' before reaching validate", async () => {
+  test("rejects recurring condition stops at create time", async () => {
     await withAutomation(async (projectID) => {
-      const raw = recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } as never })
       let captured: unknown
       try {
-        Automation.CreateInput.parse(raw)
+        Automation.create(
+          recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } }),
+          { now: 0 },
+        )
       } catch (error) {
         captured = error
       }
       expect(captured).toBeInstanceOf(Error)
+      const validation = captured as { details?: { field: string; message: string }[] }
+      expect(validation.details).toEqual(expect.arrayContaining([{ field: "stop", message: "unsupported_stop_condition" }]))
     })
   })
 

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -995,20 +995,16 @@ describe("automation scheduler", () => {
     })
   })
 
-  test("rejects recurring condition stops at create time", async () => {
+  test("CreateInput schema rejects stop kind 'condition' before reaching validate", async () => {
     await withAutomation(async (projectID) => {
+      const raw = recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } as never })
       let captured: unknown
       try {
-        Automation.create(
-          recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } }),
-          { now: 0 },
-        )
+        Automation.CreateInput.parse(raw)
       } catch (error) {
         captured = error
       }
       expect(captured).toBeInstanceOf(Error)
-      const validation = captured as { details?: { field: string; message: string }[] }
-      expect(validation.details).toEqual(expect.arrayContaining([{ field: "stop", message: "unsupported_stop_condition" }]))
     })
   })
 

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -212,6 +212,17 @@ async function waitForRunCount(automationID: string, count: number) {
   throw new Error(`Timed out waiting for automation run count: ${count}`)
 }
 
+async function waitForFailedRunCount(automationID: string, count: number) {
+  const deadline = Date.now() + 3_000
+  let latest: Automation.Run[] = []
+  while (Date.now() < deadline) {
+    latest = Automation.runs({ automationID }).items
+    if (latest.filter((r) => r.state === "failed").length >= count) return latest
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${count} failed run(s); latest=${JSON.stringify(latest)}`)
+}
+
 async function waitForStarts(starts: unknown[], count: number) {
   const deadline = Date.now() + 3_000
   while (Date.now() < deadline) {
@@ -1009,8 +1020,7 @@ describe("automation scheduler", () => {
           throw new Error("kaboom")
         },
       }).catch(() => undefined)
-      await Bun.sleep(10)
-      const failed = Automation.runs({ automationID: created.id }).items.find((r) => r.state === "failed")
+      const failed = (await waitForFailedRunCount(created.id, 1)).find((r) => r.state === "failed")
       if (!failed) throw new Error("failed missing")
 
       // Force a real ConflictError: __testBeforeReplace fires after record
@@ -1040,8 +1050,10 @@ describe("automation scheduler", () => {
       const created = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
       if (created.kind !== "recurring") throw new Error("recurring")
 
+      let expectedFailed = 0
       const triggerFailedRun = async (now: number) => {
         const sessionID = SessionID.descending()
+        expectedFailed += 1
         await Automation.runNowExecuting(created.id, {
           now,
           executor: async ({ run }) => {
@@ -1050,7 +1062,7 @@ describe("automation scheduler", () => {
             throw new Error("kaboom")
           },
         }).catch(() => undefined)
-        await Bun.sleep(10)
+        await waitForFailedRunCount(created.id, expectedFailed)
       }
 
       await triggerFailedRun(1_000)

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1084,13 +1084,12 @@ describe("automation scheduler", () => {
       const runs = await waitForRunStates(definition.id, ["stopped", "stopped"])
       expect(runs[0].triggeredAt).toBe(60_000)
       const after = Automation.get(definition.id)
-      if (after.kind !== "recurring") throw new Error("recurring")
-      expect(after.revision).toBe(definition.revision)
-      if (definition.kind === "recurring") {
-        expect(after.failureStreak).toBe(definition.failureStreak)
-        expect(after.nextFireAt).toBe(definition.nextFireAt)
-        expect(after.nextFires).toEqual(definition.nextFires)
-      }
+      if (after.kind !== "recurring" || definition.kind !== "recurring") throw new Error("recurring")
+      // failureStreak must not advance on stopped (manual conflict, writer block, missed schedule).
+      expect(after.failureStreak).toBe(definition.failureStreak)
+      // Scheduler-owned stopped (`previous_run_awaiting_input` at t=60_000) advances the stored
+      // nextFireAt preview so the UI does not display a fire time that has already elapsed.
+      expect(after.nextFireAt).toBe(120_000)
       releaseBlocker.resolve({ sessionID: SessionID.descending(), result: "blocker done", cost: 0 })
       scheduler.stop()
     })
@@ -1285,6 +1284,28 @@ describe("automation scheduler", () => {
         triggeredAt: 60_000,
         completedAt: 180_001,
       })
+      scheduler.stop()
+    })
+  })
+
+  test("missed_schedule on a recurring interval advances the stored nextFireAt preview", async () => {
+    await withAutomation(async (projectID) => {
+      const clock = new OversleepClock(0, 180_001)
+      const scheduler = AutomationScheduler.make({
+        clock,
+        executor: async () => ({ sessionID: SessionID.descending(), result: "done", cost: 0 }),
+      })
+      const definition = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
+
+      scheduler.reschedule(definition)
+      const runs = await waitForRunCount(definition.id, 1)
+      expect(runs[0]).toMatchObject({ state: "stopped", stopReason: "missed_schedule" })
+
+      const after = Automation.get(definition.id)
+      if (after.kind !== "recurring" || definition.kind !== "recurring") throw new Error("recurring")
+      expect(after.failureStreak).toBe(definition.failureStreak)
+      expect(after.nextFireAt).not.toBe(definition.nextFireAt)
+      expect(after.nextFireAt).toBeGreaterThanOrEqual(clock.now())
       scheduler.stop()
     })
   })

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -7,6 +7,7 @@ import { ProjectID } from "../../src/project/schema"
 import { trackActiveRun } from "../../src/session/lifecycle-provenance"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { createAutomateDefinition } from "../../src/tool/automate"
+import { fakeAutomationProvider } from "../fake/provider"
 import { tmpdir } from "../fixture/fixture"
 import { Flock } from "../../src/util/flock"
 
@@ -125,6 +126,12 @@ async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
   })
 }
 
+const fakeProvider = fakeAutomationProvider()
+const fixtureModel = Automation.Model.parse({
+  providerID: fakeProvider.providerID,
+  modelID: fakeProvider.modelID,
+})
+
 function oneshotInput(projectID: ProjectID, fireAt: number): Automation.CreateInput {
   return {
     kind: "oneshot",
@@ -133,6 +140,7 @@ function oneshotInput(projectID: ProjectID, fireAt: number): Automation.CreateIn
     context: "fresh",
     where: { projectID },
     timezone: "Asia/Shanghai",
+    model: fixtureModel,
     fireAt,
   }
 }
@@ -147,6 +155,7 @@ function recurringInput(projectID: ProjectID, everyMs: number, overrides: Partia
     context: "fresh",
     where: { projectID },
     timezone: "Asia/Shanghai",
+    model: fixtureModel,
     rhythm: { kind: "interval", everyMs },
     stop: { kind: "never" },
     ...overrides,
@@ -280,7 +289,7 @@ describe("automation scheduler", () => {
         clock,
         executor: async () => ({ sessionID: SessionID.descending(), result: "done", cost: 0 }),
       })
-      const tool = createAutomateDefinition()
+      const tool = createAutomateDefinition(fakeProvider.interface)
 
       const result = await Effect.runPromise(
         tool.execute(
@@ -986,28 +995,20 @@ describe("automation scheduler", () => {
     })
   })
 
-  test("does not schedule recurring condition stops without an evaluator", async () => {
+  test("rejects recurring condition stops at create time", async () => {
     await withAutomation(async (projectID) => {
-      const clock = new FakeClock(0)
-      const starts: number[] = []
-      const scheduler = AutomationScheduler.make({
-        clock,
-        executor: async () => {
-          starts.push(clock.now())
-          return { sessionID: SessionID.descending(), result: "done", cost: 0 }
-        },
-      })
-      const definition = Automation.create(
-        recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } }),
-        { now: 0 },
-      )
-
-      scheduler.reschedule(definition)
-      await clock.advance(60_000)
-
-      expect(starts).toEqual([])
-      expect(Automation.runs({ automationID: definition.id }).items).toHaveLength(0)
-      scheduler.stop()
+      let captured: unknown
+      try {
+        Automation.create(
+          recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } }),
+          { now: 0 },
+        )
+      } catch (error) {
+        captured = error
+      }
+      expect(captured).toBeInstanceOf(Error)
+      const validation = captured as { details?: { field: string; message: string }[] }
+      expect(validation.details).toEqual(expect.arrayContaining([{ field: "stop", message: "unsupported_stop_condition" }]))
     })
   })
 

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1083,6 +1083,14 @@ describe("automation scheduler", () => {
 
       const runs = await waitForRunStates(definition.id, ["stopped", "stopped"])
       expect(runs[0].triggeredAt).toBe(60_000)
+      const after = Automation.get(definition.id)
+      if (after.kind !== "recurring") throw new Error("recurring")
+      expect(after.revision).toBe(definition.revision)
+      if (definition.kind === "recurring") {
+        expect(after.failureStreak).toBe(definition.failureStreak)
+        expect(after.nextFireAt).toBe(definition.nextFireAt)
+        expect(after.nextFires).toEqual(definition.nextFires)
+      }
       releaseBlocker.resolve({ sessionID: SessionID.descending(), result: "blocker done", cost: 0 })
       scheduler.stop()
     })

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1023,19 +1023,22 @@ describe("automation scheduler", () => {
       const failed = (await waitForFailedRunCount(created.id, 1)).find((r) => r.state === "failed")
       if (!failed) throw new Error("failed missing")
 
-      // Force a real ConflictError: __testBeforeReplace fires after record
-      // reads `previous` but before it writes, so the unrelated update bumps
-      // the row's revision and the first replaceDefinition hits ConflictError.
+      // Force a real ConflictError: the test hook fires after record reads
+      // `previous` but before it writes, so the unrelated update bumps the
+      // row's revision and the first replaceDefinition hits ConflictError.
       let hookFires = 0
-      const refreshed = Automation.recordRunOutcome(failed, {
-        now: 1_500,
-        __testBeforeReplace: (previous) => {
-          if (hookFires === 0) {
-            hookFires += 1
-            Automation.update(previous.id, { title: "raced edit" }, { now: 1_400 })
-          }
-        },
-      })
+      Automation.__testHooks.beforeReplaceDefinition = (previous) => {
+        if (hookFires === 0) {
+          hookFires += 1
+          Automation.update(previous.id, { title: "raced edit" }, { now: 1_400 })
+        }
+      }
+      let refreshed: Automation.Definition | undefined
+      try {
+        refreshed = Automation.recordRunOutcome(failed, { now: 1_500 })
+      } finally {
+        delete Automation.__testHooks.beforeReplaceDefinition
+      }
       expect(hookFires).toBe(1)
       if (!refreshed || refreshed.kind !== "recurring") throw new Error("refreshed missing")
       // The retry must preserve the racing edit AND apply the run's contribution.

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -995,6 +995,50 @@ describe("automation scheduler", () => {
     })
   })
 
+  test("recordRunOutcome stays consistent across concurrent revision bumps", async () => {
+    await withAutomation(async (projectID) => {
+      const created = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
+      if (created.kind !== "recurring") throw new Error("recurring")
+
+      const triggerFailedRun = async (now: number) => {
+        const sessionID = SessionID.descending()
+        await Automation.runNowExecuting(created.id, {
+          now,
+          executor: async ({ run }) => {
+            const running = Automation.markRunStarted(run, sessionID, { now })
+            await Automation.publishRunUpdated(running)
+            throw new Error("kaboom")
+          },
+        }).catch(() => undefined)
+        await Bun.sleep(10)
+      }
+
+      await triggerFailedRun(1_000)
+      const failed1 = Automation.runs({ automationID: created.id }).items.find((r) => r.state === "failed")
+      if (!failed1) throw new Error("failed1 missing")
+      const after1 = Automation.recordRunOutcome(failed1, { now: 1_500 })
+      if (!after1 || after1.kind !== "recurring") throw new Error("after1")
+      expect(after1.failureStreak).toBe(1)
+      expect(after1.revision).toBeGreaterThan(created.revision)
+
+      const edited = Automation.update(created.id, { title: "edited" }, { now: 2_000 })
+      expect(edited.revision).toBeGreaterThan(after1.revision)
+
+      await triggerFailedRun(3_000)
+      const failed2 = Automation.runs({ automationID: created.id }).items
+        .filter((r) => r.state === "failed")
+        .find((r) => r.id !== failed1.id)
+      if (!failed2) throw new Error("failed2 missing")
+      const after2 = Automation.recordRunOutcome(failed2, { now: 3_500 })
+      if (!after2 || after2.kind !== "recurring") throw new Error("after2")
+      // Concurrent edit must not erase the streak; record reads the latest
+      // and applies the increment on top.
+      expect(after2.failureStreak).toBe(2)
+      expect(after2.title).toBe("edited")
+      expect(after2.revision).toBeGreaterThan(edited.revision)
+    })
+  })
+
   test("CreateInput schema rejects stop kind 'condition' before reaching validate", async () => {
     await withAutomation(async (projectID) => {
       const raw = recurringInput(projectID, 60_000, { stop: { kind: "condition", condition: "repo is ready" } as never })

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1287,26 +1287,4 @@ describe("automation scheduler", () => {
       scheduler.stop()
     })
   })
-
-  test("missed_schedule on a recurring interval advances the stored nextFireAt preview", async () => {
-    await withAutomation(async (projectID) => {
-      const clock = new OversleepClock(0, 180_001)
-      const scheduler = AutomationScheduler.make({
-        clock,
-        executor: async () => ({ sessionID: SessionID.descending(), result: "done", cost: 0 }),
-      })
-      const definition = Automation.create(recurringInput(projectID, 60_000), { now: 0 })
-
-      scheduler.reschedule(definition)
-      const runs = await waitForRunCount(definition.id, 1)
-      expect(runs[0]).toMatchObject({ state: "stopped", stopReason: "missed_schedule" })
-
-      const after = Automation.get(definition.id)
-      if (after.kind !== "recurring" || definition.kind !== "recurring") throw new Error("recurring")
-      expect(after.failureStreak).toBe(definition.failureStreak)
-      expect(after.nextFireAt).not.toBe(definition.nextFireAt)
-      expect(after.nextFireAt).toBeGreaterThanOrEqual(clock.now())
-      scheduler.stop()
-    })
-  })
 })

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Automation } from "../../src/automation"
+import { internalTestHooks } from "../../src/automation/__test_hooks"
 import { AutomationScheduler } from "../../src/automation/scheduler"
 import { Instance } from "../../src/project/instance"
 import { ProjectID } from "../../src/project/schema"
@@ -1027,7 +1028,7 @@ describe("automation scheduler", () => {
       // `previous` but before it writes, so the unrelated update bumps the
       // row's revision and the first replaceDefinition hits ConflictError.
       let hookFires = 0
-      Automation.__testHooks.beforeReplaceDefinition = (previous) => {
+      internalTestHooks.beforeReplaceDefinition = (previous) => {
         if (hookFires === 0) {
           hookFires += 1
           Automation.update(previous.id, { title: "raced edit" }, { now: 1_400 })
@@ -1037,7 +1038,7 @@ describe("automation scheduler", () => {
       try {
         refreshed = Automation.recordRunOutcome(failed, { now: 1_500 })
       } finally {
-        delete Automation.__testHooks.beforeReplaceDefinition
+        delete internalTestHooks.beforeReplaceDefinition
       }
       expect(hookFires).toBe(1)
       if (!refreshed || refreshed.kind !== "recurring") throw new Error("refreshed missing")

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -4,45 +4,10 @@ import { AutomateParameters, createAutomateDefinition, formatAutomateValidationE
 import { Automation } from "../../src/automation"
 import { Instance } from "../../src/project/instance"
 import { MessageID, SessionID } from "../../src/session/schema"
-import { ModelID, ProviderID } from "../../src/provider/schema"
-import type { Provider } from "../../src/provider/provider"
 import { tmpdir } from "../fixture/fixture"
-import { ProviderTest } from "../fake/provider"
+import { fakeAutomationProvider } from "../fake/provider"
 
-const fakeProviderID = ProviderID.make("openai")
-const fakeModelID = ModelID.make("test-reasoning-model")
-const fakeModel = ProviderTest.model({
-  id: fakeModelID,
-  providerID: fakeProviderID,
-  capabilities: {
-    toolcall: true,
-    attachment: false,
-    reasoning: true,
-    temperature: true,
-    interleaved: false,
-    input: { text: true, image: false, audio: false, video: false, pdf: false },
-    output: { text: true, image: false, audio: false, video: false, pdf: false },
-  },
-  api: { id: fakeModelID, url: "https://example.com", npm: "ai-gateway-provider" },
-})
-const fakeInfo = ProviderTest.info({ id: fakeProviderID }, fakeModel)
-const fakeProviderInterface: Provider.Interface = {
-  list: () => Effect.succeed({ [fakeProviderID]: fakeInfo }),
-  getProvider: (providerID) =>
-    providerID === fakeProviderID
-      ? Effect.succeed(fakeInfo)
-      : Effect.die(new Error(`Unknown provider: ${providerID}`)),
-  getModel: (providerID, modelID) =>
-    providerID === fakeProviderID && modelID === fakeModelID
-      ? Effect.succeed(fakeModel)
-      : Effect.die(new Error(`Unknown model: ${providerID}/${modelID}`)),
-  getLanguage: () => Effect.die(new Error("getLanguage not configured")),
-  closest: (providerID) =>
-    Effect.succeed(providerID === fakeProviderID ? { providerID, modelID: fakeModelID } : undefined),
-  getSmallModel: (providerID) =>
-    Effect.succeed(providerID === fakeProviderID ? fakeModel : undefined),
-  defaultModel: () => Effect.succeed({ providerID: fakeProviderID, modelID: fakeModelID }),
-}
+const { providerID: fakeProviderID, modelID: fakeModelID, interface: fakeProviderInterface } = fakeAutomationProvider()
 const fixtureModel = { providerID: fakeProviderID, modelID: fakeModelID }
 
 afterEach(async () => {

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -92,9 +92,10 @@ describe("automate tool", () => {
 
   test.each([
     ["empty cron expression", { rhythm: { kind: "cron", expression: "" }, stop: { kind: "never" } }],
+    ["empty stop condition", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "" } }],
     ["title above replay-safe limit", { title: "x".repeat(161) }],
     ["prompt above replay-safe limit", { prompt: "x".repeat(20_001) }],
-    ["stop kind condition (not yet supported as input)", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "repo is ready" } }],
+    ["condition above replay-safe limit", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "x".repeat(4_001) } }],
   ])("rejects empty nested strings before execute reaches the Zod create parser: %s", (_name, override) => {
     const decode = Schema.decodeUnknownSync(AutomateParameters)
     let error: unknown

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -92,10 +92,9 @@ describe("automate tool", () => {
 
   test.each([
     ["empty cron expression", { rhythm: { kind: "cron", expression: "" }, stop: { kind: "never" } }],
-    ["empty stop condition", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "" } }],
     ["title above replay-safe limit", { title: "x".repeat(161) }],
     ["prompt above replay-safe limit", { prompt: "x".repeat(20_001) }],
-    ["condition above replay-safe limit", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "x".repeat(4_001) } }],
+    ["stop kind condition (not yet supported as input)", { rhythm: { kind: "interval", everyMs: 60_000 }, stop: { kind: "condition", condition: "repo is ready" } }],
   ])("rejects empty nested strings before execute reaches the Zod create parser: %s", (_name, override) => {
     const decode = Schema.decodeUnknownSync(AutomateParameters)
     let error: unknown

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -4,7 +4,46 @@ import { AutomateParameters, createAutomateDefinition, formatAutomateValidationE
 import { Automation } from "../../src/automation"
 import { Instance } from "../../src/project/instance"
 import { MessageID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import type { Provider } from "../../src/provider/provider"
 import { tmpdir } from "../fixture/fixture"
+import { ProviderTest } from "../fake/provider"
+
+const fakeProviderID = ProviderID.make("openai")
+const fakeModelID = ModelID.make("test-reasoning-model")
+const fakeModel = ProviderTest.model({
+  id: fakeModelID,
+  providerID: fakeProviderID,
+  capabilities: {
+    toolcall: true,
+    attachment: false,
+    reasoning: true,
+    temperature: true,
+    interleaved: false,
+    input: { text: true, image: false, audio: false, video: false, pdf: false },
+    output: { text: true, image: false, audio: false, video: false, pdf: false },
+  },
+  api: { id: fakeModelID, url: "https://example.com", npm: "ai-gateway-provider" },
+})
+const fakeInfo = ProviderTest.info({ id: fakeProviderID }, fakeModel)
+const fakeProviderInterface: Provider.Interface = {
+  list: () => Effect.succeed({ [fakeProviderID]: fakeInfo }),
+  getProvider: (providerID) =>
+    providerID === fakeProviderID
+      ? Effect.succeed(fakeInfo)
+      : Effect.die(new Error(`Unknown provider: ${providerID}`)),
+  getModel: (providerID, modelID) =>
+    providerID === fakeProviderID && modelID === fakeModelID
+      ? Effect.succeed(fakeModel)
+      : Effect.die(new Error(`Unknown model: ${providerID}/${modelID}`)),
+  getLanguage: () => Effect.die(new Error("getLanguage not configured")),
+  closest: (providerID) =>
+    Effect.succeed(providerID === fakeProviderID ? { providerID, modelID: fakeModelID } : undefined),
+  getSmallModel: (providerID) =>
+    Effect.succeed(providerID === fakeProviderID ? fakeModel : undefined),
+  defaultModel: () => Effect.succeed({ providerID: fakeProviderID, modelID: fakeModelID }),
+}
+const fixtureModel = { providerID: fakeProviderID, modelID: fakeModelID }
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -21,6 +60,7 @@ describe("automate tool", () => {
         context: "fresh",
         where: { projectID: "project" },
         timezone: "UTC",
+        model: fixtureModel,
         rhythm: { kind: "interval", everyMs: 60_000 },
         stop: { kind: "never" },
       })
@@ -30,7 +70,7 @@ describe("automate tool", () => {
 
     expect(error).toBeDefined()
     expect(formatAutomateValidationError(error)).toContain("prompt")
-    expect(formatAutomateValidationError(error)).toContain("kind, title, prompt, context, where, timezone")
+    expect(formatAutomateValidationError(error)).toContain("model")
   })
 
   test("rejects empty strings before execute reaches the Zod create parser", () => {
@@ -44,6 +84,7 @@ describe("automate tool", () => {
         context: "fresh",
         where: { projectID: "project", worktree: "" },
         timezone: "",
+        model: fixtureModel,
         rhythm: { kind: "interval", everyMs: 60_000 },
         stop: { kind: "never" },
       })
@@ -71,6 +112,7 @@ describe("automate tool", () => {
       context: "fresh",
       where: { projectID: "project" },
       timezone: "UTC",
+      model: fixtureModel,
     }
     let error: unknown
     try {
@@ -100,6 +142,7 @@ describe("automate tool", () => {
         context: "fresh",
         where: { projectID: "project" },
         timezone: "UTC",
+        model: fixtureModel,
         ...override,
       })
     } catch (caught) {
@@ -124,6 +167,7 @@ describe("automate tool", () => {
         context: "fresh",
         where: { projectID: "project" },
         timezone: "UTC",
+        model: fixtureModel,
         rhythm: { kind: "interval", everyMs: 60_000 },
         stop: { kind: "never" },
         ...override,
@@ -144,7 +188,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition()
+        const tool = createAutomateDefinition(fakeProviderInterface)
         const sourceSessionID = SessionID.descending()
         let error: unknown
         try {
@@ -157,6 +201,7 @@ describe("automate tool", () => {
                 context: "fresh",
                 where: where(Instance.project.id),
                 timezone: "UTC",
+                model: fixtureModel,
                 rhythm: { kind: "interval", everyMs: 60_000 },
                 stop: { kind: "never" },
               },
@@ -187,7 +232,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition()
+        const tool = createAutomateDefinition(fakeProviderInterface)
         const sourceSessionID = SessionID.descending()
         const result = await Effect.runPromise(
           tool.execute(
@@ -198,6 +243,7 @@ describe("automate tool", () => {
               context: "fresh",
               where: { projectID: Instance.project.id },
               timezone: "Asia/Shanghai",
+              model: fixtureModel,
               rhythm: { kind: "interval", everyMs: 60_000 },
               stop: { kind: "never" },
             },
@@ -232,7 +278,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition()
+        const tool = createAutomateDefinition(fakeProviderInterface)
         const sourceSessionID = SessionID.descending()
         const spoofedSessionID = SessionID.descending()
         const spoofedSource = { sourceSessionID: spoofedSessionID } as Record<string, unknown>
@@ -245,6 +291,7 @@ describe("automate tool", () => {
               context: "fresh",
               where: { projectID: Instance.project.id },
               timezone: "Asia/Shanghai",
+              model: fixtureModel,
               ...spoofedSource,
               rhythm: { kind: "interval", everyMs: 60_000 },
               stop: { kind: "never" },
@@ -271,7 +318,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition()
+        const tool = createAutomateDefinition(fakeProviderInterface)
         let error: unknown
         const spoofedSession = { automationSessionID: SessionID.descending() } as Record<string, unknown>
         try {
@@ -284,6 +331,7 @@ describe("automate tool", () => {
                 context: "fresh",
                 where: { projectID: Instance.project.id },
                 timezone: "Asia/Shanghai",
+                model: fixtureModel,
                 ...spoofedSession,
                 rhythm: { kind: "interval", everyMs: 60_000 },
                 stop: { kind: "never" },

--- a/packages/sdk/js/src/v2/event-types.test-d.ts
+++ b/packages/sdk/js/src/v2/event-types.test-d.ts
@@ -36,6 +36,7 @@ const _automationDefinitionUpdated: EventAutomationDefinitionUpdated = {
     updatedAt: 1800000030000,
     timezone: "UTC",
     normalizationWarnings: [],
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
     rhythm: { kind: "interval", everyMs: 3600000 },
     stop: { kind: "never" },
     nextFireAt: null,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2469,7 +2469,7 @@ export type AutomationUpdateInput = {
   rhythm?: AutomationRhythm
   stop?: AutomationStop
   model?: AutomationModel
-  variant?: string
+  variant?: string | null
 }
 
 export type AutomationActiveRunStillRunningError = {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -358,6 +358,11 @@ export type AutomationWhere = {
   worktree?: string
 }
 
+export type AutomationModel = {
+  providerID: string
+  modelID: string
+}
+
 export type AutomationRhythm =
   | {
       kind: "interval"
@@ -397,6 +402,8 @@ export type AutomationDefinition =
       sourceSessionID?: string
       automationSessionID?: string
       normalizationWarnings: Array<string>
+      model: AutomationModel
+      variant?: string
       fireAt: number
     }
   | {
@@ -414,6 +421,8 @@ export type AutomationDefinition =
       sourceSessionID?: string
       automationSessionID?: string
       normalizationWarnings: Array<string>
+      model: AutomationModel
+      variant?: string
       rhythm: AutomationRhythm
       stop: AutomationStop
       nextFireAt: number | null
@@ -2427,6 +2436,8 @@ export type AutomationCreateInput =
       context: "continue" | "fresh"
       where: AutomationWhere
       timezone: string
+      model: AutomationModel
+      variant?: string
       fireAt: number
     }
   | {
@@ -2436,6 +2447,8 @@ export type AutomationCreateInput =
       context: "continue" | "fresh"
       where: AutomationWhere
       timezone: string
+      model: AutomationModel
+      variant?: string
       rhythm: AutomationRhythm
       stop: AutomationStop
     }
@@ -2455,6 +2468,8 @@ export type AutomationUpdateInput = {
   fireAt?: number
   rhythm?: AutomationRhythm
   stop?: AutomationStop
+  model?: AutomationModel
+  variant?: string
 }
 
 export type AutomationActiveRunStillRunningError = {


### PR DESCRIPTION
## Summary

Closes backend gaps left after PR1–5 so the PR6/PR7 frontend slice can build on a complete contract. Adds required `model` (and optional `variant`) on every `AutomationDefinition`, rejects `stop.kind === "condition"` with a structured 422 detail, persists derived scheduling fields (`nextFireAt`, `nextFires`, `failureStreak`) at create / update / after every terminal run, and extends the `automate` tool schema + Provider-backed validation so LLM-submitted automations are checked at create time instead of failing inside the run.

## Why

PR1–5 stood up the automation contract, scheduler, persistence and worktree surface, but left several pieces the frontend would have to handle at runtime:

- Runs depended on the runtime model fallback chain, which changes across restarts — automation definitions could silently target a different model after a process bounce.
- `stop.kind === "condition"` was accepted at create time but `canScheduleRecurring()` returned `false`, so the UI could surface schedules that would never fire.
- `nextFireAt` / `nextFires` / `failureStreak` were never persisted, so global-sync had nothing to render after a run completed.
- The `automate` tool schema had no model/variant slots and no Provider-backed validation, so invalid LLM submissions only failed deep inside the run.

PR6 (sidebar panel) and PR7 (form / templates / NL card) need this surface complete and stable before they can start.

## Related Issue

- Issue #950 Automation/Loop (`docs/architecture/2026-05-27-issue-950-automation-pr-plan.md`)
- Follows PR #960 (PR1), #983 (PR2), #984 (PR3), #998 (PR4), #1004 (PR5)
- Unblocks PR6 (sidebar panel) and PR7 (form / templates / NL card)

## Human Review Status

Approved by @Astro-Han

## Review Focus

- **`model` / `variant` validation contract** — create + update routes call `ProviderTransform.variants(model)` and return `422 invalid_automation` with structured `{ field, message }` details. Invariant: invalid model/variant never reaches the runner.
- **Stop condition rejection** — schema layer still accepts `{ kind: "condition" }` (kept for SDK shape parity with future evaluator support) but the validate layer rejects with `{ field: "stop", message: "unsupported_stop_condition" }`. Check that the structured detail is preserved across both HTTP and the `automate` tool error path.
- **Derived field maintenance + self-loop guard** — `recordRunOutcome` re-publishes `automation.definition.updated` after every terminal run; scheduler uses a `selfPublishedDefinitionUpdates` set keyed by `id:revision` to skip its own echoes. Check the race window and the `ConflictError` retry loop.
- **`automate` tool schema** — picks up `model` / `variant`; description points the LLM at supported `stop` kinds; tool init now takes `Provider.Interface` so model existence is checked at create time.

## Risk Notes

- **Migration drops pre-release rows.** `20260601100000_automation_model_required` deletes existing `automation_definition` / `automation_run` rows so the new NOT NULL `model` column is safe to add. The feature is still behind `OPENCODE_ENABLE_AUTOMATE_TOOL` with no user-visible entry point, so impact is limited to dev/QA installs.
- **Breaking type change.** `model` becomes required on `AutomationDefinition` — any pre-PR5.5 caller that constructs a definition without it will fail type-check and (post-migration) the runtime parse.
- **Behavior change, not a type break:** `stop.kind === "condition"` now returns 422 instead of being stored. The SDK `AutomationStop` union still includes the condition variant for future evaluator support.
- **Platform impact:** none — backend-only, no packaging, signing, updater, or shell surface touched.
- **Skipped conditional checklist items** (see below):
  - "manual UI / copy check" — no visible UI in this PR (feature still gated, sidebar/form land in PR6/PR7).
  - "macOS and Windows impact" — not touched; Windows-advisory CI jobs that ran are unrelated unit suites.

## How To Verify

```text
HEAD: 3af5bae6c1

bun test packages/opencode/test/server/automation-routes.test.ts
        + packages/opencode/test/server/automation-runner.test.ts
        + packages/opencode/test/server/automation-scheduler.test.ts
        + packages/opencode/test/server/automation-event-fixtures.test.ts
        + packages/opencode/test/tool/automate.test.ts
        + packages/opencode/test/automation/cron.test.ts
        → 129 pass / 0 fail
bun test packages/opencode/test/session/processor-effect.test.ts
        → 35 pass / 0 fail (runner change did not disturb session loop)
bun run --cwd packages/sdk/js build
        → SDK regen produces no diff vs the manually edited types.gen.ts (verified against 14fa9982aa; 3af5bae6c1 only touches test files, no schema diff)

CI on 3af5bae6c1: 28 SUCCESS / 0 FAILURE / 4 IN_PROGRESS.
  SUCCESS: ci/typecheck, ci/lint, ci/check, ci/frontend-architecture, ci/actionlint,
           ci/unit-app, ci/unit-ui, ci/unit-desktop, ci/unit-opencode,
           codeql/analyze-js-ts, dependency-review, desktop-smoke/smoke-macos-arm64,
           dev-dep-audit, e2e-artifacts, pr-triage (incl. unit results app/ui/desktop/opencode),
           windows-advisory/unit-windows-app, windows-advisory/unit-windows-desktop.
  IN_PROGRESS: CodeQL meta, plus 3 Windows-advisory shards
               (unit-windows-opencode-config-project / -session / -server-tools).
  Windows-advisory is non-blocking; the only prior Windows failure
  (unit-windows-opencode-server-tools on 14fa9982aa) was unrelated to
  automation code and that shard has restarted on 3af5bae6c1.
```

## Screenshots or Recordings

N/A — backend-only PR. Feature is still gated behind `OPENCODE_ENABLE_AUTOMATE_TOOL` and has no user-visible entry point until PR6 / PR7.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automations now require a model (provider+model ID) and optionally a variant; scheduler and runner use this selection.
  * Recurring automations compute and expose concrete nextFireAt/nextFires.
  * Stronger cron validation to reject unreachable schedules.

* **Bug Fixes / Validation**
  * Creation/update API now validates model/variant and returns structured 422 errors for invalid selections.
  * Sending variant: null clears a previously set variant.

* **Chores**
  * Migration cleared legacy persisted automations without a model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


