### PR TITLE
refactor(app): extract pawwork routing actions + deep-links from layout.tsx

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -43,7 +43,6 @@ import { playSoundById } from "@/utils/sound"
 import { setNavigate } from "@/utils/notification-click"
 import { setOpenSettings } from "@/utils/settings-navigation"
 import { Worktree as WorktreeState } from "@/utils/worktree"
-import { setSessionHandoff } from "@/pages/session/handoff"
 import { usePinnedDraft } from "@/components/prompt-input/pinned-draft"
 import {
   runHomepageMigration,
@@ -63,19 +62,12 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
-  openProjectRoute,
   startupAutoselectDirectory,
   sortedRootSessions,
   workspaceKey,
 } from "./layout/helpers"
-import {
-  collectNewSessionDeepLinks,
-  collectOpenProjectDeepLinks,
-  deepLinkEvent,
-  drainPendingDeepLinks,
-} from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
-import { pawworkSessionRouteUnhideKeys, pawworkSessionDirectories } from "./layout/pawwork-session-source"
+import { pawworkSessionDirectories } from "./layout/pawwork-session-source"
 import { findPawworkSessionNavigationTarget } from "./layout/pawwork-session-nav"
 import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
@@ -85,6 +77,7 @@ import { LayoutShellFrame } from "./layout/layout-shell-frame"
 import { createPawworkSessionPrefetch } from "./layout/pawwork-session-prefetch"
 import { createPawworkSessionController } from "./layout/pawwork-session-controller"
 import { createPawworkProjectControls } from "./layout/pawwork-project-controls"
+import { createPawworkRoutingActions } from "./layout/pawwork-routing-actions"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { createDefaultLayoutPageState, createLayoutPagePersistTarget } from "./layout/layout-page-store"
@@ -725,47 +718,6 @@ export default function Layout(props: ParentProps) {
     setState("sizing", false)
   }
 
-  function syncSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    for (const key of pawworkSessionRouteUnhideKeys(directory)) {
-      if (!store.pawworkProjectHidden[key]) continue
-      unhideProject(key)
-    }
-    notification.session.markViewed(id)
-    const expanded = untrack(() => store.workspaceExpanded[directory])
-    if (expanded === false) {
-      setStore("workspaceExpanded", directory, true)
-    }
-    requestAnimationFrame(() => scrollToSession(id, `${directory}:${id}`))
-    return root
-  }
-
-  async function navigateToProject(directory: string | undefined) {
-    if (!directory) return
-    const root = projectRoot(directory)
-    server.projects.touch(root)
-    navigate(openProjectRoute(root))
-  }
-
-  function navigateToSession(session: Session | undefined) {
-    if (session) {
-      const key = projectKeyForSession(session)
-      if (store.pawworkProjectHidden[key]) {
-        unhideProject(key)
-      }
-    }
-    shellNavigation.openSession(session)
-  }
-
-  function openPawworkHome(directory?: string) {
-    if (directory) {
-      const key = workspaceKey(directory)
-      if (store.pawworkProjectHidden[key]) {
-        unhideProject(key)
-      }
-    }
-    shellNavigation.openNewSession(directory)
-  }
-
   const shellNavigation = createShellNavigation({
     navigate,
     releaseTransientLocks: releaseTransientShellLocks,
@@ -776,49 +728,29 @@ export default function Layout(props: ParentProps) {
     closeSettingsSurface: closeSettings,
   })
 
-  function openProject(directory: string, shouldNavigate = true) {
-    layout.projects.open(directory)
-    if (shouldNavigate) return navigateToProject(directory)
-  }
-
   // Singleton; same instance returned every call.
   const pinned = usePinnedDraft()
 
-  const handleDeepLinks = (urls: string[]) => {
-    if (!server.isLocal()) return
-
-    for (const directory of collectOpenProjectDeepLinks(urls)) {
-      openProject(directory)
-    }
-
-    for (const link of collectNewSessionDeepLinks(urls)) {
-      openProject(link.directory, false)
-      const slug = base64Encode(link.directory)
-      if (link.prompt) {
-        // Pin the prompt to this directory so it is NOT carried portably to
-        // other homepages. The pinned slot is consumed by editor-input.ts when
-        // the user lands on the /repo homepage.
-        pinned.adopt({ directory: link.directory, prompt: link.prompt })
-        // Also keep the session handoff for the new-session composer region
-        // that shows the prefill text before the session is created (T7 will
-        // decide whether to clear it on submit).
-        setSessionHandoff(slug, { prompt: link.prompt })
-      }
-      const href = `/${slug}/session`
-      navigate(href)
-    }
-  }
-
-  onMount(() => {
-    const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ urls: string[] }>).detail
-      const urls = detail?.urls ?? []
-      if (urls.length === 0) return
-      handleDeepLinks(urls)
-    }
-
-    handleDeepLinks(drainPendingDeepLinks(window))
-    makeEventListener(window, deepLinkEvent, handler as EventListener)
+  const {
+    syncSessionRoute,
+    navigateToProject,
+    navigateToSession,
+    openPawworkHome,
+    openProject,
+  } = createPawworkRoutingActions({
+    navigate,
+    server,
+    store,
+    setStore,
+    notification,
+    scrollToSession,
+    pinned,
+    projectRoot,
+    activeProjectRoot,
+    shellNavigation,
+    unhideProject,
+    projectKeyForSession,
+    layout,
   })
 
   // Run the v7 homepage-draft migration as soon as a directory becomes

