### PR TITLE
fix(tool): ignore invalid custom tool exports

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -64,6 +64,10 @@ export function localToolImportSpec(input: string) {
   return input.startsWith("file://") ? input : pathToFileURL(input).href
 }
 
+function isPluginTool(value: unknown): value is ToolDefinition {
+  return typeof value === "object" && value !== null && "args" in value && "description" in value && "execute" in value
+}
+
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
 
@@ -266,7 +270,12 @@ export namespace ToolRegistry {
               }
             }
             const mod = yield* Effect.promise(() => import(spec))
-            for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
+            for (const [id, def] of Object.entries(mod)) {
+              // A `.opencode/tool/*.ts` file can export non-tool values alongside its
+              // tool(s) (helper consts, re-exported types). Skip anything that isn't a
+              // tool definition; otherwise `fromPlugin` wraps it into a bogus,
+              // description-less tool (7a012cac08).
+              if (!isPluginTool(def)) continue
               custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
             }
           }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -276,7 +276,11 @@ export namespace ToolRegistry {
               // tool definition; otherwise `fromPlugin` wraps it into a bogus,
               // description-less tool (7a012cac08).
               if (!isPluginTool(def)) continue
-              custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+              const toolId = id === "default" ? namespace : `${namespace}_${id}`
+              // A non-tool sibling export keeps the coarse pre-import `ids.every(disabled)`
+              // skip from firing, so honor per-tool disables here too.
+              if (disabled.has(toolId)) continue
+              custom.push(fromPlugin(toolId, def))
             }
           }
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -158,6 +158,43 @@ describe("tool.registry", () => {
     })
   })
 
+  test("ignores non-tool exports in .opencode/tool files (7a012cac08)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const toolDir = path.join(dir, ".opencode", "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolDir, "mixed.ts"),
+          [
+            "export const helper = 'not a tool'",
+            "export default {",
+            "  description: 'mixed tool',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await withMockedConfigInstall(async () => {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          // The valid default export still loads.
+          expect(ids).toContain("mixed")
+          // The non-tool string export must not be wrapped into a phantom tool —
+          // it has no `args`/`description`/`execute`, so `fromPlugin` would build a
+          // bogus, description-less tool keyed `mixed_helper`.
+          expect(ids).not.toContain("mixed_helper")
+        },
+      })
+    })
+  })
+
   test("bridges plugin ctx.ask and ctx.metadata so the framework Effects actually run", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -195,6 +195,53 @@ describe("tool.registry", () => {
     })
   })
 
+  test("honors a per-tool disable for a mixed-export local tool file (7a012cac08)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolDir = path.join(opencodeDir, "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        await Bun.write(
+          path.join(opencodeDir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            tools: { mixed: false },
+          }),
+        )
+
+        // A non-tool sibling export keeps the coarse pre-import `ids.every(disabled)`
+        // skip from firing (mixed_helper is not disabled), so the file is imported.
+        // The disabled real tool must still not register.
+        await Bun.write(
+          path.join(toolDir, "mixed.ts"),
+          [
+            "export const helper = 'not a tool'",
+            "export default {",
+            "  description: 'mixed tool',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await withMockedConfigInstall(async () => {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).not.toContain("mixed")
+          expect(ids).not.toContain("mixed_helper")
+        },
+      })
+    })
+  })
+
   test("bridges plugin ctx.ask and ctx.metadata so the framework Effects actually run", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## What

Guard the `.opencode/tool` custom-tool loader so it skips module exports that aren't tool definitions, and honor per-tool disables for mixed-export files.

## The PawWork gap

The local-tool loader (`tool/registry.ts`) imports each `.opencode/tool/*.ts` module and pushes **every** export through `fromPlugin`, which builds a tool from `def.args` / `def.description` / `def.execute`:

```ts
const mod = yield* Effect.promise(() => import(spec))
for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
  custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
}
```

A `.opencode/tool` file commonly exports helpers next to its tool (a shared const, a re-exported value). Those exports have no `args`/`description`/`execute`. You'd expect `fromPlugin`'s `z.object(def.args)` to reject them, but on zod 4 `z.object(undefined)` returns an **empty schema** instead of throwing — so the bogus value is silently registered as a phantom, description-less tool. A plain `export const helper = "..."` alongside a real `export default` tool surfaces an extra `<file>_helper` entry in the registry (and a useless, schema-less tool to the model).

## The fix

Add an `isPluginTool` type guard and `continue` past non-matching exports, so only genuine tool definitions reach `fromPlugin`:

```ts
function isPluginTool(value: unknown): value is ToolDefinition {
  return typeof value === "object" && value !== null && "args" in value && "description" in value && "execute" in value
}
```

**Plus** (surfaced by `/codex review`): the registration loop is now the single place that decides whether an export becomes a tool, so it also honors the already-computed `disabled` set. The coarse pre-import skip (`ids.every(id => disabled.has(id))`) only fires when *every* export of a file is disabled — a non-tool sibling export (never disabled) keeps it from firing, so a file with `tools: { mixed: false }` was still importing and registering the disabled `mixed` tool. The loop now `continue`s on `disabled.has(toolId)` too.

## Tests

Red→green regressions in `registry.test.ts`:
- `mixed.ts` with a valid `export default` tool plus `export const helper = 'not a tool'` → asserts `mixed` loads and `mixed_helper` does not (the phantom).
- Same file with `tools: { mixed: false }` → asserts neither `mixed` nor `mixed_helper` registers.

Both confirmed failing before the respective fix, passing after. Full `registry.test.ts` suite green (25 tests); `tsgo --noEmit` clean.

## Upstream

Semantic port of [anomalyco/opencode `7a012cac08`](https://github.com/anomalyco/opencode/commit/7a012cac08c0e198bbffb48dcfd75a4f908d75e7) — *fix(tool): ignore invalid custom tool exports* (thanks Dax Raad). Re-implemented against PawWork's loader (which uses `localToolImportSpec` for the `file://` import); the guard and intent match. The per-tool-disable consistency fix is a small PawWork addition beyond the upstream commit, since this loop is where the guard now lives.
