### PR TITLE
feat(opencode): sweep stale agent scratch tmp files on startup (#945)

### DIFF
--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -25,8 +25,8 @@ if (version !== CACHE_VERSION) {
   await Filesystem.write(path.join(Path.cache, "version"), CACHE_VERSION)
 }
 
-// Drop agent ${tmp} scratch artifacts left untouched past the retention window so
+// Drop per-command ${tmp} artifacts left untouched past the retention window so
 // the scratch dir does not grow without bound (#945). Not awaited: startup must
-// not block on it, and it is age-based, so a concurrently running opencode
-// process's recent files are never swept.
+// not block on best-effort cleanup. The sweep relies on ${tmp} being short-lived
+// scratch, not long-lived session-owned directories.
 void sweepScratch({ dir: Path.tmp, now: Date.now(), maxAgeMs: SCRATCH_MAX_AGE_MS }).catch(() => {})

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
 import { Global, Path } from "@opencode-ai/core/global"
+import { sweepScratch, SCRATCH_MAX_AGE_MS } from "./scratch"
 
 export { Global }
 
@@ -23,3 +24,9 @@ if (version !== CACHE_VERSION) {
   } catch (e) {}
   await Filesystem.write(path.join(Path.cache, "version"), CACHE_VERSION)
 }
+
+// Drop agent ${tmp} scratch artifacts left untouched past the retention window so
+// the scratch dir does not grow without bound (#945). Not awaited: startup must
+// not block on it, and it is age-based, so a concurrently running opencode
+// process's recent files are never swept.
+void sweepScratch({ dir: Path.tmp, now: Date.now(), maxAgeMs: SCRATCH_MAX_AGE_MS }).catch(() => {})

