### PR TITLE
fix(server): declare 400/404 on the session fork route

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -453,6 +453,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
+          ...errors(400, 404),
         },
       }),
       validator(

--- a/packages/opencode/test/server/session-core-routes.test.ts
+++ b/packages/opencode/test/server/session-core-routes.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session as SessionNs } from "../../src/session"
-import type { SessionID } from "../../src/session/schema"
+import { SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 
@@ -78,6 +78,33 @@ describe("session core routes", () => {
           await svc.remove(child.id).catch(() => undefined)
           await svc.remove(root.id).catch(() => undefined)
         }
+      },
+    })
+  })
+
+  test("declares fork bad-request and not-found failures in OpenAPI", async () => {
+    const spec = await Server.openapi()
+    const responses = spec.paths?.["/session/{sessionID}/fork"]?.post?.responses
+
+    expect(responses?.["400"]).toBeDefined()
+    expect(responses?.["404"]).toBeDefined()
+  })
+
+  test("returns 404 when forking a missing session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const missing = SessionID.descending()
+        const response = await Server.Default().app.request(`/session/${missing}/fork`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        })
+
+        expect(response.status).toBe(404)
+        const body = await response.json()
+        expect(body.name).toBe("NotFoundError")
       },
     })
   })


### PR DESCRIPTION
## What

`POST /session/:sessionID/fork` forks an existing session and calls `Session.get(sessionID)` first, which raises `NotFoundError` (mapped to 404 by `ErrorMiddleware`) when the parent session does not exist. But the route's OpenAPI contract only declared a `200` response, so the 404 (and the validator's 400) were **undocumented**: an SDK consumer reading the contract had no way to know `session.fork` could fail with not-found.

## Change

Add `errors(400, 404)` to the fork route so the published contract matches what the running server already serves.

**Runtime behavior is unchanged** — this is a purely additive contract declaration. The 404 already happened; now it is declared.

## On the SDK snapshot

Per this line's strategy, the hand-maintained `packages/sdk/openapi.json` snapshot and the generated SDK are **not** regenerated in this PR. That checked-in snapshot is already ~24 operations behind the live code (it has no committed generator and is batch-resynced occasionally), so regenerating it here would bury this one-line change under a 150KB+ accumulated-drift diff. This PR changes only the live served OpenAPI source (`Server.openapi()`); the snapshot/SDK can be resynced in a separate mechanical pass.

## Verification

- `bun test test/server/session-core-routes.test.ts` — new cases assert `Server.openapi()` declares 400 and 404 for `/session/{sessionID}/fork`, and that forking a missing session returns 404 with `NotFoundError` in the body; 3/3 pass.
- `tsgo --noEmit` clean.
- route-inventory harness green (no route added/removed).

## Context

#936 Effect error-contract line, contract-completion phase (slice A). Upstream `anomalyco/opencode` declares the equivalent fork not-found failure. Code-only slice, no SDK regen.