### PR TITLE
fix(opencode): classify Error-wrapped provider stream error payloads

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -586,9 +586,13 @@ const live: Layer.Layer<
 
             // This is a silent-stream timeout: it limits how long we wait for
             // the next provider event, not the total model runtime.
-            return Stream.fromAsyncIterable(failOnTimeout(result.fullStream, request), (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            ).pipe(Stream.tap((event) => Effect.sync(() => request.resetTimeout(event))))
+            //
+            // Preserve the raw thrown value instead of coercing to new Error(String(e)):
+            // a structured provider error payload (object/string) would otherwise be
+            // crushed to "[object Object]", losing what fromError's stream parser needs.
+            return Stream.fromAsyncIterable(failOnTimeout(result.fullStream, request), (e) => e).pipe(
+              Stream.tap((event) => Effect.sync(() => request.resetTimeout(event))),
+            )
           }),
         ),
       )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1336,9 +1336,11 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case e instanceof Error:
-      return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:
+      // A provider error can arrive raw or wrapped in an Error (the stream
+      // "error" part throws value.error; the iterator-throw mapper hands back a
+      // value). Run the stream parser for both before falling back to Unknown so
+      // Error-wrapped payloads still classify instead of being swallowed.
       try {
         const parsed = ProviderError.parseStreamError(e)
         if (parsed) {
@@ -1364,7 +1366,10 @@ export function fromError(
           ).toObject()
         }
       } catch {}
-      return new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e }).toObject()
+      return new NamedError.Unknown(
+        { message: e instanceof Error ? errorMessage(e) : JSON.stringify(e) },
+        { cause: e },
+      ).toObject()
   }
 }
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1718,6 +1718,46 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("classifies Error-wrapped stream error payloads, not just plain objects", () => {
+    const body = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "server_error",
+        code: "server_error",
+        message: "An error occurred while processing your request.",
+        param: null,
+      },
+    }
+    // Same payload as the plain-object case above, but wrapped in an Error
+    // instance — the shape it actually arrives in from the stream "error" part
+    // (processor throws value.error) and the iterator-throw mapper in llm.ts.
+    const result = MessageV2.fromError(new Error(JSON.stringify(body)), { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.error.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+        providerID,
+      },
+    })
+  })
+
+  test("leaves Error-wrapped payloads with unhandled codes as UnknownError", () => {
+    // Guard against the stream parser over-matching: an Error whose JSON message
+    // carries a code the parser does not handle must stay Unknown, not become a
+    // mislabeled APIError.
+    const payload = JSON.stringify({ type: "error", error: { code: "bad_request" } })
+    const result = MessageV2.fromError(new Error(payload), { providerID })
+
+    expect(result).toStrictEqual({
+      name: "UnknownError",
+      data: { message: payload },
+    })
+  })
+
   test("detects context overflow from APICallError provider messages", () => {
     const cases = [
       "prompt is too long: 213462 tokens > 200000 maximum",


### PR DESCRIPTION
## What

A provider error can reach `MessageV2.fromError` wrapped in an `Error` instance, and when it does the structured payload is silently lost: the error is classified as `UnknownError` instead of the real `APIError` / `ContextOverflowError`.

Two paths deliver an `Error`-wrapped payload:
- The stream `"error"` part: `processor.ts` does `case "error": throw value.error`. The AI SDK's `fullStream` error part is typed `error: unknown` (verified against `ai@6.0.158`) — it is **not** guaranteed to be an `APICallError`; SSE error events, parser/validation errors, and our own Responses provider all enqueue object / string / `Error` payloads.
- The iterator-throw mapper in `llm.ts`: `(e) => e instanceof Error ? e : new Error(String(e))` crushed a structured object to `new Error("[object Object]")`.

`fromError`'s `e instanceof Error` branch caught every `Error` and returned `UnknownError` **before** the `default` branch could run `ProviderError.parseStreamError` — even though `parseStreamError` is specifically built to read a JSON payload out of an `Error`'s `message` (it has only one caller, that unreachable `default` branch). Net effect: a `server_error` / quota / overflow payload arriving `Error`-wrapped was misclassified, so retry/recovery/UI saw `UnknownError`.

## Change

- **`message-v2.ts`** — merge the `e instanceof Error -> UnknownError` fallback into the `default` branch, so `parseStreamError` runs for **both** raw and `Error`-wrapped values before falling back to `Unknown`. A plain `Error` with no recognized payload still classifies as `UnknownError`, and an `Error` whose JSON carries an unhandled code also stays `Unknown` (parser returns `undefined`, no over-matching).
- **`llm.ts`** — stop coercing iterator-thrown failures to `new Error(String(e))`; preserve the raw thrown value. The stream error channel is already typed `Stream<Event, unknown>`, and downstream consumers (`retrySignalFor`, run-observability recorder, llm-trace) all accept `unknown` and sanitize it.

No new fields, no schema change, no behavior change for already-correct paths.

## Verification

- `bun test test/session/message-v2.test.ts` — 57 pass, including 2 new cases: an `Error`-wrapped `server_error` payload now classifies as retryable `APIError` (mirrors the existing plain-object case), and an `Error`-wrapped unhandled code stays `UnknownError` (guards against parser over-matching).
- `bun test test/session/retry.test.ts` — 35 pass (classification/retry regression).
- `tsgo --noEmit` clean.

## Context

Slice 1 of #1105 (provider-failure classification spine): make the classification entry point see the real payload before the later vocabulary/`providerFailure` work. Approach pinned with a codex consult against the vendored `ai` SDK source. Distinct from #936 (HTTP error contract).
