### PR TITLE
fix(config): tolerate invalid OPENCODE_PERMISSION JSON

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -29,7 +29,7 @@ export namespace Flag {
   export const OPENCODE_DISABLE_PRUNE = truthy("OPENCODE_DISABLE_PRUNE")
   export const OPENCODE_DISABLE_TERMINAL_TITLE = truthy("OPENCODE_DISABLE_TERMINAL_TITLE")
   export const OPENCODE_SHOW_TTFD = truthy("OPENCODE_SHOW_TTFD")
-  export const OPENCODE_PERMISSION = process.env["OPENCODE_PERMISSION"]
+  export declare const OPENCODE_PERMISSION: string | undefined
   export const OPENCODE_DISABLE_DEFAULT_PLUGINS = truthy("OPENCODE_DISABLE_DEFAULT_PLUGINS")
   export const OPENCODE_DISABLE_LSP_DOWNLOAD = truthy("OPENCODE_DISABLE_LSP_DOWNLOAD")
   export const OPENCODE_ENABLE_EXPERIMENTAL_MODELS = truthy("OPENCODE_ENABLE_EXPERIMENTAL_MODELS")
@@ -153,6 +153,17 @@ Object.defineProperty(Flag, "OPENCODE_PURE", {
 Object.defineProperty(Flag, "OPENCODE_PLUGIN_META_FILE", {
   get() {
     return process.env["OPENCODE_PLUGIN_META_FILE"]
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_PERMISSION
+// This must be evaluated at access time, not module load time,
+// because tests and external tooling may set this env var at runtime
+Object.defineProperty(Flag, "OPENCODE_PERMISSION", {
+  get() {
+    return process.env["OPENCODE_PERMISSION"]
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1059,7 +1059,11 @@ const rawLayer = Layer.effect(
         }
 
         if (Flag.OPENCODE_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.OPENCODE_PERMISSION))
+          try {
+            result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.OPENCODE_PERMISSION))
+          } catch (err) {
+            log.warn("OPENCODE_PERMISSION contains invalid JSON, skipping", { err })
+          }
         }
 
         if (result.tools) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -3176,3 +3176,26 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+// Regression for #28388: malformed OPENCODE_PERMISSION JSON used to crash
+// config load on startup with an unhandled SyntaxError. Loading the config
+// with an invalid JSON value in this env var should warn and skip, not throw.
+describe("OPENCODE_PERMISSION env var", () => {
+  test("does not crash when OPENCODE_PERMISSION contains invalid JSON", async () => {
+    const original = process.env["OPENCODE_PERMISSION"]
+    process.env["OPENCODE_PERMISSION"] = "{invalid"
+    try {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await load()
+          expect(config).toBeDefined()
+        },
+      })
+    } finally {
+      if (original === undefined) delete process.env["OPENCODE_PERMISSION"]
+      else process.env["OPENCODE_PERMISSION"] = original
+    }
+  })
+})


### PR DESCRIPTION
## Summary

A malformed JSON value in the `OPENCODE_PERMISSION` env var threw an unhandled `SyntaxError` during config load, crashing startup. This wraps the `JSON.parse` in a `try/catch` and `log.warn`, skipping the bad override instead of crashing.

The env override was read once at module load (eager `const`), so a value set at runtime was invisible to the loader and untestable. `Flag.OPENCODE_PERMISSION` is now an access-time getter, matching the other runtime flags in `flag.ts`, so external tooling and tests observe the current value.

## Why

`packages/opencode/src/config/config.ts:1061-1063` called `JSON.parse(Flag.OPENCODE_PERMISSION)` with no guard. Any user or launcher that exports a malformed `OPENCODE_PERMISSION` (truncated JSON, shell-mangled quoting) crashes the app before it can start. The permission override is a convenience input, not a hard requirement, so a bad value should warn and be skipped.

## Related Issue

No PawWork issue. Reimplemented for PawWork from upstream `anomalyco/opencode` `c035c35eba` (PR #28388, thanks Kit Langton). The fork has no common ancestor with upstream, so this is an adapted port, not a cherry-pick.

## Human Review Status

Pending

## Review Focus

The `flag.ts` change converts `OPENCODE_PERMISSION` from an eager `const` to an access-time getter. It is read in exactly one place (`config.ts:1061-1062`); confirm that timing change is harmless (in production the env var is set before launch, so the observed value is identical).

## Risk Notes

Low. The `try/catch` only changes behavior on invalid JSON (previously a crash). The getter conversion mirrors the existing `OPENCODE_DISABLE_PROJECT_CONFIG` / `OPENCODE_PURE` pattern and the flag has a single reader. No platform/packaging/UI surface touched.

## How To Verify

```text
Targeted test (with fix): bun test test/config/config.test.ts -t "OPENCODE_PERMISSION" -> 1 pass
Red proof (fix reverted, getter kept): same test -> 1 fail with SyntaxError at config.ts:1062 (test exercises the crash path)
Full file regression: bun test test/config/config.test.ts -> 105 pass, 0 fail
Typecheck: packages/core bun run typecheck -> clean; packages/opencode bun run typecheck -> clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
