### PR TITLE
docs: rework README hero to lead with BYOK + OAuth framing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,8 @@ app:
   - changed-files:
       - any-glob-to-any-file:
           - "packages/app/**"
+          - "README.md"
+          - "README_CN.md"
 
 ui:
   - changed-files:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PawWork
 
-**Open-source AI agent that works out of the box on your desktop.**
+**Open-source alternative to Codex App and Claude Cowork.**
+Bring your own key, works with any model — including ChatGPT OAuth.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![macOS](https://img.shields.io/badge/macOS-signed_and_notarized-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
@@ -8,11 +9,9 @@
 
 [中文说明](README_CN.md)
 
-PawWork is an open-source alternative to Codex App and Claude Desktop. It brings AI agent work into a polished desktop app for files, documents, spreadsheets, research, writing, code, and local tasks.
+PawWork brings AI agent work into a polished desktop app for files, documents, spreadsheets, research, writing, code, and local tasks. Use your ChatGPT Plus/Pro plan for OpenAI, or bring your own API key for Claude, Gemini, DeepSeek, Kimi, GLM, and 75+ providers, including local models.
 
-Start without a terminal, API key, or paid model plan. PawWork includes a free plan powered by OpenCode Zen, built-in web search, task cards, and support for your own model accounts when you want more choice or control.
-
-![PawWork - Open-source AI agent that works out of the box on your desktop](assets/readme/pawwork-cover.png)
+![PawWork - Open-source alternative to Codex App and Claude Cowork](assets/readme/pawwork-cover.png)
 
 ## Why PawWork
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PawWork
 
 **Open-source alternative to Codex App and Claude Cowork.**
-Bring your own key, works with any model — including ChatGPT OAuth.
+Bring your own key. Works with any model — including ChatGPT OAuth.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![macOS](https://img.shields.io/badge/macOS-signed_and_notarized-black.svg)](https://github.com/Astro-Han/pawwork/releases/latest)
@@ -9,7 +9,7 @@ Bring your own key, works with any model — including ChatGPT OAuth.
 
 [中文说明](README_CN.md)
 
-PawWork brings AI agent work into a polished desktop app for files, documents, spreadsheets, research, writing, code, and local tasks. Use your ChatGPT Plus/Pro plan for OpenAI, or bring your own API key for Claude, Gemini, DeepSeek, Kimi, GLM, and 75+ providers, including local models.
+PawWork brings AI agent work into a polished desktop app for files, documents, spreadsheets, research, writing, code, and local tasks. Use your ChatGPT Plus/Pro plan via OAuth, or bring your own API key for OpenAI, Claude, Gemini, DeepSeek, Kimi, GLM, and 75+ providers, including local models.
 
 ![PawWork - Open-source alternative to Codex App and Claude Cowork](assets/readme/pawwork-cover.png)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,7 +8,7 @@
 
 [English](README.md)
 
-爪印 PawWork 是 Codex App 和 Claude Desktop 的开源替代方案。它面向真实的桌面工作场景，在一个极简、优雅的界面里，帮你处理文档、表格、资料整理、写作、代码和本地文件。
+爪印 PawWork 是 Codex App 和 Claude Cowork 的开源替代方案。它面向真实的桌面工作场景，在一个极简、优雅的界面里，帮你处理文档、表格、资料整理、写作、代码和本地文件。
 
 无需安装复杂的工具链，无需提前准备 API 密钥，也无需购买付费模型账号。爪印 PawWork 内置来自 OpenCode Zen 的免费额度、内置搜索和任务卡片，下载打开就能开始。
 


### PR DESCRIPTION
## Summary

Two changes:

1. **README hero rework** (README.md, README_CN.md): Lead the English README hero with the open-source-alternative framing and BYOK + ChatGPT OAuth proposition. Fix the comparison target from Claude Desktop (chat app) to Claude Cowork (Anthropic's 2026-04 GA desktop agent — the actual same-category competitor in 2026) in both README and README_CN.
2. **Labeler plumbing fix** (.github/labeler.yml): Route README files to the `app` routing label so README-only PRs can satisfy the pr-triage routing-label requirement without a manual label dance.

## Why

**For the README rework:** The previous hero ("AI agent that works out of the box on your desktop") and the OpenCode-Zen-free-plan pitch optimize for non-technical Chinese-channel readers (Xiaohongshu / Zhihu). They soften the hook for the English audience that the upcoming outbound push targets: Codex App and Claude Cowork users with paid plans or developer-grade BYOK habits.

The new hero lines explicitly position PawWork against the two same-category 2026 desktop agents (Codex App, Claude Cowork) and surface BYOK + ChatGPT OAuth as the persistent value. BYOK is the main proposition; OAuth is an "including" enumeration that survives even if OpenAI later changes its OAuth policy (Anthropic already closed third-party OAuth reuse in 2026).

The OpenCode Zen free-plan pitch still appears in the "Less setup" bullet and the "Models, Plans, and Search" section, so non-technical English readers still find an on-ramp; only the hero is reframed.

README_CN.md keeps the existing Chinese-friendly framing (开箱即用 + OpenCode Zen 免费额度) because the Xiaohongshu / Zhihu audience profile matches that framing. The Chinese file only fixes the same factual error (Claude Desktop → Claude Cowork).

**For the labeler fix:** README.md / README_CN.md don't match any existing routing label glob (labeler only watches `packages/**` paths), but pr-triage requires every PR to carry one of `app` / `ui` / `platform` / `harness` / `ci`. Without this small labeler tweak, README-only PRs fail pr-triage even when `documentation` + priority labels are set correctly. README is product-facing documentation for the app shell, so the `app` routing label is the semantically correct home.

## Related Issue

None. Driven by the outbound launch shaping session, not a tracked issue.

## Human Review Status

Pending.

## Review Focus

- Whether "Open-source alternative to Codex App and Claude Cowork" is acceptable as the English hero subtitle.
- Whether "Bring your own key, works with any model — including ChatGPT OAuth" reads correctly for English-speaking developers.
- Whether dropping the OpenCode Zen free-plan pitch from the hero (but keeping it lower in the README) is the right balance for English readers.
- Whether the Claude Desktop → Claude Cowork rename matches the 2026 product reality you want to reference.
- Whether routing README files to the `app` label is the right home (vs `documentation`-as-routing, `ci`, or a new dedicated label).

## Risk Notes

- ChatGPT OAuth policy risk: if OpenAI later restricts third-party OAuth reuse the way Anthropic did, the "including ChatGPT OAuth" enumeration can be removed without touching the rest of the hero. BYOK is the main hook, so the framing survives.
- Chinese / English narrative split is intentional. Two channel audiences with different paid-plan habits; tracked in the local outbound plan rather than reconciled at the README level.
- No app code changed; no platform, packaging, signing, updater, or permissions impact.
- Labeler change applies retroactively to any future README PR — semantics are stable, no migration needed.

## How To Verify

```text
Local diff review: README.md +4/-5, README_CN.md +1/-1, .github/labeler.yml +2/-0
Rendered preview: README.md hero shows the two-line subtitle on github.com PR preview; cover alt text updated to match.
Labeler effect verified by pr-triage rerun after the labeler.yml commit lands.
No code or asset changes; no build / typecheck / test required.
```

## Screenshots or Recordings

Not needed. Text-only README and YAML changes; reviewers can use the PR file diff preview.

## Checklist

- [x] **Type label** — `documentation` (author-applied).
- [x] **Routing labels** — `app` (labeler will assign automatically after the labeler.yml commit lands).
- [x] **Priority label** — `P3` (priority-triage bot assigned).
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I listed the relevant verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope (the labeler change is the smallest plumbing fix that makes the README scope mergeable).
- [x] I manually checked visible UI or copy changes when needed, with screenshots or recordings (text-only change, PR diff preview is sufficient).
- [x] I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes (no platform impact; text-only).
- [x] I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product positioning and description in README to emphasize compatibility with any model, including ChatGPT OAuth, and "Bring your own key" approach.
  * Updated Chinese README to reflect the new product positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->