### PR TITLE
refactor(opencode): add Automation.Service and effectify automation route handlers

### DIFF
--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { Context as EffectContext, Effect, Layer } from "effect"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { Identifier } from "@/id/id"
@@ -1206,6 +1207,76 @@ export namespace Automation {
   export const publishDefinitionUpdated = (definition: Definition) => Bus.publish(Event.DefinitionUpdated, definition)
   export const publishDefinitionDeleted = (tombstone: Tombstone) => Bus.publish(Event.DefinitionDeleted, tombstone)
   export const publishRunUpdated = (run: Run) => Bus.publish(Event.RunUpdated, run)
+
+  export interface Interface {
+    readonly list: () => Effect.Effect<Definition[]>
+    readonly get: (id: string) => Effect.Effect<Definition>
+    readonly create: (
+      input: CreateInput,
+      options?: { now?: number; sourceSessionID?: SessionID },
+    ) => Effect.Effect<Definition, ValidationError>
+    readonly update: (
+      id: string,
+      patch: UpdateInput,
+      options?: { now?: number },
+    ) => Effect.Effect<Definition, ValidationError | ConflictError>
+    readonly remove: (
+      id: string,
+    ) => Effect.Effect<{ tombstone: Tombstone; stoppedRun?: Run }, ActiveRunStillRunningError>
+    readonly runNowExecuting: (
+      id: string,
+      options: { executor: RunExecutor; attendance?: AutomationRunAttendance; now?: number },
+    ) => Effect.Effect<Run>
+    readonly runs: (input: {
+      automationID: string
+      limit?: number
+      cursor?: string
+    }) => Effect.Effect<z.infer<typeof RunsResponse>>
+    readonly publishDefinitionUpdated: (definition: Definition) => Effect.Effect<void>
+    readonly publishDefinitionDeleted: (tombstone: Tombstone) => Effect.Effect<void>
+    readonly publishRunUpdated: (run: Run) => Effect.Effect<void>
+  }
+
+  export class Service extends EffectContext.Service<Service, Interface>()("@opencode/Automation") {}
+
+  export const layer: Layer.Layer<Service> = Layer.succeed(
+    Service,
+    Service.of({
+      list: () => Effect.sync(() => list()),
+      get: (id) => Effect.sync(() => get(id)),
+      create: (input, options) =>
+        Effect.try({
+          try: () => create(input, options),
+          catch: (error) => {
+            if (error instanceof ValidationError) return error
+            throw error
+          },
+        }),
+      update: (id, patch, options) =>
+        Effect.try({
+          try: () => update(id, patch, options),
+          catch: (error) => {
+            if (error instanceof ValidationError || error instanceof ConflictError) return error
+            throw error
+          },
+        }),
+      remove: (id) =>
+        Effect.tryPromise({
+          try: () => remove(id),
+          catch: (error) => {
+            if (error instanceof ActiveRunStillRunningError) return error
+            throw error
+          },
+        }),
+      runNowExecuting: (id, options) => Effect.promise(() => runNowExecuting(id, options)),
+      runs: (input) => Effect.sync(() => runs(input)),
+      publishDefinitionUpdated: (definition) => Effect.promise(() => publishDefinitionUpdated(definition)),
+      publishDefinitionDeleted: (tombstone) => Effect.promise(() => publishDefinitionDeleted(tombstone)),
+      publishRunUpdated: (run) => Effect.promise(() => publishRunUpdated(run)),
+    }),
+  )
+
+  export const defaultLayer = layer
 }
 
 export class ValidationError extends Error {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1261,13 +1261,11 @@ export namespace Automation {
           },
         }),
       remove: (id) =>
