### PR TITLE
fix(server): map provider oauth callback failures to declared 400

### DIFF
--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -15,12 +15,21 @@ import { ServerAuth } from "./auth"
 const log = Log.create({ service: "server" })
 const PTY_CONNECT_PATH = /^\/pty\/[^/]+\/connect$/
 
+// Provider-auth failures the routes already declare as 400 (errors(400)) but that
+// otherwise fall through to a 500 because their NamedError names are not NotFoundError.
+const PROVIDER_AUTH_BAD_REQUEST = new Set([
+  "ProviderAuthValidationFailed",
+  "ProviderAuthOauthMissing",
+  "ProviderAuthOauthCodeMissing",
+  "ProviderAuthOauthCallbackFailed",
+])
+
 export const ErrorMiddleware: ErrorHandler = (err, c) => {
   if (err instanceof NamedError) {
     let status: ContentfulStatusCode
     if (err instanceof NotFoundError) status = 404
     else if (err instanceof Provider.ModelNotFoundError) status = 400
-    else if (err.name === "ProviderAuthValidationFailed") status = 400
+    else if (PROVIDER_AUTH_BAD_REQUEST.has(err.name)) status = 400
     else if (err.name.startsWith("Worktree")) status = 400
     else status = 500
     if (!(err instanceof NotFoundError)) {

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { InvalidError, JsonError } from "../../src/config/error"
+import { OauthCallbackFailed, OauthCodeMissing, OauthMissing } from "../../src/provider/auth"
+import type { ProviderID } from "../../src/provider/schema"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
 import { InstanceMiddleware } from "../../src/server/routes/instance/middleware"
@@ -195,5 +197,27 @@ describe("server error middleware", () => {
 
     expect(response.status).toBe(500)
     expect(calls).toEqual([{ message: "failed", extra: { error } }])
+  })
+
+  test("maps provider oauth callback failures to 400 instead of 500", async () => {
+    const providerID = "anthropic" as ProviderID
+    const cases = [
+      new OauthMissing({ providerID }),
+      new OauthCodeMissing({ providerID }),
+      new OauthCallbackFailed({}),
+    ]
+
+    for (const error of cases) {
+      const app = new Hono().get("/boom", () => {
+        throw error
+      })
+      app.onError(ErrorMiddleware)
+
+      const response = await app.request("/boom")
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body.name).toBe(error.name)
+    }
   })
 })


### PR DESCRIPTION
## What

`POST /provider/:providerID/oauth/callback` already declares `errors(400)` in its OpenAPI contract, but the three failures its handler can raise are `NamedError` instances whose names were not recognized by `ErrorMiddleware`:

- `ProviderAuthOauthMissing` (no pending auth for the provider)
- `ProviderAuthOauthCodeMissing` (code-method callback without a code)
- `ProviderAuthOauthCallbackFailed` (provider returned a non-success result)

They fell through to the default `500` branch, so a missing or expired pending auth surfaced as an **undocumented 500** instead of the already-declared **400**.

## Change

Group the provider-auth-to-400 error names (including the existing `ProviderAuthValidationFailed`) into an exact-name `Set` and map them to 400.

This is a **runtime-only** mapping fix. The 400 response is already part of the published contract (`errors(400)` on the route), so `packages/sdk/openapi.json` and the generated SDK are unchanged - no contract drift.

## Why exact names, not a prefix

Matching the exact error names (not `name.startsWith("ProviderAuthOauth")`) keeps the mapping precise and avoids accidentally catching future provider-auth errors that may warrant a different status.

## Verification

- `bun test test/server/middleware.test.ts` - new case asserts all three oauth errors map to 400 with the error name echoed in the body; 9/9 pass.
- `tsgo --noEmit` clean.
- route-inventory harness green (no route added/removed).

## Context

Part of the #936 Effect error-contract line, contract-completion phase: routes that mis-surface user-meaningful failures as 500 are retyped to their mapped/declared 4xx. Upstream `anomalyco/opencode` declares the equivalent oauth-callback failure as a 400 as well.