### PR TITLE
feat(release): auto-publish the prod release once all targets land

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,10 @@ jobs:
 
     runs-on: ${{ matrix.host }}
     permissions:
-      actions: read
+      # actions: write lets the prod publish step dispatch mirror-release-to-r2.yml
+      # via `gh workflow run` (workflow_dispatch is the GITHUB_TOKEN anti-recursion
+      # exception; a GITHUB_TOKEN-driven publish does NOT fire release:published).
+      actions: write
       contents: write
 
     steps:
@@ -917,6 +920,21 @@ jobs:
           EXISTING_LATEST_YML_DIR: ${{ runner.temp }}/existing-latest-yml
           LATEST_YML_DIR: ${{ runner.temp }}/latest-yml
           OPENCODE_VERSION: ${{ steps.package_version.outputs.version }}
+
+      # Runs at the tail of every prod finalize/full target, after its updater
+      # metadata lands in the draft. Publishes (and pins the tag to the build
+      # commit) only when ALL targets are present, then dispatches the R2 mirror;
+      # incomplete drafts are a no-op. The LAST target to finish flips the draft.
+      - name: Publish release when all targets are complete
+        if: ${{ inputs.channel == 'prod' && ((runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label) || (runner.os == 'Windows' && inputs.phase == 'full')) }}
+        run: bun ./scripts/publish-when-complete.ts
+        working-directory: packages/desktop-electron
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: v${{ steps.package_version.outputs.version }}
+          BUILD_SHA: ${{ inputs.source_sha || github.sha }}
+          MIRROR_REF: dev
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -933,7 +933,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: v${{ steps.package_version.outputs.version }}
-          BUILD_SHA: ${{ inputs.source_sha || github.sha }}
+          # The commit the assets were actually built from: finalize repackages
+          # the submit build checked out at source_sha (see the finalize checkout
+          # above); full/submit build the checked-out github.sha. Tie BUILD_SHA to
+          # the phase so a full run can never pass a source_sha that disagrees
+          # with what it actually built.
+          BUILD_SHA: ${{ inputs.phase == 'finalize' && inputs.source_sha || github.sha }}
           MIRROR_REF: dev
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -939,6 +939,9 @@ jobs:
           # the phase so a full run can never pass a source_sha that disagrees
           # with what it actually built.
           BUILD_SHA: ${{ inputs.phase == 'finalize' && inputs.source_sha || github.sha }}
+          # Identify this target so it can upload its own provenance marker.
+          RELEASE_OS: ${{ runner.os == 'macOS' && 'mac' || 'win' }}
+          RELEASE_ARCH: ${{ matrix.arch_label }}
           MIRROR_REF: dev
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/packages/desktop-electron/scripts/finalize-latest-yml.ts
+++ b/packages/desktop-electron/scripts/finalize-latest-yml.ts
@@ -147,6 +147,30 @@ async function downloadExisting(tag: string, filename: string) {
   return mergeLatest(cached, live)
 }
 
+// Refuse to rewrite a release that is already published. In the normal flow the
+// release stays a draft until the auto-publisher flips it at the very end, after
+// every target's finalize has run; a published release here therefore means a
+// later same-version build (from a different commit) — clobbering its latest*.yml
+// would point the published metadata at hashes that no longer match the published
+// installers, breaking auto-update. Fail loudly instead (re-release with a bumped
+// version). A missing release is fine: nothing to clobber yet.
+async function assertReleaseIsDraft(releaseTag: string) {
+  let isDraft: boolean
+  try {
+    const out = await $`gh release view ${releaseTag} --json isDraft --jq .isDraft --repo ${repo}`.quiet().text()
+    isDraft = out.trim() === "true"
+  } catch (error) {
+    const message = shellErrorText(error)
+    if (/release not found|not found/i.test(message)) return
+    throw new Error(`Failed to read release state for ${releaseTag}: ${message}`)
+  }
+  if (!isDraft) {
+    throw new Error(
+      `Release ${releaseTag} is already published; refusing to overwrite its updater metadata from a later build`,
+    )
+  }
+}
+
 const output: Record<string, string> = {}
 const tag = `v${version}`
 const tmp = process.env.RUNNER_TEMP ?? "/tmp"
@@ -187,7 +211,9 @@ if (macX64 || macArm64) {
   )
 }
 
