### PR TITLE
fix(project): preserve session time_updated during global migration

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,5 +1,5 @@
 import z from "zod"
-import { and, Database, eq, NotFoundError } from "../storage/db"
+import { and, Database, eq, NotFoundError, sql } from "../storage/db"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
 import { Log } from "@opencode-ai/core/util/log"
@@ -327,7 +327,10 @@ export namespace Project {
           yield* db((d) =>
             d
               .update(SessionTable)
-              .set({ project_id: data.id })
+              // Pin time_updated to its current value so the re-parent does not
+              // trip drizzle's $onUpdate, which would bump every migrated
+              // session to the top of recents.
+              .set({ project_id: data.id, time_updated: sql`${SessionTable.time_updated}` })
               .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
               .run(),
           )

--- a/packages/opencode/test/project/migrate-global.test.ts
+++ b/packages/opencode/test/project/migrate-global.test.ts
@@ -15,7 +15,7 @@ function uid() {
   return SessionID.make(crypto.randomUUID())
 }
 
-function seed(opts: { id: SessionID; dir: string; project: ProjectID }) {
+function seed(opts: { id: SessionID; dir: string; project: ProjectID; timeUpdated?: number }) {
   const now = Date.now()
   Database.use((db) =>
     db
@@ -28,7 +28,7 @@ function seed(opts: { id: SessionID; dir: string; project: ProjectID }) {
         title: "test",
         version: "0.0.0-test",
         time_created: now,
-        time_updated: now,
+        time_updated: opts.timeUpdated ?? now,
       })
       .run(),
   )
@@ -75,6 +75,34 @@ describe("migrateFromGlobal", () => {
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()
     expect(row!.project_id).toBe(real.id)
+  })
+
+  test("preserves session time_updated while re-parenting on migration", async () => {
+    // 1. git init but no commits — "global" project
+    await using tmp = await tmpdir()
+    await $`git init`.cwd(tmp.path).quiet()
+    await $`git config user.name "Test"`.cwd(tmp.path).quiet()
+    await $`git config user.email "test@opencode.test"`.cwd(tmp.path).quiet()
+    await $`git config commit.gpgsign false`.cwd(tmp.path).quiet()
+    const { project: pre } = await Project.fromDirectory(tmp.path)
+    expect(pre.id).toBe(ProjectID.global)
+
+    // 2. Seed a session under "global" with an OLD update time
+    const id = uid()
+    const oldTime = Date.now() - 1_000_000
+    seed({ id, dir: tmp.path, project: ProjectID.global, timeUpdated: oldTime })
+
+    // 3. Commit so the project gets a real ID and the session migrates
+    await $`git commit --allow-empty -m "root"`.cwd(tmp.path).quiet()
+    const { project: real } = await Project.fromDirectory(tmp.path)
+    expect(real.id).not.toBe(ProjectID.global)
+
+    // 4. The migration re-parents the session but must NOT bump time_updated,
+    //    otherwise every migrated session jumps to the top of recents.
+    const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
+    expect(row).toBeDefined()
+    expect(row!.project_id).toBe(real.id)
+    expect(row!.time_updated).toBe(oldTime)
   })
 
   test("migrates global sessions even when project row already exists", async () => {


### PR DESCRIPTION
## What

When a directory used before `git init` later becomes a real project, its
sessions are migrated off the `global` project. That migration re-parents them
with a bare update:

```ts
d.update(SessionTable).set({ project_id: data.id }).where(...).run()
```

`time_updated` is part of the shared `Timestamps` columns
(`storage/schema.sql.ts`), defined with drizzle's
`$onUpdate(() => Date.now())`. So this update — which only means to change
`project_id` — also bumps `time_updated` to "now" for **every** migrated
session. The result: on first commit, all of a directory's older sessions jump
to the top of the recents list at once, losing their real last-used ordering.

## Fix

Pin `time_updated` to its own current value in the same `set(...)`, so the
re-parent writes the existing timestamp back instead of tripping `$onUpdate`:

```ts
.set({ project_id: data.id, time_updated: sql`${SessionTable.time_updated}` })
```

`project_id` is still updated; only the spurious timestamp bump is suppressed.

## Why this shape

Ports the idea from upstream `anomalyco/opencode` `c5c9a1d435` (#29147,
"preserve session update time during project migration"), adapted to PawWork's
diverged `project.ts`:

- PawWork's migration `where` is worktree-scoped
  (`project_id = global AND directory = data.worktree`) rather than upstream's
  `project_id = oldID`; the missing-pin bug is identical.
- `sql` is re-exported from `../storage/db` (`export * from "drizzle-orm"`), so
  no new direct dependency — added to the existing import.

## Test

`packages/opencode/test/project/migrate-global.test.ts`:

- **Red → green**: a session seeded under `global` with an old `time_updated`
  now keeps that exact timestamp after migration while still being re-parented
  to the real project id. Without the pin, `time_updated` was bumped to ~now.
- `seed()` gained an optional `timeUpdated` (defaults to now; existing tests
  unchanged).

## Verification

- `bun test test/project/` (opencode): 99 pass, 1 skip, 0 fail.
- `bun run typecheck` (opencode): clean.

Thanks to upstream (`@thdxr`) for the original fix.