### PR TITLE
fix(mcp): persist immediate OAuth connections

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -992,7 +992,13 @@ export namespace MCP {
 
   export const disconnect = async (name: string) => runPromise((svc) => svc.disconnect(name))
 
-  export const startAuth = async (mcpName: string) => runPromise((svc) => svc.startAuth(mcpName))
+  export const startAuth = async (mcpName: string) => {
+    // The /:name/auth route serializes this with c.json, so the public result
+    // must stay plain data. authenticate() consumes the connected client via the
+    // internal startAuth; never expose the live (cyclic) Client here.
+    const { authorizationUrl, oauthState } = await runPromise((svc) => svc.startAuth(mcpName))
+    return { authorizationUrl, oauthState }
+  }
 
   export const authenticate = async (mcpName: string) => runPromise((svc) => svc.authenticate(mcpName))
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -253,6 +253,12 @@ export namespace MCP {
     defs?: MCPToolDef[]
   }
 
+  interface AuthResult {
+    authorizationUrl: string
+    oauthState: string
+    client?: MCPClient
+  }
+
   // --- Effect Service ---
 
   interface State {
@@ -593,6 +599,21 @@ export namespace MCP {
         return Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
       }
 
+      const storeClient = Effect.fnUntraced(function* (
+        s: State,
+        name: string,
+        client: MCPClient,
+        listed: MCPToolDef[],
+        timeout?: number,
+      ) {
+        yield* closeClient(s, name)
+        s.status[name] = { status: "connected" }
+        s.clients[name] = client
+        s.defs[name] = listed
+        watch(s, name, client, timeout)
+        return s.status[name]
+      })
+
       const status = Effect.fn("MCP.status")(function* () {
         const s = yield* InstanceState.get(state)
 
@@ -624,11 +645,7 @@ export namespace MCP {
           return result.status
         }
 
-        yield* closeClient(s, name)
-        s.clients[name] = result.mcpClient
-        s.defs[name] = result.defs!
-        watch(s, name, result.mcpClient, mcp.timeout)
-        return result.status
+        return yield* storeClient(s, name, result.mcpClient, result.defs!, mcp.timeout)
       })
 
       const add = Effect.fn("MCP.add")(function* (name: string, mcp: Config.Mcp) {
@@ -795,14 +812,16 @@ export namespace MCP {
         return yield* Effect.tryPromise({
           try: () => {
             const client = new Client({ name: "opencode", version: Installation.VERSION })
-            return client.connect(transport).then(() => ({ authorizationUrl: "", oauthState }))
+            return client
+              .connect(transport)
+              .then(() => ({ authorizationUrl: "", oauthState, client }) satisfies AuthResult)
           },
           catch: (error) => error,
         }).pipe(
           Effect.catch((error) => {
             if (error instanceof UnauthorizedError && capturedUrl) {
               pendingOAuthTransports.set(mcpName, transport)
-              return Effect.succeed({ authorizationUrl: capturedUrl.toString(), oauthState })
+              return Effect.succeed({ authorizationUrl: capturedUrl.toString(), oauthState } satisfies AuthResult)
             }
             return Effect.die(error)
           }),
@@ -810,14 +829,35 @@ export namespace MCP {
       })
 
       const authenticate = Effect.fn("MCP.authenticate")(function* (mcpName: string) {
-        const { authorizationUrl, oauthState } = yield* startAuth(mcpName)
-        if (!authorizationUrl) return { status: "connected" } as Status
+        const result = yield* startAuth(mcpName)
+        if (!result.authorizationUrl) {
+          // Immediate connection: stored tokens were still valid, so startAuth
+          // connected without a browser redirect. Persist that connected client
+          // instead of dropping it (which leaked the transport and left the
+          // server reporting failed/no-tools).
+          const client = "client" in result ? result.client : undefined
+          const mcpConfig = yield* getMcpConfig(mcpName)
+          if (!mcpConfig) {
+            yield* Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)
+            return { status: "failed", error: "MCP config not found after auth" } as Status
+          }
 
-        log.info("opening browser for oauth", { mcpName, url: authorizationUrl, state: oauthState })
+          const listed = client ? yield* defs(mcpName, client, mcpConfig.timeout) : undefined
+          if (!client || !listed) {
+            yield* Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)
+            return { status: "failed", error: "Failed to get tools" } as Status
+          }
 
-        const callbackPromise = McpOAuthCallback.waitForCallback(oauthState, mcpName)
+          const s = yield* InstanceState.get(state)
+          yield* auth.clearOAuthState(mcpName)
+          return yield* storeClient(s, mcpName, client, listed, mcpConfig.timeout)
+        }
 
-        yield* Effect.tryPromise(() => open(authorizationUrl)).pipe(
+        log.info("opening browser for oauth", { mcpName, url: result.authorizationUrl, state: result.oauthState })
+
+        const callbackPromise = McpOAuthCallback.waitForCallback(result.oauthState, mcpName)
+
+        yield* Effect.tryPromise(() => open(result.authorizationUrl)).pipe(
           Effect.flatMap((subprocess) =>
             Effect.callback<void, Error>((resume) => {
               const timer = setTimeout(() => resume(Effect.void), 500)
@@ -835,14 +875,14 @@ export namespace MCP {
           ),
           Effect.catch(() => {
             log.warn("failed to open browser, user must open URL manually", { mcpName })
-            return bus.publish(BrowserOpenFailed, { mcpName, url: authorizationUrl }).pipe(Effect.ignore)
+            return bus.publish(BrowserOpenFailed, { mcpName, url: result.authorizationUrl }).pipe(Effect.ignore)
           }),
         )
 
         const code = yield* Effect.promise(() => callbackPromise)
 
         const storedState = yield* auth.getOAuthState(mcpName)
-        if (storedState !== oauthState) {
+        if (storedState !== result.oauthState) {
           yield* auth.clearOAuthState(mcpName)
           throw new Error("OAuth state mismatch - potential CSRF attack")
         }

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -264,3 +264,44 @@ test("authenticate() persists the client when OAuth completes without a redirect
     },
   })
 })
+
+test("startAuth() keeps the public result plain data on immediate connect (#22376)", async () => {
+  const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-startauth": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        // Stored tokens still valid → startAuth connects with no redirect. The
+        // public result is serialized by the /:name/auth route via c.json, so it
+        // must not carry the live (cyclic) client.
+        simulateAuthFlow = false
+        connectSucceedsImmediately = true
+
+        const result = await MCP.startAuth("test-oauth-startauth")
+        expect(Object.keys(result).sort()).toEqual(["authorizationUrl", "oauthState"])
+        expect("client" in result).toBe(false)
+        expect(() => JSON.stringify(result)).not.toThrow()
+      } finally {
+        await McpOAuthCallback.stop()
+      }
+    },
+  })
+})

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -18,6 +18,9 @@ const transportCalls: Array<{
 // Controls whether the mock transport simulates a 401 that triggers the SDK
 // auth flow (which calls provider.state()) or a simple UnauthorizedError.
 let simulateAuthFlow = true
+// When true, the mock transport connects without a 401 — simulating stored
+// tokens still being valid so OAuth completes with no browser redirect.
+let connectSucceedsImmediately = false
 
 // Mock the transport constructors to simulate OAuth auto-auth on 401
 mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
@@ -38,6 +41,8 @@ mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
       })
     }
     async start() {
+      if (connectSucceedsImmediately) return
+
       // Simulate what the real SDK transport does on 401:
       // It calls auth() which eventually calls provider.state(), then
       // provider.redirectToAuthorization(), then throws UnauthorizedError.
@@ -83,6 +88,14 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async connect(transport: { start: () => Promise<void> }) {
       await transport.start()
     }
+
+    setNotificationHandler() {}
+
+    async listTools() {
+      return { tools: [{ name: "test_tool", inputSchema: { type: "object", properties: {} } }] }
+    }
+
+    async close() {}
   },
 }))
 
