### PR TITLE
fix(opencode): return documented 400 on worktree-in-use removal

### DIFF
--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -355,15 +355,6 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", Worktree.RemoveInput),
       async (c) => {
         const body = c.req.valid("json")
-        const session = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const sessions = yield* Session.Service
-            return yield* sessions.findActiveWorktreeBinding(body.directory)
-          }),
-        )
-        if (session) {
-          throw new Error(`Worktree is in use by session "${session.title}". Call ExitWorktree from that session first.`)
-        }
         await AppRuntime.runPromise(
           Effect.gen(function* () {
             const worktrees = yield* Worktree.Service

--- a/packages/opencode/test/server/experimental-routes.test.ts
+++ b/packages/opencode/test/server/experimental-routes.test.ts
@@ -3,6 +3,9 @@ import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { Instance } from "../../src/project/instance"
 import { ExperimentalRoutes } from "../../src/server/instance/experimental"
+import { ErrorMiddleware } from "../../src/server/middleware"
+import { Session } from "../../src/session"
+import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -13,7 +16,7 @@ afterEach(async () => {
 
 describe("experimental routes", () => {
   function app() {
-    return new Hono().route("/experimental", ExperimentalRoutes())
+    return new Hono().route("/experimental", ExperimentalRoutes()).onError(ErrorMiddleware)
   }
 
   test("lists tool IDs through the route runtime", async () => {
@@ -54,6 +57,36 @@ describe("experimental routes", () => {
 
         expect(response.status).toBe(200)
         expect(body).toBeObject()
+      },
+    })
+  })
+
+  test("DELETE /worktree returns documented 400 when bound to an active session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const info = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const info = await Worktree.makeWorktreeInfo("bound-session")
+        await Worktree.createFromInfo(info)
+        const session = await Session.create({ title: "Bound session" })
+        await Session.updateExecutionContext({ sessionID: session.id, activeWorktree: info })
+        return info
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/experimental/worktree", {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ directory: info.directory }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body.name).toBe("WorktreeRemoveFailedError")
+        expect(body.data.message).toContain("Worktree is in use by session")
       },
     })
   })


### PR DESCRIPTION
## Summary

Remove the redundant in-use pre-check in the `DELETE /worktree` handler so the in-use conflict returns the route's documented `400` instead of a `500`.

## Why

The handler ran its own `findActiveWorktreeBinding` lookup and, when the worktree was bound to an active session, threw a plain `Error`. `ErrorMiddleware` maps a plain `Error` to `500`. This shadowed `Worktree.Service.remove`, which already performs the **identical** binding check and throws the typed `WorktreeRemoveFailedError` — and that error maps to the route's declared `400` (via `name.startsWith("Worktree")`). The handler pre-check was dead duplication that produced the wrong status for a user-actionable conflict ("Call ExitWorktree from that session first."). Part of the #936 error-contract migration: user-meaningful failures should surface through declared typed/HTTP errors.

## Related Issue

Refs #936.

## Human Review Status

Pending

## Review Focus

Confirm the deleted handler pre-check is fully redundant with the service-level guard: `Worktree.Service.remove` canonicalizes the directory and calls the same `findActiveWorktreeBinding`, which canonicalizes its input internally, so both resolve the same binding. No in-use worktree can be removed by deleting the handler check. Confirm the `500 -> 400` change matches the route's declared `...errors(400)` contract and that the user-facing message is unchanged.

## Risk Notes

Behavior change: the in-use conflict now returns `400` instead of `500`. The `400` is already declared in the route's OpenAPI (`...errors(400)`) and the message is unchanged, so there is no SDK/OpenAPI contract drift (no schema/operationId/success-shape change). Skipped conditional checklist items: UI item (no UI or copy changed); macOS/Windows item (no platform/packaging/updater/permissions surface touched); docs/deps item (no docs, dependencies, or credentials touched).

## How To Verify

```text
typecheck (tsgo --noEmit): clean
bun test test/server/experimental-routes.test.ts: 4 pass (incl. new "DELETE /worktree returns documented 400 when bound to an active session")
bun test test/project/worktree-remove.test.ts: service-level guard still rejects WorktreeRemoveFailedError; in-use worktree preserved
bun test test/server/route-inventory-harness.test.ts: green (no route inventory drift)
```

## Screenshots or Recordings

N/A — no visible UI or copy changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
