### PR TITLE
fix(config): fall back to "user" when os.userInfo() is unavailable

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1079,7 +1079,14 @@ const rawLayer = Layer.effect(
           result.permission = mergeDeep(perms, result.permission ?? {})
         }
 
-        if (!result.username) result.username = os.userInfo().username
+        if (!result.username) {
+          try {
+            result.username = os.userInfo().username || "user"
+          } catch (err) {
+            log.warn("failed to read system username, using fallback", { err })
+            result.username = "user"
+          }
+        }
 
         if (result.autoshare === true && !result.share) {
           result.share = "auto"

--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -55,7 +55,14 @@ export function parseManagedPlist(json: string): string {
 export async function readManagedPreferences() {
   if (process.platform !== "darwin") return
 
-  const user = os.userInfo().username
+  const user = (() => {
+    try {
+      return os.userInfo().username || "user"
+    } catch (err) {
+      log.warn("failed to read system username, using fallback", { err })
+      return "user"
+    }
+  })()
   const domain = managedPlistDomain()
   const paths = [
     path.join("/Library/Managed Preferences", user, `${domain}.plist`),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -24,6 +24,7 @@ const infra = CrossSpawnSpawner.defaultLayer.pipe(
 )
 import path from "path"
 import fs from "fs/promises"
+import os from "os"
 import { pathToFileURL } from "url"
 import { Global } from "../../src/global"
 import { ProjectID } from "../../src/project/schema"
@@ -3196,6 +3197,46 @@ describe("OPENCODE_PERMISSION env var", () => {
     } finally {
       if (original === undefined) delete process.env["OPENCODE_PERMISSION"]
       else process.env["OPENCODE_PERMISSION"] = original
+    }
+  })
+})
+
+// Regression for #29332: os.userInfo() can throw on minimal hosts with no
+// passwd entry (e.g. some containers), which used to crash config load.
+// The loader should fall back to a generic "user" instead of throwing.
+describe("system username fallback", () => {
+  test("falls back to 'user' when os.userInfo() throws", async () => {
+    const userInfo = spyOn(os, "userInfo").mockImplementation(() => {
+      throw Object.assign(new Error("missing passwd entry"), { code: "ENOENT" })
+    })
+    try {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.username).toBe("user")
+        },
+      })
+    } finally {
+      userInfo.mockRestore()
+    }
+  })
+
+  test("readManagedPreferences does not throw when os.userInfo() throws on darwin", async () => {
+    const originalPlatform = process.platform
+    const userInfo = spyOn(os, "userInfo").mockImplementation(() => {
+      throw Object.assign(new Error("missing passwd entry"), { code: "ENOENT" })
+    })
+    Object.defineProperty(process, "platform", { value: "darwin" })
+    try {
+      // The macOS managed-preferences paths do not exist on CI hosts, so the
+      // lookup returns undefined; the regression is that the username fallback
+      // must not let os.userInfo() throw out of readManagedPreferences().
+      await expect(ConfigManaged.readManagedPreferences()).resolves.toBeUndefined()
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform })
+      userInfo.mockRestore()
     }
   })
 })


### PR DESCRIPTION
## Summary

`os.userInfo()` throws a `SystemError` on minimal hosts that have no matching passwd entry (some containers, locked-down service accounts). Two config-load call sites called it unguarded, so a process started without a resolvable system user crashed during config load. This guards both with `try/catch`, falls back to the generic `"user"`, and also coerces an empty username to `"user"`.

## Why

- `packages/opencode/src/config/config.ts:1082` — `if (!result.username) result.username = os.userInfo().username` (unguarded; runs on every platform).
- `packages/opencode/src/config/managed.ts:58` — `const user = os.userInfo().username` (unguarded; macOS managed-preferences lookup).

Either throw aborts config load with an unhandled `SystemError`. The system username is a convenience default, not a hard requirement, so an unavailable user should degrade to a generic value rather than crash startup.

## Related Issue

No PawWork issue. Reimplemented for PawWork from upstream `anomalyco/opencode` `b5632ea700` (PR #29332, thanks Shoubhit Dash). The fork has no common ancestor with upstream, so this is an adapted port, not a cherry-pick.

## Human Review Status

Pending

## Review Focus

The two guards mirror upstream exactly. The `config.ts` guard is cross-platform; the `managed.ts` guard is darwin-only (`readManagedPreferences` returns early off macOS). Confirm the fallback value `"user"` is acceptable for both the config username default and the macOS managed-preferences path lookup.

## Risk Notes

Low. Behavior changes only when `os.userInfo()` throws or returns an empty username (previously a crash). No platform/packaging/UI surface touched. Both `log` and `os` were already in scope at both sites.

## How To Verify

```text
Targeted test (with fix): bun test test/config/config.test.ts -t "system username fallback" -> 1 pass
Red proof (config.ts guard reverted): same test -> 1 fail (SystemError thrown at config.ts:1082; test exercises the crash path)
Full file regression: bun test test/config/config.test.ts -> 106 pass, 0 fail
Typecheck: packages/opencode bun run typecheck -> clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced application startup stability through improved error handling for system username detection. When system username information is unavailable—common in containerized and minimal environments—the application now gracefully falls back to a default value instead of encountering initialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->