@@ -94,6 +107,7 @@ mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
 beforeEach(() => {
   transportCalls.length = 0
   simulateAuthFlow = true
+  connectSucceedsImmediately = false
 })
 
 // Import modules after mocking
@@ -194,6 +208,59 @@ test("state() returns existing state when one is saved", async () => {
       // state() should return the existing state
       const state = await provider.state()
       expect(state).toBe(existingState)
+    },
+  })
+})
+
+test("authenticate() persists the client when OAuth completes without a redirect (#22376)", async () => {
+  const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-connect": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        // First connect: no stored tokens → needs_auth.
+        const added = await MCP.add("test-oauth-connect", {
+          type: "remote",
+          url: "https://example.com/mcp",
+        })
+        const before = added.status as Record<string, { status: string; error?: string }>
+        expect(before["test-oauth-connect"]?.status).toBe("needs_auth")
+
+        // Stored tokens are still valid: connect succeeds with no browser redirect.
+        simulateAuthFlow = false
+        connectSucceedsImmediately = true
+
+        const result = await MCP.authenticate("test-oauth-connect")
+        expect(result.status).toBe("connected")
+
+        // The immediately-connected client must be stored, not dropped, so the
+        // server reports connected and its tools are registered (no leak).
+        const after = await MCP.status()
+        expect(after["test-oauth-connect"]?.status).toBe("connected")
+
+        const tools = await MCP.tools()
+        expect(Object.keys(tools).some((key) => key.includes("test-oauth-connect"))).toBe(true)
+      } finally {
+        await McpOAuthCallback.stop()
+      }
     },
   })
 })


