### PR TITLE
fix(mcp): include configured scope in OAuth clientMetadata

### DIFF
--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -47,6 +47,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
+      ...(this.config.scope ? { scope: this.config.scope } : {}),
     }
   }
 

--- a/packages/opencode/test/mcp/oauth-provider.test.ts
+++ b/packages/opencode/test/mcp/oauth-provider.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from "bun:test"
-import { McpOAuthProvider } from "../../src/mcp/oauth-provider"
+import { McpOAuthProvider, type McpOAuthConfig } from "../../src/mcp/oauth-provider"
 
-const makeProvider = (config: ConstructorParameters<typeof McpOAuthProvider>[2]) =>
+const makeProvider = (config: McpOAuthConfig) =>
   new McpOAuthProvider("test-server", "https://mcp.example.com/mcp", config, { onRedirect: async () => {} })
 
 describe("McpOAuthProvider.clientMetadata", () => {

--- a/packages/opencode/test/mcp/oauth-provider.test.ts
+++ b/packages/opencode/test/mcp/oauth-provider.test.ts
@@ -1,0 +1,17 @@
+import { test, expect, describe } from "bun:test"
+import { McpOAuthProvider } from "../../src/mcp/oauth-provider"
+
+const makeProvider = (config: ConstructorParameters<typeof McpOAuthProvider>[2]) =>
+  new McpOAuthProvider("test-server", "https://mcp.example.com/mcp", config, { onRedirect: async () => {} })
+
+describe("McpOAuthProvider.clientMetadata", () => {
+  test("includes scope when set in config (#28810)", () => {
+    const provider = makeProvider({ scope: "openid offline_access" })
+    expect(provider.clientMetadata.scope).toBe("openid offline_access")
+  })
+
+  test("omits scope when not set in config", () => {
+    const provider = makeProvider({})
+    expect(provider.clientMetadata.scope).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

A remote MCP server's OAuth `scope` is plumbed end-to-end — `config` (`mcp.oauth.scope`) → `McpOAuthConfig.scope` → `McpOAuthProvider` — but `clientMetadata` never included it. As a result, dynamic client registration under-requested scopes for scoped remote MCP servers. This adds the configured scope to `clientMetadata`.

## Why

`packages/opencode/src/mcp/oauth-provider.ts`: the `clientMetadata` getter (lines 42–51) builds the registration metadata but omits `scope`, even though `this.config.scope` is populated from the user's config. One-line additive fix:

```ts
...(this.config.scope ? { scope: this.config.scope } : {}),
```

## Related Issue

No PawWork issue. Re-implemented from upstream `anomalyco/opencode` `7a769dab3a` (PR #28810, thanks @sebinformix / @nexxeln). **Scope half only** — the upstream commit also adds a `callbackPort` config option, which is a separate feature and is intentionally excluded here. `dev` and `upstream/dev` have no common ancestor, so this is a semantic re-implementation, not a cherry-pick.

## Human Review Status

Pending

## Review Focus

- Additive only: `scope` is added to `clientMetadata` solely when configured; servers without a configured scope are unchanged (`scope` stays absent). Cannot regress existing unscoped behavior.
- Confirm `callbackPort` was correctly excluded (not in this diff).

## Risk Notes

Low. One additive field on an existing config-driven path; affects only scoped remote MCP servers. Confined to `mcp/oauth-provider.ts`; no platform/packaging/UI surface. None of the conditional checklist items apply (no UI/copy, no platform surface, no docs/deps/credentials).

## How To Verify

```text
bun test test/mcp/oauth-provider.test.ts  → 2 pass / 0 fail (new: scope present when set, absent when not; red→green verified)
bun test test/mcp/                         → 40 pass / 0 fail
bun run typecheck (packages/opencode)       → clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth scope is now conditionally included in client metadata when configured, enabling more flexible OAuth provider setup.

* **Tests**
  * Added test coverage for OAuth scope configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Astro-Han/pawwork/pull/1138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->