### PR TITLE
refactor(app): extract layout project pipeline (slice 10 of #1056)

### DIFF
--- a/packages/app/src/context/layout-projects.test.ts
+++ b/packages/app/src/context/layout-projects.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createPawworkLayoutProjects, type PawworkLayoutProjectsInput } from "./layout-projects"
+
+// Bun test resolves solid-js to the server build, where createEffect/onMount are
+// no-ops. These tests therefore exercise only the pure paths reachable through
+// the memos (rootFor, list, enrich), which the server build evaluates normally.
+// Effect-driven behaviour (color assignment, icon override sync, sandbox
+// routing) is preserved verbatim from layout.tsx and is covered by /codex review.
+
+type Project = { id?: string; worktree: string; icon?: { url?: string; override?: string; color?: string }; name?: string }
+type ChildStore = { project?: string; icon?: string; projectMeta?: { name?: string; commands?: { start?: string } } }
+
+type SetupOpts = {
+  serverProjects?: { worktree: string; expanded: boolean }[]
+  dataProjects?: (Project & { sandboxes?: string[] })[]
+  childStores?: Record<string, ChildStore>
+  ready?: boolean
+}
+
+function setup(opts: SetupOpts = {}) {
+  const input: PawworkLayoutProjectsInput = {
+    globalSDK: {
+      client: {
+        project: {
+          update: () => Promise.resolve({ data: {} }),
+        },
+      },
+    } as unknown as PawworkLayoutProjectsInput["globalSDK"],
+    globalSync: {
+      child: (worktree: string) => {
+        const value = opts.childStores?.[worktree] ?? {}
+        return [value] as unknown as ReturnType<PawworkLayoutProjectsInput["globalSync"]["child"]>
+      },
+      data: { project: opts.dataProjects ?? [] } as unknown as PawworkLayoutProjectsInput["globalSync"]["data"],
+      project: {
+        icon: () => undefined,
+        meta: () => undefined,
+        loadSessions: () => Promise.resolve(),
+      } as unknown as PawworkLayoutProjectsInput["globalSync"]["project"],
+      ready: opts.ready ?? true,
+    },
+    server: {
+      projects: {
+        list: () => opts.serverProjects ?? [],
+        close: () => undefined,
+        open: () => undefined,
+        expand: () => undefined,
+      } as unknown as PawworkLayoutProjectsInput["server"]["projects"],
+    },
+  }
+  return { input }
+}
+
+describe("createPawworkLayoutProjects rootFor", () => {
+  test("returns the input directory when there are no sandbox roots", () => {
+    createRoot((dispose) => {
+      const { input } = setup()
+      const { rootFor } = createPawworkLayoutProjects(input)
+      expect(rootFor("/some/path")).toBe("/some/path")
+      dispose()
+    })
+  })
+
+  test("walks the sandbox chain to the root project", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        dataProjects: [{ worktree: "/root", sandboxes: ["/sb"] }],
+      })
+      const { rootFor } = createPawworkLayoutProjects(input)
+      expect(rootFor("/sb")).toBe("/root")
+      expect(rootFor("/root")).toBe("/root")
+      expect(rootFor("/unknown")).toBe("/unknown")
+      dispose()
+    })
+  })
+
+  test("falls back to the input directory on a sandbox cycle", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        dataProjects: [
+          { worktree: "/a", sandboxes: ["/b"] },
+          { worktree: "/b", sandboxes: ["/a"] },
+        ],
+      })
+      const { rootFor } = createPawworkLayoutProjects(input)
+      expect(rootFor("/a")).toBe("/a")
+      dispose()
+    })
+  })
+})
+
+describe("createPawworkLayoutProjects list memo", () => {
+  test("returns server projects enriched with metadata", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        serverProjects: [{ worktree: "/w", expanded: true }],
+        dataProjects: [{ id: "p1", worktree: "/w", name: "Demo", icon: { color: "pink" } }],
+        childStores: { "/w": { project: "p1" } },
+      })
+      const { list } = createPawworkLayoutProjects(input)
+      const items = list()
+      expect(items).toHaveLength(1)
+      expect(items[0].id).toBe("p1")
+      expect(items[0].name).toBe("Demo")
+      expect(items[0].icon?.color).toBe("pink")
+      dispose()
+    })
+  })
+
+  test("prefers child icon when metadata has no override", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        serverProjects: [{ worktree: "/w", expanded: false }],
+        dataProjects: [{ id: "p1", worktree: "/w" }],
+        childStores: { "/w": { project: "p1", icon: "X" } },
+      })
+      const { list } = createPawworkLayoutProjects(input)
+      expect(list()[0].icon?.override).toBe("X")
+      dispose()
+    })
+  })
+
+  test("treats projectID === 'global' as a global project", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        serverProjects: [{ worktree: "/w", expanded: false }],
+        dataProjects: [{ id: "global", worktree: "/w" }],
+        childStores: { "/w": { project: "global", projectMeta: { name: "Local" } } },
+      })
+      const { list } = createPawworkLayoutProjects(input)
+      const item = list()[0]
+      expect(item.id).toBe("global")
+      expect(item.name).toBe("Local")
+      dispose()
+    })
+  })
+
+  test("treats unknown id + local overrides as global", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        serverProjects: [{ worktree: "/w", expanded: false }],
+        childStores: { "/w": { projectMeta: { name: "From local" } } },
+      })
+      const { list } = createPawworkLayoutProjects(input)
+      const item = list()[0]
+      expect(item.id).toBe("global")
+      expect(item.name).toBe("From local")
+      dispose()
+    })
+  })
+
+  test("does not assign a global id when metadata is plain", () => {
+    createRoot((dispose) => {
+      const { input } = setup({
+        serverProjects: [{ worktree: "/w", expanded: false }],
+        dataProjects: [{ id: "p1", worktree: "/w" }],
+        childStores: { "/w": { project: "p1" } },
+      })
+      const { list } = createPawworkLayoutProjects(input)
+      expect(list()[0].id).toBe("p1")
+      dispose()
+    })
+  })
+})

