### PR TITLE
fix(opencode): close shell spill stream via scoped finalizer

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -493,6 +493,21 @@ export const ShellTool = Tool.define(
         Effect.gen(function* () {
           const handle = yield* spawner.spawn(cmd(input.shell, input.name, input.command, input.cwd, input.env))
 
+          // Close the spill write stream on scope exit no matter how the scope
+          // ends (exit, abort, timeout, interrupt, or defect). Registered before
+          // the consumer fork so the consumer is interrupted first (finalizers
+          // run LIFO), leaving no write racing the close.
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(
+              () =>
+                new Promise<void>((resolve) => {
+                  if (!sink) return resolve()
+                  sink.end(() => resolve())
+                  sink.on("error", () => resolve())
+                }),
+            ),
+          )
+
           const throttle = yield* makeMetadataThrottle({
             intervalMillis: METADATA_FLUSH_INTERVAL_MS,
             byteThreshold: METADATA_FLUSH_BYTES,
@@ -602,16 +617,6 @@ export const ShellTool = Tool.define(
 
       if (meta.length > 0) {
         output += "\n\n<bash_metadata>\n" + meta.join("\n") + "\n</bash_metadata>"
-      }
-      if (sink) {
-        const stream = sink
-        yield* Effect.promise(
-          () =>
-            new Promise<void>((resolve) => {
-              stream.end(() => resolve())
-              stream.on("error", () => resolve())
-            }),
-        )
       }
 
       return {


### PR DESCRIPTION
## Summary

Fixes #1051. The shell tool's spill write stream (`sink`) was closed only after the `Effect.scoped(...).pipe(Effect.orDie)` block returned. On the interrupt/defect path — `orDie` turns a failure into a defect that unwinds past the close — the stream was never closed, leaking a file handle and dropping the unflushed spill tail. Normal exit, abort, and timeout already reached the close; only interrupt/defect leaked.

## Change

- Register the spill-stream close as a scoped finalizer (`Effect.addFinalizer`) so it always runs on scope exit regardless of how the scope ends, matching upstream.
- Register it before the consumer `Effect.forkScoped` so the consumer fiber is interrupted first (finalizers run LIFO), leaving no write racing the close.
- Remove the now-redundant post-scope close block.

## Touched files

- `packages/opencode/src/tool/shell.ts` (only)

## Verification

- `bun run typecheck` (opencode): pass
- `bun test test/tool/shell.test.ts test/tool/truncation.test.ts`: 64 pass / 0 fail
- `/codex review` (xhigh; focus on LIFO ordering, flush behavior, edge cases): no P1/P2 findings
- Normal / abort / timeout paths are behaviorally unchanged (the scoped block awaits finalizers before returning); only the interrupt/defect path now closes and flushes the stream. A deterministic interrupt repro is not feasible (the issue notes the same); correctness is by construction.

## Risk

Low. Single-file, self-contained, convergent with upstream. No public API or output-format change.

Closes #1051