### PR TITLE
fix(updater): fail closed when the github fallback offers no update

### DIFF
--- a/packages/desktop-electron/src/main/update-feed.test.ts
+++ b/packages/desktop-electron/src/main/update-feed.test.ts
@@ -166,6 +166,26 @@ describe("update feed download", () => {
     expect(setup.calls.download).toBe(1) // second download never attempted
   })
 
+  test("fails closed when the GitHub fallback reports no update available", async () => {
+    const setup = feed({
+      checkForUpdates: async () => {
+        setup.calls.check += 1
+        // first (R2) check: update available; second (github re-check): same
+        // version but no update available — must fail closed, never download.
+        return setup.calls.check === 1
+          ? available("0.2.5")
+          : { isUpdateAvailable: false, updateInfo: { version: "0.2.5", files: [{ url: "app-0.2.5.zip" }] } }
+      },
+      downloadUpdate: async () => {
+        setup.calls.download += 1
+        throw new Error("r2 blob 404")
+      },
+    })
+    await setup.feed.check()
+    await expect(setup.feed.download()).rejects.toThrow("github fallback reports no update available")
+    expect(setup.calls.download).toBe(1) // second download never attempted
+  })
+
   test("does not retry when the GitHub download fails", async () => {
     const setup = feed({
       feeds: [GITHUB],

--- a/packages/desktop-electron/src/main/update-feed.ts
+++ b/packages/desktop-electron/src/main/update-feed.ts
@@ -142,8 +142,9 @@ export function createUpdateFeed(deps: Deps) {
 
   // Download from the active feed. If an R2 download fails and GitHub is
   // available, re-check against GitHub (to rebind the provider) and retry —
-  // but only if GitHub offers the same version we validated, otherwise fail
-  // closed so the controller never marks a version ready that it did not check.
+  // but only if GitHub offers the same version we validated and still reports
+  // an update available, otherwise fail closed so the controller never marks a
+  // version ready that it did not check.
   const download = async (): Promise<unknown> => {
     try {
       return await deps.downloadUpdate()
@@ -159,6 +160,9 @@ export function createUpdateFeed(deps: Deps) {
         throw new Error(
           `github fallback version mismatch: expected ${checkedVersion ?? "unknown"}, got ${githubVersion ?? "unknown"}`,
         )
+      }
+      if (!recheck?.isUpdateAvailable) {
+        throw new Error(`github fallback reports no update available for ${checkedVersion ?? "unknown"}`)
       }
       activeLabel = "github"
       return await deps.downloadUpdate()


### PR DESCRIPTION
## What & why

The desktop updater's R2→GitHub download fallback (`update-feed.ts`) re-checks GitHub to rebind the provider before retrying a failed R2 download. It only failed closed on version mismatch. If GitHub returned the expected version but with `isUpdateAvailable=false`, the code proceeded to `downloadUpdate()` anyway, marking ready a version GitHub did not actually offer — contradicting the surrounding "never mark a version ready it did not check" intent.

## Change

- Add an `isUpdateAvailable` assertion after the version-equality check in `download()`, so the fallback fails closed with a clear error instead of downloading.
- Comment updated to state both fail-closed conditions.

## Verification

- `bun test src/main/update-feed.test.ts` → 15 pass. Added a case: same version but `isUpdateAvailable=false` → `download()` throws `github fallback reports no update available`, second download never attempted.
- `bun run typecheck` (tsgo -b) clean.

## Risk

Low. Behavior-narrowing within an already fail-closed path; only the GitHub-fallback branch of a failed R2 download is affected. No path outside the updater fallback is touched.
