### PR TITLE
refactor(app): extract homepage migration effect (slice 12 of #1056)

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -38,13 +38,6 @@ import { setNavigate } from "@/utils/notification-click"
 import { setOpenSettings } from "@/utils/settings-navigation"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { usePinnedDraft } from "@/components/prompt-input/pinned-draft"
-import {
-  runHomepageMigration,
-  HOMEPAGE_MIGRATION_SENTINEL_KEY,
-  type LegacyHomepagePromptStore,
-} from "@/components/prompt-input/homepage-migration"
-import { usePortableDraft } from "@/components/prompt-input/portable-draft"
-import { createMigrationStorageIO } from "@/components/prompt-input/homepage-migration-storage"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme } from "@opencode-ai/ui/theme/context"
@@ -64,6 +57,7 @@ import { pawworkSessionDirectories } from "./layout/pawwork-session-source"
 import { findPawworkSessionNavigationTarget } from "./layout/pawwork-session-nav"
 import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
+import { useHomepageMigration } from "./layout/layout-homepage-migration"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
 import { registerLayoutCommands } from "./layout/layout-commands"
 import { LayoutShellFrame } from "./layout/layout-shell-frame"
@@ -681,59 +675,7 @@ export default function Layout(props: ParentProps) {
     resetWorkspace,
   })
 
