### PR TITLE
fix(tool): match read permission patterns against the worktree-relative path

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -187,7 +187,10 @@ export const ReadTool = Tool.define(
 
       yield* ctx.ask({
         permission: "read",
-        patterns: [filepath],
+        // ba9e4b67ed: match the permission pattern against the worktree-relative path, like
+        // edit/write/apply_patch (edit.ts:86,131). The absolute filepath never matched a user's
+        // permission.read glob (which is relative), so read rules were silently inert.
+        patterns: [path.relative(Instance.worktree, filepath)],
         always: ["*"],
         metadata: {},
       })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -84,7 +84,6 @@ const fail = Effect.fn("ReadToolTest.fail")(function* (
   throw new Error("expected read to fail")
 })
 
-const full = (p: string) => (process.platform === "win32" ? Filesystem.normalizePath(p) : p)
 const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
 const put = Effect.fn("ReadToolTest.put")(function* (p: string, content: string | Buffer | Uint8Array) {
@@ -145,6 +144,26 @@ describe("tool.read external_directory permission", () => {
     }),
   )
 
+  it.live("asks for read permission using the worktree-relative path (ba9e4b67ed)", () =>
+    Effect.gen(function* () {
+      // The read permission pattern must be the worktree-relative path, like
+      // edit/write/apply_patch — otherwise a user's relative permission.read glob never matches
+      // the absolute filepath and read rules are silently inert.
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "subdir", "test.txt"), "nested content")
+
+      const { items, next } = asks()
+      const target = path.join(dir, "subdir", "test.txt")
+      yield* exec(dir, { filePath: target }, next)
+
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+      expect(read!.patterns).toEqual([path.relative(dir, target)])
+      // Regression guard: not the absolute path.
+      expect(read!.patterns[0]).not.toContain(dir)
+    }),
+  )
+
   if (process.platform === "win32") {
     it.live("normalizes read permission paths on Windows", () =>
       Effect.gen(function* () {
@@ -161,7 +180,9 @@ describe("tool.read external_directory permission", () => {
         yield* exec(dir, { filePath: alt }, next)
         const read = items.find((item) => item.permission === "read")
         expect(read).toBeDefined()
-        expect(read!.patterns).toEqual([full(target)])
+        // ba9e4b67ed: a weird-cased / forward-slashed Windows input still resolves to the
+        // worktree-relative pattern (not the normalized absolute path).
+        expect(read!.patterns).toEqual([path.relative(dir, target)])
       }),
     )
   }


### PR DESCRIPTION
## What

The read tool asked for the `read` permission using the **absolute** filepath as its pattern, while `edit`/`write`/`apply_patch` use the **worktree-relative** path (`edit.ts:86,131`). Users write `permission.read` globs as relative paths, so a user's rule never matched the absolute pattern — **read permissions were silently inert**.

## Why

Semantic port of upstream [`anomalyco/opencode@ba9e4b67ed`](https://github.com/anomalyco/opencode/commit/ba9e4b67ed) (Kit Langton) — aligns the read tool's permission pattern with the edit family.

## How

`tool/read.ts` — pass `path.relative(Instance.worktree, filepath)` as the `read` ask pattern instead of the absolute `filepath`. The relative is taken from the **post-`assertExternalDirectoryEffect`** filepath (the same point `edit.ts` computes its `relativeFilePath`), so external-directory canonicalization is respected. `Instance.worktree` is already bound earlier in the function. One-line swap; the separate `external_directory` ask (absolute pattern) is unchanged.

## Boundary

- `packages/opencode/src/tool/read.ts` — relative permission pattern
- `packages/opencode/test/tool/read.test.ts` — regression test + the coupled Windows test update

## Verification

- New cross-platform test **"asks for read permission using the worktree-relative path"** — asserts the `read` ask pattern equals `path.relative(dir, target)` and does **not** contain the absolute dir (red→green: pre-fix it was the absolute path).
- The Windows-only normalization test, which asserted the old absolute pattern, now asserts the relative one. Dropped the now-unused `full` test helper.
- `bun test test/tool/read.test.ts` — 38 pass. Full `bun test` (opencode) — **3664 pass / 0 fail**. `bun run typecheck` — clean.