-// Upload to release
+// Upload to release. Re-checked right before the writes to shrink the window
+// between observing a draft and clobbering it.
+await assertReleaseIsDraft(tag)
 for (const [filename, content] of Object.entries(output)) {
   const filepath = path.join(tmp, filename)
   await Bun.write(filepath, content)

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -134,15 +134,16 @@ describe("decidePublishAction", () => {
     expect(decision.reason).toContain("no longer matches recorded build hashes")
   })
 
-  test("content anchor tolerates an empty-hash marker (metadata read hiccup at marker time)", () => {
-    // A target that could not read its own updater entry when writing the marker
-    // records an empty hash list. That target simply isn't content-anchored; the
-    // commit-agreement + completeness gates still apply, so the release is not
-    // deadlocked into a permanent draft over a transient read miss.
+  test("content anchor: refuses an empty-hash marker (a target that vouches for nothing)", () => {
+    // The marker writer fails rather than emit an empty hash, so an empty record
+    // reaching the decision means corruption or a stale tool. It must not pass the
+    // anchor by vacuous truth (empty list -> nothing to mismatch); fail closed.
     const noHash: Record<string, ProvenanceMarker> = {
       ...allAgree,
       "pawwork-win-x64-2026.6.1.commit": { commit: BUILD_SHA, sha512: [] },
     }
-    expect(decide({ provenance: noHash }).kind).toBe("publish")
+    const decision = decide({ provenance: noHash })
+    expect(decision.kind).toBe("fail")
+    expect(decision.reason).toContain("no recorded hash")
   })
 })

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { decidePublishAction } from "./publish-when-complete"
+import { decidePublishAction, type ProvenanceMarker } from "./publish-when-complete"
 import { releaseProvenanceAssetNames, type GithubRelease } from "./verify-release"
 
 const BUILD_SHA = "1111111111111111111111111111111111111111"
@@ -30,8 +30,14 @@ const latestYml = "files:\n  - url: pawwork-win-x64-2026.6.1.exe\n"
 const latestMacYml = "files:\n  - url: pawwork-mac-arm64-2026.6.1.zip\n  - url: pawwork-mac-x64-2026.6.1.zip\n"
 
 const expectedProvenance = releaseProvenanceAssetNames("2026.6.1")
-// Every target's marker present and agreeing on BUILD_SHA.
-const allAgree: Record<string, string> = Object.fromEntries(expectedProvenance.map((name) => [name, BUILD_SHA]))
+
+// One distinct installer hash per target, recorded both in that target's marker
+// and in the updater metadata, so the content anchor holds when nothing drifted.
+const shaFor = (markerName: string) => `sha-${markerName}`
+const allAgree: Record<string, ProvenanceMarker> = Object.fromEntries(
+  expectedProvenance.map((name) => [name, { commit: BUILD_SHA, sha512: [shaFor(name)] }]),
+)
+const updaterSha512s = expectedProvenance.map(shaFor)
 
 const decide = (overrides: Partial<Parameters<typeof decidePublishAction>[0]> = {}) =>
   decidePublishAction({
@@ -41,6 +47,7 @@ const decide = (overrides: Partial<Parameters<typeof decidePublishAction>[0]> = 
     buildSha: BUILD_SHA,
     provenance: allAgree,
     expectedProvenance,
+    updaterSha512s,
     ...overrides,
   })
 
@@ -55,7 +62,7 @@ describe("releaseProvenanceAssetNames", () => {
 })
 
 describe("decidePublishAction", () => {
-  test("publishes a complete release when every marker agrees", () => {
+  test("publishes a complete release when every marker agrees and matches the metadata", () => {
     expect(decide().kind).toBe("publish")
   })
 
@@ -91,7 +98,9 @@ describe("decidePublishAction", () => {
   })
 
   test("refuses to publish when a marker disagrees on the build commit", () => {
-    const decision = decide({ provenance: { ...allAgree, "pawwork-win-x64-2026.6.1.commit": OTHER_SHA } })
+    const decision = decide({
+      provenance: { ...allAgree, "pawwork-win-x64-2026.6.1.commit": { commit: OTHER_SHA, sha512: ["sha-win"] } },
+    })
     expect(decision.kind).toBe("fail")
     expect(decision.reason).toContain("mixed-source release")
   })
@@ -104,8 +113,36 @@ describe("decidePublishAction", () => {
     // Two targets built from different commits never converge to "all agree":
     // the mismatch is fatal regardless of how complete the draft looks, so the
     // race where a last writer could publish a mixed release cannot occur.
-    expect(decide({ release: partial, provenance: { ...allAgree, "pawwork-mac-x64-2026.6.1.commit": OTHER_SHA } }).kind).toBe(
-      "fail",
-    )
+    expect(
+      decide({
+        release: partial,
+        provenance: { ...allAgree, "pawwork-mac-x64-2026.6.1.commit": { commit: OTHER_SHA, sha512: ["sha-x64"] } },
+      }).kind,
+    ).toBe("fail")
+  })
+
+  test("content anchor: refuses when a marker's installer hash drifted out of the metadata", () => {
+    // A target rebuilt from another commit (same version, agreeing commit field
+    // by accident) produces a different installer hash; that hash is no longer in
+    // latest*.yml, so the content anchor catches a clobber the commit field misses.
+    const drifted: Record<string, ProvenanceMarker> = {
+      ...allAgree,
+      "pawwork-win-x64-2026.6.1.commit": { commit: BUILD_SHA, sha512: ["sha-rebuilt-from-another-commit"] },
+    }
+    const decision = decide({ provenance: drifted })
+    expect(decision.kind).toBe("fail")
+    expect(decision.reason).toContain("no longer matches recorded build hashes")
+  })
+
+  test("content anchor tolerates an empty-hash marker (metadata read hiccup at marker time)", () => {
+    // A target that could not read its own updater entry when writing the marker
+    // records an empty hash list. That target simply isn't content-anchored; the
+    // commit-agreement + completeness gates still apply, so the release is not
+    // deadlocked into a permanent draft over a transient read miss.
+    const noHash: Record<string, ProvenanceMarker> = {
+      ...allAgree,
+      "pawwork-win-x64-2026.6.1.commit": { commit: BUILD_SHA, sha512: [] },
+    }
+    expect(decide({ provenance: noHash }).kind).toBe("publish")
   })
 })

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+
+import { decidePublishAction } from "./publish-when-complete"
+import type { GithubRelease } from "./verify-release"
+
+const BUILD_SHA = "1111111111111111111111111111111111111111"
+
+// A complete release payload: every installer + updater sidecar + the two
+// channel files present, matching releaseAssetNames("2026.6.1").
+const completeRelease: GithubRelease = {
+  tag_name: "v2026.6.1",
+  draft: true,
+  prerelease: false,
+  assets: [
+    "pawwork-mac-arm64-2026.6.1.dmg",
+    "pawwork-mac-arm64-2026.6.1.zip",
+    "pawwork-mac-arm64-2026.6.1.zip.blockmap",
+    "pawwork-mac-x64-2026.6.1.dmg",
+    "pawwork-mac-x64-2026.6.1.zip",
+    "pawwork-mac-x64-2026.6.1.zip.blockmap",
+    "pawwork-win-x64-2026.6.1.exe",
+    "pawwork-win-x64-2026.6.1.exe.blockmap",
+    "latest.yml",
+    "latest-mac.yml",
+  ].map((name) => ({ name, browser_download_url: `https://example.com/${name}` })),
+}
+
+const latestYml = "files:\n  - url: pawwork-win-x64-2026.6.1.exe\n"
+const latestMacYml = "files:\n  - url: pawwork-mac-arm64-2026.6.1.zip\n  - url: pawwork-mac-x64-2026.6.1.zip\n"
+
+const decide = (overrides: Partial<Parameters<typeof decidePublishAction>[0]> = {}) =>
+  decidePublishAction({ release: completeRelease, latestYml, latestMacYml, buildSha: BUILD_SHA, ...overrides })
+
+describe("decidePublishAction", () => {
+  test("publishes a complete draft and pins it to the build commit", () => {
+    expect(decide().kind).toBe("publish")
+  })
+
+  test("waits when a target's assets have not landed yet", () => {
+    const partial: GithubRelease = {
+      ...completeRelease,
+      assets: completeRelease.assets.filter((asset) => asset.name !== "pawwork-win-x64-2026.6.1.exe"),
+    }
+    const decision = decide({ release: partial })
+    expect(decision.kind).toBe("wait")
+    expect(decision.reason).toContain("pawwork-win-x64-2026.6.1.exe")
+  })
+
+  test("waits when the updater metadata asset is not uploaded yet", () => {
+    // latest.yml exists as an asset but has not been fetched (a missing target);
+    // the metadata cross-check must fail, keeping us in wait rather than publish.
+    const decision = decide({ latestYml: undefined })
+    expect(decision.kind).toBe("wait")
+  })
+
+  test("only mirrors when the release is already published (no re-publish)", () => {
+    expect(decide({ release: { ...completeRelease, draft: false } }).kind).toBe("mirror-only")
+  })
+
+  test("fails loudly on a prerelease instead of waiting forever", () => {
+    const decision = decide({ release: { ...completeRelease, prerelease: true } })
+    expect(decision.kind).toBe("fail")
+    expect(decision.reason).toContain("prerelease")
+  })
+
+  test("refuses to publish when the existing tag points at another commit", () => {
+    const decision = decide({ existingTagSha: "2222222222222222222222222222222222222222" })
+    expect(decision.kind).toBe("fail")
+    expect(decision.reason).toContain("refusing to publish mismatched sources")
+  })
+
+  test("publishes when the tag already exists at the same build commit", () => {
+    expect(decide({ existingTagSha: BUILD_SHA }).kind).toBe("publish")
+  })
+})

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
-import { decidePublishAction, recordedBuildSha } from "./publish-when-complete"
-import type { GithubRelease } from "./verify-release"
+import { decidePublishAction } from "./publish-when-complete"
+import { releaseProvenanceAssetNames, type GithubRelease } from "./verify-release"
 
 const BUILD_SHA = "1111111111111111111111111111111111111111"
 const OTHER_SHA = "2222222222222222222222222222222222222222"
@@ -12,7 +12,6 @@ const completeRelease: GithubRelease = {
   tag_name: "v2026.6.1",
   draft: true,
   prerelease: false,
-  target_commitish: BUILD_SHA,
   assets: [
     "pawwork-mac-arm64-2026.6.1.dmg",
     "pawwork-mac-arm64-2026.6.1.zip",
@@ -30,26 +29,37 @@ const completeRelease: GithubRelease = {
 const latestYml = "files:\n  - url: pawwork-win-x64-2026.6.1.exe\n"
 const latestMacYml = "files:\n  - url: pawwork-mac-arm64-2026.6.1.zip\n  - url: pawwork-mac-x64-2026.6.1.zip\n"
 
+const expectedProvenance = releaseProvenanceAssetNames("2026.6.1")
+// Every target's marker present and agreeing on BUILD_SHA.
+const allAgree: Record<string, string> = Object.fromEntries(expectedProvenance.map((name) => [name, BUILD_SHA]))
+
 const decide = (overrides: Partial<Parameters<typeof decidePublishAction>[0]> = {}) =>
   decidePublishAction({
     release: completeRelease,
     latestYml,
     latestMacYml,
     buildSha: BUILD_SHA,
-    recordedSha: BUILD_SHA,
+    provenance: allAgree,
+    expectedProvenance,
     ...overrides,
   })
 
+describe("releaseProvenanceAssetNames", () => {
+  test("derives one .commit marker per release target", () => {
+    expect(releaseProvenanceAssetNames("2026.6.1")).toEqual([
+      "pawwork-mac-arm64-2026.6.1.commit",
+      "pawwork-mac-x64-2026.6.1.commit",
+      "pawwork-win-x64-2026.6.1.commit",
+    ])
+  })
+})
+
 describe("decidePublishAction", () => {
-  test("publishes a complete, single-source draft and pins it to the build commit", () => {
+  test("publishes a complete release when every marker agrees", () => {
     expect(decide().kind).toBe("publish")
   })
 
-  test("publishes when the draft is not yet claimed (first target)", () => {
-    expect(decide({ recordedSha: undefined }).kind).toBe("publish")
-  })
-
-  test("waits when a target's assets have not landed yet", () => {
+  test("waits when a target's installer has not landed yet", () => {
     const partial: GithubRelease = {
       ...completeRelease,
       assets: completeRelease.assets.filter((asset) => asset.name !== "pawwork-win-x64-2026.6.1.exe"),
@@ -60,10 +70,14 @@ describe("decidePublishAction", () => {
   })
 
   test("waits when the updater metadata asset is not uploaded yet", () => {
-    // latest.yml exists as an asset but has not been fetched (a missing target);
-    // the metadata cross-check must fail, keeping us in wait rather than publish.
-    const decision = decide({ latestYml: undefined })
+    expect(decide({ latestYml: undefined }).kind).toBe("wait")
+  })
+
+  test("waits when a target has not uploaded its provenance marker yet", () => {
+    const { "pawwork-win-x64-2026.6.1.commit": _omit, ...rest } = allAgree
+    const decision = decide({ provenance: rest })
     expect(decision.kind).toBe("wait")
+    expect(decision.reason).toContain("pawwork-win-x64-2026.6.1.commit")
   })
 
   test("only mirrors when the release is already published (no re-publish)", () => {
@@ -76,8 +90,8 @@ describe("decidePublishAction", () => {
     expect(decision.reason).toContain("prerelease")
   })
 
-  test("refuses to publish when the draft was claimed by a different build commit", () => {
-    const decision = decide({ recordedSha: OTHER_SHA })
+  test("refuses to publish when a marker disagrees on the build commit", () => {
+    const decision = decide({ provenance: { ...allAgree, "pawwork-win-x64-2026.6.1.commit": OTHER_SHA } })
     expect(decision.kind).toBe("fail")
     expect(decision.reason).toContain("mixed-source release")
   })
@@ -87,22 +101,11 @@ describe("decidePublishAction", () => {
       ...completeRelease,
       assets: completeRelease.assets.filter((asset) => asset.name !== "pawwork-win-x64-2026.6.1.exe"),
     }
-    // A divergent source is fatal regardless of how complete the draft is, so we
-    // never reach the wait branch.
-    expect(decide({ release: partial, recordedSha: OTHER_SHA }).kind).toBe("fail")
-  })
-})
-
-describe("recordedBuildSha", () => {
-  test("returns the commit when target_commitish is a full SHA", () => {
-    expect(recordedBuildSha({ ...completeRelease, target_commitish: BUILD_SHA })).toBe(BUILD_SHA)
-  })
-
-  test("treats a branch name as unclaimed", () => {
-    expect(recordedBuildSha({ ...completeRelease, target_commitish: "dev" })).toBeUndefined()
-  })
-
-  test("treats a missing target_commitish as unclaimed", () => {
-    expect(recordedBuildSha({ ...completeRelease, target_commitish: undefined })).toBeUndefined()
+    // Two targets built from different commits never converge to "all agree":
+    // the mismatch is fatal regardless of how complete the draft looks, so the
+    // race where a last writer could publish a mixed release cannot occur.
+    expect(decide({ release: partial, provenance: { ...allAgree, "pawwork-mac-x64-2026.6.1.commit": OTHER_SHA } }).kind).toBe(
+      "fail",
+    )
   })
 })

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test"
 
-import { decidePublishAction } from "./publish-when-complete"
+import { decidePublishAction, recordedBuildSha } from "./publish-when-complete"
 import type { GithubRelease } from "./verify-release"
 
 const BUILD_SHA = "1111111111111111111111111111111111111111"
+const OTHER_SHA = "2222222222222222222222222222222222222222"
 
 // A complete release payload: every installer + updater sidecar + the two
 // channel files present, matching releaseAssetNames("2026.6.1").
@@ -11,6 +12,7 @@ const completeRelease: GithubRelease = {
   tag_name: "v2026.6.1",
   draft: true,
   prerelease: false,
+  target_commitish: BUILD_SHA,
   assets: [
     "pawwork-mac-arm64-2026.6.1.dmg",
     "pawwork-mac-arm64-2026.6.1.zip",
@@ -29,11 +31,22 @@ const latestYml = "files:\n  - url: pawwork-win-x64-2026.6.1.exe\n"
 const latestMacYml = "files:\n  - url: pawwork-mac-arm64-2026.6.1.zip\n  - url: pawwork-mac-x64-2026.6.1.zip\n"
 
 const decide = (overrides: Partial<Parameters<typeof decidePublishAction>[0]> = {}) =>
-  decidePublishAction({ release: completeRelease, latestYml, latestMacYml, buildSha: BUILD_SHA, ...overrides })
+  decidePublishAction({
+    release: completeRelease,
+    latestYml,
+    latestMacYml,
+    buildSha: BUILD_SHA,
+    recordedSha: BUILD_SHA,
+    ...overrides,
+  })
 
 describe("decidePublishAction", () => {
-  test("publishes a complete draft and pins it to the build commit", () => {
+  test("publishes a complete, single-source draft and pins it to the build commit", () => {
     expect(decide().kind).toBe("publish")
+  })
+
+  test("publishes when the draft is not yet claimed (first target)", () => {
+    expect(decide({ recordedSha: undefined }).kind).toBe("publish")
   })
 
   test("waits when a target's assets have not landed yet", () => {
@@ -63,13 +76,33 @@ describe("decidePublishAction", () => {
     expect(decision.reason).toContain("prerelease")
   })
 
-  test("refuses to publish when the existing tag points at another commit", () => {
-    const decision = decide({ existingTagSha: "2222222222222222222222222222222222222222" })
+  test("refuses to publish when the draft was claimed by a different build commit", () => {
+    const decision = decide({ recordedSha: OTHER_SHA })
     expect(decision.kind).toBe("fail")
-    expect(decision.reason).toContain("refusing to publish mismatched sources")
+    expect(decision.reason).toContain("mixed-source release")
   })
 
-  test("publishes when the tag already exists at the same build commit", () => {
-    expect(decide({ existingTagSha: BUILD_SHA }).kind).toBe("publish")
+  test("provenance mismatch beats completeness: fails even on an incomplete draft", () => {
+    const partial: GithubRelease = {
+      ...completeRelease,
+      assets: completeRelease.assets.filter((asset) => asset.name !== "pawwork-win-x64-2026.6.1.exe"),
+    }
+    // A divergent source is fatal regardless of how complete the draft is, so we
+    // never reach the wait branch.
+    expect(decide({ release: partial, recordedSha: OTHER_SHA }).kind).toBe("fail")
+  })
+})
+
+describe("recordedBuildSha", () => {
+  test("returns the commit when target_commitish is a full SHA", () => {
+    expect(recordedBuildSha({ ...completeRelease, target_commitish: BUILD_SHA })).toBe(BUILD_SHA)
+  })
+
+  test("treats a branch name as unclaimed", () => {
+    expect(recordedBuildSha({ ...completeRelease, target_commitish: "dev" })).toBeUndefined()
+  })
+
+  test("treats a missing target_commitish as unclaimed", () => {
+    expect(recordedBuildSha({ ...completeRelease, target_commitish: undefined })).toBeUndefined()
   })
 })

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -2,17 +2,32 @@
 // have landed in the draft, then dispatch the R2 mirror. Runs at the tail of
 // each finalize/full build, so the LAST target to complete flips the draft into
 // a published release. Fail-safe: missing targets leave the draft untouched;
-// only a complete, same-commit release is ever published.
+// only a complete, single-source release is ever published.
 //
 // Why a dedicated script (not the by-tag verifier): a draft release is NOT
 // reachable via GET /releases/tags/{tag} (it 404s), so we look it up through the
 // list endpoint; and its assets must be downloaded via the asset API URL with an
 // `application/octet-stream` Accept header, not browser_download_url.
+//
+// Single-source guard (the assets for one version are assembled across several
+// independent build runs — mac arm64/x64 finalize + win full — each with its own
+// source commit). The verifier only checks file names and updater metadata, so a
+// version could otherwise be published with mac and win installers built from
+// DIFFERENT commits. We use the draft's `target_commitish` as a provenance
+// ledger: electron-builder creates the draft with the branch name there and
+// never rewrites an existing draft, so the first target pins it to its build
+// commit and every later target refuses to publish unless its own commit matches.
 
 import { normalizeTag, verifyReleasePayload, type GithubRelease } from "./verify-release"
 
 const GITHUB_API = "https://api.github.com"
 const FETCH_TIMEOUT_MS = 30_000
+// Absorb GitHub read-after-write lag on the assets/metadata this target just
+// uploaded, so the last target to finish does not see a stale "incomplete" view
+// and leave the release a draft with no later run to retry the publish.
+const WAIT_POLL_ATTEMPTS = 6
+const WAIT_POLL_INTERVAL_MS = 5_000
+const FULL_SHA = /^[0-9a-f]{40}$/
 
 type ApiAsset = { name: string; url: string; browser_download_url: string }
 type ApiRelease = GithubRelease & { id: number; assets: ApiAsset[] }
@@ -24,20 +39,33 @@ export type PublishDecision =
   | { kind: "fail"; reason: string }
 
 // Pure policy: decide what to do from the current release state. Kept free of
-// I/O so it is unit-testable without GitHub.
+// I/O so it is unit-testable without GitHub. `recordedSha` is the build commit
+// already claimed on the draft (normalized to a full SHA, or undefined when the
+// draft is still unclaimed); `buildSha` is this target's build commit.
 export function decidePublishAction(args: {
   release: GithubRelease
   latestYml?: string
   latestMacYml?: string
   buildSha: string
-  existingTagSha?: string
+  recordedSha?: string
 }): PublishDecision {
-  const { release, latestYml, latestMacYml, buildSha, existingTagSha } = args
+  const { release, latestYml, latestMacYml, buildSha, recordedSha } = args
 
   // A prerelease is a bad state for this pipeline: fail loudly instead of
   // waiting forever for a "completion" that publishing would never reach.
   if (release.prerelease) {
     return { kind: "fail", reason: `release ${release.tag_name} is marked as a prerelease` }
+  }
+
+  // Provenance gate, checked before completeness: if the draft was already
+  // claimed by a different build commit, this target's assets came from a
+  // divergent source. Refuse regardless of completeness so a mixed-source
+  // release is never published (and a complete-but-mixed draft is never mirrored).
+  if (recordedSha && recordedSha !== buildSha) {
+    return {
+      kind: "fail",
+      reason: `release ${release.tag_name} was assembled from ${recordedSha}, but this target was built from ${buildSha}; refusing to publish a mixed-source release`,
+    }
   }
 
   // Completeness reuses the exact verifier logic; allowDraft so the draft state
@@ -48,20 +76,10 @@ export function decidePublishAction(args: {
     return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${failures.join("; ")}` }
   }
 
-  // Same-source gate: never let the published tag point at a commit other than
-  // the one these assets were built from. If the tag already exists pointing
-  // elsewhere, the targets were not built from a single commit -> refuse.
-  if (existingTagSha && existingTagSha !== buildSha) {
-    return {
-      kind: "fail",
-      reason: `tag ${release.tag_name} points at ${existingTagSha}, not the build commit ${buildSha}; refusing to publish mismatched sources`,
-    }
-  }
-
   if (release.draft) {
     return {
       kind: "publish",
-      reason: "all release targets present; publishing and pinning the tag to the build commit",
+      reason: "all release targets present and single-source; publishing and pinning the tag to the build commit",
     }
   }
 
@@ -69,6 +87,13 @@ export function decidePublishAction(args: {
   // release:published webhook, and an earlier mirror dispatch may have failed,
   // so re-dispatch the (idempotent, per-tag serialized) mirror to avoid a gap.
   return { kind: "mirror-only", reason: "release already published; ensuring the mirror is dispatched" }
+}
+
+// The build commit currently claimed on the draft, or undefined when the draft
+// is unclaimed (electron-builder leaves the default branch name there).
+export function recordedBuildSha(release: GithubRelease): string | undefined {
+  const value = release.target_commitish
+  return value && FULL_SHA.test(value) ? value : undefined
 }
 
 function requireEnv(name: string): string {
@@ -98,6 +123,13 @@ async function fetchReleases(repo: string): Promise<ApiRelease[]> {
   return (await res.json()) as ApiRelease[]
 }
 
+async function findRelease(repo: string, tag: string): Promise<ApiRelease> {
+  const releases = await fetchReleases(repo)
+  const release = releases.find((entry) => entry.tag_name === tag)
+  if (!release) throw new Error(`no release found for ${tag} among ${releases.length} releases`)
+  return release
+}
+
 // Returns undefined when the asset is not in the release yet (a missing target,
 // handled as "wait"); throws when the asset exists but cannot be downloaded (a
 // tooling/network error that must fail the job rather than silently wait).
@@ -107,17 +139,6 @@ async function fetchAssetText(release: ApiRelease, name: string): Promise<string
   const res = await ghFetch(asset.url, "application/octet-stream")
   if (!res.ok) throw new Error(`failed to download ${name}: ${res.status} ${res.statusText}`)
   return res.text()
-}
-
-async function fetchTagSha(repo: string, tag: string): Promise<string | undefined> {
-  const res = await ghFetch(
-    `${GITHUB_API}/repos/${repo}/git/refs/tags/${encodeURIComponent(tag)}`,
-    "application/vnd.github+json",
-  )
-  if (res.status === 404) return undefined
-  if (!res.ok) throw new Error(`failed to read tag ${tag}: ${res.status} ${res.statusText}`)
-  const body = (await res.json()) as { object?: { sha?: string } }
-  return body.object?.sha
 }
 
 async function gh(args: string[]) {
@@ -130,50 +151,72 @@ async function dispatchMirror(repo: string, tag: string, ref: string) {
   await gh(["workflow", "run", "mirror-release-to-r2.yml", "--repo", repo, "--ref", ref, "-f", `tag=${tag}`])
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Re-read the release (and its updater metadata) and decide. Pulled out so the
+// wait-poll can re-evaluate against fresh GitHub state on each attempt.
+async function evaluate(repo: string, tag: string, buildSha: string): Promise<PublishDecision> {
+  const release = await findRelease(repo, tag)
+  const latestYml = await fetchAssetText(release, "latest.yml")
+  const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
+  return decidePublishAction({ release, latestYml, latestMacYml, buildSha, recordedSha: recordedBuildSha(release) })
+}
+
 async function main() {
   const repo = requireEnv("GH_REPO")
   const tag = normalizeTag(requireEnv("RELEASE_TAG"))
   const buildSha = requireEnv("BUILD_SHA")
   const mirrorRef = process.env.MIRROR_REF ?? "dev"
 
-  const releases = await fetchReleases(repo)
-  const release = releases.find((entry) => entry.tag_name === tag)
-  if (!release) {
-    console.error(`publish-when-complete: no release found for ${tag} among ${releases.length} releases`)
+  // Claim provenance up front: pin the still-unclaimed draft to this build's
+  // commit so any later target built from a different commit is detected. If a
+  // different commit already claimed it, fail now without publishing/mirroring.
+  const initial = await findRelease(repo, tag)
+  const recorded = recordedBuildSha(initial)
+  if (recorded && recorded !== buildSha) {
+    console.error(
+      `publish-when-complete: release ${tag} was assembled from ${recorded}, but this target was built from ${buildSha}; refusing to publish a mixed-source release`,
+    )
     process.exit(1)
   }
+  if (!recorded && initial.draft) {
+    await gh(["release", "edit", tag, "--repo", repo, "--target", buildSha])
+  }
 
-  const latestYml = await fetchAssetText(release, "latest.yml")
-  const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
-  const existingTagSha = await fetchTagSha(repo, tag)
+  for (let attempt = 1; ; attempt += 1) {
+    const decision = await evaluate(repo, tag, buildSha)
+    console.log(`publish-when-complete (attempt ${attempt}/${WAIT_POLL_ATTEMPTS}): ${decision.reason}`)
 
-  const decision = decidePublishAction({ release, latestYml, latestMacYml, buildSha, existingTagSha })
-  console.log(`publish-when-complete: ${decision.reason}`)
+    if (decision.kind === "wait" && attempt < WAIT_POLL_ATTEMPTS) {
+      await sleep(WAIT_POLL_INTERVAL_MS)
+      continue
+    }
 
-  switch (decision.kind) {
-    case "fail":
-      process.exit(1)
-      return
-    case "wait":
-      return
-    case "publish":
-      await gh([
-        "release",
-        "edit",
-        tag,
-        "--repo",
-        repo,
-        "--target",
-        buildSha,
-        "--draft=false",
-        "--latest",
-        "--prerelease=false",
-      ])
-      await dispatchMirror(repo, tag, mirrorRef)
-      return
-    case "mirror-only":
-      await dispatchMirror(repo, tag, mirrorRef)
-      return
+    switch (decision.kind) {
+      case "fail":
+        process.exit(1)
+        return
+      case "wait":
+        return
+      case "publish":
+        await gh([
+          "release",
+          "edit",
+          tag,
+          "--repo",
+          repo,
+          "--target",
+          buildSha,
+          "--draft=false",
+          "--latest",
+          "--prerelease=false",
+        ])
+        await dispatchMirror(repo, tag, mirrorRef)
+        return
+      case "mirror-only":
+        await dispatchMirror(repo, tag, mirrorRef)
+        return
+    }
   }
 }
 

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -10,27 +10,23 @@
 // `application/octet-stream` Accept header, not browser_download_url.
 //
 // Single-source guard (the assets for one version are assembled across several
-// independent build runs — mac arm64/x64 finalize + win full — each with its own
-// source commit). The verifier only checks file names and updater metadata, so a
-// version could otherwise be published with mac and win installers built from
-// DIFFERENT commits. We use the draft's `target_commitish` as a provenance
-// ledger: electron-builder creates the draft with the branch name there and
-// never rewrites an existing draft, so the first target pins it to its build
-// commit and every later target refuses to publish unless its own commit matches.
-//
-// This closes the realistic case (dev advances between dispatches, so a later
-// target is built from a newer commit — caught because the targets run, and
-// finish, sequentially). It does NOT fully close a concurrent race: the two mac
-// arches serialize via the build concurrency group, but mac-finalize and win-full
-// can run at once, and if both were built from different commits AND reach the
-// claim within the same window, the last writer can still publish a mixed-source
-// release (the loser detects the mismatch on its re-read and fails loudly, which
-// surfaces the problem). Fully closing that requires per-asset commit provenance
-// (stamping each target's build commit into the release and cross-checking) —
-// deliberately out of scope here; the asymmetric build durations make a same-
-// instant, different-commit finish unlikely.
+// independent, sometimes concurrent build runs — mac arm64/x64 finalize + win
+// full — each with its own source commit). The installers carry only the version
+// in their names, so the verifier alone cannot tell whether mac and win were
+// built from the same commit. Each target therefore uploads a small per-target
+// provenance marker (`pawwork-<os>-<arch>-<version>.commit`) holding its build
+// commit. The publisher publishes only when EVERY expected marker is present and
+// they all agree. Because each target writes its own distinct marker — never a
+// shared mutable field — there is no claim race: concurrent targets built from
+// different commits leave disagreeing markers, and no run ever sees "all agree".
 
-import { normalizeTag, verifyReleasePayload, type GithubRelease } from "./verify-release"
+import {
+  normalizeTag,
+  releaseProvenanceAssetName,
+  releaseProvenanceAssetNames,
+  verifyReleasePayload,
+  type GithubRelease,
+} from "./verify-release"
 
 const GITHUB_API = "https://api.github.com"
 const FETCH_TIMEOUT_MS = 30_000
@@ -39,10 +35,9 @@ const FETCH_TIMEOUT_MS = 30_000
 // and leave the release a draft with no later run to retry the publish.
 const WAIT_POLL_ATTEMPTS = 6
 const WAIT_POLL_INTERVAL_MS = 5_000
-const FULL_SHA = /^[0-9a-f]{40}$/
 
 type ApiAsset = { name: string; url: string; browser_download_url: string }
-type ApiRelease = GithubRelease & { id: number; assets: ApiAsset[] }
+type ApiRelease = GithubRelease & { id: number; upload_url: string; assets: ApiAsset[] }
 
 export type PublishDecision =
   | { kind: "publish"; reason: string }
@@ -51,17 +46,18 @@ export type PublishDecision =
   | { kind: "fail"; reason: string }
 
 // Pure policy: decide what to do from the current release state. Kept free of
-// I/O so it is unit-testable without GitHub. `recordedSha` is the build commit
-// already claimed on the draft (normalized to a full SHA, or undefined when the
-// draft is still unclaimed); `buildSha` is this target's build commit.
+// I/O so it is unit-testable without GitHub. `provenance` maps each PRESENT
+// marker asset name to the build commit it records; `expectedProvenance` is the
+// full set of marker names a complete release must carry.
 export function decidePublishAction(args: {
   release: GithubRelease
   latestYml?: string
   latestMacYml?: string
   buildSha: string
-  recordedSha?: string
+  provenance: Record<string, string>
+  expectedProvenance: string[]
 }): PublishDecision {
-  const { release, latestYml, latestMacYml, buildSha, recordedSha } = args
+  const { release, latestYml, latestMacYml, buildSha, provenance, expectedProvenance } = args
 
   // A prerelease is a bad state for this pipeline: fail loudly instead of
   // waiting forever for a "completion" that publishing would never reach.
@@ -69,23 +65,28 @@ export function decidePublishAction(args: {
     return { kind: "fail", reason: `release ${release.tag_name} is marked as a prerelease` }
   }
 
-  // Provenance gate, checked before completeness: if the draft was already
-  // claimed by a different build commit, this target's assets came from a
-  // divergent source. Refuse regardless of completeness so a mixed-source
-  // release is never published (and a complete-but-mixed draft is never mirrored).
-  if (recordedSha && recordedSha !== buildSha) {
+  // Provenance gate, checked before completeness: any present marker that does
+  // not match this target's build commit means the release is being assembled
+  // from more than one commit. Refuse regardless of completeness, so a
+  // mixed-source draft is never published (or mirrored).
+  const mismatched = Object.entries(provenance).filter(([, sha]) => sha !== buildSha)
+  if (mismatched.length > 0) {
+    const detail = mismatched.map(([name, sha]) => `${name}=${sha}`).join(", ")
     return {
       kind: "fail",
-      reason: `release ${release.tag_name} was assembled from ${recordedSha}, but this target was built from ${buildSha}; refusing to publish a mixed-source release`,
+      reason: `release ${release.tag_name} has targets built from different commits (this target ${buildSha}; ${detail}); refusing to publish a mixed-source release`,
     }
   }
 
-  // Completeness reuses the exact verifier logic; allowDraft so the draft state
-  // itself is not counted as a failure here. Any failure now means a target's
-  // assets/updater metadata are not in yet -> keep waiting (no-op, exit 0).
+  // Completeness: every installer + updater metadata (the verifier) AND every
+  // per-target provenance marker must be present. Any gap means a target has not
+  // finished yet -> keep waiting (no-op, exit 0). allowDraft so the draft state
+  // itself is not counted as a failure here.
   const failures = verifyReleasePayload({ release, latestYml, latestMacYml }, { allowDraft: true })
-  if (failures.length > 0) {
-    return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${failures.join("; ")}` }
+  const missingMarkers = expectedProvenance.filter((name) => !(name in provenance))
+  if (failures.length > 0 || missingMarkers.length > 0) {
+    const reasons = [...failures, ...missingMarkers.map((name) => `missing provenance marker ${name}`)]
+    return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${reasons.join("; ")}` }
   }
 
   if (release.draft) {
@@ -101,36 +102,35 @@ export function decidePublishAction(args: {
   return { kind: "mirror-only", reason: "release already published; ensuring the mirror is dispatched" }
 }
 
-// The build commit currently claimed on the draft, or undefined when the draft
-// is unclaimed (electron-builder leaves the default branch name there).
-export function recordedBuildSha(release: GithubRelease): string | undefined {
-  const value = release.target_commitish
-  return value && FULL_SHA.test(value) ? value : undefined
-}
-
 function requireEnv(name: string): string {
   const value = process.env[name]
   if (!value) throw new Error(`${name} is required`)
   return value
 }
 
-function githubHeaders(accept: string) {
+function githubHeaders(accept: string, contentType?: string) {
   const headers = new Headers({ Accept: accept, "X-GitHub-Api-Version": "2022-11-28" })
   const token = process.env.GH_TOKEN
   if (token) headers.set("Authorization", `Bearer ${token}`)
+  if (contentType) headers.set("Content-Type", contentType)
   return headers
 }
 
-async function ghFetch(url: string, accept: string) {
+async function ghFetch(url: string, init: RequestInit & { accept: string; contentType?: string }) {
+  const { accept, contentType, ...rest } = init
   try {
-    return await fetch(url, { headers: githubHeaders(accept), signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+    return await fetch(url, {
+      ...rest,
+      headers: githubHeaders(accept, contentType),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
   } catch (error) {
     throw new Error(`request to ${url} failed: ${error instanceof Error ? error.message : String(error)}`)
   }
 }
 
 async function fetchReleases(repo: string): Promise<ApiRelease[]> {
-  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases?per_page=100`, "application/vnd.github+json")
+  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases?per_page=100`, { accept: "application/vnd.github+json" })
   if (!res.ok) throw new Error(`failed to list releases: ${res.status} ${res.statusText}`)
   return (await res.json()) as ApiRelease[]
 }
@@ -148,9 +148,51 @@ async function findRelease(repo: string, tag: string): Promise<ApiRelease> {
 async function fetchAssetText(release: ApiRelease, name: string): Promise<string | undefined> {
   const asset = release.assets.find((entry) => entry.name === name)
   if (!asset) return undefined
-  const res = await ghFetch(asset.url, "application/octet-stream")
+  const res = await ghFetch(asset.url, { accept: "application/octet-stream" })
   if (!res.ok) throw new Error(`failed to download ${name}: ${res.status} ${res.statusText}`)
   return res.text()
+}
+
+// Upload this target's provenance marker via the release upload_url (draft-safe:
+// the by-tag asset endpoints 404 on drafts, the release id/upload_url do not).
+// Delete any existing same-named asset first so a re-run overwrites cleanly.
+async function putProvenanceMarker(repo: string, release: ApiRelease, name: string, sha: string) {
+  const existing = release.assets.find((entry) => entry.name === name)
+  if (existing) {
+    const del = await ghFetch(existing.url, { method: "DELETE", accept: "application/vnd.github+json" })
+    if (!del.ok && del.status !== 404) throw new Error(`failed to replace marker ${name}: ${del.status} ${del.statusText}`)
+  }
+  const uploadBase = release.upload_url.replace(/\{[^}]*\}$/, "")
+  const res = await ghFetch(`${uploadBase}?name=${encodeURIComponent(name)}`, {
+    method: "POST",
+    accept: "application/vnd.github+json",
+    contentType: "text/plain",
+    body: sha,
+  })
+  if (!res.ok) throw new Error(`failed to upload marker ${name}: ${res.status} ${res.statusText}`)
+}
+
+async function readProvenance(release: ApiRelease, expected: string[]): Promise<Record<string, string>> {
+  const entries: Record<string, string> = {}
+  for (const name of expected) {
+    const text = await fetchAssetText(release, name)
+    if (text !== undefined) entries[name] = text.trim()
+  }
+  return entries
+}
+
+// Publish via the release id (draft-safe: the by-tag edit endpoints can fail to
+// resolve drafts), pinning the tag to the agreed build commit and marking it
+// latest. A GITHUB_TOKEN publish does not fire release:published, so the caller
+// still dispatches the mirror explicitly.
+async function publishRelease(repo: string, release: ApiRelease, buildSha: string) {
+  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases/${release.id}`, {
+    method: "PATCH",
+    accept: "application/vnd.github+json",
+    contentType: "application/json",
+    body: JSON.stringify({ draft: false, prerelease: false, make_latest: "true", target_commitish: buildSha }),
+  })
+  if (!res.ok) throw new Error(`failed to publish ${release.tag_name}: ${res.status} ${res.statusText}`)
 }
 
 async function gh(args: string[]) {
@@ -165,38 +207,36 @@ async function dispatchMirror(repo: string, tag: string, ref: string) {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-// Re-read the release (and its updater metadata) and decide. Pulled out so the
-// wait-poll can re-evaluate against fresh GitHub state on each attempt.
-async function evaluate(repo: string, tag: string, buildSha: string): Promise<PublishDecision> {
-  const release = await findRelease(repo, tag)
-  const latestYml = await fetchAssetText(release, "latest.yml")
-  const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
-  return decidePublishAction({ release, latestYml, latestMacYml, buildSha, recordedSha: recordedBuildSha(release) })
-}
-
 async function main() {
   const repo = requireEnv("GH_REPO")
   const tag = normalizeTag(requireEnv("RELEASE_TAG"))
   const buildSha = requireEnv("BUILD_SHA")
+  const os = requireEnv("RELEASE_OS")
+  const arch = requireEnv("RELEASE_ARCH")
   const mirrorRef = process.env.MIRROR_REF ?? "dev"
 
-  // Claim provenance up front: pin the still-unclaimed draft to this build's
-  // commit so any later target built from a different commit is detected. If a
-  // different commit already claimed it, fail now without publishing/mirroring.
-  const initial = await findRelease(repo, tag)
-  const recorded = recordedBuildSha(initial)
-  if (recorded && recorded !== buildSha) {
-    console.error(
-      `publish-when-complete: release ${tag} was assembled from ${recorded}, but this target was built from ${buildSha}; refusing to publish a mixed-source release`,
-    )
-    process.exit(1)
-  }
-  if (!recorded && initial.draft) {
-    await gh(["release", "edit", tag, "--repo", repo, "--target", buildSha])
-  }
+  const version = tag.replace(/^v/, "")
+  const expectedProvenance = releaseProvenanceAssetNames(version)
+  const thisMarker = releaseProvenanceAssetName(os, arch, version)
+
+  // Record this target's build commit before deciding, so any other target
+  // built from a different commit will find a disagreeing marker.
+  const release = await findRelease(repo, tag)
+  await putProvenanceMarker(repo, release, thisMarker, buildSha)
 
   for (let attempt = 1; ; attempt += 1) {
-    const decision = await evaluate(repo, tag, buildSha)
+    const current = await findRelease(repo, tag)
+    const latestYml = await fetchAssetText(current, "latest.yml")
+    const latestMacYml = await fetchAssetText(current, "latest-mac.yml")
+    const provenance = await readProvenance(current, expectedProvenance)
+    const decision = decidePublishAction({
+      release: current,
+      latestYml,
+      latestMacYml,
+      buildSha,
+      provenance,
+      expectedProvenance,
+    })
     console.log(`publish-when-complete (attempt ${attempt}/${WAIT_POLL_ATTEMPTS}): ${decision.reason}`)
 
     if (decision.kind === "wait" && attempt < WAIT_POLL_ATTEMPTS) {
@@ -211,18 +251,7 @@ async function main() {
       case "wait":
         return
       case "publish":
-        await gh([
-          "release",
-          "edit",
-          tag,
-          "--repo",
-          repo,
-          "--target",
-          buildSha,
-          "--draft=false",
-          "--latest",
-          "--prerelease=false",
-        ])
+        await publishRelease(repo, current, buildSha)
         await dispatchMirror(repo, tag, mirrorRef)
         return
       case "mirror-only":

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -17,8 +17,20 @@
 // provenance marker (`pawwork-<os>-<arch>-<version>.commit`) holding its build
 // commit. The publisher publishes only when EVERY expected marker is present and
 // they all agree. Because each target writes its own distinct marker — never a
-// shared mutable field — there is no claim race: concurrent targets built from
-// different commits leave disagreeing markers, and no run ever sees "all agree".
+// shared mutable field — concurrent targets built from different commits leave
+// disagreeing markers and no run ever sees "all agree"; both fail closed.
+//
+// Irreducible residual: GitHub has no atomic compare-and-swap across assets, and
+// every artifact (installer, latest*.yml, marker) is uploaded in a separate
+// step, so there is no transaction spanning "read markers" and "publish". If a
+// target is RE-RUN from a different commit and its assets are clobbered in the
+// sub-second window between another target reading "all agree" and its publish
+// PATCH, a mixed-source release could still slip through. This requires an
+// operator rerunning a target from a different commit for the same version at
+// that exact instant; the realistic cases (dev advancing between dispatches; two
+// fresh targets from different commits) are fully closed. Fully eliminating it
+// would require encoding the commit in the asset names (breaks the updater, the
+// R2 mirror, and the website download links) or abandoning multi-dispatch.
 
 import {
   normalizeTag,
@@ -35,6 +47,13 @@ const FETCH_TIMEOUT_MS = 30_000
 // and leave the release a draft with no later run to retry the publish.
 const WAIT_POLL_ATTEMPTS = 6
 const WAIT_POLL_INTERVAL_MS = 5_000
+// Retry the marker create on a transient 422 already_exists (delete not yet
+// visible / concurrent same-target run) so it never leaves a complete release
+// stuck as a draft.
+const MARKER_UPLOAD_ATTEMPTS = 4
+const MARKER_UPLOAD_RETRY_MS = 2_000
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 type ApiAsset = { name: string; url: string; browser_download_url: string }
 type ApiRelease = GithubRelease & { id: number; upload_url: string; assets: ApiAsset[] }
@@ -153,23 +172,40 @@ async function fetchAssetText(release: ApiRelease, name: string): Promise<string
   return res.text()
 }
 
+async function deleteExistingAsset(repo: string, releaseId: number, name: string) {
+  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases/${releaseId}/assets?per_page=100`, {
+    accept: "application/vnd.github+json",
+  })
+  if (!res.ok) throw new Error(`failed to list assets for release ${releaseId}: ${res.status} ${res.statusText}`)
+  const existing = ((await res.json()) as ApiAsset[]).find((entry) => entry.name === name)
+  if (!existing) return
+  const del = await ghFetch(existing.url, { method: "DELETE", accept: "application/vnd.github+json" })
+  if (!del.ok && del.status !== 404) throw new Error(`failed to replace marker ${name}: ${del.status} ${del.statusText}`)
+}
+
 // Upload this target's provenance marker via the release upload_url (draft-safe:
 // the by-tag asset endpoints 404 on drafts, the release id/upload_url do not).
-// Delete any existing same-named asset first so a re-run overwrites cleanly.
+// Asset names are unique per release, so we delete any same-named asset first.
+// GitHub can still answer the create with 422 already_exists (delete not yet
+// visible, or a concurrent same-target run); retry by re-deleting so a transient
+// clash never leaves the release stuck as a complete-but-unpublished draft.
 async function putProvenanceMarker(repo: string, release: ApiRelease, name: string, sha: string) {
-  const existing = release.assets.find((entry) => entry.name === name)
-  if (existing) {
-    const del = await ghFetch(existing.url, { method: "DELETE", accept: "application/vnd.github+json" })
-    if (!del.ok && del.status !== 404) throw new Error(`failed to replace marker ${name}: ${del.status} ${del.statusText}`)
-  }
   const uploadBase = release.upload_url.replace(/\{[^}]*\}$/, "")
-  const res = await ghFetch(`${uploadBase}?name=${encodeURIComponent(name)}`, {
-    method: "POST",
-    accept: "application/vnd.github+json",
-    contentType: "text/plain",
-    body: sha,
-  })
-  if (!res.ok) throw new Error(`failed to upload marker ${name}: ${res.status} ${res.statusText}`)
+  for (let attempt = 1; ; attempt += 1) {
+    await deleteExistingAsset(repo, release.id, name)
+    const res = await ghFetch(`${uploadBase}?name=${encodeURIComponent(name)}`, {
+      method: "POST",
+      accept: "application/vnd.github+json",
+      contentType: "text/plain",
+      body: sha,
+    })
+    if (res.ok) return
+    if (res.status === 422 && attempt < MARKER_UPLOAD_ATTEMPTS) {
+      await sleep(MARKER_UPLOAD_RETRY_MS)
+      continue
+    }
+    throw new Error(`failed to upload marker ${name}: ${res.status} ${res.statusText}`)
+  }
 }
 
 async function readProvenance(release: ApiRelease, expected: string[]): Promise<Record<string, string>> {
@@ -204,8 +240,6 @@ async function gh(args: string[]) {
 async function dispatchMirror(repo: string, tag: string, ref: string) {
   await gh(["workflow", "run", "mirror-release-to-r2.yml", "--repo", repo, "--ref", ref, "-f", `tag=${tag}`])
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 async function main() {
   const repo = requireEnv("GH_REPO")

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -9,31 +9,42 @@
 // list endpoint; and its assets must be downloaded via the asset API URL with an
 // `application/octet-stream` Accept header, not browser_download_url.
 //
-// Single-source guard (the assets for one version are assembled across several
-// independent, sometimes concurrent build runs — mac arm64/x64 finalize + win
-// full — each with its own source commit). The installers carry only the version
-// in their names, so the verifier alone cannot tell whether mac and win were
-// built from the same commit. Each target therefore uploads a small per-target
-// provenance marker (`pawwork-<os>-<arch>-<version>.commit`) holding its build
-// commit. The publisher publishes only when EVERY expected marker is present and
-// they all agree. Because each target writes its own distinct marker — never a
-// shared mutable field — concurrent targets built from different commits leave
-// disagreeing markers and no run ever sees "all agree"; both fail closed.
+// SINGLE-SOURCE GUARD. The assets for one version are assembled across several
+// independent, sometimes concurrent build runs (mac arm64/x64 finalize + win
+// full), each with its own source commit. Installers carry only the version in
+// their names, so the verifier alone cannot tell whether mac and win came from
+// the same commit. Three layers, designed to fail closed:
 //
-// Irreducible residual: GitHub has no atomic compare-and-swap across assets, and
-// every artifact (installer, latest*.yml, marker) is uploaded in a separate
-// step, so there is no transaction spanning "read markers" and "publish". If a
-// target is RE-RUN from a different commit and its assets are clobbered in the
-// sub-second window between another target reading "all agree" and its publish
-// PATCH, a mixed-source release could still slip through. This requires an
-// operator rerunning a target from a different commit for the same version at
-// that exact instant; the realistic cases (dev advancing between dispatches; two
-// fresh targets from different commits) are fully closed. Fully eliminating it
-// would require encoding the commit in the asset names (breaks the updater, the
-// R2 mirror, and the website download links) or abandoning multi-dispatch.
+//   1. Per-target marker. Each target uploads a distinct asset
+//      `pawwork-<os>-<arch>-<version>.commit` holding {commit, sha512} — its
+//      build commit and the content hash of the installer it produced. Distinct
+//      cells per target (never a shared mutable field), so there is no claim
+//      race: concurrent targets from different commits leave disagreeing markers
+//      and no run ever sees "all agree".
+//   2. Content anchor. Before publishing, every marker's recorded sha512 must
+//      still be present in the current latest*.yml. A target rebuilt from another
+//      commit produces a different installer hash, so a stale marker no longer
+//      matches the metadata — catching a clobber that landed before this run read
+//      the markers.
+//   3. Seal + re-read. Right before the publish PATCH (the only draft->published
+//      write), snapshot the installer asset URLs, settle briefly, re-read, and
+//      refuse if any asset URL changed (electron-builder's overwrite DELETEs then
+//      re-creates an asset, so a clobber always yields a new URL). The PATCH is
+//      the last write — catching a clobber that lands during the publish window.
+//
+// Residual: GitHub offers no atomic compare-and-swap across assets, so the seal's
+// re-read and the PATCH are still two statements. A mixed-source publish would
+// require an asset to be clobbered, from a different commit, in the single HTTP
+// round-trip between the final re-read and the PATCH — not reachable by the CI
+// pipeline (electron-builder's overwrite takes seconds and changes the URL), only
+// by a human manually racing the publisher. Eliminating even that would need the
+// commit in the asset filenames (breaks the updater, the R2 mirror, and the
+// website links) or a single orchestrated workflow.
 
 import {
   normalizeTag,
+  parseUpdaterShaByUrl,
+  releaseAssetNames,
   releaseProvenanceAssetName,
   releaseProvenanceAssetNames,
   verifyReleasePayload,
@@ -52,11 +63,18 @@ const WAIT_POLL_INTERVAL_MS = 5_000
 // stuck as a draft.
 const MARKER_UPLOAD_ATTEMPTS = 4
 const MARKER_UPLOAD_RETRY_MS = 2_000
+// Settle between sealing the asset URLs and the final re-read, long enough for an
+// in-flight overwrite (DELETE + re-upload) to land and change the URL.
+const SEAL_SETTLE_MS = 8_000
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 type ApiAsset = { name: string; url: string; browser_download_url: string }
 type ApiRelease = GithubRelease & { id: number; upload_url: string; assets: ApiAsset[] }
+
+// A target's provenance: its build commit and the content hash(es) of the
+// updater asset it produced.
+export type ProvenanceMarker = { commit: string; sha512: string[] }
 
 export type PublishDecision =
   | { kind: "publish"; reason: string }
@@ -66,17 +84,19 @@ export type PublishDecision =
 
 // Pure policy: decide what to do from the current release state. Kept free of
 // I/O so it is unit-testable without GitHub. `provenance` maps each PRESENT
-// marker asset name to the build commit it records; `expectedProvenance` is the
-// full set of marker names a complete release must carry.
+// marker asset name to its parsed marker; `expectedProvenance` is the full set
+// of marker names a complete release must carry; `updaterSha512s` is every
+// content hash currently in latest*.yml.
 export function decidePublishAction(args: {
   release: GithubRelease
   latestYml?: string
   latestMacYml?: string
   buildSha: string
-  provenance: Record<string, string>
+  provenance: Record<string, ProvenanceMarker>
   expectedProvenance: string[]
+  updaterSha512s: string[]
 }): PublishDecision {
-  const { release, latestYml, latestMacYml, buildSha, provenance, expectedProvenance } = args
+  const { release, latestYml, latestMacYml, buildSha, provenance, expectedProvenance, updaterSha512s } = args
 
   // A prerelease is a bad state for this pipeline: fail loudly instead of
   // waiting forever for a "completion" that publishing would never reach.
@@ -84,13 +104,12 @@ export function decidePublishAction(args: {
     return { kind: "fail", reason: `release ${release.tag_name} is marked as a prerelease` }
   }
 
-  // Provenance gate, checked before completeness: any present marker that does
-  // not match this target's build commit means the release is being assembled
-  // from more than one commit. Refuse regardless of completeness, so a
-  // mixed-source draft is never published (or mirrored).
-  const mismatched = Object.entries(provenance).filter(([, sha]) => sha !== buildSha)
+  // Provenance gate, checked before completeness: any present marker whose commit
+  // differs from this target's means the release is being assembled from more
+  // than one commit. Refuse regardless of completeness.
+  const mismatched = Object.entries(provenance).filter(([, marker]) => marker.commit !== buildSha)
   if (mismatched.length > 0) {
-    const detail = mismatched.map(([name, sha]) => `${name}=${sha}`).join(", ")
+    const detail = mismatched.map(([name, marker]) => `${name}=${marker.commit}`).join(", ")
     return {
       kind: "fail",
       reason: `release ${release.tag_name} has targets built from different commits (this target ${buildSha}; ${detail}); refusing to publish a mixed-source release`,
@@ -106,6 +125,20 @@ export function decidePublishAction(args: {
   if (failures.length > 0 || missingMarkers.length > 0) {
     const reasons = [...failures, ...missingMarkers.map((name) => `missing provenance marker ${name}`)]
     return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${reasons.join("; ")}` }
+  }
+
+  // Content anchor: every marker's recorded installer hash must still be in the
+  // current metadata. A drift means an asset was rebuilt from another commit
+  // after its marker was written -> mixed source, refuse.
+  const known = new Set(updaterSha512s)
+  const drifted = Object.entries(provenance).flatMap(([name, marker]) =>
+    marker.sha512.filter((hash) => !known.has(hash)).map((hash) => `${name}:${hash}`),
+  )
+  if (drifted.length > 0) {
+    return {
+      kind: "fail",
+      reason: `release ${release.tag_name} updater metadata no longer matches recorded build hashes (${drifted.join(", ")}); refusing to publish a mixed-source release`,
+    }
   }
 
   if (release.draft) {
@@ -189,7 +222,7 @@ async function deleteExistingAsset(repo: string, releaseId: number, name: string
 // GitHub can still answer the create with 422 already_exists (delete not yet
 // visible, or a concurrent same-target run); retry by re-deleting so a transient
 // clash never leaves the release stuck as a complete-but-unpublished draft.
-async function putProvenanceMarker(repo: string, release: ApiRelease, name: string, sha: string) {
+async function putProvenanceMarker(repo: string, release: ApiRelease, name: string, body: string) {
   const uploadBase = release.upload_url.replace(/\{[^}]*\}$/, "")
   for (let attempt = 1; ; attempt += 1) {
     await deleteExistingAsset(repo, release.id, name)
@@ -197,7 +230,7 @@ async function putProvenanceMarker(repo: string, release: ApiRelease, name: stri
       method: "POST",
       accept: "application/vnd.github+json",
       contentType: "text/plain",
-      body: sha,
+      body,
     })
     if (res.ok) return
     if (res.status === 422 && attempt < MARKER_UPLOAD_ATTEMPTS) {
@@ -208,13 +241,61 @@ async function putProvenanceMarker(repo: string, release: ApiRelease, name: stri
   }
 }
 
-async function readProvenance(release: ApiRelease, expected: string[]): Promise<Record<string, string>> {
-  const entries: Record<string, string> = {}
+function parseMarker(text: string): ProvenanceMarker | undefined {
+  try {
+    const value = JSON.parse(text) as unknown
+    if (
+      value &&
+      typeof value === "object" &&
+      typeof (value as ProvenanceMarker).commit === "string" &&
+      Array.isArray((value as ProvenanceMarker).sha512) &&
+      (value as ProvenanceMarker).sha512.every((entry) => typeof entry === "string")
+    ) {
+      const marker = value as ProvenanceMarker
+      return { commit: marker.commit, sha512: marker.sha512 }
+    }
+  } catch {
+    // Malformed marker: treat as not-yet-present (handled as "wait"), never as a
+    // valid provenance claim, so a corrupt marker can never gate a publish open.
+  }
+  return undefined
+}
+
+async function readProvenance(release: ApiRelease, expected: string[]): Promise<Record<string, ProvenanceMarker>> {
+  const entries: Record<string, ProvenanceMarker> = {}
   for (const name of expected) {
     const text = await fetchAssetText(release, name)
-    if (text !== undefined) entries[name] = text.trim()
+    if (text === undefined) continue
+    const marker = parseMarker(text)
+    if (marker) entries[name] = marker
   }
   return entries
+}
+
+function updaterSha512sFrom(latestYml?: string, latestMacYml?: string): string[] {
+  return [latestYml, latestMacYml].filter((yml): yml is string => yml !== undefined).flatMap((yml) =>
+    parseUpdaterShaByUrl(yml).map((entry) => entry.sha512),
+  )
+}
+
+// URLs of the installer/metadata assets (each embeds the asset id), keyed by
+// name. A clobber DELETEs and re-creates an asset, so a changed URL signals a
+// rebuild between the seal and the publish.
+function sealAssetUrls(release: ApiRelease, version: string): Map<string, string> {
+  const tracked = new Set(releaseAssetNames(version))
+  const urls = new Map<string, string>()
+  for (const asset of release.assets) {
+    if (tracked.has(asset.name)) urls.set(asset.name, asset.url)
+  }
+  return urls
+}
+
+function changedAssets(sealed: Map<string, string>, current: Map<string, string>): string[] {
+  const changed: string[] = []
+  for (const [name, url] of sealed) {
+    if (current.get(name) !== url) changed.push(name)
+  }
+  return changed
 }
 
 // Publish via the release id (draft-safe: the by-tag edit endpoints can fail to
@@ -241,6 +322,20 @@ async function dispatchMirror(repo: string, tag: string, ref: string) {
   await gh(["workflow", "run", "mirror-release-to-r2.yml", "--repo", repo, "--ref", ref, "-f", `tag=${tag}`])
 }
 
+// The updater asset (the file electron-updater downloads) and its metadata file,
+// per OS. Its content hash is what the marker records for the content anchor.
+function targetUpdater(os: string): { ext: string; metadata: "latest.yml" | "latest-mac.yml" } {
+  return os === "win" ? { ext: "exe", metadata: "latest.yml" } : { ext: "zip", metadata: "latest-mac.yml" }
+}
+
+async function readEvaluationState(repo: string, tag: string, expectedProvenance: string[]) {
+  const release = await findRelease(repo, tag)
+  const latestYml = await fetchAssetText(release, "latest.yml")
+  const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
+  const provenance = await readProvenance(release, expectedProvenance)
+  return { release, latestYml, latestMacYml, provenance }
+}
+
 async function main() {
   const repo = requireEnv("GH_REPO")
   const tag = normalizeTag(requireEnv("RELEASE_TAG"))
@@ -253,23 +348,27 @@ async function main() {
   const expectedProvenance = releaseProvenanceAssetNames(version)
   const thisMarker = releaseProvenanceAssetName(os, arch, version)
 
-  // Record this target's build commit before deciding, so any other target
-  // built from a different commit will find a disagreeing marker.
+  // Record this target's build commit AND the hash of the installer it produced,
+  // before deciding, so other targets can detect both a different commit and a
+  // later clobber of this target's asset.
   const release = await findRelease(repo, tag)
-  await putProvenanceMarker(repo, release, thisMarker, buildSha)
+  const { ext, metadata } = targetUpdater(os)
+  const myUpdaterAsset = `pawwork-${os}-${arch}-${version}.${ext}`
+  const myYml = await fetchAssetText(release, metadata)
+  const myEntry = myYml ? parseUpdaterShaByUrl(myYml).find((entry) => entry.name === myUpdaterAsset) : undefined
+  const marker: ProvenanceMarker = { commit: buildSha, sha512: myEntry ? [myEntry.sha512] : [] }
+  await putProvenanceMarker(repo, release, thisMarker, JSON.stringify(marker))
 
   for (let attempt = 1; ; attempt += 1) {
-    const current = await findRelease(repo, tag)
-    const latestYml = await fetchAssetText(current, "latest.yml")
-    const latestMacYml = await fetchAssetText(current, "latest-mac.yml")
-    const provenance = await readProvenance(current, expectedProvenance)
+    const state = await readEvaluationState(repo, tag, expectedProvenance)
     const decision = decidePublishAction({
-      release: current,
-      latestYml,
-      latestMacYml,
+      release: state.release,
+      latestYml: state.latestYml,
+      latestMacYml: state.latestMacYml,
       buildSha,
-      provenance,
+      provenance: state.provenance,
       expectedProvenance,
+      updaterSha512s: updaterSha512sFrom(state.latestYml, state.latestMacYml),
     })
     console.log(`publish-when-complete (attempt ${attempt}/${WAIT_POLL_ATTEMPTS}): ${decision.reason}`)
 
@@ -284,10 +383,39 @@ async function main() {
         return
       case "wait":
         return
-      case "publish":
-        await publishRelease(repo, current, buildSha)
+      case "publish": {
+        // Seal + re-read: snapshot the asset URLs, let any in-flight overwrite
+        // land, then re-evaluate. Publish only if the release is STILL a
+        // complete, single-source publish AND no tracked asset URL moved — the
+        // PATCH is the final write.
+        const sealed = sealAssetUrls(state.release, version)
+        await sleep(SEAL_SETTLE_MS)
+        const reread = await readEvaluationState(repo, tag, expectedProvenance)
+        const recheck = decidePublishAction({
+          release: reread.release,
+          latestYml: reread.latestYml,
+          latestMacYml: reread.latestMacYml,
+          buildSha,
+          provenance: reread.provenance,
+          expectedProvenance,
+          updaterSha512s: updaterSha512sFrom(reread.latestYml, reread.latestMacYml),
+        })
+        if (recheck.kind !== "publish") {
+          console.error(`publish-when-complete: release changed during seal, not publishing: ${recheck.reason}`)
+          if (recheck.kind === "fail") process.exit(1)
+          return
+        }
+        const moved = changedAssets(sealed, sealAssetUrls(reread.release, version))
+        if (moved.length > 0) {
+          console.error(
+            `publish-when-complete: release assets changed during seal (${moved.join(", ")}); refusing to publish a possibly mixed-source release`,
+          )
+          process.exit(1)
+        }
+        await publishRelease(repo, reread.release, buildSha)
         await dispatchMirror(repo, tag, mirrorRef)
         return
+      }
       case "mirror-only":
         await dispatchMirror(repo, tag, mirrorRef)
         return

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -32,14 +32,23 @@
 //      re-creates an asset, so a clobber always yields a new URL). The PATCH is
 //      the last write — catching a clobber that lands during the publish window.
 //
-// Residual: GitHub offers no atomic compare-and-swap across assets, so the seal's
-// re-read and the PATCH are still two statements. A mixed-source publish would
-// require an asset to be clobbered, from a different commit, in the single HTTP
-// round-trip between the final re-read and the PATCH — not reachable by the CI
-// pipeline (electron-builder's overwrite takes seconds and changes the URL), only
-// by a human manually racing the publisher. Eliminating even that would need the
-// commit in the asset filenames (breaks the updater, the R2 mirror, and the
-// website links) or a single orchestrated workflow.
+// Post-publish writes happen at a different site (the build's earlier publish +
+// finalize steps), so they are fenced there, not here: electron-builder leaves an
+// already-published release untouched (releaseType defaults to draft, so its
+// publisher skips a published release), and finalize-latest-yml refuses to upload
+// to a non-draft release. Together a later same-version build from a different
+// commit cannot rewrite the published installers or their updater metadata; it
+// fails loudly instead.
+//
+// Residual: GitHub offers no atomic compare-and-swap across release assets, so
+// the finalize guard's draft-check and its upload, and this seal's re-read and
+// PATCH, are each two statements. A mixed-source publish would require a write to
+// land in the single HTTP round-trip between a check and its write, from a
+// different commit, in two builds of the same version dispatched concurrently —
+// not reachable by the normal one-dispatch pipeline (each version is built once,
+// from one commit). Eliminating even that would need the commit in the asset
+// filenames (breaks the updater, the R2 mirror, and the website links) or a
+// single orchestrated workflow.
 
 import {
   normalizeTag,
@@ -127,12 +136,18 @@ export function decidePublishAction(args: {
     return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${reasons.join("; ")}` }
   }
 
-  // Content anchor: every marker's recorded installer hash must still be in the
-  // current metadata. A drift means an asset was rebuilt from another commit
-  // after its marker was written -> mixed source, refuse.
+  // Content anchor: every marker must record at least one installer hash AND
+  // every recorded hash must still be in the current metadata. A drift means an
+  // asset was rebuilt from another commit after its marker was written; an empty
+  // record means a target could not vouch for its own installer. Either way we
+  // cannot prove single-source, so refuse -- the marker writer never emits an
+  // empty record (it fails first), so an empty one here is corruption or a
+  // stale-tool artifact and must not gate the publish open.
   const known = new Set(updaterSha512s)
   const drifted = Object.entries(provenance).flatMap(([name, marker]) =>
-    marker.sha512.filter((hash) => !known.has(hash)).map((hash) => `${name}:${hash}`),
+    marker.sha512.length === 0
+      ? [`${name}:<no recorded hash>`]
+      : marker.sha512.filter((hash) => !known.has(hash)).map((hash) => `${name}:${hash}`),
   )
   if (drifted.length > 0) {
     return {
@@ -328,6 +343,25 @@ function targetUpdater(os: string): { ext: string; metadata: "latest.yml" | "lat
   return os === "win" ? { ext: "exe", metadata: "latest.yml" } : { ext: "zip", metadata: "latest-mac.yml" }
 }
 
+// Read THIS target's installer hash from its updater metadata, re-fetching to
+// absorb read-after-write lag on the asset just finalized. Throws rather than
+// returning empty: a hashless marker would disable the content anchor for this
+// target, so a genuine miss must fail the job (re-runnable) instead.
+async function readOwnUpdaterSha(repo: string, tag: string, metadata: string, assetName: string): Promise<string> {
+  for (let attempt = 1; ; attempt += 1) {
+    const release = await findRelease(repo, tag)
+    const yml = await fetchAssetText(release, metadata)
+    const entry = yml ? parseUpdaterShaByUrl(yml).find((item) => item.name === assetName) : undefined
+    if (entry) return entry.sha512
+    if (attempt >= MARKER_UPLOAD_ATTEMPTS) {
+      throw new Error(
+        `could not read sha512 for ${assetName} from ${metadata} after ${attempt} attempts; refusing to write a hashless provenance marker`,
+      )
+    }
+    await sleep(MARKER_UPLOAD_RETRY_MS)
+  }
+}
+
 async function readEvaluationState(repo: string, tag: string, expectedProvenance: string[]) {
   const release = await findRelease(repo, tag)
   const latestYml = await fetchAssetText(release, "latest.yml")
@@ -350,13 +384,15 @@ async function main() {
 
   // Record this target's build commit AND the hash of the installer it produced,
   // before deciding, so other targets can detect both a different commit and a
-  // later clobber of this target's asset.
+  // later clobber of this target's asset. Refuse to write a hashless marker: an
+  // empty hash would silently disable the content anchor for this target, so if
+  // we cannot read our own installer hash (read-after-write lag, or finalize did
+  // not run) we fail loudly instead of vouching for nothing.
   const release = await findRelease(repo, tag)
   const { ext, metadata } = targetUpdater(os)
   const myUpdaterAsset = `pawwork-${os}-${arch}-${version}.${ext}`
-  const myYml = await fetchAssetText(release, metadata)
-  const myEntry = myYml ? parseUpdaterShaByUrl(myYml).find((entry) => entry.name === myUpdaterAsset) : undefined
-  const marker: ProvenanceMarker = { commit: buildSha, sha512: myEntry ? [myEntry.sha512] : [] }
+  const mySha512 = await readOwnUpdaterSha(repo, tag, metadata, myUpdaterAsset)
+  const marker: ProvenanceMarker = { commit: buildSha, sha512: [mySha512] }
   await putProvenanceMarker(repo, release, thisMarker, JSON.stringify(marker))
 
   for (let attempt = 1; ; attempt += 1) {
@@ -382,6 +418,14 @@ async function main() {
         process.exit(1)
         return
       case "wait":
+        // Exhausted the poll window still incomplete. Expected when other targets
+        // are genuinely still building (each will run its own publisher). If every
+        // target has in fact finished but this run only saw a stale view, the
+        // release is left a draft; re-dispatching the same version (same commit)
+        // re-runs against the still-draft release and publishes it.
+        console.warn(
+          `publish-when-complete: still incomplete after ${WAIT_POLL_ATTEMPTS} attempts; leaving the release a draft (${decision.reason})`,
+        )
         return
       case "publish": {
         // Seal + re-read: snapshot the asset URLs, let any in-flight overwrite
@@ -403,6 +447,10 @@ async function main() {
         if (recheck.kind !== "publish") {
           console.error(`publish-when-complete: release changed during seal, not publishing: ${recheck.reason}`)
           if (recheck.kind === "fail") process.exit(1)
+          // Another job won the publish race during our seal window. Its publish
+          // does not fire release:published and its own mirror dispatch may have
+          // failed, so still ensure the mirror is dispatched before we exit.
+          if (recheck.kind === "mirror-only") await dispatchMirror(repo, tag, mirrorRef)
           return
         }
         const moved = changedAssets(sealed, sealAssetUrls(reread.release, version))

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -17,6 +17,18 @@
 // ledger: electron-builder creates the draft with the branch name there and
 // never rewrites an existing draft, so the first target pins it to its build
 // commit and every later target refuses to publish unless its own commit matches.
+//
+// This closes the realistic case (dev advances between dispatches, so a later
+// target is built from a newer commit — caught because the targets run, and
+// finish, sequentially). It does NOT fully close a concurrent race: the two mac
+// arches serialize via the build concurrency group, but mac-finalize and win-full
+// can run at once, and if both were built from different commits AND reach the
+// claim within the same window, the last writer can still publish a mixed-source
+// release (the loser detects the mismatch on its re-read and fails loudly, which
+// surfaces the problem). Fully closing that requires per-asset commit provenance
+// (stamping each target's build commit into the release and cross-checking) —
+// deliberately out of scope here; the asymmetric build durations make a same-
+// instant, different-commit finish unlikely.
 
 import { normalizeTag, verifyReleasePayload, type GithubRelease } from "./verify-release"
 

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -1,0 +1,185 @@
+// Auto-publish the prod release once every target's assets and updater metadata
+// have landed in the draft, then dispatch the R2 mirror. Runs at the tail of
+// each finalize/full build, so the LAST target to complete flips the draft into
+// a published release. Fail-safe: missing targets leave the draft untouched;
+// only a complete, same-commit release is ever published.
+//
+// Why a dedicated script (not the by-tag verifier): a draft release is NOT
+// reachable via GET /releases/tags/{tag} (it 404s), so we look it up through the
+// list endpoint; and its assets must be downloaded via the asset API URL with an
+// `application/octet-stream` Accept header, not browser_download_url.
+
+import { normalizeTag, verifyReleasePayload, type GithubRelease } from "./verify-release"
+
+const GITHUB_API = "https://api.github.com"
+const FETCH_TIMEOUT_MS = 30_000
+
+type ApiAsset = { name: string; url: string; browser_download_url: string }
+type ApiRelease = GithubRelease & { id: number; assets: ApiAsset[] }
+
+export type PublishDecision =
+  | { kind: "publish"; reason: string }
+  | { kind: "mirror-only"; reason: string }
+  | { kind: "wait"; reason: string }
+  | { kind: "fail"; reason: string }
+
+// Pure policy: decide what to do from the current release state. Kept free of
+// I/O so it is unit-testable without GitHub.
+export function decidePublishAction(args: {
+  release: GithubRelease
+  latestYml?: string
+  latestMacYml?: string
+  buildSha: string
+  existingTagSha?: string
+}): PublishDecision {
+  const { release, latestYml, latestMacYml, buildSha, existingTagSha } = args
+
+  // A prerelease is a bad state for this pipeline: fail loudly instead of
+  // waiting forever for a "completion" that publishing would never reach.
+  if (release.prerelease) {
+    return { kind: "fail", reason: `release ${release.tag_name} is marked as a prerelease` }
+  }
+
+  // Completeness reuses the exact verifier logic; allowDraft so the draft state
+  // itself is not counted as a failure here. Any failure now means a target's
+  // assets/updater metadata are not in yet -> keep waiting (no-op, exit 0).
+  const failures = verifyReleasePayload({ release, latestYml, latestMacYml }, { allowDraft: true })
+  if (failures.length > 0) {
+    return { kind: "wait", reason: `release incomplete, waiting for remaining targets: ${failures.join("; ")}` }
+  }
+
+  // Same-source gate: never let the published tag point at a commit other than
+  // the one these assets were built from. If the tag already exists pointing
+  // elsewhere, the targets were not built from a single commit -> refuse.
+  if (existingTagSha && existingTagSha !== buildSha) {
+    return {
+      kind: "fail",
+      reason: `tag ${release.tag_name} points at ${existingTagSha}, not the build commit ${buildSha}; refusing to publish mismatched sources`,
+    }
+  }
+
+  if (release.draft) {
+    return {
+      kind: "publish",
+      reason: "all release targets present; publishing and pinning the tag to the build commit",
+    }
+  }
+
+  // Already published by an earlier run. GITHUB_TOKEN publishes do not fire the
+  // release:published webhook, and an earlier mirror dispatch may have failed,
+  // so re-dispatch the (idempotent, per-tag serialized) mirror to avoid a gap.
+  return { kind: "mirror-only", reason: "release already published; ensuring the mirror is dispatched" }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+function githubHeaders(accept: string) {
+  const headers = new Headers({ Accept: accept, "X-GitHub-Api-Version": "2022-11-28" })
+  const token = process.env.GH_TOKEN
+  if (token) headers.set("Authorization", `Bearer ${token}`)
+  return headers
+}
+
+async function ghFetch(url: string, accept: string) {
+  try {
+    return await fetch(url, { headers: githubHeaders(accept), signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+  } catch (error) {
+    throw new Error(`request to ${url} failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+async function fetchReleases(repo: string): Promise<ApiRelease[]> {
+  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases?per_page=100`, "application/vnd.github+json")
+  if (!res.ok) throw new Error(`failed to list releases: ${res.status} ${res.statusText}`)
+  return (await res.json()) as ApiRelease[]
+}
+
+// Returns undefined when the asset is not in the release yet (a missing target,
+// handled as "wait"); throws when the asset exists but cannot be downloaded (a
+// tooling/network error that must fail the job rather than silently wait).
+async function fetchAssetText(release: ApiRelease, name: string): Promise<string | undefined> {
+  const asset = release.assets.find((entry) => entry.name === name)
+  if (!asset) return undefined
+  const res = await ghFetch(asset.url, "application/octet-stream")
+  if (!res.ok) throw new Error(`failed to download ${name}: ${res.status} ${res.statusText}`)
+  return res.text()
+}
+
+async function fetchTagSha(repo: string, tag: string): Promise<string | undefined> {
+  const res = await ghFetch(
+    `${GITHUB_API}/repos/${repo}/git/refs/tags/${encodeURIComponent(tag)}`,
+    "application/vnd.github+json",
+  )
+  if (res.status === 404) return undefined
+  if (!res.ok) throw new Error(`failed to read tag ${tag}: ${res.status} ${res.statusText}`)
+  const body = (await res.json()) as { object?: { sha?: string } }
+  return body.object?.sha
+}
+
+async function gh(args: string[]) {
+  const proc = Bun.spawn(["gh", ...args], { stdout: "inherit", stderr: "inherit" })
+  const code = await proc.exited
+  if (code !== 0) throw new Error(`gh ${args.join(" ")} exited ${code}`)
+}
+
+async function dispatchMirror(repo: string, tag: string, ref: string) {
+  await gh(["workflow", "run", "mirror-release-to-r2.yml", "--repo", repo, "--ref", ref, "-f", `tag=${tag}`])
+}
+
+async function main() {
+  const repo = requireEnv("GH_REPO")
+  const tag = normalizeTag(requireEnv("RELEASE_TAG"))
+  const buildSha = requireEnv("BUILD_SHA")
+  const mirrorRef = process.env.MIRROR_REF ?? "dev"
+
+  const releases = await fetchReleases(repo)
+  const release = releases.find((entry) => entry.tag_name === tag)
+  if (!release) {
+    console.error(`publish-when-complete: no release found for ${tag} among ${releases.length} releases`)
+    process.exit(1)
+  }
+
+  const latestYml = await fetchAssetText(release, "latest.yml")
+  const latestMacYml = await fetchAssetText(release, "latest-mac.yml")
+  const existingTagSha = await fetchTagSha(repo, tag)
+
+  const decision = decidePublishAction({ release, latestYml, latestMacYml, buildSha, existingTagSha })
+  console.log(`publish-when-complete: ${decision.reason}`)
+
+  switch (decision.kind) {
+    case "fail":
+      process.exit(1)
+      return
+    case "wait":
+      return
+    case "publish":
+      await gh([
+        "release",
+        "edit",
+        tag,
+        "--repo",
+        repo,
+        "--target",
+        buildSha,
+        "--draft=false",
+        "--latest",
+        "--prerelease=false",
+      ])
+      await dispatchMirror(repo, tag, mirrorRef)
+      return
+    case "mirror-only":
+      await dispatchMirror(repo, tag, mirrorRef)
+      return
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`publish-when-complete failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  })
+}

--- a/packages/desktop-electron/scripts/release-metadata-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-metadata-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { delimiter, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -257,6 +257,29 @@ describe("release metadata finalizer", () => {
     expect(stderr).toContain("HTTP 404: Not Found")
   })
 
+  test("refuses to overwrite updater metadata once the release is published", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
+    roots.push(root)
+    const latestDir = join(root, "latest-yml")
+    const runnerTemp = join(root, "runner")
+    const binDir = join(root, "bin")
+    mkdirSync(runnerTemp, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
+    // The release has already been published (a later same-version build): the
+    // finalizer must refuse rather than clobber the live updater metadata.
+    writeFakeGh(binDir, {}, undefined, false)
+
+    writeLatest(join(latestDir, "latest-yml-aarch64-apple-darwin"), "latest-mac.yml", "PawWork-new-arm64.zip")
+
+    const proc = spawnFinalizer(binDir, latestDir, runnerTemp)
+
+    const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain("already published")
+    const uploadsLog = join(root, "gh-uploads.log")
+    expect(existsSync(uploadsLog) ? readFileSync(uploadsLog, "utf8") : "").not.toContain("release upload")
+  })
+
   test("fails when existing metadata version does not match the release", async () => {
     const root = mkdtempSync(join(tmpdir(), "pawwork-release-metadata-"))
     roots.push(root)
@@ -313,7 +336,12 @@ function writeLatest(
   )
 }
 
-function writeFakeGh(binDir: string, downloads: Record<string, string | FixtureFile> = {}, downloadFailure?: string) {
+function writeFakeGh(
+  binDir: string,
+  downloads: Record<string, string | FixtureFile> = {},
+  downloadFailure?: string,
+  releaseIsDraft = true,
+) {
   const helper = join(binDir, "fake-gh.js")
   writeFileSync(
     helper,
@@ -322,8 +350,14 @@ function writeFakeGh(binDir: string, downloads: Record<string, string | FixtureF
       "const { join } = require('node:path')",
       `const downloads = ${JSON.stringify(downloads)}`,
       `const downloadFailure = ${JSON.stringify(downloadFailure ?? null)}`,
+      `const releaseIsDraft = ${JSON.stringify(releaseIsDraft)}`,
       `const uploadLog = ${JSON.stringify(join(binDir, "..", "gh-uploads.log"))}`,
       "const args = process.argv.slice(2)",
+      // The finalizer's published-release guard: `gh release view <tag> --jq .isDraft`.
+      "if (args[0] === 'release' && args[1] === 'view') {",
+      "  process.stdout.write(`${releaseIsDraft}\\n`)",
+      "  process.exit(0)",
+      "}",
       "if (args[0] === 'release' && args[1] === 'download') {",
       "  if (downloadFailure) {",
       "    console.error(downloadFailure)",

--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -9,6 +9,7 @@ import {
   fetchText,
   normalizeTag,
   parseUpdaterFileUrls,
+  parseUpdaterShaByUrl,
   readStartupLogFile,
   releaseAssetNames,
   releaseUpdaterAssetNames,
@@ -510,5 +511,42 @@ path: pawwork-win-x64-2026.4.28.exe
     await expect(fetchJson("https://api.github.com/example")).rejects.toThrow(
       "Failed to parse JSON from https://api.github.com/example",
     )
+  })
+})
+
+describe("parseUpdaterShaByUrl", () => {
+  test("pairs each updater file with its content sha512, keyed by asset basename", () => {
+    const yml = [
+      "version: 2026.6.1",
+      "files:",
+      "  - url: pawwork-mac-arm64-2026.6.1.zip",
+      "    sha512: HASH_ARM64",
+      "    size: 123",
+      "  - url: pawwork-mac-x64-2026.6.1.zip",
+      "    sha512: HASH_X64",
+      "    size: 456",
+      "path: pawwork-mac-arm64-2026.6.1.zip",
+      "sha512: HASH_ARM64",
+      "releaseDate: '2026-06-01T00:00:00.000Z'",
+    ].join("\n")
+
+    expect(parseUpdaterShaByUrl(yml)).toEqual([
+      { name: "pawwork-mac-arm64-2026.6.1.zip", sha512: "HASH_ARM64" },
+      { name: "pawwork-mac-x64-2026.6.1.zip", sha512: "HASH_X64" },
+    ])
+  })
+
+  test("reduces a full download URL to its basename and ignores the trailing path digest", () => {
+    const yml = [
+      "files:",
+      "  - url: https://example.com/download/pawwork-win-x64-2026.6.1.exe",
+      "    sha512: HASH_WIN",
+      "path: pawwork-win-x64-2026.6.1.exe",
+      "sha512: HASH_WIN",
+    ].join("\n")
+
+    // The top-level `sha512:` after `path:` has no preceding `- url:` entry, so it
+    // is not emitted as a phantom hash.
+    expect(parseUpdaterShaByUrl(yml)).toEqual([{ name: "pawwork-win-x64-2026.6.1.exe", sha512: "HASH_WIN" }])
   })
 })

--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -230,6 +230,32 @@ path: pawwork-win-x64-2026.4.28.exe
     ).toContain("Release v2026.4.28 is still a draft")
   })
 
+  test("allowDraft suppresses the draft failure but keeps every other check", () => {
+    const latestYml = "files:\n  - url: pawwork-win-x64-2026.4.28.exe\n"
+    const latestMacYml = "files:\n  - url: pawwork-mac-arm64-2026.4.28.zip\n  - url: pawwork-mac-x64-2026.4.28.zip\n"
+
+    // A complete draft is fully accepted when drafts are allowed.
+    expect(
+      verifyReleasePayload({ release: { ...baseRelease, draft: true }, latestYml, latestMacYml }, { allowDraft: true }),
+    ).toEqual([])
+
+    // allowDraft does not loosen anything else: missing assets still fail.
+    const failures = verifyReleasePayload(
+      {
+        release: {
+          ...baseRelease,
+          draft: true,
+          assets: baseRelease.assets.filter((asset) => asset.name !== "pawwork-mac-arm64-2026.4.28.dmg"),
+        },
+        latestYml,
+        latestMacYml,
+      },
+      { allowDraft: true },
+    )
+    expect(failures).toContain("Missing release asset: pawwork-mac-arm64-2026.4.28.dmg")
+    expect(failures).not.toContain("Release v2026.4.28 is still a draft")
+  })
+
   test("reports prerelease releases", () => {
     expect(
       verifyReleasePayload({

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -8,10 +8,6 @@ export type GithubRelease = {
   tag_name: string
   draft: boolean
   prerelease: boolean
-  // The commit/branch the release points at. A fresh electron-builder draft
-  // carries the default branch name here; the auto-publisher pins it to the
-  // build commit. Optional because the verifier itself does not need it.
-  target_commitish?: string
   assets: GithubAsset[]
 }
 
@@ -49,6 +45,19 @@ export function releaseAssetNames(version: string) {
       "latest-mac.yml",
     ]),
   ]
+}
+
+// Per-target build-provenance marker. Each build target uploads one of these
+// (containing its build commit) so the auto-publisher can confirm every target
+// of a release was built from the same commit before publishing. One distinct
+// asset per target — never a shared mutable field — so concurrent targets cannot
+// race on it. Not part of releaseAssetNames, so the R2 mirror never copies them.
+export function releaseProvenanceAssetName(os: string, arch: string, version: string) {
+  return `pawwork-${os}-${arch}-${version}.commit`
+}
+
+export function releaseProvenanceAssetNames(version: string) {
+  return RELEASE_TARGETS.map((target) => releaseProvenanceAssetName(target.os, target.arch, version))
 }
 
 export function releaseUpdaterAssetNames(version: string): Record<MetadataFile, string[]> {

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -192,7 +192,7 @@ export function verifyStartupLog(source: string, expectedTag: string) {
   return failures
 }
 
-export function verifyReleasePayload(input: VerificationInput) {
+export function verifyReleasePayload(input: VerificationInput, options?: { allowDraft?: boolean }) {
   const failures: string[] = []
   const assetNames = new Set(input.release.assets.map((asset) => asset.name))
   let version: string | undefined
@@ -202,7 +202,7 @@ export function verifyReleasePayload(input: VerificationInput) {
     failures.push(error instanceof Error ? error.message : String(error))
   }
 
-  if (input.release.draft) failures.push(`Release ${input.release.tag_name} is still a draft`)
+  if (input.release.draft && !options?.allowDraft) failures.push(`Release ${input.release.tag_name} is still a draft`)
   if (input.release.prerelease) failures.push(`Release ${input.release.tag_name} is marked as a prerelease`)
 
   const latestUrls = input.latestYml === undefined ? [] : parseUpdaterFileUrls(input.latestYml)

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -91,6 +91,33 @@ export function parseUpdaterFileUrls(source: string) {
   return urls
 }
 
+// Pair each updater file entry with its content sha512, keyed by asset basename.
+// Used by the auto-publisher's single-source guard: a marker records the sha512
+// the target produced, and publishing requires it to still match the metadata —
+// so an asset rebuilt from another commit (different hash) is caught. Same
+// deliberately-narrow scanner as parseUpdaterFileUrls; ignores the top-level
+// `sha512:` (the `path:` digest), which has no preceding `- url:` entry.
+export function parseUpdaterShaByUrl(source: string): Array<{ name: string; sha512: string }> {
+  const entries: Array<{ name: string; sha512: string }> = []
+  let currentName: string | undefined
+
+  for (const line of source.split(/\r?\n/)) {
+    const fileMatch = line.match(/^\s*-\s+url:\s*(.+?)\s*$/)
+    if (fileMatch) {
+      currentName = assetNameFromUrl(parseYamlScalar(fileMatch[1]))
+      continue
+    }
+
+    const shaMatch = line.match(/^\s*sha512:\s*(.+?)\s*$/)
+    if (shaMatch && currentName) {
+      entries.push({ name: currentName, sha512: parseYamlScalar(shaMatch[1]) })
+      currentName = undefined
+    }
+  }
+
+  return entries
+}
+
 function parseYamlScalar(value: string) {
   const trimmed = stripInlineComment(value).trim()
   const quote = trimmed[0]

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -8,6 +8,10 @@ export type GithubRelease = {
   tag_name: string
   draft: boolean
   prerelease: boolean
+  // The commit/branch the release points at. A fresh electron-builder draft
+  // carries the default branch name here; the auto-publisher pins it to the
+  // build commit. Optional because the verifier itself does not need it.
+  target_commitish?: string
   assets: GithubAsset[]
 }
 

--- a/packages/opencode/test/github/build-workflow.test.ts
+++ b/packages/opencode/test/github/build-workflow.test.ts
@@ -128,7 +128,9 @@ describe("release workflow", () => {
       })
       expect(selectBuildTarget?.permissions).toBeUndefined()
       expect(createSnapshotTag?.permissions).toEqual({ contents: "write" })
-      expect(buildElectron?.permissions).toEqual({ actions: "read", contents: "write" })
+      // actions: write lets the tail publish step dispatch the R2 mirror via
+      // workflow_dispatch (GITHUB_TOKEN publishes fire no release:published).
+      expect(buildElectron?.permissions).toEqual({ actions: "write", contents: "write" })
       expect(cleanupSnapshotTag?.permissions).toEqual({ contents: "write" })
       expect(
         Object.entries(parsed.jobs ?? {})


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

Auto-publish the **prod** GitHub release once every target's installers and updater metadata have landed in the draft, then dispatch the R2 mirror — removing the manual "publish + pin tag + dispatch mirror" step at the end of every release.

- **`scripts/publish-when-complete.ts`** (new) — runs at the tail of each prod finalize/full target; the last target to complete flips the draft to published and dispatches the mirror.
- **Single-source guard** — per-target provenance markers, a content anchor, and a seal/re-read around the publish PATCH, so a release assembled from more than one commit is never published.
- **`scripts/verify-release.ts`** — an `allowDraft` seam plus provenance/`parseUpdaterShaByUrl` helpers.
- **`scripts/finalize-latest-yml.ts`** — refuses to overwrite the updater metadata of an already-published release.
- **`.github/workflows/build.yml`** — the tail publish step and `actions: write` on `build-electron`.

No related issue; this is a self-contained release-pipeline automation.

## Why

The pipeline leaves a **draft** GitHub release after every build and nothing flips it to published, so `mirror-release-to-r2.yml` (which triggers on `release: published`) never fires, and an operator has to manually publish the draft, pin the tag to the build commit, and dispatch the mirror.

The hard part is that one version's assets are assembled across **multiple, sometimes concurrent** `workflow_dispatch` runs (mac arm64 + x64 finalize, win full), each with its own source commit, and installers carry only the *version* (not the commit) in their names. So a naive "publish when the draft looks complete" could publish a release whose mac and win halves came from different commits. The guard below is designed to fail closed against that.

## Related Issue

None — self-contained automation of an existing manual release step. Rationale stated in Summary.

## Human Review Status

`Pending`

## Review Focus

1. **The single-source guard** in `publish-when-complete.ts` — whether a mixed-source publish is still reachable by the normal one-dispatch CI pipeline (vs. only by two concurrent same-version dispatches from different commits racing a single HTTP round-trip):
   - per-target marker `pawwork-<os>-<arch>-<version>.commit` holding `{commit, sha512[]}` (distinct cell per target → no claim race);
   - content anchor (every marker's recorded installer hash must still be in the current `latest*.yml`; empty record fails closed);
   - seal → settle → re-read → refuse-if-any-asset-URL-moved before the publish PATCH (the last write).
2. **`finalize-latest-yml.ts`** published-release guard (`gh release view --jq .isDraft` before the `gh release upload --clobber` loop).
3. **`GITHUB_TOKEN` permissions** — `actions: write` for the mirror `workflow_dispatch`; `contents: write` for marker upload/delete and the release PATCH.
4. **Draft-release API correctness** — drafts found via the **list** endpoint (they 404 on `GET /releases/tags/{tag}`), asset bytes via the asset API URL with `Accept: application/octet-stream`, marker upload via `upload_url`.

## Risk Notes

- **Permissions**: `build-electron` gains `actions: write` (to `gh workflow run` the mirror) and keeps `contents: write` (release PATCH + marker upload/delete). The opencode build-workflow contract test was updated to assert this.
- **Deletion behavior**: provenance markers are delete-then-recreate on overwrite; the publish PATCH flips `draft→false` and pins `target_commitish` to the build commit.
- **Platform / packaging / updater**: touches the macOS (arm64 + x64) and Windows (x64) release/updater flow. Installer assets themselves are protected from a later same-version build by electron-builder (`releaseType` defaults to `draft`, so it skips an already-published release); only `latest*.yml` needed the finalize guard.
- **Residual race**: GitHub offers no cross-asset compare-and-swap, so a mixed-source publish is reachable only by two same-version builds from different commits dispatched concurrently and landing a write in the single HTTP round-trip between a check and its write — not the normal one-dispatch pipeline (each version is built once, from one commit). Documented in the script header. Eliminating it entirely would require the commit in asset filenames (breaks the updater, mirror, and site links) or one orchestrated workflow.
- dev/beta are unaffected: gated to `channel == 'prod'`; dev has no publish config, beta lives in a separate repo.
- No visible UI or copy changed (the UI checklist item below is intentionally left unticked for that reason).

## How To Verify

```text
desktop-electron full suite (bun test):                464 pass, 0 fail
  incl. publish-when-complete.test.ts (decision policy: commit-mismatch,
        completeness, content-anchor drift, empty-marker fail-closed),
        verify-release.test.ts (allowDraft seam, parseUpdaterShaByUrl),
        release-metadata-contract.test.ts (finalizer published-release guard),
        release-workflow-contract.test.ts
opencode workflow contract tests (bun test test/github):  46 pass, 0 fail
  incl. build-workflow.test.ts (build-electron permissions = actions:write + contents:write)
bun run typecheck:                                      clean
bun run typecheck:release:                              clean
actionlint .github/workflows/build.yml:                 no new findings (only
  pre-existing SC2086/SC2046 on unrelated Apple-key/notarize steps)
```

End-to-end cannot be exercised without a real prod release; the script is written fail-closed (incomplete → no-op draft, ambiguous/mixed → fail), so the worst case is "stays a draft, publish manually", never "publishes something broken".

## Screenshots or Recordings

N/A — no visible UI or copy changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
