### PR TITLE
refactor(app): extract session prefetch controller from layout.tsx

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -23,7 +23,7 @@ import { decode64 } from "@/utils/base64"
 import { Button } from "@opencode-ai/ui/button"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { getFilename } from "@opencode-ai/util/path"
-import { Session, type GlobalSession, type Message } from "@opencode-ai/sdk/v2/client"
+import { Session, type GlobalSession } from "@opencode-ai/sdk/v2/client"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -35,20 +35,10 @@ import { clientActionHeaders } from "@/utils/server"
 import { LayoutPageContext } from "@/context/layout-page"
 import { ShellSurfaceContext } from "@/context/shell-surface"
 import { clearWorkspaceTerminals, isTerminalGoneError } from "@/context/terminal"
-import { dropSessionCaches, pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
-import {
-  clearSessionPrefetchInflight,
-  clearSessionPrefetch,
-  getSessionPrefetch,
-  isSessionPrefetchCurrent,
-  runSessionPrefetch,
-  setSessionPrefetch,
-  shouldSkipSessionPrefetch,
-} from "@/context/global-sync/session-prefetch"
+import { dropSessionCaches } from "@/context/global-sync/session-cache"
 import { useNotification } from "@/context/notification"
 import { usePermission } from "@/context/permission"
 import { Binary } from "@opencode-ai/util/binary"
-import { retry } from "@opencode-ai/util/retry"
 import { playSoundById } from "@/utils/sound"
 import { setNavigate } from "@/utils/notification-click"
 import { setOpenSettings } from "@/utils/settings-navigation"
@@ -114,6 +104,7 @@ import {
   pawworkSessionWindowActiveRoot,
   sortPawworkSessionWindowSessions,
 } from "./layout/pawwork-session-window"
+import { createPawworkSessionPrefetch } from "./layout/pawwork-session-prefetch"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { createDefaultLayoutPageState, createLayoutPagePersistTarget, removePinnedSessionIDs } from "./layout/layout-page-store"
@@ -656,249 +647,14 @@ export default function Layout(props: ParentProps) {
     }),
   )
 
