### PR TITLE
refactor(automation): move active-run state into InstanceState

### DIFF
--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1,5 +1,7 @@
 import z from "zod"
 import { Context as EffectContext, Effect, Layer } from "effect"
+import { InstanceState } from "@/effect/instance-state"
+import { makeRuntime } from "@/effect/run-service"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { Identifier } from "@/id/id"
@@ -265,10 +267,11 @@ export namespace Automation {
     activeWriters: Set<string>
     activeRuns: Map<string, { writerKey: string; controller: AbortController; runID: string }>
   }
-  const state = Instance.state<State>(() => ({
-    activeWriters: new Set(),
-    activeRuns: new Map(),
-  }))
+  // Per-directory execution state. The container lives in InstanceState (owned by the
+  // Service layer below); the sync facade reads it through a runtime bridge (see `state`).
+  function state(): State {
+    return automationRuntime.runSync((svc) => svc.activeState())
+  }
 
   export type RunExecutor = (input: {
     definition: Definition
@@ -1235,46 +1238,56 @@ export namespace Automation {
     readonly publishDefinitionUpdated: (definition: Definition) => Effect.Effect<void>
     readonly publishDefinitionDeleted: (tombstone: Tombstone) => Effect.Effect<void>
     readonly publishRunUpdated: (run: Run) => Effect.Effect<void>
+    // Execution-face: the per-directory mutable active-run/writer state, owned by InstanceState.
+    readonly activeState: () => Effect.Effect<State>
   }
 
   export class Service extends EffectContext.Service<Service, Interface>()("@opencode/Automation") {}
 
-  export const layer: Layer.Layer<Service> = Layer.succeed(
+  export const layer: Layer.Layer<Service> = Layer.effect(
     Service,
-    Service.of({
-      list: () => Effect.sync(() => list()),
-      get: (id) => Effect.sync(() => get(id)),
-      create: (input, options) =>
-        Effect.try({
-          try: () => create(input, options),
-          catch: (error) => {
-            if (error instanceof ValidationError) return error
-            throw error
-          },
-        }),
-      update: (id, patch, options) =>
-        Effect.try({
-          try: () => update(id, patch, options),
-          catch: (error) => {
-            if (error instanceof ValidationError || error instanceof ConflictError) return error
-            throw error
-          },
-        }),
-      remove: (id) =>
-        Effect.tryPromise({ try: () => remove(id), catch: (error) => error }).pipe(
-          Effect.catch((error) =>
-            error instanceof ActiveRunStillRunningError ? Effect.fail(error) : Effect.die(error),
+    Effect.gen(function* () {
+      const activeStateHandle = yield* InstanceState.make<State>(() =>
+        Effect.sync(() => ({ activeWriters: new Set<string>(), activeRuns: new Map() })),
+      )
+      return Service.of({
+        list: () => Effect.sync(() => list()),
+        get: (id) => Effect.sync(() => get(id)),
+        create: (input, options) =>
+          Effect.try({
+            try: () => create(input, options),
+            catch: (error) => {
+              if (error instanceof ValidationError) return error
+              throw error
+            },
+          }),
+        update: (id, patch, options) =>
+          Effect.try({
+            try: () => update(id, patch, options),
+            catch: (error) => {
+              if (error instanceof ValidationError || error instanceof ConflictError) return error
+              throw error
+            },
+          }),
+        remove: (id) =>
+          Effect.tryPromise({ try: () => remove(id), catch: (error) => error }).pipe(
+            Effect.catch((error) =>
+              error instanceof ActiveRunStillRunningError ? Effect.fail(error) : Effect.die(error),
+            ),
           ),
-        ),
-      runNowExecuting: (id, options) => Effect.promise(() => runNowExecuting(id, options)),
-      runs: (input) => Effect.sync(() => runs(input)),
-      publishDefinitionUpdated: (definition) => Effect.promise(() => publishDefinitionUpdated(definition)),
-      publishDefinitionDeleted: (tombstone) => Effect.promise(() => publishDefinitionDeleted(tombstone)),
-      publishRunUpdated: (run) => Effect.promise(() => publishRunUpdated(run)),
+        runNowExecuting: (id, options) => Effect.promise(() => runNowExecuting(id, options)),
+        runs: (input) => Effect.sync(() => runs(input)),
+        publishDefinitionUpdated: (definition) => Effect.promise(() => publishDefinitionUpdated(definition)),
+        publishDefinitionDeleted: (tombstone) => Effect.promise(() => publishDefinitionDeleted(tombstone)),
+        publishRunUpdated: (run) => Effect.promise(() => publishRunUpdated(run)),
+        activeState: () => InstanceState.get(activeStateHandle),
+      })
     }),
   )
 
   export const defaultLayer = layer
+
+  const automationRuntime = makeRuntime(Service, layer)
 }
 
 export class ValidationError extends Error {


### PR DESCRIPTION
## Summary

Move automation's per-directory **active-run execution state** (`activeWriters` set + `activeRuns` map, which hold the in-flight `AbortController`s) out of the synchronous `Instance.state` and into `InstanceState`, read back through the same memoized-runtime bridge that `Bus`/`Vcs` already use. The surviving synchronous `Automation.*` facade is unchanged for all callers, so this is a behavior-preserving relocation of the state container.

- `Automation.layer` becomes `Layer.effect`, owns the `InstanceState` handle, and exposes `activeState()` on the service.
- The module-level `state()` helper now reads through `automationRuntime.runSync(svc => svc.activeState())` (lazy, memoized — tests that use bare `Instance.provide` keep working without building the layer).
- Net diff is a single file: `+47 / -34`.

Part 2 of the automation Effect migration (#950). PR1 (#1068) effectified the request face (`Automation.Service` + route handlers); this PR effectifies the execution-face state container.

## Scope decisions (deliberately narrowed)

The original PR2 sketch also proposed moving the scheduler's **owner state** into `InstanceState` and "effectifying" `scheduler.ts` / `runner.ts`. Both were intentionally left out after analysis (verified with an independent review):

1. **Owner state stays in `Instance.state`.** Instance teardown runs `State.dispose()` (old `Instance.state` disposers) and then `runDisposers()` (InstanceState cache-invalidations), and `runDisposers` fires its callbacks *concurrently* (`Promise.allSettled`). The owner-state disposer calls `scheduler.stop() -> stopOwnedRuns() -> Automation.stopRunByID()`, which reads the **active state** to fire each run's `AbortController`. Today the owner disposer runs in the earlier `State.dispose` phase, so active state is guaranteed alive. Moving owner state into `InstanceState` would put its finalizer in the same concurrent batch as the active-state invalidation, creating a force-dispose race where in-flight runs may not be aborted. The cross-directory `owners` map + `Instance.restore` reach (used by `stopDirectoryOwnedRuns` / `stopAllOwnedRuns`) also cannot be expressed through `InstanceState`'s ALS-scoped API. Safely moving it would require an explicit teardown-ordering API change, which is out of scope for this low-risk PR.
2. **No rewrite of `fire` / `scan` / `becomeOwner` / Bus callbacks.** The scheduler's external `Interface` must stay synchronous (tests assert a run's signal aborts synchronously right after `stop()` / dispose), and its run-loop must keep calling the sync `Automation` facade (deleted later in PR3). Wrapping those sync facade calls in Effect would be cosmetic and carries real regression risk across lease / missed-schedule / writer-conflict / self-published-event-suppression / cancellation logic. `runner.ts`'s `AbortSignal -> SessionPrompt.cancel` listener with `finally` cleanup is correctness-critical and is preserved as-is.

## Test plan

- [x] `tsgo --noEmit` clean
- [x] `automation-routes` / `automation-runner` / `automation-scheduler` / `automation-event-fixtures` — 107 pass, 0 fail
- [x] `automation/cron` / `automation/validation` / `tool/automate` / `event-replay` — 45 pass, 0 fail