### PR TITLE
chore: bump bundled OfficeCLI to v1.0.102

### DIFF
--- a/packages/desktop-electron/bundled-tools.json
+++ b/packages/desktop-electron/bundled-tools.json
@@ -1,6 +1,6 @@
 {
   "officecli": {
-    "version": "v1.0.93",
+    "version": "v1.0.102",
     "repo": "iOfficeAI/OfficeCLI",
     "assets": {
       "darwin-arm64": "officecli-mac-arm64",
@@ -8,6 +8,6 @@
       "win32-x64": "officecli-win-x64.exe",
       "win32-arm64": "officecli-win-arm64.exe"
     },
-    "skillsTarballSha256": "74e89a265b8ba1aec8e995972613857e395bcadec0cd919d5884f3da97630193"
+    "skillsTarballSha256": "933f63e5a73d3c136bacfd10f435af775355cc170ab69f4a42dbcf5648b9cb6a"
   }
 }

--- a/skills/morph-ppt-3d/SKILL.md
+++ b/skills/morph-ppt-3d/SKILL.md
@@ -16,8 +16,8 @@ This file covers **3D-specific additions** and an **enriched design system** com
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/morph-ppt/SKILL.md
+++ b/skills/morph-ppt/SKILL.md
@@ -15,8 +15,8 @@ When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Rea
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 
@@ -440,7 +440,7 @@ Or in a build loop:
 for SLIDE_NUM in 3 4 5 6 7 8 9 10 11; do
   # Add content specific to this slide
   officecli add "$FILE" "/slide[$SLIDE_NUM]" --type shape ...
-
+  
   # IMMEDIATELY ghost all old actors (M-2 prevention)
   officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-ring]" --prop x=36cm || true
   officecli set "$FILE" "/slide[$SLIDE_NUM]/shape[@name=!!actor-dot]" --prop x=36cm || true

--- a/skills/officecli-academic-paper/SKILL.md
+++ b/skills/officecli-academic-paper/SKILL.md
@@ -15,8 +15,8 @@ When the docx base rules cover it, the text here says `→ see docx v2 §X`. Rea
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-data-dashboard/SKILL.md
+++ b/skills/officecli-data-dashboard/SKILL.md
@@ -13,8 +13,8 @@ A dashboard is not "a spreadsheet with charts". It is a composition: **one Dashb
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-docx/SKILL.md
+++ b/skills/officecli-docx/SKILL.md
@@ -11,8 +11,8 @@ description: "Use this skill any time a .docx file is involved -- as input, outp
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-financial-model/SKILL.md
+++ b/skills/officecli-financial-model/SKILL.md
@@ -15,8 +15,8 @@ When the xlsx base rules cover it, the text here says `→ see xlsx v2 §X`. Rea
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-pitch-deck/SKILL.md
+++ b/skills/officecli-pitch-deck/SKILL.md
@@ -15,8 +15,8 @@ When the pptx base rules cover it, the text here says `→ see pptx v2 §X`. Rea
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-pptx/SKILL.md
+++ b/skills/officecli-pptx/SKILL.md
@@ -11,8 +11,8 @@ description: "Use this skill any time a .pptx file is involved -- as input, outp
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 

--- a/skills/officecli-word-form/SKILL.md
+++ b/skills/officecli-word-form/SKILL.md
@@ -17,7 +17,7 @@ description: "Use this skill to create fillable Word forms (.docx) with real Con
 
 ```bash
 if ! command -v officecli >/dev/null 2>&1; then
-    curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash
+    curl -fsSL https://d.officecli.ai/install.sh | bash
 fi
 ```
 
@@ -25,7 +25,7 @@ fi
 
 ```powershell
 if (-not (Get-Command officecli -ErrorAction SilentlyContinue)) {
-    irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex
+    irm https://d.officecli.ai/install.ps1 | iex
 }
 ```
 

--- a/skills/officecli-xlsx/SKILL.md
+++ b/skills/officecli-xlsx/SKILL.md
@@ -11,8 +11,8 @@ description: "Use this skill any time a .xlsx file is involved -- as input, outp
 
 If `officecli` is missing:
 
