### PR TITLE
fix(server): surface the declared 404 when deleting a missing message part

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1331,6 +1331,17 @@ export const SessionRoutes = lazy(() =>
         await AppRuntime.runPromise(
           Effect.gen(function* () {
             const sessions = yield* Session.Service
+            // Surface the route's declared 404 instead of silently succeeding:
+            // deleting a part that does not exist is a not-found, not a no-op.
+            // The check lives in the route, not Session.removePart, because
+            // removePart is also called internally by the message processor,
+            // which must stay a tolerant no-op for an already-gone part.
+            const part = yield* sessions.getPart({
+              sessionID: params.sessionID,
+              messageID: params.messageID,
+              partID: params.partID,
+            })
+            if (!part) throw new NotFoundError({ message: `Part not found: ${params.partID}` })
             yield* sessions.removePart({
               sessionID: params.sessionID,
               messageID: params.messageID,

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -416,6 +416,14 @@ describe("session messages endpoint", () => {
           expect(await remove.json()).toBe(true)
           expect((await svc.messages({ sessionID: session.id }))[0].parts).toHaveLength(0)
 
+          // The route's declared 404 is now real: deleting an already-removed
+          // part surfaces NotFoundError instead of silently succeeding.
+          const missing = await app.request(`/session/${session.id}/message/${messageID}/part/${partID}`, {
+            method: "DELETE",
+          })
+          expect(missing.status).toBe(404)
+          expect((await missing.json()).name).toBe("NotFoundError")
+
           await svc.remove(session.id)
         },
       }),


### PR DESCRIPTION
## Summary

Part of the staged Effect error-contract migration (#936): turn a silent 200
into the route's already-declared 404. Follows #1109, which did the same for
`session.deleteMessage`.

`DELETE /session/:sessionID/message/:messageID/part/:partID` (`part.delete`)
declares `errors(400, 404)`, but `Session.removePart` was a silent no-op: it
fired `MessageV2.Event.PartRemoved` and returned the id **without checking
existence**, so deleting a part that does not exist returned `200`. The declared
404 was a phantom.

## Change

Add the existence check in the **route handler** (via `Session.getPart`, which
returns the part or `undefined`) and throw `NotFoundError` when the part is
missing — `ErrorMiddleware` maps it to 404 (and does not error-log it).

**Why route-local, not in the service (unlike #1109):** `Session.removePart` is
also called internally by the message processor (`src/session/processor.ts:1295`),
which must stay a tolerant no-op for an already-gone part. Putting the check in
`removePart` would change the processor's behavior. Keeping it in the route makes
the public contract real with a contained blast radius.

## Behavior change & de-risk

The only change is that deleting a missing / already-removed part now returns the
**already-declared 404** instead of a misleading 200. The desktop app does **not**
call this endpoint directly — it reacts to the `message.part.removed` SSE event —
so there is no frontend impact. The processor path is untouched (full session
suite stays green).

## Verification

- `bun test test/server/session-messages.test.ts` — 12 pass (the existing part update/delete test now also asserts the 404 on a re-delete)
- `bun test test/server/` — 332 pass
- `bun test test/session/` — 790 pass / 0 fail (confirms the processor's internal `removePart` use is unaffected)
- `bun run typecheck` — clean

## Deferred (known, tracked)

The checked-in `packages/sdk/openapi.json` snapshot / `src/v2/gen` types are
regenerated in a single batched resync PR at the end of the #936 series, not
per-slice. No functional impact (the app reacts to SSE, not this response).

Refs #936