### PR TITLE
refactor(app): extract pawwork workspace lifecycle from layout.tsx

### DIFF
--- a/packages/app/src/context/global-sync/client-action-source.test.ts
+++ b/packages/app/src/context/global-sync/client-action-source.test.ts
@@ -6,7 +6,10 @@ const settingsProvidersSource = readFileSync(
   new URL("../../components/settings-providers.tsx", import.meta.url),
   "utf8",
 )
-const layoutSource = readFileSync(new URL("../../pages/layout.tsx", import.meta.url), "utf8")
+const workspaceLifecycleSource = readFileSync(
+  new URL("../../pages/layout/pawwork-workspace-lifecycle.ts", import.meta.url),
+  "utf8",
+)
 
 describe("global sync client action provenance wiring", () => {
   test("tags global config updates with client action headers", () => {
@@ -24,8 +27,8 @@ describe("global sync client action provenance wiring", () => {
   })
 
   test("tags workspace reset instance disposal with client action headers", () => {
-    expect(layoutSource).toContain("clientActionHeaders")
-    expect(layoutSource).toContain('kind: "workspace.reset"')
-    expect(layoutSource).toContain("actionClient.instance.dispose")
+    expect(workspaceLifecycleSource).toContain("clientActionHeaders")
+    expect(workspaceLifecycleSource).toContain('kind: "workspace.reset"')
+    expect(workspaceLifecycleSource).toContain("actionClient.instance.dispose")
   })
 })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -29,9 +29,8 @@ import { useSettings } from "@/context/settings"
 import { createStore, produce } from "solid-js/store"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
-import { showToast, toaster } from "@opencode-ai/ui/toast"
+import { showToast } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
-import { clientActionHeaders } from "@/utils/server"
 import { LayoutPageContext } from "@/context/layout-page"
 import { ShellSurfaceContext } from "@/context/shell-surface"
 import { clearWorkspaceTerminals } from "@/context/terminal"
@@ -60,7 +59,6 @@ import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
 import {
   displayName,
-  effectiveWorkspaceOrder,
   errorMessage,
   startupAutoselectDirectory,
   sortedRootSessions,
@@ -78,6 +76,7 @@ import { createPawworkSessionPrefetch } from "./layout/pawwork-session-prefetch"
 import { createPawworkSessionController } from "./layout/pawwork-session-controller"
 import { createPawworkProjectControls } from "./layout/pawwork-project-controls"
 import { createPawworkRoutingActions } from "./layout/pawwork-routing-actions"
+import { createPawworkWorkspaceLifecycle } from "./layout/pawwork-workspace-lifecycle"
 import { type WorkspaceSidebarContext } from "./layout/sidebar-workspace"
 import { PawworkSidebar, type PawworkSidebarSession } from "./layout/pawwork-sidebar"
 import { createDefaultLayoutPageState, createLayoutPagePersistTarget } from "./layout/layout-page-store"
@@ -753,6 +752,32 @@ export default function Layout(props: ParentProps) {
     layout,
   })
 
+  const {
+    renameWorkspace,
+    deleteWorkspace,
+    resetWorkspace,
+    createWorkspace,
+    createCurrentWorkspace,
+    toggleCurrentWorkspace,
+  } = createPawworkWorkspaceLifecycle({
+    globalSDK,
+    globalSync,
+    layout,
+    platform,
+    clearWorkspaceTerminals,
+    store,
+    setStore,
+    navigate,
+    language,
+    params,
+    setBusy,
+    currentDir,
+    currentProject,
+    projectRoot,
+    setWorkspaceName,
+    workspaceName,
+  })
+
   // Run the v7 homepage-draft migration as soon as a directory becomes
   // available (fire-and-forget). currentDir() can be empty during the initial
   // autoselect phase, so onMount alone would skip migration for that session.
@@ -818,12 +843,6 @@ export default function Layout(props: ParentProps) {
     }
 
     globalSync.project.meta(project.worktree, { name })
-  }
-
-  const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {
-    const current = workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
-    if (current === next) return
-    setWorkspaceName(directory, next, projectId, branch)
   }
 
   function closeProject(directory: string) {
@@ -895,143 +914,6 @@ export default function Layout(props: ParentProps) {
           resolve(null)
         })
     }