--- a/packages/app/src/pages/layout/pawwork-routing-actions.test.ts
+++ b/packages/app/src/pages/layout/pawwork-routing-actions.test.ts
@@ -3,10 +3,6 @@ import { createRoot } from "solid-js"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { createPawworkRoutingActions, type PawworkRoutingActionsInput } from "./pawwork-routing-actions"
 
-// syncSessionRoute schedules a scroll via requestAnimationFrame; keep it a no-op
-// so the synchronous assertions below are not affected by the deferred callback.
-globalThis.requestAnimationFrame ??= (() => 0) as typeof requestAnimationFrame
-
 type Calls = {
   navigate: string[]
   setStore: unknown[][]
@@ -18,6 +14,8 @@ type Calls = {
   openNewSession: (string | undefined)[]
   unhideProject: string[]
   projectsOpen: string[]
+  // Cross-function call order so tests can pin unhide-then-open ordering.
+  order: string[]
 }
 
 function setup(
@@ -34,6 +32,7 @@ function setup(
     openNewSession: [],
     unhideProject: [],
     projectsOpen: [],
+    order: [],
   }
   const store = {
     pawworkProjectHidden: storeOverride.pawworkProjectHidden ?? {},
@@ -47,13 +46,24 @@ function setup(
     notification: { session: { markViewed: (id: string) => calls.markViewed.push(id) } },
     scrollToSession: (id: string, key: string) => calls.scrollToSession.push([id, key]),
     pinned: { adopt: (draft: unknown) => calls.adopt.push(draft) },
-    projectRoot: (directory: string) => directory,
+    // Resolved root differs from the input directory so tests can prove the
+    // new-session slug is built from the original directory, not the root.
+    projectRoot: (directory: string) => `/resolved${directory}`,
     activeProjectRoot: (directory: string) => `root:${directory}`,
     shellNavigation: {
-      openSession: (session: unknown) => calls.openSession.push(session),
-      openNewSession: (directory: string | undefined) => calls.openNewSession.push(directory),
+      openSession: (session: unknown) => {
+        calls.openSession.push(session)
+        calls.order.push("openSession")
+      },
+      openNewSession: (directory: string | undefined) => {
+        calls.openNewSession.push(directory)
+        calls.order.push(`openNewSession:${directory}`)
+      },
     },
-    unhideProject: (key: string) => calls.unhideProject.push(key),
+    unhideProject: (key: string) => {
+      calls.unhideProject.push(key)
+      calls.order.push(`unhide:${key}`)
+    },
     projectKeyForSession: (session: { directory: string }) => session.directory,
     layout: { projects: { open: (directory: string) => calls.projectsOpen.push(directory) } },
   } as unknown as PawworkRoutingActionsInput
@@ -61,13 +71,13 @@ function setup(
 }
 
 describe("createPawworkRoutingActions", () => {
-  test("navigateToSession unhides a hidden project before opening the session", () => {
+  test("navigateToSession unhides a hidden project BEFORE opening the session", () => {
     createRoot((dispose) => {
       const { input, calls } = setup({ pawworkProjectHidden: { "/repo": true } })
       const actions = createPawworkRoutingActions(input)
       const session = { id: "s1", directory: "/repo" }
       actions.navigateToSession(session as never)
-      expect(calls.unhideProject).toEqual(["/repo"])
+      expect(calls.order).toEqual(["unhide:/repo", "openSession"])
       expect(calls.openSession).toEqual([session])
       dispose()
     })
@@ -78,32 +88,42 @@ describe("createPawworkRoutingActions", () => {
       const { input, calls } = setup()
       const actions = createPawworkRoutingActions(input)
       actions.navigateToSession({ id: "s1", directory: "/repo" } as never)
-      expect(calls.unhideProject).toEqual([])
-      expect(calls.openSession).toHaveLength(1)
+      expect(calls.order).toEqual(["openSession"])
       dispose()
     })
   })
 
-  test("openPawworkHome unhides a hidden directory before opening a new session", () => {
+  test("openPawworkHome unhides a hidden directory BEFORE opening a new session", () => {
     createRoot((dispose) => {
       const { input, calls } = setup({ pawworkProjectHidden: { "/repo": true } })
       const actions = createPawworkRoutingActions(input)
       actions.openPawworkHome("/repo")
-      expect(calls.unhideProject).toEqual(["/repo"])
-      expect(calls.openNewSession).toEqual(["/repo"])
+      expect(calls.order).toEqual(["unhide:/repo", "openNewSession:/repo"])
       dispose()
     })
   })
 
-  test("syncSessionRoute returns the resolved root, marks viewed, and expands a collapsed directory", () => {
-    createRoot((dispose) => {
-      const { input, calls } = setup({ workspaceExpanded: { "/repo": false } })
-      const actions = createPawworkRoutingActions(input)
-      expect(actions.syncSessionRoute("/repo", "s1")).toBe("root:/repo")
-      expect(calls.markViewed).toEqual(["s1"])
-      expect(calls.setStore).toContainEqual(["workspaceExpanded", "/repo", true])
-      dispose()
-    })
+  test("syncSessionRoute returns root, marks viewed, expands the directory, and schedules the scroll via rAF", () => {
+    const originalRAF = globalThis.requestAnimationFrame
+    // Run the rAF callback synchronously so the scheduled scroll is observable;
+    // this pins the RAF/untrack ordering that a naive refactor could drop.
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof requestAnimationFrame
+    try {
+      createRoot((dispose) => {
+        const { input, calls } = setup({ workspaceExpanded: { "/repo": false } })
+        const actions = createPawworkRoutingActions(input)
+        expect(actions.syncSessionRoute("/repo", "s1")).toBe("root:/repo")
+        expect(calls.markViewed).toEqual(["s1"])
+        expect(calls.setStore).toContainEqual(["workspaceExpanded", "/repo", true])
+        expect(calls.scrollToSession).toEqual([["s1", "/repo:s1"]])
+        dispose()
+      })
+    } finally {
+      globalThis.requestAnimationFrame = originalRAF
+    }
   })
 
   test("syncSessionRoute honors an explicit root argument", () => {
@@ -115,13 +135,14 @@ describe("createPawworkRoutingActions", () => {
     })
   })
 
-  test("deep-link new-session opens the project without navigating, then navigates to the original slug (not openPawworkHome)", () => {
+  test("deep-link new-session opens the project without navigating, then navigates to the ORIGINAL directory slug (not the resolved root, not openPawworkHome)", () => {
     createRoot((dispose) => {
       const { input, calls } = setup()
       const actions = createPawworkRoutingActions(input)
       actions.handleDeepLinks(["opencode://new-session?directory=/repo&prompt=hello"])
       expect(calls.projectsOpen).toEqual(["/repo"])
       expect(calls.adopt).toEqual([{ directory: "/repo", prompt: "hello" }])
+      // Original directory slug, NOT base64Encode(projectRoot("/repo")) === "/resolved/repo".
       expect(calls.navigate).toEqual([`/${base64Encode("/repo")}/session`])
       expect(calls.openNewSession).toEqual([])
       expect(calls.touch).toEqual([])
@@ -129,13 +150,14 @@ describe("createPawworkRoutingActions", () => {
     })
   })
 
-  test("deep-link open-project routes through openProject into navigateToProject", () => {
+  test("deep-link open-project routes through openProject into navigateToProject (touches the resolved root)", () => {
     createRoot((dispose) => {
       const { input, calls } = setup()
       const actions = createPawworkRoutingActions(input)
       actions.handleDeepLinks(["opencode://open-project?directory=/repo"])
       expect(calls.projectsOpen).toEqual(["/repo"])
-      expect(calls.touch).toEqual(["/repo"])
+      expect(calls.touch).toEqual(["/resolved/repo"])
+      dispose()
     })
   })
 })

--- a/packages/app/src/pages/layout/pawwork-routing-actions.test.ts
+++ b/packages/app/src/pages/layout/pawwork-routing-actions.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { createPawworkRoutingActions, type PawworkRoutingActionsInput } from "./pawwork-routing-actions"
+
+// syncSessionRoute schedules a scroll via requestAnimationFrame; keep it a no-op
+// so the synchronous assertions below are not affected by the deferred callback.
+globalThis.requestAnimationFrame ??= (() => 0) as typeof requestAnimationFrame
+
+type Calls = {
+  navigate: string[]
+  setStore: unknown[][]
+  touch: string[]
+  markViewed: string[]
+  scrollToSession: [string, string][]
+  adopt: unknown[]
+  openSession: unknown[]
+  openNewSession: (string | undefined)[]
+  unhideProject: string[]
+  projectsOpen: string[]
+}
+
+function setup(
+  storeOverride: { pawworkProjectHidden?: Record<string, boolean>; workspaceExpanded?: Record<string, boolean> } = {},
+) {
+  const calls: Calls = {
+    navigate: [],
+    setStore: [],
+    touch: [],
+    markViewed: [],
+    scrollToSession: [],
+    adopt: [],
+    openSession: [],
+    openNewSession: [],
+    unhideProject: [],
+    projectsOpen: [],
+  }
+  const store = {
+    pawworkProjectHidden: storeOverride.pawworkProjectHidden ?? {},
+    workspaceExpanded: storeOverride.workspaceExpanded ?? {},
+  }
+  const input = {
+    navigate: (href: string) => calls.navigate.push(href),
+    server: { isLocal: () => true, projects: { touch: (root: string) => calls.touch.push(root) } },
+    store,
+    setStore: (...args: unknown[]) => calls.setStore.push(args),
+    notification: { session: { markViewed: (id: string) => calls.markViewed.push(id) } },
+    scrollToSession: (id: string, key: string) => calls.scrollToSession.push([id, key]),
+    pinned: { adopt: (draft: unknown) => calls.adopt.push(draft) },
+    projectRoot: (directory: string) => directory,
+    activeProjectRoot: (directory: string) => `root:${directory}`,
+    shellNavigation: {
+      openSession: (session: unknown) => calls.openSession.push(session),
+      openNewSession: (directory: string | undefined) => calls.openNewSession.push(directory),
+    },
+    unhideProject: (key: string) => calls.unhideProject.push(key),
+    projectKeyForSession: (session: { directory: string }) => session.directory,
+    layout: { projects: { open: (directory: string) => calls.projectsOpen.push(directory) } },
+  } as unknown as PawworkRoutingActionsInput
+  return { input, calls, store }
+}
+
+describe("createPawworkRoutingActions", () => {
+  test("navigateToSession unhides a hidden project before opening the session", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ pawworkProjectHidden: { "/repo": true } })
+      const actions = createPawworkRoutingActions(input)
+      const session = { id: "s1", directory: "/repo" }
+      actions.navigateToSession(session as never)
+      expect(calls.unhideProject).toEqual(["/repo"])
+      expect(calls.openSession).toEqual([session])
+      dispose()
+    })
+  })
+
+  test("navigateToSession does not unhide a visible project", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup()
+      const actions = createPawworkRoutingActions(input)
+      actions.navigateToSession({ id: "s1", directory: "/repo" } as never)
+      expect(calls.unhideProject).toEqual([])
+      expect(calls.openSession).toHaveLength(1)
+      dispose()
+    })
+  })
+
+  test("openPawworkHome unhides a hidden directory before opening a new session", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ pawworkProjectHidden: { "/repo": true } })
+      const actions = createPawworkRoutingActions(input)
+      actions.openPawworkHome("/repo")
+      expect(calls.unhideProject).toEqual(["/repo"])
+      expect(calls.openNewSession).toEqual(["/repo"])
+      dispose()
+    })
+  })
+
+  test("syncSessionRoute returns the resolved root, marks viewed, and expands a collapsed directory", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ workspaceExpanded: { "/repo": false } })
+      const actions = createPawworkRoutingActions(input)
+      expect(actions.syncSessionRoute("/repo", "s1")).toBe("root:/repo")
+      expect(calls.markViewed).toEqual(["s1"])
+      expect(calls.setStore).toContainEqual(["workspaceExpanded", "/repo", true])
+      dispose()
+    })
+  })
+
+  test("syncSessionRoute honors an explicit root argument", () => {
+    createRoot((dispose) => {
+      const { input } = setup()
+      const actions = createPawworkRoutingActions(input)
+      expect(actions.syncSessionRoute("/repo", "s1", "explicit-root")).toBe("explicit-root")
+      dispose()
+    })
+  })
+
+  test("deep-link new-session opens the project without navigating, then navigates to the original slug (not openPawworkHome)", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup()
+      const actions = createPawworkRoutingActions(input)
+      actions.handleDeepLinks(["opencode://new-session?directory=/repo&prompt=hello"])
+      expect(calls.projectsOpen).toEqual(["/repo"])
+      expect(calls.adopt).toEqual([{ directory: "/repo", prompt: "hello" }])
+      expect(calls.navigate).toEqual([`/${base64Encode("/repo")}/session`])
+      expect(calls.openNewSession).toEqual([])
+      expect(calls.touch).toEqual([])
+      dispose()
+    })
+  })
+
+  test("deep-link open-project routes through openProject into navigateToProject", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup()
+      const actions = createPawworkRoutingActions(input)
+      actions.handleDeepLinks(["opencode://open-project?directory=/repo"])
+      expect(calls.projectsOpen).toEqual(["/repo"])
+      expect(calls.touch).toEqual(["/repo"])
+    })
+  })
+})

