### PR TITLE
refactor(opencode): split bash tool into prompt, id, and artifact orchestrator

### DIFF
--- a/packages/opencode/src/tool/bash-artifact-orchestrator.ts
+++ b/packages/opencode/src/tool/bash-artifact-orchestrator.ts
@@ -211,9 +211,7 @@ export const orchestrateArtifacts = <RunR, DepR>(
             ...(!tracked.before.comparable || !after.comparable
               ? {
                   comparable: false,
-                  errorCode:
-                    ("errorCode" in tracked.before ? tracked.before.errorCode : undefined) ??
-                    ("errorCode" in after ? after.errorCode : undefined),
+                  errorCode: tracked.before.errorCode ?? after.errorCode,
                 }
               : {}),
           }

--- a/packages/opencode/src/tool/bash-artifact-orchestrator.ts
+++ b/packages/opencode/src/tool/bash-artifact-orchestrator.ts
@@ -1,0 +1,264 @@
+import { Effect } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import type * as Tool from "./tool"
+import { sameTrackedState, type TrackedOutputState, type OutputDiscovery } from "./bash-output-capture"
+import type { RecordWriteInput, RecordUncapturedInput } from "../session/turn-change"
+
+type ToolResultLike = {
+  title: string
+  metadata: Record<string, unknown>
+  output: string
+}
+
+type TrackedOutput = {
+  path: string
+  before: TrackedOutputState
+}
+
+export type ResolveExecutionPath = (
+  raw: string,
+  root: string,
+  shell: string,
+) => Effect.Effect<string, never, any>
+
+export type AssertExternalDirectory = (
+  ctx: Tool.Context,
+  filepath: string,
+  opts: { kind: "file" },
+) => Effect.Effect<string | undefined, never, any>
+
+export type ReadTrackedState = (file: string) => Effect.Effect<TrackedOutputState, never, any>
+
+export type DiscoverOfficeOutputs = (cwd: string, projectRoot: string) => Effect.Effect<OutputDiscovery, never, any>
+
+export type OfficeCliTargetsFn = (command: string) => readonly string[]
+export type NonOfficeCliCommandTextFn = (command: string) => string
+export type IsLikelyWriteCommandFn = (command: string) => boolean
+
+export type RecordWrite = (input: RecordWriteInput) => Effect.Effect<void, never, any>
+export type RecordUncaptured = (input: RecordUncapturedInput) => Effect.Effect<void, never, any>
+
+export type ArtifactDeps = {
+  resolveExecutionPath: ResolveExecutionPath
+  assertExternalDirectory: AssertExternalDirectory
+  readTrackedState: ReadTrackedState
+  discoverOfficeOutputs: DiscoverOfficeOutputs
+  officeCliTargets: OfficeCliTargetsFn
+  nonOfficeCliCommandText: NonOfficeCliCommandTextFn
+  isLikelyWriteCommand: IsLikelyWriteCommandFn
+  recordWrite: RecordWrite
+  recordUncaptured: RecordUncaptured
+}
+
+export type ArtifactInput = {
+  ctx: Tool.Context
+  cwd: string
+  directory: string
+  shell: string
+  command: string
+  expectedOutputs: readonly string[]
+}
+
+export type ArtifactRunner<R> = () => Effect.Effect<ToolResultLike, never, R>
+
+export const orchestrateArtifacts = <R>(
+  input: ArtifactInput,
+  run: ArtifactRunner<R>,
+  deps: ArtifactDeps,
+): Effect.Effect<ToolResultLike, never, R> =>
+  Effect.gen(function* () {
+    const { ctx, cwd, directory, shell, command, expectedOutputs } = input
+    const hasMessage = !!ctx.messageID
+    const declared = expectedOutputs ?? []
+    const dedupeByNormalized = (
+      items: ReadonlyArray<{ path: string; before: TrackedOutputState; normalized: string }>,
+    ) => {
+      const out = new Map<string, TrackedOutput>()
+      for (const item of items) {
+        if (out.has(item.normalized)) continue
+        out.set(item.normalized, { path: item.path, before: item.before })
+      }
+      return Array.from(out.values())
+    }
+
+    const resolveTrackedInput = (rawPath: string) =>
+      Effect.gen(function* () {
+        const resolved = yield* deps.resolveExecutionPath(rawPath, cwd, shell)
+        const normalized = AppFileSystem.normalizePath(resolved)
+        const filepath = (yield* deps.assertExternalDirectory(ctx, normalized, { kind: "file" })) ?? normalized
+        return {
+          normalized: AppFileSystem.normalizePath(filepath),
+          path: filepath,
+          before: yield* deps.readTrackedState(filepath),
+        }
+      })
+
+    const trackedOutputs = dedupeByNormalized(
+      yield* Effect.forEach(declared, resolveTrackedInput, { concurrency: 4 }),
+    )
+
+    const exactOfficeOutputs = dedupeByNormalized(
+      yield* Effect.forEach(
+        declared.length === 0 && hasMessage ? deps.officeCliTargets(command) : [],
+        resolveTrackedInput,
+        { concurrency: 4 },
+      ),
+    )
+
+    const shouldAutoDiscover =
+      declared.length === 0 &&
+      hasMessage &&
+      deps.isLikelyWriteCommand(
+        exactOfficeOutputs.length ? deps.nonOfficeCliCommandText(command) : command,
+      )
+
+    const autoDiscoveredBefore = shouldAutoDiscover
+      ? yield* Effect.gen(function* () {
+          const discovered = yield* deps.discoverOfficeOutputs(cwd, directory)
+          if (discovered.overflowed) return { outputs: [] as TrackedOutput[], overflowed: true as const }
+          const outputs = yield* Effect.forEach(
+            discovered.paths,
+            (filepath) =>
+              Effect.gen(function* () {
+                return {
+                  path: filepath,
+                  before: yield* deps.readTrackedState(filepath),
+                }
+              }),
+            { concurrency: 4 },
+          )
+          return { outputs: outputs as TrackedOutput[], overflowed: false as const }
+        })
+      : undefined
+
+    const result = yield* run()
+
+    let outputsToRecord: TrackedOutput[] = trackedOutputs
+    let autoDiscovered = false
+    let exactOfficeTargeted = false
+
+    if (!outputsToRecord.length && exactOfficeOutputs.length) {
+      outputsToRecord = exactOfficeOutputs
+      exactOfficeTargeted = true
+    }
+
+    if (!trackedOutputs.length && shouldAutoDiscover) {
+      autoDiscovered = true
+      let overflowed = autoDiscoveredBefore?.overflowed ?? false
+      const deduped = new Map<string, TrackedOutput>()
+      for (const item of exactOfficeOutputs) {
+        const normalized = AppFileSystem.normalizePath(item.path)
+        if (deduped.has(normalized)) continue
+        deduped.set(normalized, item)
+      }
+      if (!overflowed) {
+        for (const item of autoDiscoveredBefore?.outputs ?? []) {
+          const normalized = AppFileSystem.normalizePath(item.path)
+          if (deduped.has(normalized)) continue
+          deduped.set(normalized, item)
+        }
+        const discoveredAfter = yield* deps.discoverOfficeOutputs(cwd, directory)
+        overflowed = discoveredAfter.overflowed
+        if (!overflowed) {
+          for (const filepath of discoveredAfter.paths) {
+            const normalized = AppFileSystem.normalizePath(filepath)
+            if (deduped.has(normalized)) continue
+            deduped.set(normalized, {
+              path: filepath,
+              before: { state: { exists: false }, comparable: true, kind: "missing" },
+            })
+          }
+        }
+      }
+
+      if (overflowed) {
+        if (deduped.size > 0) {
+          outputsToRecord = Array.from(deduped.values())
+        } else {
+          yield* deps.recordUncaptured({
+            sessionID: ctx.sessionID,
+            messageID: ctx.messageID,
+          })
+          return result
+        }
+      } else {
+        outputsToRecord = Array.from(deduped.values())
+      }
+    }
+
+    if (!outputsToRecord.length) {
+      if (shouldAutoDiscover) {
+        yield* deps.recordUncaptured({
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+        })
+      }
+      return result
+    }
+
+    const artifacts = yield* Effect.forEach(
+      outputsToRecord,
+      (tracked) =>
+        Effect.gen(function* () {
+          const after = yield* deps.readTrackedState(tracked.path)
+          const changed =
+            tracked.before.comparable &&
+            after.comparable &&
+            !sameTrackedState(tracked.before.state, after.state)
+          if (changed) {
+            yield* deps.recordWrite({
+              sessionID: ctx.sessionID,
+              messageID: ctx.messageID,
+              path: tracked.path,
+              before: tracked.before.state,
+              after: after.state,
+            })
+          }
+          return {
+            path: tracked.path,
+            exists: after.state.exists,
+            changed,
+            ...(after.kind === "directory" ? { directory: true } : {}),
+            ...(after.state.binary && after.kind !== "directory" ? { binary: true } : {}),
+            ...(after.state.large ? { large: true } : {}),
+            ...(!tracked.before.comparable || !after.comparable
+              ? {
+                  comparable: false,
+                  errorCode:
+                    ("errorCode" in tracked.before ? tracked.before.errorCode : undefined) ??
+                    ("errorCode" in after ? after.errorCode : undefined),
+                }
+              : {}),
+          }
+        }),
+      { concurrency: 4 },
+    )
+
+    const visibleArtifacts =
+      autoDiscovered || exactOfficeTargeted ? artifacts.filter((item) => item.changed) : artifacts
+
+    if (autoDiscovered && visibleArtifacts.length === 0) {
+      yield* deps.recordUncaptured({
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+      })
+      return result
+    }
+
+    if (exactOfficeTargeted && visibleArtifacts.length === 0) return result
+
+    if (autoDiscovered) {
+      yield* deps.recordUncaptured({
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+      })
+    }
+
+    return {
+      ...result,
+      metadata: {
+        ...result.metadata,
+        artifacts: visibleArtifacts,
+      },
+    }
+  })

