### PR TITLE
refactor(app): extract prompt-input edit-load effect into edit-load-effect.ts

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -38,6 +38,7 @@ import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
 import { promptLength } from "./prompt-input/history"
 import { createPromptDerivedState } from "./prompt-input/derived-state"
 import { createPromptCommandsAndMode } from "./prompt-input/commands-mode"
+import { createEditLoadEffect } from "./prompt-input/edit-load-effect"
 import type { PromptStore } from "./prompt-input/store-types"
 import type { FollowupDraft } from "./prompt-input/followup-draft"
 import { createPromptSubmit } from "./prompt-input/submit"
@@ -273,44 +274,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     addPart,
   } = editorInput
 
-  createEffect(
-    on(
-      () => props.edit?.id,
-      (id) => {
-        const edit = props.edit
-        if (!id || !edit) return
-
-        for (const item of prompt.context.items()) {
-          prompt.context.remove(item.key)
-        }
-
-        for (const item of edit.context) {
-          prompt.context.add({
-            type: item.type,
-            path: item.path,
-            selection: item.selection,
-            comment: item.comment,
-            commentID: item.commentID,
-            commentOrigin: item.commentOrigin,
-            preview: item.preview,
-          })
-        }
-
-        setStore("mode", "normal")
-        setStore("popover", null)
-        setStore("historyIndex", -1)
-        setStore("savedPrompt", null)
-        prompt.set(edit.prompt, promptLength(edit.prompt))
-        requestAnimationFrame(() => {
-          editorRef.focus()
-          setCursorPosition(editorRef, promptLength(edit.prompt))
-          queueScroll()
-        })
-        props.onEditLoaded?.()
-      },
-      { defer: true },
-    ),
-  )
+  createEditLoadEffect({
+    prompt,
+    setStore,
+    editorRef: () => editorRef,
+    queueScroll,
+    editDraft: () => props.edit,
+    onEditLoaded: () => props.onEditLoaded?.(),
+  })
 
   const { addAttachments, addPickedPaths, removeAttachment, handlePaste } = createPromptAttachments({
     editor: () => editorRef,

--- a/packages/app/src/components/prompt-input/edit-load-effect.ts
+++ b/packages/app/src/components/prompt-input/edit-load-effect.ts
@@ -1,0 +1,63 @@
+// Loads an edit / followup draft into the editor when props.edit changes.
+// Extracted from prompt-input.tsx; sets up one deferred createEffect keyed on the
+// edit id, so it must be called synchronously inside the component owner.
+
+import { createEffect, on } from "solid-js"
+import type { SetStoreFunction } from "solid-js/store"
+import { type Prompt, type usePrompt } from "@/context/prompt"
+import { setCursorPosition } from "./editor-dom"
+import { promptLength } from "./history"
+import type { PromptStore } from "./store-types"
+import type { FollowupDraft } from "./followup-draft"
+
+export interface EditLoadEffectDeps {
+  prompt: ReturnType<typeof usePrompt>
+  setStore: SetStoreFunction<PromptStore>
+  editorRef: () => HTMLDivElement
+  queueScroll: () => void
+  editDraft: () => { id: string; prompt: Prompt; context: FollowupDraft["context"] } | undefined
+  onEditLoaded: () => void
+}
+
+export function createEditLoadEffect(deps: EditLoadEffectDeps): void {
+  const { prompt, setStore, editorRef, queueScroll, editDraft, onEditLoaded } = deps
+
+  createEffect(
+    on(
+      () => editDraft()?.id,
+      (id) => {
+        const edit = editDraft()
+        if (!id || !edit) return
+
+        for (const item of prompt.context.items()) {
+          prompt.context.remove(item.key)
+        }
+
+        for (const item of edit.context) {
+          prompt.context.add({
+            type: item.type,
+            path: item.path,
+            selection: item.selection,
+            comment: item.comment,
+            commentID: item.commentID,
+            commentOrigin: item.commentOrigin,
+            preview: item.preview,
+          })
+        }
+
+        setStore("mode", "normal")
+        setStore("popover", null)
+        setStore("historyIndex", -1)
+        setStore("savedPrompt", null)
+        prompt.set(edit.prompt, promptLength(edit.prompt))
+        requestAnimationFrame(() => {
+          editorRef().focus()
+          setCursorPosition(editorRef(), promptLength(edit.prompt))
+          queueScroll()
+        })
+        onEditLoaded()
+      },
+      { defer: true },
+    ),
+  )
+}


### PR DESCRIPTION
## Summary

Slice 3 of the serial prompt-input.tsx slimming line (slice 1 = #1083, slice 2 = #1091). **Pure extraction** — no behavior/DOM/aria/copy/storage-key change.

Moves the deferred `createEffect` that loads an edit/followup draft into the editor (keyed on `props.edit?.id`) out of `prompt-input.tsx` into a new module `prompt-input/edit-load-effect.ts` (`createEditLoadEffect`, returns void).

## Why it stays behavior-neutral

- The factory is called **synchronously** at the effect's original position, so the effect registers in the component owner with `{ defer: true }` intact and no ordering change. All injected deps (`prompt`, `setStore`, `editorRef` getter, `queueScroll`, `editDraft`, `onEditLoaded`) are available there — no late-binding.
- `props.edit` → injected as the accessor `editDraft: () => props.edit`; the `on()` source `() => editDraft()?.id` still tracks `props.edit?.id` reactively, so the effect re-runs only on id change.
- `props.onEditLoaded` → injected as the thunk `() => props.onEditLoaded?.()`, called unconditionally as `onEditLoaded()` — optional-chaining no-op semantics and the fire timing (synchronously after scheduling the rAF) are preserved.
- The only textual changes are those injection seams: `props.edit` → `editDraft()`, `editorRef.focus()` → `editorRef().focus()`, `setCursorPosition(editorRef, ...)` → `setCursorPosition(editorRef(), ...)`, `props.onEditLoaded?.()` → `onEditLoaded()`. The 7 copied context fields, the four `setStore` calls, `prompt.set`, and the rAF block are verbatim.
- `props.edit` / `props.onEditLoaded` are used ONLY by this effect (verified), so no external surface changes. No newly-unused imports in `prompt-input.tsx` (`setCursorPosition`, `on`, `promptLength` all still used elsewhere).

`prompt-input.tsx` 601 → 572 lines; `edit-load-effect.ts` +63.

## Verification

- `bun run typecheck` 8/8 successful
- eslint clean on both files
- targeted tests: `bun test src/components/prompt-input/ use-session-followups session-action-readiness` → 404 pass / 2 pre-existing dev-base failures (`command-prepend`, `path-b-integration`: `isPromptEqual not found` bun ESM load-order flake; neither imports the changed files, zero regression — a standalone PR to fix that flake is queued next)
- independent review (codex, xhigh): GATE PASS, no P1/P2 — confirmed byte-faithful effect body, equivalent reactivity tracking, preserved `{ defer: true }`, owner-scoped registration, correct/complete imports

## Residual risk

None — pure extraction.