### PR TITLE
fix(installation): type and sanitize upgrade failures

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -82,7 +82,13 @@ export namespace Installation {
 
   export class UpgradeFailedError extends Schema.TaggedErrorClass<UpgradeFailedError>()("UpgradeFailedError", {
     stderr: Schema.String,
-  }) {}
+  }) {
+    // Without this, the TaggedError default message is empty, so the desktop upgrade API
+    // (server/instance/global.ts surfaces `err.message`) returns a blank error.
+    override get message() {
+      return this.stderr
+    }
+  }
 
   // Response schemas for external version APIs
   const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
@@ -156,6 +162,17 @@ export namespace Installation {
           return "opencode"
         })
 
+        // Sanitized, user-facing failure text. Never surface raw stderr (it can contain tokens or
+        // arbitrary command output); choco keeps its actionable elevated-shell hint.
+        const upgradeFailure = (
+          method: Method,
+          result?: { code: ChildProcessSpawner.ExitCode; stdout: string; stderr: string },
+        ) => {
+          if (method === "choco") return "not running from an elevated command shell"
+          if (result) return `Upgrade failed for ${method} (exit code ${result.code}).`
+          return `Upgrade failed for ${method}.`
+        }
+
         const upgradeCurl = Effect.fnUntraced(
           function* (target: string) {
             const response = yield* httpOk.execute(HttpClientRequest.get("https://opencode.ai/install"))
@@ -175,7 +192,7 @@ export namespace Installation {
             return { code, stdout, stderr }
           },
           Effect.scoped,
-          Effect.orDie,
+          Effect.mapError(() => new UpgradeFailedError({ stderr: upgradeFailure("curl") })),
         )
 
         const methodImpl = Effect.fn("Installation.method")(function* () {
@@ -317,11 +334,10 @@ export namespace Installation {
               result = yield* run(["scoop", "install", `opencode@${target}`])
               break
             default:
-              return yield* new UpgradeFailedError({ stderr: `Unknown method: ${m}` })
+              return yield* new UpgradeFailedError({ stderr: `Unknown installation method: ${m}` })
           }
           if (!result || result.code !== 0) {
-            const stderr = m === "choco" ? "not running from an elevated command shell" : result?.stderr || ""
-            return yield* new UpgradeFailedError({ stderr })
+            return yield* new UpgradeFailedError({ stderr: upgradeFailure(m, result) })
           }
           log.info("upgraded", {
             method: m,

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -192,6 +192,9 @@ export namespace Installation {
             return { code, stdout, stderr }
           },
           Effect.scoped,
+          // The user only sees the sanitized message; log the raw cause for diagnostics. The curl
+          // path only fetches the public install script and spawns bash, so no user token is at risk.
+          Effect.tapError((error) => Effect.sync(() => log.error("upgrade curl failed", { error }))),
           Effect.mapError(() => new UpgradeFailedError({ stderr: upgradeFailure("curl") })),
         )
 

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -11,19 +11,22 @@ function mockHttpClient(handler: (request: HttpClientRequest.HttpClientRequest) 
   return Layer.succeed(HttpClient.HttpClient, client)
 }
 
-function mockSpawner(handler: (cmd: string, args: readonly string[]) => string = () => "") {
+type SpawnResult = string | { code: number; stdout?: string; stderr?: string }
+
+function mockSpawner(handler: (cmd: string, args: readonly string[]) => SpawnResult = () => "") {
   const spawner = ChildProcessSpawner.make((command) => {
     const std = ChildProcess.isStandardCommand(command) ? command : undefined
-    const output = handler(std?.command ?? "", std?.args ?? [])
+    const result = handler(std?.command ?? "", std?.args ?? [])
+    const output = typeof result === "string" ? { code: 0, stdout: result, stderr: "" } : result
     return Effect.succeed(
       ChildProcessSpawner.makeHandle({
         pid: ChildProcessSpawner.ProcessId(0),
-        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(output.code)),
         isRunning: Effect.succeed(false),
         kill: () => Effect.void,
         stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
-        stdout: output ? Stream.make(encoder.encode(output)) : Stream.empty,
-        stderr: Stream.empty,
+        stdout: output.stdout ? Stream.make(encoder.encode(output.stdout)) : Stream.empty,
+        stderr: output.stderr ? Stream.make(encoder.encode(output.stderr)) : Stream.empty,
         all: Stream.empty,
         getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
         getOutputFd: () => Stream.empty,
@@ -43,7 +46,7 @@ function jsonResponse(body: unknown) {
 
 function testLayer(
   httpHandler: (request: HttpClientRequest.HttpClientRequest) => Response,
-  spawnHandler?: (cmd: string, args: readonly string[]) => string,
+  spawnHandler?: (cmd: string, args: readonly string[]) => SpawnResult,
 ) {
   return Installation.layer.pipe(Layer.provide(mockHttpClient(httpHandler)), Layer.provide(mockSpawner(spawnHandler)))
 }
@@ -147,6 +150,64 @@ describe("installation", () => {
         Installation.Service.use((svc) => svc.latest("brew")).pipe(Effect.provide(layer)),
       )
       expect(result).toBe("2.1.0")
+    })
+  })
+
+  describe("upgrade", () => {
+    test("returns a sanitized typed error for a failed package upgrade", async () => {
+      const layer = testLayer(
+        () => jsonResponse({}),
+        (cmd) => (cmd === "npm" ? { code: 1, stderr: "token=secret command output" } : ""),
+      )
+
+      const error = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.upgrade("npm", "9.9.9")).pipe(Effect.provide(layer), Effect.flip),
+      )
+      expect(error).toBeInstanceOf(Installation.UpgradeFailedError)
+      expect(error.stderr).toBe("Upgrade failed for npm (exit code 1).")
+      expect(error.message).toBe(error.stderr) // desktop API surfaces err.message
+      expect(error.stderr).not.toContain("secret")
+    })
+
+    test("returns a sanitized typed error when the curl install script exits non-zero", async () => {
+      const layer = testLayer(
+        () => new Response("install script with token=secret", { status: 200 }),
+        (cmd) => (cmd === "bash" ? { code: 1, stderr: "script output with token=secret" } : ""),
+      )
+
+      const error = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.upgrade("curl", "9.9.9")).pipe(Effect.provide(layer), Effect.flip),
+      )
+      expect(error).toBeInstanceOf(Installation.UpgradeFailedError)
+      expect(error.stderr).toBe("Upgrade failed for curl (exit code 1).")
+      expect(error.message).toBe(error.stderr)
+      expect(error.stderr).not.toContain("secret")
+    })
+
+    test("types a curl install-script fetch failure instead of dying", async () => {
+      // Non-2xx makes httpOk fail; the mapError must turn that defect into a typed UpgradeFailedError.
+      const layer = testLayer(() => new Response("not found", { status: 404 }))
+
+      const error = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.upgrade("curl", "9.9.9")).pipe(Effect.provide(layer), Effect.flip),
+      )
+      expect(error).toBeInstanceOf(Installation.UpgradeFailedError)
+      expect(error.stderr).toBe("Upgrade failed for curl.")
+      expect(error.message).toBe(error.stderr)
+    })
+
+    test("preserves the choco elevated-shell hint and never leaks raw stderr", async () => {
+      const layer = testLayer(
+        () => jsonResponse({}),
+        (cmd) => (cmd === "choco" ? { code: 1, stderr: "raw choco failure detail" } : ""),
+      )
+
+      const error = await Effect.runPromise(
+        Installation.Service.use((svc) => svc.upgrade("choco", "9.9.9")).pipe(Effect.provide(layer), Effect.flip),
+      )
+      expect(error.stderr).toBe("not running from an elevated command shell")
+      expect(error.message).toBe(error.stderr)
+      expect(error.stderr).not.toContain("raw choco failure detail")
     })
   })
 })


