### PR TITLE
refactor(app): extract question Mark/Option presentational components

### DIFF
--- a/packages/app/src/pages/session/composer/question-option.tsx
+++ b/packages/app/src/pages/session/composer/question-option.tsx
@@ -1,0 +1,47 @@
+import { Show } from "solid-js"
+import { Icon } from "@opencode-ai/ui/icon"
+
+export function Mark(props: { multi: boolean; picked: boolean; onClick?: (event: MouseEvent) => void }) {
+  return (
+    <span data-slot="question-option-check" aria-hidden="true" onClick={props.onClick}>
+      <span data-slot="question-option-box" data-type={props.multi ? "checkbox" : "radio"} data-picked={props.picked}>
+        <Show when={props.multi} fallback={<span data-slot="question-option-radio-dot" />}>
+          <Icon name="check-small" />
+        </Show>
+      </span>
+    </span>
+  )
+}
+
+export function Option(props: {
+  multi: boolean
+  picked: boolean
+  label: string
+  description?: string
+  disabled: boolean
+  ref?: (el: HTMLButtonElement) => void
+  onFocus?: VoidFunction
+  onClick: VoidFunction
+}) {
+  return (
+    <button
+      type="button"
+      ref={props.ref}
+      data-slot="question-option"
+      data-picked={props.picked}
+      role={props.multi ? "checkbox" : "radio"}
+      aria-checked={props.picked}
+      disabled={props.disabled}
+      onFocus={props.onFocus}
+      onClick={props.onClick}
+    >
+      <Mark multi={props.multi} picked={props.picked} />
+      <span data-slot="question-option-main">
+        <span data-slot="option-label">{props.label}</span>
+        <Show when={props.description}>
+          <span data-slot="option-description">{props.description}</span>
+        </Show>
+      </span>
+    </button>
+  )
+}

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -3,12 +3,12 @@ import { createStore } from "solid-js/store"
 import { useMutation } from "@tanstack/solid-query"
 import { Button } from "@opencode-ai/ui/button"
 import { DockPrompt } from "@opencode-ai/ui/dock-prompt"
-import { Icon } from "@opencode-ai/ui/icon"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
 import type { DockQuestionRequest } from "@/pages/session/blockers/use-session-blockers"
 import { createQuestionResponseGuard, normalizeToolRespondError, resolveSkipAction } from "./question-tool-respond"
+import { Mark, Option } from "./question-option"
 
 // One question's selected labels. Mirrors the per-row shape of the
 // `payload.answers: string[][]` body sent to POST /session/:id/tool/respond
@@ -50,51 +50,6 @@ function focusWithoutScrollingTimeline(el: HTMLElement | undefined) {
   if (!el) return
   el.focus({ preventScroll: true })
   keepVisibleInQuestionOptions(el)
-}
-
-function Mark(props: { multi: boolean; picked: boolean; onClick?: (event: MouseEvent) => void }) {
-  return (
-    <span data-slot="question-option-check" aria-hidden="true" onClick={props.onClick}>
-      <span data-slot="question-option-box" data-type={props.multi ? "checkbox" : "radio"} data-picked={props.picked}>
-        <Show when={props.multi} fallback={<span data-slot="question-option-radio-dot" />}>
-          <Icon name="check-small" />
-        </Show>
-      </span>
-    </span>
-  )
-}
-
-function Option(props: {
-  multi: boolean
-  picked: boolean
-  label: string
-  description?: string
-  disabled: boolean
-  ref?: (el: HTMLButtonElement) => void
-  onFocus?: VoidFunction
-  onClick: VoidFunction
-}) {
-  return (
-    <button
-      type="button"
-      ref={props.ref}
-      data-slot="question-option"
-      data-picked={props.picked}
-      role={props.multi ? "checkbox" : "radio"}
-      aria-checked={props.picked}
-      disabled={props.disabled}
-      onFocus={props.onFocus}
-      onClick={props.onClick}
-    >
-      <Mark multi={props.multi} picked={props.picked} />
-      <span data-slot="question-option-main">
-        <span data-slot="option-label">{props.label}</span>
-        <Show when={props.description}>
-          <span data-slot="option-description">{props.description}</span>
-        </Show>
-      </span>
-    </button>
-  )
 }
 
 export const SessionQuestionDock: Component<{ request: DockQuestionRequest; onSubmit: () => void }> = (props) => {


### PR DESCRIPTION
## Summary

Slice **Q2** of the `#1066` component-slimming production line. Pure extraction — no behavior, DOM, aria, role, or copy change.

Moves the two stateless presentational components out of `session-question-dock.tsx` into a new `question-option.tsx`:

- `Mark` — the checkbox/radio glyph (`data-slot="question-option-check"`)
- `Option` — the option button (`data-slot="question-option"`), which renders `Mark` internally

Both are exported (the dock still renders `Mark` directly for the custom-input row, and `Option` in the options list). The `@opencode-ai/ui/icon` `Icon` import follows `Mark` into the new module and is dropped from the dock; `Show` stays in the dock (still used by the component body). JSX is moved byte-for-byte.

`session-question-dock.tsx`: 691 → 645 lines.

## Test plan

- [x] `bun run typecheck` — 8/8 packages clean (prop contracts intact)
- [x] `bun test src/pages/session/composer/session-question-dock.test.ts` — 15 pass / 0 fail
- [x] `bun test src/shell-frame-contract.test.ts` — 10 pass / 0 fail
- [x] `bunx eslint` on the new + edited file — clean
- [ ] No snapshot test exists for the dock and `dev:desktop` can't be driven headlessly here; DOM-faithfulness rests on the byte-identical JSX move + typecheck confirming prop contracts.