### PR TITLE
refactor(app): extract prompt-input action bar to action-bar.tsx

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1,4 +1,3 @@
-import { useSpring } from "@opencode-ai/ui/motion-spring"
 import { useNavigate, useParams } from "@solidjs/router"
 import { createEffect, on, Component, For, Show, createMemo, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
@@ -9,14 +8,8 @@ import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { useComments } from "@/context/comments"
 import { DockSegmentForm } from "@opencode-ai/ui/dock-card"
-import { Icon } from "@opencode-ai/ui/icon"
-import { IconButton } from "@opencode-ai/ui/icon-button"
-import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { openModelPicker } from "@/components/prompt-input/model-picker"
-import { WorkspaceChip } from "@/components/prompt-input/workspace-chip"
-import { SessionContextUsage } from "@/components/session-context-usage"
-import { SendButton } from "./prompt-input/send-button"
 import { useCommand } from "@/context/command"
 import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
@@ -32,7 +25,7 @@ import {
   type PopoverControllers,
 } from "./prompt-input/popover-controllers"
 import { createPromptKeydownHandler } from "./prompt-input/keydown"
-import { PromptModelControl } from "./prompt-input/model-controls"
+import { PromptActionBar } from "./prompt-input/action-bar"
 import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
 import { promptLength } from "./prompt-input/history"
@@ -46,7 +39,6 @@ import { PromptPopover } from "./prompt-input/slash-popover"
 import { PromptContextItems } from "./prompt-input/context-items"
 import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
-import { promptSendDisabled } from "./prompt-input/readiness"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
 
 interface PromptInputProps {
@@ -142,33 +134,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     actionReadyProp: () => props.actionReady?.(),
     abortReadyProp: () => props.abortReady?.(),
   })
-
-  const buttonsSpring = useSpring(() => (store.mode === "normal" ? 1 : 0), { visualDuration: 0.2, bounce: 0 })
-  const motion = (value: number) => ({
-    opacity: value,
-    transform: `scale(${0.95 + value * 0.05})`,
-    filter: `blur(${(1 - value) * 2}px)`,
-    "pointer-events": value > 0.5 ? ("auto" as const) : ("none" as const),
-  })
-  const buttons = createMemo(() => motion(buttonsSpring()))
-
-  const tip = () => {
-    if (stopping() && abortReady()) {
-      return (
-        <div class="flex items-center gap-2">
-          <span>{language.t("prompt.action.stop")}</span>
-          <span class="text-icon-base text-h3 text-[10px]!">{language.t("common.key.esc")}</span>
-        </div>
-      )
-    }
-
-    return (
-      <div class="flex items-center gap-2">
-        <span>{language.t("prompt.action.send")}</span>
-        <Icon name="enter" class="text-icon-base" />
-      </div>
-    )
-  }
 
   const { addToHistory, navigateHistory } = createHistoryNavigation({
     store,
@@ -510,61 +475,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             }}
           />
 
-          <div class="pointer-events-none absolute inset-x-4 bottom-3 flex items-center justify-between gap-2">
-            <div
-              aria-hidden={store.mode !== "normal"}
-              class="pointer-events-auto flex min-w-0 items-center gap-1"
-              style={{
-                "pointer-events": buttonsSpring() > 0.5 ? "auto" : "none",
-              }}
-            >
-              <TooltipKeybind
-                placement="top"
-                title={language.t("prompt.action.attachFile")}
-                keybind={command.keybind("file.attach")}
-              >
-                <IconButton
-                  icon="plus"
-                  data-action="prompt-attach"
-                  type="button"
-                  style={buttons()}
-                  onClick={pick}
-                  disabled={store.mode !== "normal" || !actionReady()}
-                  tabIndex={store.mode === "normal" ? undefined : -1}
-                  aria-label={language.t("prompt.action.attachFile")}
-                />
-              </TooltipKeybind>
-              <Show when={store.mode === "normal"}>
-                <PromptModelControl
-                  triggerStyle={buttons}
-                  actionReady={actionReady}
-                  model={local.model}
-                  language={language}
-                  command={command}
-                  onClose={restoreFocus}
-                />
-              </Show>
-              <Show when={props.homeMode && store.mode === "normal"}>
-                <WorkspaceChip style={buttons()} />
-              </Show>
-            </div>
-
-            <div class="flex items-center gap-2 pointer-events-auto">
-              <SessionContextUsage placement="top" />
-              <Tooltip placement="top" inactive={(working() ? abortReady() : actionReady()) && !working() && blank()} value={tip()}>
-                <SendButton
-                  stopping={stopping()}
-                  disabled={promptSendDisabled({
-                    stopping: stopping(),
-                    actionReady: actionReady(),
-                    abortReady: abortReady(),
-                    blank: blank(),
-                  })}
-                  aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
-                />
-              </Tooltip>
-            </div>
-          </div>
+          <PromptActionBar
+            mode={store.mode}
+            homeMode={props.homeMode}
+            language={language}
+            command={command}
+            model={local.model}
+            actionReady={actionReady}
+            working={working}
+            abortReady={abortReady}
+            blank={blank}
+            stopping={stopping}
+            pick={pick}
+            restoreFocus={restoreFocus}
+          />
         </div>
       </DockSegmentForm>
     </div>

