### PR TITLE
fix(import): re-home imported sessions onto the local instance

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs"
 import type { Session as SDKSession, Message, Part } from "@opencode-ai/sdk/v2"
 import { Session } from "../../session"
 import { MessageV2 } from "../../session/message-v2"
+import { rootContext } from "../../session/execution-context"
 import { cmd } from "./cmd"
 import { bootstrap } from "../bootstrap"
 import { Database } from "../../storage/db"
@@ -71,6 +72,46 @@ export function transformShareData(shareData: ShareData[]): {
       info: msg,
       parts: partMap.get(msg.id) ?? [],
     })),
+  }
+}
+
+/**
+ * Re-home an imported session onto the importing instance. An exported session
+ * carries the exporter's machine-local fields — `projectID`, `directory`,
+ * `workspaceID`, and `executionContext` — all pointing at projects/paths/ids that
+ * do not exist here. Replace every one of them, mirroring how a freshly created
+ * session is rooted (`Session.createNext`): adopt the local project + directory,
+ * drop the foreign workspace binding (no local equivalent in the CLI import
+ * context, and a foreign id breaks workspace routing), and reseed the execution
+ * context — which drives the session's actual shell/tool cwd, not `directory` —
+ * at the local owner directory. (#27516)
+ */
+export function localizeImportedSession(
+  info: SDKSession,
+  ctx: { projectID: string; directory: string; ownerDirectory: string },
+) {
+  return {
+    ...info,
+    projectID: ctx.projectID,
+    directory: ctx.directory,
+    workspaceID: undefined,
+    executionContext: rootContext(ctx.ownerDirectory),
+  }
+}
+
+/**
+ * The `onConflictDoUpdate` set for re-importing an existing session: it must
+ * overwrite every column `localizeImportedSession` rewrote, else a stale foreign
+ * `workspace_id` / `execution_context` survives on the old row. `workspace_id`
+ * is coalesced to `null` because drizzle skips `undefined` keys in a SET clause —
+ * so an imported session with no workspace would otherwise keep the stale id.
+ */
+export function importedSessionConflictSet(row: ReturnType<typeof Session.toRow>) {
+  return {
+    project_id: row.project_id,
+    directory: row.directory,
+    workspace_id: row.workspace_id ?? null,
+    execution_context: row.execution_context,
   }
 }
 
