### PR TITLE
fix(server): map busy-session conflict to 409 and declare it on guarded routes

### DIFF
--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -1,5 +1,6 @@
 import { resolver } from "hono-openapi"
 import z from "zod"
+import { NamedError } from "@opencode-ai/util/error"
 import { NotFoundError } from "../storage/db"
 
 export const ERRORS = {
@@ -26,6 +27,16 @@ export const ERRORS = {
     content: {
       "application/json": {
         schema: resolver(NotFoundError.Schema),
+      },
+    },
+  },
+  409: {
+    description: "Conflict",
+    content: {
+      "application/json": {
+        // ErrorMiddleware wraps Session.BusyError as NamedError.Unknown, so a
+        // busy-session conflict serializes to the Unknown { name, data } shape.
+        schema: resolver(NamedError.Unknown.Schema),
       },
     },
   },

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1048,7 +1048,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1077,7 +1077,7 @@ export const SessionRoutes = lazy(() =>
         // fiber instead of being silently dropped by SessionRunState.cancel;
         // (3) the prelude path uses rejectIfBusy, so summarize calls that
         // arrive while another run is in flight throw Session.BusyError
-        // (mapped to 400) instead of resolving `true` without writing the
+        // (mapped to 409) instead of resolving `true` without writing the
         // marker. Clients should queue the action and retry once the session
         // goes idle; (4) revert.cleanup and agent derivation live inside
         // the work effect, so a busy-rejected compact leaves session state

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -772,7 +772,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -811,7 +811,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -886,7 +886,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -927,7 +927,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1275,7 +1275,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1521,7 +1521,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1553,7 +1553,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1588,7 +1588,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -43,7 +43,10 @@ export const ErrorMiddleware: ErrorHandler = (err, c) => {
     error: err,
   })
   if (err instanceof Session.BusyError) {
-    return c.json(new NamedError.Unknown({ message: err.message }).toObject(), { status: 400 })
+    // A busy session is a conflict (the run is still in progress), not a bad
+    // request — surface it as 409 so callers can distinguish retry-later from
+    // a malformed request (which the validators already return as 400).
+    return c.json(new NamedError.Unknown({ message: err.message }).toObject(), { status: 409 })
   }
   if (err instanceof HTTPException) return err.getResponse()
   const message = err instanceof Error && err.stack ? err.stack : err.toString()

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2472,7 +2472,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       // `awaitRun(existing)` and resolve to the previous run's result — the
       // requested compaction would never happen, but the route would return
       // `true`. UI callers handle the resulting `Session.BusyError` (mapped
-      // to HTTP 400 by middleware) by queuing the compact action through the
+      // to HTTP 409 by middleware) by queuing the compact action through the
       // followup machinery and auto-retrying after the session idles.
       const runLifecycle = input.traceMessageID
         ? {

--- a/packages/opencode/test/server/error.test.ts
+++ b/packages/opencode/test/server/error.test.ts
@@ -8,10 +8,11 @@ describe("errors() response helper", () => {
 
   test("throws on a status without a registered schema instead of silently dropping it", () => {
     // JSON.stringify omits undefined, so an unregistered code used to vanish
-    // from the spec (errors(409) became a no-op). The helper must fail loudly.
-    // The signature rejects unknown codes at compile time; cast to exercise the
-    // runtime guard for callers that bypass the types.
+    // from the spec (e.g. errors(409) was a no-op before 409 was registered).
+    // The helper must fail loudly. The signature rejects unknown codes at
+    // compile time; cast to exercise the runtime guard for callers that bypass
+    // the types. 418 is intentionally never registered in ERRORS.
     const loose = errors as (...codes: number[]) => unknown
-    expect(() => loose(409)).toThrow(/no response schema registered for status 409/)
+    expect(() => loose(418)).toThrow(/no response schema registered for status 418/)
   })
 })

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -4,6 +4,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { InvalidError, JsonError } from "../../src/config/error"
 import { OauthCallbackFailed, OauthCodeMissing, OauthMissing } from "../../src/provider/auth"
 import type { ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
 import { InstanceMiddleware } from "../../src/server/routes/instance/middleware"
@@ -219,5 +220,19 @@ describe("server error middleware", () => {
       expect(response.status).toBe(400)
       expect(body.name).toBe(error.name)
     }
+  })
+
+  test("maps a busy session conflict to 409", async () => {
+    const app = new Hono().get("/boom", () => {
+      throw new Session.BusyError("ses_busy")
+    })
+    app.onError(ErrorMiddleware)
+
+    const response = await app.request("/boom")
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body.name).toBe("UnknownError")
+    expect(body.data.message).toContain("busy")
   })
 })