-  }
-
-  const deleteWorkspace = async (root: string, directory: string, leaveDeletedWorkspace = false) => {
-    if (directory === root) return
-
-    const current = currentDir()
-    const currentKey = workspaceKey(current)
-    const deletedKey = workspaceKey(directory)
-    const shouldLeave = leaveDeletedWorkspace || (!!params.dir && currentKey === deletedKey)
-    if (!leaveDeletedWorkspace && shouldLeave) {
-      navigate(`/${base64Encode(root)}/session`)
-    }
-
-    setBusy(directory, true)
-
-    const result = await globalSDK.client.worktree
-      .remove({ directory: root, worktreeRemoveInput: { directory } })
-      .then((x) => x.data)
-      .catch((err) => {
-        showToast({
-          title: language.t("workspace.delete.failed.title"),
-          description: errorMessage(err, language.t("common.requestFailed")),
-        })
-        return false
-      })
-
-    setBusy(directory, false)
-
-    if (!result) return
-
-    globalSync.set(
-      "project",
-      produce((draft) => {
-        const project = draft.find((item) => item.worktree === root)
-        if (!project) return
-        project.sandboxes = (project.sandboxes ?? []).filter((sandbox) => sandbox !== directory)
-      }),
-    )
-    setStore("workspaceOrder", root, (order) => (order ?? []).filter((workspace) => workspace !== directory))
-
-    layout.projects.close(directory)
-    layout.projects.open(root)
-
-    if (shouldLeave) return
-
-    const nextCurrent = currentDir()
-    const nextKey = workspaceKey(nextCurrent)
-    const project = layout.projects.list().find((item) => item.worktree === root)
-    const dirs = project
-      ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
-      : [root]
-    const valid = dirs.some((item) => workspaceKey(item) === nextKey)
-
-    if (params.dir && projectRoot(nextCurrent) === root && !valid) {
-      navigate(`/${base64Encode(root)}/session`)
-    }
-  }
-
-  const resetWorkspace = async (root: string, directory: string) => {
-    if (directory === root) return
-    setBusy(directory, true)
-
-    const progress = showToast({
-      persistent: true,
-      title: language.t("workspace.resetting.title"),
-      description: language.t("workspace.resetting.description"),
-    })
-    const dismiss = () => toaster.dismiss(progress)
-
-    const sessions: Session[] = await globalSDK.client.session
-      .list({ directory })
-      .then((x) => x.data ?? [])
-      .catch(() => [])
-
-    clearWorkspaceTerminals(
-      directory,
-      sessions.map((s) => s.id),
-      platform,
-    )
-    const actionClient = globalSDK.createClient({
-      headers: clientActionHeaders({ kind: "workspace.reset" }),
-      throwOnError: true,
-    })
-    await actionClient.instance.dispose({ directory }).catch(() => undefined)
-
-    const result = await globalSDK.client.worktree
-      .reset({ directory: root, worktreeResetInput: { directory } })
-      .then((x) => x.data)
-      .catch((err) => {
-        showToast({
-          title: language.t("workspace.reset.failed.title"),
-          description: errorMessage(err, language.t("common.requestFailed")),
-        })
-        return false
-      })
-
-    if (!result) {
-      setBusy(directory, false)
-      dismiss()
-      return
-    }
-
-    const archivedAt = Date.now()
-    await Promise.all(
-      sessions
-        .filter((session) => session.time.archived === undefined)
-        .map((session) =>
-          globalSDK.client.session
-            .update({
-              sessionID: session.id,
-              directory: session.directory,
-              time: { archived: archivedAt },
-            })
-            .catch(() => undefined),
-        ),
-    )
-
-    setBusy(directory, false)
-    dismiss()
-
-    showToast({
-      title: language.t("workspace.reset.success.title"),
-      description: language.t("workspace.reset.success.description"),
-      actions: [
-        {
-          label: language.t("command.session.new"),
-          onClick: () => {
-            const href = `/${base64Encode(directory)}/session`
-            navigate(href)
-          },
-        },
-        {
-          label: language.t("common.dismiss"),
-          onClick: "dismiss",
-        },
-      ],
-    })
   }
 
   function DialogDeleteWorkspace(props: { root: string; directory: string }) {
@@ -1311,60 +1193,6 @@ export default function Layout(props: ParentProps) {
 
   function handleWorkspaceDragEnd() {
     setStore("activeWorkspace", undefined)
-  }
-
-  const createWorkspace = async (project: LocalProject) => {
-    const created = await globalSDK.client.worktree
-      .create({ directory: project.worktree })
-      .then((x) => x.data)
-      .catch((err) => {
-        showToast({
-          title: language.t("workspace.create.failed.title"),
-          description: errorMessage(err, language.t("common.requestFailed")),
-        })
-        return undefined
-      })
-
-    if (!created?.directory) return
-
-    setWorkspaceName(created.directory, created.branch, project.id, created.branch)
-
-    const local = project.worktree
-    const key = workspaceKey(created.directory)
-    const root = workspaceKey(local)
-
-    setBusy(created.directory, true)
-    WorktreeState.pending(created.directory)
-    setStore("workspaceExpanded", key, true)
-    if (key !== created.directory) {
-      setStore("workspaceExpanded", created.directory, true)
-    }
-    setStore("workspaceOrder", project.worktree, (prev) => {
-      const existing = prev ?? []
-      const next = existing.filter((item) => {
-        const id = workspaceKey(item)
-        return id !== root && id !== key
-      })
-      return [created.directory, ...next]
-    })
-
-    globalSync.child(created.directory)
-    navigate(`/${base64Encode(created.directory)}/session`)
-  }
-
-  function createCurrentWorkspace() {
-    const project = currentProject()
-    if (!project) return
-    return createWorkspace(project)
-  }
-
-  function toggleCurrentWorkspace() {
-    const project = currentProject()
-    if (!project) return undefined
-    if (project.vcs !== "git") return undefined
-    const wasEnabled = layout.sidebar.workspaces(project.worktree)()
-    layout.sidebar.toggleWorkspaces(project.worktree)
-    return wasEnabled
   }
 
   registerLayoutCommands({

--- a/packages/app/src/pages/layout/pawwork-workspace-lifecycle.test.ts
+++ b/packages/app/src/pages/layout/pawwork-workspace-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
 import { base64Encode } from "@opencode-ai/util/encode"
+import { toaster } from "@opencode-ai/ui/toast"
 import type { Session } from "@opencode-ai/sdk/v2/client"
 import {
   createPawworkWorkspaceLifecycle,
@@ -41,6 +42,20 @@ type SetupOpts = {
 
 function makeProject(over: Record<string, unknown> = {}) {
   return { worktree: "/repo", id: "p1", vcs: "git", sandboxes: [], ...over }
+}
+
+// resetWorkspace dismisses its persistent "resetting" toast via the module
+// singleton toaster.dismiss (not injected), so spy it directly. Async-aware:
+// restore only after the awaited body settles.
+async function withDismissSpy(fn: (dismissed: unknown[]) => Promise<void>) {
+  const dismissed: unknown[] = []
+  const original = toaster.dismiss
+  toaster.dismiss = ((id: unknown) => dismissed.push(id)) as unknown as typeof toaster.dismiss
+  try {
+    await fn(dismissed)
+  } finally {
+    toaster.dismiss = original
+  }
 }
 
 function setup(opts: SetupOpts = {}) {
@@ -257,6 +272,27 @@ describe("createPawworkWorkspaceLifecycle", () => {
     })
   })
 
+  test("deleteWorkspace with leaveDeletedWorkspace removes + mutates but never navigates (dialog already left)", async () => {
+    await createRoot(async (dispose) => {
+      // currentDir + paramsDir would normally trigger the navigate-away branch;
+      // the leave flag must suppress BOTH the pre-remove navigate and the
+      // post-success validation navigate (shouldLeave early return).
+      const { input, calls } = setup({
+        currentDir: "/repo/.wt/feat",
+        paramsDir: "slug",
+        workspaceOrder: { "/repo": ["/repo", "/repo/.wt/feat"] },
+      })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.deleteWorkspace("/repo", "/repo/.wt/feat", true)
+      expect(calls.navigate).toEqual([])
+      expect(calls.worktreeRemove.length).toBe(1)
+      expect(calls.globalSyncSet.length).toBe(1)
+      expect(calls.projectsClose).toEqual(["/repo/.wt/feat"])
+      expect(calls.projectsOpen).toEqual(["/repo"])
+      dispose()
+    })
+  })
+
   test("deleteWorkspace on remove failure does not mutate or close", async () => {
     await createRoot(async (dispose) => {
       const { input, calls } = setup({ currentDir: "/repo", removeResult: "reject" })
@@ -278,43 +314,53 @@ describe("createPawworkWorkspaceLifecycle", () => {
       { id: "s1", directory: "/repo/.wt/feat", time: { archived: undefined } },
       { id: "s2", directory: "/repo/.wt/feat", time: { archived: 123 } },
     ] as unknown as Session[]
-    await createRoot(async (dispose) => {
-      const { input, calls } = setup({ resetResult: true, sessions })
-      const actions = createPawworkWorkspaceLifecycle(input)
-      await actions.resetWorkspace("/repo", "/repo/.wt/feat")
+    await withDismissSpy(async (dismissed) => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({ resetResult: true, sessions })
+        const actions = createPawworkWorkspaceLifecycle(input)
+        await actions.resetWorkspace("/repo", "/repo/.wt/feat")
 
-      // Terminals are cleared with all session ids before the dispose/reset.
-      expect(calls.clearTerminals).toEqual([["/repo/.wt/feat", ["s1", "s2"], {}]])
-      expect(calls.order.indexOf("clearTerminals")).toBeLessThan(calls.order.indexOf("dispose"))
-      expect(calls.order.indexOf("dispose")).toBeLessThan(calls.order.indexOf("worktree.reset"))
-      expect(calls.dispose).toEqual([{ directory: "/repo/.wt/feat" }])
-      expect(calls.worktreeReset).toEqual([{ directory: "/repo", worktreeResetInput: { directory: "/repo/.wt/feat" } }])
-      // Only s1 (archived === undefined) gets an update.
-      expect(calls.sessionUpdate.length).toBe(1)
-      expect((calls.sessionUpdate[0][0] as { sessionID: string }).sessionID).toBe("s1")
-      // Busy is set true at start and cleared on success.
-      expect(calls.setBusy).toEqual([
-        ["/repo/.wt/feat", true],
-        ["/repo/.wt/feat", false],
-      ])
-      dispose()
+        // Terminals are cleared with all session ids before the dispose/reset.
+        expect(calls.clearTerminals).toEqual([["/repo/.wt/feat", ["s1", "s2"], {}]])
+        expect(calls.order.indexOf("clearTerminals")).toBeLessThan(calls.order.indexOf("dispose"))
+        expect(calls.order.indexOf("dispose")).toBeLessThan(calls.order.indexOf("worktree.reset"))
+        expect(calls.dispose).toEqual([{ directory: "/repo/.wt/feat" }])
+        expect(calls.worktreeReset).toEqual([
+          { directory: "/repo", worktreeResetInput: { directory: "/repo/.wt/feat" } },
+        ])
+        // Only s1 (archived === undefined) gets an update.
+        expect(calls.sessionUpdate.length).toBe(1)
+        expect((calls.sessionUpdate[0][0] as { sessionID: string }).sessionID).toBe("s1")
+        // Busy is set true at start and cleared on success.
+        expect(calls.setBusy).toEqual([
+          ["/repo/.wt/feat", true],
+          ["/repo/.wt/feat", false],
+        ])
+        // The persistent "resetting" toast is dismissed on success.
+        expect(dismissed.length).toBe(1)
+        dispose()
+      })
     })
   })
 
-  test("resetWorkspace on reset failure clears busy and archives nothing", async () => {
+  test("resetWorkspace on reset failure clears busy, dismisses the toast, and archives nothing", async () => {
     const sessions = [
       { id: "s1", directory: "/repo/.wt/feat", time: { archived: undefined } },
     ] as unknown as Session[]
-    await createRoot(async (dispose) => {
-      const { input, calls } = setup({ resetResult: "reject", sessions })
-      const actions = createPawworkWorkspaceLifecycle(input)
-      await actions.resetWorkspace("/repo", "/repo/.wt/feat")
-      expect(calls.sessionUpdate).toEqual([])
-      expect(calls.setBusy).toEqual([
-        ["/repo/.wt/feat", true],
-        ["/repo/.wt/feat", false],
-      ])
-      dispose()
+    await withDismissSpy(async (dismissed) => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({ resetResult: "reject", sessions })
+        const actions = createPawworkWorkspaceLifecycle(input)
+        await actions.resetWorkspace("/repo", "/repo/.wt/feat")
+        expect(calls.sessionUpdate).toEqual([])
+        expect(calls.setBusy).toEqual([
+          ["/repo/.wt/feat", true],
+          ["/repo/.wt/feat", false],
+        ])
+        // Failure branch must still dismiss the persistent "resetting" toast.
+        expect(dismissed.length).toBe(1)
+        dispose()
+      })
     })
   })
 

--- a/packages/app/src/pages/layout/pawwork-workspace-lifecycle.test.ts
+++ b/packages/app/src/pages/layout/pawwork-workspace-lifecycle.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { base64Encode } from "@opencode-ai/util/encode"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import {
+  createPawworkWorkspaceLifecycle,
+  type PawworkWorkspaceLifecycleInput,
+} from "./pawwork-workspace-lifecycle"
+
+type Calls = {
+  navigate: string[]
+  setStore: unknown[][]
+  setBusy: [string, boolean][]
+  setWorkspaceName: unknown[][]
+  globalSyncSet: unknown[]
+  globalSyncChild: string[]
+  projectsClose: string[]
+  projectsOpen: string[]
+  toggleWorkspaces: string[]
+  worktreeCreate: unknown[]
+  worktreeRemove: unknown[]
+  worktreeReset: unknown[]
+  sessionUpdate: unknown[][]
+  dispose: unknown[]
+  clearTerminals: unknown[][]
+  // Cross-call ordering so tests can pin "navigate-before-remove" etc.
+  order: string[]
+}
+
+type SetupOpts = {
+  createResult?: { directory: string; branch: string } | "reject"
+  removeResult?: boolean | "reject"
+  resetResult?: boolean | "reject"
+  sessions?: Session[]
+  currentDir?: string
+  paramsDir?: string
+  currentProject?: unknown
+  workspaceOrder?: Record<string, string[]>
+  workspaceNameValue?: string | undefined
+}
+
+function makeProject(over: Record<string, unknown> = {}) {
+  return { worktree: "/repo", id: "p1", vcs: "git", sandboxes: [], ...over }
+}
+
+function setup(opts: SetupOpts = {}) {
+  const calls: Calls = {
+    navigate: [],
+    setStore: [],
+    setBusy: [],
+    setWorkspaceName: [],
+    globalSyncSet: [],
+    globalSyncChild: [],
+    projectsClose: [],
+    projectsOpen: [],
+    toggleWorkspaces: [],
+    worktreeCreate: [],
+    worktreeRemove: [],
+    worktreeReset: [],
+    sessionUpdate: [],
+    dispose: [],
+    clearTerminals: [],
+    order: [],
+  }
+  const store = {
+    workspaceOrder: opts.workspaceOrder ?? {},
+  }
+  const input = {
+    globalSDK: {
+      client: {
+        worktree: {
+          create: (args: unknown) => {
+            calls.worktreeCreate.push(args)
+            calls.order.push("worktree.create")
+            if (opts.createResult === "reject") return Promise.reject(new Error("create failed"))
+            return Promise.resolve({ data: opts.createResult ?? { directory: "/repo/.wt/feat", branch: "feat" } })
+          },
+          remove: (args: unknown) => {
+            calls.worktreeRemove.push(args)
+            calls.order.push("worktree.remove")
+            if (opts.removeResult === "reject") return Promise.reject(new Error("remove failed"))
+            return Promise.resolve({ data: opts.removeResult ?? true })
+          },
+          reset: (args: unknown) => {
+            calls.worktreeReset.push(args)
+            calls.order.push("worktree.reset")
+            if (opts.resetResult === "reject") return Promise.reject(new Error("reset failed"))
+            return Promise.resolve({ data: opts.resetResult ?? true })
+          },
+        },
+        session: {
+          list: () => Promise.resolve({ data: opts.sessions ?? [] }),
+          update: (args: unknown) => {
+            calls.sessionUpdate.push([args])
+            return Promise.resolve({ data: {} })
+          },
+        },
+      },
+      createClient: () => ({
+        instance: {
+          dispose: (args: unknown) => {
+            calls.dispose.push(args)
+            calls.order.push("dispose")
+            return Promise.resolve({ data: {} })
+          },
+        },
+      }),
+    },
+    globalSync: {
+      child: (directory: string) => {
+        calls.globalSyncChild.push(directory)
+        return [{}] as never
+      },
+      set: (...args: unknown[]) => {
+        calls.globalSyncSet.push(args)
+      },
+    },
+    layout: {
+      projects: {
+        close: (directory: string) => {
+          calls.projectsClose.push(directory)
+          calls.order.push(`close:${directory}`)
+        },
+        open: (directory: string) => {
+          calls.projectsOpen.push(directory)
+          calls.order.push(`open:${directory}`)
+        },
+        list: () => [makeProject()],
+      },
+      sidebar: {
+        workspaces: () => () => true,
+        toggleWorkspaces: (directory: string) => calls.toggleWorkspaces.push(directory),
+      },
+    },
+    platform: {},
+    clearWorkspaceTerminals: (...args: unknown[]) => {
+      calls.clearTerminals.push(args)
+      calls.order.push("clearTerminals")
+    },
+    store,
+    setStore: (...args: unknown[]) => calls.setStore.push(args),
+    navigate: (href: string) => {
+      calls.navigate.push(href)
+      calls.order.push(`navigate:${href}`)
+    },
+    language: { t: (key: string) => key },
+    params: { dir: opts.paramsDir },
+    setBusy: (directory: string, value: boolean) => {
+      calls.setBusy.push([directory, value])
+      calls.order.push(`busy:${directory}:${value}`)
+    },
+    currentDir: () => opts.currentDir ?? "",
+    currentProject: () => opts.currentProject as never,
+    projectRoot: (directory: string) => directory,
+    setWorkspaceName: (...args: unknown[]) => calls.setWorkspaceName.push(args),
+    workspaceName: () => opts.workspaceNameValue,
+  } as unknown as PawworkWorkspaceLifecycleInput
+  return { input, calls, store }
+}
+
+describe("createPawworkWorkspaceLifecycle", () => {
+  test("renameWorkspace skips the write when the name is unchanged", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ workspaceNameValue: "same" })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      actions.renameWorkspace("/repo/wt", "same", "p1", "feat")
+      expect(calls.setWorkspaceName).toEqual([])
+      dispose()
+    })
+  })
+
+  test("renameWorkspace writes all four args when the name changes", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ workspaceNameValue: "old" })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      actions.renameWorkspace("/repo/wt", "new", "p1", "feat")
+      expect(calls.setWorkspaceName).toEqual([["/repo/wt", "new", "p1", "feat"]])
+      dispose()
+    })
+  })
+
+  test("createWorkspace names the worktree, dedups the order, syncs the child, and navigates", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({
+        createResult: { directory: "/repo/.wt/feat", branch: "feat" },
+        workspaceOrder: { "/repo": ["/repo", "/repo/.wt/feat", "/repo/other"] },
+      })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.createWorkspace(makeProject() as never)
+
+      expect(calls.setWorkspaceName).toEqual([["/repo/.wt/feat", "feat", "p1", "feat"]])
+      expect(calls.globalSyncChild).toEqual(["/repo/.wt/feat"])
+      expect(calls.navigate).toEqual([`/${base64Encode("/repo/.wt/feat")}/session`])
+
+      // workspaceOrder updater dedups the created dir + root, prepends created.
+      const orderCall = calls.setStore.find((c) => c[0] === "workspaceOrder")
+      expect(orderCall?.[1]).toBe("/repo")
+      const updater = orderCall?.[2] as (prev: string[]) => string[]
+      expect(updater(["/repo", "/repo/.wt/feat", "/repo/other"])).toEqual(["/repo/.wt/feat", "/repo/other"])
+      dispose()
+    })
+  })
+
+  test("createWorkspace aborts cleanly when the worktree create fails", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({ createResult: "reject" })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.createWorkspace(makeProject() as never)
+      expect(calls.setWorkspaceName).toEqual([])
+      expect(calls.globalSyncChild).toEqual([])
+      expect(calls.navigate).toEqual([])
+      dispose()
+    })
+  })
+
+  test("deleteWorkspace is a no-op when directory equals root", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup()
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.deleteWorkspace("/repo", "/repo")
+      expect(calls.worktreeRemove).toEqual([])
+      expect(calls.setBusy).toEqual([])
+      dispose()
+    })
+  })
+
+  test("deleteWorkspace on success removes, prunes order, and reopens the root", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({
+        currentDir: "/repo",
+        workspaceOrder: { "/repo": ["/repo", "/repo/.wt/feat"] },
+      })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.deleteWorkspace("/repo", "/repo/.wt/feat")
+
+      expect(calls.worktreeRemove).toEqual([{ directory: "/repo", worktreeRemoveInput: { directory: "/repo/.wt/feat" } }])
+      expect(calls.globalSyncSet.length).toBe(1)
+      expect(calls.projectsClose).toEqual(["/repo/.wt/feat"])
+      expect(calls.projectsOpen).toEqual(["/repo"])
+      const orderCall = calls.setStore.find((c) => c[0] === "workspaceOrder")
+      const updater = orderCall?.[2] as (prev: string[]) => string[]
+      expect(updater(["/repo", "/repo/.wt/feat"])).toEqual(["/repo"])
+      dispose()
+    })
+  })
+
+  test("deleteWorkspace navigates away BEFORE removing when deleting the active workspace", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({ currentDir: "/repo/.wt/feat", paramsDir: "slug" })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.deleteWorkspace("/repo", "/repo/.wt/feat")
+      const navIndex = calls.order.indexOf(`navigate:/${base64Encode("/repo")}/session`)
+      const removeIndex = calls.order.indexOf("worktree.remove")
+      expect(navIndex).toBeGreaterThanOrEqual(0)
+      expect(navIndex).toBeLessThan(removeIndex)
+      dispose()
+    })
+  })
+
+  test("deleteWorkspace on remove failure does not mutate or close", async () => {
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({ currentDir: "/repo", removeResult: "reject" })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.deleteWorkspace("/repo", "/repo/.wt/feat")
+      expect(calls.globalSyncSet).toEqual([])
+      expect(calls.projectsClose).toEqual([])
+      // setBusy was toggled true then false around the failed request.
+      expect(calls.setBusy).toEqual([
+        ["/repo/.wt/feat", true],
+        ["/repo/.wt/feat", false],
+      ])
+      dispose()
+    })
+  })
+
+  test("resetWorkspace disposes, resets, and archives only un-archived sessions", async () => {
+    const sessions = [
+      { id: "s1", directory: "/repo/.wt/feat", time: { archived: undefined } },
+      { id: "s2", directory: "/repo/.wt/feat", time: { archived: 123 } },
+    ] as unknown as Session[]
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({ resetResult: true, sessions })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.resetWorkspace("/repo", "/repo/.wt/feat")
+
+      // Terminals are cleared with all session ids before the dispose/reset.
+      expect(calls.clearTerminals).toEqual([["/repo/.wt/feat", ["s1", "s2"], {}]])
+      expect(calls.order.indexOf("clearTerminals")).toBeLessThan(calls.order.indexOf("dispose"))
+      expect(calls.order.indexOf("dispose")).toBeLessThan(calls.order.indexOf("worktree.reset"))
+      expect(calls.dispose).toEqual([{ directory: "/repo/.wt/feat" }])
+      expect(calls.worktreeReset).toEqual([{ directory: "/repo", worktreeResetInput: { directory: "/repo/.wt/feat" } }])
+      // Only s1 (archived === undefined) gets an update.
+      expect(calls.sessionUpdate.length).toBe(1)
+      expect((calls.sessionUpdate[0][0] as { sessionID: string }).sessionID).toBe("s1")
+      // Busy is set true at start and cleared on success.
+      expect(calls.setBusy).toEqual([
+        ["/repo/.wt/feat", true],
+        ["/repo/.wt/feat", false],
+      ])
+      dispose()
+    })
+  })
+
+  test("resetWorkspace on reset failure clears busy and archives nothing", async () => {
+    const sessions = [
+      { id: "s1", directory: "/repo/.wt/feat", time: { archived: undefined } },
+    ] as unknown as Session[]
+    await createRoot(async (dispose) => {
+      const { input, calls } = setup({ resetResult: "reject", sessions })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      await actions.resetWorkspace("/repo", "/repo/.wt/feat")
+      expect(calls.sessionUpdate).toEqual([])
+      expect(calls.setBusy).toEqual([
+        ["/repo/.wt/feat", true],
+        ["/repo/.wt/feat", false],
+      ])
+      dispose()
+    })
+  })
+
+  test("toggleCurrentWorkspace toggles a git project and returns the prior enabled state", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ currentProject: makeProject({ vcs: "git" }) })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      expect(actions.toggleCurrentWorkspace()).toBe(true)
+      expect(calls.toggleWorkspaces).toEqual(["/repo"])
+      dispose()
+    })
+  })
+
+  test("toggleCurrentWorkspace is a no-op for a non-git project", () => {
+    createRoot((dispose) => {
+      const { input, calls } = setup({ currentProject: makeProject({ vcs: "none" }) })
+      const actions = createPawworkWorkspaceLifecycle(input)
+      expect(actions.toggleCurrentWorkspace()).toBeUndefined()
+      expect(calls.toggleWorkspaces).toEqual([])
+      dispose()
+    })
+  })
+
+  test("createCurrentWorkspace creates for the current project and no-ops without one", async () => {
+    await createRoot(async (dispose) => {
+      const withProject = setup({ currentProject: makeProject() })
+      const a1 = createPawworkWorkspaceLifecycle(withProject.input)
+      await a1.createCurrentWorkspace()
+      expect(withProject.calls.worktreeCreate.length).toBe(1)
+
+      const without = setup({ currentProject: undefined })
+      const a2 = createPawworkWorkspaceLifecycle(without.input)
+      await a2.createCurrentWorkspace()
+      expect(without.calls.worktreeCreate).toEqual([])
+      dispose()
+    })
+  })
+})