-  type PrefetchQueue = {
-    inflight: Set<string>
-    pending: string[]
-    pendingSet: Set<string>
-    running: number
-  }
-
-  const prefetchChunk = 200
-  const prefetchConcurrency = 2
-  const prefetchPendingLimit = 10
-  const span = 4
-  const prefetchToken = { value: 0 }
-  const prefetchQueues = new Map<string, PrefetchQueue>()
-
-  const PREFETCH_MAX_SESSIONS_PER_DIR = 10
-  const prefetchedByDir = new Map<string, Set<string>>()
-
-  const lruFor = (directory: string) => {
-    const existing = prefetchedByDir.get(directory)
-    if (existing) return existing
-    const created = new Set<string>()
-    prefetchedByDir.set(directory, created)
-    return created
-  }
-
-  const markPrefetched = (directory: string, sessionID: string) => {
-    const lru = lruFor(directory)
-    return pickSessionCacheEvictions({
-      seen: lru,
-      keep: sessionID,
-      limit: PREFETCH_MAX_SESSIONS_PER_DIR,
-      preserve: params.id && workspaceKey(directory) === workspaceKey(currentDir()) ? [params.id] : undefined,
-    })
-  }
-
-  createEffect(() => {
-    const active = new Set(visibleSessionDirs())
-    for (const directory of [...prefetchedByDir.keys()]) {
-      if (active.has(directory)) continue
-      prefetchedByDir.delete(directory)
-    }
-  })
-
-  createEffect(() => {
-    route()
-    globalSDK.url
-
-    prefetchToken.value += 1
-    clearSessionPrefetchInflight()
-    prefetchQueues.clear()
-  })
-
-  createEffect(() => {
-    const visible = new Set(visibleSessionDirs())
-    for (const [directory, q] of prefetchQueues) {
-      if (visible.has(directory)) continue
-      q.pending.length = 0
-      q.pendingSet.clear()
-      if (q.running === 0) prefetchQueues.delete(directory)
-    }
-  })
-
-  const queueFor = (directory: string) => {
-    const existing = prefetchQueues.get(directory)
-    if (existing) return existing
-
-    const created: PrefetchQueue = {
-      inflight: new Set(),
-      pending: [],
-      pendingSet: new Set(),
-      running: 0,
-    }
-    prefetchQueues.set(directory, created)
-    return created
-  }
-
-  const mergeByID = <T extends { id: string }>(current: T[], incoming: T[]) => {
-    if (current.length === 0) {
-      return incoming.slice().sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
-    }
-
-    const map = new Map<string, T>()
-    for (const item of current) {
-      map.set(item.id, item)
-    }
-    for (const item of incoming) {
-      map.set(item.id, item)
-    }
-    return [...map.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
-  }
-
-  async function prefetchMessages(directory: string, sessionID: string, token: number) {
-    const [store, setStore] = globalSync.child(directory, { bootstrap: false })
-
-    return runSessionPrefetch({
-      directory,
-      sessionID,
-      task: (rev) =>
-        retry(() => globalSDK.client.session.messages({ directory, sessionID, limit: prefetchChunk }))
-          .then((messages) => {
-            if (prefetchToken.value !== token) return
-            if (!isSessionPrefetchCurrent(directory, sessionID, rev)) return
-
-            const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
-            const next = items.map((x) => x.info).filter((m): m is Message => !!m?.id)
-            const sorted = mergeByID([], next)
-            const stale = markPrefetched(directory, sessionID)
-            const cursor = messages.response?.headers.get("x-next-cursor") ?? undefined
-            const meta = {
-              limit: sorted.length,
-              cursor,
-              complete: !cursor,
-              at: Date.now(),
-            }
-
-            if (stale.length > 0) {
-              clearSessionPrefetch(directory, stale)
-            }
-
-            const current = store.message[sessionID] ?? []
-            const merged = mergeByID(
-              current.filter((item): item is Message => !!item?.id),
-              sorted,
-            )
-
-            if (!isSessionPrefetchCurrent(directory, sessionID, rev)) return
-
-            batch(() => {
-              if (stale.length > 0) {
-                setStore(
-                  produce((draft) => {
-                    dropSessionCaches(draft, stale)
-                  }),
-                )
-              }
-
-              setStore("message", sessionID, reconcile(merged, { key: "id" }))
-              setSessionPrefetch({ directory, sessionID, ...meta })
-
-              for (const message of items) {
-                const currentParts = store.part[message.info.id] ?? []
-                const mergedParts = mergeByID(
-                  currentParts.filter((item): item is (typeof currentParts)[number] & { id: string } => !!item?.id),
-                  message.parts.filter((item): item is (typeof message.parts)[number] & { id: string } => !!item?.id),
-                )
-
-                setStore("part", message.info.id, reconcile(mergedParts, { key: "id" }))
-              }
-            })
-
-            return meta
-          })
-          .catch(() => undefined),
-    })
-  }
-
-  const pumpPrefetch = (directory: string) => {
-    const q = queueFor(directory)
-    if (q.running >= prefetchConcurrency) return
-
-    const sessionID = q.pending.shift()
-    if (!sessionID) return
-
-    q.pendingSet.delete(sessionID)
-    q.inflight.add(sessionID)
-    q.running += 1
-
-    const token = prefetchToken.value
-
-    void prefetchMessages(directory, sessionID, token).finally(() => {
-      q.running -= 1
-      q.inflight.delete(sessionID)
-      pumpPrefetch(directory)
-    })
-  }
-
-  const prefetchSession = (session: Session, priority: "high" | "low" = "low") => {
-    const directory = session.directory
-    if (!directory) return
-
-    const [store] = globalSync.child(directory, { bootstrap: false })
-    const cached = untrack(() => {
-      const info = getSessionPrefetch(directory, session.id)
-      return shouldSkipSessionPrefetch({
-        message: store.message[session.id] !== undefined,
-        info,
-        chunk: prefetchChunk,
-      })
-    })
-    if (cached) return
-
-    const q = queueFor(directory)
-    if (q.inflight.has(session.id)) return
-    if (q.pendingSet.has(session.id)) {
-      if (priority !== "high") return
-      const index = q.pending.indexOf(session.id)
-      if (index > 0) {
-        q.pending.splice(index, 1)
-        q.pending.unshift(session.id)
-      }
-      return
-    }
-
-    const lru = lruFor(directory)
-    const known = lru.has(session.id)
-    if (!known && lru.size >= PREFETCH_MAX_SESSIONS_PER_DIR && priority !== "high") return
-
-    if (priority === "high") q.pending.unshift(session.id)
-    if (priority !== "high") q.pending.push(session.id)
-    q.pendingSet.add(session.id)
-
-    while (q.pending.length > prefetchPendingLimit) {
-      const dropped = q.pending.pop()
-      if (!dropped) continue
-      q.pendingSet.delete(dropped)
-    }
-
-    pumpPrefetch(directory)
-  }
-
-  const warm = (sessions: Session[], index: number) => {
-    for (let offset = 1; offset <= span; offset++) {
-      const next = sessions[index + offset]
-      if (next) prefetchSession(next, offset === 1 ? "high" : "low")
-
-      const prev = sessions[index - offset]
-      if (prev) prefetchSession(prev, offset === 1 ? "high" : "low")
-    }
-  }
-
-  createEffect(() => {
-    const sessions = pawworkNavigationSessions()
-    if (sessions.length === 0) return
-
-    const index = params.id ? sessions.findIndex((s) => s.id === params.id) : 0
-    if (index === -1) return
-
-    if (!params.id) {
-      const first = sessions[index]
-      if (first) prefetchSession(first, "high")
-    }
-
-    warm(sessions, index)
+  const { prefetchSession, warm } = createPawworkSessionPrefetch({
+    params,
+    route,
+    currentDir,
+    visibleSessionDirs,
+    navigationSessions: pawworkNavigationSessions,
+    globalSDK,
+    globalSync,
   })
 
   function navigateSessionByOffset(offset: number) {

--- a/packages/app/src/pages/layout/pawwork-session-prefetch.ts
+++ b/packages/app/src/pages/layout/pawwork-session-prefetch.ts
@@ -1,0 +1,279 @@
+import { batch, createEffect, untrack } from "solid-js"
+import { produce, reconcile } from "solid-js/store"
+import type { Message, Session } from "@opencode-ai/sdk/v2/client"
+import { retry } from "@opencode-ai/util/retry"
+import type { useGlobalSDK } from "@/context/global-sdk"
+import type { useGlobalSync } from "@/context/global-sync"
+import { dropSessionCaches, pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
+import {
+  clearSessionPrefetch,
+  clearSessionPrefetchInflight,
+  getSessionPrefetch,
+  isSessionPrefetchCurrent,
+  runSessionPrefetch,
+  setSessionPrefetch,
+  shouldSkipSessionPrefetch,
+} from "@/context/global-sync/session-prefetch"
+import { workspaceKey } from "./helpers"
+
+type PrefetchQueue = {
+  inflight: Set<string>
+  pending: string[]
+  pendingSet: Set<string>
+  running: number
+}
+
+export type SessionPrefetchInput = {
+  params: { readonly id?: string }
+  route: () => void
+  currentDir: () => string
+  visibleSessionDirs: () => string[]
+  navigationSessions: () => Session[]
+  globalSDK: Pick<ReturnType<typeof useGlobalSDK>, "url" | "client">
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child">
+}
+
+const prefetchChunk = 200
+const prefetchConcurrency = 2
+const prefetchPendingLimit = 10
+const span = 4
+const PREFETCH_MAX_SESSIONS_PER_DIR = 10
+
+const mergeByID = <T extends { id: string }>(current: T[], incoming: T[]) => {
+  if (current.length === 0) {
+    return incoming.slice().sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  }
+
+  const map = new Map<string, T>()
+  for (const item of current) {
+    map.set(item.id, item)
+  }
+  for (const item of incoming) {
+    map.set(item.id, item)
+  }
+  return [...map.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}
+
+export function createPawworkSessionPrefetch(input: SessionPrefetchInput) {
+  const prefetchToken = { value: 0 }
+  const prefetchQueues = new Map<string, PrefetchQueue>()
+  const prefetchedByDir = new Map<string, Set<string>>()
+
+  const lruFor = (directory: string) => {
+    const existing = prefetchedByDir.get(directory)
+    if (existing) return existing
+    const created = new Set<string>()
+    prefetchedByDir.set(directory, created)
+    return created
+  }
+
+  const markPrefetched = (directory: string, sessionID: string) => {
+    const lru = lruFor(directory)
+    return pickSessionCacheEvictions({
+      seen: lru,
+      keep: sessionID,
+      limit: PREFETCH_MAX_SESSIONS_PER_DIR,
+      preserve:
+        input.params.id && workspaceKey(directory) === workspaceKey(input.currentDir())
+          ? [input.params.id]
+          : undefined,
+    })
+  }
+
+  createEffect(() => {
+    const active = new Set(input.visibleSessionDirs())
+    for (const directory of [...prefetchedByDir.keys()]) {
+      if (active.has(directory)) continue
+      prefetchedByDir.delete(directory)
+    }
+  })
+
+  createEffect(() => {
+    input.route()
+    input.globalSDK.url
+
+    prefetchToken.value += 1
+    clearSessionPrefetchInflight()
+    prefetchQueues.clear()
+  })
+
+  createEffect(() => {
+    const visible = new Set(input.visibleSessionDirs())
+    for (const [directory, q] of prefetchQueues) {
+      if (visible.has(directory)) continue
+      q.pending.length = 0
+      q.pendingSet.clear()
+      if (q.running === 0) prefetchQueues.delete(directory)
+    }
+  })
+
+  const queueFor = (directory: string) => {
+    const existing = prefetchQueues.get(directory)
+    if (existing) return existing
+
+    const created: PrefetchQueue = {
+      inflight: new Set(),
+      pending: [],
+      pendingSet: new Set(),
+      running: 0,
+    }
+    prefetchQueues.set(directory, created)
+    return created
+  }
+
+  async function prefetchMessages(directory: string, sessionID: string, token: number) {
+    const [store, setStore] = input.globalSync.child(directory, { bootstrap: false })
+
+    return runSessionPrefetch({
+      directory,
+      sessionID,
+      task: (rev) =>
+        retry(() => input.globalSDK.client.session.messages({ directory, sessionID, limit: prefetchChunk }))
+          .then((messages) => {
+            if (prefetchToken.value !== token) return
+            if (!isSessionPrefetchCurrent(directory, sessionID, rev)) return
+
+            const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
+            const next = items.map((x) => x.info).filter((m): m is Message => !!m?.id)
+            const sorted = mergeByID([], next)
+            const stale = markPrefetched(directory, sessionID)
+            const cursor = messages.response?.headers.get("x-next-cursor") ?? undefined
+            const meta = {
+              limit: sorted.length,
+              cursor,
+              complete: !cursor,
+              at: Date.now(),
+            }
+
+            if (stale.length > 0) {
+              clearSessionPrefetch(directory, stale)
+            }
+
+            const current = store.message[sessionID] ?? []
+            const merged = mergeByID(
+              current.filter((item): item is Message => !!item?.id),
+              sorted,
+            )
+
+            if (!isSessionPrefetchCurrent(directory, sessionID, rev)) return
+
+            batch(() => {
+              if (stale.length > 0) {
+                setStore(
+                  produce((draft) => {
+                    dropSessionCaches(draft, stale)
+                  }),
+                )
+              }
+
+              setStore("message", sessionID, reconcile(merged, { key: "id" }))
+              setSessionPrefetch({ directory, sessionID, ...meta })
+
+              for (const message of items) {
+                const currentParts = store.part[message.info.id] ?? []
+                const mergedParts = mergeByID(
+                  currentParts.filter((item): item is (typeof currentParts)[number] & { id: string } => !!item?.id),
+                  message.parts.filter((item): item is (typeof message.parts)[number] & { id: string } => !!item?.id),
+                )
+
+                setStore("part", message.info.id, reconcile(mergedParts, { key: "id" }))
+              }
+            })
+
+            return meta
+          })
+          .catch(() => undefined),
+    })
+  }
+
+  const pumpPrefetch = (directory: string) => {
+    const q = queueFor(directory)
+    if (q.running >= prefetchConcurrency) return
+
+    const sessionID = q.pending.shift()
+    if (!sessionID) return
+
+    q.pendingSet.delete(sessionID)
+    q.inflight.add(sessionID)
+    q.running += 1
+
+    const token = prefetchToken.value
+
+    void prefetchMessages(directory, sessionID, token).finally(() => {
+      q.running -= 1
+      q.inflight.delete(sessionID)
+      pumpPrefetch(directory)
+    })
+  }
+
+  const prefetchSession = (session: Session, priority: "high" | "low" = "low") => {
+    const directory = session.directory
+    if (!directory) return
+
+    const [store] = input.globalSync.child(directory, { bootstrap: false })
+    const cached = untrack(() => {
+      const info = getSessionPrefetch(directory, session.id)
+      return shouldSkipSessionPrefetch({
+        message: store.message[session.id] !== undefined,
+        info,
+        chunk: prefetchChunk,
+      })
+    })
+    if (cached) return
+
+    const q = queueFor(directory)
+    if (q.inflight.has(session.id)) return
+    if (q.pendingSet.has(session.id)) {
+      if (priority !== "high") return
+      const index = q.pending.indexOf(session.id)
+      if (index > 0) {
+        q.pending.splice(index, 1)
+        q.pending.unshift(session.id)
+      }
+      return
+    }
+
+    const lru = lruFor(directory)
+    const known = lru.has(session.id)
+    if (!known && lru.size >= PREFETCH_MAX_SESSIONS_PER_DIR && priority !== "high") return
+
+    if (priority === "high") q.pending.unshift(session.id)
+    if (priority !== "high") q.pending.push(session.id)
+    q.pendingSet.add(session.id)
+
+    while (q.pending.length > prefetchPendingLimit) {
+      const dropped = q.pending.pop()
+      if (!dropped) continue
+      q.pendingSet.delete(dropped)
+    }
+
+    pumpPrefetch(directory)
+  }
+
+  const warm = (sessions: Session[], index: number) => {
+    for (let offset = 1; offset <= span; offset++) {
+      const next = sessions[index + offset]
+      if (next) prefetchSession(next, offset === 1 ? "high" : "low")
+
+      const prev = sessions[index - offset]
+      if (prev) prefetchSession(prev, offset === 1 ? "high" : "low")
+    }
+  }
+
+  createEffect(() => {
+    const sessions = input.navigationSessions()
+    if (sessions.length === 0) return
+
+    const index = input.params.id ? sessions.findIndex((s) => s.id === input.params.id) : 0
+    if (index === -1) return
+
+    if (!input.params.id) {
+      const first = sessions[index]
+      if (first) prefetchSession(first, "high")
+    }
+
+    warm(sessions, index)
+  })
+
+  return { prefetchSession, warm }
+}


### PR DESCRIPTION
## Summary

Extract the session message prefetch controller out of `pages/layout.tsx` into a focused module. Slice 1 of the layout governance split tracked in #1056 (carries on the #875 follow-up sequence).

- New `packages/app/src/pages/layout/pawwork-session-prefetch.ts` exports `createPawworkSessionPrefetch`, owning the prefetch queue: per-directory queues, bounded concurrency, pending limit, LRU eviction, priority warm of neighboring sessions, and the route/visibility-driven effects.
- `pages/layout.tsx` now calls the controller with a named dependency object and consumes the returned `{ prefetchSession, warm }`.

Mechanical extraction: the moved code is verbatim, with external references rewired to injected reactive accessors (`params`, `route`, `currentDir`, `visibleSessionDirs`, navigation sessions, `globalSDK`, `globalSync`). Effects still register under the Layout owner. No change to user-visible behavior, DOM, copy, aria labels, command IDs, storage keys, or styling.

`layout.tsx`: 2204 -> 1960 lines.

## Touched files

- `packages/app/src/pages/layout.tsx` — remove inlined prefetch block + now-unused imports; wire controller
- `packages/app/src/pages/layout/pawwork-session-prefetch.ts` — new controller

## Review focus

- Reactive boundary: deps passed as accessors/objects, not frozen values; effects under Layout owner.
- Prefetch queue semantics unchanged (concurrency 2, pending limit 10, span 4, max 10 sessions/dir).
- Import cleanup correct (`Message` type, `retry`, session-prefetch fns, `pickSessionCacheEvictions` removed from layout.tsx; `dropSessionCaches` kept).

## Verification

- `bun turbo typecheck` — green (8/8)
- `eslint` on both changed files — clean
- `bun test` layout suite (`src/pages/layout/*.test.ts(x)`) — 158 pass / 0 fail

## Tests

No new test added: this is a verbatim extraction, and the core decision logic it orchestrates (`shouldSkipSessionPrefetch`, `runSessionPrefetch`, `pickSessionCacheEvictions`) already lives in and is tested under `@/context/global-sync/session-prefetch` and `session-cache`. Directly unit-testing the controller's stateful queue would require mocking several modules (cf. known mock.module leakage in #957), not worth it for a no-behavior-change move. The existing 158 layout tests guard regressions.

## Risk

Low. Mechanical move behind a stable interface. Main risk is a reactivity regression (a dep captured as a value), mitigated by passing accessors and verified via typecheck + existing tests.

Refs #1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored session message prefetching with improved concurrency control and queue management to ensure more efficient background loading of messages across sessions and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->