### PR TITLE
fix(opencode): return documented 400 on session part mismatch

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1348,8 +1348,17 @@ export const SessionRoutes = lazy(() =>
         const params = c.req.valid("param")
         const body = c.req.valid("json")
         if (body.id !== params.partID || body.messageID !== params.messageID || body.sessionID !== params.sessionID) {
-          throw new Error(
-            `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
+          return c.json(
+            {
+              success: false as const,
+              errors: [
+                {
+                  message: `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
+                },
+              ],
+              data: null,
+            },
+            400,
           )
         }
         const part = await AppRuntime.runPromise(

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -421,6 +421,56 @@ describe("session messages endpoint", () => {
       }),
     )
   })
+
+  test("rejects a part update whose body does not match the path with a 400", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await svc.create({})
+          const messageID = MessageID.ascending()
+          const partID = PartID.ascending()
+          await svc.updateMessage({
+            id: messageID,
+            sessionID: session.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "test",
+            model: { providerID: "test", modelID: "test" },
+            tools: {},
+            mode: "",
+          } as unknown as MessageV2.Info)
+          await svc.updatePart({
+            id: partID,
+            sessionID: session.id,
+            messageID,
+            type: "text",
+            text: "before",
+          })
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/message/${messageID}/part/${partID}`, {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              id: PartID.ascending(),
+              sessionID: session.id,
+              messageID,
+              type: "text",
+              text: "after",
+            }),
+          })
+          expect(res.status).toBe(400)
+          const body = await res.json()
+          expect(body.success).toBe(false)
+          expect(Array.isArray(body.errors)).toBe(true)
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
 })
 
 describe("session.prompt_async error handling", () => {

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -465,6 +465,8 @@ describe("session messages endpoint", () => {
           const body = await res.json()
           expect(body.success).toBe(false)
           expect(Array.isArray(body.errors)).toBe(true)
+          expect(body.errors).toHaveLength(1)
+          expect(body.errors[0]?.message).toContain("Part mismatch")
 
           await svc.remove(session.id)
         },


### PR DESCRIPTION
## Summary

`PATCH /session/:sessionID/message/:messageID/part/:partID` already declares `...errors(400, 404)` in its OpenAPI contract, but on a body/path-param mismatch it threw a plain `Error`. `ErrorMiddleware` maps plain `Error` to **500**, so a client mistake surfaced as a server error and the documented 400 was unreachable. This returns the documented `BadRequestError` envelope (`{ success: false, errors: [...], data: null }`) with status **400** directly from the handler, and tightens the new test to assert the envelope is populated (length 1, message contains `Part mismatch`).

## Why

First concrete slice of the #936 Effect-migration error-contract work (Phase 1): align user-meaningful failures with the typed/HTTP error they already declare, instead of leaking through as untyped 500s. The change is intentionally small and behavior-only — no schema or generated-client change.

## Related Issue

Refs #936

## Human Review Status

`Pending`

## Review Focus

That the returned object exactly matches the documented `BadRequestError` shape (`success: false`, `errors: [{ message }]`, `data: null`) so the SDK/OpenAPI surface does not drift, and that no other route relied on the old throw-to-500 behavior.

## Risk Notes

Low risk: changes one already-declared error path from an unintended 500 to its documented 400, plus a test. Unticked conditional checklist items:

- UI / copy check — no visible UI or copy changed (backend route + test only).
- macOS / Windows impact — no platform, packaging, updater, signing, path, shell, or permission surface touched.
- Docs / release notes / deps / permissions — none of those surfaces touched.

## How To Verify

```text
bun test test/server/session-messages.test.ts        11 passed (incl. new part-mismatch 400 case)
bun run typecheck (tsgo --noEmit)                     clean
bun test test/server/route-inventory-harness.test.ts 11 passed (no contract/route drift)
git diff --check                                      clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
