### PR TITLE
refactor(app): extract question-dock pure logic to question-tool-respond

### DIFF
--- a/packages/app/src/pages/session/composer/question-tool-respond.ts
+++ b/packages/app/src/pages/session/composer/question-tool-respond.ts
@@ -1,0 +1,130 @@
+import { createStore } from "solid-js/store"
+
+type NormalizedToolRespondError =
+  | { type: "already_resolved"; requestID?: string }
+  | { type: "stale_session" }
+  | { type: "invalid_payload"; detail?: string }
+  | { type: "unknown"; detail?: string }
+
+type QuestionResponsePhase = "idle" | "submitting" | "closing"
+
+const invalidPayloadErrorCodes = new Set(["answer_count_mismatch"])
+
+export function createQuestionResponseGuard(initialRequestID: string) {
+  const [state, setState] = createStore<{ requestID: string; phase: QuestionResponsePhase }>({
+    requestID: initialRequestID,
+    phase: "idle",
+  })
+
+  const sync = (nextRequestID: string) => {
+    if (nextRequestID === state.requestID) return
+    setState({ requestID: nextRequestID, phase: "idle" })
+  }
+
+  return {
+    canInteract(nextRequestID: string) {
+      sync(nextRequestID)
+      return state.phase === "idle"
+    },
+    begin(nextRequestID: string) {
+      sync(nextRequestID)
+      if (state.phase !== "idle") return false
+      setState("phase", "submitting")
+      return true
+    },
+    confirm(nextRequestID: string) {
+      sync(nextRequestID)
+      if (state.phase === "submitting") setState("phase", "closing")
+    },
+    fail(nextRequestID: string) {
+      sync(nextRequestID)
+      setState("phase", "idle")
+    },
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function statusFromToolRespondError(err: unknown): number | undefined {
+  if (!isRecord(err)) return undefined
+  const response = err.response
+  if (isRecord(response) && typeof response.status === "number") return response.status
+  if (typeof err.status === "number") return err.status
+  if (typeof err.statusCode === "number") return err.statusCode
+  return undefined
+}
+
+function errorCodeFromToolRespondError(err: unknown): string | undefined {
+  if (!isRecord(err)) return undefined
+  const bodyError = err.error
+  if (typeof bodyError === "string") return bodyError
+  if (isRecord(bodyError)) return stringField(bodyError.error)
+  return undefined
+}
+
+function detailsFromToolRespondError(err: unknown): string | undefined {
+  if (!isRecord(err)) return undefined
+  const details = err.details
+  if (typeof details === "string") return details
+  if (isRecord(details)) {
+    try {
+      return JSON.stringify(details)
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+function requestIDFromToolRespondError(err: unknown): string | undefined {
+  if (!isRecord(err)) return undefined
+  const request = err.request
+  if (isRecord(request)) return stringField(request.id)
+  return undefined
+}
+
+export function normalizeToolRespondError(err: unknown): NormalizedToolRespondError {
+  const status = statusFromToolRespondError(err)
+  const code = errorCodeFromToolRespondError(err)
+  const details = detailsFromToolRespondError(err)
+
+  if (code === "already_resolved") return { type: "already_resolved", requestID: requestIDFromToolRespondError(err) }
+  if (code === "no_pending_tool_call") return { type: "stale_session" }
+  if (status === 404) return { type: "stale_session" }
+  if (status === 409) return { type: "already_resolved", requestID: requestIDFromToolRespondError(err) }
+  if (status === 400 || status === 422 || invalidPayloadErrorCodes.has(code ?? "") || details !== undefined) {
+    const detail = [code, details].filter(Boolean).join(" ")
+    return { type: "invalid_payload", detail: detail || undefined }
+  }
+  if (err instanceof Error) return { type: "unknown", detail: err.message }
+  if (typeof err === "string") return { type: "unknown", detail: err }
+  if (code) return { type: "unknown", detail: code }
+  return { type: "unknown" }
+}
+
+/**
+ * After skipping a question (setting its answer to []), decide the next action.
+ * Returns either the tab to navigate to, or a submit signal when all questions are settled.
+ */
+export function resolveSkipAction(
+  currentTab: number,
+  isSettled: (i: number) => boolean,
+  total: number,
+): { type: "navigate"; tab: number } | { type: "submit" } {
+  // First, look for an unsettled question after the current tab.
+  for (let i = currentTab + 1; i < total; i++) {
+    if (!isSettled(i)) return { type: "navigate", tab: i }
+  }
+  // Then, look for any unsettled question before the current tab.
+  for (let i = 0; i < currentTab; i++) {
+    if (!isSettled(i)) return { type: "navigate", tab: i }
+  }
+  // All settled — time to submit.
+  return { type: "submit" }
+}

--- a/packages/app/src/pages/session/composer/session-question-dock.test.ts
+++ b/packages/app/src/pages/session/composer/session-question-dock.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { runBrowserCheck } from "@/testing/browser-subprocess"
-import {
-  createQuestionResponseGuard,
-  isSameQuestionRequest,
-  normalizeToolRespondError,
-  resolveSkipAction,
-} from "./session-question-dock"
+import { isSameQuestionRequest } from "./session-question-dock"
+import { createQuestionResponseGuard, normalizeToolRespondError, resolveSkipAction } from "./question-tool-respond"
 
 describe("resolveSkipAction", () => {
   test("navigates to next unsettled question when one exists after current", () => {
@@ -138,7 +134,7 @@ describe("question response duplicate submission guard", () => {
   test("updates reactive disabled state immediately after begin and confirm", () => {
     runBrowserCheck(String.raw`
       import { createMemo, createRoot } from "solid-js"
-      import { createQuestionResponseGuard } from "./src/pages/session/composer/session-question-dock.tsx"
+      import { createQuestionResponseGuard } from "./src/pages/session/composer/question-tool-respond.ts"
 
       const assert = (condition, message) => {
         if (!condition) throw new Error(message)

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -8,6 +8,7 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
 import type { DockQuestionRequest } from "@/pages/session/blockers/use-session-blockers"
+import { createQuestionResponseGuard, normalizeToolRespondError, resolveSkipAction } from "./question-tool-respond"
 
 // One question's selected labels. Mirrors the per-row shape of the
 // `payload.answers: string[][]` body sent to POST /session/:id/tool/respond
@@ -17,114 +18,6 @@ type QuestionAnswer = readonly string[]
 type DraftAnswer = QuestionAnswer | undefined
 
 type QuestionRequestFingerprint = Pick<DockQuestionRequest, "id" | "sessionID" | "messageID" | "callID">
-
-type NormalizedToolRespondError =
-  | { type: "already_resolved"; requestID?: string }
-  | { type: "stale_session" }
-  | { type: "invalid_payload"; detail?: string }
-  | { type: "unknown"; detail?: string }
-
-type QuestionResponsePhase = "idle" | "submitting" | "closing"
-
-const invalidPayloadErrorCodes = new Set(["answer_count_mismatch"])
-
-export function createQuestionResponseGuard(initialRequestID: string) {
-  const [state, setState] = createStore<{ requestID: string; phase: QuestionResponsePhase }>({
-    requestID: initialRequestID,
-    phase: "idle",
-  })
-
-  const sync = (nextRequestID: string) => {
-    if (nextRequestID === state.requestID) return
-    setState({ requestID: nextRequestID, phase: "idle" })
-  }
-
-  return {
-    canInteract(nextRequestID: string) {
-      sync(nextRequestID)
-      return state.phase === "idle"
-    },
-    begin(nextRequestID: string) {
-      sync(nextRequestID)
-      if (state.phase !== "idle") return false
-      setState("phase", "submitting")
-      return true
-    },
-    confirm(nextRequestID: string) {
-      sync(nextRequestID)
-      if (state.phase === "submitting") setState("phase", "closing")
-    },
-    fail(nextRequestID: string) {
-      sync(nextRequestID)
-      setState("phase", "idle")
-    },
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
-
-function stringField(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined
-}
-
-function statusFromToolRespondError(err: unknown): number | undefined {
-  if (!isRecord(err)) return undefined
-  const response = err.response
-  if (isRecord(response) && typeof response.status === "number") return response.status
-  if (typeof err.status === "number") return err.status
-  if (typeof err.statusCode === "number") return err.statusCode
-  return undefined
-}
-
-function errorCodeFromToolRespondError(err: unknown): string | undefined {
-  if (!isRecord(err)) return undefined
-  const bodyError = err.error
-  if (typeof bodyError === "string") return bodyError
-  if (isRecord(bodyError)) return stringField(bodyError.error)
-  return undefined
-}
-
-function detailsFromToolRespondError(err: unknown): string | undefined {
-  if (!isRecord(err)) return undefined
-  const details = err.details
-  if (typeof details === "string") return details
-  if (isRecord(details)) {
-    try {
-      return JSON.stringify(details)
-    } catch {
-      return undefined
-    }
-  }
-  return undefined
-}
-
-function requestIDFromToolRespondError(err: unknown): string | undefined {
-  if (!isRecord(err)) return undefined
-  const request = err.request
-  if (isRecord(request)) return stringField(request.id)
-  return undefined
-}
-
-export function normalizeToolRespondError(err: unknown): NormalizedToolRespondError {
-  const status = statusFromToolRespondError(err)
-  const code = errorCodeFromToolRespondError(err)
-  const details = detailsFromToolRespondError(err)
-
-  if (code === "already_resolved") return { type: "already_resolved", requestID: requestIDFromToolRespondError(err) }
-  if (code === "no_pending_tool_call") return { type: "stale_session" }
-  if (status === 404) return { type: "stale_session" }
-  if (status === 409) return { type: "already_resolved", requestID: requestIDFromToolRespondError(err) }
-  if (status === 400 || status === 422 || invalidPayloadErrorCodes.has(code ?? "") || details !== undefined) {
-    const detail = [code, details].filter(Boolean).join(" ")
-    return { type: "invalid_payload", detail: detail || undefined }
-  }
-  if (err instanceof Error) return { type: "unknown", detail: err.message }
-  if (typeof err === "string") return { type: "unknown", detail: err }
-  if (code) return { type: "unknown", detail: code }
-  return { type: "unknown" }
-}
 
 export function isSameQuestionRequest(
   left: QuestionRequestFingerprint | undefined,
@@ -157,27 +50,6 @@ function focusWithoutScrollingTimeline(el: HTMLElement | undefined) {
   if (!el) return
   el.focus({ preventScroll: true })
   keepVisibleInQuestionOptions(el)
-}
-
-/**
- * After skipping a question (setting its answer to []), decide the next action.
- * Returns either the tab to navigate to, or a submit signal when all questions are settled.
- */
-export function resolveSkipAction(
-  currentTab: number,
-  isSettled: (i: number) => boolean,
-  total: number,
-): { type: "navigate"; tab: number } | { type: "submit" } {
-  // First, look for an unsettled question after the current tab.
-  for (let i = currentTab + 1; i < total; i++) {
-    if (!isSettled(i)) return { type: "navigate", tab: i }
-  }
-  // Then, look for any unsettled question before the current tab.
-  for (let i = 0; i < currentTab; i++) {
-    if (!isSettled(i)) return { type: "navigate", tab: i }
-  }
-  // All settled — time to submit.
-  return { type: "submit" }
 }
 
 function Mark(props: { multi: boolean; picked: boolean; onClick?: (event: MouseEvent) => void }) {


### PR DESCRIPTION
## Summary

Slice **Q1** of the `#1066` component-slimming production line. Pure extraction — no behavior, DOM, aria, copy, or storage-key change.

Moves the question-dock pure logic out of `session-question-dock.tsx` into a new `question-tool-respond.ts`:

- `resolveSkipAction` (+ its JSDoc)
- `normalizeToolRespondError` (+ private helpers `isRecord`/`stringField`/`status|errorCode|details|requestID FromToolRespondError`, the `NormalizedToolRespondError` type and `invalidPayloadErrorCodes` const)
- `createQuestionResponseGuard` (+ `QuestionResponsePhase` type)

`isSameQuestionRequest` and `QuestionRequestFingerprint` stay in the dock because the fingerprint type is shared by the component body (keeps the `DockQuestionRequest` type import out of the new module). The dock now imports the three moved functions from `./question-tool-respond`; internal call sites are unchanged.

Test file `session-question-dock.test.ts` keeps its name and now straddles both modules: `isSameQuestionRequest` from the dock, the other three from the new module (including the `runBrowserCheck` import path).

`session-question-dock.tsx`: 805 → 691 lines.

## Test plan

- [x] `bun run typecheck` — 8/8 packages clean
- [x] `bun test src/pages/session/composer/session-question-dock.test.ts` — 15 pass / 0 fail
- [x] `bunx eslint` on the new + edited files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to session question handling utilities.

---

**Note:** This release contains no user-facing changes. Updates focus on backend code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->