### PR TITLE
fix(ui): separate terminal safe-retry notice from preceding turn content

### DIFF
--- a/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/safe-retry-snap-fixture.tsx
@@ -1,6 +1,7 @@
 import { render } from "solid-js/web"
-import type { AssistantMessage, NoticePart } from "@opencode-ai/sdk/v2"
+import type { AssistantMessage, NoticePart, ReasoningPart } from "@opencode-ai/sdk/v2"
 import { DataProvider, I18nProvider } from "@opencode-ai/ui/context"
+import { MarkedProvider } from "@opencode-ai/ui/context/marked"
 import { dict as zh } from "@opencode-ai/ui/i18n/zh"
 import { AssistantParts } from "@opencode-ai/ui/message-part"
 import { SessionRetry } from "@opencode-ai/ui/session-retry"
@@ -27,6 +28,18 @@ const assistant: AssistantMessage = {
     created: 0,
     completed: 1,
   },
+}
+
+// A preceding reasoning part reproduces the #943 scenario: the terminal notice
+// follows a reasoning trow and must read as its own status line, not as a
+// trailing thought attached to the thinking block.
+const reasoning: ReasoningPart = {
+  id: "part_safe_retry_reasoning",
+  sessionID: assistant.sessionID,
+  messageID: assistant.id,
+  type: "reasoning",
+  text: "正在分析请求并准备调用工具继续。",
+  time: { start: 0, end: 1 },
 }
 
 const notice: NoticePart = {
@@ -71,10 +84,29 @@ function SafeRetrySnapFixture() {
             }}
           />
         </div>
-        <div data-snap="notice">
-          <DataProvider data={{ message: {}, part: { [assistant.id]: [notice] } }} directory="/Users/yuhan/PawWork">
-            <AssistantParts messages={[assistant]} />
-          </DataProvider>
+        {/* Mirror the real assistant-content container (flex column, 12px gap)
+            so the captured spacing above the notice divider matches production. */}
+        <div data-snap="notice" style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
+          <MarkedProvider>
+            <DataProvider
+              data={{ message: {}, part: { [assistant.id]: [reasoning, notice] } }}
+              directory="/Users/yuhan/PawWork"
+            >
+              <AssistantParts messages={[assistant]} />
+            </DataProvider>
+          </MarkedProvider>
+        </div>
+        {/* A notice that is the turn's only part (first-attempt connection
+            failure, reasoning removed) must NOT draw a leading divider. */}
+        <div data-snap="notice-standalone" style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
+          <MarkedProvider>
+            <DataProvider
+              data={{ message: {}, part: { [assistant.id]: [notice] } }}
+              directory="/Users/yuhan/PawWork"
+            >
+              <AssistantParts messages={[assistant]} />
+            </DataProvider>
+          </MarkedProvider>
         </div>
       </div>
     </I18nProvider>

--- a/packages/app/e2e/snap/safe-retry.snap.ts
+++ b/packages/app/e2e/snap/safe-retry.snap.ts
@@ -37,9 +37,38 @@ test("safe-retry", async ({ page }) => {
 
   const notice = page.locator('[data-snap="notice"]')
   await expect(notice).toContainText("恢复失败。你可以稍后再试，或换一个模型。", { timeout: 30_000 })
+  // The notice follows a reasoning trow; assert both render so the captured
+  // grid covers the #943 boundary scenario (notice must not attach to thinking).
+  await expect(notice.locator('[data-component="session-turn-trow-block"]')).toBeVisible({ timeout: 30_000 })
   await expect(notice.locator('[data-kind="safe_retry_failed"]')).toBeVisible({ timeout: 30_000 })
 
+  // The grid is a visual aid, not a pixel diff, so assert the divider directly:
+  // a notice that follows turn content carries the hairline + padding (#943).
+  const precededStyle = await notice.locator('[data-component="notice-part"]').evaluate((el) => {
+    const s = getComputedStyle(el)
+    return { borderTop: s.borderTopWidth, paddingTop: s.paddingTop }
+  })
+  expect(precededStyle.borderTop).toBe("1px")
+  expect(precededStyle.paddingTop).toBe("12px")
+
+  // A notice that is the turn's only part must carry no leading divider.
+  const standalone = page.locator('[data-snap="notice-standalone"]')
+  await expect(standalone.locator('[data-kind="safe_retry_failed"]')).toBeVisible({ timeout: 30_000 })
+  const standaloneStyle = await standalone.locator('[data-component="notice-part"]').evaluate((el) => {
+    const s = getComputedStyle(el)
+    return { borderTop: s.borderTopWidth, paddingTop: s.paddingTop }
+  })
+  expect(standaloneStyle.borderTop).toBe("0px")
+  expect(standaloneStyle.paddingTop).toBe("0px")
+
   const out = snapOutputPath("safe-retry")
-  await composeGrid([await captureBlock("running", running), await captureBlock("notice", notice)], out)
+  await composeGrid(
+    [
+      await captureBlock("running", running),
+      await captureBlock("notice", notice),
+      await captureBlock("notice-standalone", standalone),
+    ],
+    out,
+  )
   process.stdout.write(`\n[snap] safe-retry grid -> ${out}\n\n`)
 })