--- a/packages/app/src/context/layout-projects.test.ts
+++ b/packages/app/src/context/layout-projects.test.ts
@@ -116,7 +116,8 @@ describe("createPawworkLayoutProjects list memo", () => {
         childStores: { "/w": { project: "p1", icon: "X" } },
       })
       const { list } = createPawworkLayoutProjects(input)
-      expect(list()[0].icon?.override).toBe("X")
+      const icon = list()[0].icon as { override?: string } | undefined
+      expect(icon?.override).toBe("X")
       dispose()
     })
   })

--- a/packages/app/src/context/layout-projects.ts
+++ b/packages/app/src/context/layout-projects.ts
@@ -1,0 +1,206 @@
+import { batch, createEffect, createMemo, onCleanup, onMount } from "solid-js"
+import { createStore } from "solid-js/store"
+import type { useGlobalSDK } from "./global-sdk"
+import type { useGlobalSync } from "./global-sync"
+import type { useServer } from "./server"
+import { AVATAR_COLOR_KEYS, type AvatarColorKey } from "./layout-state"
+
+export type PawworkLayoutProjectsInput = {
+  globalSDK: Pick<ReturnType<typeof useGlobalSDK>, "client">
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child" | "data" | "project" | "ready">
+  server: Pick<ReturnType<typeof useServer>, "projects">
+}
+
+export function createPawworkLayoutProjects(input: PawworkLayoutProjectsInput) {
+  const [colors, setColors] = createStore<Record<string, AvatarColorKey>>({})
+  const colorRequested = new Map<string, AvatarColorKey>()
+
+  function pickAvailableColor(used: Set<string>): AvatarColorKey {
+    const available = AVATAR_COLOR_KEYS.filter((c) => !used.has(c))
+    if (available.length === 0) return AVATAR_COLOR_KEYS[Math.floor(Math.random() * AVATAR_COLOR_KEYS.length)]
+    return available[Math.floor(Math.random() * available.length)]
+  }
+
+  function enrich(project: { worktree: string; expanded: boolean }) {
+    const [childStore] = input.globalSync.child(project.worktree, { bootstrap: false })
+    const projectID = childStore.project
+    const metadata = projectID
+      ? input.globalSync.data.project.find((x) => x.id === projectID)
+      : input.globalSync.data.project.find((x) => x.worktree === project.worktree)
+
+    const local = childStore.projectMeta
+    const localOverride =
+      local?.name !== undefined ||
+      local?.commands?.start !== undefined ||
+      local?.icon?.override !== undefined ||
+      local?.icon?.color !== undefined
+
+    const base = {
+      ...metadata,
+      ...project,
+      icon: {
+        url: metadata?.icon?.url,
+        override: metadata?.icon?.override ?? childStore.icon,
+        color: metadata?.icon?.color,
+      },
+    }
+
+    const isGlobal = projectID === "global" || (metadata?.id === undefined && localOverride)
+    if (!isGlobal) return base
+
+    return {
+      ...base,
+      id: base.id ?? "global",
+      name: local?.name,
+      commands: local?.commands,
+      icon: {
+        url: base.icon?.url,
+        override: local?.icon?.override,
+        color: local?.icon?.color,
+      },
+    }
+  }
+
+  const roots = createMemo(() => {
+    const map = new Map<string, string>()
+    for (const project of input.globalSync.data.project) {
+      const sandboxes = project.sandboxes ?? []
+      for (const sandbox of sandboxes) {
+        map.set(sandbox, project.worktree)
+      }
+    }
+    return map
+  })
+
+  const rootFor = (directory: string) => {
+    const map = roots()
+    if (map.size === 0) return directory
+
+    const visited = new Set<string>()
+    const chain = [directory]
+
+    while (chain.length) {
+      const current = chain[chain.length - 1]
+      if (!current) return directory
+
+      const next = map.get(current)
+      if (!next) return current
+
+      if (visited.has(next)) return directory
+      visited.add(next)
+      chain.push(next)
+    }
+
+    return directory
+  }
+
+  createEffect(() => {
+    const projects = input.server.projects.list()
+    const seen = new Set(projects.map((project) => project.worktree))
+
+    batch(() => {
+      for (const project of projects) {
+        const root = rootFor(project.worktree)
+        if (root === project.worktree) continue
+
+        input.server.projects.close(project.worktree)
+
+        if (!seen.has(root)) {
+          input.server.projects.open(root)
+          seen.add(root)
+        }
+
+        if (project.expanded) input.server.projects.expand(root)
+      }
+    })
+  })
+
+  const enriched = createMemo(() => input.server.projects.list().map(enrich))
+  const list = createMemo(() => {
+    const projects = enriched()
+    return projects.map((project) => {
+      const color = project.icon?.color ?? colors[project.worktree]
+      if (!color) return project
+      const icon = project.icon ? { ...project.icon, color } : { color }
+      return { ...project, icon }
+    })
+  })
+
+  createEffect(() => {
+    const projects = enriched()
+    if (projects.length === 0) return
+    if (!input.globalSync.ready) return
+
+    for (const project of projects) {
+      if (!project.id) continue
+      if (project.id === "global") continue
+      input.globalSync.project.icon(project.worktree, project.icon?.override)
+    }
+  })
+
+  createEffect(() => {
+    const projects = enriched()
+    if (projects.length === 0) return
+
+    for (const project of projects) {
+      if (project.icon?.color) colorRequested.delete(project.worktree)
+    }
+
+    const used = new Set<string>()
+    for (const project of projects) {
+      const color = project.icon?.color ?? colors[project.worktree]
+      if (color) used.add(color)
+    }
+
+    for (const project of projects) {
+      if (project.icon?.color) continue
+      const worktree = project.worktree
+      const existing = colors[worktree]
+      const color = existing ?? pickAvailableColor(used)
+      if (!existing) {
+        used.add(color)
+        setColors(worktree, color)
+      }
+      if (!project.id) continue
+
+      const requested = colorRequested.get(worktree)
+      if (requested === color) continue
+      colorRequested.set(worktree, color)
+
+      if (project.id === "global") {
+        input.globalSync.project.meta(worktree, { icon: { color } })
+        continue
+      }
+
+      void input.globalSDK.client.project
+        .update({ projectID: project.id, directory: worktree, icon: { color } })
+        .catch(() => {
+          if (colorRequested.get(worktree) === color) colorRequested.delete(worktree)
+        })
+    }
+  })
+
+  let sessionFrame: number | undefined
+  let sessionTimer: number | undefined
+
+  onMount(() => {
+    sessionFrame = requestAnimationFrame(() => {
+      sessionFrame = undefined
+      sessionTimer = window.setTimeout(() => {
+        sessionTimer = undefined
+        void Promise.all(
+          input.server.projects.list().map((project) => {
+            return input.globalSync.project.loadSessions(project.worktree)
+          }),
+        )
+      }, 0)
+    })
+  })
+
+  onCleanup(() => {
+    if (sessionFrame !== undefined) cancelAnimationFrame(sessionFrame)
+    if (sessionTimer !== undefined) window.clearTimeout(sessionTimer)
+  })
+
+  return { list, rootFor }
+}