--- a/packages/app/src/pages/layout/pawwork-workspace-lifecycle.ts
+++ b/packages/app/src/pages/layout/pawwork-workspace-lifecycle.ts
@@ -1,0 +1,245 @@
+import { produce, type SetStoreFunction } from "solid-js/store"
+import { showToast, toaster } from "@opencode-ai/ui/toast"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { getFilename } from "@opencode-ai/util/path"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import type { useGlobalSDK } from "@/context/global-sdk"
+import type { useGlobalSync } from "@/context/global-sync"
+import type { useLayout, LocalProject } from "@/context/layout"
+import type { usePlatform } from "@/context/platform"
+import { Worktree as WorktreeState } from "@/utils/worktree"
+import { clientActionHeaders } from "@/utils/server"
+import { effectiveWorkspaceOrder, errorMessage, workspaceKey } from "./helpers"
+import { createDefaultLayoutPageState } from "./layout-page-store"
+
+type LayoutPageState = ReturnType<typeof createDefaultLayoutPageState>
+
+export type PawworkWorkspaceLifecycleInput = {
+  globalSDK: Pick<ReturnType<typeof useGlobalSDK>, "client" | "createClient">
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child" | "set">
+  layout: Pick<ReturnType<typeof useLayout>, "projects" | "sidebar">
+  platform: ReturnType<typeof usePlatform>
+  // Injected (not imported) so this controller's module graph stays free of
+  // @/context/terminal -> @solidjs/router, which evals client-only templates at
+  // import time and breaks the controller's unit test under the server build.
+  clearWorkspaceTerminals: typeof import("@/context/terminal").clearWorkspaceTerminals
+  store: LayoutPageState
+  setStore: SetStoreFunction<LayoutPageState>
+  navigate: (href: string) => void
+  language: { t: (key: string, params?: Record<string, string | number | boolean>) => string }
+  params: { dir?: string }
+  setBusy: (directory: string, value: boolean) => void
+  currentDir: () => string
+  currentProject: () => LocalProject | undefined
+  projectRoot: (directory: string) => string
+  setWorkspaceName: (directory: string, next: string, projectId?: string, branch?: string) => void
+  workspaceName: (directory: string, projectId?: string, branch?: string) => string | undefined
+}
+
+export function createPawworkWorkspaceLifecycle(input: PawworkWorkspaceLifecycleInput) {
+  const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {
+    const current = input.workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
+    if (current === next) return
+    input.setWorkspaceName(directory, next, projectId, branch)
+  }
+
+  const deleteWorkspace = async (root: string, directory: string, leaveDeletedWorkspace = false) => {
+    if (directory === root) return
+
+    const current = input.currentDir()
+    const currentKey = workspaceKey(current)
+    const deletedKey = workspaceKey(directory)
+    const shouldLeave = leaveDeletedWorkspace || (!!input.params.dir && currentKey === deletedKey)
+    if (!leaveDeletedWorkspace && shouldLeave) {
+      input.navigate(`/${base64Encode(root)}/session`)
+    }
+
+    input.setBusy(directory, true)
+
+    const result = await input.globalSDK.client.worktree
+      .remove({ directory: root, worktreeRemoveInput: { directory } })
+      .then((x) => x.data)
+      .catch((err) => {
+        showToast({
+          title: input.language.t("workspace.delete.failed.title"),
+          description: errorMessage(err, input.language.t("common.requestFailed")),
+        })
+        return false
+      })
+
+    input.setBusy(directory, false)
+
+    if (!result) return
+
+    input.globalSync.set(
+      "project",
+      produce((draft) => {
+        const project = draft.find((item) => item.worktree === root)
+        if (!project) return
+        project.sandboxes = (project.sandboxes ?? []).filter((sandbox) => sandbox !== directory)
+      }),
+    )
+    input.setStore("workspaceOrder", root, (order) => (order ?? []).filter((workspace) => workspace !== directory))
+
+    input.layout.projects.close(directory)
+    input.layout.projects.open(root)
+
+    if (shouldLeave) return
+
+    const nextCurrent = input.currentDir()
+    const nextKey = workspaceKey(nextCurrent)
+    const project = input.layout.projects.list().find((item) => item.worktree === root)
+    const dirs = project
+      ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], input.store.workspaceOrder[root])
+      : [root]
+    const valid = dirs.some((item) => workspaceKey(item) === nextKey)
+
+    if (input.params.dir && input.projectRoot(nextCurrent) === root && !valid) {
+      input.navigate(`/${base64Encode(root)}/session`)
+    }
+  }
+
+  const resetWorkspace = async (root: string, directory: string) => {
+    if (directory === root) return
+    input.setBusy(directory, true)
+
+    const progress = showToast({
+      persistent: true,
+      title: input.language.t("workspace.resetting.title"),
+      description: input.language.t("workspace.resetting.description"),
+    })
+    const dismiss = () => toaster.dismiss(progress)
+
+    const sessions: Session[] = await input.globalSDK.client.session
+      .list({ directory })
+      .then((x) => x.data ?? [])
+      .catch(() => [])
+
+    input.clearWorkspaceTerminals(
+      directory,
+      sessions.map((s) => s.id),
+      input.platform,
+    )
+    const actionClient = input.globalSDK.createClient({
+      headers: clientActionHeaders({ kind: "workspace.reset" }),
+      throwOnError: true,
+    })
+    await actionClient.instance.dispose({ directory }).catch(() => undefined)
+
+    const result = await input.globalSDK.client.worktree
+      .reset({ directory: root, worktreeResetInput: { directory } })
+      .then((x) => x.data)
+      .catch((err) => {
+        showToast({
+          title: input.language.t("workspace.reset.failed.title"),
+          description: errorMessage(err, input.language.t("common.requestFailed")),
+        })
+        return false
+      })
+
+    if (!result) {
+      input.setBusy(directory, false)
+      dismiss()
+      return
+    }
+
+    const archivedAt = Date.now()
+    await Promise.all(
+      sessions
+        .filter((session) => session.time.archived === undefined)
+        .map((session) =>
+          input.globalSDK.client.session
+            .update({
+              sessionID: session.id,
+              directory: session.directory,
+              time: { archived: archivedAt },
+            })
+            .catch(() => undefined),
+        ),
+    )
+
+    input.setBusy(directory, false)
+    dismiss()
+
+    showToast({
+      title: input.language.t("workspace.reset.success.title"),
+      description: input.language.t("workspace.reset.success.description"),
+      actions: [
+        {
+          label: input.language.t("command.session.new"),
+          onClick: () => {
+            const href = `/${base64Encode(directory)}/session`
+            input.navigate(href)
+          },
+        },
+        {
+          label: input.language.t("common.dismiss"),
+          onClick: "dismiss",
+        },
+      ],
+    })
+  }
+
+  const createWorkspace = async (project: LocalProject) => {
+    const created = await input.globalSDK.client.worktree
+      .create({ directory: project.worktree })
+      .then((x) => x.data)
+      .catch((err) => {
+        showToast({
+          title: input.language.t("workspace.create.failed.title"),
+          description: errorMessage(err, input.language.t("common.requestFailed")),
+        })
+        return undefined
+      })
+
+    if (!created?.directory) return
+
+    input.setWorkspaceName(created.directory, created.branch, project.id, created.branch)
+
+    const local = project.worktree
+    const key = workspaceKey(created.directory)
+    const root = workspaceKey(local)
+
+    input.setBusy(created.directory, true)
+    WorktreeState.pending(created.directory)
+    input.setStore("workspaceExpanded", key, true)
+    if (key !== created.directory) {
+      input.setStore("workspaceExpanded", created.directory, true)
+    }
+    input.setStore("workspaceOrder", project.worktree, (prev) => {
+      const existing = prev ?? []
+      const next = existing.filter((item) => {
+        const id = workspaceKey(item)
+        return id !== root && id !== key
+      })
+      return [created.directory, ...next]
+    })
+
+    input.globalSync.child(created.directory)
+    input.navigate(`/${base64Encode(created.directory)}/session`)
+  }
+
+  function createCurrentWorkspace() {
+    const project = input.currentProject()
+    if (!project) return
+    return createWorkspace(project)
+  }
+
+  function toggleCurrentWorkspace() {
+    const project = input.currentProject()
+    if (!project) return undefined
+    if (project.vcs !== "git") return undefined
+    const wasEnabled = input.layout.sidebar.workspaces(project.worktree)()
+    input.layout.sidebar.toggleWorkspaces(project.worktree)
+    return wasEnabled
+  }
+
+  return {
+    renameWorkspace,
+    deleteWorkspace,
+    resetWorkspace,
+    createWorkspace,
+    createCurrentWorkspace,
+    toggleCurrentWorkspace,
+  }
+}