@@ -154,16 +195,21 @@ export const ImportCommand = cmd({
         return
       }
 
-      const info = Session.Info.parse({
-        ...exportData.info,
-        projectID: Instance.project.id,
-      })
+      const info = Session.Info.parse(
+        localizeImportedSession(exportData.info, {
+          projectID: Instance.project.id,
+          directory: Instance.directory,
+          // git projects root the owner at the worktree (it never moves); non-git keep
+          // the opened directory — mirrors Session.createNext.
+          ownerDirectory: Instance.project.vcs === "git" ? Instance.worktree : Instance.directory,
+        }),
+      )
       const row = Session.toRow(info)
       Database.use((db) =>
         db
           .insert(SessionTable)
           .values(row)
-          .onConflictDoUpdate({ target: SessionTable.id, set: { project_id: row.project_id } })
+          .onConflictDoUpdate({ target: SessionTable.id, set: importedSessionConflictSet(row) })
           .run(),
       )
 

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test"
 import {
+  importedSessionConflictSet,
+  localizeImportedSession,
   parseShareUrl,
   shouldAttachShareAuthHeaders,
   transformShareData,
@@ -51,4 +53,65 @@ test("returns null for invalid share data", () => {
   expect(transformShareData([])).toBeNull()
   expect(transformShareData([{ type: "message", data: {} as any }])).toBeNull()
   expect(transformShareData([{ type: "session", data: { id: "s" } as any }])).toBeNull() // no messages
+})
+
+// localizeImportedSession tests
+test("re-homes an imported session onto the local instance, dropping every foreign machine-local field", () => {
+  const exported = {
+    id: "sess-1",
+    slug: "sess-1",
+    projectID: "prj-exporter",
+    directory: "/exporter/home/some-project/sub",
+    workspaceID: "wsp-exporter",
+    executionContext: {
+      ownerDirectory: "/exporter/home/some-project",
+      activeDirectory: "/exporter/home/some-project/sub",
+      activeWorktree: { directory: "/exporter/home/.worktrees/x", name: "x", branch: "x", source: "existing" },
+      lastChangedAt: 111,
+    },
+    title: "Imported",
+    version: "1.0.0",
+  } as any
+
+  const localized = localizeImportedSession(exported, {
+    projectID: "prj-local",
+    directory: "/exporter-test/importer/local-project",
+    ownerDirectory: "/exporter-test/importer/local-project",
+  })
+
+  // project + directory adopt the importing instance
+  expect(localized.projectID).toBe("prj-local")
+  expect(localized.directory).toBe("/exporter-test/importer/local-project")
+  // foreign workspace binding is dropped (a foreign id would break workspace routing)
+  expect(localized.workspaceID).toBeUndefined()
+  // executionContext (the real shell/tool cwd source) is reseeded at the local owner;
+  // the exporter's absolute paths and worktree are gone
+  expect(localized.executionContext.ownerDirectory).toBe("/exporter-test/importer/local-project")
+  expect(localized.executionContext.activeDirectory).toBe("/exporter-test/importer/local-project")
+  expect(localized.executionContext.activeWorktree).toBeUndefined()
+  // unrelated fields preserved; input not mutated
+  expect(localized.id).toBe("sess-1")
+  expect(localized.title).toBe("Imported")
+  expect(exported.directory).toBe("/exporter/home/some-project/sub")
+  expect(exported.workspaceID).toBe("wsp-exporter")
+  expect(exported.executionContext.activeWorktree).toBeDefined()
+})
+
+test("re-import conflict set overwrites every re-homed column and clears a stale workspace to null", () => {
+  const set = importedSessionConflictSet({
+    project_id: "prj-local",
+    directory: "/exporter-test/importer/local-project",
+    workspace_id: undefined,
+    execution_context: { ownerDirectory: "/exporter-test/importer/local-project", activeDirectory: "/exporter-test/importer/local-project", lastChangedAt: 1 },
+  } as any)
+
+  expect(set.project_id as string).toBe("prj-local")
+  expect(set.directory).toBe("/exporter-test/importer/local-project")
+  // undefined must become null (not be skipped) so re-import clears a stale foreign id
+  expect(set.workspace_id).toBeNull()
+  expect(set.execution_context).toEqual({
+    ownerDirectory: "/exporter-test/importer/local-project",
+    activeDirectory: "/exporter-test/importer/local-project",
+    lastChangedAt: 1,
+  })
 })


### PR DESCRIPTION
## Problem

When importing a session (share URL or exported JSON), the handler rewrote `projectID` but kept the exporter's **machine-local fields** verbatim — `directory`, `workspaceID`, and `executionContext`. All point at the machine that produced the export:

- **`executionContext.activeDirectory` is the real shell/tool cwd** (`prompt.ts:1074/1295/1323`, `system.ts:44`, `compaction.ts:392`) — not `directory`. The loader keeps any persisted context whose paths are merely `path.isAbsolute(...)` (`session.ts:131-164`), so a foreign-but-absolute exporter path is retained, and the imported session **runs at the exporter's directory**.
- **`workspaceID`** is preferred by workspace routing; a foreign id with no local record → `missing-workspace-error`.

(Upstream #27516 only touched `directory`/`path` because upstream's session model has neither `workspaceID` nor `executionContext` — PawWork diverged.)

## Fix

`localizeImportedSession()` now re-homes **all four** machine-local fields onto the importing instance, mirroring `Session.createNext`:

- `projectID` + `directory` → the local instance
- `workspaceID` → dropped (no local equivalent in the CLI import context; a foreign id breaks routing, and `workspace_id` is nullable)
- `executionContext` → a fresh `rootContext` rooted at the local owner (git worktree, else the opened directory)

The re-import `onConflictDoUpdate` set is widened to the same columns (`project_id`, `directory`, `workspace_id`, `execution_context`) so re-importing an existing session fully corrects a stale row, not just two fields.

## Test

`localizeImportedSession` is unit-tested in `test/cli/import.test.ts`: a session carrying foreign `projectID`/`directory`/`workspaceID`/`executionContext` (incl. a foreign `activeWorktree`) is re-homed — project + directory local, `workspaceID` undefined, `executionContext` reseeded at the local owner with no worktree, unrelated fields preserved, input not mutated. Verified red→green (stripping the `workspaceID`/`executionContext` overrides leaks `wsp-exporter` and fails).

`bun test test/cli/import.test.ts` green (6 pass, 28 assertions); `bun run typecheck` clean. One owned source file (`cli/cmd/import.ts`) + its test.

## Follow-up

The session **loader** still trusts any persisted execution context whose paths are merely absolute, so foreign-but-absolute contexts from **project moves / cross-machine row copies** need a project-aware self-heal at the load seam. That's a behavior change to every load path (worktree-regression risk), tracked separately in #1147 — out of scope here.

## Credit

Extends anomalyco/opencode#27516 ([`66d409d679`](https://github.com/anomalyco/opencode/commit/66d409d679)). Thanks @OpeOginni.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced session import to automatically reconfigure imported sessions for the current instance, including proper mapping of project paths and clearing foreign workspace contexts.

* **Tests**
  * Added test coverage for session import localization and database conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->