### PR TITLE
refactor(app): extract currentProject memo (slice 14 of #1056)

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -58,6 +58,7 @@ import { createShellNavigation } from "./layout/shell-navigation"
 import { useUpdatePolling } from "./layout/layout-update-polling"
 import { useHomepageMigration } from "./layout/layout-homepage-migration"
 import { createOpenGlobalConfigFolder } from "./layout/layout-open-global-config"
+import { createCurrentProjectMemo } from "./layout/layout-current-project"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
 import { registerLayoutCommands } from "./layout/layout-commands"
 import { LayoutShellFrame } from "./layout/layout-shell-frame"
@@ -236,29 +237,7 @@ export default function Layout(props: ParentProps) {
     element.scrollIntoView({ block: "nearest", behavior: "smooth" })
   }
 
-  const currentProject = createMemo(() => {
-    const directory = currentDir()
-    if (!directory) return
-    const key = workspaceKey(directory)
-
-    const projects = layout.projects.list()
-
-    const sandbox = projects.find((p) => p.sandboxes?.some((item) => workspaceKey(item) === key))
-    if (sandbox) return sandbox
-
-    const direct = projects.find((p) => workspaceKey(p.worktree) === key)
-    if (direct) return direct
-
-    const [child] = globalSync.child(directory, { bootstrap: false })
-    const id = child.project
-    if (!id) return
-
-    const meta = globalSync.data.project.find((p) => p.id === id)
-    const root = meta?.worktree
-    if (!root) return
-
-    return projects.find((p) => p.worktree === root)
-  })
+  const currentProject = createCurrentProjectMemo({ currentDir, layout, globalSync })
   const [autoselecting] = createResource(async () => {
     await ready.promise
     await layout.ready.promise

--- a/packages/app/src/pages/layout/layout-current-project.test.ts
+++ b/packages/app/src/pages/layout/layout-current-project.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createCurrentProjectMemo } from "./layout-current-project"
+
+type Project = { id?: string; worktree: string; expanded?: boolean; sandboxes?: string[] }
+
+function setup(opts: {
+  currentDir?: string
+  projects?: Project[]
+  child?: { project?: string }
+  dataProjects?: { id?: string; worktree?: string }[]
+}) {
+  type Input = Parameters<typeof createCurrentProjectMemo>[0]
+  return {
+    currentDir: () => opts.currentDir ?? "",
+    layout: {
+      projects: { list: () => opts.projects ?? [] },
+    } as unknown as Input["layout"],
+    globalSync: {
+      child: () => [opts.child ?? {}] as const,
+      data: { project: opts.dataProjects ?? [] },
+    } as unknown as Input["globalSync"],
+  }
+}
+
+describe("createCurrentProjectMemo", () => {
+  test("returns undefined when there is no current directory", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(setup({ currentDir: "" }))
+      expect(memo()).toBeUndefined()
+      dispose()
+    })
+  })
+
+  test("matches a project by direct worktree", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(setup({ currentDir: "/foo", projects: [{ worktree: "/foo" }] }))
+      expect(memo()?.worktree).toBe("/foo")
+      dispose()
+    })
+  })
+
+  test("matches a project by sandbox membership", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(
+        setup({ currentDir: "/sb", projects: [{ worktree: "/root", sandboxes: ["/sb"] }] }),
+      )
+      expect(memo()?.worktree).toBe("/root")
+      dispose()
+    })
+  })
+
+  test("prefers the sandbox owner when both sandbox and direct could match", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(
+        setup({
+          currentDir: "/x",
+          projects: [{ worktree: "/owner", sandboxes: ["/x"] }, { worktree: "/x" }],
+        }),
+      )
+      expect(memo()?.worktree).toBe("/owner")
+      dispose()
+    })
+  })
+
+  test("resolves through the globalSync child project id to the root project", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(
+        setup({
+          currentDir: "/somewhere",
+          projects: [{ worktree: "/root" }],
+          child: { project: "p1" },
+          dataProjects: [{ id: "p1", worktree: "/root" }],
+        }),
+      )
+      expect(memo()?.worktree).toBe("/root")
+      dispose()
+    })
+  })
+
+  test("returns undefined when child has no project id and nothing matches directly", () => {
+    createRoot((dispose) => {
+      const memo = createCurrentProjectMemo(
+        setup({ currentDir: "/unknown", projects: [{ worktree: "/root" }], child: {} }),
+      )
+      expect(memo()).toBeUndefined()
+      dispose()
+    })
+  })
+})

--- a/packages/app/src/pages/layout/layout-current-project.ts
+++ b/packages/app/src/pages/layout/layout-current-project.ts
@@ -1,0 +1,34 @@
+import { createMemo } from "solid-js"
+import type { useLayout } from "@/context/layout"
+import type { useGlobalSync } from "@/context/global-sync"
+import { workspaceKey } from "./helpers"
+
+export function createCurrentProjectMemo(input: {
+  currentDir: () => string
+  layout: Pick<ReturnType<typeof useLayout>, "projects">
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child" | "data">
+}) {
+  return createMemo(() => {
+    const directory = input.currentDir()
+    if (!directory) return
+    const key = workspaceKey(directory)
+
+    const projects = input.layout.projects.list()
+
+    const sandbox = projects.find((p) => p.sandboxes?.some((item) => workspaceKey(item) === key))
+    if (sandbox) return sandbox
+
+    const direct = projects.find((p) => workspaceKey(p.worktree) === key)
+    if (direct) return direct
+
+    const [child] = input.globalSync.child(directory, { bootstrap: false })
+    const id = child.project
+    if (!id) return
+
+    const meta = input.globalSync.data.project.find((p) => p.id === id)
+    const root = meta?.worktree
+    if (!root) return
+
+    return projects.find((p) => p.worktree === root)
+  })
+}


### PR DESCRIPTION
## Summary

Slice 14 of the #1056 layout governance line — pure extraction, no behaviour / DOM / aria / storage-key change.

Moves the `currentProject` resolution `createMemo` out of `pages/layout.tsx` into a `createCurrentProjectMemo({ currentDir, layout, globalSync })` factory in `pages/layout/layout-current-project.ts` that returns the memo accessor. Every consumer keeps calling `currentProject()` unchanged — the high fan-out is irrelevant because callers consume the returned accessor, not the memo internals.

The factory closes over three injected capability slices: `currentDir` (`() => string`), `layout` (`Pick<..., "projects">` for `projects.list()`), and `globalSync` (`Pick<..., "child" | "data">`). `workspaceKey` is a pure `./helpers` util imported directly. No explicit return annotation, so the inferred project type is byte-for-byte what the inline memo produced.

`layout.tsx` 1006 → 985 (now under 1000).

## Review focus

- Verbatim resolution order: sandbox-membership first, then direct worktree, then `globalSync.child` id → meta → root project.
- Type fidelity: the factory has no return annotation, so `currentProject`'s inferred type is unchanged; consumers' `.worktree` / `.vcs` / `.sandboxes` / `.id` accesses are unaffected.
- Factory call-sited at the original line so the memo is created under the same reactive owner.

## Verification

- [x] `bun run typecheck` clean
- [x] New `layout-current-project.test.ts`: 6 tests cover every resolution branch (no dir → undefined; direct worktree; sandbox membership; sandbox-owner preferred over direct; globalSync child id → root project; child without id + no match → undefined). The memo is drivable under bun's `solid-js` server build (`createMemo` computes on read, unlike `createEffect`).
- [x] Full `bun run test:unit`: 1742 pass / 0 fail (no regression)
- [x] `/codex review`: PASS, no findings