### PR TITLE
fix(opencode): hide Copilot models disabled by org/enterprise policy

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -11,6 +11,11 @@ export namespace CopilotModels {
         // every version looks like: `{model.id}-YYYY-MM-DD`
         version: z.string(),
         supported_endpoints: z.array(z.string()).optional(),
+        policy: z
+          .object({
+            state: z.string().optional(),
+          })
+          .optional(),
         capabilities: z.object({
           family: z.string(),
           limits: z.object({
@@ -165,7 +170,9 @@ export namespace CopilotModels {
     })
 
     const result = { ...existing }
-    const remote = new Map(data.data.filter((m) => m.model_picker_enabled).map((m) => [m.id, m] as const))
+    const remote = new Map(
+      data.data.filter((m) => m.model_picker_enabled && m.policy?.state !== "disabled").map((m) => [m.id, m] as const),
+    )
 
     // prune existing models whose api.id isn't in the endpoint response
     for (const [key, model] of Object.entries(result)) {

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -451,3 +451,46 @@ test("sets anthropic beta header only for github copilot anthropic chat headers"
   expect(copilotOpenAI.headers).not.toHaveProperty("anthropic-beta")
   expect(anthropic.headers).not.toHaveProperty("anthropic-beta")
 })
+
+test("excludes models disabled by org/enterprise policy", async () => {
+  const model = (id: string, extra: Record<string, unknown>) => ({
+    model_picker_enabled: true,
+    id,
+    name: id,
+    version: `${id}-2026-04-01`,
+    capabilities: {
+      family: "gpt",
+      limits: {
+        max_context_window_tokens: 32000,
+        max_output_tokens: 8192,
+        max_prompt_tokens: 32000,
+      },
+      supports: {
+        streaming: true,
+        tool_calls: true,
+      },
+    },
+    ...extra,
+  })
+
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            model("allowed-no-policy", {}),
+            model("allowed-enabled", { policy: { state: "enabled" } }),
+            model("blocked-by-policy", { policy: { state: "disabled" } }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get("https://api.githubcopilot.com")
+
+  expect(models["allowed-no-policy"]).toBeDefined()
+  expect(models["allowed-enabled"]).toBeDefined()
+  expect(models["blocked-by-policy"]).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

Exclude GitHub Copilot models that the account's org/enterprise policy has disabled.

Two surgical edits in `plugin/github-copilot/models.ts`:
- Schema: parse the optional `policy: { state?: string }` field on each model entry.
- Filter: drop models whose `policy.state === "disabled"` from the remote model map, in addition to the existing `model_picker_enabled` filter.

Models with no `policy` or any non-`"disabled"` state are unaffected.

## Why

GitHub Copilot Business/Enterprise lets an org or enterprise admin disable specific models. The model-list endpoint still returns those entries with `model_picker_enabled: true` but a `policy.state` of `"disabled"`. PawWork only filtered on `model_picker_enabled`, so it listed models the account cannot actually use — picking one then fails at request time.

This re-implements upstream `anomalyco/opencode` PR #23176 (`0068ccec35`) against PawWork's diverged `github-copilot/models.ts`. `dev` and `upstream/dev` share no common ancestor, so this is a semantic port, not a cherry-pick. Thanks to the upstream author. (Upstream also dropped an unused `Installation` import in `copilot.ts`; that is unrelated to this fix and intentionally not included here.)

## Related Issue

No local issue; ported from upstream PR #23176.

## Human Review Status

Pending

## Review Focus

The filter predicate `m.model_picker_enabled && m.policy?.state !== "disabled"`: `policy` is optional, so `policy?.state` is `undefined` for models without it and `!== "disabled"` keeps them. Only an explicit `"disabled"` state is excluded.

## Risk Notes

Low. Additive optional schema field plus one filter clause; no public API change. Strictly narrows the listed set — only models explicitly marked `policy.state === "disabled"` are removed. No platform/packaging/UI surface touched.

## How To Verify

```text
bun test test/plugin/github-copilot-models.test.ts → 8 pass / 0 fail (new "excludes models disabled by org/enterprise policy" included)
Red proof: reverted only the policy filter clause → new test fails (blocked-by-policy model still listed)
bun run typecheck (packages/opencode) → clean, no errors
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