-        Effect.tryPromise({
-          try: () => remove(id),
-          catch: (error) => {
-            if (error instanceof ActiveRunStillRunningError) return error
-            throw error
-          },
-        }),
+        Effect.tryPromise({ try: () => remove(id), catch: (error) => error }).pipe(
+          Effect.catch((error) =>
+            error instanceof ActiveRunStillRunningError ? Effect.fail(error) : Effect.die(error),
+          ),
+        ),
       runNowExecuting: (id, options) => Effect.promise(() => runNowExecuting(id, options)),
       runs: (input) => Effect.sync(() => runs(input)),
       publishDefinitionUpdated: (definition) => Effect.promise(() => publishDefinitionUpdated(definition)),

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -48,6 +48,7 @@ import { Installation } from "@/installation"
 import { ShareNext } from "@/share/share-next"
 import { SessionShare } from "@/share/session"
 import { ShareRuntime } from "@/share/runtime"
+import { Automation } from "@/automation"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { InstanceLayer } from "@/project/instance-layer"
 
@@ -99,6 +100,7 @@ export const AppLayer = Layer.mergeAll(
   ShareNext.defaultLayer,
   SessionShare.defaultLayer,
   ShareRuntime.cloudShareGateDefaultLayer,
+  Automation.defaultLayer,
 ).pipe(Layer.provideMerge(InstanceLayer.layer))
 
 const rt = ManagedRuntime.make(AppLayer, { memoMap })

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -26,11 +26,6 @@ function activeRunStillRunningError(error: ActiveRunStillRunningError) {
   })
 }
 
-async function publishIfChanged(previous: Automation.Definition, definition: Automation.Definition) {
-  if (definition.revision === previous.revision) return
-  await Automation.publishDefinitionUpdated(definition)
-}
-
 async function settleAutomationScheduler() {
   await AutomationScheduler.current().settleOwner()
 }
@@ -236,7 +231,9 @@ export const AutomationRoutes = (): Hono =>
               }
             }
             const definition = yield* automation.update(automationID, patch)
-            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            if (definition.revision !== previous.revision) {
+              yield* automation.publishDefinitionUpdated(definition)
+            }
             return c.json(definition)
           }),
         ),
@@ -269,7 +266,9 @@ export const AutomationRoutes = (): Hono =>
             yield* Effect.promise(() => settleAutomationScheduler())
             const previous = yield* automation.get(automationID)
             const definition = yield* automation.update(automationID, { paused: true })
-            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            if (definition.revision !== previous.revision) {
+              yield* automation.publishDefinitionUpdated(definition)
+            }
             return c.json(definition)
           }),
         ),
@@ -302,7 +301,9 @@ export const AutomationRoutes = (): Hono =>
             yield* Effect.promise(() => settleAutomationScheduler())
             const previous = yield* automation.get(automationID)
             const definition = yield* automation.update(automationID, { paused: false })
-            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            if (definition.revision !== previous.revision) {
+              yield* automation.publishDefinitionUpdated(definition)
+            }
             return c.json(definition)
           }),
         ),

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -1,12 +1,14 @@
 import { Hono } from "hono"
 import type { Context } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
+import { Cause, Effect, Exit } from "effect"
 import z from "zod"
 import { ActiveRunStillRunningError, Automation, AutomationID, ConflictError, ValidationError } from "@/automation"
 import { sessionPromptExecutor } from "@/automation/runner"
 import { AutomationScheduler } from "@/automation/scheduler"
 import { validateModelAndVariant } from "@/automation/validation"
