### PR TITLE
test(app): add question dock growth runtime CLS gate (#818)

### DIFF
--- a/packages/app/e2e/perf/runtime-cls-gate.spec.ts
+++ b/packages/app/e2e/perf/runtime-cls-gate.spec.ts
@@ -26,6 +26,10 @@ const RUNTIME_CLS_SEED_TURNS = 60
 const RUNTIME_CLS_MINIMUM_ROWS = 52
 const RUNTIME_CLS_MAXIMUM_MOUNTED_MESSAGES = 48
 const COMPOSER_GROWTH_TEXT = Array.from({ length: 8 }, (_, index) => `composer growth line ${index + 1}`).join("\n")
+const QUESTION_CUSTOM_GROWTH_TEXT = Array.from(
+  { length: 8 },
+  (_, index) => `question custom growth line ${index + 1}`,
+).join("\n")
 
 const QUESTION = [
   {
@@ -302,6 +306,12 @@ async function readPromptHeight(page: Page) {
   return box?.height ?? 0
 }
 
+async function readDockHeight(page: Page) {
+  const box = await page.locator(questionDockSelector).first().boundingBox()
+  expect(box).toBeTruthy()
+  return box?.height ?? 0
+}
+
 async function assertNoPrimaryRuntimeClsFailures(result: RuntimeClsResult) {
   const failures = collectRuntimeClsFailures(result.entries)
   const primaryEntries = result.entries.filter(isRuntimeClsPrimaryEntry)
@@ -546,6 +556,57 @@ test.describe("runtime CLS source gate", () => {
         await dock.getByRole("button", { name: /submit/i }).click()
         await expect(dock).toHaveCount(0)
         await expect(page.locator(promptSelector).first()).toBeVisible()
+        await settleFrames(page, 6)
+        return await stopRuntimeClsProbe(page)
+      })
+
+      await assertNoPrimaryRuntimeClsFailures(result)
+    })
+  })
+
+  test("question dock growth does not move visible timeline primary sources", async ({ page, project, llm }) => {
+    // #818 owns the question dock open/growth path. Mounting the dock from absent
+    // is too noisy to measure deterministically (seeding side effects + async
+    // option render), so this gate keeps seeding + parent hydration OUTSIDE the
+    // probe window and measures only the dock growing taller — a real user typing
+    // a multi-line custom answer — which is the controlled dock-height transaction
+    // the gate owns. Asserts the visible parent timeline primary sources hold.
+    await installRuntimeClsProbe(page)
+    await project.open()
+    await withSession(project.sdk, `runtime cls question growth ${Date.now()}`, async (session) => {
+      await seedRuntimeClsSession(project, session.id)
+      const child = await project.sdk.session
+        .create({ title: `runtime cls child question growth ${Date.now()}`, parentID: session.id })
+        .then((response) => response.data)
+      if (!child?.id) throw new Error("Child session create did not return an id")
+      project.trackSession(child.id)
+      const dock = page.locator(questionDockSelector)
+      const customInput = dock.locator('[data-slot="question-custom-input"]')
+      await test.step("seed child question dock outside the measured window", async () => {
+        await llm.toolMatch(inputMatch({ questions: QUESTION }), "question", { questions: QUESTION })
+        await seedSessionQuestion(project.sdk, { sessionID: child.id, questions: QUESTION })
+      })
+      const targetMessageID = await test.step(
+        "reveal a long visible parent timeline window with the dock open",
+        async () => {
+          const target = await prepareRuntimeClsWindow(page, project, session.id)
+          await expect(dock).toBeVisible({ timeout: 30_000 })
+          // Enter custom-answer editing mode (button -> textarea) outside the
+          // window, so the measured growth is only the textarea getting taller
+          // from typing, not the one-time edit-mode swap.
+          await dock.locator('[data-slot="question-option"][data-custom="true"]').click()
+          await expect(customInput).toBeVisible()
+          await settleFrames(page, 6)
+          return target
+        },
+      )
+      const beforeHeight = await readDockHeight(page)
+
+      const result = await test.step("grow the question dock with a multi-line custom answer under the probe", async () => {
+        await startRuntimeClsProbe(page, "question-dock-growth", { targetMessageID })
+        await customInput.click()
+        await customInput.fill(QUESTION_CUSTOM_GROWTH_TEXT)
+        await expect.poll(async () => readDockHeight(page)).toBeGreaterThan(beforeHeight + 16)
         await settleFrames(page, 6)
         return await stopRuntimeClsProbe(page)
       })

--- a/packages/app/e2e/perf/runtime-cls-gate.spec.ts
+++ b/packages/app/e2e/perf/runtime-cls-gate.spec.ts
@@ -604,7 +604,6 @@ test.describe("runtime CLS source gate", () => {
 
       const result = await test.step("grow the question dock with a multi-line custom answer under the probe", async () => {
         await startRuntimeClsProbe(page, "question-dock-growth", { targetMessageID })
-        await customInput.click()
         await customInput.fill(QUESTION_CUSTOM_GROWTH_TEXT)
         await expect.poll(async () => readDockHeight(page)).toBeGreaterThan(beforeHeight + 16)
         await settleFrames(page, 6)


### PR DESCRIPTION
## Summary

Closes #818. #814 shipped runtime CLS gates for composer growth/shrink and question dock **close**, but deferred question dock **open/growth** because mounting the dock from absent mixes question seeding and async option render into the measured window (see the comment on the existing `question dock close` test).

This adds a deterministic gate for the dock-**growth** path.

## Approach

Per the acceptance criteria, the measured window must start after route hydration/history reveal settle and capture only the dock growing, not seeding or unrelated timeline mutation. So:

1. Seed the child question and reveal + position the parent timeline mid-history (user-scrolled) — **outside** the probe window.
2. Enter the custom-answer editing mode (`button` → `textarea`) — also **outside** the window, so the one-time edit-mode swap is not measured.
3. **Under the probe**, type a multi-line custom answer; `resizeInput` grows the `question-custom-input` textarea, growing the dock height. This is the controlled dock-height transaction, isolated from seeding/mount — directly mirroring the existing `composer growth` gate.

The "growth" path (not "open from absent") was chosen after a design consult: open-from-absent can only be triggered by seeding, whose parent-side effects (active-question state, dock reservation, status subscription) would leak into the measurement and defeat "not measuring question tool seeding". `acceptance` says "opens **or** grows", so one deterministic gate suffices.

Reuses #814 source-level failure semantics via `assertNoPrimaryRuntimeClsFailures`: `hadRecentInput` entries included; visible primary timeline sources (incl. `primary-turn-descendant`) fail; dock-only shifts stay diagnostic unless a visible primary ancestor also shifts.

## Verification

- `bun --cwd packages/app test:e2e:local:runtime-cls` — **9 passed** (the 5 existing gates + the new `question dock growth`), confirming no regression to the existing gates. Runs in PR CI via `perf-probe-baseline.yml` (`test:e2e:local:runtime-cls`, head checkout).
- `bun --cwd packages/app run typecheck` clean.

Design reviewed with a codex consult before implementation (growth-vs-open, measurement-window isolation, flake risk = dock height not settled before stop probe → covered by the `expect.poll` height grow + `settleFrames`).

Relates to #814.