### PR TITLE
refactor(app): extract pawwork session commands from layout

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -31,10 +31,8 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { LayoutPageContext } from "@/context/layout-page"
 import { ShellSurfaceContext } from "@/context/shell-surface"
 import { clearWorkspaceTerminals } from "@/context/terminal"
-import { dropSessionCaches } from "@/context/global-sync/session-cache"
 import { useNotification } from "@/context/notification"
 import { usePermission } from "@/context/permission"
-import { Binary } from "@opencode-ai/util/binary"
 import { playSoundById } from "@/utils/sound"
 import { setNavigate } from "@/utils/notification-click"
 import { setOpenSettings } from "@/utils/settings-navigation"
@@ -61,6 +59,7 @@ import {
   workspaceKey,
 } from "./layout/helpers"
 import { createInlineEditorController } from "./layout/inline-editor"
+import { createPawworkSessionCommands, type SessionDeleteTarget } from "./layout/pawwork-session-commands"
 import { pawworkSessionDirectories } from "./layout/pawwork-session-source"
 import { findPawworkSessionNavigationTarget } from "./layout/pawwork-session-nav"
 import { createShellNavigation } from "./layout/shell-navigation"
@@ -452,32 +451,6 @@ export default function Layout(props: ParentProps) {
     navigateToSession(session)
   }
 
-  async function renamePawworkSession(session: Session, next: string) {
-    const title = next.trim()
-    if (!title || title === (session.title ?? "")) return
-
-    try {
-      await globalSDK.client.session.update({
-        directory: session.directory,
-        sessionID: session.id,
-        title,
-      })
-
-      const [, setStore] = globalSync.child(session.directory)
-      setStore(
-        produce((draft) => {
-          const match = Binary.search(draft.session, session.id, (item) => item.id)
-          if (match.found) draft.session[match.index].title = title
-        }),
-      )
-    } catch (error) {
-      showToast({
-        title: language.t("common.requestFailed"),
-        description: errorMessage(error, language.t("common.requestFailed")),
-      })
-    }
-  }
-
   const {
     togglePinnedSession,
     dragPawworkSession,
@@ -498,111 +471,15 @@ export default function Layout(props: ParentProps) {
     setWorkspaceName,
   })
 