-import { AppRuntime } from "@/effect/app-runtime"
+import { Provider } from "@/provider/provider"
+import { AppRuntime, type AppServices } from "@/effect/app-runtime"
 import { errors } from "../error"
 
 function validationError(error: ValidationError) {
@@ -33,9 +35,23 @@ async function settleAutomationScheduler() {
   await AutomationScheduler.current().settleOwner()
 }
 
-async function modelValidationDetails(model: Automation.Model, variant?: string) {
-  if (process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION === "1") return []
-  return AppRuntime.runPromise(validateModelAndVariant(model, variant))
+function modelValidation(
+  model: Automation.Model,
+  variant?: string,
+): Effect.Effect<Automation.ValidationErrorDetail[], never, Provider.Service> {
+  if (process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION === "1") return Effect.succeed([])
+  return validateModelAndVariant(model, variant)
+}
+
+function runRoute(c: Context, effect: Effect.Effect<Response, unknown, AppServices>): Promise<Response> {
+  return AppRuntime.runPromiseExit(effect).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value
+    const error = Cause.squash(exit.cause)
+    if (error instanceof ValidationError) return c.json(validationError(error), 422)
+    if (error instanceof ConflictError) return c.json(conflictError(error), 409)
+    if (error instanceof ActiveRunStillRunningError) return c.json(activeRunStillRunningError(error), 409)
+    return Promise.reject(error)
+  })
 }
 
 function validationIssuePath(issue: unknown) {
@@ -100,10 +116,16 @@ export const AutomationRoutes = (): Hono =>
           },
         },
       }),
