### PR TITLE
fix(server): declare tool/respond route-local failures, harden errors() helper

### DIFF
--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -31,6 +31,16 @@ export const ERRORS = {
   },
 } as const
 
-export function errors(...codes: number[]) {
-  return Object.fromEntries(codes.map((code) => [code, ERRORS[code as keyof typeof ERRORS]]))
+export function errors(...codes: (keyof typeof ERRORS)[]) {
+  return Object.fromEntries(
+    codes.map((code) => {
+      const entry = ERRORS[code]
+      // Fail loudly instead of silently dropping the response: JSON.stringify
+      // omits undefined, so an unregistered code used to vanish from the spec
+      // (e.g. errors(409) became a no-op). Routes with bespoke error bodies
+      // must declare them inline rather than route them through this helper.
+      if (!entry) throw new Error(`errors(): no response schema registered for status ${code}`)
+      return [code, entry]
+    }),
+  )
 }

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -35,6 +35,16 @@ import { Env } from "@/env"
 
 const log = Log.create({ service: "server" })
 const AbortSource = z.string().regex(/^[A-Za-z0-9._-]{1,80}$/)
+
+// tool/respond returns route-local failure bodies ({ error } for not-found /
+// already-resolved, plus optional decoder { details } on 422) rather than the
+// shared NotFoundError/BadRequest envelopes, so it declares them inline. The
+// schema is left un-refed (no .meta ref) so it inlines directly into each
+// response instead of a shared component.
+const ToolRespondFailure = z.object({
+  error: z.string(),
+  details: z.unknown().optional(),
+})
 const e2eSessionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 
 function publishTurnChangeFiles(display: TurnChangeDisplay, mode: "undo" | "redo", mutatedPaths?: string[]) {
@@ -487,7 +497,19 @@ export const SessionRoutes = lazy(() =>
             description: "Resolved",
             content: { "application/json": { schema: resolver(z.object({ status: z.literal("ok") })) } },
           },
-          ...errors(400, 404, 409, 422),
+          ...errors(400),
+          404: {
+            description: "No pending tool call for the given (session, message, call)",
+            content: { "application/json": { schema: resolver(ToolRespondFailure) } },
+          },
+          409: {
+            description: "The pending tool call was already resolved",
+            content: { "application/json": { schema: resolver(ToolRespondFailure) } },
+          },
+          422: {
+            description: "The submitted payload failed the tool-owned decoder",
+            content: { "application/json": { schema: resolver(ToolRespondFailure) } },
+          },
         },
       }),
       validator("param", z.object({ sessionID: SessionID.zod })),

--- a/packages/opencode/test/server/error.test.ts
+++ b/packages/opencode/test/server/error.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { errors } from "../../src/server/error"
+
+describe("errors() response helper", () => {
+  test("declares the registered status codes", () => {
+    expect(Object.keys(errors(400, 404))).toEqual(["400", "404"])
+  })
+
+  test("throws on a status without a registered schema instead of silently dropping it", () => {
+    // JSON.stringify omits undefined, so an unregistered code used to vanish
+    // from the spec (errors(409) became a no-op). The helper must fail loudly.
+    // The signature rejects unknown codes at compile time; cast to exercise the
+    // runtime guard for callers that bypass the types.
+    const loose = errors as (...codes: number[]) => unknown
+    expect(() => loose(409)).toThrow(/no response schema registered for status 409/)
+  })
+})

--- a/packages/opencode/test/server/tool-respond-route.test.ts
+++ b/packages/opencode/test/server/tool-respond-route.test.ts
@@ -280,4 +280,22 @@ describe("POST /session/:sessionID/tool/respond", () => {
       },
     })
   })
+
+  test("declares its route-local failure bodies in OpenAPI", async () => {
+    const spec = await Server.openapi()
+    const responses = spec.paths?.["/session/{sessionID}/tool/respond"]?.post?.responses
+
+    // 404 / 409 / 422 carry the inline route-local { error, details? } body,
+    // not the shared NotFoundError envelope. Asserting the inline schema keeps
+    // this robust against component-ref registration order across the suite.
+    for (const status of ["404", "409", "422"] as const) {
+      const response = responses?.[status]
+      if (!response || "$ref" in response) throw new Error(`expected inline ${status} response`)
+      expect(response.content?.["application/json"]?.schema, status).toMatchObject({
+        type: "object",
+        properties: { error: { type: "string" } },
+        required: ["error"],
+      })
+    }
+  })
 })


### PR DESCRIPTION
## Root cause

The `errors()` response helper silently dropped any status code not present in its `ERRORS` map. It built `{ [code]: ERRORS[code] }` with `ERRORS[code]` `undefined`, and `JSON.stringify` omits `undefined`, so the declaration vanished from the generated OpenAPI.

`POST /session/:sessionID/tool/respond` declared `errors(400, 404, 409, 422)`, so:
- its **409 and 422 were no-ops** (never appeared in the contract), and
- its **404 was declared with the shared `NotFoundError` schema** even though the handler returns route-local bodies (`{ error: "no_pending_tool_call" }`, `{ error: "already_resolved" }`, `{ error, details }`).

## Change

- **Harden `errors()`**: tighten the signature to `(keyof typeof ERRORS)[]` so an unregistered status is a **typecheck error at the call site**, and `throw` at runtime as a defensive guard for casted/JS callers — instead of emitting an empty declaration. As `ERRORS` grows (e.g. when 409 is added for busy conflicts), the accepted set grows with it.
- **Fix tool/respond**: keep `errors(400)` for the zod-validator bad-request, and declare `404` / `409` / `422` inline with a route-local `ToolRespondFailure` schema (`{ error: string, details?: unknown }`) that matches what the handler actually returns. This also corrects the pre-existing 404 schema mismatch.

**Runtime behavior is unchanged** — this only corrects the published contract. The handler already returned these bodies and statuses (covered by the existing `tool-respond-route` runtime tests); now the contract documents them accurately.

## On the SDK snapshot

Per this line's strategy, the hand-maintained `packages/sdk/openapi.json` snapshot and generated SDK are **not** regenerated here (it is ~24 operations behind the live code and has no committed generator; batch-resynced separately). This PR changes only the live served OpenAPI source.

## Verification

- `bun test test/server/error.test.ts test/server/tool-respond-route.test.ts` — new cases assert `errors()` throws on an unregistered code, and that the tool/respond OpenAPI declares 404/409/422 as `ToolRespondFailure` rather than `NotFoundError`; 10/10 pass.
- `tsgo --noEmit` clean (the tightened `errors()` signature type-checks all ~70 existing call sites).
- route-inventory harness green.

## Context

#936 Effect error-contract line, contract-completion phase. Enabler/cleanup that unblocks the upcoming busy-conflict 409 slice (which will register `409` in `ERRORS`) without that change retroactively mis-declaring tool/respond's 409. Code-only slice, no SDK regen.