### PR TITLE
refactor(app): drop dead project/workspace drag handlers from layout

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -25,7 +25,6 @@ import { Session } from "@opencode-ai/sdk/v2/client"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
 import { createStore, produce } from "solid-js/store"
-import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -52,7 +51,6 @@ import { createMigrationStorageIO } from "@/components/prompt-input/homepage-mig
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme } from "@opencode-ai/ui/theme/context"
 import { useCommand } from "@/context/command"
-import { getDraggableId } from "@/utils/solid-dnd"
 import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
 import {
@@ -1004,28 +1002,6 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
-  function handleDragStart(event: unknown) {
-    const id = getDraggableId(event)
-    if (!id) return
-    setStore("activeProject", id)
-  }
-
-  function handleDragOver(event: DragEvent) {
-    const { draggable, droppable } = event
-    if (draggable && droppable) {
-      const projects = layout.projects.list()
-      const fromIndex = projects.findIndex((p) => p.worktree === draggable.id.toString())
-      const toIndex = projects.findIndex((p) => p.worktree === droppable.id.toString())
-      if (fromIndex !== toIndex && toIndex !== -1) {
-        layout.projects.move(draggable.id.toString(), toIndex)
-      }
-    }
-  }
-
-  function handleDragEnd() {
-    setStore("activeProject", undefined)
-  }
-
   function workspaceIds(project: LocalProject | undefined) {
     return pawworkSessionDirectories({
       project,
@@ -1033,42 +1009,6 @@ export default function Layout(props: ParentProps) {
       currentDirectory: currentDir(),
       workspaceOrder: project ? store.workspaceOrder[project.worktree] : undefined,
     })
-  }
-
-  const sidebarProject = createMemo(() => currentProject())
-
-  function handleWorkspaceDragStart(event: unknown) {
-    const id = getDraggableId(event)
-    if (!id) return
-    setStore("activeWorkspace", id)
-  }
-
-  function handleWorkspaceDragOver(event: DragEvent) {
-    const { draggable, droppable } = event
-    if (!draggable || !droppable) return
-
-    const project = sidebarProject()
-    if (!project) return
-
-    const ids = workspaceIds(project)
-    const fromIndex = ids.findIndex((dir) => dir === draggable.id.toString())
-    const toIndex = ids.findIndex((dir) => dir === droppable.id.toString())
-    if (fromIndex === -1 || toIndex === -1) return
-    if (fromIndex === toIndex) return
-
-    const result = ids.slice()
-    const [item] = result.splice(fromIndex, 1)
-    if (!item) return
-    result.splice(toIndex, 0, item)
-    setStore(
-      "workspaceOrder",
-      project.worktree,
-      result.filter((directory) => workspaceKey(directory) !== workspaceKey(project.worktree)),
-    )
-  }
-
-  function handleWorkspaceDragEnd() {
-    setStore("activeWorkspace", undefined)
   }
 
   registerLayoutCommands({

--- a/packages/app/src/pages/layout/layout-page-store.ts
+++ b/packages/app/src/pages/layout/layout-page-store.ts
@@ -60,8 +60,6 @@ function hasLayoutPageFields(value: Record<string, unknown>) {
 
 export function createDefaultLayoutPageState() {
   return {
-    activeProject: undefined as string | undefined,
-    activeWorkspace: undefined as string | undefined,
     workspaceOrder: {} as Record<string, string[]>,
     workspaceName: {} as Record<string, string>,
     workspaceBranchName: {} as Record<string, Record<string, string>>,


### PR DESCRIPTION
## Summary

Slice 7 of the #1056 layout governance line. Investigation showed this slice ("workspace drag/drop") is **not** an extraction target — the handlers are dead code, so this is a removal PR.

- Removed six handlers from the `Layout` component: `handleDragStart` / `handleDragOver` / `handleDragEnd` (project drag) and `handleWorkspaceDragStart` / `handleWorkspaceDragOver` / `handleWorkspaceDragEnd` (workspace drag). They are local closures that are **never** wired into JSX or passed as props, so they are unreachable.
- Removed the two transient store fields they wrote — `activeProject` / `activeWorkspace` (in `layout-page-store.ts`) — which are read **nowhere** in the app.
- Removed the now-unused imports `getDraggableId` (`@/utils/solid-dnd`) and the `DragEvent` type (`@thisbeyond/solid-dnd`).
- Kept `workspaceIds` — it still feeds a live filter (`layout.tsx`, project session list).

### Why these are dead
Sidebar drag/drop is now handled **inside** `pawwork-sidebar-drag.ts` via `createSortableAttacher` + the `onDragSession` prop; the layout handlers are leftovers from the pre-rewrite implementation. `git log -S` confirms the symbols trace back to the upstream `initial` import and were last touched (but not removed) by a prior cleanup (`57ee5b4b91 chore(app): drop dead SidebarPanel and orphan imports`). Pickaxe for any prop wiring (`onDragStart={handleDragStart}`, `onWorkspaceDragStart`) returns zero hits across the file's history.

No user-visible behavior / DOM / copy / aria / command ID / **storage key** / style change — the dropped store fields were always `undefined` and never persisted meaningfully, and the localStorage `layout-page` key is untouched.

`layout.tsx` 1234 -> 1174.

## Test plan
- [x] `bun run typecheck` (8/8)
- [x] `eslint` on changed files (clean)
- [x] `bun test src/pages/layout` (179 pass)
- [x] source-guard tests reading layout.tsx: `shell-frame-contract.test.ts` + `update-install-flow-source.test.ts` (13 pass)
- [ ] CI required checks green

Refs #1056.