-      async (c) => {
-        await settleAutomationScheduler()
-        return c.json({ items: Automation.list() })
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const items = yield* automation.list()
+            return c.json({ items })
+          }),
+        ),
     )
     .post(
       "/",
@@ -124,25 +146,25 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("json", Automation.CreateInput, automationBodyValidationHook),
-      async (c) => {
-        try {
-          await settleAutomationScheduler()
-          const input = c.req.valid("json")
-          const modelDetails = await modelValidationDetails(input.model, input.variant)
-          if (modelDetails.length) {
-            return c.json(
-              Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
-              422,
-            )
-          }
-          const definition = Automation.create(input)
-          await Automation.publishDefinitionUpdated(definition)
-          return c.json(definition)
-        } catch (error) {
-          if (error instanceof ValidationError) return c.json(validationError(error), 422)
-          throw error
-        }
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const input = c.req.valid("json")
+            const modelDetails = yield* modelValidation(input.model, input.variant)
+            if (modelDetails.length) {
+              return c.json(
+                Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
+                422,
+              )
+            }
+            const definition = yield* automation.create(input)
+            yield* automation.publishDefinitionUpdated(definition)
+            return c.json(definition)
+          }),
+        ),
     )
     .get(
       "/:automationID",
@@ -159,10 +181,15 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) => {
-        await settleAutomationScheduler()
-        return c.json(Automation.get(c.req.valid("param").automationID))
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            yield* Effect.promise(() => settleAutomationScheduler())
+            return c.json(yield* automation.get(c.req.valid("param").automationID))
+          }),
+        ),
     )
     .put(
       "/:automationID",
@@ -188,32 +215,31 @@ export const AutomationRoutes = (): Hono =>
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
       validator("json", Automation.UpdateInput, automationBodyValidationHook),
-      async (c) => {
-        try {
-          const automationID = c.req.valid("param").automationID
-          await settleAutomationScheduler()
-          const previous = Automation.get(automationID)
-          const patch = c.req.valid("json")
-          if (patch.model !== undefined || patch.variant !== undefined) {
-            const effectiveModel = patch.model ?? previous.model
-            const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
-            const modelDetails = await modelValidationDetails(effectiveModel, effectiveVariant)
-            if (modelDetails.length) {
-              return c.json(
-                Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
-                422,
-              )
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            const automationID = c.req.valid("param").automationID
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const previous = yield* automation.get(automationID)
+            const patch = c.req.valid("json")
+            if (patch.model !== undefined || patch.variant !== undefined) {
+              const effectiveModel = patch.model ?? previous.model
+              const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
+              const modelDetails = yield* modelValidation(effectiveModel, effectiveVariant)
+              if (modelDetails.length) {
+                return c.json(
+                  Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
+                  422,
+                )
+              }
             }
-          }
-          const definition = Automation.update(automationID, patch)
-          await publishIfChanged(previous, definition)
-          return c.json(definition)
-        } catch (error) {
-          if (error instanceof ValidationError) return c.json(validationError(error), 422)
-          if (error instanceof ConflictError) return c.json(conflictError(error), 409)
-          throw error
-        }
-      },
+            const definition = yield* automation.update(automationID, patch)
+            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            return c.json(definition)
+          }),
+        ),
     )
     .post(
       "/:automationID/pause",
@@ -234,19 +260,19 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) => {
-        try {
-          const automationID = c.req.valid("param").automationID
-          await settleAutomationScheduler()
-          const previous = Automation.get(automationID)
-          const definition = Automation.update(automationID, { paused: true })
-          await publishIfChanged(previous, definition)
-          return c.json(definition)
-        } catch (error) {
-          if (error instanceof ConflictError) return c.json(conflictError(error), 409)
-          throw error
-        }
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            const automationID = c.req.valid("param").automationID
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const previous = yield* automation.get(automationID)
+            const definition = yield* automation.update(automationID, { paused: true })
+            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            return c.json(definition)
+          }),
+        ),
     )
     .post(
       "/:automationID/resume",
@@ -267,19 +293,19 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) => {
-        try {
-          const automationID = c.req.valid("param").automationID
-          await settleAutomationScheduler()
-          const previous = Automation.get(automationID)
-          const definition = Automation.update(automationID, { paused: false })
-          await publishIfChanged(previous, definition)
-          return c.json(definition)
-        } catch (error) {
-          if (error instanceof ConflictError) return c.json(conflictError(error), 409)
-          throw error
-        }
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            const automationID = c.req.valid("param").automationID
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const previous = yield* automation.get(automationID)
+            const definition = yield* automation.update(automationID, { paused: false })
+            yield* Effect.promise(() => publishIfChanged(previous, definition))
+            return c.json(definition)
+          }),
+        ),
     )
     .delete(
       "/:automationID",
@@ -301,20 +327,20 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) => {
-        try {
-          const scheduler = AutomationScheduler.current()
-          await scheduler.settleOwner()
-          const removed = await Automation.remove(c.req.valid("param").automationID)
-          scheduler.cancel(removed.tombstone.id)
-          if (removed.stoppedRun) await Automation.publishRunUpdated(removed.stoppedRun)
-          await Automation.publishDefinitionDeleted(removed.tombstone)
-          return c.json(removed.tombstone)
-        } catch (error) {
-          if (error instanceof ActiveRunStillRunningError) return c.json(activeRunStillRunningError(error), 409)
-          throw error
-        }
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            const scheduler = AutomationScheduler.current()
+            yield* Effect.promise(() => scheduler.settleOwner())
+            const removed = yield* automation.remove(c.req.valid("param").automationID)
+            yield* Effect.sync(() => scheduler.cancel(removed.tombstone.id))
+            if (removed.stoppedRun) yield* automation.publishRunUpdated(removed.stoppedRun)
+            yield* automation.publishDefinitionDeleted(removed.tombstone)
+            return c.json(removed.tombstone)
+          }),
+        ),
     )
     .post(
       "/:automationID/run",
@@ -331,14 +357,19 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) => {
-        await settleAutomationScheduler()
-        const run = await Automation.runNowExecuting(c.req.valid("param").automationID, {
-          executor: sessionPromptExecutor,
-        })
-        await Automation.publishRunUpdated(run)
-        return c.json(run)
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            yield* Effect.promise(() => settleAutomationScheduler())
+            const run = yield* automation.runNowExecuting(c.req.valid("param").automationID, {
+              executor: sessionPromptExecutor,
+            })
+            yield* automation.publishRunUpdated(run)
+            return c.json(run)
+          }),
+        ),
     )
     .get(
       "/:automationID/runs",
@@ -362,8 +393,13 @@ export const AutomationRoutes = (): Hono =>
           cursor: AutomationID.Run.zod.optional(),
         }),
       ),
