### PR TITLE
refactor(app): extract detectSubmitOwnership into submit-ownership.ts

### DIFF
--- a/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
+++ b/packages/app/src/components/prompt-input/draft-isolation.integration.test.ts
@@ -14,15 +14,9 @@ import { createPortableDraftOwner } from "./portable-draft"
 import { createPinnedDraftOwner } from "./pinned-draft"
 import { buildRequestParts } from "./build-request-parts"
 import { captureCommentMentions } from "./mention-metadata"
+import { detectSubmitOwnership } from "./submit-ownership"
 
-let detectSubmitOwnership: any
-
-beforeAll(async () => {
-  // submit.ts pulls in router/sdk/etc. at module scope; mock bare minimum.
-  mock.module("@solidjs/router", () => ({
-    useNavigate: () => () => undefined,
-    useParams: () => ({}),
-  }))
+beforeAll(() => {
   // Use a real FNV-1a checksum so that Persist.workspace() still produces
   // distinct storage names for different directories (the string-length mock
   // used in submit-ownership.test.ts is order-dependent and leaks into
@@ -42,8 +36,6 @@ beforeAll(async () => {
     checksum: fnv1a,
     sampledChecksum: fnv1a,
   }))
-  const mod = await import("./submit")
-  detectSubmitOwnership = mod.detectSubmitOwnership
 })
 
 // Minimal non-empty payload for a given text string.

--- a/packages/app/src/components/prompt-input/submit-ownership.test.ts
+++ b/packages/app/src/components/prompt-input/submit-ownership.test.ts
@@ -1,23 +1,15 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 import { createPortableDraftOwner } from "./portable-draft"
 import { createPinnedDraftOwner } from "./pinned-draft"
+import { detectSubmitOwnership, type SubmitOwnership } from "./submit-ownership"
 
-let detectSubmitOwnership: any
-type SubmitOwnership = any
-
-beforeAll(async () => {
-  mock.module("@solidjs/router", () => ({
-    useNavigate: () => () => undefined,
-    useParams: () => ({}),
-  }))
+beforeAll(() => {
   mock.module("@opencode-ai/util/encode", () => ({
     base64Encode: (value: string) => value,
     base64Decode: (value: string) => value,
     checksum: (value: string) => String(value.length),
     sampledChecksum: (value: string) => String(value.length),
   }))
-  const mod = await import("./submit")
-  detectSubmitOwnership = mod.detectSubmitOwnership
 })
 
 const ROUTE_SCOPE = { dir: "L3JlcG8vbWFpbg", id: undefined } as const

--- a/packages/app/src/components/prompt-input/submit-ownership.ts
+++ b/packages/app/src/components/prompt-input/submit-ownership.ts
@@ -1,0 +1,43 @@
+import type { PromptRouteScope } from "@/pages/session/prompt-route-scope"
+import type { PortableDraftOwner } from "./portable-draft"
+import type { PinnedDraftOwner } from "./pinned-draft"
+
+/**
+ * Submit ownership identifies which draft owner a given submit attempt operates on.
+ * Captured once at the top of handleSubmit and frozen for the lifetime of that submit.
+ * Used by clearInput/restoreInput so a successful clear or failure restore only
+ * touches the owner whose revision matches the captured value at submit time.
+ */
+export type SubmitOwnership =
+  | { kind: "portable"; revision: number; sourceFilesystemDirectory: string }
+  | { kind: "pinned"; revision: number; directory: string }
+  | { kind: "route"; scope: PromptRouteScope }
+
+/**
+ * Decide which owner owns this submit. Pinned beats portable when both match the
+ * current homepage directory. When on a concrete session route (id present),
+ * ownership is always the route-scoped prompt store.
+ */
+export function detectSubmitOwnership(params: {
+  isHomepage: boolean
+  pinned: PinnedDraftOwner
+  portable: PortableDraftOwner
+  sourceFilesystemDirectory: string
+  routeScope: PromptRouteScope
+}): SubmitOwnership {
+  if (params.isHomepage) {
+    const pinnedSlot = params.pinned.current()
+    if (pinnedSlot && pinnedSlot.directory === params.sourceFilesystemDirectory) {
+      return { kind: "pinned", revision: pinnedSlot.revision, directory: pinnedSlot.directory }
+    }
+    const portableSnapshot = params.portable.snapshot()
+    if (portableSnapshot && portableSnapshot.sourceFilesystemDirectory === params.sourceFilesystemDirectory) {
+      return {
+        kind: "portable",
+        revision: portableSnapshot.revision,
+        sourceFilesystemDirectory: portableSnapshot.sourceFilesystemDirectory,
+      }
+    }
+  }
+  return { kind: "route", scope: params.routeScope }
+}

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -23,50 +23,11 @@ import { reportInvariantBreach } from "./invariant"
 import { formatServerError } from "@/utils/server-errors"
 import { canSubmitPrompt } from "@/pages/session/session-action-readiness"
 import { type PromptRouteScope, promptScopeForSession } from "@/pages/session/prompt-route-scope"
-import { type PortableDraftOwner, usePortableDraft } from "./portable-draft"
-import { type PinnedDraftOwner, usePinnedDraft } from "./pinned-draft"
+import { usePortableDraft } from "./portable-draft"
+import { usePinnedDraft } from "./pinned-draft"
 import type { ResolvedMention } from "./mention-metadata"
 import { followupCommandText, type FollowupDraft } from "./followup-draft"
-
-/**
- * Submit ownership identifies which draft owner a given submit attempt operates on.
- * Captured once at the top of handleSubmit and frozen for the lifetime of that submit.
- * Used by clearInput/restoreInput so a successful clear or failure restore only
- * touches the owner whose revision matches the captured value at submit time.
- */
-export type SubmitOwnership =
-  | { kind: "portable"; revision: number; sourceFilesystemDirectory: string }
-  | { kind: "pinned"; revision: number; directory: string }
-  | { kind: "route"; scope: PromptRouteScope }
-
-/**
- * Decide which owner owns this submit. Pinned beats portable when both match the
- * current homepage directory. When on a concrete session route (id present),
- * ownership is always the route-scoped prompt store.
- */
-export function detectSubmitOwnership(params: {
-  isHomepage: boolean
-  pinned: PinnedDraftOwner
-  portable: PortableDraftOwner
-  sourceFilesystemDirectory: string
-  routeScope: PromptRouteScope
-}): SubmitOwnership {
-  if (params.isHomepage) {
-    const pinnedSlot = params.pinned.current()
-    if (pinnedSlot && pinnedSlot.directory === params.sourceFilesystemDirectory) {
-      return { kind: "pinned", revision: pinnedSlot.revision, directory: pinnedSlot.directory }
-    }
-    const portableSnapshot = params.portable.snapshot()
-    if (portableSnapshot && portableSnapshot.sourceFilesystemDirectory === params.sourceFilesystemDirectory) {
-      return {
-        kind: "portable",
-        revision: portableSnapshot.revision,
-        sourceFilesystemDirectory: portableSnapshot.sourceFilesystemDirectory,
-      }
-    }
-  }
-  return { kind: "route", scope: params.routeScope }
-}
+import { detectSubmitOwnership, type SubmitOwnership } from "./submit-ownership"
 
 type PendingPrompt = {
   abort: AbortController


### PR DESCRIPTION
## Summary

Slice S1 of the submit.ts / session-question-dock.tsx slimming production line (#1066). Pure extraction, no behavior change.

- Move the `SubmitOwnership` discriminated union + `detectSubmitOwnership` pure function out of `submit.ts` into a focused `submit-ownership.ts` with type-only imports (`PromptRouteScope` / `PortableDraftOwner` / `PinnedDraftOwner`).
- `submit.ts` imports `detectSubmitOwnership` for internal use instead of defining and exporting it (−45 lines); it is still called at the same pre-await capture point with identical arguments.
- Repoint `submit-ownership.test.ts` and `draft-isolation.integration.test.ts` to import `detectSubmitOwnership` statically from the new module. Both previously pulled it via a dynamic `import("./submit")` guarded by a `@solidjs/router` mock that existed only because `submit.ts` loads the router at module scope. With the function isolated, that router mock is dead and removed. The `@opencode-ai/util/encode` mocks are kept — owners / `buildRequestParts` still consume them, and `history-navigation.test.ts`'s cross-file leak chain depends on the checksum mock, not the router mock.

## Verification

- `bun run typecheck` — 8/8 pass
- `bun test src/components/prompt-input/` — 382 pass, 2 pre-existing `isPromptEqual` failures (unrelated, also present on clean `dev`)
- relevant files (submit-ownership / submit / draft-isolation / build-request-parts / history-navigation) — 83 pass / 0 fail
- `eslint` clean
- `/codex` review (xhigh, read-only): no P1/P2 — confirmed logic equivalence, identical wiring in `submit.ts`, and that the leak chain depends on the encode checksum mock (kept), not the router mock (removed)

## Test plan

- [x] typecheck (8/8)
- [x] prompt-input unit tests green (no new failures vs dev)
- [x] eslint clean
- [x] codex review pass