### PR TITLE
refactor(app): extract navigateProjectByOffset controller (slice 15 of #1056)

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -59,6 +59,7 @@ import { useUpdatePolling } from "./layout/layout-update-polling"
 import { useHomepageMigration } from "./layout/layout-homepage-migration"
 import { createOpenGlobalConfigFolder } from "./layout/layout-open-global-config"
 import { createCurrentProjectMemo } from "./layout/layout-current-project"
+import { createNavigateProjectByOffset } from "./layout/layout-navigate-project"
 import { sessionNotificationHref, useSDKNotificationToasts } from "./layout/layout-sdk-event-effects"
 import { registerLayoutCommands } from "./layout/layout-commands"
 import { LayoutShellFrame } from "./layout/layout-shell-frame"
@@ -386,28 +387,6 @@ export default function Layout(props: ParentProps) {
     navigateToSession(session)
   }
 
-  function navigateProjectByOffset(offset: number) {
-    const projects = layout.projects.list()
-    if (projects.length === 0) return
-
-    const current = currentProject()?.worktree
-    const fallback = currentDir() ? projectRoot(currentDir()) : undefined
-    const active = current ?? fallback
-    const index = active ? projects.findIndex((project) => project.worktree === active) : -1
-
-    const target =
-      index === -1
-        ? offset > 0
-          ? projects[0]
-          : projects[projects.length - 1]
-        : projects[(index + offset + projects.length) % projects.length]
-    if (!target) return
-
-    // warm up child store to prevent flicker
-    globalSync.child(target.worktree)
-    openProject(target.worktree)
-  }
-
   function navigateSessionByUnseen(offset: number) {
     const target = findPawworkSessionNavigationTarget({
       sections: pawworkSessionSections(),
@@ -595,6 +574,15 @@ export default function Layout(props: ParentProps) {
     unhideProject,
     projectKeyForSession,
     layout,
+  })
+
+  const navigateProjectByOffset = createNavigateProjectByOffset({
+    layout,
+    currentProject,
+    currentDir,
+    projectRoot,
+    globalSync,
+    openProject,
   })
 
   const {

--- a/packages/app/src/pages/layout/layout-navigate-project.test.ts
+++ b/packages/app/src/pages/layout/layout-navigate-project.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { createNavigateProjectByOffset } from "./layout-navigate-project"
+
+function setup(opts: {
+  projects?: { worktree: string }[]
+  current?: string
+  currentDir?: string
+  projectRoot?: (dir: string) => string
+}) {
+  // `events` records the cross-call order so the child-before-openProject
+  // warm-up invariant is actually provable (separate arrays cannot prove it).
+  const calls = { child: [] as string[], openProject: [] as string[], events: [] as string[] }
+  type Input = Parameters<typeof createNavigateProjectByOffset>[0]
+  const navigate = createNavigateProjectByOffset({
+    layout: { projects: { list: () => opts.projects ?? [] } } as unknown as Input["layout"],
+    currentProject: (() =>
+      opts.current ? { worktree: opts.current } : undefined) as unknown as Input["currentProject"],
+    currentDir: () => opts.currentDir ?? "",
+    projectRoot: opts.projectRoot ?? ((dir: string) => dir),
+    globalSync: {
+      child: (worktree: string) => {
+        calls.child.push(worktree)
+        calls.events.push(`child:${worktree}`)
+        return [{}]
+      },
+    } as unknown as Input["globalSync"],
+    openProject: ((worktree: string) => {
+      calls.openProject.push(worktree)
+      calls.events.push(`open:${worktree}`)
+      return Promise.resolve()
+    }) as unknown as Input["openProject"],
+  })
+  return { navigate, calls }
+}
+
+const THREE = [{ worktree: "/a" }, { worktree: "/b" }, { worktree: "/c" }]
+
+describe("createNavigateProjectByOffset", () => {
+  test("does nothing when there are no projects", () => {
+    const { navigate, calls } = setup({ projects: [] })
+    navigate(1)
+    expect(calls.openProject).toEqual([])
+  })
+
+  test("moves to the next project, warming the child store before opening it", () => {
+    const { navigate, calls } = setup({ projects: THREE, current: "/b" })
+    navigate(1)
+    // Single ordered log proves child-store warm-up precedes openProject.
+    expect(calls.events).toEqual(["child:/c", "open:/c"])
+  })
+
+  test("moves to the previous project", () => {
+    const { navigate, calls } = setup({ projects: THREE, current: "/b" })
+    navigate(-1)
+    expect(calls.openProject).toEqual(["/a"])
+  })
+
+  test("wraps from the last project forward to the first", () => {
+    const { navigate, calls } = setup({ projects: THREE, current: "/c" })
+    navigate(1)
+    expect(calls.openProject).toEqual(["/a"])
+  })
+
+  test("wraps from the first project backward to the last", () => {
+    const { navigate, calls } = setup({ projects: THREE, current: "/a" })
+    navigate(-1)
+    expect(calls.openProject).toEqual(["/c"])
+  })
+
+  test("falls back to the first project forward when nothing is active", () => {
+    const { navigate, calls } = setup({ projects: THREE, currentDir: "" })
+    navigate(1)
+    expect(calls.openProject).toEqual(["/a"])
+  })
+
+  test("falls back to the last project backward when nothing is active", () => {
+    const { navigate, calls } = setup({ projects: THREE, currentDir: "" })
+    navigate(-1)
+    expect(calls.openProject).toEqual(["/c"])
+  })
+
+  test("resolves the active project from currentDir via projectRoot when no currentProject", () => {
+    const { navigate, calls } = setup({
+      projects: THREE,
+      currentDir: "/somewhere",
+      projectRoot: () => "/b",
+    })
+    navigate(1)
+    expect(calls.openProject).toEqual(["/c"])
+  })
+})

--- a/packages/app/src/pages/layout/layout-navigate-project.ts
+++ b/packages/app/src/pages/layout/layout-navigate-project.ts
@@ -1,0 +1,35 @@
+import type { useLayout } from "@/context/layout"
+import type { useGlobalSync } from "@/context/global-sync"
+import type { createCurrentProjectMemo } from "./layout-current-project"
+import type { createPawworkRoutingActions } from "./pawwork-routing-actions"
+
+export function createNavigateProjectByOffset(input: {
+  layout: Pick<ReturnType<typeof useLayout>, "projects">
+  currentProject: ReturnType<typeof createCurrentProjectMemo>
+  currentDir: () => string
+  projectRoot: (directory: string) => string
+  globalSync: Pick<ReturnType<typeof useGlobalSync>, "child">
+  openProject: ReturnType<typeof createPawworkRoutingActions>["openProject"]
+}): (offset: number) => void {
+  return function navigateProjectByOffset(offset: number) {
+    const projects = input.layout.projects.list()
+    if (projects.length === 0) return
+
+    const current = input.currentProject()?.worktree
+    const fallback = input.currentDir() ? input.projectRoot(input.currentDir()) : undefined
+    const active = current ?? fallback
+    const index = active ? projects.findIndex((project) => project.worktree === active) : -1
+
+    const target =
+      index === -1
+        ? offset > 0
+          ? projects[0]
+          : projects[projects.length - 1]
+        : projects[(index + offset + projects.length) % projects.length]
+    if (!target) return
+
+    // warm up child store to prevent flicker
+    input.globalSync.child(target.worktree)
+    input.openProject(target.worktree)
+  }
+}


### PR DESCRIPTION
## Summary

Slice 15 of the #1056 layout governance line — pure extraction, no behaviour / DOM / aria / storage-key change.

Moves the `navigateProjectByOffset` controller out of `pages/layout.tsx` into a `createNavigateProjectByOffset({ layout, currentProject, currentDir, projectRoot, globalSync, openProject })` factory in `pages/layout/layout-navigate-project.ts`. The body (active-worktree resolution, index + wraparound modulo math, child-store warm-up, `openProject`) is byte-for-byte identical with `input.*` prefixes.

`layout.tsx` 985 → 973.

## Hoisting note (the one non-mechanical wrinkle)

The original was a hoisted `function navigateProjectByOffset` whose body resolved `openProject` (a `const` from the `createPawworkRoutingActions` destructure) lazily at call time. The replacement `const navigateProjectByOffset = createNavigateProjectByOffset({ …openProject… })` reads `openProject` eagerly, so the factory call is placed **after** that destructure (not at the original site) to keep it out of the TDZ. The sole consumer (`registerLayoutCommands` `moveProject`) runs later, so definition-before-use holds; no reference exists between the old and new sites.

## Review focus

- Definition-before-use + dep scope at the new call position (all 6 injected deps defined earlier).
- Byte-for-byte body equivalence (wraparound math, child warm-up ordering before `openProject`).
- New `.ts` file has only `import type` — zero runtime value imports, so nothing pulls `@/context/terminal` / `@solidjs/router` into the bun test graph.

## Verification

- [x] `bun run typecheck` clean
- [x] New `layout-navigate-project.test.ts`: 8 tests cover the navigation math (empty → noop; next / prev; forward + backward wraparound; no-active fallback to first / last; active resolved from `currentDir` via `projectRoot`) and assert child-store warm-up precedes `openProject` via a single ordered event log.
- [x] Full `bun run test:unit`: 1750 pass / 0 fail (no regression)
- [x] `/codex review` (custom focus on the hoisting move): no P1. One P2 — the warm-up ordering test originally asserted two separate arrays (couldn't prove cross-call order); fixed to a single ordered `events` log.