### PR TITLE
refactor(automation): inject Automation service into the automate tool

### DIFF
--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1208,7 +1208,6 @@ export namespace Automation {
   }
 
   export const publishDefinitionUpdated = (definition: Definition) => Bus.publish(Event.DefinitionUpdated, definition)
-  export const publishDefinitionDeleted = (tombstone: Tombstone) => Bus.publish(Event.DefinitionDeleted, tombstone)
   export const publishRunUpdated = (run: Run) => Bus.publish(Event.RunUpdated, run)
 
   export interface Interface {
@@ -1278,7 +1277,7 @@ export namespace Automation {
         runNowExecuting: (id, options) => Effect.promise(() => runNowExecuting(id, options)),
         runs: (input) => Effect.sync(() => runs(input)),
         publishDefinitionUpdated: (definition) => Effect.promise(() => publishDefinitionUpdated(definition)),
-        publishDefinitionDeleted: (tombstone) => Effect.promise(() => publishDefinitionDeleted(tombstone)),
+        publishDefinitionDeleted: (tombstone) => Effect.promise(() => Bus.publish(Event.DefinitionDeleted, tombstone)),
         publishRunUpdated: (run) => Effect.promise(() => publishRunUpdated(run)),
         activeState: () => InstanceState.get(activeStateHandle),
       })

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -84,6 +84,7 @@ function sessionModel(sessionID: SessionID) {
 
 export function createAutomateDefinition(
   provider: Provider.Interface,
+  automation: Automation.Interface,
 ): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
     description:
@@ -116,7 +117,7 @@ export function createAutomateDefinition(
         // a stale instant that a crossed cron boundary turns into an already-due
         // time.
         const now = Date.now()
-        const definition = yield* Effect.try({
+        const parsed = yield* Effect.try({
           try: () => {
             const common = {
               title: params.title,
@@ -144,15 +145,18 @@ export function createAutomateDefinition(
                     rhythm: { kind: "cron" as const, expression: params.cron },
                     stop: { kind: "never" as const },
                   }
-            const parsed = Automation.CreateInput.parse(createInput)
+            const validated = Automation.CreateInput.parse(createInput)
             AutomationScheduler.current()
-            // sourceSessionID always comes from ctx, never from input, so a
-            // model cannot spoof it; automationSessionID is not on the surface.
-            return Automation.create(parsed, { now, sourceSessionID: ctx.sessionID })
+            return validated
           },
           catch: readableAutomationError,
         })
-        yield* Effect.promise(() => Automation.publishDefinitionUpdated(definition))
+        // sourceSessionID always comes from ctx, never from input, so a model
+        // cannot spoof it; automationSessionID is not on the surface.
+        const definition = yield* automation
+          .create(parsed, { now, sourceSessionID: ctx.sessionID })
+          .pipe(Effect.mapError(readableAutomationError))
+        yield* automation.publishDefinitionUpdated(definition)
         return {
           title: "Automation created",
           metadata: { automationDefinition: definition },
@@ -166,6 +170,7 @@ export const AutomateTool = Tool.define(
   "automate",
   Effect.gen(function* () {
     const provider = yield* Provider.Service
-    return createAutomateDefinition(provider)
+    const automation = yield* Automation.Service
+    return createAutomateDefinition(provider, automation)
   }),
 )

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -32,6 +32,7 @@ import { ApplyPatchTool } from "./apply_patch"
 import { EnterWorktreeTool } from "./enter-worktree"
 import { ExitWorktreeTool } from "./exit-worktree"
 import { AutomateTool } from "./automate"
+import { Automation } from "@/automation"
 import { Permission } from "../permission"
 import { Glob } from "../util/glob"
 import path from "path"
@@ -111,6 +112,7 @@ export namespace ToolRegistry {
     | Ripgrep.Service
     | Format.Service
     | Truncate.Service
+    | Automation.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -430,6 +432,7 @@ export namespace ToolRegistry {
       Layer.provide(CrossSpawnSpawner.defaultLayer),
       Layer.provide(Ripgrep.defaultLayer),
       Layer.provide(Truncate.defaultLayer),
+      Layer.provide(Automation.defaultLayer),
     ),
   )
 

--- a/packages/opencode/test/server/automation-scheduler.test.ts
+++ b/packages/opencode/test/server/automation-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, ManagedRuntime } from "effect"
 import { Automation } from "../../src/automation"
 import { internalTestHooks } from "../../src/automation/__test_hooks"
 import { AutomationScheduler } from "../../src/automation/scheduler"
@@ -11,6 +11,11 @@ import { createAutomateDefinition } from "../../src/tool/automate"
 import { fakeAutomationProvider } from "../fake/provider"
 import { tmpdir } from "../fixture/fixture"
 import { Flock } from "../../src/util/flock"
+
+// createAutomateDefinition now takes the resolved Automation service; resolve it
+// once (injected in production from AppRuntime, like provider).
+const runtime = ManagedRuntime.make(Automation.defaultLayer)
+const automation = await runtime.runPromise(Effect.gen(function* () { return yield* Automation.Service }))
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -301,7 +306,7 @@ describe("automation scheduler", () => {
         clock,
         executor: async () => ({ sessionID: SessionID.descending(), result: "done", cost: 0 }),
       })
-      const tool = createAutomateDefinition(fakeProvider.interface)
+      const tool = createAutomateDefinition(fakeProvider.interface, automation)
 
       const result = await Effect.runPromise(
         tool.execute(

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -43,6 +43,7 @@ import { SystemPrompt } from "../../src/session/system"
 import { Shell } from "../../src/shell/shell"
 import { Snapshot } from "../../src/snapshot"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Automation } from "../../src/automation"
 import { WebSearchAuth } from "../../src/tool/websearch-auth"
 import { Truncate } from "../../src/tool/truncate"
 import { Log } from "@opencode-ai/core/util/log"
@@ -274,6 +275,7 @@ function makeHttp(httpLayer: Layer.Layer<HttpClient.HttpClient> = FetchHttpClien
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
     Layer.provide(SubagentRun.defaultLayer),
+    Layer.provide(Automation.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(deps),
   )

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -52,6 +52,7 @@ import { SessionStatus } from "../../src/session/status"
 import { TurnChange } from "../../src/session/turn-change"
 import { Snapshot } from "../../src/snapshot"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Automation } from "../../src/automation"
 import { WebSearchAuth } from "../../src/tool/websearch-auth"
 import { Truncate } from "../../src/tool/truncate"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -138,6 +139,7 @@ function makeHttp() {
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
     Layer.provide(SubagentRun.defaultLayer),
+    Layer.provide(Automation.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(deps),
   )

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
-import { Effect, Schema } from "effect"
+import { Effect, ManagedRuntime, Schema } from "effect"
 import { AutomateParameters, createAutomateDefinition, formatAutomateValidationError } from "../../src/tool/automate"
 import { Automation } from "../../src/automation"
 import { Instance } from "../../src/project/instance"
@@ -11,6 +11,11 @@ import { tmpdir } from "../fixture/fixture"
 import { fakeAutomationProvider } from "../fake/provider"
 
 const { providerID: fakeProviderID, modelID: fakeModelID, interface: fakeProviderInterface } = fakeAutomationProvider()
+
+// createAutomateDefinition now takes the resolved Automation service (injected
+// in production from AppRuntime, like provider). Resolve it once for the tests.
+const runtime = ManagedRuntime.make(Automation.defaultLayer)
+const automation = await runtime.runPromise(Effect.gen(function* () { return yield* Automation.Service }))
 
 const ctx = (sessionID: SessionID) => ({
   sessionID,
@@ -81,7 +86,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition(fakeProviderInterface)
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
         const sourceSessionID = SessionID.descending()
         const result = await Effect.runPromise(
           tool.execute(
@@ -114,7 +119,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition(fakeProviderInterface)
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
         const before = Date.now()
         const result = await Effect.runPromise(
           tool.execute(
@@ -135,7 +140,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition(fakeProviderInterface)
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
         const result = await Effect.runPromise(
           tool.execute(
             {
@@ -162,7 +167,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition(fakeProviderInterface)
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
         let error: unknown
         try {
           await Effect.runPromise(
@@ -196,7 +201,7 @@ describe("automate tool", () => {
           throw new Error("storage corrupt")
         }) as typeof MessageV2.stream)
         try {
-          const tool = createAutomateDefinition(fakeProviderInterface)
+          const tool = createAutomateDefinition(fakeProviderInterface, automation)
           let error: unknown
           try {
             await Effect.runPromise(
@@ -227,7 +232,7 @@ describe("automate tool", () => {
           throw new NotFoundError({ message: "Session not found" })
         }) as typeof MessageV2.stream)
         try {
-          const tool = createAutomateDefinition(fakeProviderInterface)
+          const tool = createAutomateDefinition(fakeProviderInterface, automation)
           const result = await Effect.runPromise(
             tool.execute(
               { title: "Daily repo brief", prompt: "Summarize repo changes.", cron: "0 9 * * *" },
@@ -265,7 +270,7 @@ describe("automate tool", () => {
           }) as Provider.Interface["getModel"],
         }
         try {
-          const tool = createAutomateDefinition(slowProvider)
+          const tool = createAutomateDefinition(slowProvider, automation)
           const result = await Effect.runPromise(
             tool.execute(
               {
@@ -294,7 +299,7 @@ describe("automate tool", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tool = createAutomateDefinition(fakeProviderInterface)
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
         const sourceSessionID = SessionID.descending()
         const spoof = {
           sourceSessionID: SessionID.descending(),


### PR DESCRIPTION
## Summary

Part 3 (final) of the automation Effect migration (#950). Migrates the last
production caller of the synchronous `Automation.*` facade onto the `Automation`
service, then removes the one facade export that this leaves caller-less.

- **automate tool → service injection.** The `automate` tool's builder now
  resolves `Automation.Service` (alongside `Provider.Service`) and injects it
  into `createAutomateDefinition`. `execute()` calls `automation.create(...)`
  and `automation.publishDefinitionUpdated(...)` through the service instead of
  the sync `Automation.create` / `Automation.publishDefinitionUpdated` exports.
- **Why builder injection (not `yield*` inside execute):** a tool's `execute`
  is typed `R=never` (`Tool.DefWithoutID.execute` resolves to
  `Effect<ExecuteResult, unknown, never>`), so the service cannot be yielded
  inside `execute`. It is resolved in the `Tool.define` builder and passed as a
  parameter, mirroring the existing `provider` injection.
- **Remove caller-less facade export.** With that caller migrated,
  `Automation.publishDefinitionDeleted` had no remaining sync caller (the server
  delete handler already uses the service method). The namespace export is
  removed and the service method inlines
  `Bus.publish(Event.DefinitionDeleted, ...)`.
- **Scope kept deliberately minimal (Option A).** The load-bearing sync facade
  the scheduler/runner run-loop still depends on
  (`create`/`update`/`remove`/`runs`/`get`/`list`/`publishRunUpdated`/
  `publishDefinitionUpdated`/`runNowExecuting`/...) is **kept**. The ~130
  synchronous test call sites that use those functions inside bare
  `Instance.provide` are left as-is — migrating them would make the tests far
  more verbose for no coverage gain.

## Behavior preservation

- `service.create`'s error channel is `ValidationError`, mapped to a readable
  `Error` via `Effect.mapError(readableAutomationError)` — exactly what the old
  in-`try` `catch: readableAutomationError` did for the create call.
- Non-`ValidationError` create failures (untested, infra-only) now surface as
  defects rather than failures. Both still reject the executing promise with the
  original error, so the observable tool-failure behavior is unchanged.
- `sourceSessionID` still comes only from `ctx`, never from input; the
  spoof/identity tests are unchanged and pass.

## Tool registry plumbing

`ToolRegistry.layer` gains `Automation.Service` as a requirement (the builder
yields it), discharged in `ToolRegistry.defaultLayer` via
`Layer.provide(Automation.defaultLayer)` — the same pattern used for every other
tool dependency. Tests that compose `ToolRegistry.layer` raw (`prompt-effect`,
`snapshot-tool-race`) provide `Automation.defaultLayer` the same way. The
`automate` / `automation-scheduler` tests resolve the service once from a
`ManagedRuntime` over `Automation.defaultLayer` and pass it to
`createAutomateDefinition`.

## Test plan

- [x] `bun run typecheck` (packages/opencode) — clean
- [x] `bun test test/tool/automate.test.ts test/server/automation-scheduler.test.ts` — 57 pass
- [x] `bun test test/automation/` — 8 pass
- [x] `bun test test/server/automation-event-fixtures.test.ts test/server/automation-routes.test.ts test/server/automation-runner.test.ts` — 67 pass
- [x] `bun test test/session/snapshot-tool-race.test.ts` — 1 pass
- [x] `bun test test/session/prompt-effect.test.ts` — 63 pass

Builds on PR1 (#1068, request face) and PR2 (#1081, active-run state into InstanceState).