--- a/packages/opencode/src/tool/bash-artifact-orchestrator.ts
+++ b/packages/opencode/src/tool/bash-artifact-orchestrator.ts
@@ -15,39 +15,26 @@ type TrackedOutput = {
   before: TrackedOutputState
 }
 
-export type ResolveExecutionPath = (
-  raw: string,
-  root: string,
-  shell: string,
-) => Effect.Effect<string, never, any>
-
-export type AssertExternalDirectory = (
-  ctx: Tool.Context,
-  filepath: string,
-  opts: { kind: "file" },
-) => Effect.Effect<string | undefined, never, any>
-
-export type ReadTrackedState = (file: string) => Effect.Effect<TrackedOutputState, never, any>
-
-export type DiscoverOfficeOutputs = (cwd: string, projectRoot: string) => Effect.Effect<OutputDiscovery, never, any>
-
-export type OfficeCliTargetsFn = (command: string) => readonly string[]
-export type NonOfficeCliCommandTextFn = (command: string) => string
-export type IsLikelyWriteCommandFn = (command: string) => boolean
-
-export type RecordWrite = (input: RecordWriteInput) => Effect.Effect<void, never, any>
-export type RecordUncaptured = (input: RecordUncapturedInput) => Effect.Effect<void, never, any>
-
-export type ArtifactDeps = {
-  resolveExecutionPath: ResolveExecutionPath
-  assertExternalDirectory: AssertExternalDirectory
-  readTrackedState: ReadTrackedState
-  discoverOfficeOutputs: DiscoverOfficeOutputs
-  officeCliTargets: OfficeCliTargetsFn
-  nonOfficeCliCommandText: NonOfficeCliCommandTextFn
-  isLikelyWriteCommand: IsLikelyWriteCommandFn
-  recordWrite: RecordWrite
-  recordUncaptured: RecordUncaptured
+// All Effect-returning deps share one requirement type parameter `DepR`.
+// This makes service requirements (InstanceState, ChildProcessSpawner,
+// TurnChange.Service, etc.) bubble up to the orchestrator's return type
+// instead of being swallowed by `any` — wiring the orchestrator into a
+// runtime that lacks one of those services becomes a compile error, not
+// a runtime crash.
+export type ArtifactDeps<DepR = never> = {
+  resolveExecutionPath: (raw: string, root: string, shell: string) => Effect.Effect<string, never, DepR>
+  assertExternalDirectory: (
+    ctx: Tool.Context,
+    filepath: string,
+    opts: { kind: "file" },
+  ) => Effect.Effect<string | undefined, never, DepR>
+  readTrackedState: (file: string) => Effect.Effect<TrackedOutputState, never, DepR>
+  discoverOfficeOutputs: (cwd: string, projectRoot: string) => Effect.Effect<OutputDiscovery, never, DepR>
+  officeCliTargets: (command: string) => readonly string[]
+  nonOfficeCliCommandText: (command: string) => string
+  isLikelyWriteCommand: (command: string) => boolean
+  recordWrite: (input: RecordWriteInput) => Effect.Effect<void, never, DepR>
+  recordUncaptured: (input: RecordUncapturedInput) => Effect.Effect<void, never, DepR>
 }
 
 export type ArtifactInput = {
@@ -61,11 +48,11 @@ export type ArtifactInput = {
 
 export type ArtifactRunner<R> = () => Effect.Effect<ToolResultLike, never, R>
 
-export const orchestrateArtifacts = <R>(
+export const orchestrateArtifacts = <RunR, DepR>(
   input: ArtifactInput,
-  run: ArtifactRunner<R>,
-  deps: ArtifactDeps,
-): Effect.Effect<ToolResultLike, never, R> =>
+  run: ArtifactRunner<RunR>,
+  deps: ArtifactDeps<DepR>,
+): Effect.Effect<ToolResultLike, never, RunR | DepR> =>
   Effect.gen(function* () {
     const { ctx, cwd, directory, shell, command, expectedOutputs } = input
     const hasMessage = !!ctx.messageID

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -663,8 +663,11 @@ export const BashTool = Tool.define(
                 }),
               )
 
-              const env = yield* shellEnv(ctx, cwd)
-
+              // shellEnv() must run AFTER the orchestrator's before-snapshots.
+              // A `shell.env` plugin can create or modify files (config, sockets,
+              // bundled-tool drops) as a side effect; running it before the
+              // before-state read would fold that mutation into "before" and the
+              // subsequent change would never surface as a turn-change record.
               return yield* orchestrateArtifacts(
                 {
                   ctx,
@@ -675,18 +678,21 @@ export const BashTool = Tool.define(
                   expectedOutputs: params.expected_outputs ?? [],
                 },
                 () =>
-                  run(
-                    {
-                      shell,
-                      name,
-                      command: params.command,
-                      cwd,
-                      env,
-                      timeout,
-                      description: params.description,
-                    },
-                    ctx,
-                  ),
+                  Effect.gen(function* () {
+                    const env = yield* shellEnv(ctx, cwd)
+                    return yield* run(
+                      {
+                        shell,
+                        name,
+                        command: params.command,
+                        cwd,
+                        env,
+                        timeout,
+                        description: params.description,
+                      },
+                      ctx,
+                    )
+                  }),
                 deps,
               )
             }),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -29,6 +29,7 @@ import { isLikelyWriteCommand } from "./bash-write-heuristic"
 import { nonOfficeCliCommandText, officeCliTargets } from "./bash-office-artifacts"
 import { discoverOfficeOutputs, readTrackedState } from "./bash-output-capture"
 import { Parameters, render as renderDescription, type Limits } from "./bash/prompt"
+import { ToolID as BashToolID } from "./bash/id"
 import { orchestrateArtifacts, type ArtifactDeps } from "./bash-artifact-orchestrator"
 
 const MAX_METADATA_LENGTH = 30_000
@@ -268,7 +269,7 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 
   if (scan.patterns.size === 0) return
   yield* ctx.ask({
-    permission: "bash",
+    permission: BashToolID,
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
     metadata: {},
@@ -321,9 +322,11 @@ const parser = lazy(async () => {
   return { bash, ps }
 })
 
-// TODO: we may wanna rename this tool so it works better on other shells
+// Public tool id stays "bash" indefinitely (kept in BashToolID for the
+// single source of truth — saved permissions, plugins, and config all
+// reference this literal).
 export const BashTool = Tool.define(
-  "bash",
+  BashToolID,
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner
     const afs = yield* AppFileSystem.Service

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,9 +1,8 @@
-import { Schema } from "effect"
+import type { Schema } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
 import path from "path"
-import DESCRIPTION from "./bash.txt"
 import { Log } from "../util"
 import { Instance, type InstanceContext } from "../project/instance"
 import { lazy } from "@/util/lazy"
@@ -28,12 +27,9 @@ import { InstanceState } from "@/effect/instance-state"
 import { TurnChange } from "@/session/turn-change"
 import { isLikelyWriteCommand } from "./bash-write-heuristic"
 import { nonOfficeCliCommandText, officeCliTargets } from "./bash-office-artifacts"
-import {
-  discoverOfficeOutputs,
-  readTrackedState,
-  sameTrackedState,
-  type TrackedOutputState,
-} from "./bash-output-capture"
+import { discoverOfficeOutputs, readTrackedState } from "./bash-output-capture"
+import { Parameters, render as renderDescription, type Limits } from "./bash/prompt"
+import { orchestrateArtifacts, type ArtifactDeps } from "./bash-artifact-orchestrator"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -63,24 +59,6 @@ const FILES = new Set([
 ])
 const FLAGS = new Set(["-destination", "-literalpath", "-path"])
 const SWITCHES = new Set(["-confirm", "-debug", "-force", "-nonewline", "-recurse", "-verbose", "-whatif"])
-
-export const Parameters = Schema.Struct({
-  command: Schema.String.annotate({ description: "The command to execute" }),
-  timeout: Schema.optional(Schema.Number).annotate({ description: "Optional timeout in milliseconds" }),
-  workdir: Schema.optional(Schema.String).annotate({
-    description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
-  }),
-  expected_outputs: Schema.optional(
-    Schema.Array(Schema.String).annotate({
-      description:
-        "Optional absolute or workdir-relative file paths that this command is expected to create or modify. The runtime will verify these paths after execution and register any real file changes in turn-change.",
-    }),
-  ),
-  description: Schema.String.annotate({
-    description:
-      "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-  }),
-})
 
 type Part = {
   type: string
@@ -634,20 +612,31 @@ export const BashTool = Tool.define(
         const directory = (yield* InstanceState.context).directory
         const shell = Shell.acceptable()
         const name = Shell.name(shell)
-        const chain =
-          name === "powershell"
-            ? "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
-            : "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
         log.info("bash tool using shell", { shell })
 
+        const limits: Limits = { maxLines: Truncate.MAX_LINES, maxBytes: Truncate.MAX_BYTES }
+        const description = renderDescription({
+          name,
+          platform: process.platform,
+          directory,
+          tmp: Global.Path.tmp,
+          limits,
+        })
+
+        const deps: ArtifactDeps = {
+          resolveExecutionPath,
+          assertExternalDirectory: assertExternalDirectoryEffect,
+          readTrackedState,
+          discoverOfficeOutputs,
+          officeCliTargets,
+          nonOfficeCliCommandText,
+          isLikelyWriteCommand,
+          recordWrite: (input) => turnChange.recordWrite(input),
+          recordUncaptured: (input) => turnChange.recordUncaptured(input),
+        }
+
         return {
-          description: DESCRIPTION.replaceAll("${directory}", directory)
-            .replaceAll("${tmp}", Global.Path.tmp)
-            .replaceAll("${os}", process.platform)
-            .replaceAll("${shell}", name)
-            .replaceAll("${chaining}", chain)
-            .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
-            .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES)),
+          description,
           parameters: Parameters,
           execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
             Effect.gen(function* () {
@@ -674,216 +663,32 @@ export const BashTool = Tool.define(
                 }),
               )
 
-              const trackedOutputs = yield* Effect.forEach(
-                params.expected_outputs ?? [],
-                (rawPath) =>
-                  Effect.gen(function* () {
-                    const resolved = yield* resolveExecutionPath(rawPath, cwd, shell)
-                    const normalized = AppFileSystem.normalizePath(resolved)
-                    const filepath =
-                      (yield* assertExternalDirectoryEffect(ctx, normalized, { kind: "file" })) ?? normalized
-                    return {
-                      normalized: AppFileSystem.normalizePath(filepath),
-                      path: filepath,
-                      before: yield* readTrackedState(filepath),
-                    }
-                  }),
-                { concurrency: 4 },
-              ).pipe(
-                Effect.map((items) => {
-                  const deduped = new Map<string, { path: string; before: TrackedOutputState }>()
-                  for (const item of items) {
-                    if (deduped.has(item.normalized)) continue
-                    deduped.set(item.normalized, { path: item.path, before: item.before })
-                  }
-                  return Array.from(deduped.values())
-                }),
-              )
-              const exactOfficeOutputs = yield* Effect.forEach(
-                (params.expected_outputs ?? []).length === 0 && !!ctx.messageID ? officeCliTargets(params.command) : [],
-                (rawPath) =>
-                  Effect.gen(function* () {
-                    const resolved = yield* resolveExecutionPath(rawPath, cwd, shell)
-                    const normalized = AppFileSystem.normalizePath(resolved)
-                    const filepath =
-                      (yield* assertExternalDirectoryEffect(ctx, normalized, { kind: "file" })) ?? normalized
-                    return {
-                      normalized: AppFileSystem.normalizePath(filepath),
-                      path: filepath,
-                      before: yield* readTrackedState(filepath),
-                    }
-                  }),
-                { concurrency: 4 },
-              ).pipe(
-                Effect.map((items) => {
-                  const deduped = new Map<string, { path: string; before: TrackedOutputState }>()
-                  for (const item of items) {
-                    if (deduped.has(item.normalized)) continue
-                    deduped.set(item.normalized, { path: item.path, before: item.before })
-                  }
-                  return Array.from(deduped.values())
-                }),
-              )
-              const shouldAutoDiscoverOutputs =
-                (params.expected_outputs ?? []).length === 0 &&
-                !!ctx.messageID &&
-                isLikelyWriteCommand(
-                  exactOfficeOutputs.length ? nonOfficeCliCommandText(params.command) : params.command,
-                )
-              const autoDiscoveredBefore = shouldAutoDiscoverOutputs
-                ? yield* Effect.gen(function* () {
-                    const discovered = yield* discoverOfficeOutputs(cwd, directory)
-                    if (discovered.overflowed) return { outputs: [], overflowed: true }
-                    const outputs = yield* Effect.forEach(
-                      discovered.paths,
-                      (filepath) =>
-                        Effect.gen(function* () {
-                          return {
-                            path: filepath,
-                            before: yield* readTrackedState(filepath),
-                          }
-                        }),
-                      { concurrency: 4 },
-                    )
-                    return { outputs, overflowed: false }
-                  })
-                : undefined
+              const env = yield* shellEnv(ctx, cwd)
 
-              const result = yield* run(
+              return yield* orchestrateArtifacts(
                 {
-                  shell,
-                  name,
-                  command: params.command,
+                  ctx,
                   cwd,
-                  env: yield* shellEnv(ctx, cwd),
-                  timeout,
-                  description: params.description,
+                  directory,
+                  shell,
+                  command: params.command,
+                  expectedOutputs: params.expected_outputs ?? [],
                 },
-                ctx,
+                () =>
+                  run(
+                    {
+                      shell,
+                      name,
+                      command: params.command,
+                      cwd,
+                      env,
+                      timeout,
+                      description: params.description,
+                    },
+                    ctx,
+                  ),
+                deps,
               )
-
-              let outputsToRecord = trackedOutputs
-              let autoDiscovered = false
-              let exactOfficeTargeted = false
-              if (!outputsToRecord.length && exactOfficeOutputs.length) {
-                outputsToRecord = exactOfficeOutputs
-                exactOfficeTargeted = true
-              }
-              if (!trackedOutputs.length && shouldAutoDiscoverOutputs) {
-                autoDiscovered = true
-                let overflowed = autoDiscoveredBefore?.overflowed ?? false
-                const deduped = new Map<string, { path: string; before: TrackedOutputState }>()
-                for (const item of exactOfficeOutputs) {
-                  const normalized = AppFileSystem.normalizePath(item.path)
-                  if (deduped.has(normalized)) continue
-                  deduped.set(normalized, item)
-                }
-                if (!overflowed) {
-                  for (const item of autoDiscoveredBefore?.outputs ?? []) {
-                    const normalized = AppFileSystem.normalizePath(item.path)
-                    if (deduped.has(normalized)) continue
-                    deduped.set(normalized, item)
-                  }
-                  const discoveredAfter = yield* discoverOfficeOutputs(cwd, directory)
-                  overflowed = discoveredAfter.overflowed
-                  if (!overflowed) {
-                    for (const filepath of discoveredAfter.paths) {
-                      const normalized = AppFileSystem.normalizePath(filepath)
-                      if (deduped.has(normalized)) continue
-                      deduped.set(normalized, {
-                        path: filepath,
-                        before: { state: { exists: false }, comparable: true, kind: "missing" },
-                      })
-                    }
-                  }
-                }
-
-                if (overflowed) {
-                  if (deduped.size > 0) {
-                    outputsToRecord = Array.from(deduped.values())
-                  } else {
-                    yield* turnChange.recordUncaptured({
-                      sessionID: ctx.sessionID,
-                      messageID: ctx.messageID,
-                    })
-                    return result
-                  }
-                } else {
-                  outputsToRecord = Array.from(deduped.values())
-                }
-              }
-
-              if (!outputsToRecord.length) {
-                if (shouldAutoDiscoverOutputs) {
-                  yield* turnChange.recordUncaptured({
-                    sessionID: ctx.sessionID,
-                    messageID: ctx.messageID,
-                  })
-                }
-                return result
-              }
-
-              const artifacts = yield* Effect.forEach(
-                outputsToRecord,
-                (tracked) =>
-                  Effect.gen(function* () {
-                    const after = yield* readTrackedState(tracked.path)
-                    const changed =
-                      tracked.before.comparable &&
-                      after.comparable &&
-                      !sameTrackedState(tracked.before.state, after.state)
-                    if (changed) {
-                      yield* turnChange.recordWrite({
-                        sessionID: ctx.sessionID,
-                        messageID: ctx.messageID,
-                        path: tracked.path,
-                        before: tracked.before.state,
-                        after: after.state,
-                      })
-                    }
-                    return {
-                      path: tracked.path,
-                      exists: after.state.exists,
-                      changed,
-                      ...(after.kind === "directory" ? { directory: true } : {}),
-                      ...(after.state.binary && after.kind !== "directory" ? { binary: true } : {}),
-                      ...(after.state.large ? { large: true } : {}),
-                      ...(!tracked.before.comparable || !after.comparable
-                        ? {
-                            comparable: false,
-                            errorCode:
-                              ("errorCode" in tracked.before ? tracked.before.errorCode : undefined) ??
-                              ("errorCode" in after ? after.errorCode : undefined),
-                          }
-                        : {}),
-                    }
-                  }),
-                { concurrency: 4 },
-              )
-              const visibleArtifacts =
-                autoDiscovered || exactOfficeTargeted ? artifacts.filter((item) => item.changed) : artifacts
-              if (autoDiscovered && visibleArtifacts.length === 0) {
-                yield* turnChange.recordUncaptured({
-                  sessionID: ctx.sessionID,
-                  messageID: ctx.messageID,
-                })
-                return result
-              }
-              if (exactOfficeTargeted && visibleArtifacts.length === 0) return result
-              if (autoDiscovered) {
-                yield* turnChange.recordUncaptured({
-                  sessionID: ctx.sessionID,
-                  messageID: ctx.messageID,
-                })
-              }
-
-              return {
-                ...result,
-                metadata: {
-                  ...result.metadata,
-                  artifacts: visibleArtifacts,
-                },
-              }
             }),
         }
       })

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -1,4 +1,4 @@
-Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+Executes one command in the selected shell with optional timeout. Each BashTool call runs in a fresh process; cwd and environment do not persist across calls - use the `workdir` parameter to set the working directory.
 
 Be aware: OS: ${os}, Shell: ${shell}
 

--- a/packages/opencode/src/tool/bash/id.ts
+++ b/packages/opencode/src/tool/bash/id.ts
@@ -21,5 +21,3 @@ export function toKind(value: string): Kind {
 // Public tool id and permission key — keep as "bash" indefinitely.
 export const ToolID = "bash"
 export type ToolID = typeof ToolID
-
-export * as BashID from "./id"

--- a/packages/opencode/src/tool/bash/id.ts
+++ b/packages/opencode/src/tool/bash/id.ts
@@ -1,0 +1,25 @@
+// Internal shell-kind taxonomy. NOT a public rename of the bash tool.
+// The exposed tool id, schema name, and permission key all remain "bash" for
+// backward compatibility with saved permissions, plugins, and existing config.
+// This module only labels the shell kind internally so prompts and per-shell
+// logic can branch cleanly.
+
+const kinds = ["bash", "pwsh", "powershell", "cmd"] as const
+
+export type Kind = (typeof kinds)[number]
+
+const kindSet = new Set<string>(kinds)
+
+export function isKind(value: string): value is Kind {
+  return kindSet.has(value)
+}
+
+export function toKind(value: string): Kind {
+  return isKind(value) ? value : "bash"
+}
+
+// Public tool id and permission key — keep as "bash" indefinitely.
+export const ToolID = "bash"
+export type ToolID = typeof ToolID
+
+export * as BashID from "./id"

--- a/packages/opencode/src/tool/bash/prompt.ts
+++ b/packages/opencode/src/tool/bash/prompt.ts
@@ -34,7 +34,7 @@ export function chainingFor(name: string) {
 }
 
 export const EXPECTED_OUTPUTS_DESCRIPTION =
-  "Absolute or workdir-relative file paths the command will create or modify. Set this ONLY for commands that produce deliverable artifacts (officecli writes to .docx / .xlsx / .pptx, scripts generating reports, binary outputs, or files written outside the working directory). DO NOT set it for: tests, builds, installs, package managers, git inspection (status / log / diff), lint / typecheck, cat / ls / grep / find, dev servers, or any read-only inspection. When unsure, leave it empty."
+  "Absolute or workdir-relative file paths the command will create or modify. Set this ONLY for commands that produce deliverable artifacts (officecli writes to .docx / .xlsx / .pptx, scripts generating reports, a specific named binary or report you will then consume, or files written outside the working directory). DO NOT set it for: tests, routine builds, installs, package managers, git inspection (status / log / diff), lint / typecheck, cat / ls / grep / find, dev servers, or any read-only inspection. A build that emits a specific named deliverable counts as a deliverable artifact — list that file; a routine project rebuild does not. When unsure, leave it empty."
 
 export function parameterSchema() {
   return Schema.Struct({

--- a/packages/opencode/src/tool/bash/prompt.ts
+++ b/packages/opencode/src/tool/bash/prompt.ts
@@ -1,0 +1,69 @@
+import { Schema } from "effect"
+import DESCRIPTION from "../bash.txt"
+
+export type Limits = {
+  maxLines: number
+  maxBytes: number
+}
+
+const POWERSHELL_CHAIN =
+  "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
+
+const PWSH_CHAIN =
+  "If the commands depend on each other and must run sequentially, chain them with '&&' (supported in PowerShell 7+, e.g., `git add . && git commit -m \"message\" && git push`). For maximum portability with Windows PowerShell 5.1, fall back to `cmd1; if ($?) { cmd2 }`."
+
+const CMD_CHAIN =
+  "If the commands depend on each other and must run sequentially, chain them with '&&' in cmd.exe (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before copy, or git add before git commit), run these operations sequentially instead."
+
+const BASH_CHAIN =
+  "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
+
+export function chainingFor(name: string) {
+  if (name === "powershell") return POWERSHELL_CHAIN
+  if (name === "pwsh") return PWSH_CHAIN
+  if (name === "cmd") return CMD_CHAIN
+  return BASH_CHAIN
+}
+
+export const EXPECTED_OUTPUTS_DESCRIPTION =
+  "Absolute or workdir-relative file paths the command will create or modify. Set this ONLY for commands that produce deliverable artifacts (officecli writes to .docx / .xlsx / .pptx, scripts generating reports, binary outputs, or files written outside the working directory). DO NOT set it for: tests, builds, installs, package managers, git inspection (status / log / diff), lint / typecheck, cat / ls / grep / find, dev servers, or any read-only inspection. When unsure, leave it empty."
+
+export function parameterSchema() {
+  return Schema.Struct({
+    command: Schema.String.annotate({ description: "The command to execute" }),
+    timeout: Schema.optional(Schema.Number).annotate({ description: "Optional timeout in milliseconds" }),
+    workdir: Schema.optional(Schema.String).annotate({
+      description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
+    }),
+    expected_outputs: Schema.optional(
+      Schema.Array(Schema.String).annotate({
+        description: EXPECTED_OUTPUTS_DESCRIPTION,
+      }),
+    ),
+    description: Schema.String.annotate({
+      description:
+        "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
+    }),
+  })
+}
+
+export const Parameters = parameterSchema()
+export type Parameters = Schema.Schema.Type<typeof Parameters>
+
+export function render(input: {
+  name: string
+  platform: NodeJS.Platform
+  directory: string
+  tmp: string
+  limits: Limits
+}) {
+  return DESCRIPTION.replaceAll("${directory}", input.directory)
+    .replaceAll("${tmp}", input.tmp)
+    .replaceAll("${os}", input.platform)
+    .replaceAll("${shell}", input.name)
+    .replaceAll("${chaining}", chainingFor(input.name))
+    .replaceAll("${maxLines}", String(input.limits.maxLines))
+    .replaceAll("${maxBytes}", String(input.limits.maxBytes))
+}
+
+export * as BashPrompt from "./prompt"

--- a/packages/opencode/src/tool/bash/prompt.ts
+++ b/packages/opencode/src/tool/bash/prompt.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect"
 import DESCRIPTION from "../bash.txt"
+import { toKind } from "./id"
 
 export type Limits = {
   maxLines: number
@@ -19,10 +20,17 @@ const BASH_CHAIN =
   "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
 
 export function chainingFor(name: string) {
-  if (name === "powershell") return POWERSHELL_CHAIN
-  if (name === "pwsh") return PWSH_CHAIN
-  if (name === "cmd") return CMD_CHAIN
-  return BASH_CHAIN
+  switch (toKind(name)) {
+    case "powershell":
+      return POWERSHELL_CHAIN
+    case "pwsh":
+      return PWSH_CHAIN
+    case "cmd":
+      return CMD_CHAIN
+    case "bash":
+    default:
+      return BASH_CHAIN
+  }
 }
 
 export const EXPECTED_OUTPUTS_DESCRIPTION =
@@ -65,5 +73,3 @@ export function render(input: {
     .replaceAll("${maxLines}", String(input.limits.maxLines))
     .replaceAll("${maxBytes}", String(input.limits.maxBytes))
 }
-
-export * as BashPrompt from "./prompt"

--- a/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
+++ b/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { orchestrateArtifacts, type ArtifactDeps } from "../../src/tool/bash-artifact-orchestrator"
 import type { TrackedOutputState, OutputDiscovery } from "../../src/tool/bash-output-capture"
 import type { RecordWriteInput, RecordUncapturedInput } from "../../src/session/turn-change"
 import { MessageID, SessionID } from "../../src/session/schema"
+
+// Orchestrator internally feeds every path through AppFileSystem.normalizePath
+// before calling deps.readTrackedState / building artifact.path. On Windows
+// that rewrites "/tmp/work/foo" to "D:\\tmp\\work\\foo", so the mock state
+// dictionary must be keyed by the platform-native form. np() is a no-op on
+// POSIX, so the same test file works on every runner.
+const np = (p: string) => AppFileSystem.normalizePath(p)
 
 type ToolResult = { title: string; metadata: Record<string, unknown>; output: string }
 
@@ -115,7 +123,7 @@ function build(opts: {
 
 describe("orchestrateArtifacts", () => {
   test("declared expected_outputs, file changed → recordWrite + artifact visible", async () => {
-    const file = "/tmp/work/out.docx"
+    const file = np("/tmp/work/out.docx")
     const harness = build({
       states: { [file]: [stateMissing(), stateFile("h1")] },
     })
@@ -144,7 +152,7 @@ describe("orchestrateArtifacts", () => {
   })
 
   test("declared expected_outputs, file unchanged → no recordWrite, artifact changed:false", async () => {
-    const file = "/tmp/work/same.docx"
+    const file = np("/tmp/work/same.docx")
     const harness = build({
       states: { [file]: [stateFile("h1"), stateFile("h1")] },
     })
@@ -172,7 +180,7 @@ describe("orchestrateArtifacts", () => {
   })
 
   test("exact OfficeCLI target, no declared outputs, file changed → recordWrite + visible only when changed", async () => {
-    const file = "/tmp/work/x.xlsx"
+    const file = np("/tmp/work/x.xlsx")
     const harness = build({
       states: { [file]: [stateMissing(), stateFile("hx")] },
       officeTargets: [file],
@@ -310,12 +318,12 @@ describe("orchestrateArtifacts", () => {
   })
 
   test("expected_outputs present → only declared recorded; discoverOfficeOutputs is NOT called", async () => {
-    const declared = "/tmp/work/decl.docx"
+    const declared = np("/tmp/work/decl.docx")
     const harness = build({
       states: { [declared]: [stateMissing(), stateFile("d1")] },
-      officeTargets: ["/tmp/work/should-be-ignored.docx"], // would surface if expected_outputs were empty
+      officeTargets: [np("/tmp/work/should-be-ignored.docx")], // would surface if expected_outputs were empty
       isWrite: true,
-      discoverPaths: ["/tmp/work/side.docx"],
+      discoverPaths: [np("/tmp/work/side.docx")],
     })
 
     const result = await Effect.runPromise(

--- a/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
+++ b/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
@@ -73,7 +73,7 @@ function build(opts: {
       return stateMissing()
     })
 
-  const discoverOfficeOutputs = (_cwd: string, _root: string): Effect.Effect<OutputDiscovery, never, any> =>
+  const discoverOfficeOutputs = (_cwd: string, _root: string): Effect.Effect<OutputDiscovery, never, never> =>
     Effect.sync(() => {
       discoverCalls++
       if (discoverCalls === 1) {
@@ -257,6 +257,56 @@ describe("orchestrateArtifacts", () => {
     expect(harness.uncaptured).toHaveLength(0)
     expect(harness.discoverCalls).toBe(0)
     expect((result.metadata as any).artifacts).toBeUndefined()
+  })
+
+  test("before-snapshot precedes runner — protects against shell.env-style side-effect ordering regressions", async () => {
+    const file = "/tmp/work/ordered.docx"
+    const order: string[] = []
+    const stateCounts = new Map<string, number>()
+    const readTrackedState = (target: string) =>
+      Effect.sync(() => {
+        const count = stateCounts.get(target) ?? 0
+        stateCounts.set(target, count + 1)
+        order.push(`read:${count === 0 ? "before" : "after"}`)
+        if (count === 0) return stateMissing()
+        return stateFile("written")
+      })
+
+    const deps: ArtifactDeps = {
+      resolveExecutionPath: (raw) => Effect.succeed(raw),
+      assertExternalDirectory: (_ctx, fp) => Effect.succeed(fp),
+      readTrackedState,
+      discoverOfficeOutputs: () => Effect.succeed({ paths: [], overflowed: false }),
+      officeCliTargets: () => [],
+      nonOfficeCliCommandText: (c) => c,
+      isLikelyWriteCommand: () => false,
+      recordWrite: () => Effect.void,
+      recordUncaptured: () => Effect.void,
+    }
+
+    await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "officecli docx create ordered.docx",
+          expectedOutputs: [file],
+        },
+        () =>
+          Effect.sync(() => {
+            order.push("runner")
+            return buildResult()
+          }),
+        deps,
+      ),
+    )
+
+    const beforeIndex = order.indexOf("read:before")
+    const runnerIndex = order.indexOf("runner")
+    expect(beforeIndex).toBeGreaterThanOrEqual(0)
+    expect(runnerIndex).toBeGreaterThan(beforeIndex)
   })
 
   test("expected_outputs present → only declared recorded; discoverOfficeOutputs is NOT called", async () => {

--- a/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
+++ b/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { orchestrateArtifacts, type ArtifactDeps } from "../../src/tool/bash-artifact-orchestrator"
+import type { TrackedOutputState, OutputDiscovery } from "../../src/tool/bash-output-capture"
+import type { RecordWriteInput, RecordUncapturedInput } from "../../src/session/turn-change"
+import { MessageID, SessionID } from "../../src/session/schema"
+
+type ToolResult = { title: string; metadata: Record<string, unknown>; output: string }
+
+const sessionID = SessionID.make("ses_test_orch")
+const messageID = MessageID.make("msg_test_orch")
+
+const ctx = {
+  sessionID,
+  messageID,
+  callID: "call_test",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+} as any
+
+function buildResult(): ToolResult {
+  return {
+    title: "test",
+    metadata: { output: "ok", exit: 0, description: "test" },
+    output: "ok",
+  }
+}
+
+function stateMissing(): TrackedOutputState {
+  return { state: { exists: false }, comparable: true, kind: "missing" }
+}
+
+function stateFile(hash: string): TrackedOutputState {
+  return {
+    state: { exists: true, restorable: false, hash, binary: true },
+    comparable: true,
+    kind: "file",
+  }
+}
+
+type MockHarness = {
+  deps: ArtifactDeps
+  writes: RecordWriteInput[]
+  uncaptured: RecordUncapturedInput[]
+  discoverCalls: number
+}
+
+function build(opts: {
+  states: Record<string, TrackedOutputState[]>
+  officeTargets?: string[]
+  isWrite?: boolean
+  discoverPaths?: string[]
+  discoverOverflowed?: boolean
+  discoverPathsAfter?: string[]
+  discoverOverflowedAfter?: boolean
+  nonOfficeCommandText?: (cmd: string) => string
+}): MockHarness {
+  const writes: RecordWriteInput[] = []
+  const uncaptured: RecordUncapturedInput[] = []
+  let discoverCalls = 0
+  const stateCounts = new Map<string, number>()
+
+  const readTrackedState = (file: string) =>
+    Effect.sync(() => {
+      const seq = opts.states[file]
+      const count = stateCounts.get(file) ?? 0
+      stateCounts.set(file, count + 1)
+      if (seq && seq[count]) return seq[count]
+      if (seq && seq.length > 0) return seq[seq.length - 1]
+      return stateMissing()
+    })
+
+  const discoverOfficeOutputs = (_cwd: string, _root: string): Effect.Effect<OutputDiscovery, never, any> =>
+    Effect.sync(() => {
+      discoverCalls++
+      if (discoverCalls === 1) {
+        return { paths: opts.discoverPaths ?? [], overflowed: opts.discoverOverflowed ?? false }
+      }
+      return {
+        paths: opts.discoverPathsAfter ?? opts.discoverPaths ?? [],
+        overflowed: opts.discoverOverflowedAfter ?? opts.discoverOverflowed ?? false,
+      }
+    })
+
+  const deps: ArtifactDeps = {
+    resolveExecutionPath: (raw, _root, _shell) => Effect.succeed(raw),
+    assertExternalDirectory: (_ctx, filepath, _opts) => Effect.succeed(filepath),
+    readTrackedState,
+    discoverOfficeOutputs,
+    officeCliTargets: () => opts.officeTargets ?? [],
+    nonOfficeCliCommandText: opts.nonOfficeCommandText ?? ((cmd) => cmd),
+    isLikelyWriteCommand: () => opts.isWrite ?? false,
+    recordWrite: (input) =>
+      Effect.sync(() => {
+        writes.push(input)
+      }),
+    recordUncaptured: (input) =>
+      Effect.sync(() => {
+        uncaptured.push(input)
+      }),
+  }
+
+  return {
+    deps,
+    writes,
+    uncaptured,
+    get discoverCalls() {
+      return discoverCalls
+    },
+  } as MockHarness
+}
+
+describe("orchestrateArtifacts", () => {
+  test("declared expected_outputs, file changed → recordWrite + artifact visible", async () => {
+    const file = "/tmp/work/out.docx"
+    const harness = build({
+      states: { [file]: [stateMissing(), stateFile("h1")] },
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "officecli docx create out.docx",
+          expectedOutputs: [file],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.writes).toHaveLength(1)
+    expect(harness.writes[0].path).toBe(file)
+    expect(harness.uncaptured).toHaveLength(0)
+    const artifacts = (result.metadata as any).artifacts
+    expect(artifacts).toBeArrayOfSize(1)
+    expect(artifacts[0]).toMatchObject({ path: file, changed: true, exists: true })
+  })
+
+  test("declared expected_outputs, file unchanged → no recordWrite, artifact changed:false", async () => {
+    const file = "/tmp/work/same.docx"
+    const harness = build({
+      states: { [file]: [stateFile("h1"), stateFile("h1")] },
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "officecli docx set same.docx --key x",
+          expectedOutputs: [file],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.writes).toHaveLength(0)
+    expect(harness.uncaptured).toHaveLength(0)
+    const artifacts = (result.metadata as any).artifacts
+    expect(artifacts).toBeArrayOfSize(1)
+    expect(artifacts[0]).toMatchObject({ path: file, changed: false, exists: true })
+  })
+
+  test("exact OfficeCLI target, no declared outputs, file changed → recordWrite + visible only when changed", async () => {
+    const file = "/tmp/work/x.xlsx"
+    const harness = build({
+      states: { [file]: [stateMissing(), stateFile("hx")] },
+      officeTargets: [file],
+      isWrite: false,
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "officecli xlsx create x.xlsx",
+          expectedOutputs: [],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.writes).toHaveLength(1)
+    expect(harness.writes[0].path).toBe(file)
+    expect(harness.uncaptured).toHaveLength(0)
+    const artifacts = (result.metadata as any).artifacts
+    expect(artifacts).toBeArrayOfSize(1)
+    expect(artifacts[0].changed).toBe(true)
+  })
+
+  test("auto-discovery overflow with no captured items → recordUncaptured, no artifacts metadata", async () => {
+    const harness = build({
+      states: {},
+      officeTargets: [],
+      isWrite: true,
+      discoverPaths: [],
+      discoverOverflowed: true,
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "node make-many-docs.js",
+          expectedOutputs: [],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.writes).toHaveLength(0)
+    expect(harness.uncaptured).toHaveLength(1)
+    expect((result.metadata as any).artifacts).toBeUndefined()
+  })
+
+  test("read-only command → no orchestration noise, no recordUncaptured, no artifacts", async () => {
+    const harness = build({
+      states: {},
+      officeTargets: [],
+      isWrite: false, // isLikelyWriteCommand returns false
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "cat README.md",
+          expectedOutputs: [],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.writes).toHaveLength(0)
+    expect(harness.uncaptured).toHaveLength(0)
+    expect(harness.discoverCalls).toBe(0)
+    expect((result.metadata as any).artifacts).toBeUndefined()
+  })
+
+  test("expected_outputs present → only declared recorded; discoverOfficeOutputs is NOT called", async () => {
+    const declared = "/tmp/work/decl.docx"
+    const harness = build({
+      states: { [declared]: [stateMissing(), stateFile("d1")] },
+      officeTargets: ["/tmp/work/should-be-ignored.docx"], // would surface if expected_outputs were empty
+      isWrite: true,
+      discoverPaths: ["/tmp/work/side.docx"],
+    })
+
+    const result = await Effect.runPromise(
+      orchestrateArtifacts(
+        {
+          ctx,
+          cwd: "/tmp/work",
+          directory: "/tmp/work",
+          shell: "/bin/bash",
+          command: "officecli docx create decl.docx",
+          expectedOutputs: [declared],
+        },
+        () => Effect.succeed(buildResult()),
+        harness.deps,
+      ),
+    )
+
+    expect(harness.discoverCalls).toBe(0)
+    expect(harness.writes).toHaveLength(1)
+    expect(harness.writes[0].path).toBe(declared)
+    expect(harness.uncaptured).toHaveLength(0)
+    const artifacts = (result.metadata as any).artifacts
+    expect(artifacts).toBeArrayOfSize(1)
+    expect(artifacts[0].path).toBe(declared)
+  })
+})

--- a/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
+++ b/packages/opencode/test/tool/bash-artifact-orchestrator.test.ts
@@ -15,7 +15,7 @@ const ctx = {
   messageID,
   callID: "call_test",
   agent: "build",
-  abort: AbortSignal.any([]),
+  abort: new AbortController().signal,
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,

--- a/packages/opencode/test/tool/bash-prompt.test.ts
+++ b/packages/opencode/test/tool/bash-prompt.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { chainingFor, EXPECTED_OUTPUTS_DESCRIPTION, render } from "../../src/tool/bash/prompt"
+
+const LIMITS = { maxLines: 2000, maxBytes: 50 * 1024 }
+const DEFAULTS = {
+  platform: "darwin" as NodeJS.Platform,
+  directory: "/tmp/pawwork-test",
+  tmp: "/tmp/global",
+  limits: LIMITS,
+}
+
+describe("bash prompt", () => {
+  describe("chainingFor", () => {
+    test("powershell rejects '&&' and recommends if ($?) conditional", () => {
+      const text = chainingFor("powershell")
+      expect(text).toContain("avoid '&&'")
+      expect(text).toContain("Windows PowerShell 5.1")
+      expect(text).toContain("cmd1; if ($?) { cmd2 }")
+    })
+
+    test("pwsh recommends '&&' with 5.1 fallback hint", () => {
+      const text = chainingFor("pwsh")
+      expect(text).toContain("'&&'")
+      expect(text).toContain("PowerShell 7+")
+      expect(text).toContain("cmd1; if ($?) { cmd2 }")
+    })
+
+    test("cmd recommends '&&' for cmd.exe", () => {
+      const text = chainingFor("cmd")
+      expect(text).toContain("'&&'")
+      expect(text).toContain("cmd.exe")
+      expect(text).not.toContain("PowerShell")
+    })
+
+    test("bash recommends '&&' single-call chaining", () => {
+      const text = chainingFor("bash")
+      expect(text).toContain("'&&'")
+      expect(text).toContain("single Bash call")
+      expect(text).not.toContain("PowerShell")
+      expect(text).not.toContain("cmd.exe")
+    })
+
+    test("zsh and sh fall through to bash chaining", () => {
+      expect(chainingFor("zsh")).toBe(chainingFor("bash"))
+      expect(chainingFor("sh")).toBe(chainingFor("bash"))
+    })
+  })
+
+  describe("render", () => {
+    test("interpolates tmp, shell, os, maxLines, maxBytes", () => {
+      const out = render({ ...DEFAULTS, name: "bash" })
+      expect(out).toContain("/tmp/global")
+      expect(out).toContain("Shell: bash")
+      expect(out).toContain("OS: darwin")
+      expect(out).toContain("2000 lines")
+      expect(out).toContain("51200 bytes")
+    })
+
+    test("no unreplaced template placeholders", () => {
+      for (const name of ["bash", "pwsh", "powershell", "cmd"]) {
+        const out = render({ ...DEFAULTS, name, platform: name === "bash" ? "darwin" : "win32" })
+        expect(out).not.toMatch(/\$\{[a-zA-Z]+\}/)
+      }
+    })
+
+    test("snapshot: powershell rendering carries the if ($?) hint", () => {
+      const out = render({ ...DEFAULTS, name: "powershell", platform: "win32" })
+      expect(out).toContain("cmd1; if ($?) { cmd2 }")
+      expect(out).toContain("Shell: powershell")
+      expect(out).toContain("OS: win32")
+      expect(out).toContain("avoid '&&'")
+    })
+
+    test("snapshot: pwsh rendering keeps '&&' recommendation", () => {
+      const out = render({ ...DEFAULTS, name: "pwsh", platform: "win32" })
+      expect(out).toContain("PowerShell 7+")
+      expect(out).toContain("Shell: pwsh")
+      expect(out).not.toContain("avoid '&&'")
+    })
+
+    test("snapshot: cmd rendering points at cmd.exe", () => {
+      const out = render({ ...DEFAULTS, name: "cmd", platform: "win32" })
+      expect(out).toContain("cmd.exe")
+      expect(out).toContain("Shell: cmd")
+      expect(out).not.toContain("avoid '&&'")
+    })
+
+    test("snapshot: bash rendering has POSIX wording", () => {
+      const out = render({ ...DEFAULTS, name: "bash" })
+      expect(out).toContain("single Bash call")
+      expect(out).toContain("Shell: bash")
+      expect(out).not.toContain("avoid '&&'")
+    })
+
+    test("description corrects the one-shot wording (no persistent shell session claim)", () => {
+      const out = render({ ...DEFAULTS, name: "bash" })
+      expect(out).toContain("Each BashTool call runs in a fresh process")
+      expect(out).not.toContain("persistent shell session")
+    })
+
+    test("expected_outputs description carries the strict ONLY/NEVER rule", () => {
+      // Pinned at constant level so future edits cannot silently re-broaden
+      // the rule without updating this test.
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("ONLY")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("deliverable artifact")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("DO NOT set it for")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("read-only inspection")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("officecli")
+    })
+  })
+})

--- a/packages/opencode/test/tool/bash-prompt.test.ts
+++ b/packages/opencode/test/tool/bash-prompt.test.ts
@@ -107,5 +107,15 @@ describe("bash prompt", () => {
       expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("read-only inspection")
       expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("officecli")
     })
+
+    test("expected_outputs description: routine builds DO NOT set; named build deliverables DO", () => {
+      // Routine compile/install loops must stay out of expected_outputs to
+      // avoid noise, but a build that emits a specific named deliverable
+      // (binary, report) MUST list that file or it slips past turn-change.
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("routine builds")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("named deliverable")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).toContain("list that file")
+      expect(EXPECTED_OUTPUTS_DESCRIPTION).not.toMatch(/DO NOT set it for: tests, builds,/)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Refactor PawWork's 891-line `bash.ts` into a thinner pipeline by extracting prompt rendering, internal shell-kind taxonomy, and PawWork-specific artifact orchestration into focused modules. Keeps the public tool id, schema name, and permission key as `bash` for backward compatibility.

Plan and review history live on issue #1038 ([initial plan](https://github.com/Astro-Han/pawwork/issues/1038#issuecomment-4592160553), [revised plan after first review](https://github.com/Astro-Han/pawwork/issues/1038#issuecomment-4592418707)).

## Changes

- New `packages/opencode/src/tool/bash/prompt.ts` owns `Parameters`, `Limits`, `parameterSchema()`, `render()`, and per-shell chaining text for `bash` / `pwsh` / `powershell` / `cmd`. Powershell 5.1 keeps the `cmd1; if ($?) { cmd2 }` advice; pwsh 7+ gets `&&` plus a 5.1 fallback hint; cmd gets `&&` framed for cmd.exe.
- New `packages/opencode/src/tool/bash/id.ts` carries the internal `Kind` taxonomy and `ToolID = "bash"` compatibility constant. File header explicitly states this is **not** a public rename.
- New `packages/opencode/src/tool/bash-artifact-orchestrator.ts` owns `expected_outputs` resolution, exact OfficeCLI target snapshots, auto-discovery before/after diff, and `recordWrite` / `recordUncaptured` dispatch. Dependencies arrive via a typed `ArtifactDeps<DepR>` interface — tests can mock individual hooks (e.g. assert `discoverOfficeOutputs` is **not** called when `expected_outputs` is present).
- `bash.ts` `execute()` becomes a thin pipeline: validate → resolve `workdir` → permission scan + ask → `orchestrateArtifacts(input, run, deps)`. **891 → 696 LOC.**
- `bash.txt` first line corrected: the previous "persistent shell session" wording was inaccurate — each call spawns a fresh process. New wording is explicit about that and points the model at `workdir`.
- `expected_outputs` description tightened with explicit `ONLY` / `DO NOT set it for` rules and locked behind an exported constant (`EXPECTED_OUTPUTS_DESCRIPTION`) so a future edit can't silently re-broaden the rule.

## Out of scope (deferred to follow-ups)

- Public rename `bash` → `shell`. Tool name, schema, and `"bash"` permission key unchanged.
- `cmd.exe`-specific spawn branch and `CMD_FILES` permission scan. Documented for a follow-up.
- Metadata streaming throttle. Separate PR with its own performance motivation and throttle-specific regression tests (PR 2 of the #1038 plan).
- Tree-sitter per-shell lazy WASM load. Optional follow-up (PR 3 of the #1038 plan).
- Pre-existing PowerShell `&` call-operator gap in `commandHead()` (`bash-office-artifacts.ts`). Surfaced by Codex review on this branch but not introduced here; will track separately.

## Upstream alignment

Mirrors the `anomalyco/opencode` split (`tool/shell.ts` + `tool/shell/prompt.ts` + `tool/shell/id.ts`) at the structural level, but keeps the PawWork-specific Office artifact path intact and the public tool name unchanged.

## Verification

Local in worktree:

- `bun run typecheck` — pass.
- `bun test test/tool/ test/permission/` — 648 pass, 1 skip, 0 fail across 33 files.
- Bash-specific suite (`bash.test.ts`, `bash-office-artifacts.test.ts`, `bash-write-heuristic.test.ts`, `bash-env-source.test.ts`, plus new `bash-prompt.test.ts` and `bash-artifact-orchestrator.test.ts`) — 226 pass, 0 fail.

## Review trail

Codex challenge pass against the initial commit flagged two issues, both fixed in `fa34fdf`:

1. **shellEnv ordering regression.** First draft called `shellEnv()` before `orchestrateArtifacts()`, which would have folded any `shell.env` plugin file side effect into the "before" snapshot. Moved into the runner closure so before-state reads happen first. New test (`before-snapshot precedes runner — protects against shell.env-style side-effect ordering regressions`) locks the invariant.
2. **ArtifactDeps type leakage.** Initial draft typed Effect deps as `Effect.Effect<X, never, any>`, hiding real service requirements. Replaced with a single `DepR` generic so `orchestrateArtifacts<RunR, DepR>` returns `Effect<X, never, RunR | DepR>` — service requirements now propagate at the type level.

Codex re-review of the fixup confirmed the corrections are effective and no new issues introduced.

Refs #1038.

## Test plan

- [x] `bun run typecheck` passes locally.
- [x] All tests under `test/tool/` and `test/permission/` pass locally.
- [x] No model-visible rename: `bash` tool id, schema, and `"bash"` permission key unchanged.
- [ ] CI green on `dev`-targeted checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated artifact capture for bash runs, detecting and reporting produced outputs.

* **Refactor**
  * Bash execution now delegates artifact orchestration to a centralized mechanism, simplifying run flow.

* **Bug Fixes**
  * Clarified Bash tool docs to state each call runs in a fresh process (no persistent shell state).

* **Documentation**
  * Improved command parameter schema and added platform-specific chaining guidance.

* **Tests**
  * New test suites covering artifact orchestration and prompt rendering/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->