--- a/packages/app/src/context/layout-state.ts
+++ b/packages/app/src/context/layout-state.ts
@@ -15,6 +15,9 @@ export const DEFAULT_RIGHT_PANEL_WIDTH = 380
 export const MIN_RIGHT_PANEL_WIDTH = 360
 export const MAX_RIGHT_PANEL_WIDTH = 520
 
+export const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
+export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]
+
 export function clampRightPanelWidth(raw: number | undefined): number {
   if (typeof raw !== "number" || !Number.isFinite(raw)) return DEFAULT_RIGHT_PANEL_WIDTH
   return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, raw))

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -22,6 +22,8 @@ import {
   type ShellTabState,
 } from "@/pages/session/right-panel-tabs"
 import {
+  AVATAR_COLOR_KEYS,
+  type AvatarColorKey,
   clampRightPanelWidth,
   createDefaultLayoutState,
   createSessionKeyReader,
@@ -41,6 +43,7 @@ import {
   type ReviewDiffStyle,
 } from "./layout-state"
 export {
+  type AvatarColorKey,
   clampRightPanelWidth,
   createDefaultLayoutState,
   createSessionKeyReader,
@@ -55,9 +58,7 @@ export {
   pruneSessionKeys,
   type ReviewDiffStyle,
 } from "./layout-state"
-
-const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
-export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]
+import { createPawworkLayoutProjects } from "./layout-projects"
 
 function getAvatarColors(key?: string) {
   if (key && AVATAR_COLOR_KEYS.includes(key as AvatarColorKey)) {
@@ -200,194 +201,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       })
     })
 