-  // Run the v7 homepage-draft migration as soon as a directory becomes
-  // available (fire-and-forget). currentDir() can be empty during the initial
-  // autoselect phase, so onMount alone would skip migration for that session.
-  // The migration writes a sentinel internally and is idempotent, so subsequent
-  // effect ticks are no-ops once it has run.
-  let homepageMigrationStarted = false
-  createEffect(() => {
-    if (homepageMigrationStarted) return
-    const directory = currentDir()
-    if (!directory) return
-    homepageMigrationStarted = true
-
-    const portable = usePortableDraft()
-    const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)
-    const { read: readRaw, write: writeRaw, remove: removeRaw } = createMigrationStorageIO(platform)
-
-    void runHomepageMigration({
-      portable,
-      currentDirectory: directory,
-      readSentinel: async () => {
-        const raw = await readRaw(sentinelTarget)
-        if (!raw) return null
-        try {
-          return JSON.parse(raw) as import("@/components/prompt-input/homepage-migration").MigrationSentinel
-        } catch {
-          return null
-        }
-      },
-      writeSentinel: async (sentinel) => {
-        await writeRaw(sentinelTarget, JSON.stringify(sentinel))
-      },
-      loadLegacyHomepage: async (dir) => {
-        const target = Persist.workspace(dir, "prompt")
-        const raw = await readRaw(target)
-        if (!raw) return null
-        try {
-          return JSON.parse(raw) as LegacyHomepagePromptStore
-        } catch {
-          return null
-        }
-      },
-      clearLegacyHomepage: async (dir) => {
-        // Must await: desktop removeItem is async and a rejection here must
-        // propagate up to homepage-migration's failed-sentinel path. Without
-        // the await, the migration would write status: "complete" even if
-        // the legacy store delete failed.
-        await removeRaw(Persist.workspace(dir, "prompt"))
-      },
-    }).catch((err) => {
-      // Log diagnostic; migration retries automatically on next boot.
-      console.warn("[homepage-migration] unexpected failure", err)
-    })
-  })
+  useHomepageMigration({ currentDir, platform })
 
   async function renameProject(project: LocalProject, next: string) {
     const current = displayName(project)

--- a/packages/app/src/pages/layout/layout-homepage-migration.ts
+++ b/packages/app/src/pages/layout/layout-homepage-migration.ts
@@ -1,0 +1,66 @@
+import { createEffect } from "solid-js"
+import type { Platform } from "@/context/platform"
+import { Persist } from "@/utils/persist"
+import {
+  runHomepageMigration,
+  HOMEPAGE_MIGRATION_SENTINEL_KEY,
+  type LegacyHomepagePromptStore,
+} from "@/components/prompt-input/homepage-migration"
+import { usePortableDraft } from "@/components/prompt-input/portable-draft"
+import { createMigrationStorageIO } from "@/components/prompt-input/homepage-migration-storage"
+
+export function useHomepageMigration(input: { currentDir: () => string; platform: Platform }) {
+  // Run the v7 homepage-draft migration as soon as a directory becomes
+  // available (fire-and-forget). currentDir() can be empty during the initial
+  // autoselect phase, so onMount alone would skip migration for that session.
+  // The migration writes a sentinel internally and is idempotent, so subsequent
+  // effect ticks are no-ops once it has run.
+  let homepageMigrationStarted = false
+  createEffect(() => {
+    if (homepageMigrationStarted) return
+    const directory = input.currentDir()
+    if (!directory) return
+    homepageMigrationStarted = true
+
+    const portable = usePortableDraft()
+    const sentinelTarget = Persist.global(HOMEPAGE_MIGRATION_SENTINEL_KEY)
+    const { read: readRaw, write: writeRaw, remove: removeRaw } = createMigrationStorageIO(input.platform)
+
+    void runHomepageMigration({
+      portable,
+      currentDirectory: directory,
+      readSentinel: async () => {
+        const raw = await readRaw(sentinelTarget)
+        if (!raw) return null
+        try {
+          return JSON.parse(raw) as import("@/components/prompt-input/homepage-migration").MigrationSentinel
+        } catch {
+          return null
+        }
+      },
+      writeSentinel: async (sentinel) => {
+        await writeRaw(sentinelTarget, JSON.stringify(sentinel))
+      },
+      loadLegacyHomepage: async (dir) => {
+        const target = Persist.workspace(dir, "prompt")
+        const raw = await readRaw(target)
+        if (!raw) return null
+        try {
+          return JSON.parse(raw) as LegacyHomepagePromptStore
+        } catch {
+          return null
+        }
+      },
+      clearLegacyHomepage: async (dir) => {
+        // Must await: desktop removeItem is async and a rejection here must
+        // propagate up to homepage-migration's failed-sentinel path. Without
+        // the await, the migration would write status: "complete" even if
+        // the legacy store delete failed.
+        await removeRaw(Persist.workspace(dir, "prompt"))
+      },
+    }).catch((err) => {
+      // Log diagnostic; migration retries automatically on next boot.
+      console.warn("[homepage-migration] unexpected failure", err)
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Slice 12 of the #1056 layout governance line — pure extraction, no behaviour / DOM / aria / copy / storage-key change.

Moves the fire-and-forget v7 homepage-draft migration `createEffect` out of `pages/layout.tsx` into a new `useHomepageMigration({ currentDir, platform })` factory in `pages/layout/layout-homepage-migration.ts`, mirroring the sibling `useUpdatePolling` / `layout-update-polling.ts` injection pattern. The effect registers in the parent reactive root exactly as before (call-sited where the effect previously lived), so owner and registration order are unchanged.

Five now-unused imports drop from `layout.tsx` (`runHomepageMigration`, `HOMEPAGE_MIGRATION_SENTINEL_KEY`, `LegacyHomepagePromptStore`, `usePortableDraft`, `createMigrationStorageIO`); the new file imports them directly. `Persist` and `createEffect` stay (still used elsewhere in `layout.tsx`).

`layout.tsx` 1084 → 1026 (-58).

## Review focus

- Verbatim equivalence of the moved effect (sentinel read/write, idempotent `homepageMigrationStarted` guard, fire-and-forget `.catch`, legacy-store clear with the `await` propagation comment).
- Injection correctness: `currentDir` (`() => string` from the `route().dir` memo) and `platform` (full `Platform`, as `createMigrationStorageIO` requires) — no other closure captured.
- Owner / registration: factory called in the provider body at the original effect's position, so the effect runs under the same reactive owner.
- The desktop-vs-web storage branch already lived in `homepage-migration-storage.ts` (not `layout.tsx`), so `shell-frame-contract.test.ts`'s "no `platform.platform === \"desktop\"` in the shell file" invariant is unaffected.

## Verification

- [x] `bun run typecheck` clean
- [x] Source-guard tests (`shell-frame-contract`, `update-install-flow-source`) + homepage-migration logic tests: 27 pass (guards make only negative assertions unrelated to migration → nothing needed to move with the code)
- [x] Full `bun run test:unit`: 1734 pass / 0 fail (no regression)
- [x] `/codex review`: PASS, no findings

No new unit test: the extracted unit is a pure effect wrapper with no memo / pure-helper path, and bun's `solid-js` server build no-ops `createEffect`, so the effect body is not drivable under bun (same constraint as slice 10). The migration logic it wires is already covered by `homepage-migration.test.ts`.