### PR TITLE
fix(config): anchor agent/command name matching at the relative path

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -1,5 +1,6 @@
 export * as ConfigAgent from "./agent"
 
+import path from "path"
 import { Schema } from "effect"
 import z from "zod"
 import { Bus } from "@/bus"
@@ -142,8 +143,7 @@ export async function load(dir: string) {
     })
     if (!md) continue
 
-    const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-    const name = configEntryNameFromPath(item, patterns)
+    const name = configEntryNameFromPath(path.relative(dir, item), ["agent/", "agents/"])
 
     const config = {
       ...md.data,
@@ -182,7 +182,7 @@ export async function loadMode(dir: string) {
 
     const config = {
       ...md.data,
-      name: configEntryNameFromPath(item, []),
+      name: configEntryNameFromPath(path.relative(dir, item), ["mode/", "modes/"]),
       prompt: md.content.trim(),
     }
     const parsed = Info.safeParse(config)

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -1,5 +1,6 @@
 export * as ConfigCommand from "./command"
 
+import path from "path"
 import { Log } from "../util"
 import { Schema } from "effect"
 import { NamedError } from "@opencode-ai/util/error"
@@ -56,8 +57,7 @@ export async function load(dir: string) {
     })
     if (!md) continue
 
-    const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
-    const name = configEntryNameFromPath(item, patterns)
+    const name = configEntryNameFromPath(path.relative(dir, item), ["command/", "commands/"])
 
     const config = {
       ...md.data,

--- a/packages/opencode/src/config/entry-name.ts
+++ b/packages/opencode/src/config/entry-name.ts
@@ -1,23 +1,30 @@
 import path from "path"
 
-function sliceAfterMatch(filePath: string, searchRoots: string[]) {
-  const normalizedPath = filePath.replaceAll("\\", "/")
+// Strips a known prefix anchored at the START of an already-relative path.
+// Callers pass the path relative to the directory they scanned (e.g.
+// `path.relative(dir, item)`), so the prefix match is anchored. Matching a
+// prefix anywhere in an absolute path used to mis-key entries whose parent or
+// home segments coincidentally contained a prefix name — e.g. a user under
+// `/Users/agent/` leaked the intervening path into the agent key (see #28359 /
+// upstream #25713). Matching stays case-insensitive and roots are normalized to
+// preserve PawWork's prior behavior.
+function stripPrefix(relativePath: string, prefixes: string[]) {
+  const normalizedPath = relativePath.replaceAll("\\", "/")
   const comparablePath = normalizedPath.toLowerCase()
-  const normalizedRoots = searchRoots
-    .map((root) => root.replaceAll("\\", "/").replace(/\/+$/, ""))
+  const normalizedPrefixes = prefixes
+    .map((prefix) => prefix.replaceAll("\\", "/").replace(/\/+$/, ""))
     .filter(Boolean)
     .sort((a, b) => b.length - a.length)
 
-  for (const searchRoot of normalizedRoots) {
-    const needle = `${searchRoot}/`
-    const index = comparablePath.indexOf(needle.toLowerCase())
-    if (index === -1) continue
-    return normalizedPath.slice(index + needle.length).replace(/^\/+/, "")
+  for (const prefix of normalizedPrefixes) {
+    const needle = `${prefix}/`
+    if (!comparablePath.startsWith(needle.toLowerCase())) continue
+    return normalizedPath.slice(needle.length).replace(/^\/+/, "")
   }
 }
 
-export function configEntryNameFromPath(filePath: string, searchRoots: string[]) {
-  const candidate = sliceAfterMatch(filePath, searchRoots) ?? path.basename(filePath)
+export function configEntryNameFromPath(relativePath: string, prefixes: string[]) {
+  const candidate = stripPrefix(relativePath, prefixes) ?? path.basename(relativePath)
   const ext = path.extname(candidate)
   return ext.length ? candidate.slice(0, -ext.length) : candidate
 }

--- a/packages/opencode/test/config/entry-name.test.ts
+++ b/packages/opencode/test/config/entry-name.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { posix } from "path"
+import { configEntryNameFromPath } from "@/config/entry-name"
+
+// The prefixes shipped by config/agent.ts after the relative-path refactor.
+const AGENT_PREFIXES = ["agent/", "agents/"]
+
+describe("configEntryNameFromPath", () => {
+  test("strips an `agents/` prefix and returns the bare name", () => {
+    expect(configEntryNameFromPath("agents/build.md", AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("strips an `agent/` (singular) prefix", () => {
+    expect(configEntryNameFromPath("agent/build.md", AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("preserves nested subdirectories in the key", () => {
+    expect(configEntryNameFromPath("agents/team/build.md", AGENT_PREFIXES)).toBe("team/build")
+  })
+
+  test("normalizes Windows-style backslashes", () => {
+    expect(configEntryNameFromPath("agents\\team\\build.md", AGENT_PREFIXES)).toBe("team/build")
+  })
+
+  // PawWork-specific: prefix matching is case-insensitive, but the returned key
+  // preserves the original casing of the entry name.
+  test("matches the prefix case-insensitively and preserves entry casing", () => {
+    expect(configEntryNameFromPath("Agents/Build.md", AGENT_PREFIXES)).toBe("Build")
+    expect(configEntryNameFromPath("AGENT/Build.md", AGENT_PREFIXES)).toBe("Build")
+    expect(configEntryNameFromPath("agents/Team/Build.md", ["AGENTS/"])).toBe("Team/Build")
+  })
+
+  test("falls back to basename when no prefix matches", () => {
+    expect(configEntryNameFromPath("orphaned.md", AGENT_PREFIXES)).toBe("orphaned")
+    expect(configEntryNameFromPath("anywhere/orphaned.md", [])).toBe("orphaned")
+  })
+
+  // Regression for #28359 (upstream #25713): a parent/home segment containing
+  // `agent` or `agents` used to win the substring match before the real
+  // `agents/` directory, leaking the intervening path into the key (e.g.
+  // `proj/agent/build`). Anchoring at the caller via `path.relative(dir, item)`
+  // makes this impossible — the relative path is always rooted at the prefix.
+  test("regression #28359: caller passes relative path; parent /agent/ segment is irrelevant", () => {
+    const dir = "/Users/agent/proj"
+    const item = "/Users/agent/proj/agent/build.md"
+    const relative = posix.relative(dir, item)
+    expect(relative).toBe("agent/build.md")
+    expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("build")
+  })
+
+  // Anchoring is what makes the relative-path contract safe: a prefix that
+  // appears only in a deeper/parent segment of an absolute path is NOT stripped
+  // (the helper falls back to the basename). Before #28359 the unanchored
+  // substring match returned "proj/agent/build" here.
+  test("regression #28359: does not strip from a misleading parent segment", () => {
+    expect(configEntryNameFromPath("/Users/agent/proj/agent/build.md", AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("regression #28359: parent /agents/ segment is irrelevant for nested entries", () => {
+    const dir = "/srv/agents/team/proj"
+    const item = "/srv/agents/team/proj/agents/team/build.md"
+    const relative = posix.relative(dir, item)
+    expect(relative).toBe("agents/team/build.md")
+    expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("team/build")
+  })
+})


### PR DESCRIPTION
## Summary

`configEntryNameFromPath` matched a known prefix (`agent/`, `agents/`, `command/`, `commands/`, `mode/`, `modes/`) **anywhere** in the absolute file path. A user or parent directory whose name coincidentally contained one of those segments won the substring match before the real entry directory, leaking the intervening path into the key — an agent at `/Users/agent/proj/agent/build.md` keyed as `proj/agent/build` instead of `build`.

This anchors the match at the **start** of the path and has the three call sites pass the path **relative** to the directory they scanned (`path.relative(dir, item)`), so the relative path is always rooted at the prefix.

## Why

`Glob.scan` already scans `{agent,agents}/**`, `{command,commands}/**`, and `{mode,modes}/*` with `cwd=dir`, so `path.relative(dir, item)` is always `agent/…`, `command/…`, etc. With the relative path, anchoring at the start fixes the mis-keying and the `.opencode/` prefix variants become unnecessary (`.opencode` lives in `dir`, not in the relative path), so the prefix list simplifies to the bare directory names. PawWork's case-insensitive matching and nested-subdirectory keys (`agents/team/build.md` → `team/build`) are preserved.

## Related Issue

No PawWork issue. Reimplemented for PawWork from upstream `anomalyco/opencode` `e94d46af86` (PR #28359, original regression #25713, thanks Kit Langton). The fork has no common ancestor with upstream, so this is an adapted port that keeps PawWork's case-insensitive normalization (upstream's variant is case-sensitive), not a cherry-pick.

## Human Review Status

Pending

## Review Focus

Medium risk: `configEntryNameFromPath` feeds agent/command/mode keys across three call sites. Confirm (1) the contract change from absolute path → `path.relative(dir, item)` is correct for all three (the glob guarantees items are under `dir`), (2) case-insensitive matching is preserved, and (3) nested-subdirectory keys are preserved. The existing `config.test.ts` "tolerate unnormalized roots" assertion still passes unchanged.

## Risk Notes

Medium. The helper's contract changed (now expects a relative path); all three in-repo call sites were updated in the same change and there are no other callers. Behavior for the normal case is unchanged; only the mis-keyed parent-segment case changes (now correct). No platform/packaging/UI surface touched.

## How To Verify

```text
New unit test: bun test test/config/entry-name.test.ts -> 9 pass
Red proof (startsWith reverted to indexOf): the misleading-parent-segment case fails with Received "proj/agent/build" (1 fail, 8 pass)
Existing assertion: bun test test/config/config.test.ts -t "tolerate unnormalized roots" -> 1 pass
Full config suite regression: bun test test/config/ -> 222 pass, 0 fail
Typecheck: packages/opencode bun run typecheck -> clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