-  // Export hits the embedded sidecar via main-process IPC. When the user has
-  // switched the active server to a remote target, the sidecar holds different
-  // data than the UI; hide the action rather than ship a misleading export.
-  const exportSessionAvailable = createMemo(
-    () => !!platform.exportSession && server.current?.type === "sidecar",
-  )
-
-  async function exportSession(session: Session) {
-    if (!platform.exportSession) return
-    const [store] = globalSync.child(session.directory)
-    const sessionInfo = store.session?.find((s) => s.id === session.id)
-    const slugSource = sessionInfo?.slug ?? session.id
-    const sanitized = slugSource.replace(/[\\/:*?"<>|]/g, "-").slice(0, 32)
-    const slug = /[\p{L}\p{N}]/u.test(sanitized) ? sanitized : session.id.slice(-8)
-    const stamp = new Date().toISOString().replace(/[:T]/g, "-").replace(/\..+$/, "")
-    const defaultName = `pawwork-session-${slug}-${stamp}.json`
-
-    let result: { ok: true; path: string } | { ok: false; error: string }
-    try {
-      result = await platform.exportSession(
-        session.id,
-        session.directory,
-        defaultName,
-        language.t("session.export.action.export"),
-      )
-    } catch (err) {
-      showToast({
-        title: language.t("session.export.error.failed"),
-        description: errorMessage(err, language.t("common.requestFailed")),
-        variant: "error",
-      })
-      return
-    }
-    if (!result.ok) {
-      if (result.error === "cancelled") return
-      showToast({
-        title: language.t("session.export.error.failed"),
-        description: result.error,
-        variant: "error",
-      })
-      return
-    }
-    showToast({
-      title: language.t("session.export.success"),
-      description: result.path,
-    })
-  }
-
-  type SessionDeleteTarget = Pick<Session, "id" | "directory">
-
-  async function deleteSession(session: SessionDeleteTarget) {
-    const [store, setStore] = globalSync.child(session.directory)
-    const sessions = (store.session ?? []).filter((s) => !s.parentID && !s.time?.archived)
-    const index = sessions.findIndex((s) => s.id === session.id)
-    const nextSession = index === -1 ? undefined : (sessions[index + 1] ?? sessions[index - 1])
-
-    const result = await globalSDK.client.session
-      .delete({ directory: session.directory, sessionID: session.id })
-      .then((x) => x.data)
-      .catch((err) => {
-        showToast({
-          title: language.t("session.delete.failed.title"),
-          description: errorMessage(err, language.t("common.requestFailed")),
-          variant: "error",
-        })
-        return undefined
-      })
-
-    if (!result) return
-
-    setStore(
-      produce((draft) => {
-        const removed = new Set<string>([session.id])
-        const byParent = new Map<string, string[]>()
-        for (const item of draft.session) {
-          const parentID = item.parentID
-          if (!parentID) continue
-          const existing = byParent.get(parentID)
-          if (existing) {
-            existing.push(item.id)
-            continue
-          }
-          byParent.set(parentID, [item.id])
-        }
-        const stack = [session.id]
-        while (stack.length) {
-          const parentID = stack.pop()
-          if (!parentID) continue
-          const children = byParent.get(parentID)
-          if (!children) continue
-          for (const child of children) {
-            if (removed.has(child)) continue
-            removed.add(child)
-            stack.push(child)
-          }
-        }
-        dropSessionCaches(draft, [...removed])
-        draft.session = draft.session.filter((s) => !removed.has(s.id))
-      }),
-    )
-
-    if (session.id === params.id) {
-      navigate(nextSession ? `/${params.dir}/session/${nextSession.id}` : `/${params.dir}/session`)
-    }
-  }
+  const { exportSessionAvailable, renamePawworkSession, exportSession, deleteSession } = createPawworkSessionCommands({
+    globalSDK,
+    globalSync,
+    platform,
+    server,
+    language,
+    navigate,
+    params,
+  })
 
   function confirmDeleteSession(session: Session) {
     const target: SessionDeleteTarget = { id: session.id, directory: session.directory }

--- a/packages/app/src/pages/layout/pawwork-session-commands.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-commands.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { toaster } from "@opencode-ai/ui/toast"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { createPawworkSessionCommands, type PawworkSessionCommandsInput } from "./pawwork-session-commands"
+
+// showToast renders through the module-singleton toaster.show (not injected);
+// spy it to count toasts. The render closure is never invoked, so no JSX runs.
+async function withToastSpy(fn: (shown: unknown[]) => Promise<void>) {
+  const shown: unknown[] = []
+  const original = toaster.show
+  toaster.show = ((render: unknown) => {
+    shown.push(render)
+    return "toast-id"
+  }) as unknown as typeof toaster.show
+  try {
+    await fn(shown)
+  } finally {
+    toaster.show = original
+  }
+}
+
+type SetupOpts = {
+  sessions?: unknown[]
+  updateReject?: boolean
+  deleteReject?: boolean
+  deleteResult?: unknown
+  exportSession?: PawworkSessionCommandsInput["platform"]["exportSession"]
+  exportResult?: { ok: true; path: string } | { ok: false; error: string }
+  exportThrow?: boolean
+  serverCurrent?: { type: string } | undefined
+  paramsId?: string
+  paramsDir?: string
+}
+
+function setup(opts: SetupOpts = {}) {
+  const calls = {
+    sessionUpdate: [] as unknown[],
+    sessionDelete: [] as unknown[],
+    child: [] as string[],
+    navigate: [] as string[],
+    exportArgs: [] as unknown[][],
+  }
+  const [childStore, setChildStore] = createStore<{
+    session: unknown[]
+    session_status: Record<string, unknown>
+    turn_change_aggregate: Record<string, unknown>
+    todo: Record<string, unknown>
+    message: Record<string, unknown>
+    part: Record<string, unknown>
+    permission: Record<string, unknown>
+  }>({
+    session: opts.sessions ?? [],
+    session_status: {},
+    turn_change_aggregate: {},
+    todo: {},
+    message: {},
+    part: {},
+    permission: {},
+  })
+  const defaultExport = ((id: string, dir: string, name: string, label: string) => {
+    calls.exportArgs.push([id, dir, name, label])
+    if (opts.exportThrow) return Promise.reject(new Error("export crashed"))
+    return Promise.resolve(opts.exportResult ?? { ok: true, path: "/out/file.json" })
+  }) as unknown as PawworkSessionCommandsInput["platform"]["exportSession"]
+  // Distinguish "explicitly no bridge" (exportSession: undefined) from "default".
+  const exportSession = "exportSession" in opts ? opts.exportSession : defaultExport
+  const input = {
+    globalSDK: {
+      client: {
+        session: {
+          update: (args: unknown) => {
+            calls.sessionUpdate.push(args)
+            if (opts.updateReject) return Promise.reject(new Error("update failed"))
+            return Promise.resolve({ data: {} })
+          },
+          delete: (args: unknown) => {
+            calls.sessionDelete.push(args)
+            if (opts.deleteReject) return Promise.reject(new Error("delete failed"))
+            return Promise.resolve({ data: opts.deleteResult ?? { ok: true } })
+          },
+        },
+      },
+    },
+    globalSync: {
+      child: (directory: string) => {
+        calls.child.push(directory)
+        return [childStore, setChildStore] as never
+      },
+    },
+    platform: { exportSession },
+    server: { current: opts.serverCurrent },
+    language: { t: (key: string) => key },
+    navigate: (href: string) => calls.navigate.push(href),
+    params: { id: opts.paramsId, dir: opts.paramsDir },
+  } as unknown as PawworkSessionCommandsInput
+  return { input, calls, childStore }
+}
+
+const makeSession = (over: Record<string, unknown> = {}) =>
+  ({ id: "s1", directory: "/repo", title: "old", ...over }) as unknown as Session
+
+describe("createPawworkSessionCommands", () => {
+  test("renamePawworkSession skips the write for an empty or unchanged title", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup()
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.renamePawworkSession(makeSession({ title: "kept" }), "   ")
+        await cmd.renamePawworkSession(makeSession({ title: "kept" }), "kept")
+        expect(calls.sessionUpdate).toEqual([])
+        expect(shown.length).toBe(0)
+        dispose()
+      })
+    })
+  })
+
+  test("renamePawworkSession updates the server and the child store title", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls, childStore } = setup({
+          sessions: [{ id: "s1", title: "old" }],
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.renamePawworkSession(makeSession({ id: "s1", directory: "/repo", title: "old" }), "  fresh  ")
+        expect(calls.sessionUpdate).toEqual([{ directory: "/repo", sessionID: "s1", title: "fresh" }])
+        expect((childStore.session[0] as { title: string }).title).toBe("fresh")
+        expect(shown.length).toBe(0)
+        dispose()
+      })
+    })
+  })
+
+  test("renamePawworkSession surfaces a toast and leaves the store on failure", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, childStore } = setup({
+          sessions: [{ id: "s1", title: "old" }],
+          updateReject: true,
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.renamePawworkSession(makeSession({ id: "s1", title: "old" }), "fresh")
+        expect((childStore.session[0] as { title: string }).title).toBe("old")
+        expect(shown.length).toBe(1)
+        dispose()
+      })
+    })
+  })
+
+  test("exportSessionAvailable requires platform export and a sidecar server", () => {
+    createRoot((dispose) => {
+      const sidecar = setup({ exportSession: (() => Promise.resolve({ ok: true, path: "" })) as never, serverCurrent: { type: "sidecar" } })
+      expect(createPawworkSessionCommands(sidecar.input).exportSessionAvailable()).toBe(true)
+
+      const remote = setup({ exportSession: (() => Promise.resolve({ ok: true, path: "" })) as never, serverCurrent: { type: "remote" } })
+      expect(createPawworkSessionCommands(remote.input).exportSessionAvailable()).toBe(false)
+
+      const noExport = setup({ exportSession: undefined, serverCurrent: { type: "sidecar" } })
+      expect(createPawworkSessionCommands(noExport.input).exportSessionAvailable()).toBe(false)
+      dispose()
+    })
+  })
+
+  test("exportSession is a no-op without a platform export bridge", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({ exportSession: undefined })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.exportSession(makeSession())
+        expect(calls.exportArgs).toEqual([])
+        expect(shown.length).toBe(0)
+        dispose()
+      })
+    })
+  })
+
+  test("exportSession builds a slug filename and toasts the path on success", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [{ id: "s1", slug: "hello-world" }],
+          exportResult: { ok: true, path: "/out/done.json" },
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.exportSession(makeSession({ id: "s1" }))
+        const defaultName = calls.exportArgs[0][2] as string
+        expect(defaultName.startsWith("pawwork-session-hello-world-")).toBe(true)
+        expect(defaultName.endsWith(".json")).toBe(true)
+        expect(shown.length).toBe(1)
+        dispose()
+      })
+    })
+  })
+
+  test("exportSession falls back to the session id suffix when the slug has no alphanumerics", async () => {
+    await withToastSpy(async () => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [{ id: "sess_abcd1234", slug: "***" }],
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.exportSession(makeSession({ id: "sess_abcd1234" }))
+        const defaultName = calls.exportArgs[0][2] as string
+        expect(defaultName.includes("abcd1234")).toBe(true)
+        dispose()
+      })
+    })
+  })
+
+  test("exportSession stays silent when the user cancels", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input } = setup({
+          sessions: [{ id: "s1", slug: "hi" }],
+          exportResult: { ok: false, error: "cancelled" },
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.exportSession(makeSession({ id: "s1" }))
+        expect(shown.length).toBe(0)
+        dispose()
+      })
+    })
+  })
+
+  test("exportSession toasts on a thrown bridge error and on a non-cancel failure", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const thrown = setup({ sessions: [{ id: "s1", slug: "hi" }], exportThrow: true })
+        await createPawworkSessionCommands(thrown.input).exportSession(makeSession({ id: "s1" }))
+        const failed = setup({ sessions: [{ id: "s1", slug: "hi" }], exportResult: { ok: false, error: "disk full" } })
+        await createPawworkSessionCommands(failed.input).exportSession(makeSession({ id: "s1" }))
+        expect(shown.length).toBe(2)
+        dispose()
+      })
+    })
+  })
+
+  test("deleteSession cascades to descendants, drops them from the store, and navigates the active route", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls, childStore } = setup({
+          sessions: [
+            { id: "p", directory: "/repo", parentID: undefined, time: {} },
+            { id: "c1", directory: "/repo", parentID: "p", time: {} },
+            { id: "c2", directory: "/repo", parentID: "c1", time: {} },
+            { id: "keep", directory: "/repo", parentID: undefined, time: {} },
+          ],
+          paramsId: "p",
+          paramsDir: "dirslug",
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.deleteSession({ id: "p", directory: "/repo" })
+
+        expect(calls.sessionDelete).toEqual([{ directory: "/repo", sessionID: "p" }])
+        const remaining = (childStore.session as { id: string }[]).map((s) => s.id)
+        expect(remaining).toEqual(["keep"])
+        // p was the active session and is the first top-level; next is "keep".
+        expect(calls.navigate).toEqual(["/dirslug/session/keep"])
+        expect(shown.length).toBe(0)
+        dispose()
+      })
+    })
+  })
+
+  test("deleteSession does not navigate when the deleted session is not the active one", async () => {
+    await withToastSpy(async () => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [
+            { id: "p", directory: "/repo", parentID: undefined, time: {} },
+            { id: "other", directory: "/repo", parentID: undefined, time: {} },
+          ],
+          paramsId: "other",
+          paramsDir: "dirslug",
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.deleteSession({ id: "p", directory: "/repo" })
+        expect(calls.navigate).toEqual([])
+        dispose()
+      })
+    })
+  })
+
+  test("deleteSession falls back to the bare session route when no sibling remains", async () => {
+    await withToastSpy(async () => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [{ id: "only", directory: "/repo", parentID: undefined, time: {} }],
+          paramsId: "only",
+          paramsDir: "dirslug",
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.deleteSession({ id: "only", directory: "/repo" })
+        expect(calls.navigate).toEqual(["/dirslug/session"])
+        dispose()
+      })
+    })
+  })
+
+  test("deleteSession toasts and leaves the store untouched when the request fails", async () => {
+    await withToastSpy(async (shown) => {
+      await createRoot(async (dispose) => {
+        const { input, calls, childStore } = setup({
+          sessions: [{ id: "p", directory: "/repo", parentID: undefined, time: {} }],
+          paramsId: "p",
+          paramsDir: "dirslug",
+          deleteReject: true,
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.deleteSession({ id: "p", directory: "/repo" })
+        expect((childStore.session as { id: string }[]).map((s) => s.id)).toEqual(["p"])
+        expect(calls.navigate).toEqual([])
+        expect(shown.length).toBe(1)
+        dispose()
+      })
+    })
+  })
+})

