### PR TITLE
fix(acp): include tool image attachments in updates

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -341,33 +341,7 @@ export namespace ACP {
                 this.toolStarts.delete(part.callID)
                 this.bashSnapshots.delete(part.callID)
                 const kind = toToolKind(part.tool)
-                const content: ToolCallContent[] = [
-                  {
-                    type: "content",
-                    content: {
-                      type: "text",
-                      text: part.state.output,
-                    },
-                  },
-                ]
-
-                if (kind === "edit") {
-                  const input = part.state.input
-                  const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
-                  const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
-                  const newText =
-                    typeof input["newString"] === "string"
-                      ? input["newString"]
-                      : typeof input["content"] === "string"
-                        ? input["content"]
-                        : ""
-                  content.push({
-                    type: "diff",
-                    path: filePath,
-                    oldText,
-                    newText,
-                  })
-                }
+                const content = completedToolContent(part, kind)
 
                 if (part.tool === "todowrite") {
                   const parsedTodos = z.array(Todo.Info).safeParse(JSON.parse(part.state.output))
@@ -407,10 +381,7 @@ export namespace ACP {
                       content,
                       title: part.state.title,
                       rawInput: part.state.input,
-                      rawOutput: {
-                        output: part.state.output,
-                        metadata: part.state.metadata,
-                      },
+                      rawOutput: completedToolRawOutput(part),
                     },
                   })
                   .catch((error) => {
@@ -879,33 +850,7 @@ export namespace ACP {
               this.toolStarts.delete(part.callID)
               this.bashSnapshots.delete(part.callID)
               const kind = toToolKind(part.tool)
-              const content: ToolCallContent[] = [
-                {
-                  type: "content",
-                  content: {
-                    type: "text",
-                    text: part.state.output,
-                  },
-                },
-              ]
-
-              if (kind === "edit") {
-                const input = part.state.input
-                const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
-                const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
-                const newText =
-                  typeof input["newString"] === "string"
-                    ? input["newString"]
-                    : typeof input["content"] === "string"
-                      ? input["content"]
-                      : ""
-                content.push({
-                  type: "diff",
-                  path: filePath,
-                  oldText,
-                  newText,
-                })
-              }
+              const content = completedToolContent(part, kind)
 
               if (part.tool === "todowrite") {
                 const parsedTodos = z.array(Todo.Info).safeParse(JSON.parse(part.state.output))
@@ -945,10 +890,7 @@ export namespace ACP {
                     content,
                     title: part.state.title,
                     rawInput: part.state.input,
-                    rawOutput: {
-                      output: part.state.output,
-                      metadata: part.state.metadata,
-                    },
+                    rawOutput: completedToolRawOutput(part),
                   },
                 })
                 .catch((err) => {
@@ -1600,6 +1542,73 @@ export namespace ACP {
       default:
         return []
     }
+  }
+
+  function completedToolContent(part: ToolPart, kind: ToolKind): ToolCallContent[] {
+    if (part.state.status !== "completed") return []
+
+    const content: ToolCallContent[] = [
+      {
+        type: "content",
+        content: {
+          type: "text",
+          text: part.state.output,
+        },
+      },
+    ]
+
+    if (kind === "edit") {
+      const input = part.state.input
+      const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
+      const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
+      const newText =
+        typeof input["newString"] === "string"
+          ? input["newString"]
+          : typeof input["content"] === "string"
+            ? input["content"]
+            : ""
+      content.push({
+        type: "diff",
+        path: filePath,
+        oldText,
+        newText,
+      })
+    }
+
+    content.push(...imageContents(part.state.attachments ?? []))
+    return content
+  }
+
+  function completedToolRawOutput(part: ToolPart) {
+    if (part.state.status !== "completed") return {}
+    return {
+      output: part.state.output,
+      metadata: part.state.metadata,
+      ...(part.state.attachments?.length ? { attachments: part.state.attachments } : {}),
+    }
+  }
+
+  function imageContents(attachments: Array<{ mime: string; url: string }>): ToolCallContent[] {
+    return attachments.flatMap((attachment): ToolCallContent[] => {
+      // The inner class excludes ";" so each parameter segment matches
+      // unambiguously — avoids catastrophic backtracking (ReDoS) on adversarial
+      // tool/MCP attachment URLs with many ";" and no trailing ";base64,".
+      const match = attachment.url.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.*)$/)
+      const mime = match?.[1] ?? attachment.mime
+      if (!mime.startsWith("image/")) return []
+      const data = match?.[2]
+      if (data === undefined) return []
+      return [
+        {
+          type: "content" as const,
+          content: {
+            type: "image" as const,
+            mimeType: mime,
+            data,
+          },
+        },
+      ]
+    })
   }
 
   async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ providerID: ProviderID; modelID: ModelID }> {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { ACP } from "../../src/acp/agent"
 import type { AgentSideConnection } from "@agentclientprotocol/sdk"
-import type { Event, EventMessagePartUpdated, ToolStatePending, ToolStateRunning } from "@opencode-ai/sdk/v2"
+import type {
+  Event,
+  EventMessagePartUpdated,
+  FilePart,
+  ToolStateCompleted,
+  ToolStatePending,
+  ToolStateRunning,
+} from "@opencode-ai/sdk/v2"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -42,9 +49,13 @@ function toolEvent(
     callID: string
     tool: string
     input: Record<string, unknown>
-  } & ({ status: "running"; metadata?: Record<string, unknown> } | { status: "pending"; raw: string }),
+  } & (
+    | { status: "running"; metadata?: Record<string, unknown> }
+    | { status: "pending"; raw: string }
+    | { status: "completed"; output: string; metadata?: Record<string, unknown>; title?: string; attachments?: FilePart[] }
+  ),
 ): GlobalEventEnvelope {
-  const state: ToolStatePending | ToolStateRunning =
+  const state: ToolStatePending | ToolStateRunning | ToolStateCompleted =
     opts.status === "running"
       ? {
           status: "running",
@@ -52,11 +63,21 @@ function toolEvent(
           ...(opts.metadata && { metadata: opts.metadata }),
           time: { start: Date.now() },
         }
-      : {
-          status: "pending",
-          input: opts.input,
-          raw: opts.raw,
-        }
+      : opts.status === "completed"
+        ? {
+            status: "completed",
+            input: opts.input,
+            output: opts.output,
+            title: opts.title ?? "test",
+            metadata: opts.metadata ?? {},
+            ...(opts.attachments && { attachments: opts.attachments }),
+            time: { start: Date.now(), end: Date.now() },
+          }
+        : {
+            status: "pending",
+            input: opts.input,
+            raw: opts.raw,
+          }
   const payload: EventMessagePartUpdated = {
     type: "message.part.updated",
     properties: {
@@ -678,6 +699,79 @@ describe("acp.agent event subscription", () => {
           .map((u) => inProgressText(u.update))
 
         expect(snapshots).toEqual(["a", "a"])
+        stop()
+      },
+    })
+  })
+
+  test("includes image attachments as content blocks on completed tool calls", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const image: FilePart = {
+          id: "file_1",
+          sessionID: sessionId,
+          messageID: "msg_call_1",
+          type: "file",
+          mime: "image/png",
+          url: "data:image/png;base64,iVBORw0KGgoAAAA=",
+        }
+        // A non-image attachment must be skipped, not turned into a content block.
+        const textFile: FilePart = {
+          id: "file_2",
+          sessionID: sessionId,
+          messageID: "msg_call_1",
+          type: "file",
+          mime: "text/plain",
+          url: "data:text/plain;base64,aGVsbG8=",
+        }
+        // A malformed data URL (many ";" and no ";base64,") must be skipped
+        // quickly — it is the ReDoS-shaped input the parser guards against.
+        const malformed: FilePart = {
+          id: "file_3",
+          sessionID: sessionId,
+          messageID: "msg_call_1",
+          type: "file",
+          mime: "image/png",
+          url: "data:image/png" + ";".repeat(64) + "x",
+        }
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_1",
+            tool: "bash",
+            status: "completed",
+            input: { command: "screenshot" },
+            output: "captured",
+            attachments: [image, textFile, malformed],
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const update = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCallUpdate(u) && u.toolCallId === "call_1" && u.status === "completed")
+        expect(update && isToolCallUpdate(update)).toBe(true)
+
+        const content = isToolCallUpdate(update!) ? update!.content : undefined
+        expect(content).toContainEqual({
+          type: "content",
+          content: { type: "image", mimeType: "image/png", data: "iVBORw0KGgoAAAA=" },
+        })
+        // The text output is still present alongside the image.
+        expect(
+          content?.some(
+            (c) => c.type === "content" && c.content.type === "text" && c.content.text === "captured",
+          ),
+        ).toBe(true)
+        // Only the image attachment becomes an image block; text/plain is dropped.
+        const imageBlocks = content?.filter((c) => c.type === "content" && c.content.type === "image")
+        expect(imageBlocks).toHaveLength(1)
         stop()
       },
     })


