### PR TITLE
fix(opencode): dedupe concurrent Codex OAuth token refreshes

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -136,6 +136,11 @@ interface TokenResponse {
   expires_in?: number
 }
 
+interface CodexAuthPluginOptions {
+  issuer?: string
+  codexApiEndpoint?: string
+}
+
 function proxyEnvSummary() {
   return {
     HTTP_PROXY: Boolean(process.env.HTTP_PROXY || process.env.http_proxy),
@@ -201,8 +206,8 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
   return response.json()
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
+async function refreshAccessToken(refreshToken: string, issuer = ISSUER): Promise<TokenResponse> {
+  const response = await fetch(`${issuer}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -434,7 +439,10 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
   })
 }
 
-export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
+export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPluginOptions = {}): Promise<Hooks> {
+  const issuer = options.issuer ?? ISSUER
+  const codexApiEndpoint = options.codexApiEndpoint ?? CODEX_API_ENDPOINT
+
   return {
     provider: {
       id: "openai",
@@ -472,6 +480,13 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
+        let refreshPromise:
+          | Promise<{
+              access: string
+              accountId: string | undefined
+            }>
+          | undefined
+
         return {
           apiKey: OAUTH_DUMMY_KEY,
           async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
@@ -496,21 +511,37 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
 
             // Check if token needs refresh
             if (!currentAuth.access || currentAuth.expires < Date.now()) {
-              log.info("refreshing codex access token")
-              const tokens = await refreshAccessToken(currentAuth.refresh)
-              const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
-              await input.client.auth.set({
-                path: { id: "openai" },
-                body: {
-                  type: "oauth",
-                  refresh: tokens.refresh_token,
-                  access: tokens.access_token,
-                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                  ...(newAccountId && { accountId: newAccountId }),
-                },
-              })
-              currentAuth.access = tokens.access_token
-              authWithAccount.accountId = newAccountId
+              // Dedupe concurrent refreshes: the OAuth server rotates the refresh token on
+              // first use, so a second concurrent refresh would hit invalid_grant and could
+              // clobber the freshly stored auth. Share one in-flight refresh across fetches.
+              if (!refreshPromise) {
+                log.info("refreshing codex access token")
+                refreshPromise = refreshAccessToken(currentAuth.refresh, issuer)
+                  .then(async (tokens) => {
+                    const accountId = extractAccountId(tokens) || authWithAccount.accountId
+                    await input.client.auth.set({
+                      path: { id: "openai" },
+                      body: {
+                        type: "oauth",
+                        refresh: tokens.refresh_token,
+                        access: tokens.access_token,
+                        expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                        ...(accountId && { accountId }),
+                      },
+                    })
+                    return {
+                      access: tokens.access_token,
+                      accountId,
+                    }
+                  })
+                  .finally(() => {
+                    refreshPromise = undefined
+                  })
+              }
+
+              const refreshed = await refreshPromise
+              currentAuth.access = refreshed.access
+              authWithAccount.accountId = refreshed.accountId
             }
 
             // Build headers
@@ -544,7 +575,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                 : new URL(typeof requestInput === "string" ? requestInput : requestInput.url)
             const url =
               parsed.pathname.includes("/v1/responses") || parsed.pathname.includes("/chat/completions")
-                ? new URL(CODEX_API_ENDPOINT)
+                ? new URL(codexApiEndpoint)
                 : parsed
 
             return fetch(url, {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -246,6 +246,101 @@ describe("plugin.codex", () => {
         cache: { read: 0, write: 0 },
       })
     })
+
+    test("deduplicates concurrent Codex token refreshes", async () => {
+      let auth = {
+        type: "oauth" as const,
+        refresh: "refresh-old",
+        access: "",
+        expires: 0,
+      }
+      const authUpdates: Array<{
+        body: { refresh: string; access: string; expires: number; accountId?: string }
+      }> = []
+      let resolveRefresh: (() => void) | undefined
+      const refreshReady = new Promise<void>((resolve) => {
+        resolveRefresh = resolve
+      })
+      let refreshRequests = 0
+      const apiRequests: { authorization: string | null; accountId: string | null }[] = []
+
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/oauth/token") {
+            expect(await request.text()).toContain("refresh_token=refresh-old")
+            refreshRequests += 1
+            await refreshReady
+            return Response.json({
+              id_token: createTestJwt({ chatgpt_account_id: "acc-123" }),
+              access_token: "access-new",
+              refresh_token: "refresh-new",
+              expires_in: 3600,
+            })
+          }
+
+          if (url.pathname === "/backend-api/codex/responses") {
+            apiRequests.push({
+              authorization: request.headers.get("authorization"),
+              accountId: request.headers.get("ChatGPT-Account-Id"),
+            })
+            return new Response("{}", { status: 200 })
+          }
+
+          return new Response("unexpected request", { status: 500 })
+        },
+      })
+
+      const hooks = await CodexAuthPlugin(
+        {
+          client: {
+            auth: {
+              async set(input: { body: { refresh: string; access: string; expires: number; accountId?: string } }) {
+                authUpdates.push(input)
+                auth = {
+                  type: "oauth",
+                  refresh: input.body.refresh,
+                  access: input.body.access,
+                  expires: input.body.expires,
+                  ...(input.body.accountId && { accountId: input.body.accountId }),
+                }
+              },
+            },
+          },
+          project: {} as never,
+          directory: "",
+          worktree: "",
+          experimental_workspace: {
+            register() {},
+          },
+        } as never,
+        {
+          issuer: server.url.origin,
+          codexApiEndpoint: new URL("/backend-api/codex/responses", server.url).toString(),
+        },
+      )
+      const loaded = await hooks.auth!.loader!(async () => auth as never, {} as never)
+
+      const first = loaded.fetch!("https://api.openai.com/v1/responses")
+      const second = loaded.fetch!("https://api.openai.com/v1/responses")
+
+      await waitFor(() => refreshRequests === 1)
+      expect(apiRequests).toHaveLength(0)
+
+      resolveRefresh!()
+      await Promise.all([first, second])
+
+      expect(refreshRequests).toBe(1)
+      expect(authUpdates).toHaveLength(1)
+      expect(authUpdates[0]?.body.refresh).toBe("refresh-new")
+      expect(authUpdates[0]?.body.access).toBe("access-new")
+      expect(authUpdates[0]?.body.accountId).toBe("acc-123")
+      expect(apiRequests).toEqual([
+        { authorization: "Bearer access-new", accountId: "acc-123" },
+        { authorization: "Bearer access-new", accountId: "acc-123" },
+      ])
+    })
   })
 
   describe("formatOAuthFailure", () => {
@@ -289,3 +384,11 @@ describe("plugin.codex", () => {
     })
   })
 })
+
+async function waitFor(predicate: () => boolean) {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > 1_000) throw new Error("timed out waiting for condition")
+    await new Promise((resolve) => setTimeout(resolve, 1))
+  }
+}


### PR DESCRIPTION
## Summary

Dedupe concurrent Codex OAuth token refreshes in the auth loader.

When a Codex OAuth access token is expired, every concurrent request flowing through the loader's `fetch` independently called `refreshAccessToken` + `client.auth.set`. Now a single loader-scoped in-flight `refreshPromise` is shared across concurrent fetches and cleared in `.finally`, so all in-flight requests reuse one refresh and a later expiry refreshes again.

A test-only `issuer` / `codexApiEndpoint` option is threaded through `CodexAuthPlugin` so the regression test can point the refresh and Codex endpoints at a local `Bun.serve`. Production callers pass no options and keep the existing constants.

## Why

The OAuth server rotates the refresh token on first use. With two concurrent refreshes, the second one sends the already-rotated refresh token, hits `invalid_grant`, and can clobber the freshly stored auth — surfacing as intermittent Codex OAuth failures. PawWork's `plugin/codex.ts` was byte-identical to upstream's pre-fix code with no in-flight dedup.

This re-implements upstream `anomalyco/opencode` PR #28236 (`c64ac905e1`) against PawWork's diverged `plugin/codex.ts`. `dev` and `upstream/dev` share no common ancestor, so this is a semantic port, not a cherry-pick. Thanks to the upstream authors.

## Related Issue

No local issue; ported from upstream PR #28236.

## Human Review Status

Pending

## Review Focus

The dedup closure: the shared `refreshPromise` does the `auth.set` once and returns `{ access, accountId }`; concurrent fetches await it and apply the result to their own `currentAuth`. Confirm the `.finally` reset cannot strand a permanently-set promise, and that a refresh failure rejects all awaiters (it does — the rejected promise is shared and `.finally` clears it for the next attempt).

## Risk Notes

Low. Closure-local promise, no public API change. The new `issuer`/`codexApiEndpoint` plugin option is optional and test-only; production behavior is unchanged (defaults to `ISSUER` / `CODEX_API_ENDPOINT`). No platform/packaging/UI surface touched.

## How To Verify

```text
bun test test/plugin/codex.test.ts → 22 pass / 0 fail (includes new "deduplicates concurrent Codex token refreshes")
Red proof: reverted only the dedup block → new test fails with refreshRequests Expected 1, Received 2
bun run typecheck (packages/opencode) → clean, no errors
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

