### PR TITLE
refactor(app): extract waitForWorktree from submit.ts

### DIFF
--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -26,6 +26,7 @@ import { detectSubmitOwnership, type SubmitOwnership } from "./submit-ownership"
 import { sendFollowupDraft } from "./send-followup-draft"
 import { createAbort, pending } from "./submit-abort"
 import { createPromptDraftLifecycle } from "./prompt-draft-lifecycle"
+import { createWaitForWorktree } from "./wait-for-worktree"
 
 type PromptSubmitInput = {
   sessionID?: Accessor<string | undefined>
@@ -461,61 +462,15 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       },
     }).catch(() => {})
 
-    const waitForWorktree = async () => {
-      const worktree = WorktreeState.get(sessionDirectory)
-      if (!worktree || worktree.status !== "pending") return true
-
-      if (sessionDirectory === projectDirectory) {
-        sync.set("session_status", session.id, { type: "busy" })
-      }
-
-      const controller = new AbortController()
-      const cleanup = () => {
-        if (sessionDirectory === projectDirectory) {
-          sync.set("session_status", session.id, { type: "idle" })
-        }
-        removeOptimisticMessage()
-        // restoreInput handles route-case comment items internally; owner-backed
-        // cases re-push context from the snapshot via replaceAll.
-        lifecycle.restoreInput()
-      }
-
-      pending.set(session.id, { abort: controller, cleanup })
-
-      const abortWait = new Promise<Awaited<ReturnType<typeof WorktreeState.wait>>>((resolve) => {
-        if (controller.signal.aborted) {
-          resolve({ status: "failed", message: "aborted" })
-          return
-        }
-        controller.signal.addEventListener(
-          "abort",
-          () => {
-            resolve({ status: "failed", message: "aborted" })
-          },
-          { once: true },
-        )
-      })
-
-      const timeoutMs = 5 * 60 * 1000
-      const timer = { id: undefined as number | undefined }
-      const timeout = new Promise<Awaited<ReturnType<typeof WorktreeState.wait>>>((resolve) => {
-        timer.id = window.setTimeout(() => {
-          resolve({
-            status: "failed",
-            message: language.t("workspace.error.stillPreparing"),
-          })
-        }, timeoutMs)
-      })
-
-      const result = await Promise.race([WorktreeState.wait(sessionDirectory), abortWait, timeout]).finally(() => {
-        if (timer.id === undefined) return
-        clearTimeout(timer.id)
-      })
-      pending.delete(session.id)
-      if (controller.signal.aborted) return false
-      if (result.status === "failed") throw new Error(result.message)
-      return true
-    }
+    const waitForWorktree = createWaitForWorktree({
+      sessionDirectory,
+      projectDirectory,
+      sessionID: session.id,
+      sync,
+      language,
+      removeOptimisticMessage,
+      restoreInput: lifecycle.restoreInput,
+    })
 
     void sendFollowupDraft({
       client,

--- a/packages/app/src/components/prompt-input/wait-for-worktree.ts
+++ b/packages/app/src/components/prompt-input/wait-for-worktree.ts
@@ -1,0 +1,74 @@
+import type { useLanguage } from "@/context/language"
+import type { useSync } from "@/context/sync"
+import { Worktree as WorktreeState } from "@/utils/worktree"
+import { pending } from "./submit-abort"
+
+type WaitForWorktreeInput = {
+  sessionDirectory: string
+  projectDirectory: string
+  sessionID: string
+  sync: ReturnType<typeof useSync>
+  language: ReturnType<typeof useLanguage>
+  removeOptimisticMessage: () => void
+  restoreInput: () => void
+}
+
+export function createWaitForWorktree(input: WaitForWorktreeInput) {
+  const { sessionDirectory, projectDirectory, sessionID, sync, language, removeOptimisticMessage, restoreInput } = input
+
+  return async () => {
+    const worktree = WorktreeState.get(sessionDirectory)
+    if (!worktree || worktree.status !== "pending") return true
+
+    if (sessionDirectory === projectDirectory) {
+      sync.set("session_status", sessionID, { type: "busy" })
+    }
+
+    const controller = new AbortController()
+    const cleanup = () => {
+      if (sessionDirectory === projectDirectory) {
+        sync.set("session_status", sessionID, { type: "idle" })
+      }
+      removeOptimisticMessage()
+      // restoreInput handles route-case comment items internally; owner-backed
+      // cases re-push context from the snapshot via replaceAll.
+      restoreInput()
+    }
+
+    pending.set(sessionID, { abort: controller, cleanup })
+
+    const abortWait = new Promise<Awaited<ReturnType<typeof WorktreeState.wait>>>((resolve) => {
+      if (controller.signal.aborted) {
+        resolve({ status: "failed", message: "aborted" })
+        return
+      }
+      controller.signal.addEventListener(
+        "abort",
+        () => {
+          resolve({ status: "failed", message: "aborted" })
+        },
+        { once: true },
+      )
+    })
+
+    const timeoutMs = 5 * 60 * 1000
+    const timer = { id: undefined as number | undefined }
+    const timeout = new Promise<Awaited<ReturnType<typeof WorktreeState.wait>>>((resolve) => {
+      timer.id = window.setTimeout(() => {
+        resolve({
+          status: "failed",
+          message: language.t("workspace.error.stillPreparing"),
+        })
+      }, timeoutMs)
+    })
+
+    const result = await Promise.race([WorktreeState.wait(sessionDirectory), abortWait, timeout]).finally(() => {
+      if (timer.id === undefined) return
+      clearTimeout(timer.id)
+    })
+    pending.delete(sessionID)
+    if (controller.signal.aborted) return false
+    if (result.status === "failed") throw new Error(result.message)
+    return true
+  }
+}


### PR DESCRIPTION
## Summary

Slice S5 (final submit.ts slice) of the component-slimming production line (#1066). Pure extraction — no behavior, DOM, aria, copy, or storage-key change.

- Move the per-submit `waitForWorktree` closure out of `submit.ts` into a new `wait-for-worktree.ts`, exported as `createWaitForWorktree(deps)`.
- The factory receives `restoreInput` as an injected bound `VoidFunction` (from `lifecycle.restoreInput`), so the new module carries no `SubmitOwnership` / draft-lifecycle knowledge — completing the S4 decoupling.
- Shared `pending` registry (from `submit-abort.ts`) and `WorktreeState` (`@/utils/worktree`) are imported directly; `sync` / `language` referenced via type-only imports. `submit.ts` keeps both `pending` and `WorktreeState` imports — still used outside this closure (`pending.delete` in the send `.catch`, `WorktreeState.pending` at session creation).
- `submit.ts`: 554 → 509 lines (−45). Call site `before: waitForWorktree` unchanged.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/components/prompt-input/` — 382 pass / 2 pre-existing `isPromptEqual` fails (unrelated), 0 new failures
- [x] `bunx eslint` clean on both files
- [ ] Required CI green on dev