-      async (c) => {
-        await settleAutomationScheduler()
-        return c.json(Automation.runs({ automationID: c.req.valid("param").automationID, ...c.req.valid("query") }))
-      },
+      async (c) =>
+        runRoute(
+          c,
+          Effect.gen(function* () {
+            const automation = yield* Automation.Service
+            yield* Effect.promise(() => settleAutomationScheduler())
+            return c.json(yield* automation.runs({ automationID: c.req.valid("param").automationID, ...c.req.valid("query") }))
+          }),
+        ),
     )

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -727,6 +727,13 @@ describe("automation routes", () => {
     })
   })
 
+  test("delete returns 404 for an unknown automation", async () => {
+    await withAutomationApp(async ({ app }) => {
+      const response = await app.request(`/automation/${AutomationID.Definition.ascending()}`, { method: "DELETE" })
+      expect(response.status).toBe(404)
+    })
+  })
+
   test("update accepts a deterministic timestamp", async () => {
     await withAutomationApp(async ({ projectID }) => {
       const definition = Automation.create(recurringInput(projectID), { now: 100 })


### PR DESCRIPTION
## Summary

Add an Effect `Automation.Service` (request-face operations) and rewrite the `server/instance/automation.ts` route handlers to run through `AppRuntime.runPromiseExit(Effect.gen(...))`. This is **PR 1 of 3** of the automation Effect-migration tracked in #950 — the "request face". The sync namespace facade is left intact; the execution face (scheduler/runner) and facade removal follow in PR2 and PR3.

Two review-sized commits:
1. `feat: add Automation.Service effect layer` — Service + `defaultLayer`, registered in `effect/app-runtime.ts`. Delegates to the existing sync namespace and lifts domain throws into the typed error channel.
2. `refactor: wrap automation route handlers in AppRuntime` — each handler becomes a single `runRoute(c, Effect.gen(...))`; reaches operations via `yield* Automation.Service`.

## Why

`automation/**` and `server/instance/automation.ts` were never effectified, while the other server route handlers were systematically migrated in #1015–1035 (`config.ts` is the template). Per `AGENTS.md` opencode Effect rules, a route handler's target form is a single `AppRuntime.runPromise(Effect.gen(...))`. This pays down that debt for the request face without touching the high-risk scheduler/runner cancellation surface.

## Related Issue

#950

## Human Review Status

Pending

## Review Focus

- **Error mapping in `runRoute`.** Automation errors (`ValidationError`/`ConflictError`/`ActiveRunStillRunningError`) extend plain `Error`, not `NamedError`, so the global `ErrorMiddleware` does not map them. `runRoute` uses `runPromiseExit` + `Cause.squash` to recover the original error instance (a plain `runPromise` would reject with an opaque `FiberFailure`, regressing 404/422/409 → 500) and centrally maps 422/409. Any other error (e.g. `NotFoundError`) is re-rejected so the global middleware still maps it to 404.
- **Instance ALS propagation.** Handlers run inside `Instance.provide(...)`; `AppRuntime.runPromiseExit` is invoked synchronously within that scope, so the AsyncLocalStorage context still reaches the sync namespace calls inside the Effect. The real-HTTP route suite is the safety net here.
- The nested `AppRuntime.runPromise` inside the old `modelValidationDetails` is collapsed into `yield* modelValidation(...)` — no runPromise nested inside Effect.gen.

## Risk Notes

- One minor broadening: `runRoute` now also maps `ValidationError` → 422 on pause/resume, but a `{ paused }` patch cannot yield a `ValidationError`, so the path is unreachable. No observable change.
- No public shape change to `Automation.Definition/Run/Event/CreateInput` or the error responses.
- No platform/packaging/UI surface touched.

## How To Verify

```text
typecheck (tsgo --noEmit): exit 0
test/server/automation-routes.test.ts: 43 pass, 0 fail (real HTTP, 204 expect)
test/server/automation-runner.test.ts + automation-scheduler.test.ts: 62 pass, 0 fail
test/automation/cron.test.ts + validation.test.ts + test/tool/automate.test.ts: 25 pass, 0 fail
```

## Screenshots or Recordings

N/A — no visible UI change (backend only).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. (`harness`)
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. (`P2`)
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