### PR DESCRIPTION
## Summary

When `startAuth()` reconnects to a remote MCP server whose stored OAuth tokens are still valid, the SDK transport connects immediately — no browser redirect — and hands back a connected client. `authenticate()` then dropped that client and returned a bare `{ status: "connected" }` without storing it. Result: the connected transport leaked, the client was never registered in state, and the server kept its prior `needs_auth`/`failed` status with no tools available.

This threads the already-connected client through `AuthResult` and, in `authenticate()`'s no-redirect branch, lists its tools and stores it (new `storeClient` helper, also used by `createAndStore`) instead of re-creating a client.

## Why

`packages/opencode/src/mcp/index.ts`: `startAuth()` returned `{ authorizationUrl: "", oauthState }` on immediate success, discarding the connected `client`; `authenticate()` returned `{ status: "connected" }` without writing it to state. The connected client is byte-for-byte the right one to keep — re-creating or dropping it both leak the transport and leave the server unusable.

## Related Issue

No PawWork issue. Re-implemented from upstream `anomalyco/opencode` `4626458175` (PR #22376, thanks @kitlangton). `dev` and `upstream/dev` have no common ancestor, so this is a semantic re-implementation, not a cherry-pick. Scope matches upstream's `index.ts` change.

## Human Review Status

Pending

## Review Focus

- **No double-close.** `storeClient` calls `closeClient(s, name)`, which only closes a *prior* client stored under the same name — never the new one. The two failure branches (`config not found`, `failed to get tools`) close the threaded client exactly once and return failed.
- The `"client" in result` guard: `startAuth`'s two return shapes differ only by the optional `client` key; the guard narrows the union safely (typecheck passes).
- `clearOAuthState` placement in the immediate branch mirrors the browser path (state was written by `startAuth`, cleared on success).

## Risk Notes

Low–med (touches the OAuth happy path, a less-covered surface). Confined to `mcp/index.ts`; no platform/packaging/UI surface. None of the conditional checklist items apply (no UI/copy, no platform surface, no docs/deps/credentials).

## How To Verify

```text
bun test test/mcp/oauth-auto-connect.test.ts  → 4 pass / 0 fail (incl. new immediate-connect test)
  (red→green verified: reverting only the src fix → the new test fails with stored status "needs_auth")
bun test test/mcp/                            → 37 pass / 0 fail
bun run typecheck (packages/opencode)          → clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.