### PR TITLE
fix(provider): tolerate invalid config small_model in getSmallModel

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1708,7 +1708,14 @@ const layer: Layer.Layer<
 
       if (cfg.small_model) {
         const parsed = parseModel(cfg.small_model)
-        return yield* getModel(parsed.providerID, parsed.modelID)
+        // getModel throws ModelNotFoundError as a defect (Effect.fn), so an invalid
+        // small_model would crash title/summary gen. Swallow only that defect and fall
+        // back to undefined; re-die anything else.
+        return yield* getModel(parsed.providerID, parsed.modelID).pipe(
+          Effect.catchDefect((defect) =>
+            ModelNotFoundError.isInstance(defect) ? Effect.succeed(undefined) : Effect.die(defect),
+          ),
+        )
       }
 
       const s = yield* currentState()

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1207,6 +1207,29 @@ test("getSmallModel respects config small_model override", async () => {
   })
 })
 
+test("getSmallModel ignores invalid config small_model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          small_model: "anthropic/not-a-real-model",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      expect(await getSmallModel(ProviderID.anthropic)).toBeUndefined()
+    },
+  })
+})
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },


### PR DESCRIPTION
## Summary

An invalid or stale `config.small_model` (a typo, or a model that no longer exists) crashed title/summary generation instead of falling back to the provider's default small model.

`getSmallModel` resolves the configured override via `getModel`, which throws `ModelNotFoundError` **as an Effect defect** (the `throw` lives inside an `Effect.fn` generator). So a bad config value surfaced as an uncaught defect that took down title/summary gen, rather than degrading gracefully.

## Fix

Wrap only the config-override `getModel` call with `Effect.catchDefect`, swallow the defect **only** when `ModelNotFoundError.isInstance(defect)` and fall back to `undefined` (the caller then picks a default); re-die any other defect so unrelated failures still surface.

The priority-loop `getModel` calls below are intentionally left untouched — they resolve catalog-derived model IDs, not user-supplied config.

## PawWork gap vs upstream

Adapted from upstream `anomalyco/opencode` `9818c9e8d0` (PR #27405 — thanks Kit Langton). Upstream uses `Effect.catchTag("ProviderModelNotFoundError", ...)`, but PawWork's `getModel` throws the error as a **defect** rather than a typed failure, so `catchTag` would silently miss it. `catchDefect` + `ModelNotFoundError.isInstance` is the correct equivalent here (same pattern already used in `automation/validation.ts`).

`dev` and `upstream/dev` have no common ancestor; this is a re-implementation, not a cherry-pick.

## Test

Added `getSmallModel ignores invalid config small_model` (regression). Proven red → green: without the fix it throws `ProviderModelNotFoundError`; with the fix it returns `undefined`.

## Verification

- `bun test test/provider/provider.test.ts` — 96 pass, 0 fail
- `bun run typecheck` — clean