### PR DESCRIPTION
## Summary

Type and sanitize `Installation` upgrade failures: give `UpgradeFailedError` a `message`, and replace raw command stderr with a sanitized, user-facing string.

## Why

Two user-facing defects in `installation/index.ts`:

1. **Empty desktop error.** `UpgradeFailedError` had no `message` getter, so the TaggedError default `.message` is empty. The desktop/server upgrade API surfaces `err instanceof Error ? err.message : String(err)` (`server/instance/global.ts:507`), so a failed upgrade returned a blank error to the user.
2. **Raw stderr leak.** The failure branch put raw `result.stderr` into the error, leaking tokens / arbitrary command output.

Fix (boundary: `installation/index.ts` + its test only):
- `override get message()` returns `stderr` so the desktop error is non-empty.
- `upgradeFailure(method, result?)` produces a sanitized `Upgrade failed for {method} (exit code {code}).`; `choco` keeps its actionable "not running from an elevated command shell" hint.
- Type the curl install-script path with `mapError` instead of `orDie`, so a fetch/spawn failure surfaces as a typed `UpgradeFailedError` rather than a defect.

Re-implements upstream `anomalyco/opencode` #28883 (`536ee857c6`). Thanks to the upstream author (Shoubhit Dash).

## Related Issue

No tracked issue; surfaced via the upstream value-mining ledger.

## Human Review Status

Pending

## Review Focus

- `upgradeFailure` covers every failure exit: package managers (with exit code), `choco` (hint preserved), unknown method, and the curl `mapError` (no result → "Upgrade failed for curl.").
- `get message()` returning `stderr` is what the desktop API needs; verify no caller depended on the old empty message.

## Risk Notes

Low. Error *contents* change (sanitized, non-empty); the error type and the `Effect.Effect<void, UpgradeFailedError>` signature are unchanged. The curl path moves from defect (`orDie`) to typed failure, which callers already handle (`cli/cmd/upgrade.ts` checks `instanceof UpgradeFailedError`).

## How To Verify

```text
bun test test/installation/installation.test.ts  → 12 pass (8 existing + 4 new upgrade tests)
red->green: the 4 new tests fail without the fix (raw stderr leak + empty message)
bun run typecheck (tsgo --noEmit)                → clean
```

## Screenshots or Recordings

N/A — no UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
