### PR TITLE
refactor(app): extract prompt-input editor surface to editor-surface.tsx

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from "@solidjs/router"
-import { createEffect, on, Component, For, Show, createMemo, createSignal } from "solid-js"
+import { createEffect, on, Component, For, createMemo, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { useFile } from "@/context/file"
@@ -27,7 +27,7 @@ import {
 import { createPromptKeydownHandler } from "./prompt-input/keydown"
 import { PromptActionBar } from "./prompt-input/action-bar"
 import { createPromptAttachments } from "./prompt-input/attachments"
-import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
+import { PromptEditorSurface } from "./prompt-input/editor-surface"
 import { promptLength } from "./prompt-input/history"
 import { createPromptDerivedState } from "./prompt-input/derived-state"
 import { createPromptCommandsAndMode } from "./prompt-input/commands-mode"
@@ -396,83 +396,26 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             editorRef?.focus()
           }}
         >
-          <div
-            class="relative min-h-[100px] max-h-[240px] overflow-y-auto no-scrollbar"
-            ref={(el) => (scrollRef = el)}
-            style={{ "scroll-padding-bottom": space }}
-          >
-            <div
-              data-component="prompt-input"
-              ref={(el) => {
-                editorRef = el
-                props.ref?.(el)
-              }}
-              role="textbox"
-              aria-multiline="true"
-              aria-label={placeholder()}
-              contenteditable="true"
-              autocapitalize={store.mode === "normal" ? "sentences" : "off"}
-              autocorrect={store.mode === "normal" ? "on" : "off"}
-              spellcheck={store.mode === "normal"}
-              inputMode="text"
-              // @ts-expect-error
-              autocomplete="off"
-              onInput={handleInput}
-              onCopy={handleCopy}
-              onPaste={(event) => {
-                const hasFiles = Array.from(event.clipboardData?.items ?? []).some((item) => item.kind === "file")
-                if (!actionReady() && hasFiles) {
-                  event.preventDefault()
-                  return
-                }
-                handlePaste(event)
-              }}
-              onCompositionStart={handleCompositionStart}
-              onCompositionEnd={handleCompositionEnd}
-              onBlur={handleBlur}
-              onKeyDown={handleKeyDown}
-              classList={{
-                "select-text": true,
-                "w-full pl-4 pr-4 pt-4 text-body text-fg-strong focus:outline-none whitespace-pre-wrap": true,
-                "[&_[data-type=file]]:text-syntax-property": true,
-                "[&_[data-type=agent]]:text-syntax-type": true,
-                "font-mono!": store.mode === "shell",
-              }}
-              style={{ "padding-bottom": space }}
-            />
-            <Show when={!prompt.dirty()}>
-              <div
-                data-component="prompt-placeholder"
-                class="absolute top-0 inset-x-0 pl-4 pr-4 pt-4 text-body text-fg-weak pointer-events-none whitespace-nowrap truncate"
-                classList={{ "font-mono!": store.mode === "shell" }}
-                style={{ "padding-bottom": space }}
-              >
-                {placeholder()}
-              </div>
-            </Show>
-          </div>
-
-          <div
-            aria-hidden="true"
-            class="pointer-events-none absolute inset-x-0 bottom-0"
-            style={{
-              height: space,
-              background:
-                "linear-gradient(to top, var(--surface-raised) calc(100% - 20px), transparent)",
+          <PromptEditorSurface
+            setScrollRef={(el) => (scrollRef = el)}
+            setEditorRef={(el) => {
+              editorRef = el
+              props.ref?.(el)
             }}
-          />
-
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            accept={ACCEPTED_FILE_TYPES.join(",")}
-            class="hidden"
-            onChange={(e) => {
-              const list = e.currentTarget.files
-              if (list && actionReady()) void addAttachments(Array.from(list))
-              e.currentTarget.value = ""
-            }}
+            setFileInputRef={(el) => (fileInputRef = el)}
+            mode={store.mode}
+            placeholder={placeholder}
+            dirty={prompt.dirty}
+            space={space}
+            actionReady={actionReady}
+            onInput={handleInput}
+            onCopy={handleCopy}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            handlePaste={handlePaste}
+            addAttachments={addAttachments}
           />
 
           <PromptActionBar

--- a/packages/app/src/components/prompt-input/editor-surface.tsx
+++ b/packages/app/src/components/prompt-input/editor-surface.tsx
@@ -1,0 +1,109 @@
+// The composer's editable surface: the scrollable contenteditable region with
+// its overlaid placeholder, the bottom fade gradient, and the hidden file
+// input. Returns a fragment so DOM order inside the rounded container is
+// unchanged. The three DOM refs are mutable and consumed by the parent, so
+// they are forwarded via setter callbacks rather than owned here.
+
+import { Show, type Accessor } from "solid-js"
+import { ACCEPTED_FILE_TYPES } from "./files"
+import type { PromptStore } from "./store-types"
+
+export interface PromptEditorSurfaceProps {
+  setEditorRef: (el: HTMLDivElement) => void
+  setScrollRef: (el: HTMLDivElement) => void
+  setFileInputRef: (el: HTMLInputElement) => void
+  mode: PromptStore["mode"]
+  placeholder: Accessor<string>
+  dirty: Accessor<boolean>
+  space: string
+  actionReady: Accessor<boolean>
+  onInput: (event?: InputEvent) => void
+  onCopy: (event: ClipboardEvent) => void
+  onCompositionStart: () => void
+  onCompositionEnd: () => void
+  onBlur: () => void
+  onKeyDown: (event: KeyboardEvent) => void
+  handlePaste: (event: ClipboardEvent) => void
+  addAttachments: (files: File[]) => void
+}
+
+export function PromptEditorSurface(props: PromptEditorSurfaceProps) {
+  return (
+    <>
+      <div
+        class="relative min-h-[100px] max-h-[240px] overflow-y-auto no-scrollbar"
+        ref={props.setScrollRef}
+        style={{ "scroll-padding-bottom": props.space }}
+      >
+        <div
+          data-component="prompt-input"
+          ref={props.setEditorRef}
+          role="textbox"
+          aria-multiline="true"
+          aria-label={props.placeholder()}
+          contenteditable="true"
+          autocapitalize={props.mode === "normal" ? "sentences" : "off"}
+          autocorrect={props.mode === "normal" ? "on" : "off"}
+          spellcheck={props.mode === "normal"}
+          inputMode="text"
+          // @ts-expect-error
+          autocomplete="off"
+          onInput={props.onInput}
+          onCopy={props.onCopy}
+          onPaste={(event) => {
+            const hasFiles = Array.from(event.clipboardData?.items ?? []).some((item) => item.kind === "file")
+            if (!props.actionReady() && hasFiles) {
+              event.preventDefault()
+              return
+            }
+            props.handlePaste(event)
+          }}
+          onCompositionStart={props.onCompositionStart}
+          onCompositionEnd={props.onCompositionEnd}
+          onBlur={props.onBlur}
+          onKeyDown={props.onKeyDown}
+          classList={{
+            "select-text": true,
+            "w-full pl-4 pr-4 pt-4 text-body text-fg-strong focus:outline-none whitespace-pre-wrap": true,
+            "[&_[data-type=file]]:text-syntax-property": true,
+            "[&_[data-type=agent]]:text-syntax-type": true,
+            "font-mono!": props.mode === "shell",
+          }}
+          style={{ "padding-bottom": props.space }}
+        />
+        <Show when={!props.dirty()}>
+          <div
+            data-component="prompt-placeholder"
+            class="absolute top-0 inset-x-0 pl-4 pr-4 pt-4 text-body text-fg-weak pointer-events-none whitespace-nowrap truncate"
+            classList={{ "font-mono!": props.mode === "shell" }}
+            style={{ "padding-bottom": props.space }}
+          >
+            {props.placeholder()}
+          </div>
+        </Show>
+      </div>
+
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-x-0 bottom-0"
+        style={{
+          height: props.space,
+          background: "linear-gradient(to top, var(--surface-raised) calc(100% - 20px), transparent)",
+        }}
+      />
+
+      <input
+        ref={props.setFileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPTED_FILE_TYPES.join(",")}
+        class="hidden"
+        onChange={(e) => {
+          const list = e.currentTarget.files
+          if (list && props.actionReady()) void props.addAttachments(Array.from(list))
+          e.currentTarget.value = ""
+        }}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## What

Slice 5 (final) of the serial slimming of `packages/app/src/components/prompt-input.tsx`. Moves the composer's editable surface out of `prompt-input.tsx` into a new `PromptEditorSurface` component in `prompt-input/editor-surface.tsx`.

The moved JSX:
- the scrollable contenteditable editor `<div data-component="prompt-input">` + its overlaid placeholder (`<Show when={!dirty}>`)
- the bottom fade gradient
- the hidden file `<input>`

The component **returns a fragment** (`<>…</>`), so DOM order inside the parent's rounded container stays byte-identical: editor-scroll → gradient → file-input → `<PromptActionBar/>` (unchanged sibling).

## Why

Final extraction of the prompt-input governance line. `prompt-input.tsx` drops from 496 to 439 lines (659 → 439 across the five slices).

## Change boundary

Pure extraction — **no behavior, DOM, aria, copy, or storage-key change**.

- The three DOM refs (`editorRef`/`scrollRef`/`fileInputRef`) stay owned by the parent (consumed by editor imperatives, `onMouseDown` focus, attachments, commands-mode, keydown). They are forwarded via setter callbacks: `setEditorRef={(el) => { editorRef = el; props.ref?.(el) }}`, `setScrollRef`, `setFileInputRef`. Assignment timing (on mount) is unchanged, and `props.ref?.(el)` still fires exactly once.
- `mode` is passed as a value prop and stays reactive via Solid's compiled prop getter; `placeholder`/`dirty` pass as accessors and are called in the child.
- The editor handlers (`onInput`/`onCopy`/`onComposition*`/`onBlur`/`onKeyDown`) pass through as props. The `onPaste` and file `onChange` wrappers are rebuilt in the child reading `props.actionReady`/`props.handlePaste`/`props.addAttachments` — logic byte-identical.
- Parent cleanup: drop now-unused `Show` and `ACCEPTED_FILE_TYPES` imports; add `PromptEditorSurface`.

Two files touched:
- `prompt-input.tsx` (−78)
- `prompt-input/editor-surface.tsx` (new, +109)

## Verification

- `bun run typecheck` (`@opencode-ai/app`, forced) — 5 successful, 5 total
- `bun test src/components/prompt-input/` — 406 pass, 0 fail
- `bunx eslint` on both files — clean
- Visual: `bun run snap prompt-placeholder` — editor surface identical across en/zh × 1440/768/768+rightpanel (placeholder copy, narrow-width truncation, gradient, padding, action bar position)
- Codex review (xhigh) — no findings; confirmed ref-forwarding timing, reactivity, and handler equivalence preserved

## Risk

Low. Bounded JSX extraction returning a fragment (identical DOM); the wide prop surface is inherent to the editor. No test mounts the full `PromptInput`, so coverage is the unchanged prompt-input unit tests plus the visual snap.