--- a/packages/app/src/pages/layout/pawwork-routing-actions.ts
+++ b/packages/app/src/pages/layout/pawwork-routing-actions.ts
@@ -1,0 +1,132 @@
+import { onMount, untrack } from "solid-js"
+import type { SetStoreFunction } from "solid-js/store"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import type { useServer } from "@/context/server"
+import type { useNotification } from "@/context/notification"
+import type { useLayout } from "@/context/layout"
+import type { usePinnedDraft } from "@/components/prompt-input/pinned-draft"
+import { setSessionHandoff } from "@/pages/session/handoff"
+import { openProjectRoute, workspaceKey } from "./helpers"
+import {
+  collectNewSessionDeepLinks,
+  collectOpenProjectDeepLinks,
+  deepLinkEvent,
+  drainPendingDeepLinks,
+} from "./deep-links"
+import { pawworkSessionRouteUnhideKeys } from "./pawwork-session-source"
+import type { createShellNavigation } from "./shell-navigation"
+import { createDefaultLayoutPageState } from "./layout-page-store"
+
+type LayoutPageState = ReturnType<typeof createDefaultLayoutPageState>
+
+export type PawworkRoutingActionsInput = {
+  navigate: (href: string) => void
+  server: Pick<ReturnType<typeof useServer>, "isLocal" | "projects">
+  store: LayoutPageState
+  setStore: SetStoreFunction<LayoutPageState>
+  notification: Pick<ReturnType<typeof useNotification>, "session">
+  scrollToSession: (sessionId: string, sessionKey: string) => void
+  pinned: Pick<ReturnType<typeof usePinnedDraft>, "adopt">
+  projectRoot: (directory: string) => string
+  activeProjectRoot: (directory: string) => string
+  shellNavigation: Pick<ReturnType<typeof createShellNavigation>, "openSession" | "openNewSession">
+  unhideProject: (projectKey: string) => void
+  projectKeyForSession: (session: Session) => string
+  layout: Pick<ReturnType<typeof useLayout>, "projects">
+}
+
+export function createPawworkRoutingActions(input: PawworkRoutingActionsInput) {
+  function syncSessionRoute(directory: string, id: string, root = input.activeProjectRoot(directory)) {
+    for (const key of pawworkSessionRouteUnhideKeys(directory)) {
+      if (!input.store.pawworkProjectHidden[key]) continue
+      input.unhideProject(key)
+    }
+    input.notification.session.markViewed(id)
+    const expanded = untrack(() => input.store.workspaceExpanded[directory])
+    if (expanded === false) {
+      input.setStore("workspaceExpanded", directory, true)
+    }
+    requestAnimationFrame(() => input.scrollToSession(id, `${directory}:${id}`))
+    return root
+  }
+
+  async function navigateToProject(directory: string | undefined) {
+    if (!directory) return
+    const root = input.projectRoot(directory)
+    input.server.projects.touch(root)
+    input.navigate(openProjectRoute(root))
+  }
+
+  function navigateToSession(session: Session | undefined) {
+    if (session) {
+      const key = input.projectKeyForSession(session)
+      if (input.store.pawworkProjectHidden[key]) {
+        input.unhideProject(key)
+      }
+    }
+    input.shellNavigation.openSession(session)
+  }
+
+  function openPawworkHome(directory?: string) {
+    if (directory) {
+      const key = workspaceKey(directory)
+      if (input.store.pawworkProjectHidden[key]) {
+        input.unhideProject(key)
+      }
+    }
+    input.shellNavigation.openNewSession(directory)
+  }
+
+  function openProject(directory: string, shouldNavigate = true) {
+    input.layout.projects.open(directory)
+    if (shouldNavigate) return navigateToProject(directory)
+  }
+
+  const handleDeepLinks = (urls: string[]) => {
+    if (!input.server.isLocal()) return
+
+    for (const directory of collectOpenProjectDeepLinks(urls)) {
+      openProject(directory)
+    }
+
+    for (const link of collectNewSessionDeepLinks(urls)) {
+      openProject(link.directory, false)
+      const slug = base64Encode(link.directory)
+      if (link.prompt) {
+        // Pin the prompt to this directory so it is NOT carried portably to
+        // other homepages. The pinned slot is consumed by editor-input.ts when
+        // the user lands on the /repo homepage.
+        input.pinned.adopt({ directory: link.directory, prompt: link.prompt })
+        // Also keep the session handoff for the new-session composer region
+        // that shows the prefill text before the session is created (T7 will
+        // decide whether to clear it on submit).
+        setSessionHandoff(slug, { prompt: link.prompt })
+      }
+      const href = `/${slug}/session`
+      input.navigate(href)
+    }
+  }
+
+  onMount(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ urls: string[] }>).detail
+      const urls = detail?.urls ?? []
+      if (urls.length === 0) return
+      handleDeepLinks(urls)
+    }
+
+    handleDeepLinks(drainPendingDeepLinks(window))
+    makeEventListener(window, deepLinkEvent, handler as EventListener)
+  })
+
+  return {
+    syncSessionRoute,
+    navigateToProject,
+    navigateToSession,
+    openPawworkHome,
+    openProject,
+    handleDeepLinks,
+  }
+}


