### PR TITLE
chore(release): cut v2026.6.1 and document the R2 mirror step

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -118,7 +118,28 @@ Publish the release as the latest stable release:
 gh release edit vX.Y.Z --repo Astro-Han/pawwork --draft=false --latest --prerelease=false
 ```
 
-## 5. Post-Release Verification
+## 5. Mirror Downloads to Cloudflare R2
+
+The China-accessible landing page (dl.pawwork.ai) serves downloads from the R2 mirror, not GitHub. The mirror is gated by `verify-release` and only runs against a published (non-draft) release, so it must run after Step 4.
+
+Publishing in Step 4 with your own credentials emits a `release: published` event, which triggers `.github/workflows/mirror-release-to-r2.yml` automatically. (A workflow that published the release with the built-in `GITHUB_TOKEN` would NOT trigger it — that path would need an explicit dispatch.) Confirm the run started, or dispatch it manually:
+
+```bash
+gh run list --workflow mirror-release-to-r2.yml --repo Astro-Han/pawwork --limit 3
+# If no run was triggered for this tag, dispatch it manually:
+gh workflow run mirror-release-to-r2.yml --repo Astro-Han/pawwork --ref dev -f tag=vX.Y.Z
+```
+
+Then confirm the landing page points at the new version on R2:
+
+```bash
+curl -fsSL https://dl.pawwork.ai/latest.json            # "version" should read X.Y.Z
+curl -fsI https://dl.pawwork.ai/pawwork-mac-arm64-X.Y.Z.dmg | head -1   # expect HTTP/2 200
+```
+
+If `latest.json` still shows the previous version, the mirror has not finished — do not announce the release until it does. The mirror fails closed, so a failed run leaves the site pointing at the previous good release.
+
+## 6. Post-Release Verification
 
 Run the verification helper:
 
@@ -234,6 +255,6 @@ Keep `.zip`, `.blockmap`, and `latest*.yml` assets unless updater requirements a
 
 If verification fails, check the reported missing or malformed asset first, rerun only the affected build phase, and publish the release only after the verification helper passes.
 
-## 6. Close Release Issues
+## 7. Close Release Issues
 
 Only close release-blocking issues after post-release verification passes. Leave a short comment with the release link and the verified artifact names.

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.5.29",
+  "version": "2026.6.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Prepares the **v2026.6.1** desktop release (first June 2026 release; `vYYYY.M.N` resets `N` to 1 each month) and closes a gap in the release runbook around the Cloudflare R2 download mirror.

Two atomic commits:

1. `chore(release): bump desktop app to 2026.6.1` — bumps the single source of truth (`packages/desktop-electron/package.json`); `build.yml` reads this and tags `v2026.6.1`.
2. `docs(release): add explicit Cloudflare R2 mirror step to the checklist` — the checklist had **no** step for the R2 mirror; it silently relied on the publish event auto-triggering `mirror-release-to-r2.yml`. Adds Step 5 to confirm/dispatch the mirror and verify `dl.pawwork.ai/latest.json` points at the new version, then renumbers the following steps.

## Why the mirror step matters

The China-accessible landing page serves downloads from R2 (`dl.pawwork.ai`), not GitHub. The live pointer currently reads `2026.5.29`; for v2026.6.1, users only get the new build from the official site once the mirror runs for the new tag. Publishing the release with a human/PAT credential emits `release: published` and auto-triggers the mirror — but a workflow publishing with the built-in `GITHUB_TOKEN` would **not** trigger it (GitHub's anti-recursion rule), so the explicit confirm/dispatch step removes that footgun.

## Scope / non-goals

- This is the **release-first** path. Fully automating publish + mirror dispatch (so no manual step is needed) is deferred to a separate feature PR per maintainer decision.
- R2 infrastructure is already provisioned (secrets present, mirror ran successfully on 2026-05-30, `dl.pawwork.ai` live).

## Verification

- Version is a single source of truth: `grep -rn 2026.5.29 --include=package.json` matched only `packages/desktop-electron/package.json`.
- Checklist renumbered 1–7, continuous; only cross-references point at Step 4 (Publish), which is correct.
- Release readiness was assessed separately across build-health (typecheck + lint + ~6700 unit tests green), feature/regression review, and E2E smoke (35/35); the broad non-smoke E2E failures were investigated and confirmed to be pre-existing test debt, not regressions.

No code/runtime behavior changes; version string + docs only.