--- a/packages/ui/src/components/message-part/parts/notice.css
+++ b/packages/ui/src/components/message-part/parts/notice.css
@@ -1,0 +1,15 @@
+/*
+ * A terminal notice (safe_retry_failed) is a turn-level status line, not a
+ * trailing thought. When it follows other turn content it sat in the bare 12px
+ * column gap and read as more model thinking (#943). A hairline top rule — the
+ * canonical divider treatment (DESIGN.md "Borders") — plus padding above the
+ * text sets it apart. The `* +` guard keeps the rule off a notice that is the
+ * turn's only part (e.g. a first-attempt connection failure, where the failed
+ * attempt's reasoning was removed), so no stray line floats with nothing above.
+ * Spacing below the rule comes from padding-top; spacing above comes from the
+ * container's existing gap, so the divider stays centered between the two.
+ */
+* + [data-component="notice-part"] {
+  padding-top: 12px;
+  border-top: 1px solid var(--border-weaker);
+}

--- a/packages/ui/src/components/message-part/parts/notice.tsx
+++ b/packages/ui/src/components/message-part/parts/notice.tsx
@@ -2,6 +2,7 @@ import { Match, Switch } from "solid-js"
 import type { NoticePart } from "@opencode-ai/sdk/v2"
 import { useI18n } from "../../../context/i18n"
 import { registerPartComponent } from "../registry"
+import "./notice.css"
 
 registerPartComponent("notice", function NoticePartDisplay(props) {
   const i18n = useI18n()


### PR DESCRIPTION
## Summary

The `safe_retry_failed` terminal notice rendered as a bare caption with no boundary. When it followed a reasoning or tool trow it sat in the assistant-content column's 12px gap and read as more model thinking. This adds a hairline top rule (the canonical divider treatment) plus padding, guarded by a `* +` sibling combinator so the divider only appears when the notice follows other turn content.

## Why

Fixes #943: the terminal stream-failure notice appears attached to reasoning output, so users read "恢复失败…" as part of the model's thinking rather than a turn-level status line.

## Related Issue

Closes #943

## Human Review Status

Pending

## Review Focus

The `* + [data-component="notice-part"]` selector. It must add the divider only when the notice follows a sibling, and must NOT draw a leading hairline when the notice is the turn's only part — a real case: a first-attempt connection failure where the failed attempt's reasoning is removed (`removeReasoningForAttempt`) before the notice is written, leaving the notice alone. Spacing above the divider deliberately relies on the production container's existing `gap: 12px`; padding-top provides the spacing below.

## Risk Notes

UI-only; no behavior, data, permission, or platform surface touched. One nuance: the snap fixture mirrors the real `[data-slot="session-turn-assistant-content"]` flex/gap via inline style rather than reusing the production CSS, so a future change to that container gap won't auto-propagate to the fixture. The two conditional checklist items left unticked: no platform/packaging surface, and no docs/release/deps surface.

## How To Verify

```text
typecheck (ui + app): pass
snap safe-retry: 1 passed — grid shows (a) notice after a reasoning trow with the hairline divider, (b) standalone notice with no leading line
  getComputedStyle assertions: preceded notice border-top 1px / padding-top 12px; standalone 0px / 0px
unit (ui grouping + message-part-registry + session-safe-retry-contract): 22 pass
lint (notice.tsx): clean
codex review (xhigh): PASS — one P2 (snap was visual-only, didn't assert the divider) addressed by the getComputedStyle assertions above
```

## Screenshots or Recordings

Visual surface checked with the `safe-retry` snap target (`bun run snap safe-retry`). The regenerated grid under `docs/design/preview/screenshots/safe-retry.png` shows the notice clearly separated from the preceding "思考中" reasoning block, and a standalone notice with no stray divider.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