--- a/packages/opencode/src/global/scratch.ts
+++ b/packages/opencode/src/global/scratch.ts
@@ -42,9 +42,11 @@ async function newestTimestamp(entry: string): Promise<number> {
 /**
  * Remove scratch entries whose whole subtree has gone untouched for longer than
  * `maxAgeMs`. Best-effort and idempotent: a missing directory is a no-op and a
- * per-entry removal failure is swallowed so it never blocks startup. Because it
- * is age-based it is cross-process safe — a concurrently running opencode
- * process's recent scratch files keep a fresh timestamp and are never deleted.
+ * per-entry removal failure is swallowed so it never blocks startup. This is a
+ * lock-free cleanup for per-command `${tmp}` artifacts: recent writes keep an
+ * entry fresh, but a process that starts writing into an already-stale subtree
+ * after the freshness check can still race with removal. A cooperative
+ * ownership/liveness protocol is intentionally out of scope for this P3 cleanup.
  */
 export async function sweepScratch(options: { dir: string; now: number; maxAgeMs: number }): Promise<void> {
   const { dir, now, maxAgeMs } = options

--- a/packages/opencode/src/global/scratch.ts
+++ b/packages/opencode/src/global/scratch.ts
@@ -1,0 +1,63 @@
+import fs from "fs/promises"
+import path from "path"
+
+/**
+ * How long an entry in the agent scratch directory (`Global.Path.tmp`) may sit
+ * untouched before a startup sweep removes it. The scratch dir holds the agent's
+ * `${tmp}` shell artifacts (PR drafts, patches, debug output) which are
+ * write-and-forget, so a one-day window is safe: anything an active session
+ * wrote recently keeps a fresh timestamp and survives.
+ */
+export const SCRATCH_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Newest modify/change time across an entry's subtree, following no symlinks.
+ * Uses `max(mtimeMs, ctimeMs)` so a file whose mtime was restored to the past
+ * (`cp -p`, unzip) but was actually just created still reads as recent. Returns
+ * `Infinity` when anything cannot be stat-ed, so an uncertain entry is treated
+ * as fresh and left in place; a future timestamp is likewise large and kept.
+ */
+async function newestTimestamp(entry: string): Promise<number> {
+  let stat
+  try {
+    stat = await fs.lstat(entry)
+  } catch {
+    return Infinity
+  }
+  let newest = Math.max(stat.mtimeMs, stat.ctimeMs)
+  if (stat.isDirectory()) {
+    let children: string[]
+    try {
+      children = await fs.readdir(entry)
+    } catch {
+      return Infinity
+    }
+    for (const child of children) {
+      newest = Math.max(newest, await newestTimestamp(path.join(entry, child)))
+    }
+  }
+  return newest
+}
+
+/**
+ * Remove scratch entries whose whole subtree has gone untouched for longer than
+ * `maxAgeMs`. Best-effort and idempotent: a missing directory is a no-op and a
+ * per-entry removal failure is swallowed so it never blocks startup. Because it
+ * is age-based it is cross-process safe — a concurrently running opencode
+ * process's recent scratch files keep a fresh timestamp and are never deleted.
+ */
+export async function sweepScratch(options: { dir: string; now: number; maxAgeMs: number }): Promise<void> {
+  const { dir, now, maxAgeMs } = options
+  const cutoff = now - maxAgeMs
+  let entries: string[]
+  try {
+    entries = await fs.readdir(dir)
+  } catch {
+    return
+  }
+  for (const name of entries) {
+    const entry = path.join(dir, name)
+    if ((await newestTimestamp(entry)) >= cutoff) continue
+    await fs.rm(entry, { recursive: true, force: true }).catch(() => {})
+  }
+}

--- a/packages/opencode/src/global/scratch.ts
+++ b/packages/opencode/src/global/scratch.ts
@@ -11,32 +11,35 @@ import path from "path"
 export const SCRATCH_MAX_AGE_MS = 24 * 60 * 60 * 1000
 
 /**
- * Newest modify/change time across an entry's subtree, following no symlinks.
- * Uses `max(mtimeMs, ctimeMs)` so a file whose mtime was restored to the past
- * (`cp -p`, unzip) but was actually just created still reads as recent. Returns
- * `Infinity` when anything cannot be stat-ed, so an uncertain entry is treated
- * as fresh and left in place; a future timestamp is likewise large and kept.
+ * Whether every node in an entry's subtree is older than `cutoff`, following no
+ * symlinks. Short-circuits on the first node at or after `cutoff` — one recent
+ * file keeps the whole entry — so a large kept tree (a cloned repo, a build dir)
+ * is not walked in full on startup. Freshness uses `max(mtimeMs, ctimeMs)` so a
+ * file whose mtime was restored to the past (`cp -p`, unzip) but was actually
+ * just created still reads as recent. A node that cannot be stat-ed is treated
+ * as fresh (returns `false`) so an uncertain entry is left in place; a future
+ * timestamp is likewise recent and keeps the entry.
  */
-async function newestTimestamp(entry: string): Promise<number> {
+async function isSubtreeStale(entry: string, cutoff: number): Promise<boolean> {
   let stat
   try {
     stat = await fs.lstat(entry)
   } catch {
-    return Infinity
+    return false
   }
-  let newest = Math.max(stat.mtimeMs, stat.ctimeMs)
+  if (Math.max(stat.mtimeMs, stat.ctimeMs) >= cutoff) return false
   if (stat.isDirectory()) {
     let children: string[]
     try {
       children = await fs.readdir(entry)
     } catch {
-      return Infinity
+      return false
     }
     for (const child of children) {
-      newest = Math.max(newest, await newestTimestamp(path.join(entry, child)))
+      if (!(await isSubtreeStale(path.join(entry, child), cutoff))) return false
     }
   }
-  return newest
+  return true
 }
 
 /**
@@ -59,7 +62,9 @@ export async function sweepScratch(options: { dir: string; now: number; maxAgeMs
   }
   for (const name of entries) {
     const entry = path.join(dir, name)
-    if ((await newestTimestamp(entry)) >= cutoff) continue
-    await fs.rm(entry, { recursive: true, force: true }).catch(() => {})
+    if (!(await isSubtreeStale(entry, cutoff))) continue
+    // maxRetries rides out transient Windows locks (AV / indexer) on otherwise
+    // stale entries; force ignores a concurrent delete.
+    await fs.rm(entry, { recursive: true, force: true, maxRetries: 30, retryDelay: 100 }).catch(() => {})
   }
 }

--- a/packages/opencode/test/global/scratch.test.ts
+++ b/packages/opencode/test/global/scratch.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { sweepScratch } from "@/global/scratch"
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+async function setMtime(file: string, ms: number) {
+  const t = new Date(ms)
+  await fs.utimes(file, t, t)
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.lstat(target)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Tests that exercise the *removal* path advance the injected `now` into the
+// future rather than ageing files with utimes: a freshly created entry keeps a
+// recent ctime, and sweepScratch uses max(mtime, ctime), so the only portable
+// way to make an entry read as stale is to move the clock past it.
+describe("sweepScratch", () => {
+  test("removes a top-level entry untouched past the window", async () => {
+    await using dir = await tmpdir()
+    const created = Date.now()
+    const stale = path.join(dir.path, "draft.md")
+    await fs.writeFile(stale, "old pr draft")
+
+    await sweepScratch({ dir: dir.path, now: created + 2 * DAY, maxAgeMs: DAY })
+
+    expect(await exists(stale)).toBe(false)
+  })
+
+  test("keeps a recently modified file", async () => {
+    await using dir = await tmpdir()
+    const fresh = path.join(dir.path, "draft.md")
+    await fs.writeFile(fresh, "active pr draft")
+
+    await sweepScratch({ dir: dir.path, now: Date.now(), maxAgeMs: DAY })
+
+    expect(await exists(fresh)).toBe(true)
+  })
+
+  test("keeps a file with old mtime but recent ctime (cp -p / unzip)", async () => {
+    await using dir = await tmpdir()
+    const fresh = path.join(dir.path, "restored.patch")
+    await fs.writeFile(fresh, "just created")
+    // Restore mtime far into the past; ctime stays ~now because the inode just changed.
+    await setMtime(fresh, Date.now() - 10 * DAY)
+
+    await sweepScratch({ dir: dir.path, now: Date.now(), maxAgeMs: DAY })
+
+    expect(await exists(fresh)).toBe(true)
+  })
+
+  test("keeps a stale directory that holds one fresh nested file", async () => {
+    await using dir = await tmpdir()
+    const created = Date.now()
+    const sub = path.join(dir.path, "work")
+    await fs.mkdir(sub, { recursive: true })
+    const oldFile = path.join(sub, "old.log")
+    const liveFile = path.join(sub, "live.log")
+    await fs.writeFile(oldFile, "old")
+    await fs.writeFile(liveFile, "live")
+    // One nested file modified well after the (future) cutoff keeps the subtree.
+    await setMtime(liveFile, created + 10 * DAY)
+
+    await sweepScratch({ dir: dir.path, now: created + 2 * DAY, maxAgeMs: DAY })
+
+    expect(await exists(sub)).toBe(true)
+    expect(await exists(liveFile)).toBe(true)
+  })
+
+  test("removes a directory whose whole subtree is stale", async () => {
+    await using dir = await tmpdir()
+    const created = Date.now()
+    const sub = path.join(dir.path, "work")
+    await fs.mkdir(sub, { recursive: true })
+    await fs.writeFile(path.join(sub, "old.log"), "old")
+
+    await sweepScratch({ dir: dir.path, now: created + 2 * DAY, maxAgeMs: DAY })
+
+    expect(await exists(sub)).toBe(false)
+  })
+
+  test("removes a stale symlink without following it to its target", async () => {
+    await using dir = await tmpdir()
+    await using outside = await tmpdir()
+    const created = Date.now()
+    const target = path.join(outside.path, "keep.txt")
+    await fs.writeFile(target, "external data")
+    const link = path.join(dir.path, "link")
+    await fs.symlink(target, link)
+
+    await sweepScratch({ dir: dir.path, now: created + 2 * DAY, maxAgeMs: DAY })
+
+    expect(await exists(link)).toBe(false)
+    expect(await exists(target)).toBe(true)
+  })
+
+  test("is a no-op for a missing directory", async () => {
+    await using dir = await tmpdir()
+    const missing = path.join(dir.path, "does-not-exist")
+    await expect(sweepScratch({ dir: missing, now: Date.now(), maxAgeMs: DAY })).resolves.toBeUndefined()
+  })
+})

--- a/packages/opencode/test/global/scratch.test.ts
+++ b/packages/opencode/test/global/scratch.test.ts
@@ -7,6 +7,10 @@ import { sweepScratch } from "@/global/scratch"
 const HOUR = 60 * 60 * 1000
 const DAY = 24 * HOUR
 
+// Creating a file symlink on Windows needs elevated privileges or developer
+// mode, which CI runners do not grant; skip the symlink case there.
+const symlinkTest = process.platform === "win32" ? test.skip : test
+
 async function setMtime(file: string, ms: number) {
   const t = new Date(ms)
   await fs.utimes(file, t, t)
@@ -89,7 +93,7 @@ describe("sweepScratch", () => {
     expect(await exists(sub)).toBe(false)
   })
 
-  test("removes a stale symlink without following it to its target", async () => {
+  symlinkTest("removes a stale symlink without following it to its target", async () => {
     await using dir = await tmpdir()
     await using outside = await tmpdir()
     const created = Date.now()


### PR DESCRIPTION
## Summary

Closes #945. The agent's `${tmp}` scratch dir (`Global.Path.tmp`) collects PR drafts, patches, and debug artifacts with arbitrary filenames and was never cleaned, so it grew without bound — the reporter saw 46 entries / 217MB over a few weeks.

Adds a best-effort, age-based sweep run once at opencode startup, next to the existing cache-version housekeeping in `global/index.ts`.

## Design

- `sweepScratch` removes any top-level scratch entry whose **whole subtree** has gone untouched longer than `SCRATCH_MAX_AGE_MS` (24h). Scratch is write-and-forget, so 24h is safe and far tighter than `Truncate`'s 7d (whose outputs are referenced later by saved-path hints).
- Age is `max(mtimeMs, ctimeMs)` over the subtree, computed **recursively**, so a stale parent dir holding one freshly written nested file is kept (directory mtime alone does not reflect nested writes); a restored-mtime file (`cp -p` / unzip) reads as recent via `ctime` and is kept.
- `lstat`-based: symlinks are removed as links, never followed to their target.
- Uncertain entries (stat/readdir failure) return `Infinity` and are left in place.
- **Not awaited** at import: startup never blocks on it, and removal failures are swallowed per entry.

## Why age-based, not wipe-on-startup

A standalone `opencode` CLI can run concurrently with the desktop session, sharing the same per-user `Path.tmp`. An unconditional startup wipe could clobber another live process's in-use files. Age-based keeps any recently touched file.

**Trade-off (called out for review):** a file from a session that ended minutes ago survives until it ages out, so this does not *immediately* clear the previous session's files on the very next launch. The issue's actual pain is unbounded multi-week accumulation, which this fully resolves. Doing literal "clear last session on reopen" safely would need session-scoped tmp dirs or per-process ownership markers — a much larger change, out of proportion for a P3.

## Review follow-up (codex)

Codex review raised a [P2]: the lock-free age check has an irreducible TOCTOU — a process that begins writing into an *already-stale* subtree between the freshness scan and `fs.rm` can still race with removal. After a second codex consult on the right altitude, the conclusion was to **accept the residual** rather than add ownership locks: `${tmp}` is documented as per-command short-lived scratch, the sweep only touches entries untouched for 24h, and the remaining race requires a live process to start writing into an already-stale subtree within the scan→rm window — outside intended usage, while a cooperative ownership/liveness protocol is out of scope for this P3 GC. The follow-up commit narrows the code comments so they no longer claim a hard cross-process guarantee (they previously said "cross-process safe" / "never deleted", which the lock-free check cannot promise). `Flock` was evaluated as a single-process gate and ruled out: its public API only blocks/throws (no non-blocking try-acquire) and scratch writers do not hold that lock.

## Verification

- `bun test test/global` — 9 pass. New `scratch.test.ts` covers: remove-stale, keep-fresh, ctime-recent (`cp -p`), recursive keep (stale dir + one fresh nested file), recursive remove (whole subtree stale), symlink no-follow (link removed, target survives), missing-dir no-op.
- `bun run typecheck` clean.
- The sweep runs in the opencode server process (CLI and embedded desktop server alike); behavior is identical on macOS/Windows. No Electron-specific branch touched.

Design reviewed with codex consults before implementation and after review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of temporary scratch files: Files and directories older than 24 hours are now cleaned up automatically on startup
  * Non-blocking operation: Cleanup runs in the background without delaying application startup
  * Disk space optimization: Removes stale temporary files to help manage disk usage

* **Tests**
  * Comprehensive test suite added for cleanup functionality, covering file retention, deletion, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->