### PR TITLE
refactor(app): extract openGlobalConfigFolder controller (slice 13 of #1056)

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -46,7 +46,6 @@ import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
 import {
   displayName,
-  errorMessage,
   startupAutoselectDirectory,
   sortedRootSessions,
   workspaceKey,
@@ -58,6 +57,7 @@ import { findPawworkSessionNavigationTarget } from "./layout/pawwork-session-nav
 import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
 import { useHomepageMigration } from "./layout/layout-homepage-migration"
+import { createOpenGlobalConfigFolder } from "./layout/layout-open-global-config"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
 import { registerLayoutCommands } from "./layout/layout-commands"
 import { LayoutShellFrame } from "./layout/layout-shell-frame"
@@ -529,27 +529,7 @@ export default function Layout(props: ParentProps) {
     shellNavigation.openSettings(tab)
   }
 
-  async function openGlobalConfigFolder() {
-    const target = await globalSDK.client.path
-      .get({ ensureConfig: true })
-      .then((x) => x.data?.config)
-      .catch((err) => {
-        showToast({
-          title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-          description: errorMessage(err, language.t("common.requestFailed")),
-          variant: "error",
-        })
-        return undefined
-      })
-    if (!target) return
-    await platform.openPath?.(target).catch((err) => {
-      showToast({
-        title: language.t("toast.settings.openGlobalConfigFolderFailed.title"),
-        description: errorMessage(err, language.t("common.requestFailed")),
-        variant: "error",
-      })
-    })
-  }
+  const openGlobalConfigFolder = createOpenGlobalConfigFolder({ globalSDK, platform, language })
 
   createEffect(() => {
     command.setModalOpen(activeSurface() !== "none")

--- a/packages/app/src/pages/layout/layout-open-global-config.test.ts
+++ b/packages/app/src/pages/layout/layout-open-global-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { createOpenGlobalConfigFolder } from "./layout-open-global-config"
+
+// These tests exercise the no-toast control flow (config present / absent),
+// driving the factory's injected deps. The error branches call the module
+// singleton showToast, so they are left to codex review rather than spied
+// here (avoids the cross-file mock.module leakage trap, see #1084).
+
+type GetResult = { data?: { config?: string } }
+
+function setup(opts: { get: () => Promise<GetResult> }) {
+  const calls = { get: 0, openPath: [] as string[] }
+  const open = createOpenGlobalConfigFolder({
+    globalSDK: {
+      client: {
+        path: {
+          get: (args: unknown) => {
+            calls.get++
+            void args
+            return opts.get()
+          },
+        },
+      },
+    } as unknown as Parameters<typeof createOpenGlobalConfigFolder>[0]["globalSDK"],
+    platform: {
+      openPath: (target: string) => {
+        calls.openPath.push(target)
+        return Promise.resolve()
+      },
+    } as unknown as Parameters<typeof createOpenGlobalConfigFolder>[0]["platform"],
+    language: { t: (key: string | number) => String(key) },
+  })
+  return { open, calls }
+}
+
+describe("createOpenGlobalConfigFolder", () => {
+  test("opens the resolved config path", async () => {
+    const { open, calls } = setup({ get: () => Promise.resolve({ data: { config: "/cfg" } }) })
+    await open()
+    expect(calls.get).toBe(1)
+    expect(calls.openPath).toEqual(["/cfg"])
+  })
+
+  test("does nothing when the response carries no config path", async () => {
+    const { open, calls } = setup({ get: () => Promise.resolve({ data: {} }) })
+    await open()
+    expect(calls.get).toBe(1)
+    expect(calls.openPath).toEqual([])
+  })
+})

--- a/packages/app/src/pages/layout/layout-open-global-config.ts
+++ b/packages/app/src/pages/layout/layout-open-global-config.ts
@@ -1,0 +1,33 @@
+import { showToast } from "@opencode-ai/ui/toast"
+import type { useGlobalSDK } from "@/context/global-sdk"
+import type { usePlatform } from "@/context/platform"
+import type { useLanguage } from "@/context/language"
+import { errorMessage } from "./helpers"
+
+export function createOpenGlobalConfigFolder(input: {
+  globalSDK: Pick<ReturnType<typeof useGlobalSDK>, "client">
+  platform: Pick<ReturnType<typeof usePlatform>, "openPath">
+  language: Pick<ReturnType<typeof useLanguage>, "t">
+}): () => Promise<void> {
+  return async function openGlobalConfigFolder() {
+    const target = await input.globalSDK.client.path
+      .get({ ensureConfig: true })
+      .then((x) => x.data?.config)
+      .catch((err) => {
+        showToast({
+          title: input.language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+          description: errorMessage(err, input.language.t("common.requestFailed")),
+          variant: "error",
+        })
+        return undefined
+      })
+    if (!target) return
+    await input.platform.openPath?.(target).catch((err) => {
+      showToast({
+        title: input.language.t("toast.settings.openGlobalConfigFolderFailed.title"),
+        description: errorMessage(err, input.language.t("common.requestFailed")),
+        variant: "error",
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Slice 13 of the #1056 layout governance line — pure extraction, no behaviour / DOM / aria / copy / storage-key change.

Moves the `openGlobalConfigFolder` async controller out of `pages/layout.tsx` into a `createOpenGlobalConfigFolder({ globalSDK, platform, language })` factory in `pages/layout/layout-open-global-config.ts`. The factory closes over only three injected context capability slices (`globalSDK.client`, `platform.openPath`, `language.t`); `showToast` (`@opencode-ai/ui/toast`) and `errorMessage` (`./helpers`) are pure utilities imported directly by the new file. No forward refs, mutable store closures, memos, or effect registration — it is invoked only on user action, so call order is irrelevant.

The `registerLayoutCommands` call site consumes the returned function unchanged. `errorMessage` drops from `layout.tsx`'s helpers import (now unused there); `showToast` stays (still used elsewhere).

`layout.tsx` 1026 → 1006.

## Review focus

- Verbatim equivalence of the moved body (two-stage `path.get` → `openPath`, the two identical error-toast branches, the `if (!target) return` guard).
- Injection correctness: the three `Pick<ReturnType<typeof useX>, ...>` capability slices match exactly what the body calls.
- Call-site: `const openGlobalConfigFolder = createOpenGlobalConfigFolder({ globalSDK, platform, language })` returns a `() => Promise<void>` identical to the old inline `async function`.

## Verification

- [x] `bun run typecheck` clean
- [x] New `layout-open-global-config.test.ts`: 2 tests drive the injected control flow (config present → `openPath` called with the path; config absent → `openPath` not called). The error branches call the `showToast` module singleton, so they are left to codex rather than spied (avoids the #1084 cross-file `mock.module` leakage trap).
- [x] Guard test `layout-commands.test.ts`: pass — it stubs the callback and asserts command-catalog shape, not `layout.tsx` source, so no guard needed to move.
- [x] Full `bun run test:unit`: 1736 pass / 0 fail (no regression)
- [x] `/codex review`: PASS, no findings