### PR TITLE
fix(config): allow models to declare a single modality direction

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -46,8 +46,8 @@ export const Model = Schema.Struct({
   ),
   modalities: Schema.optional(
     Schema.Struct({
-      input: Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"]))),
-      output: Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"]))),
+      input: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),
+      output: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),
     }),
   ),
   experimental: Schema.optional(Schema.Boolean),

--- a/packages/opencode/test/provider/model-modalities-optional.test.ts
+++ b/packages/opencode/test/provider/model-modalities-optional.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { Model as ConfigProviderModel } from "../../src/config/provider"
+
+// Regression for #29268: a model may declare only one modality direction. The config
+// schema must not require both input and output (consumers read modalities?.input/
+// .output ?? false and degrade gracefully), so config load should not crash.
+
+test("config provider Model schema accepts modalities with only input", () => {
+  const result = ConfigProviderModel.zod.safeParse({ modalities: { input: ["text", "image"] } })
+  expect(result.success).toBe(true)
+})
+
+test("config provider Model schema accepts modalities with only output", () => {
+  const result = ConfigProviderModel.zod.safeParse({ modalities: { output: ["text"] } })
+  expect(result.success).toBe(true)
+})


### PR DESCRIPTION
## Summary

A model declaring `modalities` with only one direction crashed config load. The config `Model` schema required **both** `modalities.input` and `modalities.output` whenever `modalities` was present, so an input-only (or output-only) model was rejected during validation — `ConfigParse.schema` throws `InvalidError` on a failed `safeParse` — instead of loading.

## Fix

Wrap `modalities.input` and `modalities.output` in `Schema.optional` (`config/provider.ts:49-50`). Consumers already read `model.modalities?.input?.includes(...) ?? false` / `?.output?... ?? false` (`provider.ts:1056-1067`), so a missing direction degrades gracefully to all-false capabilities. No other code change needed.

## PawWork gap vs upstream

Adapted from upstream `anomalyco/opencode` `0bfa55b623` (PR #29268 — thanks Robert Poschenrieder). The upstream change is verbatim-equivalent (wrap each direction in `Schema.optional`); `dev` and `upstream/dev` share no common ancestor, so this is a re-implementation, not a cherry-pick. Scope is config/provider.ts only — the models.dev catalog schema is untouched (upstream didn't touch it either).

## Test

Added `model-modalities-optional.test.ts`: asserts the config `Model` schema (via its derived `.zod`, the actual config-load validator) accepts modalities with only `input` and with only `output`. Proven red → green (without the change both `safeParse` calls return `success: false`).

## Verification

- `bun test test/provider/model-modalities-optional.test.ts` — 2 pass (red→green confirmed)
- `bun run typecheck` — clean
