### PR TITLE
fix(server): surface the declared 404 when deleting a missing message

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1060,6 +1060,11 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       sessionID: SessionID
       messageID: MessageID
     }) {
+      // Surface the route's declared 404 instead of silently succeeding:
+      // removing a message that does not exist is a not-found, not a no-op.
+      // MessageV2.get throws NotFoundError for a missing row, which
+      // ErrorMiddleware maps to 404 (the deleteMessage route already declares it).
+      yield* Effect.sync(() => MessageV2.get({ sessionID: input.sessionID, messageID: input.messageID }))
       yield* Effect.sync(() =>
         SyncEvent.run(MessageV2.Event.Removed, {
           sessionID: input.sessionID,

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -422,6 +422,36 @@ describe("session messages endpoint", () => {
     )
   })
 
+  test("deletes a message through the route runtime and 404s a missing one", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await svc.create({})
+          const [messageID] = await fill(session.id, 1)
+          const app = Server.Default().app
+
+          // An existing message still deletes with 200 and is gone afterwards.
+          const ok = await app.request(`/session/${session.id}/message/${messageID}`, { method: "DELETE" })
+          expect(ok.status).toBe(200)
+          expect(await ok.json()).toBe(true)
+          expect(await svc.messages({ sessionID: session.id })).toHaveLength(0)
+
+          // The route's declared 404 is now real: deleting a message that does
+          // not exist surfaces NotFoundError instead of silently succeeding.
+          const miss = await app.request(`/session/${session.id}/message/${MessageID.ascending()}`, {
+            method: "DELETE",
+          })
+          expect(miss.status).toBe(404)
+          expect((await miss.json()).name).toBe("NotFoundError")
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
   test("rejects a part update whose body does not match the path with a 400", async () => {
     await using tmp = await tmpdir({ git: true })
     await withoutWatcher(() =>


### PR DESCRIPTION
## Summary

Part of the staged Effect error-contract migration (#936): turn a silent 200
into the route's already-declared 404.

`DELETE /session/:sessionID/message/:messageID` (`session.deleteMessage`)
declares `errors(400, 404, 409)`, but `Session.removeMessage` was a silent
no-op: it fired `MessageV2.Event.Removed` and returned the id **without checking
existence**, so deleting a message that does not exist returned `200`. The
declared 404 was a phantom that never fired.

## Change

`Session.removeMessage` now verifies the message exists first via
`MessageV2.get` (the same throwing lookup the sibling `GET .../message/:messageID`
route relies on for its 404). `MessageV2.get` throws `NotFoundError` for a
missing row, which `ErrorMiddleware` maps to 404 (and does not error-log).

**Why in the service, not the route:** `removeMessage` is the "delete a message"
domain operation and has exactly one caller — the route handler (no top-level
wrapper) — so putting the existence check there makes the operation correct with
a contained blast radius. `assertNotBusy` stays in the route, so the ordering is
preserved: a busy session still wins with **409**, and only the idle + missing
case flips from a silent **200** to **404**.

## Behavior change & de-risk

The only change is that deleting a message that does not exist (e.g. a
double-delete, or an unknown id) now returns the **already-declared 404** instead
of a misleading 200. The desktop app does **not** call this endpoint directly —
it reacts to the `message.removed` SSE event — so there is no frontend impact.
Verified there are no internal callers of `removeMessage` that relied on the
silent no-op (the full session suite stays green).

## Scope (deliberately one route)

This is the first, smallest slice of the silent-200 cleanup. The sibling
candidates are intentionally **not** bundled, each for a concrete reason:
- `part.delete` — `removePart` is also reused internally by `processor.ts`, so its fix must be route-level, not service-level; different shape.
- `permission.reply` — separate subsystem with CLI/ACP/test callers; larger surface.
- `experimental.console.switchOrg` — `account.use` is a blind upsert and the account errors are Effect `TaggedErrorClass` (not the mapped `NamedError`); needs new validation + a mapped error type (design).
- `permission.respond` — already `deprecated` and fire-and-forget.

## Verification

- `bun test test/server/session-messages.test.ts` — 12 pass (new test covers both the 200 success delete and the 404 on a missing id)
- `bun test test/server/` — 332 pass
- `bun test test/session/` — 790 pass / 0 fail (confirms no internal consumer relied on the silent no-op)
- `bun run typecheck` — clean

## Deferred (known, tracked)

The checked-in `packages/sdk/openapi.json` snapshot / `src/v2/gen` types are
regenerated in a single batched resync PR at the end of the #936 series, not
per-slice. No functional impact (the app reacts to SSE, not this response).

Refs #936