### PR TITLE
fix(provider): isolate plugin hook mutations from internal provider state

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -950,6 +950,19 @@ export const ConfigProvidersResult = Schema.Struct({
 export type ConfigProvidersResult = Types.DeepMutable<Schema.Schema.Type<typeof ConfigProvidersResult>>
 export type Language = LanguageModelV3
 
+// JSON-safe deep clone for handing provider Info to plugin hooks, so a plugin
+// mutating its argument cannot corrupt internal provider state. Drops functions,
+// symbols and undefined; stringifies bigint. Info is plain-data, so it round-trips.
+export function toPublicInfo(provider: Info): Info {
+  return JSON.parse(
+    JSON.stringify(provider, (_, value) => {
+      if (typeof value === "function" || typeof value === "symbol" || value === undefined) return undefined
+      if (typeof value === "bigint") return value.toString()
+      return value
+    }),
+  )
+}
+
 export function defaultModelID<T extends { id?: string; models: Record<string, { id: string }> }>(
   provider: T,
   fallbackID?: string,
@@ -1195,7 +1208,7 @@ const layer: Layer.Layer<
             }
 
             provider.models = yield* Effect.promise(async () => {
-              const next = await models(provider, { auth: pluginAuth })
+              const next = await models(toPublicInfo(provider), { auth: pluginAuth })
               return Object.fromEntries(
                 Object.entries(next).map(([id, model]) => [
                   id,
@@ -1352,10 +1365,11 @@ const layer: Layer.Layer<
           if (!stored) continue
           if (!plugin.auth.loader) continue
 
+          const authProvider = database[plugin.auth!.provider]
           const options = yield* Effect.promise(() =>
             plugin.auth!.loader!(
               () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
-              database[plugin.auth!.provider],
+              authProvider ? toPublicInfo(authProvider) : authProvider,
             ),
           )
           const opts = options ?? {}

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1230,6 +1230,49 @@ test("getSmallModel ignores invalid config small_model", async () => {
   })
 })
 
+test("plugin provider.models hook cannot mutate internal provider state", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const pluginDir = path.join(dir, ".opencode", "plugin")
+      await mkdir(pluginDir, { recursive: true })
+      await Bun.write(
+        path.join(pluginDir, "provider-models-mutation.ts"),
+        [
+          "export default {",
+          '  id: "test.provider-models-mutation",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "anthropic",',
+          "      models: async (provider) => {",
+          '        provider.name = "mutated-by-plugin"',
+          "        provider.options = { ...provider.options, mutatedByPlugin: true }",
+          "        return provider.models ?? {}",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const anthropic = await getProvider(ProviderID.anthropic)
+      // The hook mutated its argument; with a deep-cloned input that must not leak
+      // into internal provider state.
+      expect(anthropic.name).not.toBe("mutated-by-plugin")
+      expect((anthropic.options as Record<string, unknown> | undefined)?.mutatedByPlugin).not.toBe(true)
+      // Models still resolve normally after the hook runs.
+      expect(Object.keys(anthropic.models).length).toBeGreaterThan(0)
+    },
+  })
+}, 30000)
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },


### PR DESCRIPTION
## Summary

Plugin `provider.models()` hooks were handed the **live internal `provider` Info object**. A plugin that mutates its argument (e.g. `provider.name`, `provider.options`, or model fields) corrupted the provider state the rest of the engine reads — the final provider returned by `getProvider`/`list` is built from that same object via `mergeDeep`, so the mutation leaks straight through.

## Fix

Add a `toPublicInfo()` JSON-safe deep clone (drops functions/symbols/undefined, stringifies bigint; `Info` is plain-data so it round-trips) and pass the clone into **both** plugin entry points that expose the internal `Info`:

1. the `provider.models()` hook (`models(toPublicInfo(provider), …)`), and
2. the plugin auth `loader` (`toPublicInfo(authProvider)`).

The auth-loader site keeps its existing nullable behavior — it clones only when the provider is present, because in PawWork `database[plugin.auth.provider]` can be `undefined` there and `toPublicInfo(undefined)` would throw. The `models()` site is already guarded (`if (!provider) continue`), so it clones unconditionally.

## PawWork gap vs upstream

Adapted from upstream `anomalyco/opencode` `5e49029e70` (PR #26561 — thanks Kit Langton). Upstream already had `toPublicInfo` and applied it to the `models()` hook; PawWork had **neither** `toPublicInfo` nor the protection on either site, so this ports the helper and wires both. `dev` and `upstream/dev` share no common ancestor; this is a re-implementation, not a cherry-pick.

## Test

Added `plugin provider.models hook cannot mutate internal provider state`: loads a `.opencode/plugin` whose `provider.models` hook mutates its argument, then asserts the resolved provider's `name`/`options` are untouched and models still resolve. Proven red → green (without the clone the mutated name leaks into provider state).

## Verification

- `bun test test/provider/provider.test.ts` — 97 pass, 0 fail
- `bun test test/plugin/auth-override.test.ts test/plugin/codex.test.ts test/plugin/github-copilot-models.test.ts` — 31 pass (auth-loader path unaffected)
- `bun run typecheck` — clean
