### PR TITLE
fix(opencode): scan pushd/chdir targets for external_directory permission

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -47,9 +47,21 @@ const METADATA_FLUSH_BYTES = 4 * 1024
 const CONSUMER_DRAIN_TIMEOUT = Duration.seconds(1)
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 const PS = new Set(["powershell", "pwsh"])
+// CWD commands are skipped from the generic bash-command prompt below (they are
+// pure navigation builtins). Only put a command here when it is a real cwd
+// builtin on every shell that reaches it — otherwise a same-named PATH
+// executable would slip past the bash prompt (see pushd/chdir in FILES).
 const CWD = new Set(["cd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
+  // pushd (POSIX) and chdir (cmd.exe) change the cwd into their target, so the
+  // target argument must be scanned for external_directory the same way cd's is
+  // (#1052: `pushd /external` previously read outside the project unprompted).
+  // They stay OUT of CWD on purpose: pushd is not a builtin in sh/dash and chdir
+  // is not a POSIX builtin at all, so they must still raise the generic bash
+  // prompt — only the external-target scan is shared with cd.
+  "pushd",
+  "chdir",
   "rm",
   "cp",
   "mv",

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1589,6 +1589,70 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  // pushd (POSIX) and chdir (cmd.exe) change the cwd into their target, so they
+  // must scan that target for external_directory the same way cd does (#1052:
+  // `pushd /etc` previously read outside the project unprompted).
+  for (const changer of ["pushd", "chdir"]) {
+    each(`asks for external_directory when ${changer} enters an external directory`, async () => {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const bash = await initBash()
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          const dir = process.platform === "win32" ? process.env.WINDIR!.replaceAll("\\", "/") : "/etc"
+          const want =
+            process.platform === "win32"
+              ? glob(path.join(process.env.WINDIR!, "*"))
+              : path.join(await fs.promises.realpath("/etc"), "*")
+          await expect(
+            Effect.runPromise(
+              bash.execute(
+                {
+                  command: `${changer} ${dir}`,
+                  description: `Change into external directory with ${changer}`,
+                },
+                capture(requests, err),
+              ),
+            ),
+          ).rejects.toThrow(err.message)
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(want)
+        },
+      })
+    })
+  }
+
+  // Unlike cd, pushd/chdir stay OUT of the CWD skip-set, so an in-project target
+  // (no external_directory) still raises the generic bash prompt. This guards
+  // against a same-named PATH executable slipping past unprompted — chdir is no
+  // POSIX builtin and pushd is none in sh/dash (#1052 review).
+  for (const changer of ["pushd", "chdir"]) {
+    each(`still asks for bash permission when ${changer} target stays in the project`, async () => {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const bash = await initBash()
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          await expect(
+            Effect.runPromise(
+              bash.execute(
+                { command: `${changer} src`, description: `In-project ${changer}` },
+                capture(requests, err),
+              ),
+            ),
+          ).rejects.toThrow(err.message)
+          expect(requests.find((r) => r.permission === "external_directory")).toBeUndefined()
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.always).toContain(`${changer} *`)
+        },
+      })
+    })
+  }
+
   if (process.platform === "win32") {
     if (bash) {
       test(


### PR DESCRIPTION
## Summary

The shell tool's permission scan only treated `cd` / `push-location` / `set-location` as directory-changers, so `pushd /external && cat secret` read a file outside the project without ever firing the `external_directory` prompt that `cd /external` triggers. This adds `pushd` (POSIX) and `chdir` (cmd.exe) to the `FILES` scan set so their target argument is scanned for external access the same way `cd`'s is.

They are added to `FILES`, **not** `CWD`, on purpose. `CWD` members are also skipped from the generic bash-command prompt because they are pure navigation builtins — but `chdir` is no POSIX builtin and `pushd` is none in `sh`/`dash`, so a same-named PATH executable must still raise the bash prompt. Keeping `pushd`/`chdir` out of `CWD` shares only the external-target scan with `cd` and avoids opening a new bypass.

## Why

Closes #1052. A user who broadly allows the shell tool and relies on `external_directory` to catch out-of-project access could read outside the project via `pushd`/`chdir` with no `external_directory` prompt. The general shell prompt still fired, so this was a bounded evasion of the `external_directory` guardrail, not a full bypass — but it is the guardrail this fix restores at parity with `cd`.

## Related Issue

Closes #1052

## Human Review Status

Pending

## Review Focus

`FILES` vs `CWD` placement in `packages/opencode/src/tool/shell.ts`. The security-relevant property is: `pushd`/`chdir` into an **external** dir must request `external_directory`, while `pushd`/`chdir` whose target stays **in-project** must still raise the generic `bash` prompt (so a non-builtin `chdir`/`pushd` PATH executable cannot slip through unprompted). Both directions are asserted in `shell.test.ts`.

This is an intentionally **partial** fix scoped to the `external_directory` gap. Deferred (not regressions introduced here, confirmed in review):
- Full cwd simulation across a compound command (relative file ops after a cwd change resolve against the new cwd) — this also affects `cd` today and is a separate, larger behavior change.
- cmd.exe-native file commands (`type`/`copy`/`del`/`move`) and case-insensitive command normalization, via a shell-gated `CMD_FILES` set (deferred from #1038). `type` is a bash builtin, so it cannot be folded into the shared `FILES` set; un-normalized cmd.exe case variants still fall to the generic bash prompt, so nothing is silently allowed.

## Risk Notes

Security-sensitive (changes permission scoping), but the change only **widens** prompting: external `pushd`/`chdir` now additionally request `external_directory`, and in-project `pushd`/`chdir` keep the existing bash prompt. An external target yields both an `external_directory` and a `bash` request — conservative and intended (one gate for out-of-project access, one for running the command). This is a shell/permission change spanning both platforms: `pushd` is the POSIX path, `chdir` the cmd.exe path; cmd.exe case-insensitive command normalization is the one cmd-specific piece deferred (un-normalized variants still hit the generic bash prompt). No packaging/updater/signing surface and no docs/deps, so only the docs/deps conditional item is left unticked.

## How To Verify

```text
unit (packages/opencode test/tool/shell.test.ts): 54 pass — incl. 4 new:
  - pushd /etc -> external_directory for /etc
  - chdir /etc -> external_directory for /etc
  - in-project `pushd src` -> no external_directory, still a bash prompt (`pushd *`)
  - in-project `chdir src` -> no external_directory, still a bash prompt (`chdir *`)
unit (test/tool/external-directory.test.ts): 14 pass (resolver unchanged)
typecheck (packages/opencode): pass
codex review (xhigh, security focus): PASS after one round — first version put pushd/chdir
  in CWD, codex flagged [P1] that a non-builtin chdir/pushd PATH executable targeting an
  in-project path would bypass all prompts; reworked to FILES-only, re-review PASS.
```

## Screenshots or Recordings

N/A — no visible UI; permission-scan behavior is covered by the unit tests above.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