### PR DESCRIPTION
## Summary
Pure extraction (layout governance slice 4, refs #1056) of the pawwork routing actions and deep-link handling out of `packages/app/src/pages/layout.tsx` into `packages/app/src/pages/layout/pawwork-routing-actions.ts`. Design reviewed via /codex consult before implementation.

## What moved (verbatim, no behavior change)
- **Routing actions**: `syncSessionRoute`, `navigateToProject`, `navigateToSession`, `openPawworkHome`, `openProject`
- **Deep-link**: `handleDeepLinks` + the `onMount` that drains pending deep-links and registers the window `deepLinkEvent` listener

Exposed as `createPawworkRoutingActions(input)`. The 5 routing actions are destructured back into layout.tsx with identical names; every call site (startup autoselect `createResource`, keyboard-nav `navigateSessionByOffset`/`navigateSessionByUnseen`, `chooseProject`, active-route effect, command/sidebar config) is byte-unchanged.

## Scope boundary (per /codex design consult)
- `projectRoot` / `activeProjectRoot` / `shellNavigation` **stay in layout.tsx** and are injected as input. `shellNavigation` also serves settings (`openSettings`) and would form a cycle with `projectRoot` if moved; keeping them in layout is the cleanest boundary and matches "layout as composition root".
- Composition layer (`navigateSessionByOffset`/`navigateSessionByUnseen`/`navigateProjectByOffset`) stays in layout — it coordinates slice 1/2/3 controllers.
- `onMount` + deep-link listener live in the controller (precedent: `layout-update-polling.ts`, `layout-sdk-event-effects.ts` register lifecycle internally); `makeEventListener` cleanup stays under the Layout owner.
- **Three behaviors explicitly preserved (codex-flagged)**: deep-link new-session keeps `openProject(dir,false)` + navigate to the original slug (NOT `openPawworkHome`, which would resolve a different project root); `syncSessionRoute` keeps returning `root` (consumed by `activeRoute.sessionProject` dedupe); `navigateToSession` keeps unhide-then-openSession order. The inner `requestAnimationFrame`/`untrack` positions are preserved verbatim.

## Touched files
- `packages/app/src/pages/layout.tsx` (+22 / -90; 1598->1530 lines; removed 5 fn defs + deep-link block + 6 now-unused imports: `openProjectRoute`, the 4 deep-links helpers, `pawworkSessionRouteUnhideKeys`, `setSessionHandoff`)
- `packages/app/src/pages/layout/pawwork-routing-actions.ts` (new, ~130 lines)
- `packages/app/src/pages/layout/pawwork-routing-actions.test.ts` (new, 7 focused tests)

## Verification
- `bun turbo typecheck`: 8/8 pass
- `cd packages/app && bun test src/pages/layout`: 165 pass / 0 fail (7 new routing tests: hidden-project unhide on navigateToSession/openPawworkHome, syncSessionRoute return/markViewed/expand, deep-link new-session uses openProject+slug-navigate not openPawworkHome, deep-link open-project routes through navigateToProject)
- No DOM/copy/aria/command-id/storage-key/styling change. Relying on CI `e2e-artifacts` for rendered routing/deep-link paths.

## Risk
Low. TDZ note: `openProject` is captured by the startup-autoselect `createResource` closure; the fetcher `await`s ready/layout.ready before calling it, so the destructured const is initialized by the time it runs. `layout.tsx` is also touched by open PR #1053 (automation) in non-overlapping regions; #1053 rebases after this merges (per repo owner).

Refs #1056, follow-up to #875.