--- a/packages/opencode/test/server/session-core-routes.test.ts
+++ b/packages/opencode/test/server/session-core-routes.test.ts
@@ -121,6 +121,9 @@ describe("session core routes", () => {
       "session.shell",
       "session.revert",
       "session.unrevert",
+      // summarize rejects a busy session through SessionPrompt.loop's prelude
+      // (rejectIfBusy), unlike the plain prompt/command routes which queue.
+      "session.summarize",
     ])
 
     const spec = await Server.openapi()

--- a/packages/opencode/test/server/session-core-routes.test.ts
+++ b/packages/opencode/test/server/session-core-routes.test.ts
@@ -108,4 +108,33 @@ describe("session core routes", () => {
       },
     })
   })
+
+  test("declares 409 conflict on every busy-guarded session route", async () => {
+    // Routes that reject a busy session with Session.BusyError (mapped to 409
+    // by ErrorMiddleware) must advertise the 409 in their contract.
+    const busyOps = new Set([
+      "session.turnChangeUndo",
+      "session.turnChangeRedo",
+      "session.turnChangesAggregateUndo",
+      "session.turnChangesAggregateRedo",
+      "session.deleteMessage",
+      "session.shell",
+      "session.revert",
+      "session.unrevert",
+    ])
+
+    const spec = await Server.openapi()
+    const seen = new Set<string>()
+    for (const item of Object.values(spec.paths ?? {})) {
+      for (const method of ["get", "post", "put", "delete", "patch"] as const) {
+        const operation = item?.[method]
+        const operationId = operation?.operationId
+        if (!operationId || !busyOps.has(operationId)) continue
+        seen.add(operationId)
+        expect(operation.responses?.["409"], operationId).toBeDefined()
+      }
+    }
+
+    expect(seen).toEqual(busyOps)
+  })
 })


### PR DESCRIPTION
## Summary

Part of the staged Effect error-contract migration (#936): surface a busy
session as a **409 Conflict** instead of a 400 Bad Request, and declare the 409
in the OpenAPI contract of every route that can reject a busy session.

A busy session means an agent run is still in progress. That is a conflict, not
a malformed request. `ErrorMiddleware` previously wrapped `Session.BusyError` as
`NamedError.Unknown` with status **400**, conflating it with validator-level bad
requests, so a caller could not tell "retry later" apart from "fix your request".

## Changes

- `server/middleware.ts` — `Session.BusyError` now maps to **409** (was 400).
- `server/error.ts` — register `409` in `ERRORS` (body = `NamedError.Unknown.Schema`, the same `{ name, data }` shape the middleware emits).
- `server/instance/session.ts` — add `409` to the contract of the **nine** session routes that can reject a busy session:
  - via `state.assertNotBusy`: `turnChangeUndo`, `turnChangeRedo`, `turnChangesAggregateUndo`, `turnChangesAggregateRedo`, `deleteMessage`
  - via `SessionRevert.{revert,unrevert}` (which call `assertNotBusy`): `revert`, `unrevert`
  - via `startShell`'s `rejectIfBusy`: `shell`
  - via `SessionPrompt.loop`'s compaction **prelude** (sets `ensureRunning` `rejectIfBusy`): `summarize`

## Completeness

`Session.BusyError` is thrown at exactly three sites: `assertNotBusy`
(run-state.ts), `startShell` (run-state.ts), and `ensureRunning` when
`rejectIfBusy` is set, which only happens for a `loop` call **with a prelude**
(prompt.ts). An exhaustive up-trace from those three sites to route handlers
yields precisely the nine routes above. The plain `prompt` / `command` / `init`
routes call `loop` **without** a prelude, so they queue behind the active run
instead of rejecting, and correctly stay out of the 409 set.

`summarize` was added after first-pass review caught that its prelude path also
rejects when busy; the two stale "mapped to 400" comments next to that path
(session.ts, prompt.ts) are refreshed to 409.

## ⚠️ Behavior change

These nine routes now return **409 instead of 400** on a busy session. This is
intentional and the point of the PR. De-risk: the desktop app does **not** branch
on this HTTP status — its "busy" handling keys off session-status events
(`busy`/`idle`/`retry`), not the route response body or status — so no frontend
change is required.

## Deferred (known, tracked)

The checked-in `packages/sdk/openapi.json` snapshot and `src/v2/gen` SDK types are
regenerated in a single batched resync PR at the end of the #936 series, not
per-slice. The app/ui consume the generated SDK and handle the 409 by runtime
status, so the lag has no functional impact.

## Verification

- `bun test test/server/middleware.test.ts test/server/error.test.ts test/server/session-core-routes.test.ts` — 16 pass
- `bun test test/server/` — 331 pass (full suite, guards against the cross-file `.meta({ref})` registration fragility seen earlier)
- `bun run typecheck` — clean

New tests: middleware maps `Session.BusyError` → 409; `session-core-routes`
asserts every busy-guarded operation (all nine) declares `responses["409"]`
(iterates the generated spec by `operationId` and asserts the set is exactly the
nine); `error.test` guards `errors()` failing loudly on an unregistered code (418).

Refs #936