### PR TITLE
fix(provider): skip reasoningEffort for azure gpt-5.5

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1191,6 +1191,13 @@ export function options(input: {
     result["enable_thinking"] = true
   }
 
+  // Azure's gpt-5.5 completions API rejects reasoningEffort; only reasoningSummary is accepted.
+  // Return early so the shared gpt-5 block below never sets reasoningEffort for this provider.
+  if (input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
+    result["reasoningSummary"] = "auto"
+    return result
+  }
+
   if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
     if (!input.model.api.id.includes("gpt-5-pro")) {
       result["reasoningEffort"] = "medium"

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -396,6 +396,46 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   })
 })
 
+describe("ProviderTransform.options - azure gpt-5.5 reasoningEffort", () => {
+  const sessionID = "test-session-123"
+
+  const createAzureModel = (apiId: string) =>
+    ({
+      id: `azure/${apiId}`,
+      providerID: "azure",
+      api: {
+        id: apiId,
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("azure gpt-5.5 should NOT set reasoningEffort (Azure rejects it)", () => {
+    const result = ProviderTransform.options({
+      model: createAzureModel("gpt-5.5"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBe("auto")
+  })
+})
+
 describe("ProviderTransform.options - gateway", () => {
   const sessionID = "test-session-123"
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -434,6 +434,27 @@ describe("ProviderTransform.options - azure gpt-5.5 reasoningEffort", () => {
     expect(result.reasoningEffort).toBeUndefined()
     expect(result.reasoningSummary).toBe("auto")
   })
+
+  // Guard must be scoped to gpt-5.5 only; other azure gpt-5.x keep reasoningEffort.
+  test("azure gpt-5.1 should still set reasoningEffort to medium", () => {
+    const result = ProviderTransform.options({
+      model: createAzureModel("gpt-5.1"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+  })
+
+  test("azure gpt-5.2 should still set reasoningEffort to medium", () => {
+    const result = ProviderTransform.options({
+      model: createAzureModel("gpt-5.2"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+  })
 })
 
 describe("ProviderTransform.options - gateway", () => {


### PR DESCRIPTION
## Summary

`ProviderTransform.options` adds `reasoningEffort: "medium"` to any model whose api id contains `gpt-5` (excluding `gpt-5-chat`/`gpt-5-pro`). Azure's `gpt-5.5` matches that block, but Azure's completions API rejects the `reasoningEffort` parameter, so the request fails and the provider is unusable.

This adds an early-return guard: for `@ai-sdk/azure` models whose id contains `gpt-5.5`, set only `reasoningSummary: "auto"` and return before the shared `gpt-5` block runs.

No local issue — this is an upstream-port fix.

## Why

Without the guard, Azure `gpt-5.5` users get a hard provider error on every request. The fix is the smallest adaptation of the upstream change to current `dev` (line numbers drifted; logic re-proven against the current `gpt-5` block).

## Related Issue

None. Ports upstream anomalyco/opencode#26222 (thanks @frederiknsgo).

## Human Review Status

Pending

## Review Focus

Guard placement and predicate: it sits after the `enable_thinking` blocks and before the shared `gpt-5` block, keyed on `api.npm === "@ai-sdk/azure" && api.id.includes("gpt-5.5")`. Confirm it does not shadow other Azure gpt-5.x models (only `gpt-5.5` is matched) and that returning early is correct (no later block in `options` applies to this case).

## Risk Notes

Behavior change is scoped to Azure `gpt-5.5` only; all other providers/models keep their existing options.

Known pre-existing limitation (out of scope, not a regression from this change): `ProviderTransform.variants()` still returns `reasoningEffort` entries for Azure `gpt-5.5` reasoning variants, and `session/llm.ts` merges the selected variant's options after `ProviderTransform.options(...)`. So if a user explicitly selects a reasoning-effort variant for Azure `gpt-5.5`, `reasoningEffort` is reintroduced and Azure still rejects it. The upstream fix (anomalyco/opencode#26222) has the same scope and also leaves the variant path untouched. Closing the variant path requires a product decision about whether Azure `gpt-5.5` should expose reasoning-effort controls at all, plus a change at the out-of-scope merge site — tracked separately rather than expanded into this minimal port.

Skipped conditional checklist items:

- UI/copy item — no visible UI or copy changed (server-side provider options only).
- Platform item — no platform, packaging, updater, signing, paths, shell, or permissions surface touched.
- Docs/release/deps item — no docs, dependencies, generated files, or local file surfaces touched.

## How To Verify

```text
Red→green (worktree): with guard removed, new test fails — result.reasoningEffort === "medium"; with guard, it is undefined and reasoningSummary === "auto".
bun test test/provider/transform.test.ts: 205 pass, 0 fail
bun test (packages/opencode, full): 3669 pass, 9 skip, 1 todo, 0 fail (273 files)
bun run typecheck (turbo, all 9 packages): 8 successful, 0 errors
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

