### PR TITLE
fix(session): exclude interrupted orphan tool parts from run-loop continuation

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -81,6 +81,13 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 const log = Log.create({ service: "session.prompt" })
 const elog = EffectLogger.create({ service: "session.prompt" })
 
+function isOrphanedInterruptedTool(part: MessageV2.ToolPart) {
+  // The interrupt cleanup marks abandoned tool calls as status:"error" with
+  // metadata.interrupted (see processor.ts / session.ts). They are not pending
+  // work, so they must not count as live tool calls and re-trigger the loop.
+  return part.state.status === "error" && part.state.metadata?.interrupted === true
+}
+
 export type TitleGenerationState = "not_started" | "in_flight" | "completed_before_abort" | "completed_after_abort"
 
 type TitleGenerationProgress = {
@@ -2000,11 +2007,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
           // Some providers return "stop" even when the assistant message contains tool calls.
-          // Keep the loop running so tool results can be sent back to the model.
-          // Skip provider-executed tool parts — those were fully handled within the
+          // Keep the loop running so tool results can be sent back to the model, but ignore
+          // cleanup-marked interrupted orphans — those are abandoned, not pending work.
+          // Skip provider-executed tool parts too — those were fully handled within the
           // provider's stream (e.g. DWS Agent Platform) and don't need a re-loop.
           const hasToolCalls =
-            lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
+            lastAssistantMsg?.parts.some(
+              (part) => part.type === "tool" && !part.metadata?.providerExecuted && !isOrphanedInterruptedTool(part),
+            ) ?? false
 
           if (
             lastAssistant?.finish &&
@@ -2032,6 +2042,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 })
                 continue
               }
+            }
+            const orphan = lastAssistantMsg?.parts.find(
+              (part): part is MessageV2.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
+            )
+            if (orphan) {
+              yield* slog.warn("loop exit with orphaned interrupted tool", {
+                messageID: lastAssistant.id,
+                tool: orphan.tool,
+                callID: orphan.callID,
+              })
             }
             yield* slog.info("exiting loop")
             break

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -8,6 +8,7 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, PartID } from "../../src/session/schema"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 
@@ -473,6 +474,122 @@ describe("session.prompt regression", () => {
               if (last?.info.role === "assistant") {
                 expect(last.info.error?.name).toBe("MessageAbortedError")
               }
+            }),
+          ),
+      })
+    } finally {
+      void server.stop(true)
+    }
+  })
+
+  test("loop exits without an LLM request for an interrupted orphan tool call", async () => {
+    let calls = 0
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) {
+          return new Response("not found", { status: 404 })
+        }
+        calls++
+        return new Response(chat("should never be requested"), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              const sessions = yield* Session.Service
+              const session = yield* sessions.create({ title: "Interrupted orphan" })
+              const model = { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") }
+
+              // A finished assistant turn (finish "stop") that still carries a tool part the
+              // interrupt cleanup marked status:"error" + metadata.interrupted — an orphan, not
+              // pending work. With no newer user message the loop must exit, not prefill the LLM.
+              const user = yield* sessions.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: session.id,
+                agent: "build",
+                model,
+                time: { created: Date.now() },
+              })
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: user.id,
+                sessionID: session.id,
+                type: "text",
+                text: "do something",
+              })
+
+              const assistant: MessageV2.Assistant = {
+                id: MessageID.ascending(),
+                role: "assistant",
+                sessionID: session.id,
+                parentID: user.id,
+                mode: "build",
+                agent: "build",
+                path: { cwd: tmp.path, root: tmp.path },
+                cost: 0,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                modelID: model.modelID,
+                providerID: model.providerID,
+                time: { created: Date.now() },
+                finish: "stop",
+              }
+              yield* sessions.updateMessage(assistant)
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: assistant.id,
+                sessionID: session.id,
+                type: "tool",
+                callID: "interrupted-call",
+                tool: "edit",
+                state: {
+                  status: "error",
+                  input: {},
+                  error: "Tool execution aborted",
+                  metadata: { interrupted: true },
+                  time: { start: 1, end: 2 },
+                },
+              })
+
+              const result = yield* prompt.loop({ sessionID: session.id })
+              expect(result.info.id).toBe(assistant.id)
+              expect(calls).toBe(0)
             }),
           ),
       })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -597,6 +597,137 @@ describe("session.prompt regression", () => {
       void server.stop(true)
     }
   })