-- **macOS / Linux**: `curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash`
-- **Windows (PowerShell)**: `irm https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.ps1 | iex`
+- **macOS / Linux**: `curl -fsSL https://d.officecli.ai/install.sh | bash`
+- **Windows (PowerShell)**: `irm https://d.officecli.ai/install.ps1 | iex`
 
 Verify with `officecli --version` (open a new terminal if PATH hasn't picked up). If install fails, download a binary from https://github.com/iOfficeAI/OfficeCLI/releases.
 


### PR DESCRIPTION
## Summary

Bump the bundled OfficeCLI version in `packages/desktop-electron/bundled-tools.json` from `v1.0.93` to `v1.0.102`, refresh `officecli.skillsTarballSha256`, and re-sync the vendored `skills/` bundle to the upstream v1.0.102 content with the PawWork override blockquote re-injected after the upstream frontmatter.

## Why

Upstream OfficeCLI published several releases since the bundle was last bumped (`v1.0.94` through `v1.0.102`, with `v1.0.102` on 2026-05-28). The scheduled `officecli-bump` workflow keeps failing at the "Create bump pull request" step (see workflow runs `26744544092` and the just-triggered `26806907135`); #735 is the in-flight fix for that automation. To unblock the next release cut, this PR completes the bump handoff manually using the same script path the workflow runs.

## Related Issue

No issue. This is the periodic upstream OfficeCLI bump that the scheduled workflow would normally produce; #735 tracks repairing the workflow's PR-creation step.

## Human Review Status

Pending. A human should make the final merge decision after reviewing the diff and verification evidence.

## Review Focus

- Confirm `v1.0.102` is the intended upstream OfficeCLI release.
- Confirm `skillsTarballSha256` (`933f63e5a73d3c136bacfd10f435af775355cc170ab69f4a42dbcf5648b9cb6a`) matches the computed v1.0.102 skills bundle content SHA.
- Confirm the `skills/` diff is the expected upstream sync (mainly install-URL changes from `raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.*` to `d.officecli.ai/install.*`) with the PawWork override blockquote present in every synced `SKILL.md`.
- Confirm desktop asset verification covered all four bundled targets.

## Risk Notes

- No product code, release workflow, or updater behavior changed.
- This changes the pinned OfficeCLI version and the vendored skills content consumed by desktop packaging.
- All four bundled desktop targets (darwin-arm64, darwin-x64, win32-x64, win32-arm64) were verified locally via `packages/desktop-electron/scripts/prepare-officecli.ts` before commit.
- No upstream skill add/remove this cycle; same 10 skills as v1.0.93.

## How To Verify

```text
Pinned OfficeCLI: v1.0.93 -> v1.0.102
Upstream release: https://github.com/iOfficeAI/OfficeCLI/releases/tag/v1.0.102

Local verification:
- bun packages/desktop-electron/scripts/prepare-officecli.ts --platform darwin --arch arm64
- bun packages/desktop-electron/scripts/prepare-officecli.ts --platform darwin --arch x64
- bun packages/desktop-electron/scripts/prepare-officecli.ts --platform win32 --arch x64
- bun packages/desktop-electron/scripts/prepare-officecli.ts --platform win32 --arch arm64
  result: all four "Prepared OfficeCLI v1.0.102 for <target>" with downloaded binary

- bun packages/desktop-electron/scripts/sync-officecli-skills.ts --compute-sha
  result: computed content SHA256 933f63e5...8b9cb6a; wrote skillsTarballSha256

- bun packages/desktop-electron/scripts/sync-officecli-skills.ts
  result: wrote 120 files across 10 skills (10 SKILL.md with override + 110 companion files); pruned 0 stale dirs

Workflow attempts that failed at PR-create step (manual bump complements #735):
- officecli-bump run 26806907135 (workflow_dispatch)
- officecli-bump run 26744544092 (schedule)
```

## Screenshots or Recordings

Not needed. Dependency pin + vendored skills maintenance PR with no visible UI change.

## Checklist

- [x] Human review status is stated above as pending, approved, or not required
- [x] I linked the related issue, or stated why there is no issue
- [x] This PR has exactly one type label (`bug`, `enhancement`, `task`, or `documentation`), at least one primary routing label (`app`, `ui`, `platform`, `harness`, or `ci`), and exactly one priority label (`P0` to `P3`), or I requested maintainer labeling
- [x] I described the review focus and any meaningful risks
- [x] I listed the relevant verification steps and the key result for each
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English