### PR TITLE
fix(watcher): emit vcs.branch.updated for linked-worktree checkouts

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -776,13 +776,24 @@ export namespace FileWatcher {
               // checkout. A linked worktree keeps HEAD/index in the per-worktree --git-dir while
               // packed-refs/refs live in the shared --git-common-dir; watch both so branch and ref
               // events fire. They coincide in a normal repo, so dedupe to a single subscription.
-              const result = yield* git.run(
-                ["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"],
-                { cwd: ctx.directory },
-              )
+              // rev-parse may print relative paths (e.g. ".git"), so resolve each against
+              // ctx.directory rather than depending on --path-format=absolute (Git 2.31+).
+              const result = yield* git.run(["rev-parse", "--git-dir", "--git-common-dir"], {
+                cwd: ctx.directory,
+              })
               const vcsDirs =
                 result.exitCode === 0
-                  ? [...new Set(result.text().trim().split("\n").map((line) => line.trim()).filter(Boolean))]
+                  ? [
+                      ...new Set(
+                        result
+                          .text()
+                          .trim()
+                          .split("\n")
+                          .map((line) => line.trim())
+                          .filter(Boolean)
+                          .map((line) => path.resolve(ctx.directory, line)),
+                      ),
+                    ]
                   : []
               for (const vcsDir of vcsDirs) {
                 if (cfgIgnores.includes(".git") || cfgIgnores.includes(vcsDir)) continue

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -770,12 +770,22 @@ export namespace FileWatcher {
             }
 
             if (ctx.project.vcs === "git") {
-              const result = yield* git.run(["rev-parse", "--git-dir"], {
-                cwd: ctx.project.worktree,
-              })
-              const vcsDir =
-                result.exitCode === 0 ? path.resolve(ctx.project.worktree, result.text().trim()) : undefined
-              if (vcsDir && !cfgIgnores.includes(".git") && !cfgIgnores.includes(vcsDir)) {
+              // Resolve git metadata roots from ctx.directory (the active session dir), the same
+              // anchor Vcs.state reads the branch from. ctx.project.worktree points at the MAIN
+              // repository for a linked worktree, so its .git/HEAD never changes on a per-worktree
+              // checkout. A linked worktree keeps HEAD/index in the per-worktree --git-dir while
+              // packed-refs/refs live in the shared --git-common-dir; watch both so branch and ref
+              // events fire. They coincide in a normal repo, so dedupe to a single subscription.
+              const result = yield* git.run(
+                ["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"],
+                { cwd: ctx.directory },
+              )
+              const vcsDirs =
+                result.exitCode === 0
+                  ? [...new Set(result.text().trim().split("\n").map((line) => line.trim()).filter(Boolean))]
+                  : []
+              for (const vcsDir of vcsDirs) {
+                if (cfgIgnores.includes(".git") || cfgIgnores.includes(vcsDir)) continue
                 const ignore = vcsWatcherIgnoreEntries(yield* Effect.promise(() => readdir(vcsDir).catch(() => [])))
                 log.info(
                   "watcher subscription configured",

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -155,8 +155,10 @@ describeVcs("Vcs", () => {
       const pending = nextBranchUpdate(dir)
 
       // Resolve the real per-worktree HEAD; in a linked worktree <dir>/.git is a
-      // pointer file, so never join `${dir}/.git/HEAD` directly.
-      const head = (await $`git rev-parse --path-format=absolute --git-path HEAD`.cwd(dir).text()).trim()
+      // pointer file, so never join `${dir}/.git/HEAD` directly. rev-parse may print
+      // a relative path, so resolve it against dir instead of relying on --path-format.
+      const headPath = (await $`git rev-parse --git-path HEAD`.cwd(dir).text()).trim()
+      const head = path.resolve(dir, headPath)
       await fs.writeFile(head, `ref: refs/heads/${branch}\n`)
 
       const updated = await pending

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -138,6 +138,31 @@ describeVcs("Vcs", () => {
       expect(current).toBe(branch)
     })
   })
+
+  test("publishes BranchUpdated when HEAD changes in a linked worktree", async () => {
+    // Regression for #1016: a linked worktree keeps its live HEAD at
+    // <gitcommondir>/worktrees/<name>/HEAD, not the main repository's .git/HEAD.
+    // The watcher must subscribe to the per-worktree git dir resolved from the
+    // active session directory, otherwise per-worktree checkouts never fire.
+    await using tmp = await tmpdir({ git: true })
+    await using parent = await tmpdir()
+    const dir = path.join(parent.path, "linked")
+    const branch = `wt-${Math.random().toString(36).slice(2)}`
+    await $`git branch ${branch}`.cwd(tmp.path).quiet()
+    await $`git worktree add -b wt-initial ${dir} HEAD`.cwd(tmp.path).quiet()
+
+    await withVcs(dir, async () => {
+      const pending = nextBranchUpdate(dir)
+
+      // Resolve the real per-worktree HEAD; in a linked worktree <dir>/.git is a
+      // pointer file, so never join `${dir}/.git/HEAD` directly.
+      const head = (await $`git rev-parse --path-format=absolute --git-path HEAD`.cwd(dir).text()).trim()
+      await fs.writeFile(head, `ref: refs/heads/${branch}\n`)
+
+      const updated = await pending
+      expect(updated).toBe(branch)
+    })
+  })
 })
 
 describe("Vcs diff", () => {


### PR DESCRIPTION
## Summary

Fixes #1016. In a Git **linked worktree** (`git worktree add`), running `git checkout <branch>` inside a session never emitted `vcs.branch.updated`, so the right-panel Status branch row stayed stale until reload.

## Root cause

The VCS file watcher resolved its git metadata dir with `git rev-parse --git-dir` from `ctx.project.worktree`. For a linked worktree, `Project.fromDirectory` deliberately sets `project.worktree` to the **main repository** top-level (`dirname(--git-common-dir)`), so the watcher subscribed to `<main>/.git` and only watched `<main>/.git/HEAD`.

A `git checkout` in a linked worktree mutates the **per-worktree** HEAD at `<gitcommondir>/worktrees/<name>/HEAD`, which was never watched. Meanwhile `Vcs.state` reads the branch from `ctx.directory` (the active session dir), so the branch source and the watched HEAD had diverged. The issue's suggested fix was misdirected — the code already used `git rev-parse --git-dir`; the real bug was the **cwd**.

## Change

- Resolve git roots from `ctx.directory` instead of `ctx.project.worktree`, via `git rev-parse --path-format=absolute --git-dir --git-common-dir`.
- Subscribe to **both** roots: the per-worktree dir carries `HEAD`/`index`; the shared common dir carries `packed-refs`/`refs/heads`/`refs/remotes`. They coincide in a normal repo and are deduped to one subscription. Watching both avoids trading the branch-event fix for a regression in ref/packed-refs refresh (e.g. review-panel "branch" diff after a commit) inside a worktree.
- `project.worktree` semantics are unchanged.

The app already whitelists `.git/worktrees/...` and `.git/refs/...` in `isFileWatcherVcsRefreshEvent`, so the frontend consumes these events once the backend emits them.

## Test

Added a regression test in `test/project/vcs.test.ts` that drives a real `git worktree add` and asserts `BranchUpdated` fires when the per-worktree HEAD changes. It **times out against the old code** and **passes with the fix** (verified locally by reverting the watcher change).

## Verification

- `bun test test/project/vcs.test.ts` — 21 pass (incl. new linked-worktree case)
- `bun test test/file/watcher.test.ts` — 19 pass
- `bun run typecheck` (opencode) — clean
- Native-watcher tests are `describe.skip` in CI; ran locally where the `@parcel/watcher` binding exists.

## Notes

Approach reviewed via an independent second opinion (codex consult) before implementation; it confirmed the root cause and the dual-subscription scope.