### PR TITLE
fix(provider): accept "active" model status in config and catalog schemas

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -51,7 +51,7 @@ export const Model = Schema.Struct({
     }),
   ),
   experimental: Schema.optional(Schema.Boolean),
-  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated"])),
+  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated", "active"])),
   provider: Schema.optional(
     Schema.Struct({ npm: Schema.optional(Schema.String), api: Schema.optional(Schema.String) }),
   ),

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -94,7 +94,7 @@ export const Model = z.object({
         .optional(),
     })
     .optional(),
-  status: z.enum(["alpha", "beta", "deprecated"]).optional(),
+  status: z.enum(["alpha", "beta", "deprecated", "active"]).optional(),
   provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
 })
 export type Model = z.infer<typeof Model>
@@ -160,7 +160,7 @@ const PublishModel = z
           .optional(),
       })
       .optional(),
-    status: z.enum(["alpha", "beta", "deprecated"]).optional(),
+    status: z.enum(["alpha", "beta", "deprecated", "active"]).optional(),
     provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
   })
   .passthrough()

--- a/packages/opencode/test/provider/model-status-active.test.ts
+++ b/packages/opencode/test/provider/model-status-active.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { Model as ConfigProviderModel } from "../../src/config/provider"
+import { ModelsDev } from "../../src/provider"
+
+// Regression for #26592: the runtime emits status "active" (provider.ts), so both the
+// config-load schema and the models.dev catalog schema must accept it instead of
+// crashing config load on a model that declares status: "active".
+
+test("config provider Model schema accepts status: active", () => {
+  const result = ConfigProviderModel.zod.safeParse({ status: "active" })
+  expect(result.success).toBe(true)
+})
+
+test("models.dev Model schema accepts status: active", () => {
+  const result = ModelsDev.Model.safeParse({
+    id: "test-model",
+    name: "Test Model",
+    release_date: "2026-01-01",
+    attachment: false,
+    reasoning: false,
+    temperature: false,
+    tool_call: false,
+    limit: { context: 128000, output: 8192 },
+    status: "active",
+  })
+  expect(result.success).toBe(true)
+})


### PR DESCRIPTION
## Summary

A user config or models.dev catalog entry declaring `status: "active"` crashed config load. The runtime already **emits and reads** `"active"` (provider.ts default `model.status ?? "active"` at :1041 and :1267), but the config-load schema and the catalog schema only allowed `"alpha" | "beta" | "deprecated"`. So a model with `status: "active"` was rejected during validation — `ConfigParse.schema` throws `InvalidError` on a failed `safeParse` — instead of loading.

## Fix

Add `"active"` to the status literal set in all three schemas:

- `config/provider.ts:54` — the config `Model` (Effect Schema `Schema.Literals`), used to validate `opencode.json`.
- `provider/models.ts:97` — the models.dev `Model` (zod `z.enum`).
- `provider/models.ts:163` — the models.dev `PublishModel` (zod `z.enum`).

Strictly widens the accepted set, so no previously valid input is rejected.

## PawWork gap vs upstream

Adapted from upstream `anomalyco/opencode` `00c3248295` (PR #26592 — thanks Kit Langton). Upstream widens two Effect-Schema literal sets; PawWork's catalog schema (`provider/models.ts`) uses **zod**, so the port adds `"active"` to the zod `z.enum` there and to the Effect-Schema `Literals` in `config/provider.ts`. `dev` and `upstream/dev` share no common ancestor; re-implementation, not a cherry-pick.

## Test

Added `model-status-active.test.ts`: asserts both the config `Model` schema (via its derived `.zod`, the actual config-load validator) and the models.dev `Model` schema accept `status: "active"`. Proven red → green (without the widen both `safeParse` calls return `success: false`).

## Verification

- `bun test test/provider/model-status-active.test.ts` — 2 pass (red→green confirmed)
- `bun test test/provider/models-refresh.test.ts test/config/provider.test.ts` — 14 pass (no regression)
- `bun run typecheck` — clean