### PR DESCRIPTION
## Summary

Slice 5 of the layout governance line (#1056). Pure extraction: moves the workspace lifecycle actions out of `pages/layout.tsx` into a new controller `pages/layout/pawwork-workspace-lifecycle.ts`.

Extracted (verbatim, `input.`-prefixed): `createWorkspace`, `createCurrentWorkspace`, `deleteWorkspace`, `resetWorkspace`, `renameWorkspace`, `toggleCurrentWorkspace`. `layout.tsx` 1530 → 1358.

No user-visible behavior change (DOM / copy / aria / command IDs / storage keys / styles untouched).

## Touched files
- `packages/app/src/pages/layout.tsx` — remove the 6 functions + now-unused imports (`clearWorkspaceTerminals` re-added and passed as input; `clientActionHeaders`, `effectiveWorkspaceOrder`, `toaster` dropped), wire up the controller destructure.
- `packages/app/src/pages/layout/pawwork-workspace-lifecycle.ts` — new controller (`createPawworkWorkspaceLifecycle`).
- `packages/app/src/pages/layout/pawwork-workspace-lifecycle.test.ts` — 13 new focused tests.

## Review focus
- **Verbatim equivalence** of the 6 extracted functions under `input.` injection.
- **Boundary**: `setWorkspaceName` and `renameProject` stay in `layout.tsx` (already injected into the slice-3 project-controls controller → shared primitives, injected here not moved).
- **`clearWorkspaceTerminals` injected, not imported**: importing `@/context/terminal` pulls `@solidjs/router`, which evals a client-only solid template at module load and breaks the unit test under the server build. Exact type recovered via `typeof import("@/context/terminal").clearWorkspaceTerminals` (type-only, no runtime load).
- **Dead code left untouched**: `closeProject` / `toggleProjectWorkspaces` have zero references across `packages/` — left in place (pure extraction, not cleanup).
- **Reactivity / ordering**: delete navigates-before-remove when deleting the active workspace; reset clears-terminals → dispose → reset → archive ordering.

## Verification
- `bun run typecheck` 8/8
- `cd packages/app && bun test src/pages/layout` → 178 pass (165 prior + 13 new)
- `eslint` clean on changed files

## Risk
Low. Mechanical extraction; behavior preserved and covered by the new tests. The only non-mechanical decision is injecting `clearWorkspaceTerminals` (documented above). #1053 (automation) also touches `pages/layout.tsx` and will rebase on top.

Refs #1056.