### PR TITLE
fix(mcp): tolerate unresolvable tool output-schema $refs

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -6,6 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
+  ToolSchema,
   type Tool as MCPToolDef,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -165,12 +166,55 @@ export namespace MCP {
     })
   }
 
-  function defs(key: string, client: MCPClient, timeout?: number) {
+  // Some MCP servers (e.g. Google Stitch) ship tool output schemas with $refs the
+  // SDK can't resolve, so the strict listTools() decode throws. Re-list with output
+  // schema validation relaxed instead of marking the whole server failed.
+  const TolerantToolSchema = ToolSchema.extend({
+    outputSchema: z.unknown().optional(),
+  })
+
+  const TolerantListToolsResultSchema = z.looseObject({
+    tools: z.array(TolerantToolSchema),
+    nextCursor: z.string().optional(),
+  })
+
+  function isOutputSchemaValidationError(error: Error) {
+    return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
+      error.message,
+    )
+  }
+
+  function listTools(key: string, client: MCPClient, timeout: number) {
     return Effect.tryPromise({
-      try: () => withTimeout(client.listTools(), timeout ?? DEFAULT_TIMEOUT),
+      try: () => withTimeout(client.listTools(), timeout),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(
       Effect.map((result) => result.tools),
+      Effect.catch((error) => {
+        if (!isOutputSchemaValidationError(error)) return Effect.fail(error)
+
+        log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", {
+          key,
+          error,
+        })
+        return Effect.tryPromise({
+          try: () => withTimeout(client.request({ method: "tools/list" }, TolerantListToolsResultSchema), timeout),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.map((result) =>
+            result.tools.map((tool) => ({
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+            })),
+          ),
+        )
+      }),
+    )
+  }
+
+  function defs(key: string, client: MCPClient, timeout?: number) {
+    return listTools(key, client, timeout ?? DEFAULT_TIMEOUT).pipe(
       Effect.catch((err) => {
         log.error("failed to get tools from client", { key, error: err })
         return Effect.succeed(undefined)

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -4,8 +4,9 @@ import { test, expect, mock, beforeEach } from "bun:test"
 
 // Per-client state for controlling mock behavior
 interface MockClientState {
-  tools: Array<{ name: string; description?: string; inputSchema: object }>
+  tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
   listToolsCalls: number
+  requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
   listPromptsShouldFail: boolean
@@ -33,6 +34,7 @@ function getOrCreateClientState(name?: string): MockClientState {
     state = {
       tools: [{ name: "test_tool", description: "A test tool", inputSchema: { type: "object", properties: {} } }],
       listToolsCalls: 0,
+      requestCalls: 0,
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
       listPromptsShouldFail: false,
@@ -131,6 +133,12 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
         throw new Error(this._state.listToolsError)
       }
       return { tools: this._state?.tools ?? [] }
+    }
+
+    async request(request: { method: string }, schema: { parse: (value: unknown) => unknown }) {
+      if (this._state) this._state.requestCalls++
+      if (request.method === "tools/list") return schema.parse({ tools: this._state?.tools ?? [] })
+      throw new Error(`unsupported request: ${request.method}`)
     }
 
     async listPrompts() {
@@ -410,6 +418,61 @@ test(
       expect(Object.keys(tools).some((k) => k.includes("good_tool"))).toBe(true)
     },
   ),
+)
+
+// ========================================================================
+// Test: tolerate output-schema $ref failures (#26614)
+// ========================================================================
+
+test(
+  "falls back when MCP output schema refs fail SDK tool discovery",
+  withInstance({}, async () => {
+    lastCreatedClientName = "stitch-like-server"
+    const serverState = getOrCreateClientState("stitch-like-server")
+    serverState.listToolsShouldFail = true
+    serverState.listToolsError = "can't resolve reference #/$defs/ScreenInstance from id #"
+    serverState.tools = [
+      {
+        name: "render_screen",
+        description: "renders a screen",
+        inputSchema: { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] },
+        outputSchema: { type: "object", properties: { screen: { $ref: "#/$defs/ScreenInstance" } } },
+      },
+    ]
+
+    const addResult = await MCP.add("stitch-like-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    const serverStatus = (addResult.status as any)["stitch-like-server"] ?? addResult.status
+    expect(serverStatus.status).toBe("connected")
+
+    const tools = await MCP.tools()
+    expect(Object.keys(tools).some((key) => key.includes("render_screen"))).toBe(true)
+    expect(serverState.listToolsCalls).toBe(1)
+    expect(serverState.requestCalls).toBe(1)
+  }),
+)
+
+test(
+  "does not fall back for non-schema MCP tool discovery errors",
+  withInstance({}, async () => {
+    lastCreatedClientName = "broken-server"
+    const serverState = getOrCreateClientState("broken-server")
+    serverState.listToolsShouldFail = true
+    serverState.listToolsError = "transport closed"
+
+    const addResult = await MCP.add("broken-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    const serverStatus = (addResult.status as any)["broken-server"] ?? addResult.status
+    expect(serverStatus.status).toBe("failed")
+    expect(serverState.listToolsCalls).toBe(1)
+    expect(serverState.requestCalls).toBe(0)
+  }),
 )
 
 // ========================================================================


### PR DESCRIPTION
## Summary

When an MCP server advertises a tool whose `outputSchema` contains a `$ref` the SDK cannot resolve, the strict `listTools()` decode throws. `defs()` then returned `undefined`, the create flow closed the client, and the entire server was marked `failed` with zero tools — even when every other tool was valid.

This adds a fallback: on a schema-validation error, re-list tools via a raw `tools/list` request with output-schema validation relaxed (`TolerantListToolsResultSchema`), keeping only `name`/`description`/`inputSchema`. Genuine non-schema failures (e.g. transport closed) still fail exactly as before.

## Why

Google Stitch and similar MCP servers ship `outputSchema` entries like `{ "screen": { "$ref": "#/$defs/ScreenInstance" } }`. PawWork's `defs()` at `mcp/index.ts` is byte-identical to upstream's pre-fix version: a single strict `listTools()` whose failure collapses the whole server to `failed`. The result is a confusing "MCP server failed / no tools" with no usable tools for an otherwise-healthy server.

## Related Issue

No PawWork issue. Re-implemented from upstream `anomalyco/opencode` `79d6b10d7c` (PR #26614, thanks @kitlangton). `dev` and `upstream/dev` have no common ancestor, so this is a semantic re-implementation, not a cherry-pick — adapted to PawWork's `withTimeout`-based `listTools` and `zod/v4` schemas. Scope matches upstream's `index.ts` change exactly (the upstream `callbackPort`-style features are unrelated and not present here).

## Human Review Status

Pending

## Review Focus

- The validation-error guard regex breadth (`isOutputSchemaValidationError`). Over-matching is low-risk: a wrongly-triggered fallback just attempts one extra `tools/list` request that, if the underlying failure is genuine, also fails and falls through to the same `failed` status — it can never mask a real failure, because `TolerantToolSchema` still validates `inputSchema` strictly.
- Type compatibility of the fallback-mapped `{ name, description, inputSchema }` with `MCPToolDef` consumers (`convertMcpTool` reads only those three fields).

## Risk Notes

Low. New code path runs only when the first `listTools()` throws a schema-shaped error. Local-only engine change, no platform/packaging/UI surface touched. None of the conditional checklist items apply (no UI/copy, no platform surface, no docs/deps/credentials).

## How To Verify

\`\`\`text
bun test test/mcp/lifecycle.test.ts  → 21 pass / 0 fail (incl. 2 new: fallback path + non-schema-error path)
bun test test/mcp/                   → 36 pass / 0 fail
bun run typecheck (packages/opencode) → clean
\`\`\`

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.