### PR TITLE
refactor(app): extract question draft cache and option-focus helpers

### DIFF
--- a/packages/app/src/pages/session/composer/question-draft.ts
+++ b/packages/app/src/pages/session/composer/question-draft.ts
@@ -1,0 +1,8 @@
+// One question's selected labels. Mirrors the per-row shape of the
+// `payload.answers: string[][]` body sent to POST /session/:id/tool/respond
+// (validated by questionDecoder in packages/opencode/src/tool/question.ts).
+export type QuestionAnswer = readonly string[]
+
+export type DraftAnswer = QuestionAnswer | undefined
+
+export const cache = new Map<string, { tab: number; answers: DraftAnswer[]; custom: string[]; customOn: boolean[] }>()

--- a/packages/app/src/pages/session/composer/question-option-focus.ts
+++ b/packages/app/src/pages/session/composer/question-option-focus.ts
@@ -1,0 +1,18 @@
+function keepVisibleInQuestionOptions(el: HTMLElement) {
+  const scroller = el.closest('[data-slot="question-options"]')
+  if (!(scroller instanceof HTMLElement)) return
+
+  const optionRect = el.getBoundingClientRect()
+  const scrollerRect = scroller.getBoundingClientRect()
+  if (optionRect.top < scrollerRect.top) {
+    scroller.scrollTop -= scrollerRect.top - optionRect.top
+  } else if (optionRect.bottom > scrollerRect.bottom) {
+    scroller.scrollTop += optionRect.bottom - scrollerRect.bottom
+  }
+}
+
+export function focusWithoutScrollingTimeline(el: HTMLElement | undefined) {
+  if (!el) return
+  el.focus({ preventScroll: true })
+  keepVisibleInQuestionOptions(el)
+}

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -9,13 +9,8 @@ import { useSDK } from "@/context/sdk"
 import type { DockQuestionRequest } from "@/pages/session/blockers/use-session-blockers"
 import { createQuestionResponseGuard, normalizeToolRespondError, resolveSkipAction } from "./question-tool-respond"
 import { Mark, Option } from "./question-option"
-
-// One question's selected labels. Mirrors the per-row shape of the
-// `payload.answers: string[][]` body sent to POST /session/:id/tool/respond
-// (validated by questionDecoder in packages/opencode/src/tool/question.ts).
-type QuestionAnswer = readonly string[]
-
-type DraftAnswer = QuestionAnswer | undefined
+import { cache, type DraftAnswer, type QuestionAnswer } from "./question-draft"
+import { focusWithoutScrollingTimeline } from "./question-option-focus"
 
 type QuestionRequestFingerprint = Pick<DockQuestionRequest, "id" | "sessionID" | "messageID" | "callID">
 
@@ -29,27 +24,6 @@ export function isSameQuestionRequest(
     return false
   if (errorRequestID !== undefined && errorRequestID !== right.id) return false
   return left.id === right.id
-}
-
-const cache = new Map<string, { tab: number; answers: DraftAnswer[]; custom: string[]; customOn: boolean[] }>()
-
-function keepVisibleInQuestionOptions(el: HTMLElement) {
-  const scroller = el.closest('[data-slot="question-options"]')
-  if (!(scroller instanceof HTMLElement)) return
-
-  const optionRect = el.getBoundingClientRect()
-  const scrollerRect = scroller.getBoundingClientRect()
-  if (optionRect.top < scrollerRect.top) {
-    scroller.scrollTop -= scrollerRect.top - optionRect.top
-  } else if (optionRect.bottom > scrollerRect.bottom) {
-    scroller.scrollTop += optionRect.bottom - scrollerRect.bottom
-  }
-}
-
-function focusWithoutScrollingTimeline(el: HTMLElement | undefined) {
-  if (!el) return
-  el.focus({ preventScroll: true })
-  keepVisibleInQuestionOptions(el)
 }
 
 export const SessionQuestionDock: Component<{ request: DockQuestionRequest; onSubmit: () => void }> = (props) => {

--- a/packages/app/src/pages/session/timeline-scroll-command-allowlist.ts
+++ b/packages/app/src/pages/session/timeline-scroll-command-allowlist.ts
@@ -2,7 +2,7 @@ import type { TimelineScrollOwnershipAllowlistEntry } from "./timeline-scroll-ow
 
 export const timelineScrollCommandAllowlist: TimelineScrollOwnershipAllowlistEntry[] = [
   {
-    filePath: "packages/app/src/pages/session/composer/session-question-dock.tsx",
+    filePath: "packages/app/src/pages/session/composer/question-option-focus.ts",
     symbol: "keepVisibleInQuestionOptions",
     reason: "Question option list is a nested composer scroller, not the session timeline viewport.",
     owner: "session composer",

--- a/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
+++ b/packages/app/src/pages/session/timeline-scroll-ownership-guard.test.ts
@@ -62,7 +62,7 @@ describe("timeline scroll ownership guard", () => {
   test("matches reviewed exceptions when scanned file paths use Windows separators", () => {
     expect(
       scanTimelineScrollOwnershipText({
-        filePath: "packages\\app\\src\\pages\\session\\composer\\session-question-dock.tsx",
+        filePath: "packages\\app\\src\\pages\\session\\composer\\question-option-focus.ts",
         sourceText: `
           function keepVisibleInQuestionOptions(scroller: HTMLElement) {
             scroller.scrollTop += 1


### PR DESCRIPTION
## Summary

Slice **Q3** of the `#1066` component-slimming production line. Pure extraction — no behavior change.

Splits two unrelated concerns out of `session-question-dock.tsx` into two small modules:

- **`question-draft.ts`** — the per-request draft `cache` (a `Map`), together with the `QuestionAnswer` / `DraftAnswer` answer types. The cache's value shape is defined in terms of `DraftAnswer`, so the types move with it to keep a one-way dependency (dock → module) rather than a type-only back-import. The dock re-imports `cache` (value) and the two types.
- **`question-option-focus.ts`** — the `focusWithoutScrollingTimeline` helper (exported) and its private `keepVisibleInQuestionOptions` dependency. Zero deps; the dock imports `focusWithoutScrollingTimeline`.

All logic is moved byte-for-byte. `session-question-dock.tsx`: 645 → 619 lines.

## Test plan

- [x] `bun run typecheck` — 8/8 packages clean
- [x] `bun test src/pages/session/composer/session-question-dock.test.ts` — 15 pass / 0 fail
- [x] `bunx eslint` on the two new + edited file — clean