-    const [colors, setColors] = createStore<Record<string, AvatarColorKey>>({})
-    const colorRequested = new Map<string, AvatarColorKey>()
-
-    function pickAvailableColor(used: Set<string>): AvatarColorKey {
-      const available = AVATAR_COLOR_KEYS.filter((c) => !used.has(c))
-      if (available.length === 0) return AVATAR_COLOR_KEYS[Math.floor(Math.random() * AVATAR_COLOR_KEYS.length)]
-      return available[Math.floor(Math.random() * available.length)]
-    }
-
-    function enrich(project: { worktree: string; expanded: boolean }) {
-      const [childStore] = globalSync.child(project.worktree, { bootstrap: false })
-      const projectID = childStore.project
-      const metadata = projectID
-        ? globalSync.data.project.find((x) => x.id === projectID)
-        : globalSync.data.project.find((x) => x.worktree === project.worktree)
-
-      const local = childStore.projectMeta
-      const localOverride =
-        local?.name !== undefined ||
-        local?.commands?.start !== undefined ||
-        local?.icon?.override !== undefined ||
-        local?.icon?.color !== undefined
-
-      const base = {
-        ...metadata,
-        ...project,
-        icon: {
-          url: metadata?.icon?.url,
-          override: metadata?.icon?.override ?? childStore.icon,
-          color: metadata?.icon?.color,
-        },
-      }
-
-      const isGlobal = projectID === "global" || (metadata?.id === undefined && localOverride)
-      if (!isGlobal) return base
-
-      return {
-        ...base,
-        id: base.id ?? "global",
-        name: local?.name,
-        commands: local?.commands,
-        icon: {
-          url: base.icon?.url,
-          override: local?.icon?.override,
-          color: local?.icon?.color,
-        },
-      }
-    }
-
-    const roots = createMemo(() => {
-      const map = new Map<string, string>()
-      for (const project of globalSync.data.project) {
-        const sandboxes = project.sandboxes ?? []
-        for (const sandbox of sandboxes) {
-          map.set(sandbox, project.worktree)
-        }
-      }
-      return map
-    })
-
-    const rootFor = (directory: string) => {
-      const map = roots()
-      if (map.size === 0) return directory
-
-      const visited = new Set<string>()
-      const chain = [directory]
-
-      while (chain.length) {
-        const current = chain[chain.length - 1]
-        if (!current) return directory
-
-        const next = map.get(current)
-        if (!next) return current
-
-        if (visited.has(next)) return directory
-        visited.add(next)
-        chain.push(next)
-      }
-
-      return directory
-    }
-
-    createEffect(() => {
-      const projects = server.projects.list()
-      const seen = new Set(projects.map((project) => project.worktree))
-
-      batch(() => {
-        for (const project of projects) {
-          const root = rootFor(project.worktree)
-          if (root === project.worktree) continue
-
-          server.projects.close(project.worktree)
-
-          if (!seen.has(root)) {
-            server.projects.open(root)
-            seen.add(root)
-          }
-
-          if (project.expanded) server.projects.expand(root)
-        }
-      })
-    })
-
-    const enriched = createMemo(() => server.projects.list().map(enrich))
-    const list = createMemo(() => {
-      const projects = enriched()
-      return projects.map((project) => {
-        const color = project.icon?.color ?? colors[project.worktree]
-        if (!color) return project
-        const icon = project.icon ? { ...project.icon, color } : { color }
-        return { ...project, icon }
-      })
-    })
-
-    createEffect(() => {
-      const projects = enriched()
-      if (projects.length === 0) return
-      if (!globalSync.ready) return
-
-      for (const project of projects) {
-        if (!project.id) continue
-        if (project.id === "global") continue
-        globalSync.project.icon(project.worktree, project.icon?.override)
-      }
-    })
-
-    createEffect(() => {
-      const projects = enriched()
-      if (projects.length === 0) return
-
-      for (const project of projects) {
-        if (project.icon?.color) colorRequested.delete(project.worktree)
-      }
-
-      const used = new Set<string>()
-      for (const project of projects) {
-        const color = project.icon?.color ?? colors[project.worktree]
-        if (color) used.add(color)
-      }
-
-      for (const project of projects) {
-        if (project.icon?.color) continue
-        const worktree = project.worktree
-        const existing = colors[worktree]
-        const color = existing ?? pickAvailableColor(used)
-        if (!existing) {
-          used.add(color)
-          setColors(worktree, color)
-        }
-        if (!project.id) continue
-
-        const requested = colorRequested.get(worktree)
-        if (requested === color) continue
-        colorRequested.set(worktree, color)
-
-        if (project.id === "global") {
-          globalSync.project.meta(worktree, { icon: { color } })
-          continue
-        }
-
-        void globalSdk.client.project
-          .update({ projectID: project.id, directory: worktree, icon: { color } })
-          .catch(() => {
-            if (colorRequested.get(worktree) === color) colorRequested.delete(worktree)
-          })
-      }
-    })
-
-    let sessionFrame: number | undefined
-    let sessionTimer: number | undefined
-
-    onMount(() => {
-      sessionFrame = requestAnimationFrame(() => {
-        sessionFrame = undefined
-        sessionTimer = window.setTimeout(() => {
-          sessionTimer = undefined
-          void Promise.all(
-            server.projects.list().map((project) => {
-              return globalSync.project.loadSessions(project.worktree)
-            }),
-          )
-        }, 0)
-      })
-    })
-
-    onCleanup(() => {
-      if (sessionFrame !== undefined) cancelAnimationFrame(sessionFrame)
-      if (sessionTimer !== undefined) window.clearTimeout(sessionTimer)
+    const { list, rootFor } = createPawworkLayoutProjects({
+      globalSDK: globalSdk,
+      globalSync,
+      server,
     })
 
     const layout = {


### PR DESCRIPTION
## Summary

Slice 10 of the #1056 layout governance line — pure extraction, no user-visible behaviour change.

Moves the project enrichment pipeline out of `context/layout.tsx` into a new `createPawworkLayoutProjects` factory in `context/layout-projects.ts`:

- colors store + `pickAvailableColor`
- `enrich()` (metadata merge + global detection)
- `roots` memo + `rootFor`
- sandbox routing `createEffect` (close child + re-open at root)
- color assignment `createEffect` (SDK update or `globalSync.project.meta` for global)
- icon override sync `createEffect`
- session preload `onMount` + `onCleanup` (RAF + setTimeout)

`AVATAR_COLOR_KEYS` + `AvatarColorKey` move to `context/layout-state.ts` so the new factory has no circular dep back to `layout.tsx`. The avatar dead-code helper `getAvatarColors` stays in `layout.tsx` as before.

`layout.tsx` 923 → 740 (-183).

## Test plan

- [x] `bun run typecheck` clean
- [x] Full `bun run test:unit`: 1730 pass + 4 fail (matches plain origin/dev baseline; no regressions from slice 10)
- [x] 8 new unit tests in `layout-projects.test.ts` cover `rootFor` (empty / sandbox chain / cycle) and the `list` memo (metadata pass-through, child icon, global detection via projectID, global detection via local override). Effect-driven paths preserved verbatim from `layout.tsx`; bun's `solid-js` server build no-ops `createEffect`/`onMount`, so those paths rely on /codex review for equivalence checking.
- [x] /codex review (2 rounds): first round flagged a P1 typecheck issue in the new test (icon-union narrowing); fixed in commit 74e49cd5. Second round PASS — "behavior-preserving extraction" with no blocking findings.