### PR TITLE
fix(opencode): return documented 404 on project update for missing project

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,5 +1,5 @@
 import z from "zod"
-import { and, Database, eq } from "../storage/db"
+import { and, Database, eq, NotFoundError } from "../storage/db"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
 import { Log } from "@opencode-ai/core/util/log"
@@ -383,7 +383,7 @@ export namespace Project {
             .returning()
             .get(),
         )
-        if (!result) throw new Error(`Project not found: ${input.projectID}`)
+        if (!result) throw new NotFoundError({ message: `Project not found: ${input.projectID}` })
         const data = fromRow(result)
         yield* emitUpdated(data)
         return data

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -342,7 +342,10 @@ describe("Project.update", () => {
         projectID: ProjectID.make("nonexistent-project-id"),
         name: "Should Fail",
       }),
-    ).rejects.toThrow("Project not found: nonexistent-project-id")
+    ).rejects.toMatchObject({
+      name: "NotFoundError",
+      data: { message: "Project not found: nonexistent-project-id" },
+    })
   })
 
   test("should emit GlobalBus event on update", async () => {

--- a/packages/opencode/test/server/project-routes.test.ts
+++ b/packages/opencode/test/server/project-routes.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { Log } from "@opencode-ai/core/util/log"
+import { Instance } from "../../src/project/instance"
+import { ProjectRoutes } from "../../src/server/instance/project"
+import { ErrorMiddleware } from "../../src/server/middleware"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("project routes", () => {
+  function app() {
+    return new Hono().route("/project", ProjectRoutes()).onError(ErrorMiddleware)
+  }
+
+  test("PATCH /:projectID returns documented 404 when the project does not exist", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/project/nonexistent-project-id", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "Should Fail" }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(404)
+        expect(body.name).toBe("NotFoundError")
+        expect(body.data.message).toContain("Project not found: nonexistent-project-id")
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`PATCH /:projectID` declares `errors(400, 404)` in its OpenAPI responses, but `Project.update` threw a bare `Error` when the project row did not exist. A bare `Error` is not a `NamedError`, so `ErrorMiddleware` fell through to its default branch and returned an undocumented **500** instead of the declared **404**.

Same contract-alignment pattern as #1067 / #1082: align a route to its already-declared 4xx instead of leaking a 500. No new contract surface — 404 was already declared.

## Touched files

- `src/project/project.ts` — throw the typed `NotFoundError` (mapped to 404 by `ErrorMiddleware`) instead of a bare `Error` on the missing-row path. Same `Project not found: <id>` text now in `data.message`; body matches the declared `NotFoundError.Schema`.
- `test/project/project.test.ts` — the existing not-found test asserted `.toThrow("Project not found: ...")`, but `NamedError` sets `Error.message` to its name, so the business message moved to `data.message`. Updated to assert `{ name, data.message }`.
- `test/server/project-routes.test.ts` — new HTTP regression: PATCH on a non-existent project returns 404 with the `NotFoundError` body.

## Verification

- `bun run typecheck` (tsgo) — green
- targeted: `test/project/project.test.ts`, `test/server/project-routes.test.ts`, `test/server/route-inventory-harness.test.ts` — 39 pass / 0 fail

## Risk

Low. Pure error-contract alignment: success path, response body shape, status of already-correct surfaces, and operationId all unchanged. The only behavior change is the missing-project failure moving from an undocumented 500 to the already-declared 404. `Project.update` now rejects with `NotFoundError` rather than a bare `Error`; the one in-repo consumer asserting the old message was updated, and the front-end consumer (`layout.tsx` via SDK) only observes the HTTP status, where 404 was already part of the declared contract.

ref #936
