### PR TITLE
test(app): stop toast mock.module from leaking across test files

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.test.ts
+++ b/packages/app/src/components/prompt-input/attachments.test.ts
@@ -32,9 +32,10 @@ class TestFileReader {
 // global, persistent, non-restoring registry override that leaked this toast
 // mock into every later test file and broke suites relying on the real
 // showToast (e.g. pawwork-session-commands.test.ts).
-spyOn(uiToast, "showToast").mockImplementation(((toast: (typeof toasts)[number]) => {
-  toasts.push(toast)
-}) as never)
+spyOn(uiToast, "showToast").mockImplementation((toast) => {
+  toasts.push(toast as (typeof toasts)[number])
+  return 0
+})
 
 mock.module("@/context/language", () => ({
   useLanguage: () => ({

--- a/packages/app/src/components/prompt-input/attachments.test.ts
+++ b/packages/app/src/components/prompt-input/attachments.test.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer"
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as uiToast from "@opencode-ai/ui/toast"
 import { attachmentMime } from "./files"
 import { pasteMode } from "./paste"
 import type { createPromptAttachments as createPromptAttachmentsType } from "./attachments"
@@ -27,11 +28,13 @@ class TestFileReader {
   }
 }
 
-mock.module("@opencode-ai/ui/toast", () => ({
-  showToast: (toast: (typeof toasts)[number]) => {
-    toasts.push(toast)
-  },
-}))
+// spyOn + afterAll restore instead of mock.module: bun's mock.module is a
+// global, persistent, non-restoring registry override that leaked this toast
+// mock into every later test file and broke suites relying on the real
+// showToast (e.g. pawwork-session-commands.test.ts).
+spyOn(uiToast, "showToast").mockImplementation(((toast: (typeof toasts)[number]) => {
+  toasts.push(toast)
+}) as never)
 
 mock.module("@/context/language", () => ({
   useLanguage: () => ({
@@ -68,6 +71,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   ;(globalThis as unknown as { FileReader: typeof originalFileReader }).FileReader = originalFileReader
+  mock.restore()
 })
 
 beforeEach(() => {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as uiToast from "@opencode-ai/ui/toast"
 import type { Prompt } from "@/context/prompt"
 import type { createPromptSubmit as createPromptSubmitType } from "./submit"
 import { _portableDraftTesting, usePortableDraft } from "./portable-draft"
@@ -119,9 +120,11 @@ beforeAll(async () => {
     },
   }))
 
-  mock.module("@opencode-ai/ui/toast", () => ({
-    showToast: () => 0,
-  }))
+  // spyOn + afterAll restore instead of mock.module: bun's mock.module is a
+  // global, persistent, non-restoring registry override, so a noop toast mock
+  // here leaked into every later test file in the run and broke suites that
+  // rely on the real showToast (e.g. pawwork-session-commands.test.ts).
+  spyOn(uiToast, "showToast").mockImplementation(() => 0 as never)
 
   mock.module("@opencode-ai/util/encode", () => ({
     base64Encode: (value: string) => value,
@@ -272,6 +275,10 @@ beforeAll(async () => {
 
   const mod = await import("./submit")
   createPromptSubmit = mod.createPromptSubmit
+})
+
+afterAll(() => {
+  mock.restore()
 })
 
 beforeEach(() => {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -124,7 +124,7 @@ beforeAll(async () => {
   // global, persistent, non-restoring registry override, so a noop toast mock
   // here leaked into every later test file in the run and broke suites that
   // rely on the real showToast (e.g. pawwork-session-commands.test.ts).
-  spyOn(uiToast, "showToast").mockImplementation(() => 0 as never)
+  spyOn(uiToast, "showToast").mockImplementation(() => 0)
 
   mock.module("@opencode-ai/util/encode", () => ({
     base64Encode: (value: string) => value,


### PR DESCRIPTION
## Summary

The last ~10 merges showed a red **Windows advisory** CI job. This is a real test-isolation regression, not flake.

`submit.test.ts` and `attachments.test.ts` stub `showToast` with `mock.module("@opencode-ai/ui/toast", ...)`. bun's `mock.module` is a **global, persistent, non-restoring** registry override: once registered it replaces the module for every later test file in the same `bun test` process and is never torn down.

That poisons `pawwork-session-commands.test.ts`, which relies on the real `showToast` → `toaster.show` chain to count emitted toasts. With `showToast` permanently stubbed (noop in submit, capture-array in attachments), its 4 toast-asserting tests observe zero toasts and fail.

**Why CI only failed on Windows/macOS:** bun's test-file traversal order is filesystem-dependent. On case-sensitive Linux (the required `ci` gate) the polluters run *after* the victim, so it stays green. On case-insensitive macOS/Windows they run *before* it, surfacing the failure. The Windows job is advisory (non-blocking, self-retrying), so the regression slipped through ~10 merges unnoticed.

## Fix

Replace `mock.module` with `spyOn(uiToast, "showToast").mockImplementation(...)` + `mock.restore()` in `afterAll`, scoping each stub to the file that needs it and tearing it down before the next file runs.

## Verification

- Full app suite `bun test --preload ./happydom.ts ./src ./e2e/perf/*.unit.ts`: **4 fail → 0 fail** (1726 pass)
- `bun run lint`: clean
- `@opencode-ai/app` typecheck: clean

## Residual risk / deferred

- The Windows advisory job remains non-blocking, so a future cross-file `mock.module` leak could again merge silently. Not changed here.
- ~9 other test files still `mock.module` *other* shared `@opencode-ai/ui/*` modules with the same non-restoring pattern. They aren't currently breaking another suite, so they're out of scope for this fix but worth a follow-up sweep.