### PR TITLE
fix(app): extract pure prompt-equality helpers so prompt-input tests don't load @solidjs/router

### DIFF
--- a/packages/app/src/components/prompt-input/command-backspace.test.ts
+++ b/packages/app/src/components/prompt-input/command-backspace.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test"
 import type { Prompt, TextPart, FileAttachmentPart, AgentPart, ImageAttachmentPart } from "@/context/prompt"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import { computeCommandBackspaceResult } from "./command-backspace"
 
 // Helpers -----------------------------------------------------------------

--- a/packages/app/src/components/prompt-input/command-backspace.ts
+++ b/packages/app/src/components/prompt-input/command-backspace.ts
@@ -9,7 +9,7 @@
 //   3. Marked content is exactly "/<name> " AND no rest: collapse to DEFAULT_PROMPT.
 
 import type { Prompt, TextPart } from "@/context/prompt"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 
 /**
  * Compute the new Prompt after a Backspace that fires the command fallback

--- a/packages/app/src/components/prompt-input/command-paste.test.ts
+++ b/packages/app/src/components/prompt-input/command-paste.test.ts
@@ -9,7 +9,7 @@ import type {
   ImageAttachmentPart,
   Prompt,
 } from "@/context/prompt"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import type { CommandDescriptor } from "./command-text-part"
 import { tryPathCConversion } from "./command-paste"
 

--- a/packages/app/src/components/prompt-input/command-paste.ts
+++ b/packages/app/src/components/prompt-input/command-paste.ts
@@ -13,7 +13,7 @@ import type {
   ImageAttachmentPart,
   Prompt,
 } from "@/context/prompt"
-import { isStructurallyEmpty } from "@/context/prompt"
+import { isStructurallyEmpty } from "@/context/prompt-equality"
 import type { CommandDescriptor } from "./command-text-part"
 import { tryParseLeadingCommandFromText } from "./command-text-part"
 

--- a/packages/app/src/components/prompt-input/command-prepend.test.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test"
 import type { Prompt, TextPart, FileAttachmentPart, AgentPart, ImageAttachmentPart } from "@/context/prompt"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import type { CommandDescriptor } from "./command-text-part"
 import { prependCommandMark } from "./command-prepend"
 

--- a/packages/app/src/components/prompt-input/command-prepend.ts
+++ b/packages/app/src/components/prompt-input/command-prepend.ts
@@ -15,7 +15,7 @@
 // preserved exactly — no cloning of incoming parts.
 
 import type { ImageAttachmentPart, Prompt, TextPart } from "@/context/prompt"
-import { DEFAULT_PROMPT, isPromptEqual } from "@/context/prompt"
+import { DEFAULT_PROMPT, isPromptEqual } from "@/context/prompt-equality"
 import { createCommandTextPart, type CommandDescriptor } from "./command-text-part"
 
 // Slash trigger regex — must match `editor-input.ts:261` exactly so the

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -6,14 +6,8 @@
 import { createEffect, createSignal, on, type Accessor } from "solid-js"
 import { createOwnerMirrorEffect } from "./owner-mirror"
 import type { SetStoreFunction } from "solid-js/store"
-import {
-  type ContentPart,
-  DEFAULT_PROMPT,
-  type ImageAttachmentPart,
-  isPromptEqual,
-  type Prompt,
-  type usePrompt,
-} from "@/context/prompt"
+import { type ContentPart, type ImageAttachmentPart, type Prompt, type usePrompt } from "@/context/prompt"
+import { DEFAULT_PROMPT, isPromptEqual } from "@/context/prompt-equality"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { useParams } from "@solidjs/router"

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -1,14 +1,8 @@
 // DOM ↔ Parts bidirectional serialization for the contenteditable composer.
 // Pure functions, no Solid reactivity. Pairs with editor-dom (cursor primitives).
 
-import {
-  type AgentPart,
-  type CommandSource,
-  type FileAttachmentPart,
-  type TextPart,
-  type Prompt,
-  DEFAULT_PROMPT,
-} from "@/context/prompt"
+import type { AgentPart, CommandSource, FileAttachmentPart, TextPart, Prompt } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import { resolveCommandIconSvg } from "@opencode-ai/ui/command-icon"
 import { createTextFragment } from "./editor-dom"
 import "./command-pill.css"

--- a/packages/app/src/components/prompt-input/homepage-migration.test.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration.test.ts
@@ -6,7 +6,7 @@ import {
   type LegacyHomepagePromptStore,
 } from "./homepage-migration"
 import { createPortableDraftOwner } from "./portable-draft"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/app/src/components/prompt-input/homepage-migration.ts
+++ b/packages/app/src/components/prompt-input/homepage-migration.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Prompt, ContextItem } from "@/context/prompt"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import type { PortableDraftOwner } from "./portable-draft"
 
 export const HOMEPAGE_MIGRATION_SENTINEL_KEY = "prompt-portable-migration"

--- a/packages/app/src/components/prompt-input/path-b-integration.test.ts
+++ b/packages/app/src/components/prompt-input/path-b-integration.test.ts
@@ -16,7 +16,8 @@
 //      leading slash
 
 import { describe, expect, test } from "bun:test"
-import { isPromptEqual, type CommandSource } from "@/context/prompt"
+import { isPromptEqual } from "@/context/prompt-equality"
+import type { CommandSource } from "@/context/prompt"
 import { tryPathBConversion } from "./command-space-trigger"
 import {
   isNormalizedEditor,

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -5,13 +5,8 @@
 import { createEffect, createMemo, onCleanup, type Accessor, type Setter } from "solid-js"
 import type { SetStoreFunction } from "solid-js/store"
 import { useFilteredList } from "@opencode-ai/ui/hooks"
-import {
-  type ContentPart,
-  DEFAULT_PROMPT,
-  type ImageAttachmentPart,
-  type Prompt,
-  type usePrompt,
-} from "@/context/prompt"
+import { type ContentPart, type ImageAttachmentPart, type Prompt, type usePrompt } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import type { useCommand } from "@/context/command"
 import type { useSync } from "@/context/sync"
 import type { useFile } from "@/context/file"

--- a/packages/app/src/components/prompt-input/portable-draft.test.ts
+++ b/packages/app/src/components/prompt-input/portable-draft.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach } from "bun:test"
 import { createPortableDraftOwner } from "./portable-draft"
 import type { PortableDraftPayload } from "./portable-draft"
-import { DEFAULT_PROMPT } from "@/context/prompt"
+import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 
 // Helper: build a non-empty payload
 function makePayload(text: string): PortableDraftPayload {

--- a/packages/app/src/context/prompt-equality.ts
+++ b/packages/app/src/context/prompt-equality.ts
@@ -1,0 +1,58 @@
+// Pure prompt-equality and default-prompt helpers, split out of prompt.tsx so
+// they can be imported without loading the prompt context provider (which pulls
+// in @solidjs/router, a client-only module that throws when evaluated in bun's
+// server-side test env). Runtime imports here must stay empty / type-only.
+
+import type { FileSelection } from "@/context/file"
+import type { ContentPart, ContextItem, ImageAttachmentPart, Prompt, TextPart } from "./prompt"
+
+export const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
+
+function isSelectionEqual(a?: FileSelection, b?: FileSelection) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return (
+    a.startLine === b.startLine && a.startChar === b.startChar && a.endLine === b.endLine && a.endChar === b.endChar
+  )
+}
+
+function isCommandMetaEqual(a: TextPart["command"], b: TextPart["command"]) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return a.name === b.name && a.source === b.source && a.icon === b.icon
+}
+
+function isPartEqual(partA: ContentPart, partB: ContentPart) {
+  switch (partA.type) {
+    case "text":
+      return (
+        partB.type === "text" &&
+        partA.content === partB.content &&
+        isCommandMetaEqual(partA.command, partB.command)
+      )
+    case "file":
+      return partB.type === "file" && partA.path === partB.path && isSelectionEqual(partA.selection, partB.selection)
+    case "agent":
+      return partB.type === "agent" && partA.name === partB.name
+    case "image":
+      return partB.type === "image" && partA.id === partB.id
+  }
+}
+
+export function isPromptEqual(promptA: Prompt, promptB: Prompt): boolean {
+  if (promptA.length !== promptB.length) return false
+  for (let i = 0; i < promptA.length; i++) {
+    if (!isPartEqual(promptA[i], promptB[i])) return false
+  }
+  return true
+}
+
+export function isStructurallyEmpty(
+  prompt: Prompt,
+  contextItems: readonly ContextItem[],
+  imageAttachments: readonly ImageAttachmentPart[],
+): boolean {
+  if (contextItems.length > 0) return false
+  if (imageAttachments.length > 0) return false
+  return isPromptEqual(prompt, DEFAULT_PROMPT)
+}

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -6,6 +6,9 @@ import { batch, createMemo, createRoot, getOwner, onCleanup } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import type { FileSelection } from "@/context/file"
 import { Persist, persisted } from "@/utils/persist"
+import { DEFAULT_PROMPT, isPromptEqual, isStructurallyEmpty } from "./prompt-equality"
+
+export { DEFAULT_PROMPT, isPromptEqual, isStructurallyEmpty }
 
 interface PartBase {
   content: string
@@ -59,57 +62,6 @@ export type FileContextItem = {
 }
 
 export type ContextItem = FileContextItem
-
-export const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
-
-function isSelectionEqual(a?: FileSelection, b?: FileSelection) {
-  if (!a && !b) return true
-  if (!a || !b) return false
-  return (
-    a.startLine === b.startLine && a.startChar === b.startChar && a.endLine === b.endLine && a.endChar === b.endChar
-  )
-}
-
-function isCommandMetaEqual(a: TextPart["command"], b: TextPart["command"]) {
-  if (!a && !b) return true
-  if (!a || !b) return false
-  return a.name === b.name && a.source === b.source && a.icon === b.icon
-}
-
-function isPartEqual(partA: ContentPart, partB: ContentPart) {
-  switch (partA.type) {
-    case "text":
-      return (
-        partB.type === "text" &&
-        partA.content === partB.content &&
-        isCommandMetaEqual(partA.command, partB.command)
-      )
-    case "file":
-      return partB.type === "file" && partA.path === partB.path && isSelectionEqual(partA.selection, partB.selection)
-    case "agent":
-      return partB.type === "agent" && partA.name === partB.name
-    case "image":
-      return partB.type === "image" && partA.id === partB.id
-  }
-}
-
-export function isPromptEqual(promptA: Prompt, promptB: Prompt): boolean {
-  if (promptA.length !== promptB.length) return false
-  for (let i = 0; i < promptA.length; i++) {
-    if (!isPartEqual(promptA[i], promptB[i])) return false
-  }
-  return true
-}
-
-export function isStructurallyEmpty(
-  prompt: Prompt,
-  contextItems: readonly ContextItem[],
-  imageAttachments: readonly ImageAttachmentPart[],
-): boolean {
-  if (contextItems.length > 0) return false
-  if (imageAttachments.length > 0) return false
-  return isPromptEqual(prompt, DEFAULT_PROMPT)
-}
 
 function cloneSelection(selection?: FileSelection) {
   if (!selection) return undefined


### PR DESCRIPTION
## Summary

Fixes a **deterministic** test failure (inserted between prompt-input slimming slice 3 and slice 4 at maintainer request).

`command-prepend`, `command-backspace`, `command-paste`, `portable-draft`, and `path-b-integration` tests fail in isolation / locally with the misleading `SyntaxError: Export named 'isPromptEqual' not found in module .../context/prompt.tsx`.

## Root cause

`prompt.tsx` imports `useParams` from `@solidjs/router` at module top. `@solidjs/router` calls a **client-only** solid-js API at module-eval time, which throws `Client-only API called on the server side` in bun's server-side test env (the `happydom.ts` preload only adds DOM globals; it doesn't change `solid-js/web` server-build resolution). Any test that **value-imports** `prompt.tsx` (triggering its eval → loading the router) without mocking `@solidjs/router` fails — bun surfaces the eval failure as a missing export.

These tests passed in CI only because an earlier test in the full `unit-app` run leaks a non-restoring `mock.module("@solidjs/router")` globally (the #1084 pattern), so they were accidentally depending on mock-leak ordering. `import type` is erased, which is why most tests are unaffected.

## Fix

Extract the pure equality/default-prompt helpers — `DEFAULT_PROMPT`, `isSelectionEqual`, `isCommandMetaEqual`, `isPartEqual`, `isPromptEqual`, `isStructurallyEmpty` — out of `prompt.tsx` into a new pure module `context/prompt-equality.ts` whose imports are **all type-only** (zero runtime deps, never loads `@solidjs/router`). `prompt.tsx` imports them back and **re-exports** them, so the `@/context/prompt` public surface is unchanged.

All pure-symbol **value** consumers are redirected to import from `@/context/prompt-equality` while keeping their type-only imports from `@/context/prompt`: `command-prepend.ts`, `command-backspace.ts`, `command-paste.ts`, `editor-input.ts`, `editor-serialize.ts`, `popover-controllers.ts`, `homepage-migration.ts`, and the 6 test files. `prompt-input.tsx` is intentionally **not** redirected (it imports `usePrompt`, so it loads the context anyway).

This also reduces the codebase's reliance on the leaked router mock (helps #1084).

## Verification

- `bun run typecheck` 8/8 successful
- eslint clean on production files (test files are config-ignored)
- **full app unit suite: 1715 pass / 0 fail** (previously had 2 deterministic failures)
- all 5 formerly-broken tests now pass **in isolation**; full `prompt-input/` dir 406 pass / 0 fail
- independent review (codex, xhigh) **GATE PASS, no P1/P2** — codex independently re-ran the 6 target tests (86 pass) + `prompt.test.ts` (13 pass), verified the pure-module invariant (type-only imports, no router load), no runtime import cycle, re-export compat, and that `import { type X }` is fully erased under the project's TS config

## Residual risk

None for runtime behavior — the `@/context/prompt` public API is byte-identical (same exports, now partly via re-export); the moved helpers are logically unchanged.