### PR TITLE
ci: retry windows-advisory unit step once on transient failure

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -300,6 +300,10 @@ jobs:
           echo "first_exit_code=$first_status" >> "$GITHUB_OUTPUT"
 
           if [ "$status" -eq 0 ] && [ "$first_status" -ne 0 ]; then
+            # ::notice surfaces the recovery in the run-level annotations panel
+            # and in each check's annotation list, not just buried in the
+            # collapsed step summary, so flake rate stays observable.
+            echo "::notice title=Windows unit recovered on retry::package=${{ matrix.package }}; attempt 1 exit code=$first_status; attempt 2 succeeded"
             {
               echo "### Windows unit recovered on retry"
               echo ""
@@ -308,6 +312,10 @@ jobs:
               echo "- attempt 2: success"
             } >> "$GITHUB_STEP_SUMMARY"
           elif [ "$status" -ne 0 ]; then
+            # ::warning gives the run-level annotation a yellow icon on a red
+            # job — the step is still failing (advisory signal red), but the
+            # annotation makes the post-retry failure scannable at a glance.
+            echo "::warning title=Windows unit failed advisory signal after retry::package=${{ matrix.package }}; final exit code=$status; attempts=$attempts"
             {
               echo "### Windows unit diagnostic"
               echo ""

--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -258,19 +258,62 @@ jobs:
 
       - name: unit
         id: unit
+        # Windows-advisory has shown transient flake (sleep-based timing in
+        # opencode session tests and occasional Bun native crashes on
+        # `windows-latest`). Linux `ci` is the load-bearing required gate;
+        # this workflow is advisory and non-blocking. Retry once at the
+        # process level so a single transient failure does not turn the
+        # advisory red, but keep the first-attempt failure visible in the
+        # step summary so persistent regressions are not hidden by retry.
+        # Each attempt runs in a subshell so `cd packages/...` in
+        # matrix.command does not leak between attempts.
         run: |
           set +e
-          ${{ matrix.command }}
-          status=$?
-          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          attempts=2
+          first_status=
+          for attempt in $(seq 1 "$attempts"); do
+            echo "::group::Windows unit attempt $attempt of $attempts"
+            ( ${{ matrix.command }} )
+            status=$?
+            echo "::endgroup::"
 
-          if [ "$status" -ne 0 ]; then
+            if [ "$attempt" -eq 1 ]; then
+              first_status=$status
+            fi
+
+            if [ "$status" -eq 0 ]; then
+              break
+            fi
+
+            if [ "$attempt" -lt "$attempts" ]; then
+              {
+                echo "### Windows unit attempt $attempt failed (retrying)"
+                echo ""
+                echo "- package: ${{ matrix.package }}"
+                echo "- exit code: $status"
+                echo "- next attempt: $((attempt + 1)) of $attempts"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          echo "first_exit_code=$first_status" >> "$GITHUB_OUTPUT"
+
+          if [ "$status" -eq 0 ] && [ "$first_status" -ne 0 ]; then
+            {
+              echo "### Windows unit recovered on retry"
+              echo ""
+              echo "- package: ${{ matrix.package }}"
+              echo "- attempt 1 exit code: $first_status"
+              echo "- attempt 2: success"
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$status" -ne 0 ]; then
             {
               echo "### Windows unit diagnostic"
               echo ""
               echo "- package: ${{ matrix.package }}"
               echo "- exit code: $status"
-              echo "- status: failed advisory signal"
+              echo "- status: failed advisory signal after $attempts attempts"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -628,6 +628,12 @@ describe("ci workflow", () => {
     expect(unitRun).toContain("### Windows unit attempt $attempt failed (retrying)")
     expect(unitRun).toContain("### Windows unit recovered on retry")
 
+    // The recovered and final-failed outcomes also emit run-level annotations
+    // (::notice / ::warning) so the signal is visible in the Actions UI
+    // annotations panel, not only inside the collapsed step summary.
+    expect(unitRun).toContain("::notice title=Windows unit recovered on retry")
+    expect(unitRun).toContain("::warning title=Windows unit failed advisory signal after retry")
+
     // The final exit code is the last attempt's status, not the first.
     // Otherwise a recovered run would still turn the advisory red.
     expect(unitRun).toMatch(/exit "\$status"\s*$/)

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -609,6 +609,30 @@ describe("ci workflow", () => {
     )
   })
 
+  test("retries the Windows unit step once on transient failure", () => {
+    const unitRun = stepByName(windowsUnitJobName, "unit", windowsAdvisoryWorkflowPath)?.run ?? ""
+
+    // Retry budget: exactly one extra attempt (max_attempts=2).
+    expect(unitRun).toContain("attempts=2")
+
+    // Each attempt runs in a subshell so `cd packages/...` in matrix.command
+    // does not leak working directory across attempts.
+    expect(unitRun).toContain("( ${{ matrix.command }} )")
+
+    // First-attempt exit code must be exported so downstream steps and humans
+    // can tell a recovered run apart from a clean-first-pass run.
+    expect(unitRun).toContain('echo "first_exit_code=$first_status" >> "$GITHUB_OUTPUT"')
+
+    // First-attempt failure is surfaced in the step summary even when the
+    // retry recovers — the advisory must not silently swallow transient flake.
+    expect(unitRun).toContain("### Windows unit attempt $attempt failed (retrying)")
+    expect(unitRun).toContain("### Windows unit recovered on retry")
+
+    // The final exit code is the last attempt's status, not the first.
+    // Otherwise a recovered run would still turn the advisory red.
+    expect(unitRun).toMatch(/exit "\$status"\s*$/)
+  })
+
   test("defines Windows unit packages and opencode shards", () => {
     const parsed = parseWorkflow(windowsAdvisoryWorkflowPath)
     const job = parsed.jobs?.[windowsUnitJobName]


### PR DESCRIPTION
## Summary

Wrap each matrix shard's `unit` step in `.github/workflows/windows-advisory.yml` in a process-level retry (max_attempts=2). A first-attempt failure now writes a step-summary header (`Windows unit attempt 1 failed (retrying)` / `Windows unit recovered on retry`) and the job only turns red if both attempts fail. Each attempt runs in a subshell so `cd packages/opencode && ...` in some matrix commands does not leak working directory across attempts.

## Why

The `windows-advisory` workflow has been ~40% red over the last ten runs on `dev` due to transient flake that does not come from the merged PRs:

- PR #1043 (`010c6d6`) failed only on `SessionRunState > defers disposeAll across all loaded directories when any directory has an active run` in `packages/opencode/test/session/run-state.test.ts`, which uses `Effect.sleep("10/20 millis")` timing assertions on Windows's coarser wall clock. Same-SHA rerun passed. PR diff was 5 files all under `packages/app/`.
- PR #1028 (`05d8ba1`) failed with a Bun 1.3.14 native segfault on `windows-latest` (`Ywatcher.node` stack frames), unrelated to PR content.

Linux `ci` is the load-bearing required gate; `windows-advisory` is advisory and non-blocking. A single transient failure should not turn the advisory red, but persistent regressions still must be visible — hence retry with first-attempt failure surfaced in the step summary rather than silently swallowed.

## Related Issue

No issue; surfaced from CI history triage on 2026-06-01 after two recent `dev` merges (#1043, #1037) showed `windows-advisory` failure.

## Human Review Status

Pending

## Review Focus

- The retry loop preserves the four substrings the `ci-workflow.test.ts` self-test asserts: `${{ matrix.command }}`, `echo "exit_code=$status"`, `### Windows unit diagnostic`, `failed advisory signal`. Confirm none of these are accidentally broken.
- Subshell `( ${{ matrix.command }} )` per attempt — verify this is the right scoping for matrix shards that contain `cd packages/...` (opencode-session, opencode-config-project, opencode-server-tools).
- Bash `for` loop instead of `nick-fields/retry@v3` — this matches the repo's SHA-pinned-actions discipline; if you prefer the third-party action anyway, say so.
- Retry applied uniformly across all 5 matrix shards (app / opencode-session / opencode-config-project / opencode-server-tools / desktop) rather than only `opencode-session`, because the Bun-segfault failure class is process-level and shard-agnostic.

## Risk Notes

- Retry hides the first-attempt failure signal at the check-result level. Mitigation: the step summary still records `attempt 1 exit code` whenever retry recovers, so persistent flake remains visible to humans reviewing the workflow run. The required Linux `ci` gate is untouched, so genuine product regressions are still blocked from merging.
- The `Upload unit artifacts` step uploads the JUnit XML from whichever attempt wrote it last; on retry recovery the artifact reflects attempt 2. Acceptable for an advisory signal.
- No test-layer changes. Rewriting `Effect.sleep`-based timing in `run-state.test.ts` to deterministic primitives is a larger Effect-TS surgery; deferred until after the 2026-06-15 `windows-latest` → `windows-2025-vs2026` runner migration, since flake patterns will shift.

## How To Verify

```text
actionlint .github/workflows/windows-advisory.yml: ok
bun test test/github/ci-workflow.test.ts test/github/bun-version-workflow.test.ts (in packages/opencode): 19 pass, 0 fail, 304 expect() calls
Self-test substrings preserved: '${{ matrix.command }}', 'echo "exit_code=$status"', '### Windows unit diagnostic', 'failed advisory signal' — all still present
CI on this PR: windows-advisory run #26758835117 currently in_progress; will exercise the new retry path
```

## Screenshots or Recordings

N/A — CI workflow change, no UI surface.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.