+
+  test("loop still continues when an interrupted orphan coexists with a real tool call", async () => {
+    let calls = 0
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) {
+          return new Response("not found", { status: 404 })
+        }
+        calls++
+        return new Response(chat("continued"), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () =>
+          run(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              const sessions = yield* Session.Service
+              const session = yield* sessions.create({ title: "Orphan plus real tool" })
+              const model = { providerID: ProviderID.make("alibaba"), modelID: ModelID.make("qwen-plus") }
+
+              const user = yield* sessions.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: session.id,
+                agent: "build",
+                model,
+                time: { created: Date.now() },
+              })
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: user.id,
+                sessionID: session.id,
+                type: "text",
+                text: "do something",
+              })
+
+              const assistant: MessageV2.Assistant = {
+                id: MessageID.ascending(),
+                role: "assistant",
+                sessionID: session.id,
+                parentID: user.id,
+                mode: "build",
+                agent: "build",
+                path: { cwd: tmp.path, root: tmp.path },
+                cost: 0,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                modelID: model.modelID,
+                providerID: model.providerID,
+                time: { created: Date.now() },
+                finish: "stop",
+              }
+              yield* sessions.updateMessage(assistant)
+              // An interrupted orphan...
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: assistant.id,
+                sessionID: session.id,
+                type: "tool",
+                callID: "interrupted-call",
+                tool: "edit",
+                state: {
+                  status: "error",
+                  input: {},
+                  error: "Tool execution aborted",
+                  metadata: { interrupted: true },
+                  time: { start: 1, end: 2 },
+                },
+              })
+              // ...alongside a real, completed tool call. The real call must keep the
+              // loop alive, so the orphan exclusion must not suppress continuation.
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: assistant.id,
+                sessionID: session.id,
+                type: "tool",
+                callID: "real-call",
+                tool: "bash",
+                state: {
+                  status: "completed",
+                  input: {},
+                  output: "ok",
+                  title: "done",
+                  metadata: {},
+                  time: { start: 1, end: 2 },
+                },
+              })
+
+              yield* prompt.loop({ sessionID: session.id })
+              expect(calls).toBeGreaterThan(0)
+            }),
+          ),
+      })
+    } finally {
+      void server.stop(true)
+    }
+  })
 })
 
 describe("session.prompt agent variant", () => {


### PR DESCRIPTION
## Summary

The session run loop could fire an extra, wasteful LLM request after a tool call was interrupted. When the interrupt cleanup marks an abandoned tool part as `state.status: "error"` with `metadata.interrupted: true`, the loop's `hasToolCalls` check still counted it as a live tool call, so an assistant turn that finished with a non-`tool-calls` reason (e.g. `"stop"`) but still carried such an orphan kept `hasToolCalls = true`. That suppressed the `!hasToolCalls` loop-exit guard, so instead of stopping the loop did another assistant prefill request.

This excludes interrupted orphans from `hasToolCalls` (new `isOrphanedInterruptedTool` helper) and logs a diagnostic `warn` when the loop exits with one present.

No existing PawWork issue tracked this; it was found by mining `upstream`.

## Why

`packages/opencode/src/session/prompt.ts:2006` computed `hasToolCalls` as "any non-provider-executed tool part exists". The interrupt cleanup at `processor.ts:1097-1110` / `session.ts` independently stamps interrupted tool parts as `status: "error", metadata.interrupted: true`. An errored/interrupted tool is abandoned work, not a pending tool call awaiting a result, so it must not keep the loop alive — otherwise every interrupt that leaves a trailing non-`tool-calls` finish costs one needless model request.

## Related Issue

None. Semantic port of upstream `anomalyco/opencode` #26178 (`748fcb7ebd`) — thanks to André Cruz and Aiden Cline. `dev` and `upstream/dev` share no common ancestor, so this is a re-implementation adapted to PawWork's Zod `MessageV2` and the public `prompt.loop()`, not a cherry-pick.

## Human Review Status

Pending

## Review Focus

The `hasToolCalls` predicate change and the orphan-detection helper in `prompt.ts`. Confirm an interrupted orphan must not be treated as pending work, and that the exit-guard semantics are otherwise unchanged for normal tool-call turns.

## Risk Notes

Low. Pure narrowing of one loop-exit predicate; only affects sessions whose last assistant message carries an interrupted/errored tool part with no newer user message — exactly the case that previously caused an unwanted extra request. No schema, storage, or API surface changed.

Conditional checklist items left unticked:
- Visible UI/copy: none changed (engine-only).
- macOS/Windows platform surface: none touched.
- Docs/release-notes/deps/permissions/credentials: none touched.

## How To Verify

```text
bun test test/session/prompt.test.ts -t "interrupted orphan"
  - before fix: FAIL — loop made an extra request and returned a newly-created assistant message
  - after fix:  PASS — 1 pass, 2 expect() calls; loop returns the seeded assistant, 0 LLM requests
bun test test/session/prompt.test.ts   -> 12 pass, 0 fail (11 existing + 1 new regression)
bun run typecheck (tsgo --noEmit, packages/opencode) -> clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. (Confirm bot choice after open.)
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. (Confirm bot suggestion after open.)
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
