### PR TITLE
fix(opencode): stop recommending auto-retry for terminal provider failures

### DIFF
--- a/packages/opencode/src/session/run-observability/recorder.ts
+++ b/packages/opencode/src/session/run-observability/recorder.ts
@@ -675,6 +675,7 @@ export function createRecorder(input: RecorderInput): Recorder {
         reasoningOutputStarted: terminalAttempt?.reasoning_output_started ?? incident?.facts.reasoning_output_started ?? false,
         toolExecutionStarted: terminalAttempt?.tool_execution_started ?? toolExecutionStarted,
         unsafeSideEffectStarted: terminalAttempt?.unsafe_side_effect_started ?? unsafeSideEffectStarted,
+        retryable: failure?.type === "transport" ? failure.retryable : undefined,
       })
       const completedAt = final.completedAt
       const failureMonotonicMs = failure?.monotonicMs
@@ -868,6 +869,7 @@ function retrySafetyFor(input: {
   reasoningOutputStarted: boolean
   toolExecutionStarted: boolean
   unsafeSideEffectStarted: boolean
+  retryable?: boolean
 }): Summary["retry_safety"] {
   const base = { safety_scope: "user_visible_and_tool_side_effects" as const }
   if (input.classification === "success") {
@@ -883,6 +885,9 @@ function retrySafetyFor(input: {
     return { ...base, recommendation: "ask_user", confidence: "medium", reason: "tool_execution_started" }
   }
   if (input.classification === "external_stream_disconnect") {
+    if (input.retryable === false) {
+      return { ...base, recommendation: "do_not_auto_retry", confidence: "high", reason: "provider_terminal_failure" }
+    }
     if (input.reasoningOutputStarted && input.visibleOutputSeen) {
       return {
         ...base,

--- a/packages/opencode/src/session/run-observability/types.ts
+++ b/packages/opencode/src/session/run-observability/types.ts
@@ -40,6 +40,7 @@ export type RetrySafety = {
     | "tool_execution_started"
     | "unsafe_side_effect_started"
     | "local_abort_or_lifecycle_close"
+    | "provider_terminal_failure"
     | "unknown"
   safety_scope: "user_visible_and_tool_side_effects"
 }

--- a/packages/opencode/test/session/run-observability.test.ts
+++ b/packages/opencode/test/session/run-observability.test.ts
@@ -660,6 +660,80 @@ describe("RunObservability", () => {
     expect(summary.durations_ms.last_event_to_failure).toBe(130)
   })
 
+  test("does not recommend auto-retry for a terminal provider failure on external stream disconnect", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_terminal_provider"),
+      traceID: MessageID.make("msg_terminal_provider"),
+      sessionID: SessionID.make("ses_terminal_provider"),
+      messageID: MessageID.make("msg_terminal_provider"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 25,
+      monotonicMs: 250,
+      error: {
+        name: "TypeError",
+        message: "terminated",
+        cause: { name: "SocketError", message: "other side closed", code: "UND_ERR_SOCKET" },
+      },
+      evidence: ["provider_progress_seen", "iterator_error"],
+      retryable: false,
+    })
+
+    const summary = recorder.finalize({ completedAt: 26, monotonicMs: 260 })
+    expect(summary.classification).toBe("external_stream_disconnect")
+    expect(summary.retry_safety).toEqual({
+      recommendation: "do_not_auto_retry",
+      confidence: "high",
+      reason: "provider_terminal_failure",
+      safety_scope: "user_visible_and_tool_side_effects",
+    })
+  })
+
+  test("keeps candidate auto-retry for a retryable external stream disconnect", () => {
+    const recorder = RunObservability.createRecorder({
+      runID: RunObservability.RunID.make("run_retryable_transport"),
+      traceID: MessageID.make("msg_retryable_transport"),
+      sessionID: SessionID.make("ses_retryable_transport"),
+      messageID: MessageID.make("msg_retryable_transport"),
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      createdAt: 10,
+      monotonicStartMs: 100,
+    })
+
+    const attempt = recorder.beginAttempt({ attemptIndex: 1, at: 11, monotonicMs: 110 })
+    recorder.recordProviderProgress({ attemptID: attempt.attemptID, at: 12, monotonicMs: 120 })
+    recorder.recordTransportFailure({
+      attemptID: attempt.attemptID,
+      at: 25,
+      monotonicMs: 250,
+      error: {
+        name: "TypeError",
+        message: "terminated",
+        cause: { name: "SocketError", message: "other side closed", code: "UND_ERR_SOCKET" },
+      },
+      evidence: ["provider_progress_seen", "iterator_error"],
+      retryable: true,
+    })
+
+    const summary = recorder.finalize({ completedAt: 26, monotonicMs: 260 })
+    expect(summary.classification).toBe("external_stream_disconnect")
+    expect(summary.retry_safety).toEqual({
+      recommendation: "candidate_safe_auto_retry",
+      confidence: "medium",
+      reason: "no_visible_output_or_tool_execution",
+      safety_scope: "user_visible_and_tool_side_effects",
+    })
+  })
+
   test("derives provider transport incident during partial tool input instead of tool failure", () => {
     const recorder = RunObservability.createRecorder({
       runID: RunObservability.RunID.make("run_partial_tool_input_disconnect"),


### PR DESCRIPTION
## Why

Part of the #1105 provider-failure classification spine. Earlier slices made `classifyRetry` read `providerFailure.kind`, so terminal provider failures (auth / invalid_request / quota_exhausted) are no longer retried. But the run-observability diagnostics layer never got that memo: those failures are recorded through the transport-failure path and classified as `external_stream_disconnect`, whose `retry_safety` branch unconditionally returned `candidate_safe_auto_retry`.

That left two diagnostics signals contradicting each other for the same failure: the recovery decision already records `technical_retryable=false`, while `retry_safety` recommended a safe auto-retry.

## What

- Thread the recorded transport failure's `retryable` flag into `retrySafetyFor`.
- In the `external_stream_disconnect` branch, when the failure is non-retryable (`retryable === false`), return `do_not_auto_retry` with a new `provider_terminal_failure` reason — checked first, before the existing `candidate_safe_auto_retry` returns.
- The run-phase classification label (`external_stream_disconnect`) is intentionally left unchanged. Only the retry-safety recommendation is corrected; this is a diagnostics-layer fix, not a re-taxonomy.

`retryable === true` and the `undefined` fallback keep their prior behavior, so genuine stream disconnects still surface as `candidate_safe_auto_retry`.

## End to end

The production wiring already passes `retryable` through `recordAttemptFailureAndDeriveRecovery`: `retrySignalFor` returns `{retryable: false}` for terminal classifications (when `classifyRetry` returns `undefined` or `retryAction === "stop"`). So the guard fires for real terminal provider failures, closing the inconsistency end to end. `halt()`'s fallback `recordTransportFailure` does not set `retryable`, but it only writes via `failure ??=` after the attempt loop has already recorded the failure, so the flag is preserved.

## Tests

- New: terminal provider failure (`retryable: false`) on `external_stream_disconnect` → `do_not_auto_retry` / `provider_terminal_failure`, classification unchanged.
- New: retryable disconnect (`retryable: true`) still → `candidate_safe_auto_retry` / `no_visible_output_or_tool_execution`.
- Full `run-observability.test.ts` suite green (70 pass), `tsgo --noEmit` clean.

Stays within `packages/opencode`. No schema field is removed; `RetrySafety.reason` gains one optional union member. Sessions persist as JSON and this only widens an existing string union, so back-compat holds.