### PR TITLE
docs(release): align release checklist with the #1119 auto-publish flow

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -84,7 +84,7 @@ source_run_id: 123456789
 source_run_attempt: 1
 source_ref: dev
 source_sha: 0123456789abcdef0123456789abcdef01234567
-source_workflow_ref: dev
+source_workflow_ref: workflow-snapshot-123456789-1-macos-arm64
 source_workflow_sha: 0123456789abcdef0123456789abcdef01234567
 submission_id: 00000000-0000-0000-0000-000000000000
 ```
@@ -104,27 +104,36 @@ Build and publish the Windows installer:
 gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=full -f channel=prod -f target=windows -f arch=x64
 ```
 
+> **All three final targets must be the same build commit.** mac finalize rebuilds from the commit pinned by its submit snapshot tag (`source_sha`), while the Windows `full` build uses the current `dev` HEAD (`github.sha`). If `dev` moves between the macOS submits and the Windows build, the targets disagree and the auto-publisher (Step 4) refuses to publish — by design. Freeze `dev` for the duration of the release, or confirm the Windows build's commit matches the macOS `source_sha` before expecting auto-publish to fire.
+
 ## 4. Publish
 
-> **prod auto-publishes (PR #1119).** The build pipeline's tail `publish-when-complete` step flips the draft to published — pinned to the build commit — and dispatches the R2 mirror automatically once every target's assets and updater metadata have landed. For a normal prod release, Steps 4–5 are a **verification fallback**: use them only if the auto-publish did not run (a non-prod channel, or a partial build that left a draft).
+**A prod release publishes itself (PR #1119).** The tail `publish-when-complete` step of the last target's finalize/full build flips the draft to published — pinning the tag to the build commit and marking it latest — then dispatches the R2 mirror. It only does so once every target's installers and updater metadata are present AND all targets agree on a single build commit. So for a normal prod release you do **not** run `gh release edit` by hand; you confirm the auto-publish outcome.
 
-Verify the draft release has all expected user-facing installers before publishing:
-
-```bash
-gh release view vX.Y.Z --repo Astro-Han/pawwork --json isDraft,isPrerelease,assets,url
-```
-
-Publish the release as the latest stable release:
+Check the "Publish release when all targets are complete" step in the last build run, then the release state:
 
 ```bash
-gh release edit vX.Y.Z --repo Astro-Han/pawwork --draft=false --latest --prerelease=false
+gh release view vX.Y.Z --repo Astro-Han/pawwork --json isDraft,isPrerelease,targetCommitish,assets,url
 ```
+
+- **Published** (`isDraft: false`, `targetCommitish` = the build commit) → done, go to Step 6.
+- **Still a draft, a target missing** (the step logged `wait`) → finish or re-run the missing target; its own tail step will publish. Do not publish by hand.
+- **The step failed** (mixed-source, updater-metadata drift, or a missing/empty provenance marker) → **do not publish.** The guard is refusing a release built from more than one commit or with mismatched metadata. Rebuild all three targets from a single commit (see the same-commit note in Step 3) and let auto-publish run.
+
+Manual publish is a **last resort** — e.g. a non-prod channel that has no auto-publish, or recovering a release the pipeline genuinely cannot finish. It bypasses every guard (completeness, single-source markers, the updater-metadata hash anchor, seal/re-read), so only after you have confirmed the draft holds all three installers AND they were built from the same commit, publish and pin the tag to that commit:
+
+```bash
+# LAST RESORT — bypasses the auto-publisher's safety checks.
+gh release edit vX.Y.Z --repo Astro-Han/pawwork --draft=false --latest --prerelease=false --target <build-commit-sha>
+```
+
+Never publish a non-prod (beta/dev) build as `--latest --prerelease=false`, and never hand-publish a partial draft.
 
 ## 5. Mirror Downloads to Cloudflare R2
 
-The China-accessible landing page (dl.pawwork.ai) serves downloads from the R2 mirror, not GitHub. The mirror is gated by `verify-release` and only runs against a published (non-draft) release, so it must run after Step 4.
+The China-accessible landing page (dl.pawwork.ai) serves downloads from the R2 mirror, not GitHub. The mirror is gated by `verify-release` and only runs against a published (non-draft) release, so it runs after the release is published in Step 4.
 
-Publishing in Step 4 with your own credentials emits a `release: published` event, which triggers `.github/workflows/mirror-release-to-r2.yml` automatically. (A workflow that published the release with the built-in `GITHUB_TOKEN` would NOT trigger it — that path would need an explicit dispatch.) Confirm the run started, or dispatch it manually:
+On the normal path the auto-publisher (Step 4) dispatches `.github/workflows/mirror-release-to-r2.yml` itself, immediately after publishing: a release published with the built-in `GITHUB_TOKEN` does NOT emit a `release: published` event, so the auto-publisher triggers the mirror explicitly. (A manual last-resort publish with your own credentials *does* emit `release: published`, which also triggers the mirror.) Either way, confirm a run started, and dispatch it manually if none did:
 
 ```bash
 gh run list --workflow mirror-release-to-r2.yml --repo Astro-Han/pawwork --limit 3

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -106,6 +106,8 @@ gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=full -f ch
 
 ## 4. Publish
 
+> **prod auto-publishes (PR #1119).** The build pipeline's tail `publish-when-complete` step flips the draft to published — pinned to the build commit — and dispatches the R2 mirror automatically once every target's assets and updater metadata have landed. For a normal prod release, Steps 4–5 are a **verification fallback**: use them only if the auto-publish did not run (a non-prod channel, or a partial build that left a draft).
+
 Verify the draft release has all expected user-facing installers before publishing:
 
 ```bash


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

Bring `.github/RELEASE_CHECKLIST.md` in line with the auto-publish flow merged in PR #1119. A Codex audit of the checklist against the actual pipeline (`build.yml` + the release scripts) found the manual publish steps now read as required/safe when they bypass the auto-publisher's guards. This rewrites Steps 3–5:

- **Step 4** — a prod release publishes itself; document how to read the auto-publish outcome (published / wait / fail) and what to do for each. Manual `gh release edit` is demoted to a clearly-marked **last resort** that pins `target_commitish` and is never used for a partial draft or to mark a non-prod build latest.
- **Step 5** — correct the R2 trigger: the normal path is the auto-publisher's explicit `workflow_dispatch` (a `GITHUB_TOKEN` publish emits no `release: published`); the webhook fires only on a manual personal-credential publish.
- **Step 3** — note all three final targets must come from one build commit (mac finalize uses `source_sha`, win `full` uses `dev` HEAD) or auto-publish fails closed; fix the stale `source_workflow_ref` example.

Docs only — no code change. Follow-up to PR #1119; no separate issue.

## Why

PR #1119 made prod releases publish automatically with a single-source guard (per-target provenance markers, content anchor, seal/re-read). The checklist still presented manual `gh release edit --draft=false --latest` as a normal/fallback step. Codex flagged two [P1]s: (1) the manual command bypasses every guard, and the "use it for a partial build / non-prod" framing invites publishing an incomplete or non-stable release as latest; (2) when auto-publish has **failed closed** (mixed-source / metadata drift / missing marker), following the manual step force-publishes exactly the bad state the guard caught — and it didn't pin `target_commitish`. This rewrite makes the runbook match what the code actually does and removes the foot-gun.

## Related Issue

None — documentation follow-up to PR #1119.

## Human Review Status

`Pending`

## Review Focus

Accuracy of the rewritten steps against the merged pipeline: that auto-publish fires for the Step 3 build commands, publishes pinned to the build commit + latest, and dispatches the mirror; that the "wait / fail → do not hand-publish" guidance matches `publish-when-complete.ts`; and that the same-commit requirement (mac `source_sha` vs win `github.sha`) is stated correctly.

## Risk Notes

Documentation only — no code, workflow, dependency, permission, or behavior change. The change removes a dangerous instruction (manual publish that bypasses the #1119 guards) and reframes it as a guarded last resort. The two `gh` surfaces referenced were verified to exist (`gh release edit --target`, `gh release view --json targetCommitish`). No visible app UI or copy changed (UI checklist item left unticked for that reason).

## How To Verify

```text
Audited each step against build.yml + publish-when-complete.ts / finalize-latest-yml.ts /
verify-release.ts / mirror-release-to-r2.{yml,ts} (Codex, read-only) — 2 P1 + 3 P2 found, all
addressed in this rewrite.
gh CLI surfaces used in the doc confirmed present:
  gh release edit --help    -> --target <branch/SHA> exists
  gh release view --json targetCommitish -> field accepted (reached "release not found")
git diff dev...HEAD: only .github/RELEASE_CHECKLIST.md, Steps 3-5; manual path kept as last resort.
```

## Screenshots or Recordings

N/A — repository documentation only.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