--- a/packages/app/src/pages/layout/pawwork-session-commands.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-commands.test.ts
@@ -193,6 +193,21 @@ describe("createPawworkSessionCommands", () => {
     })
   })
 
+  test("exportSession sanitizes filesystem-hostile slug characters", async () => {
+    await withToastSpy(async () => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [{ id: "s1", slug: 'a/b:c*?"<>|d' }],
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.exportSession(makeSession({ id: "s1" }))
+        const defaultName = calls.exportArgs[0][2] as string
+        expect(defaultName.startsWith("pawwork-session-a-b-c------d-")).toBe(true)
+        dispose()
+      })
+    })
+  })
+
   test("exportSession falls back to the session id suffix when the slug has no alphanumerics", async () => {
     await withToastSpy(async () => {
       await createRoot(async (dispose) => {
@@ -277,6 +292,28 @@ describe("createPawworkSessionCommands", () => {
         const cmd = createPawworkSessionCommands(input)
         await cmd.deleteSession({ id: "p", directory: "/repo" })
         expect(calls.navigate).toEqual([])
+        dispose()
+      })
+    })
+  })
+
+  test("deleteSession navigates to the previous sibling when the deleted session is last, skipping archived ones", async () => {
+    await withToastSpy(async () => {
+      await createRoot(async (dispose) => {
+        const { input, calls } = setup({
+          sessions: [
+            { id: "a", directory: "/repo", parentID: undefined, time: {} },
+            { id: "b", directory: "/repo", parentID: undefined, time: {} },
+            { id: "arch", directory: "/repo", parentID: undefined, time: { archived: 123 } },
+          ],
+          paramsId: "b",
+          paramsDir: "dirslug",
+        })
+        const cmd = createPawworkSessionCommands(input)
+        await cmd.deleteSession({ id: "b", directory: "/repo" })
+        // "b" is the last non-archived top-level; next falls back to the prior
+        // sibling "a" (archived "arch" is excluded from the candidate list).
+        expect(calls.navigate).toEqual(["/dirslug/session/a"])
         dispose()
       })
     })

--- a/packages/app/src/pages/layout/pawwork-session-commands.ts
+++ b/packages/app/src/pages/layout/pawwork-session-commands.ts
@@ -1,0 +1,157 @@
+import { createMemo } from "solid-js"
+import { produce } from "solid-js/store"
+import { Binary } from "@opencode-ai/util/binary"
+import { showToast } from "@opencode-ai/ui/toast"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import type { useGlobalSDK } from "@/context/global-sdk"
+import type { useGlobalSync } from "@/context/global-sync"
+import type { usePlatform } from "@/context/platform"
+import type { useServer } from "@/context/server"
+import { dropSessionCaches } from "@/context/global-sync/session-cache"
+import { errorMessage } from "./helpers"
+
+export type SessionDeleteTarget = Pick<Session, "id" | "directory">
+
+export type PawworkSessionCommandsInput = {
+  globalSDK: Pick<ReturnType<typeof useGlobalSDK>, "client">
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child">
+  platform: Pick<ReturnType<typeof usePlatform>, "exportSession">
+  server: Pick<ReturnType<typeof useServer>, "current">
+  language: { t: (key: string, params?: Record<string, string | number | boolean>) => string }
+  navigate: (href: string) => void
+  params: { id?: string; dir?: string }
+}
+
+export function createPawworkSessionCommands(input: PawworkSessionCommandsInput) {
+  async function renamePawworkSession(session: Session, next: string) {
+    const title = next.trim()
+    if (!title || title === (session.title ?? "")) return
+
+    try {
+      await input.globalSDK.client.session.update({
+        directory: session.directory,
+        sessionID: session.id,
+        title,
+      })
+
+      const [, setStore] = input.globalSync.child(session.directory)
+      setStore(
+        produce((draft) => {
+          const match = Binary.search(draft.session, session.id, (item) => item.id)
+          if (match.found) draft.session[match.index].title = title
+        }),
+      )
+    } catch (error) {
+      showToast({
+        title: input.language.t("common.requestFailed"),
+        description: errorMessage(error, input.language.t("common.requestFailed")),
+      })
+    }
+  }
+
+  // Export hits the embedded sidecar via main-process IPC. When the user has
+  // switched the active server to a remote target, the sidecar holds different
+  // data than the UI; hide the action rather than ship a misleading export.
+  const exportSessionAvailable = createMemo(
+    () => !!input.platform.exportSession && input.server.current?.type === "sidecar",
+  )
+
+  async function exportSession(session: Session) {
+    if (!input.platform.exportSession) return
+    const [store] = input.globalSync.child(session.directory)
+    const sessionInfo = store.session?.find((s) => s.id === session.id)
+    const slugSource = sessionInfo?.slug ?? session.id
+    const sanitized = slugSource.replace(/[\\/:*?"<>|]/g, "-").slice(0, 32)
+    const slug = /[\p{L}\p{N}]/u.test(sanitized) ? sanitized : session.id.slice(-8)
+    const stamp = new Date().toISOString().replace(/[:T]/g, "-").replace(/\..+$/, "")
+    const defaultName = `pawwork-session-${slug}-${stamp}.json`
+
+    let result: { ok: true; path: string } | { ok: false; error: string }
+    try {
+      result = await input.platform.exportSession(
+        session.id,
+        session.directory,
+        defaultName,
+        input.language.t("session.export.action.export"),
+      )
+    } catch (err) {
+      showToast({
+        title: input.language.t("session.export.error.failed"),
+        description: errorMessage(err, input.language.t("common.requestFailed")),
+        variant: "error",
+      })
+      return
+    }
+    if (!result.ok) {
+      if (result.error === "cancelled") return
+      showToast({
+        title: input.language.t("session.export.error.failed"),
+        description: result.error,
+        variant: "error",
+      })
+      return
+    }
+    showToast({
+      title: input.language.t("session.export.success"),
+      description: result.path,
+    })
+  }
+
+  async function deleteSession(session: SessionDeleteTarget) {
+    const [store, setStore] = input.globalSync.child(session.directory)
+    const sessions = (store.session ?? []).filter((s) => !s.parentID && !s.time?.archived)
+    const index = sessions.findIndex((s) => s.id === session.id)
+    const nextSession = index === -1 ? undefined : (sessions[index + 1] ?? sessions[index - 1])
+
+    const result = await input.globalSDK.client.session
+      .delete({ directory: session.directory, sessionID: session.id })
+      .then((x) => x.data)
+      .catch((err) => {
+        showToast({
+          title: input.language.t("session.delete.failed.title"),
+          description: errorMessage(err, input.language.t("common.requestFailed")),
+          variant: "error",
+        })
+        return undefined
+      })
+
+    if (!result) return
+
+    setStore(
+      produce((draft) => {
+        const removed = new Set<string>([session.id])
+        const byParent = new Map<string, string[]>()
+        for (const item of draft.session) {
+          const parentID = item.parentID
+          if (!parentID) continue
+          const existing = byParent.get(parentID)
+          if (existing) {
+            existing.push(item.id)
+            continue
+          }
+          byParent.set(parentID, [item.id])
+        }
+        const stack = [session.id]
+        while (stack.length) {
+          const parentID = stack.pop()
+          if (!parentID) continue
+          const children = byParent.get(parentID)
+          if (!children) continue
+          for (const child of children) {
+            if (removed.has(child)) continue
+            removed.add(child)
+            stack.push(child)
+          }
+        }
+        dropSessionCaches(draft, [...removed])
+        draft.session = draft.session.filter((s) => !removed.has(s.id))
+      }),
+    )
+
+    if (session.id === input.params.id) {
+      input.navigate(nextSession ? `/${input.params.dir}/session/${nextSession.id}` : `/${input.params.dir}/session`)
+    }
+  }
+
+  return { exportSessionAvailable, renamePawworkSession, exportSession, deleteSession }
+}


### PR DESCRIPTION
## Summary

Slice 8 of the #1056 layout governance line. Extracts the session **mutation command** cluster out of the `Layout` component into a new injectable factory, `pages/layout/pawwork-session-commands.ts` → `createPawworkSessionCommands(input)`:

- `renamePawworkSession` — server `session.update` + child-store title write (via `Binary.search`), toast on failure.
- `exportSessionAvailable` — memo gating export to a sidecar server with a platform export bridge.
- `exportSession` — slug/timestamp default filename, with success / cancel / error toast branches.
- `deleteSession` — descendant cascade, `dropSessionCaches`, store prune, active-route navigate to the next sibling (or bare session route).

Capabilities are injected through a narrow input: `globalSDK` (Pick `client`), `globalSync` (Pick `child`), `platform` (Pick `exportSession`), `server` (Pick `current`), `language` (`{t}`), `navigate`, `params` (`{id?, dir?}`).

### Boundary
`confirmDeleteSession` stays in `layout.tsx` — it renders the `<DialogDeleteSession>` JSX wrapper and calls the injected `deleteSession`. Keeping the dialog in the page (a) preserves layout as the composition layer and (b) keeps the controller a plain `.ts` module with no client-only `solid-js/web` template eval, so it unit-tests under the bun server build.

Removed now-unused layout imports `Binary` and `dropSessionCaches` (both followed the extracted functions).

No user-visible behavior / DOM / copy / aria / command ID / **storage key** / style change.

`layout.tsx` 1174 → 1051.

## Test plan
- [x] `bun run typecheck` (8/8)
- [x] `eslint` on changed files (clean)
- [x] 13 new focused unit tests (`pawwork-session-commands.test.ts`): rename no-op guard + success/failure; export filename slug + id-suffix fallback + every toast branch; delete cascade / navigate-target / no-navigate / failure.
- [x] `bun test src/pages/layout` + source-guard tests (`shell-frame-contract`, `update-install-flow-source`, `client-action-source`) — 208 pass
- [ ] CI required checks green

Refs #1056.