### PR DESCRIPTION
## What

When a tool call completes, the ACP agent forwards its result to the client as
`tool_call_update` content. PawWork only emitted the **text** output (plus an
`edit` diff). Any image attachments the tool produced — e.g. a screenshot tool
returning a PNG — were silently dropped from both the live event path and the
session-replay path. The image bytes live on `part.state.attachments`
(`FilePart[]`, each with `mime` + a data `url`) but never reached the client.

## Fix

Extract the duplicated completed-tool content/`rawOutput` building (identical in
the live and replay branches) into shared helpers, and emit image attachments
as ACP `image` content blocks:

- `imageContents(attachments)` parses each attachment's `data:` URL for mime +
  base64 data (falling back to the attachment's own `mime`), skips non-image
  attachments, and yields `{ type: "content", content: { type: "image", mimeType, data } }`.
- `completedToolContent(part, kind)` builds text + edit-diff (unchanged) then
  appends the image blocks.
- `completedToolRawOutput(part)` additionally surfaces the raw `attachments`
  under `rawOutput` when present.

Both completed-tool branches now call these helpers, so the two paths stay in
sync.

## Why this shape

Ports upstream `anomalyco/opencode` `817cb076a8` (#25128,
"include tool image attachments in updates"), adapted to PawWork's diverged
`agent.ts`. PawWork's tool-part completed state already carries
`attachments: FilePart[]` (confirmed in the SDK gen types and
`message-v2.ts`), so the change is purely additive at the ACP surface — no
schema change, one source file.

## Test

`packages/opencode/test/acp/event-subscription.test.ts`:

- **Red → green**: a completed `bash` tool event carrying an `image/png`
  attachment now produces an image content block (`mimeType` + base64 `data`)
  alongside the preserved text output. Without the fix the content array held
  only the text block.
- `toolEvent()` gained a `completed` variant (output / metadata / title /
  attachments); existing running/pending tests untouched.

## Verification

- `bun test test/acp/` (opencode): 11 pass, 0 fail.
- `bun run typecheck` (opencode): clean.

Thanks to upstream (`@SteffenDE`) for the original fix.