--- a/packages/app/src/components/prompt-input/action-bar.tsx
+++ b/packages/app/src/components/prompt-input/action-bar.tsx
@@ -1,0 +1,125 @@
+// Bottom action bar of the composer: attach / model / workspace chips on the
+// left, context-usage + send-or-stop on the right. Owns the button-reveal
+// spring (driven by mode) and the send/stop tooltip, since both exist only to
+// serve these controls.
+
+import { createMemo, Show, type Accessor, type JSX } from "solid-js"
+import { useSpring } from "@opencode-ai/ui/motion-spring"
+import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
+import { SessionContextUsage } from "@/components/session-context-usage"
+import type { useCommand } from "@/context/command"
+import type { useLanguage } from "@/context/language"
+import type { useLocal } from "@/context/local"
+import { PromptModelControl } from "./model-controls"
+import { WorkspaceChip } from "./workspace-chip"
+import { SendButton } from "./send-button"
+import { promptSendDisabled } from "./readiness"
+import type { PromptStore } from "./store-types"
+
+export interface PromptActionBarProps {
+  mode: PromptStore["mode"]
+  homeMode?: boolean
+  language: ReturnType<typeof useLanguage>
+  command: ReturnType<typeof useCommand>
+  model: ReturnType<typeof useLocal>["model"]
+  actionReady: Accessor<boolean>
+  working: Accessor<boolean>
+  abortReady: Accessor<boolean>
+  blank: Accessor<boolean>
+  stopping: Accessor<boolean>
+  pick: () => void
+  restoreFocus: () => void
+}
+
+export function PromptActionBar(props: PromptActionBarProps): JSX.Element {
+  const buttonsSpring = useSpring(() => (props.mode === "normal" ? 1 : 0), { visualDuration: 0.2, bounce: 0 })
+  const motion = (value: number) => ({
+    opacity: value,
+    transform: `scale(${0.95 + value * 0.05})`,
+    filter: `blur(${(1 - value) * 2}px)`,
+    "pointer-events": value > 0.5 ? ("auto" as const) : ("none" as const),
+  })
+  const buttons = createMemo(() => motion(buttonsSpring()))
+
+  const tip = () => {
+    if (props.stopping() && props.abortReady()) {
+      return (
+        <div class="flex items-center gap-2">
+          <span>{props.language.t("prompt.action.stop")}</span>
+          <span class="text-icon-base text-h3 text-[10px]!">{props.language.t("common.key.esc")}</span>
+        </div>
+      )
+    }
+
+    return (
+      <div class="flex items-center gap-2">
+        <span>{props.language.t("prompt.action.send")}</span>
+        <Icon name="enter" class="text-icon-base" />
+      </div>
+    )
+  }
+
+  return (
+    <div class="pointer-events-none absolute inset-x-4 bottom-3 flex items-center justify-between gap-2">
+      <div
+        aria-hidden={props.mode !== "normal"}
+        class="pointer-events-auto flex min-w-0 items-center gap-1"
+        style={{
+          "pointer-events": buttonsSpring() > 0.5 ? "auto" : "none",
+        }}
+      >
+        <TooltipKeybind
+          placement="top"
+          title={props.language.t("prompt.action.attachFile")}
+          keybind={props.command.keybind("file.attach")}
+        >
+          <IconButton
+            icon="plus"
+            data-action="prompt-attach"
+            type="button"
+            style={buttons()}
+            onClick={props.pick}
+            disabled={props.mode !== "normal" || !props.actionReady()}
+            tabIndex={props.mode === "normal" ? undefined : -1}
+            aria-label={props.language.t("prompt.action.attachFile")}
+          />
+        </TooltipKeybind>
+        <Show when={props.mode === "normal"}>
+          <PromptModelControl
+            triggerStyle={buttons}
+            actionReady={props.actionReady}
+            model={props.model}
+            language={props.language}
+            command={props.command}
+            onClose={props.restoreFocus}
+          />
+        </Show>
+        <Show when={props.homeMode && props.mode === "normal"}>
+          <WorkspaceChip style={buttons()} />
+        </Show>
+      </div>
+
+      <div class="flex items-center gap-2 pointer-events-auto">
+        <SessionContextUsage placement="top" />
+        <Tooltip
+          placement="top"
+          inactive={(props.working() ? props.abortReady() : props.actionReady()) && !props.working() && props.blank()}
+          value={tip()}
+        >
+          <SendButton
+            stopping={props.stopping()}
+            disabled={promptSendDisabled({
+              stopping: props.stopping(),
+              actionReady: props.actionReady(),
+              abortReady: props.abortReady(),
+              blank: props.blank(),
+            })}
+            aria-label={props.stopping() ? props.language.t("prompt.action.stop") : props.language.t("prompt.action.send")}
+          />
+        </Tooltip>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Slice 4 of the serial slimming of `packages/app/src/components/prompt-input.tsx`. Moves the composer's bottom action bar JSX out of `prompt-input.tsx` into a new `PromptActionBar` component in `prompt-input/action-bar.tsx`.

The new component owns the controls it renders:
- left group: attach `IconButton`, `PromptModelControl`, home-mode `WorkspaceChip`
- right group: `SessionContextUsage` + send/stop `Tooltip`/`SendButton`

The button-reveal spring (`useSpring` driven by `mode`), its `motion` style helper, the `buttons` memo, and the send/stop `tip()` helper move with it, since they are used only by the action bar. The action bar `<div>` is always mounted (no `<Show>` gates it), so relocating the spring into the child preserves its lifetime and animation behavior.

## Why

Continue extracting cohesive units so `prompt-input.tsx` stays small and grep-friendly. `prompt-input.tsx` drops from 572 to 496 lines.

## Change boundary

Pure extraction — **no behavior, DOM, aria, copy, or storage-key change**. The only seam edits are reading injected props (`props.mode`, `props.actionReady()`, `props.language`, …) in place of the parent's locals. `mode` is passed as a value prop (`mode={store.mode}`), kept reactive by Solid's compiled prop getter, so the spring target still tracks `store.mode`.

Two files touched:
- `prompt-input.tsx` (−91): drop the action bar JSX, the spring/`motion`/`buttons` trio, `tip()`, and 8 now-unused imports; add the `PromptActionBar` import + element.
- `prompt-input/action-bar.tsx` (new, +125).

## Verification

- `bun run typecheck` — 8 successful, 8 total
- `bun test src/components/prompt-input/` — 406 pass, 0 fail
- `bunx eslint` on both files — clean
- Visual: `bun run snap prompt-placeholder` — action bar renders identically across en/zh × 1440/768/768+rightpanel (attach `+`, model control, home-mode workspace chip, orange send button, correct left/right layout)
- Codex review (xhigh) — no P0/P1/P2/P3 findings; confirmed reactivity preserved and rendered output aligned

## Risk

Low. Bounded JSX extraction with identical output; no test mounts the full `PromptInput`, so coverage is the unchanged unit tests of the moved components plus the visual snap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the prompt input interface by refactoring the action bar into a dedicated component structure. This improves internal code organization and maintainability while preserving all user-facing functionality, including send/stop controls, file attachments, model selection, and workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->